### PR TITLE
feat: phase 3.2 — statistics, cost tracking, request log, thought tree

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,6 +15,7 @@ import PipelineDetail from "@/pages/PipelineDetail";
 import PipelineRun from "@/pages/PipelineRun";
 import Settings from "@/pages/Settings";
 import Privacy from "@/pages/Privacy";
+import Statistics from "@/pages/Statistics";
 
 function Router() {
   return (
@@ -46,6 +47,9 @@ function Router() {
         )} />
         <Route path="/privacy" component={() => (
           <ErrorBoundary><Privacy /></ErrorBoundary>
+        )} />
+        <Route path="/stats" component={() => (
+          <ErrorBoundary><Statistics /></ErrorBoundary>
         )} />
         <Route component={NotFound} />
       </Switch>

--- a/client/src/components/layout/MainLayout.tsx
+++ b/client/src/components/layout/MainLayout.tsx
@@ -8,6 +8,7 @@ import {
   ShieldAlert,
   MessageCircleQuestion,
   ShieldCheck,
+  BarChart3,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePendingQuestions } from "@/hooks/use-pipeline";
@@ -30,6 +31,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
       href: "/pipelines",
       badge: pendingCount > 0 ? pendingCount : undefined,
     },
+    { icon: BarChart3, label: "Statistics", href: "/stats" },
     { icon: ShieldCheck, label: "Privacy", href: "/privacy" },
     { icon: Settings, label: "Settings", href: "/settings" },
   ];

--- a/client/src/components/pipeline/StageOutput.tsx
+++ b/client/src/components/pipeline/StageOutput.tsx
@@ -5,8 +5,9 @@ import { ChevronDown, ChevronRight, Copy, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import StrategyViewer from "./StrategyViewer";
 import SandboxOutput from "./SandboxOutput";
-import { CodeBlock, detectLanguageFromPath } from "@/components/ui/CodeBlock";
-import type { StrategyResult, SandboxResult } from "@shared/types";
+import ThoughtTree from "./ThoughtTree";
+import { CodeBlock } from "@/components/ui/CodeBlock";
+import type { StrategyResult, SandboxResult, ThoughtTree as ThoughtTreeType } from "@shared/types";
 
 interface StageOutputProps {
   teamId: string;
@@ -14,6 +15,7 @@ interface StageOutputProps {
   output: Record<string, unknown>;
   strategyResult?: StrategyResult | null;
   isActive?: boolean;
+  thoughtTree?: ThoughtTreeType | null;
 }
 
 export default function StageOutput({
@@ -22,6 +24,7 @@ export default function StageOutput({
   output,
   strategyResult,
   isActive,
+  thoughtTree,
 }: StageOutputProps) {
   const [expanded, setExpanded] = useState(isActive ?? false);
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
@@ -152,6 +155,11 @@ export default function StageOutput({
               <p className="text-xs font-medium text-muted-foreground">Sandbox Execution</p>
               <SandboxOutput result={sandboxResult} />
             </div>
+          )}
+
+          {/* Thought Tree */}
+          {thoughtTree && thoughtTree.length > 0 && (
+            <ThoughtTree nodes={thoughtTree} />
           )}
 
           {/* Strategy intermediate outputs */}

--- a/client/src/components/pipeline/ThoughtTree.tsx
+++ b/client/src/components/pipeline/ThoughtTree.tsx
@@ -1,0 +1,174 @@
+import { useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ThoughtNode, ThoughtTree as ThoughtTreeType } from "@shared/types";
+
+interface ThoughtTreeProps {
+  nodes: ThoughtTreeType;
+}
+
+type FilterType = "all" | "reasoning" | "decision" | "tool";
+
+const NODE_ICONS: Record<ThoughtNode["type"], string> = {
+  reasoning: "Brain",
+  tool_call: "Search",
+  tool_result: "FileText",
+  decision: "CheckSquare",
+  guardrail: "AlertTriangle",
+  memory_recall: "MessageCircle",
+};
+
+const NODE_EMOJI: Record<ThoughtNode["type"], string> = {
+  reasoning: "🧠",
+  tool_call: "🔍",
+  tool_result: "📄",
+  decision: "✅",
+  guardrail: "⚠️",
+  memory_recall: "💭",
+};
+
+const NODE_COLORS: Record<ThoughtNode["type"], string> = {
+  reasoning: "border-blue-500/30 bg-blue-500/5",
+  tool_call: "border-purple-500/30 bg-purple-500/5",
+  tool_result: "border-slate-500/30 bg-slate-500/5",
+  decision: "border-green-500/30 bg-green-500/5",
+  guardrail: "border-amber-500/30 bg-amber-500/5",
+  memory_recall: "border-cyan-500/30 bg-cyan-500/5",
+};
+
+function ThoughtNodeRow({ node, depth }: { node: ThoughtNode; depth: number }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasContent = node.content && node.content !== node.label;
+
+  return (
+    <div style={{ marginLeft: depth * 16 }}>
+      <div
+        className={cn(
+          "rounded-md border px-3 py-2 mb-1 cursor-pointer transition-colors",
+          NODE_COLORS[node.type],
+          hasContent ? "hover:brightness-110" : "cursor-default",
+        )}
+        onClick={() => hasContent && setExpanded(!expanded)}
+      >
+        <div className="flex items-start gap-2">
+          <span className="text-sm shrink-0">{NODE_EMOJI[node.type]}</span>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-medium text-foreground truncate">
+                {node.label}
+              </span>
+              {node.durationMs !== undefined && (
+                <span className="text-[10px] text-muted-foreground shrink-0">
+                  {node.durationMs}ms
+                </span>
+              )}
+              {node.metadata?.tokensUsed !== undefined && (
+                <span className="text-[10px] text-muted-foreground shrink-0">
+                  {node.metadata.tokensUsed} tok
+                </span>
+              )}
+              {hasContent && (
+                <span className="ml-auto shrink-0">
+                  {expanded
+                    ? <ChevronDown className="h-3 w-3 text-muted-foreground" />
+                    : <ChevronRight className="h-3 w-3 text-muted-foreground" />
+                  }
+                </span>
+              )}
+            </div>
+            {expanded && hasContent && (
+              <pre className="mt-2 text-[11px] text-muted-foreground whitespace-pre-wrap font-mono leading-relaxed">
+                {node.content}
+              </pre>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ThoughtTree({ nodes }: ThoughtTreeProps) {
+  const [filter, setFilter] = useState<FilterType>("all");
+
+  if (!nodes || nodes.length === 0) return null;
+
+  const filtered = nodes.filter((n) => {
+    if (filter === "all") return true;
+    if (filter === "reasoning") return n.type === "reasoning";
+    if (filter === "decision") return n.type === "decision";
+    if (filter === "tool") return n.type === "tool_call" || n.type === "tool_result";
+    return true;
+  });
+
+  // Build a depth map: root nodes are depth 0, children depth 1, etc.
+  const idToDepth = new Map<string, number>();
+  for (const node of nodes) {
+    if (!node.parentId) {
+      idToDepth.set(node.id, 0);
+    } else {
+      const parentDepth = idToDepth.get(node.parentId) ?? 0;
+      idToDepth.set(node.id, parentDepth + 1);
+    }
+  }
+
+  // Totals for footer
+  const totalDuration = nodes.reduce((s, n) => s + (n.durationMs ?? 0), 0);
+  const totalTokens = nodes.reduce((s, n) => s + (n.metadata?.tokensUsed ?? 0), 0);
+  const decisionCount = nodes.filter((n) => n.type === "decision").length;
+  const toolCallCount = nodes.filter((n) => n.type === "tool_call").length;
+
+  const filters: { label: string; value: FilterType }[] = [
+    { label: "All", value: "all" },
+    { label: "Reasoning", value: "reasoning" },
+    { label: "Decisions", value: "decision" },
+    { label: "Tools", value: "tool" },
+  ];
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-medium text-muted-foreground">Thought Tree</p>
+        <div className="flex gap-1">
+          {filters.map((f) => (
+            <button
+              key={f.value}
+              onClick={() => setFilter(f.value)}
+              className={cn(
+                "text-[10px] px-2 py-0.5 rounded-full border transition-colors",
+                filter === f.value
+                  ? "bg-primary text-primary-foreground border-primary"
+                  : "border-border text-muted-foreground hover:border-primary/50",
+              )}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border p-2 max-h-64 overflow-y-auto">
+        {filtered.length === 0 ? (
+          <p className="text-xs text-muted-foreground text-center py-4">
+            No {filter === "all" ? "" : filter} nodes
+          </p>
+        ) : (
+          filtered.map((node) => (
+            <ThoughtNodeRow
+              key={node.id}
+              node={node}
+              depth={idToDepth.get(node.id) ?? 0}
+            />
+          ))
+        )}
+      </div>
+
+      <div className="flex gap-4 text-[10px] text-muted-foreground px-1">
+        {totalDuration > 0 && <span>Duration: {totalDuration}ms</span>}
+        {totalTokens > 0 && <span>Tokens: {totalTokens}</span>}
+        {decisionCount > 0 && <span>Decisions: {decisionCount}</span>}
+        {toolCallCount > 0 && <span>Tool calls: {toolCallCount}</span>}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/Statistics.tsx
+++ b/client/src/pages/Statistics.tsx
@@ -1,0 +1,539 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { Download, ChevronDown, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ─── API types ───────────────────────────────────────────────────────────────
+
+interface StatsOverview {
+  totalRequests: number;
+  totalTokens: { input: number; output: number; total: number };
+  totalCostUsd: number;
+  totalRuns: number;
+}
+
+interface ModelStat {
+  modelSlug: string;
+  provider: string;
+  requests: number;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  avgLatencyMs: number;
+  errorRate: number;
+}
+
+interface TimelinePoint {
+  date: string;
+  requests: number;
+  tokens: number;
+  costUsd: number;
+}
+
+interface LlmRequestRow {
+  id: number;
+  createdAt: string | null;
+  modelSlug: string;
+  provider: string;
+  teamId: string | null;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  estimatedCostUsd: number | null;
+  latencyMs: number;
+  status: string;
+  runId: string | null;
+}
+
+interface RequestsResponse {
+  rows: LlmRequestRow[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+// ─── Fetchers ────────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+
+// ─── Small utilities ─────────────────────────────────────────────────────────
+
+function fmt(n: number, decimals = 0) {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toFixed(decimals);
+}
+
+function fmtCost(n: number) {
+  if (n < 0.01 && n > 0) return `$${n.toFixed(4)}`;
+  return `$${n.toFixed(2)}`;
+}
+
+function fmtDate(iso: string | null) {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  return d.toLocaleString();
+}
+
+// ─── Summary Cards ───────────────────────────────────────────────────────────
+
+function SummaryCards({ overview }: { overview: StatsOverview }) {
+  const cards = [
+    { label: "Total Requests", value: fmt(overview.totalRequests) },
+    { label: "Total Tokens", value: fmt(overview.totalTokens.total) },
+    { label: "Pipeline Runs", value: fmt(overview.totalRuns) },
+    { label: "Estimated Cost", value: fmtCost(overview.totalCostUsd) },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+      {cards.map((c) => (
+        <div
+          key={c.label}
+          className="rounded-lg border border-border bg-card p-4"
+        >
+          <p className="text-xs text-muted-foreground">{c.label}</p>
+          <p className="text-2xl font-semibold mt-1">{c.value}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ─── Timeline Chart ───────────────────────────────────────────────────────────
+
+type Granularity = "day" | "week";
+type ChartMetric = "requests" | "tokens" | "costUsd";
+
+function TimelineChart() {
+  const [granularity, setGranularity] = useState<Granularity>("day");
+  const [metric, setMetric] = useState<ChartMetric>("requests");
+
+  const { data, isLoading } = useQuery<TimelinePoint[]>({
+    queryKey: ["stats-timeline", granularity],
+    queryFn: () => fetchJson(`/api/stats/timeline?granularity=${granularity}`),
+  });
+
+  const metricLabels: Record<ChartMetric, string> = {
+    requests: "Requests",
+    tokens: "Tokens",
+    costUsd: "Cost ($)",
+  };
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <p className="text-sm font-medium">Timeline</p>
+        <div className="flex gap-2 flex-wrap">
+          <div className="flex gap-1">
+            {(["day", "week"] as Granularity[]).map((g) => (
+              <button
+                key={g}
+                onClick={() => setGranularity(g)}
+                className={cn(
+                  "text-xs px-2 py-1 rounded border transition-colors",
+                  granularity === g
+                    ? "bg-primary text-primary-foreground border-primary"
+                    : "border-border text-muted-foreground hover:border-primary/50",
+                )}
+              >
+                {g.charAt(0).toUpperCase() + g.slice(1)}
+              </button>
+            ))}
+          </div>
+          <div className="flex gap-1">
+            {(Object.keys(metricLabels) as ChartMetric[]).map((m) => (
+              <button
+                key={m}
+                onClick={() => setMetric(m)}
+                className={cn(
+                  "text-xs px-2 py-1 rounded border transition-colors",
+                  metric === m
+                    ? "bg-primary text-primary-foreground border-primary"
+                    : "border-border text-muted-foreground hover:border-primary/50",
+                )}
+              >
+                {metricLabels[m]}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="h-48 flex items-center justify-center text-xs text-muted-foreground">
+          Loading...
+        </div>
+      ) : !data || data.length === 0 ? (
+        <div className="h-48 flex items-center justify-center text-xs text-muted-foreground">
+          No data yet — run a pipeline to generate statistics.
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height={200}>
+          <AreaChart data={data} margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>
+            <defs>
+              <linearGradient id="areaGrad" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="hsl(var(--primary))" stopOpacity={0.4} />
+                <stop offset="95%" stopColor="hsl(var(--primary))" stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+            <XAxis
+              dataKey="date"
+              tick={{ fontSize: 10 }}
+              tickFormatter={(v: string) => v.slice(5)}
+            />
+            <YAxis tick={{ fontSize: 10 }} width={50} tickFormatter={(v) => fmt(v as number)} />
+            <Tooltip
+              contentStyle={{ fontSize: 11 }}
+              formatter={(v: number) =>
+                metric === "costUsd" ? fmtCost(v) : fmt(v)
+              }
+            />
+            <Area
+              type="monotone"
+              dataKey={metric}
+              stroke="hsl(var(--primary))"
+              strokeWidth={2}
+              fill="url(#areaGrad)"
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  );
+}
+
+// ─── Model Breakdown Table ────────────────────────────────────────────────────
+
+type ModelSortKey = keyof ModelStat;
+
+function ModelTable() {
+  const { data, isLoading } = useQuery<ModelStat[]>({
+    queryKey: ["stats-by-model"],
+    queryFn: () => fetchJson("/api/stats/by-model"),
+  });
+
+  const [sortKey, setSortKey] = useState<ModelSortKey>("requests");
+  const [sortAsc, setSortAsc] = useState(false);
+
+  const toggleSort = (key: ModelSortKey) => {
+    if (sortKey === key) setSortAsc(!sortAsc);
+    else { setSortKey(key); setSortAsc(false); }
+  };
+
+  const sorted = [...(data ?? [])].sort((a, b) => {
+    const av = a[sortKey] as number;
+    const bv = b[sortKey] as number;
+    return sortAsc ? av - bv : bv - av;
+  });
+
+  const cols: { label: string; key: ModelSortKey; fmt?: (v: number) => string }[] = [
+    { label: "Model", key: "modelSlug" },
+    { label: "Provider", key: "provider" },
+    { label: "Requests", key: "requests", fmt: (v) => fmt(v) },
+    { label: "Tokens", key: "inputTokens", fmt: (v) => fmt(v) },
+    { label: "Cost", key: "costUsd", fmt: (v) => fmtCost(v) },
+    { label: "Avg Latency", key: "avgLatencyMs", fmt: (v) => `${Math.round(v)}ms` },
+    { label: "Error Rate", key: "errorRate", fmt: (v) => `${(v * 100).toFixed(1)}%` },
+  ];
+
+  if (isLoading) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-4">
+        <p className="text-sm font-medium mb-3">Per-Model Breakdown</p>
+        <p className="text-xs text-muted-foreground">Loading...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+      <p className="text-sm font-medium">Per-Model Breakdown</p>
+      {sorted.length === 0 ? (
+        <p className="text-xs text-muted-foreground">No data yet.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-border">
+                {cols.map((c) => (
+                  <th
+                    key={c.key}
+                    className="text-left pb-2 pr-4 text-muted-foreground font-medium cursor-pointer hover:text-foreground whitespace-nowrap"
+                    onClick={() => toggleSort(c.key)}
+                  >
+                    {c.label} {sortKey === c.key ? (sortAsc ? "▲" : "▼") : ""}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((row) => (
+                <tr key={row.modelSlug} className="border-b border-border/50 hover:bg-muted/30">
+                  <td className="py-2 pr-4 font-mono">{row.modelSlug}</td>
+                  <td className="py-2 pr-4 text-muted-foreground">{row.provider}</td>
+                  <td className="py-2 pr-4">{fmt(row.requests)}</td>
+                  <td className="py-2 pr-4">{fmt(row.inputTokens + row.outputTokens)}</td>
+                  <td className="py-2 pr-4">{fmtCost(row.costUsd)}</td>
+                  <td className="py-2 pr-4">{Math.round(row.avgLatencyMs)}ms</td>
+                  <td className="py-2 pr-4">{(row.errorRate * 100).toFixed(1)}%</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Request Log ─────────────────────────────────────────────────────────────
+
+function RequestLog() {
+  const [page, setPage] = useState(1);
+  const [modelFilter, setModelFilter] = useState("");
+  const [providerFilter, setProviderFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+
+  const params = new URLSearchParams({
+    page: String(page),
+    limit: "50",
+    ...(modelFilter ? { model: modelFilter } : {}),
+    ...(providerFilter ? { provider: providerFilter } : {}),
+    ...(statusFilter ? { status: statusFilter } : {}),
+  });
+
+  const { data, isLoading } = useQuery<RequestsResponse>({
+    queryKey: ["stats-requests", page, modelFilter, providerFilter, statusFilter],
+    queryFn: () => fetchJson(`/api/stats/requests?${params}`),
+  });
+
+  const { data: detail } = useQuery<LlmRequestRow & { messages: unknown; responseContent: string }>({
+    queryKey: ["stats-request-detail", expandedId],
+    queryFn: () => fetchJson(`/api/stats/requests/${expandedId}`),
+    enabled: expandedId !== null,
+  });
+
+  const totalPages = data ? Math.ceil(data.total / 50) : 1;
+
+  async function handleExport(format: "csv" | "json") {
+    const res = await fetch(`/api/stats/export?format=${format}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: modelFilter || undefined,
+        provider: providerFilter || undefined,
+        status: statusFilter || undefined,
+      }),
+    });
+    if (!res.ok) return;
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `llm_requests.${format}`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <p className="text-sm font-medium">Request Log</p>
+        <div className="flex gap-2">
+          <button
+            onClick={() => handleExport("csv")}
+            className="flex items-center gap-1 text-xs px-2 py-1 rounded border border-border hover:border-primary/50 text-muted-foreground"
+          >
+            <Download className="h-3 w-3" /> CSV
+          </button>
+          <button
+            onClick={() => handleExport("json")}
+            className="flex items-center gap-1 text-xs px-2 py-1 rounded border border-border hover:border-primary/50 text-muted-foreground"
+          >
+            <Download className="h-3 w-3" /> JSON
+          </button>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="flex gap-2 flex-wrap">
+        <input
+          type="text"
+          placeholder="Filter by model..."
+          value={modelFilter}
+          onChange={(e) => { setModelFilter(e.target.value); setPage(1); }}
+          className="text-xs px-2 py-1 rounded border border-border bg-background text-foreground placeholder:text-muted-foreground"
+        />
+        <input
+          type="text"
+          placeholder="Filter by provider..."
+          value={providerFilter}
+          onChange={(e) => { setProviderFilter(e.target.value); setPage(1); }}
+          className="text-xs px-2 py-1 rounded border border-border bg-background text-foreground placeholder:text-muted-foreground"
+        />
+        <select
+          value={statusFilter}
+          onChange={(e) => { setStatusFilter(e.target.value); setPage(1); }}
+          className="text-xs px-2 py-1 rounded border border-border bg-background text-foreground"
+        >
+          <option value="">All statuses</option>
+          <option value="success">Success</option>
+          <option value="error">Error</option>
+        </select>
+      </div>
+
+      {isLoading ? (
+        <p className="text-xs text-muted-foreground">Loading...</p>
+      ) : !data || data.rows.length === 0 ? (
+        <p className="text-xs text-muted-foreground">No requests found.</p>
+      ) : (
+        <>
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-border">
+                  {["Time", "Model", "Team", "In Tok", "Out Tok", "Cost", "Latency", "Status"].map((h) => (
+                    <th key={h} className="text-left pb-2 pr-3 text-muted-foreground font-medium whitespace-nowrap">
+                      {h}
+                    </th>
+                  ))}
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.rows.map((row) => (
+                  <>
+                    <tr
+                      key={row.id}
+                      className="border-b border-border/50 hover:bg-muted/30 cursor-pointer"
+                      onClick={() => setExpandedId(expandedId === row.id ? null : row.id)}
+                    >
+                      <td className="py-1.5 pr-3 text-muted-foreground whitespace-nowrap">
+                        {fmtDate(row.createdAt).slice(0, 16)}
+                      </td>
+                      <td className="py-1.5 pr-3 font-mono truncate max-w-[150px]">{row.modelSlug}</td>
+                      <td className="py-1.5 pr-3 text-muted-foreground">{row.teamId ?? "—"}</td>
+                      <td className="py-1.5 pr-3">{fmt(row.inputTokens)}</td>
+                      <td className="py-1.5 pr-3">{fmt(row.outputTokens)}</td>
+                      <td className="py-1.5 pr-3">{row.estimatedCostUsd ? fmtCost(row.estimatedCostUsd) : "—"}</td>
+                      <td className="py-1.5 pr-3">{row.latencyMs}ms</td>
+                      <td className="py-1.5 pr-3">
+                        <span className={cn(
+                          "px-1.5 py-0.5 rounded text-[10px] font-medium",
+                          row.status === "success"
+                            ? "bg-green-500/10 text-green-500"
+                            : "bg-red-500/10 text-red-500",
+                        )}>
+                          {row.status}
+                        </span>
+                      </td>
+                      <td className="py-1.5">
+                        {expandedId === row.id
+                          ? <ChevronDown className="h-3 w-3 text-muted-foreground" />
+                          : <ChevronRight className="h-3 w-3 text-muted-foreground" />
+                        }
+                      </td>
+                    </tr>
+                    {expandedId === row.id && detail && (
+                      <tr key={`${row.id}-detail`} className="border-b border-border/50">
+                        <td colSpan={9} className="pb-3 pr-3">
+                          <div className="rounded-md border border-border bg-muted/20 p-3 space-y-2 text-xs">
+                            <div>
+                              <p className="text-muted-foreground font-medium mb-1">Messages</p>
+                              <pre className="text-[11px] whitespace-pre-wrap font-mono max-h-40 overflow-y-auto">
+                                {JSON.stringify(detail.messages, null, 2)}
+                              </pre>
+                            </div>
+                            {detail.responseContent && (
+                              <div>
+                                <p className="text-muted-foreground font-medium mb-1">Response</p>
+                                <pre className="text-[11px] whitespace-pre-wrap font-mono max-h-40 overflow-y-auto">
+                                  {detail.responseContent}
+                                </pre>
+                              </div>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Pagination */}
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>{data.total} total</span>
+            <div className="flex gap-2 items-center">
+              <button
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1}
+                className="px-2 py-1 rounded border border-border disabled:opacity-40 hover:border-primary/50"
+              >
+                Prev
+              </button>
+              <span>{page} / {totalPages}</span>
+              <button
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page >= totalPages}
+                className="px-2 py-1 rounded border border-border disabled:opacity-40 hover:border-primary/50"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function Statistics() {
+  const { data: overview, isLoading: overviewLoading } = useQuery<StatsOverview>({
+    queryKey: ["stats-overview"],
+    queryFn: () => fetchJson("/api/stats/overview"),
+  });
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      <div className="h-16 border-b border-border flex items-center px-6 shrink-0">
+        <h1 className="text-base font-semibold">Statistics</h1>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-6 space-y-6">
+        {overviewLoading || !overview ? (
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="rounded-lg border border-border bg-card p-4 animate-pulse h-20" />
+            ))}
+          </div>
+        ) : (
+          <SummaryCards overview={overview} />
+        )}
+
+        <TimelineChart />
+        <ModelTable />
+        <RequestLog />
+      </div>
+    </div>
+  );
+}

--- a/server/controller/pipeline-controller.ts
+++ b/server/controller/pipeline-controller.ts
@@ -4,6 +4,7 @@ import type { WsManager } from "../ws/manager";
 import type { PipelineStageConfig, WsEvent, SandboxFile, StageOutput } from "@shared/types";
 import type { PipelineRun } from "@shared/schema";
 import { SandboxExecutor } from "../sandbox/executor";
+import { ThoughtTreeCollector } from "../pipeline/thought-tree-collector";
 
 export class PipelineController {
   private activeRuns: Map<string, AbortController> = new Map();
@@ -189,6 +190,16 @@ export class PipelineController {
         // Pass execution strategy (undefined = single, handled in BaseTeam)
         const result = await team.execute(stageInput, context, stage.executionStrategy);
 
+        // Collect thought tree from stage output
+        const collector = new ThoughtTreeCollector();
+        const rawOutput = result.output.raw as string | undefined;
+        if (rawOutput) {
+          collector.addFromLlmResponse(rawOutput, stage.modelSlug);
+        } else if (typeof result.output.summary === "string") {
+          collector.addFromLlmResponse(result.output.summary as string, stage.modelSlug);
+        }
+        const thoughtTree = collector.getTree();
+
         // Check if team needs clarification
         if (result.questions && result.questions.length > 0) {
           for (const q of result.questions) {
@@ -277,12 +288,13 @@ export class PipelineController {
           }
         }
 
-        // Stage completed
+        // Stage completed — persist thought tree alongside output
         await this.storage.updateStageExecution(stageExec.id, {
           status: "completed",
           output: result.output,
           tokensUsed: result.tokensUsed,
           completedAt: new Date(),
+          thoughtTree: thoughtTree.length > 0 ? (thoughtTree as unknown as Record<string, unknown>[]) : null,
           ...(sandboxResult ? { sandboxResult } : {}),
         });
 
@@ -302,6 +314,17 @@ export class PipelineController {
           },
           timestamp: new Date().toISOString(),
         });
+
+        // Broadcast thought tree if present
+        if (thoughtTree.length > 0) {
+          this.broadcast(run.id, {
+            type: "stage:thought_tree",
+            runId: run.id,
+            stageExecutionId: stageExec.id,
+            payload: { stageIndex: i, nodes: thoughtTree },
+            timestamp: new Date().toISOString(),
+          });
+        }
 
         // Also send a chat message for the stage output
         await this.storage.createChatMessage({

--- a/server/gateway/index.ts
+++ b/server/gateway/index.ts
@@ -1,5 +1,5 @@
 import type { IStorage } from "../storage";
-import type { GatewayRequest, GatewayResponse, ILLMProvider, PrivacySettings } from "@shared/types";
+import type { GatewayRequest, GatewayResponse, ILLMProvider, ILLMProviderOptions, PrivacySettings, ProviderMessage } from "@shared/types";
 import { MockProvider } from "./providers/mock";
 import { VllmProvider } from "./providers/vllm";
 import { OllamaProvider } from "./providers/ollama";
@@ -7,10 +7,17 @@ import { ClaudeProvider } from "./providers/claude";
 import { GeminiProvider } from "./providers/gemini";
 import { GrokProvider } from "./providers/grok";
 import { AnonymizerService } from "../privacy/anonymizer";
+import { estimateCostUsd } from "@shared/constants";
 
 export interface GatewayPrivacyOptions {
   privacy?: PrivacySettings;
   sessionId?: string;
+}
+
+export interface GatewayLoggingOptions {
+  runId?: string;
+  stageExecutionId?: string;
+  teamId?: string;
 }
 
 type CloudProviderKey = "anthropic" | "google" | "xai";
@@ -97,9 +104,63 @@ export class Gateway {
     return !!(privacy?.enabled && privacy.level !== "off");
   }
 
+  /**
+   * Extract system prompt from messages array (for logging — does NOT mutate).
+   */
+  private extractSystemPrompt(messages: ProviderMessage[]): string | undefined {
+    const systemParts = messages.filter((m) => m.role === "system").map((m) => m.content);
+    return systemParts.length > 0 ? systemParts.join("\n") : undefined;
+  }
+
+  /**
+   * Log an LLM request to storage. Errors here are swallowed so they never
+   * interrupt actual pipeline execution.
+   */
+  private async logRequest(params: {
+    modelSlug: string;
+    providerKey: string;
+    messages: ProviderMessage[];
+    options?: ILLMProviderOptions & GatewayLoggingOptions;
+    result?: { content: string; tokensUsed: number; inputTokens?: number; outputTokens?: number };
+    latencyMs: number;
+    status: 'success' | 'error';
+    errorMessage?: string;
+  }): Promise<void> {
+    try {
+      const inputTokens = params.result?.inputTokens ?? 0;
+      const outputTokens = params.result?.outputTokens ?? 0;
+      const totalTokens = params.result?.tokensUsed ?? 0;
+      const costUsd = estimateCostUsd(params.modelSlug, inputTokens, outputTokens);
+
+      await this.storage.createLlmRequest({
+        runId: params.options?.runId ?? null,
+        stageExecutionId: params.options?.stageExecutionId ?? null,
+        modelSlug: params.modelSlug,
+        provider: params.providerKey,
+        messages: params.messages as unknown as Record<string, unknown>[],
+        systemPrompt: this.extractSystemPrompt(params.messages),
+        temperature: params.options?.temperature ?? null,
+        maxTokens: params.options?.maxTokens ?? null,
+        responseContent: params.result?.content ?? "",
+        inputTokens,
+        outputTokens,
+        totalTokens,
+        latencyMs: params.latencyMs,
+        estimatedCostUsd: costUsd > 0 ? costUsd : null,
+        status: params.status,
+        errorMessage: params.errorMessage ?? null,
+        teamId: params.options?.teamId ?? null,
+        tags: [],
+      });
+    } catch (logErr) {
+      console.warn("[gateway] Failed to log LLM request:", logErr);
+    }
+  }
+
   async complete(
     request: GatewayRequest,
     privacyOptions?: GatewayPrivacyOptions,
+    loggingOptions?: GatewayLoggingOptions,
   ): Promise<GatewayResponse> {
     const model = await this.storage.getModelBySlug(request.modelSlug);
     const providerKey = model?.provider ?? "mock";
@@ -123,21 +184,47 @@ export class Gateway {
       }));
     }
 
+    const start = Date.now();
     let result: { content: string; tokensUsed: number };
-    if (provider) {
-      result = await provider.complete(modelId, messages, {
-        maxTokens: request.maxTokens,
-        temperature: request.temperature,
+    try {
+      if (provider) {
+        result = await provider.complete(modelId, messages, {
+          maxTokens: request.maxTokens,
+          temperature: request.temperature,
+        });
+      } else {
+        result = await this.mockProvider.complete(messages, {
+          maxTokens: request.maxTokens,
+        });
+      }
+    } catch (err) {
+      const latencyMs = Date.now() - start;
+      await this.logRequest({
+        modelSlug: request.modelSlug,
+        providerKey,
+        messages,
+        options: { ...request, ...loggingOptions },
+        latencyMs,
+        status: 'error',
+        errorMessage: String(err),
       });
-    } else {
-      result = await this.mockProvider.complete(messages, {
-        maxTokens: request.maxTokens,
-      });
+      throw err;
     }
 
+    const latencyMs = Date.now() - start;
     const content = this.shouldAnonymize(privacy)
       ? this.anonymizer.rehydrate(result.content, sessionId)
       : result.content;
+
+    await this.logRequest({
+      modelSlug: request.modelSlug,
+      providerKey,
+      messages,
+      options: { ...request, ...loggingOptions },
+      result: { content, tokensUsed: result.tokensUsed, inputTokens: 0, outputTokens: 0 },
+      latencyMs,
+      status: 'success',
+    });
 
     return {
       content,

--- a/server/pipeline/thought-tree-collector.ts
+++ b/server/pipeline/thought-tree-collector.ts
@@ -1,0 +1,146 @@
+import { randomUUID } from "crypto";
+import type { ThoughtNode, ThoughtTree } from "@shared/types";
+
+/**
+ * Collects and structures LLM reasoning steps, tool calls, and decisions
+ * into a tree structure that can be visualized on the frontend.
+ */
+export class ThoughtTreeCollector {
+  private nodes: ThoughtNode[] = [];
+
+  /**
+   * Parse an LLM response for structured thought content.
+   * Extracts:
+   *   - <thinking>...</thinking> blocks → reasoning nodes
+   *   - ## Step N: ... headings → reasoning nodes
+   *   - Lines starting with "Decision:" → decision nodes
+   */
+  addFromLlmResponse(content: string, model?: string): void {
+    const now = Date.now();
+
+    // Extract <thinking>...</thinking> blocks
+    const thinkingRegex = /<thinking>([\s\S]*?)<\/thinking>/gi;
+    let match: RegExpExecArray | null;
+    while ((match = thinkingRegex.exec(content)) !== null) {
+      const thinkingContent = match[1].trim();
+      if (thinkingContent) {
+        this.nodes.push({
+          id: randomUUID(),
+          parentId: null,
+          type: "reasoning",
+          label: "Thinking",
+          content: thinkingContent,
+          timestamp: now,
+          metadata: model ? { model } : undefined,
+        });
+      }
+    }
+
+    // Extract ## Step N: heading blocks
+    const stepRegex = /^#{1,3}\s+(?:Step\s+\d+[:.]\s*)(.+)$/gm;
+    while ((match = stepRegex.exec(content)) !== null) {
+      const label = match[1].trim();
+      // Capture the content after this heading until the next heading
+      const headingEnd = match.index + match[0].length;
+      const nextHeading = content.indexOf("\n#", headingEnd);
+      const stepContent = (
+        nextHeading > -1
+          ? content.slice(headingEnd, nextHeading)
+          : content.slice(headingEnd)
+      ).trim();
+
+      if (label && !label.match(/<thinking>/i)) {
+        this.nodes.push({
+          id: randomUUID(),
+          parentId: null,
+          type: "reasoning",
+          label,
+          content: stepContent || label,
+          timestamp: now,
+          metadata: model ? { model } : undefined,
+        });
+      }
+    }
+
+    // Extract "Decision:" lines
+    const decisionRegex = /^(?:Final\s+)?Decision:\s*(.+)$/gim;
+    while ((match = decisionRegex.exec(content)) !== null) {
+      const decision = match[1].trim();
+      if (decision) {
+        this.nodes.push({
+          id: randomUUID(),
+          parentId: null,
+          type: "decision",
+          label: "Decision",
+          content: decision,
+          timestamp: now,
+          metadata: { decision, model },
+        });
+      }
+    }
+
+    // If no structured thoughts were found, add the whole content as a reasoning node
+    if (this.nodes.length === 0 && content.trim()) {
+      const preview = content.length > 120 ? content.slice(0, 120) + "…" : content;
+      this.nodes.push({
+        id: randomUUID(),
+        parentId: null,
+        type: "reasoning",
+        label: "Response",
+        content: preview,
+        timestamp: now,
+        metadata: model ? { model } : undefined,
+      });
+    }
+  }
+
+  /** Explicitly add a decision node. */
+  addDecision(label: string, content: string): void {
+    this.nodes.push({
+      id: randomUUID(),
+      parentId: null,
+      type: "decision",
+      label,
+      content,
+      timestamp: Date.now(),
+      metadata: { decision: content },
+    });
+  }
+
+  /**
+   * Add a tool call node. Returns the node ID so the result can be linked.
+   */
+  addToolCall(toolName: string, args: string): string {
+    const id = randomUUID();
+    this.nodes.push({
+      id,
+      parentId: null,
+      type: "tool_call",
+      label: `Tool: ${toolName}`,
+      content: args,
+      timestamp: Date.now(),
+      metadata: { toolName },
+    });
+    return id;
+  }
+
+  /** Add a tool result node linked to the preceding tool call. */
+  addToolResult(parentId: string, result: string): void {
+    this.nodes.push({
+      id: randomUUID(),
+      parentId,
+      type: "tool_result",
+      label: "Tool Result",
+      content: result,
+      timestamp: Date.now(),
+    });
+  }
+
+  getTree(): ThoughtTree {
+    return this.nodes;
+  }
+
+  serialize(): string {
+    return JSON.stringify(this.nodes);
+  }
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -12,6 +12,7 @@ import { registerChatRoutes } from "./routes/chat";
 import { registerGatewayRoutes } from "./routes/gateway";
 import { registerStrategyRoutes } from "./routes/strategies";
 import { registerPrivacyRoutes } from "./routes/privacy";
+import { registerStatsRoutes } from "./routes/stats";
 import { DEFAULT_MODELS, DEFAULT_PIPELINE_STAGES } from "@shared/constants";
 import { log } from "./index";
 
@@ -33,6 +34,7 @@ export async function registerRoutes(
   registerGatewayRoutes(app, gateway);
   registerStrategyRoutes(app, storage);
   registerPrivacyRoutes(app);
+  registerStatsRoutes(app, storage);
 
   // Seed default models
   const existingModels = await storage.getModels();

--- a/server/routes/stats.ts
+++ b/server/routes/stats.ts
@@ -1,0 +1,244 @@
+import type { Express } from "express";
+import { z } from "zod";
+import type { IStorage } from "../storage";
+
+const filtersSchema = z.object({
+  page: z.coerce.number().int().min(1).optional().default(1),
+  limit: z.coerce.number().int().min(1).max(200).optional().default(50),
+  model: z.string().optional(),
+  provider: z.string().optional(),
+  runId: z.string().optional(),
+  status: z.string().optional(),
+  from: z.string().optional(),
+  to: z.string().optional(),
+});
+
+// Separate schema for export with higher limit ceiling
+const exportFiltersSchema = z.object({
+  page: z.coerce.number().int().min(1).optional().default(1),
+  limit: z.coerce.number().int().min(1).max(5000).optional().default(5000),
+  model: z.string().optional(),
+  provider: z.string().optional(),
+  runId: z.string().optional(),
+  status: z.string().optional(),
+  from: z.string().optional(),
+  to: z.string().optional(),
+});
+
+const timelineSchema = z.object({
+  granularity: z.enum(["day", "week"]).optional().default("day"),
+  from: z.string().optional(),
+  to: z.string().optional(),
+});
+
+const exportFormatSchema = z.object({
+  format: z.enum(["csv", "json"]).optional().default("json"),
+});
+
+export function registerStatsRoutes(app: Express, storage: IStorage): void {
+
+  // GET /api/stats/overview
+  app.get("/api/stats/overview", async (_req, res) => {
+    try {
+      const [llmStats, allRuns] = await Promise.all([
+        storage.getLlmRequestStats(),
+        storage.getPipelineRuns(),
+      ]);
+      res.json({
+        totalRequests: llmStats.totalRequests,
+        totalTokens: {
+          input: llmStats.totalInputTokens,
+          output: llmStats.totalOutputTokens,
+          total: llmStats.totalInputTokens + llmStats.totalOutputTokens,
+        },
+        totalCostUsd: llmStats.totalCostUsd,
+        totalRuns: allRuns.length,
+      });
+    } catch (err) {
+      console.error("/api/stats/overview error:", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  // GET /api/stats/by-model
+  app.get("/api/stats/by-model", async (_req, res) => {
+    try {
+      const stats = await storage.getLlmStatsByModel();
+      res.json(stats);
+    } catch (err) {
+      console.error("/api/stats/by-model error:", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  // GET /api/stats/by-provider
+  app.get("/api/stats/by-provider", async (_req, res) => {
+    try {
+      const stats = await storage.getLlmStatsByProvider();
+      res.json(stats);
+    } catch (err) {
+      console.error("/api/stats/by-provider error:", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  // GET /api/stats/by-team
+  app.get("/api/stats/by-team", async (_req, res) => {
+    try {
+      const stats = await storage.getLlmStatsByTeam();
+      res.json(stats);
+    } catch (err) {
+      console.error("/api/stats/by-team error:", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  // GET /api/stats/timeline
+  app.get("/api/stats/timeline", async (req, res) => {
+    try {
+      const parsed = timelineSchema.safeParse(req.query);
+      if (!parsed.success) {
+        res.status(400).json({ error: parsed.error.flatten() });
+        return;
+      }
+      const { granularity, from, to } = parsed.data;
+      const now = new Date();
+      const fromDate = from ? new Date(from) : new Date(now.getTime() - 30 * 86_400_000);
+      const toDate = to ? new Date(to) : now;
+
+      const timeline = await storage.getLlmTimeline(fromDate, toDate, granularity);
+      res.json(timeline);
+    } catch (err) {
+      console.error("/api/stats/timeline error:", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  // GET /api/stats/requests — paginated request log
+  app.get("/api/stats/requests", async (req, res) => {
+    try {
+      const parsed = filtersSchema.safeParse(req.query);
+      if (!parsed.success) {
+        res.status(400).json({ error: parsed.error.flatten() });
+        return;
+      }
+      const { page, limit, model, provider, runId, status, from, to } = parsed.data;
+
+      const result = await storage.getLlmRequests({
+        page,
+        limit,
+        modelSlug: model,
+        provider,
+        runId,
+        status,
+        from: from ? new Date(from) : undefined,
+        to: to ? new Date(to) : undefined,
+      });
+
+      // Strip messages/responseContent from list view for safety
+      const sanitizedRows = result.rows.map(({ messages: _m, responseContent: _r, ...rest }) => rest);
+
+      res.json({ rows: sanitizedRows, total: result.total, page, limit });
+    } catch (err) {
+      console.error("/api/stats/requests error:", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  // GET /api/stats/requests/:id — full request detail
+  app.get("/api/stats/requests/:id", async (req, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      if (isNaN(id)) {
+        res.status(400).json({ error: "Invalid request ID" });
+        return;
+      }
+      const request = await storage.getLlmRequestById(id);
+      if (!request) {
+        res.status(404).json({ error: "Request not found" });
+        return;
+      }
+      res.json(request);
+    } catch (err) {
+      console.error("/api/stats/requests/:id error:", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  // POST /api/stats/export — CSV or JSON download
+  app.post("/api/stats/export", async (req, res) => {
+    try {
+      const formatParsed = exportFormatSchema.safeParse(req.query);
+      const format = formatParsed.success ? formatParsed.data.format : "json";
+
+      // Parse body filters with high limit ceiling for export
+      const bodyParsed = exportFiltersSchema.safeParse({ ...req.body, limit: 5000, page: 1 });
+      const filterData = bodyParsed.success ? bodyParsed.data : { page: 1, limit: 5000 };
+
+      const { rows } = await storage.getLlmRequests({
+        page: filterData.page,
+        limit: filterData.limit,
+        modelSlug: filterData.model,
+        provider: filterData.provider,
+        runId: filterData.runId,
+        status: filterData.status,
+        from: filterData.from ? new Date(filterData.from) : undefined,
+        to: filterData.to ? new Date(filterData.to) : undefined,
+      });
+
+      if (format === "csv") {
+        const cols = [
+          "id", "createdAt", "modelSlug", "provider", "teamId",
+          "inputTokens", "outputTokens", "totalTokens",
+          "estimatedCostUsd", "latencyMs", "status",
+        ] as const;
+        const csvRows = rows.map((r) =>
+          cols.map((c) => {
+            const val = r[c as keyof typeof r];
+            const str = val === null || val === undefined ? "" : String(val);
+            return `"${str.replace(/"/g, '""')}"`;
+          }).join(",")
+        );
+        const csv = [cols.join(","), ...csvRows].join("\n");
+
+        res.setHeader("Content-Type", "text/csv");
+        res.setHeader("Content-Disposition", "attachment; filename=llm_requests.csv");
+        res.send(csv);
+      } else {
+        res.setHeader("Content-Type", "application/json");
+        res.setHeader("Content-Disposition", "attachment; filename=llm_requests.json");
+        // Strip messages/response for bulk export
+        const sanitized = rows.map(({ messages: _m, responseContent: _r, ...rest }) => rest);
+        res.json(sanitized);
+      }
+    } catch (err) {
+      console.error("/api/stats/export error:", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  // GET /api/runs/:runId/stages/:stageIndex/thought-tree
+  app.get("/api/runs/:runId/stages/:stageIndex/thought-tree", async (req, res) => {
+    try {
+      const { runId, stageIndex } = req.params;
+      const idx = parseInt(stageIndex, 10);
+      if (isNaN(idx)) {
+        res.status(400).json({ error: "Invalid stage index" });
+        return;
+      }
+
+      const executions = await storage.getStageExecutions(runId);
+      const exec = executions.find((e) => e.stageIndex === idx);
+      if (!exec) {
+        res.status(404).json({ error: "Stage execution not found" });
+        return;
+      }
+
+      const thoughtTree = exec.thoughtTree ?? [];
+      res.json(thoughtTree);
+    } catch (err) {
+      console.error("/api/runs/:runId/stages/:stageIndex/thought-tree error:", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+}

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -1,9 +1,9 @@
-import { eq, desc, and } from "drizzle-orm";
+import { eq, desc, and, gte, lte, sql as drizzleSql } from "drizzle-orm";
 import { db } from "./db";
-import type { IStorage } from "./storage";
+import type { IStorage, LlmRequestFilters, LlmRequestStats, LlmStatsByModel, LlmStatsByProvider, LlmStatsByTeam, LlmTimelinePoint } from "./storage";
 import {
   users, models, pipelines, pipelineRuns,
-  stageExecutions, questions, chatMessages,
+  stageExecutions, questions, chatMessages, llmRequests,
   type User, type InsertUser,
   type Model, type InsertModel,
   type Pipeline, type InsertPipeline,
@@ -11,6 +11,7 @@ import {
   type StageExecution, type InsertStageExecution,
   type Question, type InsertQuestion,
   type ChatMessage, type InsertChatMessage,
+  type LlmRequest, type InsertLlmRequest,
 } from "@shared/schema";
 
 export class PgStorage implements IStorage {
@@ -250,5 +251,170 @@ export class PgStorage implements IStorage {
   async createChatMessage(message: InsertChatMessage): Promise<ChatMessage> {
     const [row] = await db.insert(chatMessages).values(message).returning();
     return row;
+  }
+
+  // ─── LLM Requests ───────────────────────────────────
+
+  async createLlmRequest(data: InsertLlmRequest): Promise<LlmRequest> {
+    const [row] = await db.insert(llmRequests).values(data).returning();
+    return row;
+  }
+
+  async getLlmRequests(filters: LlmRequestFilters): Promise<{ rows: LlmRequest[]; total: number }> {
+    const conditions = [];
+    if (filters.runId) conditions.push(eq(llmRequests.runId, filters.runId));
+    if (filters.provider) conditions.push(eq(llmRequests.provider, filters.provider));
+    if (filters.modelSlug) conditions.push(eq(llmRequests.modelSlug, filters.modelSlug));
+    if (filters.status) conditions.push(eq(llmRequests.status, filters.status));
+    if (filters.from) conditions.push(gte(llmRequests.createdAt, filters.from));
+    if (filters.to) conditions.push(lte(llmRequests.createdAt, filters.to));
+
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
+
+    // Count total
+    const [countRow] = await db
+      .select({ count: drizzleSql<number>`count(*)::int` })
+      .from(llmRequests)
+      .where(whereClause);
+    const total = countRow?.count ?? 0;
+
+    // Paginated rows
+    const page = filters.page ?? 1;
+    const limit = filters.limit ?? 50;
+    const offset = (page - 1) * limit;
+
+    const rows = await db
+      .select()
+      .from(llmRequests)
+      .where(whereClause)
+      .orderBy(desc(llmRequests.createdAt))
+      .limit(limit)
+      .offset(offset);
+
+    return { rows, total };
+  }
+
+  async getLlmRequestById(id: number): Promise<LlmRequest | undefined> {
+    const [row] = await db
+      .select()
+      .from(llmRequests)
+      .where(eq(llmRequests.id, id));
+    return row;
+  }
+
+  async getLlmRequestStats(): Promise<LlmRequestStats> {
+    const [row] = await db
+      .select({
+        totalRequests: drizzleSql<number>`count(*)::int`,
+        totalInputTokens: drizzleSql<number>`coalesce(sum(input_tokens), 0)::int`,
+        totalOutputTokens: drizzleSql<number>`coalesce(sum(output_tokens), 0)::int`,
+        totalCostUsd: drizzleSql<number>`coalesce(sum(estimated_cost_usd), 0)::float`,
+      })
+      .from(llmRequests);
+
+    return {
+      totalRequests: row?.totalRequests ?? 0,
+      totalInputTokens: row?.totalInputTokens ?? 0,
+      totalOutputTokens: row?.totalOutputTokens ?? 0,
+      totalCostUsd: row?.totalCostUsd ?? 0,
+    };
+  }
+
+  async getLlmStatsByModel(): Promise<LlmStatsByModel[]> {
+    const rows = await db
+      .select({
+        modelSlug: llmRequests.modelSlug,
+        provider: llmRequests.provider,
+        requests: drizzleSql<number>`count(*)::int`,
+        inputTokens: drizzleSql<number>`coalesce(sum(input_tokens), 0)::int`,
+        outputTokens: drizzleSql<number>`coalesce(sum(output_tokens), 0)::int`,
+        costUsd: drizzleSql<number>`coalesce(sum(estimated_cost_usd), 0)::float`,
+        avgLatencyMs: drizzleSql<number>`coalesce(avg(latency_ms), 0)::float`,
+        errorCount: drizzleSql<number>`count(*) filter (where status = 'error')::int`,
+      })
+      .from(llmRequests)
+      .groupBy(llmRequests.modelSlug, llmRequests.provider);
+
+    return rows.map((r) => ({
+      modelSlug: r.modelSlug,
+      provider: r.provider,
+      requests: r.requests,
+      inputTokens: r.inputTokens,
+      outputTokens: r.outputTokens,
+      costUsd: r.costUsd,
+      avgLatencyMs: r.avgLatencyMs,
+      errorRate: r.requests > 0 ? r.errorCount / r.requests : 0,
+    }));
+  }
+
+  async getLlmStatsByProvider(): Promise<LlmStatsByProvider[]> {
+    const rows = await db
+      .select({
+        provider: llmRequests.provider,
+        requests: drizzleSql<number>`count(*)::int`,
+        inputTokens: drizzleSql<number>`coalesce(sum(input_tokens), 0)::int`,
+        outputTokens: drizzleSql<number>`coalesce(sum(output_tokens), 0)::int`,
+        costUsd: drizzleSql<number>`coalesce(sum(estimated_cost_usd), 0)::float`,
+        avgLatencyMs: drizzleSql<number>`coalesce(avg(latency_ms), 0)::float`,
+        errorCount: drizzleSql<number>`count(*) filter (where status = 'error')::int`,
+      })
+      .from(llmRequests)
+      .groupBy(llmRequests.provider);
+
+    return rows.map((r) => ({
+      provider: r.provider,
+      requests: r.requests,
+      inputTokens: r.inputTokens,
+      outputTokens: r.outputTokens,
+      costUsd: r.costUsd,
+      avgLatencyMs: r.avgLatencyMs,
+      errorRate: r.requests > 0 ? r.errorCount / r.requests : 0,
+    }));
+  }
+
+  async getLlmStatsByTeam(): Promise<LlmStatsByTeam[]> {
+    const rows = await db
+      .select({
+        teamId: llmRequests.teamId,
+        requests: drizzleSql<number>`count(*)::int`,
+        inputTokens: drizzleSql<number>`coalesce(sum(input_tokens), 0)::int`,
+        outputTokens: drizzleSql<number>`coalesce(sum(output_tokens), 0)::int`,
+        costUsd: drizzleSql<number>`coalesce(sum(estimated_cost_usd), 0)::float`,
+      })
+      .from(llmRequests)
+      .where(drizzleSql`team_id is not null`)
+      .groupBy(llmRequests.teamId);
+
+    return rows
+      .filter((r) => r.teamId !== null)
+      .map((r) => ({
+        teamId: r.teamId as string,
+        requests: r.requests,
+        inputTokens: r.inputTokens,
+        outputTokens: r.outputTokens,
+        costUsd: r.costUsd,
+      }));
+  }
+
+  async getLlmTimeline(from: Date, to: Date, granularity: 'day' | 'week'): Promise<LlmTimelinePoint[]> {
+    const truncFn = granularity === 'week' ? 'week' : 'day';
+    const rows = await db
+      .select({
+        date: drizzleSql<string>`date_trunc('${drizzleSql.raw(truncFn)}', created_at)::date::text`,
+        requests: drizzleSql<number>`count(*)::int`,
+        tokens: drizzleSql<number>`coalesce(sum(input_tokens + output_tokens), 0)::int`,
+        costUsd: drizzleSql<number>`coalesce(sum(estimated_cost_usd), 0)::float`,
+      })
+      .from(llmRequests)
+      .where(and(gte(llmRequests.createdAt, from), lte(llmRequests.createdAt, to)))
+      .groupBy(drizzleSql`date_trunc('${drizzleSql.raw(truncFn)}', created_at)`)
+      .orderBy(drizzleSql`date_trunc('${drizzleSql.raw(truncFn)}', created_at)`);
+
+    return rows.map((r) => ({
+      date: r.date,
+      requests: r.requests,
+      tokens: r.tokens,
+      costUsd: r.costUsd,
+    }));
   }
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -13,9 +13,67 @@ import {
   type InsertQuestion,
   type ChatMessage,
   type InsertChatMessage,
+  type LlmRequest,
+  type InsertLlmRequest,
 } from "@shared/schema";
 import { randomUUID } from "crypto";
 import { PgStorage } from "./storage-pg";
+
+// ─── LLM Request query filters ───────────────────────────────────────────────
+
+export interface LlmRequestFilters {
+  runId?: string;
+  provider?: string;
+  modelSlug?: string;
+  status?: string;
+  from?: Date;
+  to?: Date;
+  page?: number;
+  limit?: number;
+}
+
+export interface LlmRequestStats {
+  totalRequests: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+}
+
+export interface LlmStatsByModel {
+  modelSlug: string;
+  provider: string;
+  requests: number;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  avgLatencyMs: number;
+  errorRate: number;
+}
+
+export interface LlmStatsByProvider {
+  provider: string;
+  requests: number;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  avgLatencyMs: number;
+  errorRate: number;
+}
+
+export interface LlmStatsByTeam {
+  teamId: string;
+  requests: number;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+}
+
+export interface LlmTimelinePoint {
+  date: string;
+  requests: number;
+  tokens: number;
+  costUsd: number;
+}
 
 export interface IStorage {
   // Users
@@ -62,6 +120,16 @@ export interface IStorage {
   // Chat Messages
   getChatMessages(runId?: string, limit?: number): Promise<ChatMessage[]>;
   createChatMessage(message: InsertChatMessage): Promise<ChatMessage>;
+
+  // LLM Requests
+  createLlmRequest(data: InsertLlmRequest): Promise<LlmRequest>;
+  getLlmRequests(filters: LlmRequestFilters): Promise<{ rows: LlmRequest[]; total: number }>;
+  getLlmRequestById(id: number): Promise<LlmRequest | undefined>;
+  getLlmRequestStats(): Promise<LlmRequestStats>;
+  getLlmStatsByModel(): Promise<LlmStatsByModel[]>;
+  getLlmStatsByProvider(): Promise<LlmStatsByProvider[]>;
+  getLlmStatsByTeam(): Promise<LlmStatsByTeam[]>;
+  getLlmTimeline(from: Date, to: Date, granularity: 'day' | 'week'): Promise<LlmTimelinePoint[]>;
 }
 
 export class MemStorage implements IStorage {
@@ -72,6 +140,8 @@ export class MemStorage implements IStorage {
   private stages: Map<string, StageExecution>;
   private questionsMap: Map<string, Question>;
   private messages: Map<string, ChatMessage>;
+  private llmRequestsMap: Map<number, LlmRequest>;
+  private llmRequestIdSeq: number;
 
   constructor() {
     this.users = new Map();
@@ -81,6 +151,8 @@ export class MemStorage implements IStorage {
     this.stages = new Map();
     this.questionsMap = new Map();
     this.messages = new Map();
+    this.llmRequestsMap = new Map();
+    this.llmRequestIdSeq = 1;
   }
 
   // ─── Users ──────────────────────────────────────
@@ -262,6 +334,7 @@ export class MemStorage implements IStorage {
       startedAt: insert.startedAt ?? null,
       completedAt: insert.completedAt ?? null,
       sandboxResult: insert.sandboxResult ?? null,
+      thoughtTree: insert.thoughtTree ?? null,
       createdAt: new Date(),
     };
     this.stages.set(id, stage);
@@ -366,6 +439,178 @@ export class MemStorage implements IStorage {
     };
     this.messages.set(id, msg);
     return msg;
+  }
+
+  // ─── LLM Requests ───────────────────────────────
+
+  async createLlmRequest(data: InsertLlmRequest): Promise<LlmRequest> {
+    const id = this.llmRequestIdSeq++;
+    const req: LlmRequest = {
+      id,
+      runId: data.runId ?? null,
+      stageExecutionId: data.stageExecutionId ?? null,
+      modelSlug: data.modelSlug,
+      provider: data.provider,
+      messages: data.messages,
+      systemPrompt: data.systemPrompt ?? null,
+      temperature: data.temperature ?? null,
+      maxTokens: data.maxTokens ?? null,
+      responseContent: data.responseContent ?? "",
+      inputTokens: data.inputTokens ?? 0,
+      outputTokens: data.outputTokens ?? 0,
+      totalTokens: data.totalTokens ?? 0,
+      latencyMs: data.latencyMs ?? 0,
+      estimatedCostUsd: data.estimatedCostUsd ?? null,
+      status: data.status ?? "success",
+      errorMessage: data.errorMessage ?? null,
+      teamId: data.teamId ?? null,
+      tags: data.tags ?? [],
+      createdAt: new Date(),
+    };
+    this.llmRequestsMap.set(id, req);
+    return req;
+  }
+
+  async getLlmRequests(filters: LlmRequestFilters): Promise<{ rows: LlmRequest[]; total: number }> {
+    let rows = Array.from(this.llmRequestsMap.values());
+
+    if (filters.runId) rows = rows.filter((r) => r.runId === filters.runId);
+    if (filters.provider) rows = rows.filter((r) => r.provider === filters.provider);
+    if (filters.modelSlug) rows = rows.filter((r) => r.modelSlug === filters.modelSlug);
+    if (filters.status) rows = rows.filter((r) => r.status === filters.status);
+    if (filters.from) rows = rows.filter((r) => r.createdAt && r.createdAt >= filters.from!);
+    if (filters.to) rows = rows.filter((r) => r.createdAt && r.createdAt <= filters.to!);
+
+    rows.sort((a, b) => (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0));
+
+    const total = rows.length;
+    const page = filters.page ?? 1;
+    const limit = filters.limit ?? 50;
+    const start = (page - 1) * limit;
+    rows = rows.slice(start, start + limit);
+
+    return { rows, total };
+  }
+
+  async getLlmRequestById(id: number): Promise<LlmRequest | undefined> {
+    return this.llmRequestsMap.get(id);
+  }
+
+  async getLlmRequestStats(): Promise<LlmRequestStats> {
+    const all = Array.from(this.llmRequestsMap.values());
+    return {
+      totalRequests: all.length,
+      totalInputTokens: all.reduce((s, r) => s + (r.inputTokens ?? 0), 0),
+      totalOutputTokens: all.reduce((s, r) => s + (r.outputTokens ?? 0), 0),
+      totalCostUsd: all.reduce((s, r) => s + (r.estimatedCostUsd ?? 0), 0),
+    };
+  }
+
+  async getLlmStatsByModel(): Promise<LlmStatsByModel[]> {
+    const all = Array.from(this.llmRequestsMap.values());
+    const map = new Map<string, LlmStatsByModel>();
+    for (const r of all) {
+      const key = r.modelSlug;
+      const existing = map.get(key) ?? {
+        modelSlug: r.modelSlug,
+        provider: r.provider,
+        requests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        costUsd: 0,
+        avgLatencyMs: 0,
+        errorRate: 0,
+      };
+      existing.requests++;
+      existing.inputTokens += r.inputTokens ?? 0;
+      existing.outputTokens += r.outputTokens ?? 0;
+      existing.costUsd += r.estimatedCostUsd ?? 0;
+      existing.avgLatencyMs += r.latencyMs ?? 0;
+      if (r.status === "error") existing.errorRate++;
+      map.set(key, existing);
+    }
+    return Array.from(map.values()).map((s) => ({
+      ...s,
+      avgLatencyMs: s.requests > 0 ? s.avgLatencyMs / s.requests : 0,
+      errorRate: s.requests > 0 ? s.errorRate / s.requests : 0,
+    }));
+  }
+
+  async getLlmStatsByProvider(): Promise<LlmStatsByProvider[]> {
+    const all = Array.from(this.llmRequestsMap.values());
+    const map = new Map<string, LlmStatsByProvider>();
+    for (const r of all) {
+      const key = r.provider;
+      const existing = map.get(key) ?? {
+        provider: r.provider,
+        requests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        costUsd: 0,
+        avgLatencyMs: 0,
+        errorRate: 0,
+      };
+      existing.requests++;
+      existing.inputTokens += r.inputTokens ?? 0;
+      existing.outputTokens += r.outputTokens ?? 0;
+      existing.costUsd += r.estimatedCostUsd ?? 0;
+      existing.avgLatencyMs += r.latencyMs ?? 0;
+      if (r.status === "error") existing.errorRate++;
+      map.set(key, existing);
+    }
+    return Array.from(map.values()).map((s) => ({
+      ...s,
+      avgLatencyMs: s.requests > 0 ? s.avgLatencyMs / s.requests : 0,
+      errorRate: s.requests > 0 ? s.errorRate / s.requests : 0,
+    }));
+  }
+
+  async getLlmStatsByTeam(): Promise<LlmStatsByTeam[]> {
+    const all = Array.from(this.llmRequestsMap.values()).filter((r) => r.teamId);
+    const map = new Map<string, LlmStatsByTeam>();
+    for (const r of all) {
+      const key = r.teamId!;
+      const existing = map.get(key) ?? {
+        teamId: key,
+        requests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        costUsd: 0,
+      };
+      existing.requests++;
+      existing.inputTokens += r.inputTokens ?? 0;
+      existing.outputTokens += r.outputTokens ?? 0;
+      existing.costUsd += r.estimatedCostUsd ?? 0;
+      map.set(key, existing);
+    }
+    return Array.from(map.values());
+  }
+
+  async getLlmTimeline(from: Date, to: Date, granularity: 'day' | 'week'): Promise<LlmTimelinePoint[]> {
+    const all = Array.from(this.llmRequestsMap.values()).filter((r) => {
+      const ts = r.createdAt;
+      return ts && ts >= from && ts <= to;
+    });
+
+    const buckets = new Map<string, LlmTimelinePoint>();
+    for (const r of all) {
+      const d = r.createdAt!;
+      let key: string;
+      if (granularity === 'week') {
+        const weekStart = new Date(d);
+        weekStart.setDate(d.getDate() - d.getDay());
+        key = weekStart.toISOString().slice(0, 10);
+      } else {
+        key = d.toISOString().slice(0, 10);
+      }
+      const existing = buckets.get(key) ?? { date: key, requests: 0, tokens: 0, costUsd: 0 };
+      existing.requests++;
+      existing.tokens += (r.inputTokens ?? 0) + (r.outputTokens ?? 0);
+      existing.costUsd += r.estimatedCostUsd ?? 0;
+      buckets.set(key, existing);
+    }
+
+    return Array.from(buckets.values()).sort((a, b) => a.date.localeCompare(b.date));
   }
 }
 

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -652,3 +652,30 @@ export const SANDBOX_DEFAULTS = {
   workdir: "/workspace",
   failOnNonZero: true,
 } as const;
+
+// ─── Model Pricing ───────────────────────────────────────────────────────────
+
+export const MODEL_PRICING: Record<string, { inputPer1M: number; outputPer1M: number }> = {
+  "claude-sonnet-4-6": { inputPer1M: 3.00,  outputPer1M: 15.00 },
+  "claude-haiku-4-5":  { inputPer1M: 0.80,  outputPer1M: 4.00 },
+  "gemini-2.0-flash":  { inputPer1M: 0.075, outputPer1M: 0.30 },
+  "grok-3":            { inputPer1M: 3.00,  outputPer1M: 15.00 },
+  "grok-3-mini":       { inputPer1M: 0.30,  outputPer1M: 0.50 },
+};
+
+/**
+ * Estimate cost in USD for a given model and token counts.
+ * Returns 0 for vllm/ollama/mock or unknown models (no cloud cost).
+ */
+export function estimateCostUsd(
+  modelSlug: string,
+  inputTokens: number,
+  outputTokens: number,
+): number {
+  const pricing = MODEL_PRICING[modelSlug];
+  if (!pricing) return 0;
+  return (
+    (inputTokens / 1_000_000) * pricing.inputPer1M +
+    (outputTokens / 1_000_000) * pricing.outputPer1M
+  );
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -8,6 +8,7 @@ import {
   timestamp,
   jsonb,
   serial,
+  real,
 } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
@@ -122,6 +123,7 @@ export const stageExecutions = pgTable("stage_executions", {
   startedAt: timestamp("started_at"),
   completedAt: timestamp("completed_at"),
   sandboxResult: jsonb("sandbox_result"),
+  thoughtTree: jsonb("thought_tree"),
   createdAt: timestamp("created_at").defaultNow(),
 });
 
@@ -230,3 +232,36 @@ export const anonymizationLog = pgTable("anonymization_log", {
 });
 
 export type AnonymizationLogEntry = typeof anonymizationLog.$inferSelect;
+
+// ─── LLM Requests ───────────────────────────────────
+
+export const llmRequests = pgTable("llm_requests", {
+  id: serial("id").primaryKey(),
+  runId: varchar("run_id"),
+  stageExecutionId: varchar("stage_execution_id"),
+  modelSlug: text("model_slug").notNull(),
+  provider: text("provider").notNull(),
+  messages: jsonb("messages").notNull(),
+  systemPrompt: text("system_prompt"),
+  temperature: real("temperature"),
+  maxTokens: integer("max_tokens"),
+  responseContent: text("response_content").notNull().default(""),
+  inputTokens: integer("input_tokens").notNull().default(0),
+  outputTokens: integer("output_tokens").notNull().default(0),
+  totalTokens: integer("total_tokens").notNull().default(0),
+  latencyMs: integer("latency_ms").notNull().default(0),
+  estimatedCostUsd: real("estimated_cost_usd"),
+  status: text("status").notNull().default("success"),
+  errorMessage: text("error_message"),
+  teamId: text("team_id"),
+  tags: jsonb("tags").default(sql`'[]'::jsonb`),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
+export const insertLlmRequestSchema = createInsertSchema(llmRequests).omit({
+  id: true,
+  createdAt: true,
+});
+
+export type InsertLlmRequest = z.infer<typeof insertLlmRequestSchema>;
+export type LlmRequest = typeof llmRequests.$inferSelect;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -195,7 +195,8 @@ export type WsEventType =
   | "strategy:completed"
   | "sandbox:starting"
   | "sandbox:output"
-  | "sandbox:completed";
+  | "sandbox:completed"
+  | "stage:thought_tree";
 
 export interface WsEvent {
   type: WsEventType;
@@ -314,6 +315,12 @@ export interface ILLMProviderOptions {
   temperature?: number;
   /** Per-request timeout override in milliseconds. Defaults to provider default (30s). */
   timeoutMs?: number;
+  /** Associate this request with a pipeline run for logging. */
+  runId?: string;
+  /** Associate this request with a stage execution for logging. */
+  stageExecutionId?: string;
+  /** Team identifier for cost/usage grouping. */
+  teamId?: string;
 }
 
 export interface ILLMProvider {
@@ -365,3 +372,24 @@ export interface FactCheckOutput {
   enrichedOutput: string;
   summary: string;
 }
+
+// ─── Thought Tree Types ───────────────────────────────────────────────────────
+
+export interface ThoughtNode {
+  id: string;
+  parentId: string | null;
+  type: 'reasoning' | 'tool_call' | 'tool_result' | 'decision' | 'guardrail' | 'memory_recall';
+  label: string;
+  content: string;
+  timestamp: number;
+  durationMs?: number;
+  metadata?: {
+    model?: string;
+    tokensUsed?: number;
+    toolName?: string;
+    decision?: string;
+    confidence?: number;
+  };
+}
+
+export type ThoughtTree = ThoughtNode[];


### PR DESCRIPTION
## Summary

- **llm_requests table** — every gateway call is logged with model, provider, tokens, latency, and estimated USD cost
- **Cost tracking** — MODEL_PRICING table in shared/constants with estimateCostUsd() for Anthropic, Google, xAI; returns 0 for vllm/ollama/mock
- **Thought tree** — ThoughtTreeCollector parses `<thinking>` blocks, `## Step N:` headings, and `Decision:` lines from LLM output; tree stored in stage_executions.thought_tree and broadcast as stage:thought_tree WS event
- **Stats API** — 8 new endpoints: /api/stats/overview, /api/stats/by-model, /api/stats/by-provider, /api/stats/by-team, /api/stats/timeline, /api/stats/requests, /api/stats/requests/:id, /api/stats/export (CSV + JSON)
- **Statistics page** — /stats with summary cards, recharts area chart (day/week, requests/tokens/cost), sortable model table, paginated request log with filters and expand-to-detail
- **ThoughtTree component** — filter by All/Reasoning/Decisions/Tools, expandable nodes with emoji icons, footer totals
- Both PgStorage (SQL aggregations) and MemStorage (in-memory fallback) implement all new methods

## Changed files

- `shared/schema.ts` — llmRequests table, thoughtTree column on stageExecutions
- `shared/types.ts` — ThoughtNode, ThoughtTree, stage:thought_tree WS event, extended ILLMProviderOptions
- `shared/constants.ts` — MODEL_PRICING, estimateCostUsd()
- `server/storage.ts` — IStorage interface + MemStorage for LLM request methods
- `server/storage-pg.ts` — PgStorage SQL implementations
- `server/gateway/index.ts` — wraps complete() to log every call with try/catch
- `server/pipeline/thought-tree-collector.ts` — new collector class
- `server/controller/pipeline-controller.ts` — collects + stores thought tree per stage
- `server/routes/stats.ts` — all stats + thought-tree endpoints
- `server/routes.ts` — registers stats routes
- `client/src/components/pipeline/ThoughtTree.tsx` — new component
- `client/src/components/pipeline/StageOutput.tsx` — wires ThoughtTree
- `client/src/pages/Statistics.tsx` — new page
- `client/src/components/layout/MainLayout.tsx` — Statistics nav link
- `client/src/App.tsx` — /stats route

## Test plan

- [ ] Run a pipeline with a real cloud model (claude-sonnet-4-6 or grok-3) — confirm a row appears in /api/stats/requests with non-zero tokens, non-null estimatedCostUsd
- [ ] Run with mock provider — confirm estimatedCostUsd is null (0 cost)
- [ ] GET /api/stats/overview returns correct counts
- [ ] GET /api/stats/by-model groups by slug with correct aggregations
- [ ] GET /api/stats/timeline returns dated buckets
- [ ] GET /api/stats/requests/:id returns full messages + responseContent
- [ ] POST /api/stats/export?format=csv downloads a valid CSV
- [ ] POST /api/stats/export?format=json downloads valid JSON without messages field
- [ ] Completed pipeline stage shows thought tree in StageOutput (expand stage card)
- [ ] /stats page loads, all four sections render
- [ ] Statistics link visible in sidebar nav