### PR TITLE
feat: Phase 3.6 — multi-model execution strategies (MoA, Debate, Voting)

### DIFF
--- a/client/src/components/pipeline/StageOutput.tsx
+++ b/client/src/components/pipeline/StageOutput.tsx
@@ -4,11 +4,14 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { ChevronDown, ChevronRight, Copy, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
+import StrategyViewer from "./StrategyViewer";
+import type { StrategyResult } from "@shared/types";
 
 interface StageOutputProps {
   teamId: string;
   teamName: string;
   output: Record<string, unknown>;
+  strategyResult?: StrategyResult | null;
   isActive?: boolean;
 }
 
@@ -16,6 +19,7 @@ export default function StageOutput({
   teamId,
   teamName,
   output,
+  strategyResult,
   isActive,
 }: StageOutputProps) {
   const [expanded, setExpanded] = useState(isActive ?? false);
@@ -135,6 +139,11 @@ export default function StageOutput({
                 </pre>
               </ScrollArea>
             </div>
+          )}
+
+          {/* Strategy intermediate outputs */}
+          {strategyResult && strategyResult.strategy !== "single" && (
+            <StrategyViewer strategyResult={strategyResult} />
           )}
         </CardContent>
       )}

--- a/client/src/components/pipeline/StrategyViewer.tsx
+++ b/client/src/components/pipeline/StrategyViewer.tsx
@@ -1,0 +1,271 @@
+import { useState } from "react";
+import { ChevronDown, ChevronRight, Layers, MessageSquare, Vote } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
+import type { StrategyResult, MoaDetails, DebateDetails, VotingDetails } from "@shared/types";
+
+interface StrategyViewerProps {
+  strategyResult: StrategyResult;
+}
+
+export default function StrategyViewer({ strategyResult }: StrategyViewerProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (strategyResult.strategy === "single" || !strategyResult.details) {
+    return null;
+  }
+
+  const strategyLabel = {
+    moa: "Mixture of Agents",
+    debate: "Debate",
+    voting: "Voting",
+    single: "Single",
+  }[strategyResult.strategy];
+
+  const strategyIcon = {
+    moa: <Layers className="h-3 w-3" />,
+    debate: <MessageSquare className="h-3 w-3" />,
+    voting: <Vote className="h-3 w-3" />,
+    single: null,
+  }[strategyResult.strategy];
+
+  return (
+    <div className="mt-3 border border-border rounded-lg overflow-hidden">
+      <button
+        type="button"
+        className="w-full flex items-center gap-2 px-3 py-2 bg-muted/40 hover:bg-muted/60 transition-colors text-left"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        {expanded
+          ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground shrink-0" />}
+        {strategyIcon}
+        <span className="text-xs font-medium">{strategyLabel} — intermediate steps</span>
+        <Badge variant="outline" className="ml-auto text-[9px] h-4 px-1.5">
+          {strategyResult.totalTokensUsed} tokens · {Math.round(strategyResult.durationMs / 1000)}s
+        </Badge>
+      </button>
+
+      {expanded && (
+        <div className="px-3 pb-3 pt-2 space-y-3">
+          {strategyResult.strategy === "moa" && (
+            <MoaDetailsView details={strategyResult.details as MoaDetails} />
+          )}
+          {strategyResult.strategy === "debate" && (
+            <DebateDetailsView details={strategyResult.details as DebateDetails} />
+          )}
+          {strategyResult.strategy === "voting" && (
+            <VotingDetailsView details={strategyResult.details as VotingDetails} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MoaDetailsView({ details }: { details: MoaDetails }) {
+  return (
+    <div className="space-y-2">
+      <p className="text-[11px] text-muted-foreground font-medium uppercase tracking-wide">
+        Proposer Responses
+      </p>
+      {details.proposerResponses.map((p, idx) => (
+        <ProposerCard key={idx} modelSlug={p.modelSlug} role={p.role} content={p.content} index={idx} />
+      ))}
+      <p className="text-[11px] text-muted-foreground mt-2">
+        Aggregated by: <span className="font-mono">{details.aggregatorModelSlug}</span>
+      </p>
+    </div>
+  );
+}
+
+function ProposerCard({
+  modelSlug,
+  role,
+  content,
+  index,
+}: {
+  modelSlug: string;
+  role?: string;
+  content: string;
+  index: number;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="border border-border rounded overflow-hidden">
+      <button
+        type="button"
+        className="w-full flex items-center gap-2 px-2.5 py-1.5 bg-muted/30 hover:bg-muted/50 text-left"
+        onClick={() => setOpen((v) => !v)}
+      >
+        {open ? <ChevronDown className="h-3 w-3 shrink-0" /> : <ChevronRight className="h-3 w-3 shrink-0" />}
+        <span className="text-[11px] font-mono">{modelSlug}</span>
+        {role && <Badge variant="secondary" className="text-[9px] h-4 px-1">{role}</Badge>}
+        <span className="text-[10px] text-muted-foreground ml-auto">Proposer {index + 1}</span>
+      </button>
+      {open && (
+        <ScrollArea className="max-h-[200px]">
+          <pre className="p-2.5 text-[11px] font-mono whitespace-pre-wrap leading-relaxed text-foreground/80">
+            {content}
+          </pre>
+        </ScrollArea>
+      )}
+    </div>
+  );
+}
+
+function DebateDetailsView({ details }: { details: DebateDetails }) {
+  const rounds = Array.from(new Set(details.rounds.map((r) => r.round))).sort((a, b) => a - b);
+
+  return (
+    <div className="space-y-3">
+      {rounds.map((round) => {
+        const entries = details.rounds.filter((r) => r.round === round);
+        return (
+          <RoundGroup key={round} round={round} entries={entries} />
+        );
+      })}
+      <div className="border border-primary/30 rounded p-2.5 bg-primary/5">
+        <p className="text-[11px] font-medium mb-1 text-primary">
+          Judge ({details.judgeModelSlug})
+        </p>
+        <ScrollArea className="max-h-[200px]">
+          <pre className="text-[11px] font-mono whitespace-pre-wrap leading-relaxed">
+            {details.verdict}
+          </pre>
+        </ScrollArea>
+      </div>
+    </div>
+  );
+}
+
+const ROLE_COLORS: Record<string, string> = {
+  proposer: "bg-blue-500/10 text-blue-600 border-blue-500/20",
+  critic: "bg-orange-500/10 text-orange-600 border-orange-500/20",
+  devil_advocate: "bg-purple-500/10 text-purple-600 border-purple-500/20",
+};
+
+function RoundGroup({
+  round,
+  entries,
+}: {
+  round: number;
+  entries: DebateDetails["rounds"];
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="border border-border rounded overflow-hidden">
+      <button
+        type="button"
+        className="w-full flex items-center gap-2 px-2.5 py-1.5 bg-muted/30 hover:bg-muted/50 text-left"
+        onClick={() => setOpen((v) => !v)}
+      >
+        {open ? <ChevronDown className="h-3 w-3 shrink-0" /> : <ChevronRight className="h-3 w-3 shrink-0" />}
+        <span className="text-[11px] font-medium">Round {round}</span>
+        <span className="text-[10px] text-muted-foreground ml-1">
+          {entries.map((e) => e.role).join(" → ")}
+        </span>
+      </button>
+      {open && (
+        <div className="p-2 space-y-2">
+          {entries.map((entry, idx) => (
+            <div
+              key={idx}
+              className={cn(
+                "rounded border px-2.5 py-2",
+                ROLE_COLORS[entry.role] ?? "bg-muted/20 border-border",
+              )}
+            >
+              <div className="flex items-center gap-1.5 mb-1">
+                <span className="text-[10px] font-mono">{entry.participant}</span>
+                <Badge variant="outline" className="text-[9px] h-3.5 px-1">
+                  {entry.role}
+                </Badge>
+              </div>
+              <ScrollArea className="max-h-[160px]">
+                <pre className="text-[11px] font-mono whitespace-pre-wrap leading-relaxed">
+                  {entry.content}
+                </pre>
+              </ScrollArea>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function VotingDetailsView({ details }: { details: VotingDetails }) {
+  return (
+    <div className="space-y-2">
+      <p className="text-[11px] text-muted-foreground font-medium uppercase tracking-wide">
+        Candidates · Agreement: {Math.round(details.agreement * 100)}%
+      </p>
+      {details.candidates.map((c, idx) => (
+        <CandidateCard
+          key={idx}
+          modelSlug={c.modelSlug}
+          content={c.content}
+          passed={c.passed}
+          isWinner={idx === details.winnerIndex}
+          index={idx}
+        />
+      ))}
+    </div>
+  );
+}
+
+function CandidateCard({
+  modelSlug,
+  content,
+  passed,
+  isWinner,
+  index,
+}: {
+  modelSlug: string;
+  content: string;
+  passed: boolean;
+  isWinner: boolean;
+  index: number;
+}) {
+  const [open, setOpen] = useState(isWinner);
+
+  return (
+    <div
+      className={cn(
+        "border rounded overflow-hidden",
+        isWinner ? "border-green-500/40 bg-green-500/5" : "border-border",
+      )}
+    >
+      <button
+        type="button"
+        className="w-full flex items-center gap-2 px-2.5 py-1.5 text-left hover:bg-muted/20 transition-colors"
+        onClick={() => setOpen((v) => !v)}
+      >
+        {open ? <ChevronDown className="h-3 w-3 shrink-0" /> : <ChevronRight className="h-3 w-3 shrink-0" />}
+        <span className="text-[11px] font-mono">{modelSlug}</span>
+        <span className="text-[10px] text-muted-foreground">Candidate {index + 1}</span>
+        <div className="ml-auto flex items-center gap-1">
+          {isWinner && (
+            <Badge className="text-[9px] h-4 px-1 bg-green-600 hover:bg-green-600">Winner</Badge>
+          )}
+          <Badge
+            variant="outline"
+            className={cn("text-[9px] h-4 px-1", passed ? "border-green-500/50 text-green-600" : "border-red-500/50 text-red-600")}
+          >
+            {passed ? "passed" : "failed"}
+          </Badge>
+        </div>
+      </button>
+      {open && (
+        <ScrollArea className="max-h-[200px]">
+          <pre className="p-2.5 text-[11px] font-mono whitespace-pre-wrap leading-relaxed text-foreground/80">
+            {content}
+          </pre>
+        </ScrollArea>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/workflow/AgentNode.tsx
+++ b/client/src/components/workflow/AgentNode.tsx
@@ -9,6 +9,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { ChevronDown, ChevronUp, Pencil } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { SDLC_TEAMS, DEFAULT_TEMPERATURE, DEFAULT_MAX_TOKENS, MIN_TEMPERATURE, MAX_TEMPERATURE, TEMPERATURE_STEP } from "@shared/constants";
+import StrategyConfig from "./StrategyConfig";
+import type { ExecutionStrategy } from "@shared/types";
 
 interface ModelOption {
   label: string;
@@ -27,11 +29,13 @@ interface AgentNodeProps {
   systemPromptOverride?: string;
   temperature?: number;
   maxTokens?: number;
+  executionStrategy?: ExecutionStrategy;
   onModelChange: (id: string, model: string) => void;
   onToggle: () => void;
   onSystemPromptChange: (id: string, prompt: string) => void;
   onTemperatureChange: (id: string, temperature: number) => void;
   onMaxTokensChange: (id: string, maxTokens: number) => void;
+  onStrategyChange: (id: string, strategy: ExecutionStrategy) => void;
   isLast: boolean;
 }
 
@@ -66,11 +70,13 @@ export default function AgentNode({
   systemPromptOverride,
   temperature,
   maxTokens,
+  executionStrategy,
   onModelChange,
   onToggle,
   onSystemPromptChange,
   onTemperatureChange,
   onMaxTokensChange,
+  onStrategyChange,
   isLast,
 }: AgentNodeProps) {
   const team = SDLC_TEAMS[role as keyof typeof SDLC_TEAMS];
@@ -240,6 +246,15 @@ export default function AgentNode({
               </div>
             )}
           </div>
+
+          {/* Strategy Config */}
+          <StrategyConfig
+            strategy={executionStrategy}
+            models={models}
+            defaultModelSlug={model}
+            enabled={enabled}
+            onChange={(s) => onStrategyChange(id, s)}
+          />
 
           {team && (
             <div className="p-2 rounded bg-muted/50 border border-border">

--- a/client/src/components/workflow/MultiAgentPipeline.tsx
+++ b/client/src/components/workflow/MultiAgentPipeline.tsx
@@ -3,11 +3,11 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Save, RotateCcw, Zap } from "lucide-react";
+import { Save, RotateCcw, Zap, Network } from "lucide-react";
 import AgentNode from "./AgentNode";
 import { usePipelines, useUpdatePipeline, useModels } from "@/hooks/use-pipeline";
-import { SDLC_TEAMS, TEAM_ORDER, STRATEGY_PRESETS } from "@shared/constants";
-import type { PipelineStageConfig } from "@shared/types";
+import { SDLC_TEAMS, TEAM_ORDER, STRATEGY_PRESETS, EXECUTION_STRATEGY_PRESETS } from "@shared/constants";
+import type { PipelineStageConfig, ExecutionStrategy, MoaStrategy, DebateStrategy, VotingStrategy } from "@shared/types";
 
 interface MultiAgentPipelineProps {
   pipelineId?: string;
@@ -63,6 +63,18 @@ export default function MultiAgentPipeline({ pipelineId }: MultiAgentPipelinePro
     setDirty(true);
   };
 
+  const updateStrategy = (teamId: string, strategy: ExecutionStrategy) => {
+    setLocalStages(prev => prev.map(s => {
+      if (s.teamId !== teamId) return s;
+      if (strategy.type === "single") {
+        const { executionStrategy: _removed, ...rest } = s as PipelineStageConfig & { executionStrategy?: ExecutionStrategy };
+        return rest as PipelineStageConfig;
+      }
+      return { ...s, executionStrategy: strategy };
+    }));
+    setDirty(true);
+  };
+
   const applyPreset = (presetId: string) => {
     const preset = STRATEGY_PRESETS.find(p => p.id === presetId);
     if (!preset) return;
@@ -74,6 +86,20 @@ export default function MultiAgentPipeline({ pipelineId }: MultiAgentPipelinePro
         temperature: override?.temperature ?? preset.temperature,
         maxTokens: preset.maxTokens,
       };
+    }));
+    setDirty(true);
+  };
+
+  const applyExecutionPreset = (presetId: string) => {
+    const preset = EXECUTION_STRATEGY_PRESETS.find(p => p.id === presetId);
+    if (!preset) return;
+    setLocalStages(prev => prev.map(s => {
+      const stageStrategy = preset.stageStrategies[s.teamId as keyof typeof preset.stageStrategies];
+      if (!stageStrategy) {
+        const { executionStrategy: _removed, ...rest } = s as PipelineStageConfig & { executionStrategy?: ExecutionStrategy };
+        return rest as PipelineStageConfig;
+      }
+      return { ...s, executionStrategy: stageStrategy };
     }));
     setDirty(true);
   };
@@ -127,14 +153,13 @@ export default function MultiAgentPipeline({ pipelineId }: MultiAgentPipelinePro
         </div>
       </div>
 
-      {/* Strategy Presets */}
+      {/* Model Presets */}
       <Card className="border-border bg-card p-4 space-y-3">
         <div className="flex items-center gap-2">
           <Zap className="h-4 w-4 text-amber-500" />
-          <span className="text-sm font-medium">Strategy Presets</span>
+          <span className="text-sm font-medium">Model Presets</span>
         </div>
 
-        {/* Preset quick-pick buttons */}
         <div className="flex flex-wrap gap-2">
           {STRATEGY_PRESETS.map(preset => (
             <Button
@@ -149,15 +174,16 @@ export default function MultiAgentPipeline({ pipelineId }: MultiAgentPipelinePro
           ))}
         </div>
 
-        {/* Visual constructor: stage × model grid */}
+        {/* Stage Model Matrix */}
         <div className="mt-3">
           <div className="text-xs text-muted-foreground mb-2 font-medium">Stage Model Matrix</div>
           <div className="space-y-1.5">
             {localStages.map(stage => {
               const team = SDLC_TEAMS[stage.teamId as keyof typeof SDLC_TEAMS];
               if (!team) return null;
+              const strat = stage.executionStrategy;
               return (
-                <div key={stage.teamId} className="grid grid-cols-[140px_1fr_80px_80px] gap-2 items-center">
+                <div key={stage.teamId} className="grid grid-cols-[140px_1fr_60px_60px_56px] gap-2 items-center">
                   <span className="text-xs font-medium truncate">{team.name}</span>
                   <Select
                     value={stage.modelSlug}
@@ -181,11 +207,44 @@ export default function MultiAgentPipeline({ pipelineId }: MultiAgentPipelinePro
                   <span className="text-[10px] text-muted-foreground text-right font-mono">
                     {stage.maxTokens ?? 2048}tk
                   </span>
+                  {strat && strat.type !== "single" ? (
+                    <Badge variant="secondary" className="text-[9px] h-4 px-1 justify-center">
+                      {strategyBadge(strat)}
+                    </Badge>
+                  ) : (
+                    <span />
+                  )}
                 </div>
               );
             })}
           </div>
         </div>
+      </Card>
+
+      {/* Execution Strategy Presets */}
+      <Card className="border-border bg-card p-4 space-y-3">
+        <div className="flex items-center gap-2">
+          <Network className="h-4 w-4 text-violet-500" />
+          <span className="text-sm font-medium">Execution Strategy Presets</span>
+          <span className="text-xs text-muted-foreground">(multi-model orchestration)</span>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {EXECUTION_STRATEGY_PRESETS.map(preset => (
+            <Button
+              key={preset.id}
+              variant="outline"
+              size="sm"
+              className="text-xs h-7"
+              onClick={() => applyExecutionPreset(preset.id)}
+            >
+              {preset.label}
+            </Button>
+          ))}
+        </div>
+        <p className="text-[11px] text-muted-foreground">
+          Quality Max uses MoA, Debate, and Voting for maximum output quality.
+          Apply a preset, then save to persist.
+        </p>
       </Card>
 
       {/* Stage Pipeline */}
@@ -207,11 +266,13 @@ export default function MultiAgentPipeline({ pipelineId }: MultiAgentPipelinePro
                 systemPromptOverride={stage.systemPromptOverride}
                 temperature={stage.temperature}
                 maxTokens={stage.maxTokens}
+                executionStrategy={stage.executionStrategy}
                 onModelChange={(_, model) => updateStageModel(stage.teamId, model)}
                 onToggle={() => toggleStage(stage.teamId)}
                 onSystemPromptChange={(_, prompt) => updateSystemPrompt(stage.teamId, prompt)}
                 onTemperatureChange={(_, temp) => updateTemperature(stage.teamId, temp)}
                 onMaxTokensChange={(_, tokens) => updateMaxTokens(stage.teamId, tokens)}
+                onStrategyChange={(_, strategy) => updateStrategy(stage.teamId, strategy)}
                 isLast={idx === localStages.length - 1}
               />
             );
@@ -237,8 +298,8 @@ export default function MultiAgentPipeline({ pipelineId }: MultiAgentPipelinePro
               <div className="text-muted-foreground">Full task context and prior outputs passed to each team</div>
             </div>
             <div className="p-2 rounded border border-border bg-card">
-              <div className="font-medium mb-1">Model Flexibility</div>
-              <div className="text-muted-foreground">Assign any registered model to any team stage</div>
+              <div className="font-medium mb-1">Multi-Model Strategies</div>
+              <div className="text-muted-foreground">Each stage can use MoA, Debate, or Voting for higher quality</div>
             </div>
           </div>
         </div>
@@ -252,6 +313,7 @@ export default function MultiAgentPipeline({ pipelineId }: MultiAgentPipelinePro
             const team = SDLC_TEAMS[teamId];
             const stage = localStages.find(s => s.teamId === teamId);
             const model = modelList.find(m => m.value === stage?.modelSlug);
+            const strat = stage?.executionStrategy;
             return (
               <div key={teamId} className="flex gap-2">
                 <span className="font-mono text-blue-500">→</span>
@@ -260,6 +322,11 @@ export default function MultiAgentPipeline({ pipelineId }: MultiAgentPipelinePro
                   {model && <span className="ml-1">({model.label})</span>}
                   {stage?.systemPromptOverride && (
                     <Badge variant="outline" className="ml-2 text-[9px] h-4 px-1">custom prompt</Badge>
+                  )}
+                  {strat && strat.type !== "single" && (
+                    <Badge variant="secondary" className="ml-2 text-[9px] h-4 px-1">
+                      {strategyBadge(strat)}
+                    </Badge>
                   )}
                   {' — '}{team.description}
                 </span>
@@ -270,4 +337,13 @@ export default function MultiAgentPipeline({ pipelineId }: MultiAgentPipelinePro
       </Card>
     </div>
   );
+}
+
+function strategyBadge(strategy: ExecutionStrategy): string {
+  switch (strategy.type) {
+    case "moa": return `MoA×${(strategy as MoaStrategy).proposers.length}`;
+    case "debate": return `Debate ${(strategy as DebateStrategy).rounds}r`;
+    case "voting": return `Vote×${(strategy as VotingStrategy).candidates.length}`;
+    default: return "Single";
+  }
 }

--- a/client/src/components/workflow/StrategyConfig.tsx
+++ b/client/src/components/workflow/StrategyConfig.tsx
@@ -1,0 +1,547 @@
+import { useState } from "react";
+import { Plus, Trash2, ChevronDown, ChevronUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Slider } from "@/components/ui/slider";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { computeCostMultiplier } from "@shared/constants";
+import type {
+  ExecutionStrategy,
+  ExecutionStrategyType,
+  MoaStrategy,
+  DebateStrategy,
+  VotingStrategy,
+  ProposerConfig,
+  DebateParticipant,
+  CandidateConfig,
+} from "@shared/types";
+
+interface ModelOption {
+  label: string;
+  value: string;
+  provider: string;
+}
+
+interface StrategyConfigProps {
+  strategy: ExecutionStrategy | undefined;
+  models: ModelOption[];
+  defaultModelSlug: string;
+  enabled: boolean;
+  onChange: (strategy: ExecutionStrategy) => void;
+}
+
+const STRATEGY_OPTIONS: Array<{ value: ExecutionStrategyType; label: string; description: string }> = [
+  { value: "single", label: "Single", description: "One model, one response" },
+  { value: "moa", label: "Mixture of Agents", description: "Parallel proposers + aggregator" },
+  { value: "debate", label: "Debate", description: "Proposer vs critic, judge decides" },
+  { value: "voting", label: "Voting", description: "Multiple candidates, consensus winner" },
+];
+
+export default function StrategyConfig({
+  strategy,
+  models,
+  defaultModelSlug,
+  enabled,
+  onChange,
+}: StrategyConfigProps) {
+  const [expanded, setExpanded] = useState(false);
+  const currentType: ExecutionStrategyType = strategy?.type ?? "single";
+  const multiplier = strategy ? computeCostMultiplier(strategy as Parameters<typeof computeCostMultiplier>[0]) : 1;
+
+  const handleTypeChange = (type: ExecutionStrategyType) => {
+    switch (type) {
+      case "single":
+        onChange({ type: "single" });
+        break;
+      case "moa":
+        onChange({
+          type: "moa",
+          proposers: [
+            { modelSlug: defaultModelSlug, role: "primary", temperature: 0.7 },
+            { modelSlug: models[1]?.value ?? defaultModelSlug, role: "alternative", temperature: 0.6 },
+          ],
+          aggregator: { modelSlug: defaultModelSlug },
+        });
+        break;
+      case "debate":
+        onChange({
+          type: "debate",
+          participants: [
+            { modelSlug: defaultModelSlug, role: "proposer" },
+            { modelSlug: models[1]?.value ?? defaultModelSlug, role: "critic" },
+          ],
+          judge: { modelSlug: defaultModelSlug },
+          rounds: 3,
+        });
+        break;
+      case "voting":
+        onChange({
+          type: "voting",
+          candidates: [
+            { modelSlug: defaultModelSlug, temperature: 0.5 },
+            { modelSlug: models[1]?.value ?? defaultModelSlug, temperature: 0.6 },
+            { modelSlug: models[2]?.value ?? defaultModelSlug, temperature: 0.7 },
+          ],
+          threshold: 0.6,
+          validationMode: "text_similarity",
+        });
+        break;
+    }
+  };
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+        disabled={!enabled}
+      >
+        <span>Strategy</span>
+        {currentType !== "single" && (
+          <Badge variant="secondary" className="text-[9px] h-4 px-1 ml-1">
+            {strategyBadge(strategy!)}
+          </Badge>
+        )}
+        {multiplier > 1 && (
+          <span className="text-[10px] text-amber-500 ml-1">{multiplier}x cost</span>
+        )}
+        {expanded
+          ? <ChevronUp className="h-3 w-3 ml-1" />
+          : <ChevronDown className="h-3 w-3 ml-1" />}
+      </button>
+
+      {expanded && (
+        <div className="mt-3 p-3 rounded border border-border bg-muted/30 space-y-3">
+          {/* Strategy type selector */}
+          <div>
+            <label className="text-xs font-medium text-muted-foreground mb-1 block">
+              Execution Strategy
+            </label>
+            <Select value={currentType} onValueChange={(v) => handleTypeChange(v as ExecutionStrategyType)} disabled={!enabled}>
+              <SelectTrigger className="h-8 text-xs bg-background border-border">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {STRATEGY_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    <div>
+                      <span>{opt.label}</span>
+                      <span className="text-muted-foreground ml-2 text-[10px]">{opt.description}</span>
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* MoA config */}
+          {strategy?.type === "moa" && (
+            <MoaConfig strategy={strategy} models={models} enabled={enabled} onChange={onChange} />
+          )}
+
+          {/* Debate config */}
+          {strategy?.type === "debate" && (
+            <DebateConfig strategy={strategy} models={models} enabled={enabled} onChange={onChange} />
+          )}
+
+          {/* Voting config */}
+          {strategy?.type === "voting" && (
+            <VotingConfig strategy={strategy} models={models} enabled={enabled} onChange={onChange} />
+          )}
+
+          {/* Cost estimate */}
+          {currentType !== "single" && (
+            <p className="text-[10px] text-amber-500/80">
+              Estimated cost: ~{multiplier}x a single call per stage execution
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── MoA Config ──────────────────────────────────────────────────────────────
+
+function MoaConfig({
+  strategy,
+  models,
+  enabled,
+  onChange,
+}: {
+  strategy: MoaStrategy;
+  models: ModelOption[];
+  enabled: boolean;
+  onChange: (s: ExecutionStrategy) => void;
+}) {
+  const addProposer = () => {
+    if (strategy.proposers.length >= 5) return;
+    onChange({
+      ...strategy,
+      proposers: [
+        ...strategy.proposers,
+        { modelSlug: models[0]?.value ?? "llama3-70b", temperature: 0.7 },
+      ],
+    });
+  };
+
+  const removeProposer = (idx: number) => {
+    if (strategy.proposers.length <= 1) return;
+    onChange({
+      ...strategy,
+      proposers: strategy.proposers.filter((_, i) => i !== idx),
+    });
+  };
+
+  const updateProposer = (idx: number, patch: Partial<ProposerConfig>) => {
+    onChange({
+      ...strategy,
+      proposers: strategy.proposers.map((p, i) => i === idx ? { ...p, ...patch } : p),
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <label className="text-xs font-medium text-muted-foreground">Proposers ({strategy.proposers.length}/5)</label>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 text-[10px] px-2"
+          onClick={addProposer}
+          disabled={!enabled || strategy.proposers.length >= 5}
+        >
+          <Plus className="h-3 w-3 mr-1" /> Add
+        </Button>
+      </div>
+
+      {strategy.proposers.map((p, idx) => (
+        <div key={idx} className="flex gap-1.5 items-center">
+          <Select
+            value={p.modelSlug}
+            onValueChange={(v) => updateProposer(idx, { modelSlug: v })}
+            disabled={!enabled}
+          >
+            <SelectTrigger className="h-7 text-[11px] flex-1">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {models.map((m) => (
+                <SelectItem key={m.value} value={m.value} className="text-xs">{m.label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <span className="text-[10px] text-muted-foreground w-6 text-center shrink-0">
+            {(p.temperature ?? 0.7).toFixed(1)}
+          </span>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 shrink-0"
+            onClick={() => removeProposer(idx)}
+            disabled={!enabled || strategy.proposers.length <= 1}
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        </div>
+      ))}
+
+      <div>
+        <label className="text-xs font-medium text-muted-foreground mb-1 block">Aggregator</label>
+        <Select
+          value={strategy.aggregator.modelSlug}
+          onValueChange={(v) => onChange({ ...strategy, aggregator: { ...strategy.aggregator, modelSlug: v } })}
+          disabled={!enabled}
+        >
+          <SelectTrigger className="h-7 text-[11px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {models.map((m) => (
+              <SelectItem key={m.value} value={m.value} className="text-xs">{m.label}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}
+
+// ─── Debate Config ────────────────────────────────────────────────────────────
+
+const DEBATE_ROLES: DebateParticipant["role"][] = ["proposer", "critic", "devil_advocate"];
+const ROLE_LABELS: Record<DebateParticipant["role"], string> = {
+  proposer: "Proposer",
+  critic: "Critic",
+  devil_advocate: "Devil's Advocate",
+};
+
+function DebateConfig({
+  strategy,
+  models,
+  enabled,
+  onChange,
+}: {
+  strategy: DebateStrategy;
+  models: ModelOption[];
+  enabled: boolean;
+  onChange: (s: ExecutionStrategy) => void;
+}) {
+  const addParticipant = () => {
+    onChange({
+      ...strategy,
+      participants: [
+        ...strategy.participants,
+        { modelSlug: models[0]?.value ?? "llama3-70b", role: "critic" },
+      ],
+    });
+  };
+
+  const removeParticipant = (idx: number) => {
+    if (strategy.participants.length <= 2) return;
+    onChange({ ...strategy, participants: strategy.participants.filter((_, i) => i !== idx) });
+  };
+
+  const updateParticipant = (idx: number, patch: Partial<DebateParticipant>) => {
+    onChange({
+      ...strategy,
+      participants: strategy.participants.map((p, i) => i === idx ? { ...p, ...patch } : p),
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <label className="text-xs font-medium text-muted-foreground">Participants</label>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 text-[10px] px-2"
+          onClick={addParticipant}
+          disabled={!enabled}
+        >
+          <Plus className="h-3 w-3 mr-1" /> Add
+        </Button>
+      </div>
+
+      {strategy.participants.map((p, idx) => (
+        <div key={idx} className="flex gap-1.5 items-center">
+          <Select
+            value={p.modelSlug}
+            onValueChange={(v) => updateParticipant(idx, { modelSlug: v })}
+            disabled={!enabled}
+          >
+            <SelectTrigger className="h-7 text-[11px] flex-1">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {models.map((m) => (
+                <SelectItem key={m.value} value={m.value} className="text-xs">{m.label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={p.role}
+            onValueChange={(v) => updateParticipant(idx, { role: v as DebateParticipant["role"] })}
+            disabled={!enabled}
+          >
+            <SelectTrigger className="h-7 text-[11px] w-28 shrink-0">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {DEBATE_ROLES.map((r) => (
+                <SelectItem key={r} value={r} className="text-xs">{ROLE_LABELS[r]}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 shrink-0"
+            onClick={() => removeParticipant(idx)}
+            disabled={!enabled || strategy.participants.length <= 2}
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        </div>
+      ))}
+
+      <div>
+        <label className="text-xs font-medium text-muted-foreground mb-1 block">Judge</label>
+        <Select
+          value={strategy.judge.modelSlug}
+          onValueChange={(v) => onChange({ ...strategy, judge: { ...strategy.judge, modelSlug: v } })}
+          disabled={!enabled}
+        >
+          <SelectTrigger className="h-7 text-[11px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {models.map((m) => (
+              <SelectItem key={m.value} value={m.value} className="text-xs">{m.label}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between mb-1">
+          <label className="text-xs font-medium text-muted-foreground">Rounds</label>
+          <span className="text-xs font-mono">{strategy.rounds}</span>
+        </div>
+        <Slider
+          min={1}
+          max={5}
+          step={1}
+          value={[strategy.rounds]}
+          onValueChange={([v]) => onChange({ ...strategy, rounds: v })}
+          disabled={!enabled}
+          className="h-4"
+        />
+        <div className="flex justify-between text-[10px] text-muted-foreground mt-0.5">
+          <span>1</span>
+          <span>5</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Voting Config ────────────────────────────────────────────────────────────
+
+function VotingConfig({
+  strategy,
+  models,
+  enabled,
+  onChange,
+}: {
+  strategy: VotingStrategy;
+  models: ModelOption[];
+  enabled: boolean;
+  onChange: (s: ExecutionStrategy) => void;
+}) {
+  const addCandidate = () => {
+    if (strategy.candidates.length >= 7) return;
+    onChange({
+      ...strategy,
+      candidates: [...strategy.candidates, { modelSlug: models[0]?.value ?? "llama3-70b", temperature: 0.7 }],
+    });
+  };
+
+  const removeCandidate = (idx: number) => {
+    if (strategy.candidates.length <= 2) return;
+    onChange({ ...strategy, candidates: strategy.candidates.filter((_, i) => i !== idx) });
+  };
+
+  const updateCandidate = (idx: number, patch: Partial<CandidateConfig>) => {
+    onChange({
+      ...strategy,
+      candidates: strategy.candidates.map((c, i) => i === idx ? { ...c, ...patch } : c),
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <label className="text-xs font-medium text-muted-foreground">
+          Candidates ({strategy.candidates.length}/7)
+        </label>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 text-[10px] px-2"
+          onClick={addCandidate}
+          disabled={!enabled || strategy.candidates.length >= 7}
+        >
+          <Plus className="h-3 w-3 mr-1" /> Add
+        </Button>
+      </div>
+
+      {strategy.candidates.map((c, idx) => (
+        <div key={idx} className="flex gap-1.5 items-center">
+          <Select
+            value={c.modelSlug}
+            onValueChange={(v) => updateCandidate(idx, { modelSlug: v })}
+            disabled={!enabled}
+          >
+            <SelectTrigger className="h-7 text-[11px] flex-1">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {models.map((m) => (
+                <SelectItem key={m.value} value={m.value} className="text-xs">{m.label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <span className="text-[10px] text-muted-foreground shrink-0 w-8">
+            t={((c.temperature ?? 0.7)).toFixed(1)}
+          </span>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 shrink-0"
+            onClick={() => removeCandidate(idx)}
+            disabled={!enabled || strategy.candidates.length <= 2}
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        </div>
+      ))}
+
+      <div>
+        <div className="flex items-center justify-between mb-1">
+          <label className="text-xs font-medium text-muted-foreground">Consensus Threshold</label>
+          <span className="text-xs font-mono">{strategy.threshold.toFixed(2)}</span>
+        </div>
+        <Slider
+          min={0.5}
+          max={1.0}
+          step={0.05}
+          value={[strategy.threshold]}
+          onValueChange={([v]) => onChange({ ...strategy, threshold: v })}
+          disabled={!enabled}
+          className="h-4"
+        />
+        <div className="flex justify-between text-[10px] text-muted-foreground mt-0.5">
+          <span>Lenient (0.5)</span>
+          <span>Strict (1.0)</span>
+        </div>
+      </div>
+
+      <div>
+        <label className="text-xs font-medium text-muted-foreground mb-1 block">Validation Mode</label>
+        <div className="flex gap-2">
+          {(["text_similarity", "test_execution"] as const).map((mode) => (
+            <button
+              key={mode}
+              type="button"
+              disabled={!enabled}
+              onClick={() => onChange({ ...strategy, validationMode: mode })}
+              className={cn(
+                "text-[11px] px-2 py-1 rounded border transition-colors",
+                strategy.validationMode === mode
+                  ? "bg-primary text-primary-foreground border-primary"
+                  : "border-border text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {mode === "text_similarity" ? "Text Similarity" : "Test Execution"}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Badge helper ─────────────────────────────────────────────────────────────
+
+function strategyBadge(strategy: ExecutionStrategy): string {
+  switch (strategy.type) {
+    case "moa": return `MoA×${(strategy as MoaStrategy).proposers.length}`;
+    case "debate": return `Debate ${(strategy as DebateStrategy).rounds}r`;
+    case "voting": return `Vote×${(strategy as VotingStrategy).candidates.length}`;
+    default: return "Single";
+  }
+}

--- a/server/controller/pipeline-controller.ts
+++ b/server/controller/pipeline-controller.ts
@@ -111,6 +111,7 @@ export class PipelineController {
           stageIndex: i,
           teamId: stage.teamId,
           modelSlug: stage.modelSlug,
+          executionStrategy: stage.executionStrategy?.type ?? "single",
         },
         timestamp: new Date().toISOString(),
       });
@@ -138,7 +139,8 @@ export class PipelineController {
           previousOutputs,
         };
 
-        const result = await team.execute(stageInput, context);
+        // Pass execution strategy (undefined = single, handled in BaseTeam)
+        const result = await team.execute(stageInput, context, stage.executionStrategy);
 
         // Check if team needs clarification
         if (result.questions && result.questions.length > 0) {
@@ -193,6 +195,7 @@ export class PipelineController {
             teamId: stage.teamId,
             output: result.output,
             tokensUsed: result.tokensUsed,
+            strategyResult: result.strategyResult ?? null,
           },
           timestamp: new Date().toISOString(),
         });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -10,6 +10,7 @@ import { registerPipelineRoutes } from "./routes/pipelines";
 import { registerRunRoutes } from "./routes/runs";
 import { registerChatRoutes } from "./routes/chat";
 import { registerGatewayRoutes } from "./routes/gateway";
+import { registerStrategyRoutes } from "./routes/strategies";
 import { DEFAULT_MODELS, DEFAULT_PIPELINE_STAGES } from "@shared/constants";
 import { log } from "./index";
 
@@ -20,7 +21,7 @@ export async function registerRoutes(
   // Initialize core systems
   const wsManager = new WsManager(httpServer);
   const gateway = new Gateway(storage);
-  const teamRegistry = new TeamRegistry(gateway);
+  const teamRegistry = new TeamRegistry(gateway, wsManager);
   const controller = new PipelineController(storage, teamRegistry, wsManager);
 
   // Register route groups
@@ -29,6 +30,7 @@ export async function registerRoutes(
   registerRunRoutes(app, storage, controller);
   registerChatRoutes(app, storage, gateway, wsManager);
   registerGatewayRoutes(app, gateway);
+  registerStrategyRoutes(app, storage);
 
   // Seed default models
   const existingModels = await storage.getModels();

--- a/server/routes/strategies.ts
+++ b/server/routes/strategies.ts
@@ -1,0 +1,150 @@
+import { Router } from "express";
+import { z } from "zod";
+import type { IStorage } from "../storage";
+import { EXECUTION_STRATEGY_PRESETS } from "@shared/constants";
+import type { ExecutionStrategy, PipelineStageConfig, TeamId } from "@shared/types";
+
+// ─── Zod schemas for input validation ────────────────────────────────────────
+
+const ProposerConfigSchema = z.object({
+  modelSlug: z.string().min(1),
+  role: z.string().optional(),
+  temperature: z.number().min(0).max(2).optional(),
+});
+
+const AggregatorConfigSchema = z.object({
+  modelSlug: z.string().min(1),
+  systemPrompt: z.string().optional(),
+});
+
+const MoaStrategySchema = z.object({
+  type: z.literal("moa"),
+  proposers: z.array(ProposerConfigSchema).min(1).max(5),
+  aggregator: AggregatorConfigSchema,
+  proposerPromptOverride: z.string().optional(),
+});
+
+const DebateParticipantSchema = z.object({
+  modelSlug: z.string().min(1),
+  role: z.enum(["proposer", "critic", "devil_advocate"]),
+  persona: z.string().optional(),
+});
+
+const JudgeConfigSchema = z.object({
+  modelSlug: z.string().min(1),
+  criteria: z.array(z.string()).optional(),
+});
+
+const DebateStrategySchema = z.object({
+  type: z.literal("debate"),
+  participants: z.array(DebateParticipantSchema).min(2),
+  judge: JudgeConfigSchema,
+  rounds: z.number().int().min(1).max(5),
+  stopEarly: z.boolean().optional(),
+});
+
+const CandidateConfigSchema = z.object({
+  modelSlug: z.string().min(1),
+  temperature: z.number().min(0).max(2).optional(),
+});
+
+const VotingStrategySchema = z.object({
+  type: z.literal("voting"),
+  candidates: z.array(CandidateConfigSchema).min(2).max(7),
+  threshold: z.number().min(0.5).max(1.0),
+  validationMode: z.enum(["text_similarity", "test_execution"]),
+});
+
+const SingleStrategySchema = z.object({ type: z.literal("single") });
+
+const ExecutionStrategySchema = z.discriminatedUnion("type", [
+  SingleStrategySchema,
+  MoaStrategySchema,
+  DebateStrategySchema,
+  VotingStrategySchema,
+]);
+
+export function registerStrategyRoutes(router: Router, storage: IStorage): void {
+  // GET /api/strategies/presets — return named execution strategy presets
+  router.get("/api/strategies/presets", (_req, res) => {
+    res.json(EXECUTION_STRATEGY_PRESETS);
+  });
+
+  // PATCH /api/pipelines/:id/stages/:stageIndex/strategy — update strategy for a stage
+  router.patch(
+    "/api/pipelines/:id/stages/:stageIndex/strategy",
+    async (req, res) => {
+      const pipelineId = req.params.id;
+      const stageIndex = parseInt(req.params.stageIndex, 10);
+
+      if (isNaN(stageIndex) || stageIndex < 0) {
+        return res.status(400).json({ message: "Invalid stageIndex" });
+      }
+
+      const parseResult = ExecutionStrategySchema.safeParse(req.body);
+      if (!parseResult.success) {
+        return res.status(400).json({
+          message: "Invalid strategy",
+          errors: parseResult.error.flatten(),
+        });
+      }
+
+      const strategy = parseResult.data as ExecutionStrategy;
+
+      const pipeline = await storage.getPipeline(pipelineId);
+      if (!pipeline) {
+        return res.status(404).json({ message: "Pipeline not found" });
+      }
+
+      const stages = pipeline.stages as PipelineStageConfig[];
+      if (stageIndex >= stages.length) {
+        return res.status(400).json({ message: "Stage index out of bounds" });
+      }
+
+      const updatedStages = stages.map((s, idx) => {
+        if (idx !== stageIndex) return s;
+        if (strategy.type === "single") {
+          const { executionStrategy: _removed, ...rest } = s as PipelineStageConfig & { executionStrategy?: ExecutionStrategy };
+          return rest as PipelineStageConfig;
+        }
+        return { ...s, executionStrategy: strategy };
+      });
+
+      const updated = await storage.updatePipeline(pipelineId, { stages: updatedStages });
+      res.json(updated);
+    },
+  );
+
+  // PATCH /api/pipelines/:id/execution-preset — apply a named execution strategy preset
+  router.patch("/api/pipelines/:id/execution-preset", async (req, res) => {
+    const schema = z.object({ presetId: z.string().min(1) });
+    const parseResult = schema.safeParse(req.body);
+    if (!parseResult.success) {
+      return res.status(400).json({ message: "presetId is required" });
+    }
+
+    const preset = EXECUTION_STRATEGY_PRESETS.find((p) => p.id === parseResult.data.presetId);
+    if (!preset) {
+      return res.status(404).json({ message: "Execution strategy preset not found" });
+    }
+
+    const pipeline = await storage.getPipeline(req.params.id);
+    if (!pipeline) {
+      return res.status(404).json({ message: "Pipeline not found" });
+    }
+
+    const stages = pipeline.stages as PipelineStageConfig[];
+    const updatedStages = stages.map((s) => {
+      const stageStrategy = preset.stageStrategies[s.teamId as TeamId];
+      if (!stageStrategy) {
+        // No override — reset to single
+        const { executionStrategy: _removed, ...rest } = s as PipelineStageConfig & { executionStrategy?: ExecutionStrategy };
+        return rest as PipelineStageConfig;
+      }
+      return { ...s, executionStrategy: stageStrategy };
+    });
+
+    const updated = await storage.updatePipeline(req.params.id, { stages: updatedStages });
+    res.json(updated);
+  });
+}

--- a/server/services/strategy-executor.ts
+++ b/server/services/strategy-executor.ts
@@ -1,0 +1,460 @@
+import type { Gateway } from "../gateway/index";
+import type { WsManager } from "../ws/manager";
+import type {
+  ExecutionStrategy,
+  MoaStrategy,
+  DebateStrategy,
+  VotingStrategy,
+  StrategyResult,
+  MoaDetails,
+  DebateDetails,
+  VotingDetails,
+  ProviderMessage,
+} from "@shared/types";
+
+export interface StrategyContext {
+  runId: string;
+  stageId: string;
+  maxTokens?: number;
+}
+
+export class StrategyExecutor {
+  constructor(
+    private gateway: Gateway,
+    private wsManager: WsManager,
+  ) {}
+
+  async execute(
+    strategy: ExecutionStrategy,
+    basePrompt: ProviderMessage[],
+    context: StrategyContext,
+  ): Promise<StrategyResult> {
+    const start = Date.now();
+
+    this.wsManager.broadcastToRun(context.runId, {
+      type: "strategy:started",
+      runId: context.runId,
+      payload: { stageId: context.stageId, strategy: strategy.type },
+      timestamp: new Date().toISOString(),
+    });
+
+    let result: StrategyResult;
+
+    switch (strategy.type) {
+      case "single":
+        result = await this.executeSingle(basePrompt, context, start);
+        break;
+      case "moa":
+        result = await this.executeMoA(strategy, basePrompt, context, start);
+        break;
+      case "debate":
+        result = await this.executeDebate(strategy, basePrompt, context, start);
+        break;
+      case "voting":
+        result = await this.executeVoting(strategy, basePrompt, context, start);
+        break;
+    }
+
+    this.wsManager.broadcastToRun(context.runId, {
+      type: "strategy:completed",
+      runId: context.runId,
+      payload: { stageId: context.stageId, result },
+      timestamp: new Date().toISOString(),
+    });
+
+    return result;
+  }
+
+  private async executeSingle(
+    messages: ProviderMessage[],
+    context: StrategyContext,
+    start: number,
+  ): Promise<StrategyResult> {
+    const modelSlug = this.extractModelSlug(messages);
+    const response = await this.gateway.complete({
+      modelSlug,
+      messages,
+      maxTokens: context.maxTokens,
+    });
+
+    return {
+      finalContent: response.content,
+      strategy: "single",
+      details: null,
+      totalTokensUsed: response.tokensUsed,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  private async executeMoA(
+    strategy: MoaStrategy,
+    basePrompt: ProviderMessage[],
+    context: StrategyContext,
+    start: number,
+  ): Promise<StrategyResult> {
+    validateMoaStrategy(strategy);
+
+    // Run all proposers in parallel
+    const proposerPromises = strategy.proposers.map((p, idx) =>
+      this.runProposer(p, basePrompt, strategy.proposerPromptOverride, context, idx),
+    );
+
+    const proposerResults = await Promise.all(proposerPromises);
+    let totalTokens = proposerResults.reduce((sum, r) => sum + r.tokensUsed, 0);
+
+    // Build aggregation prompt
+    const aggregationMessages = buildAggregationPrompt(basePrompt, proposerResults, strategy.aggregator.systemPrompt);
+
+    const aggregatorResponse = await this.gateway.complete({
+      modelSlug: strategy.aggregator.modelSlug,
+      messages: aggregationMessages,
+      maxTokens: context.maxTokens,
+    });
+
+    totalTokens += aggregatorResponse.tokensUsed;
+
+    const details: MoaDetails = {
+      proposerResponses: proposerResults.map((r, i) => ({
+        modelSlug: strategy.proposers[i].modelSlug,
+        content: r.content,
+        role: strategy.proposers[i].role,
+      })),
+      aggregatorModelSlug: strategy.aggregator.modelSlug,
+    };
+
+    return {
+      finalContent: aggregatorResponse.content,
+      strategy: "moa",
+      details,
+      totalTokensUsed: totalTokens,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  private async runProposer(
+    proposer: MoaStrategy["proposers"][number],
+    basePrompt: ProviderMessage[],
+    promptOverride: string | undefined,
+    context: StrategyContext,
+    index: number,
+  ): Promise<{ content: string; tokensUsed: number }> {
+    const messages = promptOverride
+      ? replaceSystemPrompt(basePrompt, promptOverride)
+      : basePrompt;
+
+    const response = await this.gateway.complete({
+      modelSlug: proposer.modelSlug,
+      messages,
+      temperature: proposer.temperature,
+      maxTokens: context.maxTokens,
+    });
+
+    this.wsManager.broadcastToRun(context.runId, {
+      type: "strategy:proposer",
+      runId: context.runId,
+      payload: {
+        stageId: context.stageId,
+        modelSlug: proposer.modelSlug,
+        role: proposer.role,
+        content: response.content,
+        index,
+      },
+      timestamp: new Date().toISOString(),
+    });
+
+    return { content: response.content, tokensUsed: response.tokensUsed };
+  }
+
+  private async executeDebate(
+    strategy: DebateStrategy,
+    basePrompt: ProviderMessage[],
+    context: StrategyContext,
+    start: number,
+  ): Promise<StrategyResult> {
+    validateDebateStrategy(strategy);
+
+    const debateRounds: DebateDetails["rounds"] = [];
+    let totalTokens = 0;
+    const conversationHistory: ProviderMessage[] = [...basePrompt];
+
+    for (let round = 1; round <= strategy.rounds; round++) {
+      for (const participant of strategy.participants) {
+        const rolePrompt = buildDebateRolePrompt(participant.role, participant.persona, round, strategy.rounds);
+        const messages: ProviderMessage[] = [
+          ...conversationHistory,
+          { role: "user", content: rolePrompt },
+        ];
+
+        const response = await this.gateway.complete({
+          modelSlug: participant.modelSlug,
+          messages,
+          maxTokens: context.maxTokens,
+        });
+
+        totalTokens += response.tokensUsed;
+
+        const entry = {
+          round,
+          participant: participant.modelSlug,
+          role: participant.role,
+          content: response.content,
+        };
+        debateRounds.push(entry);
+
+        // Add to conversation so next participant sees this
+        conversationHistory.push({ role: "assistant", content: response.content });
+
+        this.wsManager.broadcastToRun(context.runId, {
+          type: "strategy:debate:round",
+          runId: context.runId,
+          payload: { stageId: context.stageId, ...entry },
+          timestamp: new Date().toISOString(),
+        });
+      }
+
+      if (strategy.stopEarly && round < strategy.rounds) {
+        const shouldStop = checkConsensus(debateRounds, round);
+        if (shouldStop) break;
+      }
+    }
+
+    // Judge delivers verdict
+    const judgePrompt = buildJudgePrompt(debateRounds, strategy.judge.criteria);
+    const judgeMessages: ProviderMessage[] = [
+      ...basePrompt,
+      { role: "user", content: judgePrompt },
+    ];
+
+    const judgeResponse = await this.gateway.complete({
+      modelSlug: strategy.judge.modelSlug,
+      messages: judgeMessages,
+      maxTokens: context.maxTokens,
+    });
+
+    totalTokens += judgeResponse.tokensUsed;
+
+    this.wsManager.broadcastToRun(context.runId, {
+      type: "strategy:debate:judge",
+      runId: context.runId,
+      payload: { stageId: context.stageId, verdict: judgeResponse.content },
+      timestamp: new Date().toISOString(),
+    });
+
+    const details: DebateDetails = {
+      rounds: debateRounds,
+      judgeModelSlug: strategy.judge.modelSlug,
+      verdict: judgeResponse.content,
+    };
+
+    return {
+      finalContent: judgeResponse.content,
+      strategy: "debate",
+      details,
+      totalTokensUsed: totalTokens,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  private async executeVoting(
+    strategy: VotingStrategy,
+    basePrompt: ProviderMessage[],
+    context: StrategyContext,
+    start: number,
+  ): Promise<StrategyResult> {
+    validateVotingStrategy(strategy);
+
+    // Run all candidates in parallel
+    const candidatePromises = strategy.candidates.map((c) =>
+      this.gateway.complete({
+        modelSlug: c.modelSlug,
+        messages: basePrompt,
+        temperature: c.temperature,
+        maxTokens: context.maxTokens,
+      }),
+    );
+
+    const candidateResults = await Promise.all(candidatePromises);
+    const totalTokens = candidateResults.reduce((sum, r) => sum + r.tokensUsed, 0);
+
+    const contents = candidateResults.map((r) => r.content);
+    const scores = computeSimilarityScores(contents);
+
+    const passedIndices = scores
+      .map((score, idx) => ({ score, idx }))
+      .filter(({ score }) => score >= strategy.threshold)
+      .map(({ idx }) => idx);
+
+    // Winner: first passing candidate; fallback to highest-scored
+    const winnerIndex = passedIndices.length > 0
+      ? passedIndices[0]
+      : scores.indexOf(Math.max(...scores));
+
+    const agreement = scores[winnerIndex] ?? 0;
+
+    const candidateDetails = candidateResults.map((r, i) => ({
+      modelSlug: strategy.candidates[i].modelSlug,
+      content: r.content,
+      passed: passedIndices.includes(i),
+    }));
+
+    candidateDetails.forEach((c, idx) => {
+      this.wsManager.broadcastToRun(context.runId, {
+        type: "strategy:voting:candidate",
+        runId: context.runId,
+        payload: { stageId: context.stageId, modelSlug: c.modelSlug, index: idx, passed: c.passed },
+        timestamp: new Date().toISOString(),
+      });
+    });
+
+    const details: VotingDetails = {
+      candidates: candidateDetails,
+      winnerIndex,
+      agreement,
+    };
+
+    return {
+      finalContent: candidateResults[winnerIndex].content,
+      strategy: "voting",
+      details,
+      totalTokensUsed: totalTokens,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  /** Pull the modelSlug from the first message if stored in context, else fall back. */
+  private extractModelSlug(messages: ProviderMessage[]): string {
+    // The gateway will resolve the slug; we pass a placeholder — caller sets modelSlug via context
+    return (messages as Array<ProviderMessage & { _modelSlug?: string }>)[0]?._modelSlug ?? "llama3-70b";
+  }
+}
+
+// ─── Pure helper functions ────────────────────────────────────────────────────
+
+function validateMoaStrategy(s: MoaStrategy): void {
+  if (s.proposers.length < 1) throw new Error("MoA requires at least 1 proposer");
+  if (s.proposers.length > 5) throw new Error("MoA supports at most 5 proposers");
+}
+
+function validateDebateStrategy(s: DebateStrategy): void {
+  if (s.participants.length < 2) throw new Error("Debate requires at least 2 participants");
+  if (s.rounds < 1 || s.rounds > 5) throw new Error("Debate rounds must be between 1 and 5");
+}
+
+function validateVotingStrategy(s: VotingStrategy): void {
+  if (s.candidates.length < 2) throw new Error("Voting requires at least 2 candidates");
+  if (s.candidates.length > 7) throw new Error("Voting supports at most 7 candidates");
+  if (s.threshold < 0.5 || s.threshold > 1.0) throw new Error("Threshold must be between 0.5 and 1.0");
+}
+
+function replaceSystemPrompt(messages: ProviderMessage[], newSystem: string): ProviderMessage[] {
+  const hasSystem = messages[0]?.role === "system";
+  if (hasSystem) {
+    return [{ role: "system", content: newSystem }, ...messages.slice(1)];
+  }
+  return [{ role: "system", content: newSystem }, ...messages];
+}
+
+function buildAggregationPrompt(
+  original: ProviderMessage[],
+  proposerResults: Array<{ content: string }>,
+  aggregatorSystemPrompt?: string,
+): ProviderMessage[] {
+  const systemPrompt = aggregatorSystemPrompt ??
+    "You are a synthesis expert. Review the following candidate responses and produce the single best response that combines their insights.";
+
+  const proposerText = proposerResults
+    .map((r, i) => `### Candidate ${i + 1}\n${r.content}`)
+    .join("\n\n");
+
+  const lastUserMessage = [...original].reverse().find((m) => m.role === "user");
+  const task = lastUserMessage?.content ?? "Complete the task.";
+
+  return [
+    { role: "system", content: systemPrompt },
+    {
+      role: "user",
+      content: `Original task:\n${task}\n\nCandidate responses:\n\n${proposerText}\n\nSynthesize the best response:`,
+    },
+  ];
+}
+
+function buildDebateRolePrompt(
+  role: string,
+  persona: string | undefined,
+  round: number,
+  totalRounds: number,
+): string {
+  const personaNote = persona ? ` You embody the persona: "${persona}".` : "";
+  const roundNote = `This is round ${round} of ${totalRounds}.`;
+
+  switch (role) {
+    case "proposer":
+      return `${roundNote} You are the proposer.${personaNote} Present or refine your solution clearly.`;
+    case "critic":
+      return `${roundNote} You are the critic.${personaNote} Identify flaws, risks, or missing considerations in the current proposal.`;
+    case "devil_advocate":
+      return `${roundNote} You are the devil's advocate.${personaNote} Challenge assumptions and propose radical alternatives.`;
+    default:
+      return `${roundNote} Contribute your perspective.${personaNote}`;
+  }
+}
+
+function buildJudgePrompt(
+  rounds: DebateDetails["rounds"],
+  criteria?: string[],
+): string {
+  const criteriaNote = criteria?.length
+    ? `Evaluate based on: ${criteria.join(", ")}.`
+    : "Evaluate based on correctness, completeness, and practicality.";
+
+  const transcript = rounds
+    .map((r) => `[Round ${r.round}] [${r.role}] (${r.participant}):\n${r.content}`)
+    .join("\n\n---\n\n");
+
+  return `You are the judge. ${criteriaNote}\n\nDebate transcript:\n\n${transcript}\n\nDeliver the final verdict and best solution:`;
+}
+
+function checkConsensus(rounds: DebateDetails["rounds"], currentRound: number): boolean {
+  const thisRound = rounds.filter((r) => r.round === currentRound);
+  if (thisRound.length < 2) return false;
+  const proposerContent = thisRound.find((r) => r.role === "proposer")?.content ?? "";
+  const criticContent = thisRound.find((r) => r.role === "critic")?.content ?? "";
+  // Rough heuristic: if critic's response is very short, they found little to critique
+  return criticContent.length < proposerContent.length * 0.15;
+}
+
+/**
+ * Compute pairwise text similarity scores using word overlap (Jaccard).
+ * Returns a score per candidate: average similarity with all other candidates.
+ */
+function computeSimilarityScores(contents: string[]): number[] {
+  const tokenSets = contents.map(tokenize);
+
+  return tokenSets.map((tokens, i) => {
+    if (tokenSets.length === 1) return 1;
+    let totalSim = 0;
+    let count = 0;
+    for (let j = 0; j < tokenSets.length; j++) {
+      if (i === j) continue;
+      totalSim += jaccardSimilarity(tokens, tokenSets[j]);
+      count++;
+    }
+    return count > 0 ? totalSim / count : 0;
+  });
+}
+
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, " ")
+      .split(/\s+/)
+      .filter((w) => w.length > 2),
+  );
+}
+
+function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+  const intersection = new Set([...a].filter((x) => b.has(x)));
+  const union = new Set([...a, ...b]);
+  return union.size === 0 ? 0 : intersection.size / union.size;
+}

--- a/server/teams/base.ts
+++ b/server/teams/base.ts
@@ -1,11 +1,21 @@
 import type { Gateway } from "../gateway/index";
-import type { TeamConfig, StageContext, TeamResult } from "@shared/types";
+import type { WsManager } from "../ws/manager";
+import type { TeamConfig, StageContext, TeamResult, ExecutionStrategy, ProviderMessage } from "@shared/types";
+import { StrategyExecutor } from "../services/strategy-executor";
 
 export abstract class BaseTeam {
+  private strategyExecutor: StrategyExecutor;
+
   constructor(
     protected gateway: Gateway,
     protected config: TeamConfig,
-  ) {}
+    protected wsManager?: WsManager,
+  ) {
+    // WsManager may be injected later for backwards compat — create executor lazily
+    this.strategyExecutor = wsManager
+      ? new StrategyExecutor(gateway, wsManager)
+      : createNoOpStrategyExecutor(gateway);
+  }
 
   abstract buildPrompt(
     input: Record<string, unknown>,
@@ -17,8 +27,23 @@ export abstract class BaseTeam {
   async execute(
     input: Record<string, unknown>,
     context: StageContext,
+    executionStrategy?: ExecutionStrategy,
   ): Promise<TeamResult> {
     const messages = this.buildPrompt(input, context);
+
+    const strategy = executionStrategy ?? { type: "single" as const };
+
+    if (strategy.type === "single") {
+      return this.executeSingleModel(messages, context);
+    }
+
+    return this.executeWithStrategy(strategy, messages, context);
+  }
+
+  private async executeSingleModel(
+    messages: ProviderMessage[],
+    context: StageContext,
+  ): Promise<TeamResult> {
     const response = await this.gateway.complete({
       modelSlug: context.modelSlug || this.config.defaultModelSlug,
       messages,
@@ -37,10 +62,38 @@ export abstract class BaseTeam {
     };
   }
 
+  private async executeWithStrategy(
+    strategy: Exclude<ExecutionStrategy, { type: "single" }>,
+    messages: ProviderMessage[],
+    context: StageContext,
+  ): Promise<TeamResult> {
+    const strategyResult = await this.strategyExecutor.execute(
+      strategy,
+      messages,
+      {
+        runId: context.runId,
+        stageId: String(context.stageIndex),
+        maxTokens: context.maxTokens,
+      },
+    );
+
+    const parsed = this.parseOutput(strategyResult.finalContent);
+    const questions = this.extractQuestions(parsed);
+
+    return {
+      output: parsed,
+      tokensUsed: strategyResult.totalTokensUsed,
+      raw: strategyResult.finalContent,
+      questions: questions.length > 0 ? questions : undefined,
+      strategyResult,
+    };
+  }
+
   async *executeStream(
     input: Record<string, unknown>,
     context: StageContext,
   ): AsyncGenerator<string> {
+    // Streaming always uses single model — intermediate strategy steps are WS events only
     const messages = this.buildPrompt(input, context);
     yield* this.gateway.stream({
       modelSlug: context.modelSlug || this.config.defaultModelSlug,
@@ -78,4 +131,12 @@ export abstract class BaseTeam {
   protected serializeInput(input: Record<string, unknown>): string {
     return JSON.stringify(input, null, 2);
   }
+}
+
+/** Minimal no-op executor used when WsManager is not available (backwards compat). */
+function createNoOpStrategyExecutor(gateway: Gateway): StrategyExecutor {
+  const noOpWs = {
+    broadcastToRun: () => undefined,
+  } as unknown as WsManager;
+  return new StrategyExecutor(gateway, noOpWs);
 }

--- a/server/teams/registry.ts
+++ b/server/teams/registry.ts
@@ -1,4 +1,5 @@
 import type { Gateway } from "../gateway/index";
+import type { WsManager } from "../ws/manager";
 import type { TeamId } from "@shared/types";
 import { SDLC_TEAMS } from "@shared/constants";
 import { BaseTeam } from "./base";
@@ -13,15 +14,15 @@ import { MonitoringTeam } from "./monitoring";
 export class TeamRegistry {
   private teams: Map<TeamId, BaseTeam>;
 
-  constructor(gateway: Gateway) {
+  constructor(gateway: Gateway, wsManager?: WsManager) {
     this.teams = new Map();
-    this.teams.set("planning", new PlanningTeam(gateway, SDLC_TEAMS.planning));
-    this.teams.set("architecture", new ArchitectureTeam(gateway, SDLC_TEAMS.architecture));
-    this.teams.set("development", new DevelopmentTeam(gateway, SDLC_TEAMS.development));
-    this.teams.set("testing", new TestingTeam(gateway, SDLC_TEAMS.testing));
-    this.teams.set("code_review", new CodeReviewTeam(gateway, SDLC_TEAMS.code_review));
-    this.teams.set("deployment", new DeploymentTeam(gateway, SDLC_TEAMS.deployment));
-    this.teams.set("monitoring", new MonitoringTeam(gateway, SDLC_TEAMS.monitoring));
+    this.teams.set("planning", new PlanningTeam(gateway, SDLC_TEAMS.planning, wsManager));
+    this.teams.set("architecture", new ArchitectureTeam(gateway, SDLC_TEAMS.architecture, wsManager));
+    this.teams.set("development", new DevelopmentTeam(gateway, SDLC_TEAMS.development, wsManager));
+    this.teams.set("testing", new TestingTeam(gateway, SDLC_TEAMS.testing, wsManager));
+    this.teams.set("code_review", new CodeReviewTeam(gateway, SDLC_TEAMS.code_review, wsManager));
+    this.teams.set("deployment", new DeploymentTeam(gateway, SDLC_TEAMS.deployment, wsManager));
+    this.teams.set("monitoring", new MonitoringTeam(gateway, SDLC_TEAMS.monitoring, wsManager));
   }
 
   getTeam(teamId: TeamId): BaseTeam {

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,4 +1,4 @@
-import type { TeamConfig, TeamId, PipelineStageConfig, StrategyPreset } from "./types";
+import type { TeamConfig, TeamId, PipelineStageConfig, StrategyPreset, ExecutionStrategyPreset } from "./types";
 
 export const SDLC_TEAMS: Record<TeamId, TeamConfig> = {
   planning: {
@@ -398,3 +398,203 @@ export const STRATEGY_PRESETS: StrategyPreset[] = [
     },
   },
 ];
+
+// ─── Execution Strategy Presets ──────────────────────────────────────────────
+
+export const EXECUTION_STRATEGY_PRESETS: ExecutionStrategyPreset[] = [
+  {
+    id: "single",
+    label: "Single",
+    description: "All stages use a single model — default, backwards-compatible",
+    stageStrategies: {},
+  },
+  {
+    id: "quality_max",
+    label: "Quality Max",
+    description: "Multi-model orchestration on every stage for maximum output quality",
+    stageStrategies: {
+      planning: {
+        type: "moa",
+        proposers: [
+          { modelSlug: "llama3-70b", role: "optimist", temperature: 0.8 },
+          { modelSlug: "mixtral-8x7b", role: "skeptic", temperature: 0.6 },
+          { modelSlug: "phi3-mini", role: "pragmatist", temperature: 0.5 },
+        ],
+        aggregator: { modelSlug: "llama3-70b" },
+      },
+      architecture: {
+        type: "debate",
+        participants: [
+          { modelSlug: "llama3-70b", role: "proposer" },
+          { modelSlug: "mixtral-8x7b", role: "critic" },
+          { modelSlug: "phi3-mini", role: "devil_advocate" },
+        ],
+        judge: { modelSlug: "llama3-70b", criteria: ["scalability", "maintainability", "security"] },
+        rounds: 3,
+      },
+      development: {
+        type: "moa",
+        proposers: [
+          { modelSlug: "deepseek-coder", role: "primary", temperature: 0.4 },
+          { modelSlug: "llama3-70b", role: "reviewer", temperature: 0.5 },
+          { modelSlug: "mixtral-8x7b", role: "alternative", temperature: 0.6 },
+        ],
+        aggregator: { modelSlug: "deepseek-coder" },
+      },
+      testing: {
+        type: "voting",
+        candidates: [
+          { modelSlug: "mixtral-8x7b", temperature: 0.5 },
+          { modelSlug: "llama3-70b", temperature: 0.5 },
+          { modelSlug: "phi3-mini", temperature: 0.4 },
+          { modelSlug: "deepseek-coder", temperature: 0.4 },
+          { modelSlug: "mixtral-8x7b", temperature: 0.7 },
+        ],
+        threshold: 0.6,
+        validationMode: "text_similarity",
+      },
+      code_review: {
+        type: "debate",
+        participants: [
+          { modelSlug: "llama3-70b", role: "proposer" },
+          { modelSlug: "mixtral-8x7b", role: "critic" },
+        ],
+        judge: { modelSlug: "llama3-70b", criteria: ["correctness", "security", "performance"] },
+        rounds: 3,
+      },
+      deployment: {
+        type: "voting",
+        candidates: [
+          { modelSlug: "deepseek-coder", temperature: 0.4 },
+          { modelSlug: "llama3-70b", temperature: 0.5 },
+          { modelSlug: "mixtral-8x7b", temperature: 0.5 },
+        ],
+        threshold: 0.6,
+        validationMode: "text_similarity",
+      },
+      monitoring: {
+        type: "moa",
+        proposers: [
+          { modelSlug: "mixtral-8x7b", role: "primary", temperature: 0.5 },
+          { modelSlug: "llama3-70b", role: "secondary", temperature: 0.6 },
+        ],
+        aggregator: { modelSlug: "mixtral-8x7b" },
+      },
+    },
+  },
+  {
+    id: "balanced_multi",
+    label: "Balanced",
+    description: "Multi-model on planning and architecture; single for the rest",
+    stageStrategies: {
+      planning: {
+        type: "moa",
+        proposers: [
+          { modelSlug: "llama3-70b", role: "primary", temperature: 0.7 },
+          { modelSlug: "mixtral-8x7b", role: "secondary", temperature: 0.6 },
+        ],
+        aggregator: { modelSlug: "llama3-70b" },
+      },
+      architecture: {
+        type: "debate",
+        participants: [
+          { modelSlug: "llama3-70b", role: "proposer" },
+          { modelSlug: "mixtral-8x7b", role: "critic" },
+        ],
+        judge: { modelSlug: "llama3-70b" },
+        rounds: 2,
+      },
+    },
+  },
+  {
+    id: "cost_optimized_multi",
+    label: "Cost Optimized",
+    description: "Multi-model only where quality matters most: architecture, testing",
+    stageStrategies: {
+      architecture: {
+        type: "debate",
+        participants: [
+          { modelSlug: "llama3-70b", role: "proposer" },
+          { modelSlug: "phi3-mini", role: "critic" },
+        ],
+        judge: { modelSlug: "llama3-70b" },
+        rounds: 2,
+      },
+      testing: {
+        type: "voting",
+        candidates: [
+          { modelSlug: "mixtral-8x7b", temperature: 0.5 },
+          { modelSlug: "phi3-mini", temperature: 0.4 },
+          { modelSlug: "mixtral-8x7b", temperature: 0.7 },
+        ],
+        threshold: 0.6,
+        validationMode: "text_similarity",
+      },
+    },
+  },
+  {
+    id: "code_focus",
+    label: "Code Focus",
+    description: "Multi-model on development, testing, and code review stages",
+    stageStrategies: {
+      development: {
+        type: "moa",
+        proposers: [
+          { modelSlug: "deepseek-coder", role: "primary", temperature: 0.4 },
+          { modelSlug: "llama3-70b", role: "alternative", temperature: 0.5 },
+          { modelSlug: "mixtral-8x7b", role: "creative", temperature: 0.7 },
+        ],
+        aggregator: { modelSlug: "deepseek-coder" },
+      },
+      testing: {
+        type: "voting",
+        candidates: [
+          { modelSlug: "mixtral-8x7b", temperature: 0.5 },
+          { modelSlug: "llama3-70b", temperature: 0.5 },
+          { modelSlug: "deepseek-coder", temperature: 0.4 },
+          { modelSlug: "phi3-mini", temperature: 0.4 },
+          { modelSlug: "mixtral-8x7b", temperature: 0.7 },
+        ],
+        threshold: 0.6,
+        validationMode: "text_similarity",
+      },
+      code_review: {
+        type: "debate",
+        participants: [
+          { modelSlug: "llama3-70b", role: "proposer" },
+          { modelSlug: "deepseek-coder", role: "critic" },
+          { modelSlug: "mixtral-8x7b", role: "devil_advocate" },
+        ],
+        judge: { modelSlug: "llama3-70b", criteria: ["correctness", "security", "performance"] },
+        rounds: 3,
+      },
+    },
+  },
+];
+
+// Strategy cost multiplier hints for UI display
+export const STRATEGY_COST_MULTIPLIERS: Record<string, number> = {
+  single: 1,
+  moa: 0, // computed dynamically: proposers + 1 aggregator
+  debate: 0, // computed dynamically: participants * rounds + 1 judge
+  voting: 0, // computed dynamically: candidates
+};
+
+export function computeCostMultiplier(strategy: { type: string; proposers?: unknown[]; participants?: unknown[]; rounds?: number; candidates?: unknown[] }): number {
+  switch (strategy.type) {
+    case "single": return 1;
+    case "moa": {
+      const proposers = Array.isArray(strategy.proposers) ? strategy.proposers.length : 2;
+      return proposers + 1;
+    }
+    case "debate": {
+      const participants = Array.isArray(strategy.participants) ? strategy.participants.length : 2;
+      const rounds = typeof strategy.rounds === "number" ? strategy.rounds : 3;
+      return participants * rounds + 1;
+    }
+    case "voting": {
+      return Array.isArray(strategy.candidates) ? strategy.candidates.length : 3;
+    }
+    default: return 1;
+  }
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -40,6 +40,98 @@ export interface TeamConfig {
   icon: string;
 }
 
+// ─── Execution Strategy Types ────────────────────────────────────────────────
+
+export type ExecutionStrategyType = "single" | "moa" | "debate" | "voting";
+
+export interface SingleStrategy {
+  type: "single";
+}
+
+export interface ProposerConfig {
+  modelSlug: string;
+  role?: string;
+  temperature?: number;
+}
+
+export interface AggregatorConfig {
+  modelSlug: string;
+  systemPrompt?: string;
+}
+
+export interface MoaStrategy {
+  type: "moa";
+  proposers: ProposerConfig[];
+  aggregator: AggregatorConfig;
+  proposerPromptOverride?: string;
+}
+
+export interface DebateParticipant {
+  modelSlug: string;
+  role: "proposer" | "critic" | "devil_advocate";
+  persona?: string;
+}
+
+export interface JudgeConfig {
+  modelSlug: string;
+  criteria?: string[];
+}
+
+export interface DebateStrategy {
+  type: "debate";
+  participants: DebateParticipant[];
+  judge: JudgeConfig;
+  rounds: number;
+  stopEarly?: boolean;
+}
+
+export interface CandidateConfig {
+  modelSlug: string;
+  temperature?: number;
+}
+
+export interface VotingStrategy {
+  type: "voting";
+  candidates: CandidateConfig[];
+  threshold: number;
+  validationMode: "text_similarity" | "test_execution";
+}
+
+export type ExecutionStrategy =
+  | SingleStrategy
+  | MoaStrategy
+  | DebateStrategy
+  | VotingStrategy;
+
+// ─── Strategy Result Detail Types ────────────────────────────────────────────
+
+export interface MoaDetails {
+  proposerResponses: Array<{ modelSlug: string; content: string; role?: string }>;
+  aggregatorModelSlug: string;
+}
+
+export interface DebateDetails {
+  rounds: Array<{ round: number; participant: string; role: string; content: string }>;
+  judgeModelSlug: string;
+  verdict: string;
+}
+
+export interface VotingDetails {
+  candidates: Array<{ modelSlug: string; content: string; passed: boolean }>;
+  winnerIndex: number;
+  agreement: number;
+}
+
+export interface StrategyResult {
+  finalContent: string;
+  strategy: ExecutionStrategyType;
+  details: MoaDetails | DebateDetails | VotingDetails | null;
+  totalTokensUsed: number;
+  durationMs: number;
+}
+
+// ─── WS Event Types ──────────────────────────────────────────────────────────
+
 export type WsEventType =
   | "pipeline:started"
   | "pipeline:completed"
@@ -54,7 +146,13 @@ export type WsEventType =
   | "chat:message"
   | "chat:stream_chunk"
   | "chat:stream_end"
-  | "model:status";
+  | "model:status"
+  | "strategy:started"
+  | "strategy:proposer"
+  | "strategy:debate:round"
+  | "strategy:debate:judge"
+  | "strategy:voting:candidate"
+  | "strategy:completed";
 
 export interface WsEvent {
   type: WsEventType;
@@ -86,6 +184,7 @@ export interface PipelineStageConfig {
   temperature?: number;
   maxTokens?: number;
   enabled: boolean;
+  executionStrategy?: ExecutionStrategy;
 }
 
 export interface StageContext {
@@ -103,6 +202,7 @@ export interface TeamResult {
   tokensUsed: number;
   raw: string;
   questions?: string[];
+  strategyResult?: StrategyResult;
 }
 
 export type ProviderMessage = { role: string; content: string };
@@ -131,4 +231,24 @@ export interface ILLMProvider {
     messages: ProviderMessage[],
     options?: ILLMProviderOptions,
   ): AsyncGenerator<string>;
+}
+
+// ─── Strategy Preset (existing usage in constants.ts) ────────────────────────
+
+export interface StrategyPreset {
+  id: string;
+  label: string;
+  description: string;
+  temperature: number;
+  maxTokens: number;
+  stageOverrides?: Partial<Record<TeamId, { modelSlug?: string; temperature?: number }>>;
+}
+
+// ─── Execution Strategy Preset ───────────────────────────────────────────────
+
+export interface ExecutionStrategyPreset {
+  id: string;
+  label: string;
+  description: string;
+  stageStrategies: Partial<Record<TeamId, ExecutionStrategy>>;
 }


### PR DESCRIPTION
## Summary

- **4 execution strategies** per pipeline stage: `single` (default, fully backwards-compatible), `moa` (Mixture of Agents), `debate` (round-loop with judge), `voting` (consensus by Jaccard similarity)
- **StrategyExecutor** service handles all orchestration; emits WS events per intermediate step (`strategy:started`, `strategy:proposer`, `strategy:debate:round`, `strategy:debate:judge`, `strategy:voting:candidate`, `strategy:completed`)
- **5 named execution presets**: Single, Quality Max, Balanced, Cost Optimized, Code Focus — applied per-stage with one click
- **Full UI**: per-stage strategy config UI in AgentNode, strategy badges in MultiAgentPipeline, StrategyViewer shows intermediate outputs (proposers, debate rounds, candidates) in a collapsible section below final output
- **Zero regressions**: single strategy path is unchanged; `executionStrategy` is optional on `PipelineStageConfig`
- **TypeScript strict**: `tsc --noEmit` passes with zero errors

## Architecture

```
PipelineController.executeStages()
  → team.execute(input, context, stage.executionStrategy)
     → StrategyExecutor.execute(strategy, messages, wsCtx)
        → executeMoA / executeDebate / executeVoting
        → WS events per intermediate step
        → returns StrategyResult { finalContent, details, ... }
  → stage:completed payload includes strategyResult
```

## Files Changed

**Backend** (7 files)
- `shared/types.ts` — strategy types, result types, new WS event union
- `shared/constants.ts` — `EXECUTION_STRATEGY_PRESETS`, `computeCostMultiplier`
- `server/services/strategy-executor.ts` — new: StrategyExecutor, Jaccard voting
- `server/teams/base.ts` — strategy dispatch, WsManager injection
- `server/teams/registry.ts` — pass WsManager to team constructors
- `server/controller/pipeline-controller.ts` — forward `executionStrategy`
- `server/routes/strategies.ts` — new: 3 endpoints, Zod-validated
- `server/routes.ts` — register strategy routes

**Frontend** (5 files)
- `client/src/components/workflow/StrategyConfig.tsx` — new: MoA/Debate/Voting sub-forms
- `client/src/components/workflow/AgentNode.tsx` — Strategy section added
- `client/src/components/workflow/MultiAgentPipeline.tsx` — presets card, badges
- `client/src/components/pipeline/StrategyViewer.tsx` — new: intermediate output viewer
- `client/src/components/pipeline/StageOutput.tsx` — render StrategyViewer

## Test plan

- [ ] Default single-model pipeline runs unchanged (regression)
- [ ] MoA: set 3 proposers on planning stage, run pipeline — see 3 proposer WS events + aggregator response
- [ ] Debate: set 2 participants + judge on architecture stage, verify round events emitted
- [ ] Voting: set 5 candidates on testing stage, verify consensus winner selected
- [ ] Edge cases: 1 proposer MoA, rounds=1 debate, threshold=1.0 voting (no candidate passes → fallback to highest-scored)
- [ ] Apply "Quality Max" preset, save, run — all 7 stages use multi-model strategies
- [ ] StrategyViewer renders all intermediate steps in StageOutput
- [ ] `GET /api/strategies/presets` returns 5 presets
- [ ] `PATCH /api/pipelines/:id/stages/0/strategy` with invalid body returns 400 with Zod errors
- [ ] TypeScript: `tsc --noEmit` passes