### PR TITLE
feat: Phase 3.3 — Cross-Run Memory System

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,6 +16,7 @@ import PipelineRun from "@/pages/PipelineRun";
 import Settings from "@/pages/Settings";
 import Privacy from "@/pages/Privacy";
 import Statistics from "@/pages/Statistics";
+import Memory from "@/pages/Memory";
 
 function Router() {
   return (
@@ -50,6 +51,9 @@ function Router() {
         )} />
         <Route path="/stats" component={() => (
           <ErrorBoundary><Statistics /></ErrorBoundary>
+        )} />
+        <Route path="/memories" component={() => (
+          <ErrorBoundary><Memory /></ErrorBoundary>
         )} />
         <Route component={NotFound} />
       </Switch>

--- a/client/src/components/layout/MainLayout.tsx
+++ b/client/src/components/layout/MainLayout.tsx
@@ -9,6 +9,7 @@ import {
   MessageCircleQuestion,
   ShieldCheck,
   BarChart3,
+  Brain,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePendingQuestions } from "@/hooks/use-pipeline";
@@ -32,6 +33,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
       badge: pendingCount > 0 ? pendingCount : undefined,
     },
     { icon: BarChart3, label: "Statistics", href: "/stats" },
+    { icon: Brain, label: "Memory", href: "/memories" },
     { icon: ShieldCheck, label: "Privacy", href: "/privacy" },
     { icon: Settings, label: "Settings", href: "/settings" },
   ];

--- a/client/src/pages/Memory.tsx
+++ b/client/src/pages/Memory.tsx
@@ -1,0 +1,378 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Brain, Search, Plus, Trash2, ChevronDown, ChevronUp, X } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+type MemoryScope = "global" | "workspace" | "pipeline" | "run";
+type MemoryType = "decision" | "pattern" | "fact" | "preference" | "issue" | "dependency";
+
+interface Memory {
+  id: number;
+  scope: MemoryScope;
+  scopeId: string | null;
+  type: MemoryType;
+  key: string;
+  content: string;
+  source: string | null;
+  confidence: number;
+  tags: string[] | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+const TYPE_COLORS: Record<MemoryType, string> = {
+  decision: "bg-blue-500/15 text-blue-600 border-blue-500/30",
+  pattern: "bg-purple-500/15 text-purple-600 border-purple-500/30",
+  fact: "bg-emerald-500/15 text-emerald-600 border-emerald-500/30",
+  preference: "bg-amber-500/15 text-amber-600 border-amber-500/30",
+  issue: "bg-red-500/15 text-red-600 border-red-500/30",
+  dependency: "bg-slate-500/15 text-slate-600 border-slate-500/30",
+};
+
+function ConfidenceBar({ value }: { value: number }) {
+  const pct = Math.max(0, Math.min(1, value)) * 100;
+  const color = pct >= 70 ? "bg-emerald-500" : pct >= 40 ? "bg-amber-500" : "bg-red-500";
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex-1 h-1.5 bg-muted rounded-full overflow-hidden">
+        <div className={cn("h-full rounded-full transition-all", color)} style={{ width: `${pct}%` }} />
+      </div>
+      <span className="text-[10px] text-muted-foreground w-7 text-right">{pct.toFixed(0)}%</span>
+    </div>
+  );
+}
+
+function timeAgo(dateStr: string | null): string {
+  if (!dateStr) return "unknown";
+  const ms = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(ms / 60000);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+interface AddMemoryFormProps {
+  onDone: () => void;
+}
+
+function AddMemoryForm({ onDone }: AddMemoryFormProps) {
+  const qc = useQueryClient();
+  const [scope, setScope] = useState<MemoryScope>("global");
+  const [type, setType] = useState<MemoryType>("fact");
+  const [key, setKey] = useState("");
+  const [content, setContent] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const create = useMutation({
+    mutationFn: async () => {
+      const res = await fetch("/api/memories", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scope, type, key: key.trim(), content: content.trim() }),
+      });
+      if (!res.ok) throw new Error("Failed to create memory");
+      return res.json();
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ["/api/memories"] });
+      onDone();
+    },
+    onError: (err: Error) => setError(err.message),
+  });
+
+  const handleSubmit = () => {
+    if (!key.trim() || !content.trim()) {
+      setError("Key and content are required");
+      return;
+    }
+    setError(null);
+    create.mutate();
+  };
+
+  return (
+    <div className="border border-border rounded-lg p-4 space-y-3 bg-card">
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="text-xs font-medium text-muted-foreground mb-1 block">Scope</label>
+          <Select value={scope} onValueChange={(v) => setScope(v as MemoryScope)}>
+            <SelectTrigger className="h-8 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="global">Global</SelectItem>
+              <SelectItem value="pipeline">Pipeline</SelectItem>
+              <SelectItem value="workspace">Workspace</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div>
+          <label className="text-xs font-medium text-muted-foreground mb-1 block">Type</label>
+          <Select value={type} onValueChange={(v) => setType(v as MemoryType)}>
+            <SelectTrigger className="h-8 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="decision">Decision</SelectItem>
+              <SelectItem value="pattern">Pattern</SelectItem>
+              <SelectItem value="fact">Fact</SelectItem>
+              <SelectItem value="preference">Preference</SelectItem>
+              <SelectItem value="issue">Issue</SelectItem>
+              <SelectItem value="dependency">Dependency</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div>
+        <label className="text-xs font-medium text-muted-foreground mb-1 block">Key</label>
+        <Input
+          className="h-8 text-xs font-mono"
+          placeholder="my-key"
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+        />
+      </div>
+      <div>
+        <label className="text-xs font-medium text-muted-foreground mb-1 block">Content</label>
+        <textarea
+          className="w-full h-20 text-xs rounded-md border border-input bg-background px-3 py-2 resize-none focus:outline-none focus:ring-1 focus:ring-ring"
+          placeholder="Memory content..."
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+        />
+      </div>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+      <div className="flex gap-2 justify-end">
+        <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={onDone}>
+          Cancel
+        </Button>
+        <Button size="sm" className="h-7 text-xs" onClick={handleSubmit} disabled={create.isPending}>
+          {create.isPending ? "Saving..." : "Save"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+interface MemoryCardProps {
+  memory: Memory;
+  onDelete: (id: number) => void;
+}
+
+function MemoryCard({ memory, onDelete }: MemoryCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const PREVIEW_LEN = 120;
+  const isLong = memory.content.length > PREVIEW_LEN;
+
+  return (
+    <div className="border border-border rounded-lg p-3 bg-card space-y-2 hover:border-primary/30 transition-colors">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-xs font-mono font-medium text-foreground truncate">{memory.key}</span>
+            <Badge className={cn("text-[10px] border", TYPE_COLORS[memory.type])}>
+              {memory.type}
+            </Badge>
+            <Badge variant="outline" className="text-[10px]">{memory.scope}</Badge>
+          </div>
+          <p className="text-xs text-muted-foreground mt-1">
+            {expanded || !isLong
+              ? memory.content
+              : memory.content.slice(0, PREVIEW_LEN) + "..."}
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 text-muted-foreground hover:text-destructive shrink-0"
+          onClick={() => onDelete(memory.id)}
+        >
+          <X className="h-3 w-3" />
+        </Button>
+      </div>
+
+      <ConfidenceBar value={memory.confidence} />
+
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] text-muted-foreground">
+          {memory.source ?? "unknown"} · {timeAgo(memory.updatedAt)}
+        </span>
+        {isLong && (
+          <button
+            className="text-[10px] text-primary hover:underline flex items-center gap-0.5"
+            onClick={() => setExpanded(!expanded)}
+          >
+            {expanded ? <><ChevronUp className="h-3 w-3" /> Less</> : <><ChevronDown className="h-3 w-3" /> More</>}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function Memory() {
+  const qc = useQueryClient();
+  const [search, setSearch] = useState("");
+  const [scopeFilter, setScopeFilter] = useState<string>("all");
+  const [typeFilter, setTypeFilter] = useState<string>("all");
+  const [showAddForm, setShowAddForm] = useState(false);
+
+  const queryKey = search
+    ? [`/api/memories?q=${encodeURIComponent(search)}`]
+    : ["/api/memories"];
+
+  const { data: memories = [], isLoading } = useQuery<Memory[]>({
+    queryKey,
+    queryFn: async () => {
+      const url = search
+        ? `/api/memories?q=${encodeURIComponent(search)}`
+        : "/api/memories";
+      const res = await fetch(url);
+      if (!res.ok) throw new Error("Failed to fetch memories");
+      return res.json() as Promise<Memory[]>;
+    },
+  });
+
+  const deleteMemory = useMutation({
+    mutationFn: async (id: number) => {
+      const res = await fetch(`/api/memories/${id}`, { method: "DELETE" });
+      if (!res.ok && res.status !== 204) throw new Error("Delete failed");
+    },
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ["/api/memories"] }),
+  });
+
+  const clearStale = useMutation({
+    mutationFn: async () => {
+      const res = await fetch("/api/memories/stale", { method: "DELETE" });
+      if (!res.ok) throw new Error("Failed to clear stale");
+      return res.json() as Promise<{ deleted: number }>;
+    },
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ["/api/memories"] }),
+  });
+
+  const filtered = memories.filter((m) => {
+    if (scopeFilter !== "all" && m.scope !== scopeFilter) return false;
+    if (typeFilter !== "all" && m.type !== typeFilter) return false;
+    return true;
+  });
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="h-16 border-b border-border flex items-center px-6 bg-card shrink-0">
+        <Brain className="h-5 w-5 mr-3 text-muted-foreground" />
+        <h1 className="text-lg font-semibold">Memory</h1>
+        <span className="ml-3 text-sm text-muted-foreground">
+          {memories.length} entries
+        </span>
+      </div>
+
+      <ScrollArea className="flex-1">
+        <div className="max-w-4xl mx-auto p-6 space-y-4">
+          {/* Search + Actions */}
+          <div className="flex items-center gap-3">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+              <Input
+                className="h-9 pl-9 text-sm"
+                placeholder="Search memories..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-9 text-xs text-destructive hover:text-destructive"
+              onClick={() => clearStale.mutate()}
+              disabled={clearStale.isPending}
+            >
+              <Trash2 className="h-3.5 w-3.5 mr-1.5" />
+              {clearStale.isPending ? "Clearing..." : "Clear Stale"}
+            </Button>
+            <Button
+              size="sm"
+              className="h-9 text-xs"
+              onClick={() => setShowAddForm(true)}
+            >
+              <Plus className="h-3.5 w-3.5 mr-1.5" /> Add Memory
+            </Button>
+          </div>
+
+          {/* Filters */}
+          <div className="flex items-center gap-3">
+            <Select value={scopeFilter} onValueChange={setScopeFilter}>
+              <SelectTrigger className="h-8 w-36 text-xs">
+                <SelectValue placeholder="Scope" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Scopes</SelectItem>
+                <SelectItem value="global">Global</SelectItem>
+                <SelectItem value="pipeline">Pipeline</SelectItem>
+                <SelectItem value="workspace">Workspace</SelectItem>
+                <SelectItem value="run">Run</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={typeFilter} onValueChange={setTypeFilter}>
+              <SelectTrigger className="h-8 w-40 text-xs">
+                <SelectValue placeholder="Type" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Types</SelectItem>
+                <SelectItem value="decision">Decision</SelectItem>
+                <SelectItem value="pattern">Pattern</SelectItem>
+                <SelectItem value="fact">Fact</SelectItem>
+                <SelectItem value="preference">Preference</SelectItem>
+                <SelectItem value="issue">Issue</SelectItem>
+                <SelectItem value="dependency">Dependency</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Add Form */}
+          {showAddForm && (
+            <AddMemoryForm onDone={() => setShowAddForm(false)} />
+          )}
+
+          {/* Memory Grid */}
+          {isLoading ? (
+            <div className="text-sm text-muted-foreground py-8 text-center">
+              Loading memories...
+            </div>
+          ) : filtered.length === 0 ? (
+            <Card>
+              <CardContent className="py-12">
+                <div className="text-center text-muted-foreground">
+                  <Brain className="h-10 w-10 mx-auto mb-3 opacity-30" />
+                  <p className="text-sm">No memories found</p>
+                  <p className="text-xs mt-1">Run pipelines to accumulate memories, or add one manually.</p>
+                </div>
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {filtered.map((m) => (
+                <MemoryCard
+                  key={m.id}
+                  memory={m}
+                  onDelete={(id) => deleteMemory.mutate(id)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -23,6 +23,7 @@ import {
   Save,
   Eye,
   EyeOff,
+  Brain,
 } from "lucide-react";
 import {
   useModels,
@@ -61,6 +62,86 @@ const CLOUD_PROVIDERS: Array<{
   { key: "google",    name: "Google (Gemini)",    envVar: "GOOGLE_API_KEY"    },
   { key: "xai",       name: "xAI (Grok)",         envVar: "XAI_API_KEY"       },
 ];
+
+const PREFERENCE_ROWS = [
+  { key: "preferred-language", label: "Preferred Language", placeholder: "e.g. TypeScript" },
+  { key: "error-handling-style", label: "Error Handling Style", placeholder: "e.g. throw exceptions, return Result types" },
+  { key: "preferred-db", label: "Preferred Database", placeholder: "e.g. PostgreSQL, SQLite" },
+  { key: "code-style", label: "Code Style", placeholder: "e.g. functional, OOP" },
+  { key: "test-framework", label: "Test Framework", placeholder: "e.g. Jest, Vitest" },
+];
+
+function MemoryPreferences() {
+  const qc = useQueryClient();
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [saved, setSaved] = useState<Record<string, boolean>>({});
+
+  const savePreference = useMutation({
+    mutationFn: async ({ key, value }: { key: string; value: string }) => {
+      const res = await fetch("/api/memories", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          scope: "global",
+          type: "preference",
+          key,
+          content: value,
+          confidence: 1.0,
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to save preference");
+      return res.json();
+    },
+    onSuccess: (_data, { key }) => {
+      setSaved((prev) => ({ ...prev, [key]: true }));
+      void qc.invalidateQueries({ queryKey: ["/api/memories"] });
+      setTimeout(() => setSaved((prev) => ({ ...prev, [key]: false })), 2000);
+    },
+  });
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Brain className="h-4 w-4" /> Project Memory Preferences
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-xs text-muted-foreground">
+          These preferences are stored as global memories and injected into every pipeline stage, helping the AI make consistent decisions aligned with your preferences.
+        </p>
+        {PREFERENCE_ROWS.map(({ key, label, placeholder }) => (
+          <div key={key} className="flex items-center gap-3">
+            <label className="text-xs font-medium w-44 shrink-0">{label}</label>
+            <Input
+              className="h-8 text-xs flex-1"
+              placeholder={placeholder}
+              value={values[key] ?? ""}
+              onChange={(e) => setValues((prev) => ({ ...prev, [key]: e.target.value }))}
+            />
+            <Button
+              size="sm"
+              className="h-8 text-xs shrink-0"
+              disabled={!values[key]?.trim() || savePreference.isPending}
+              onClick={() => {
+                const value = values[key]?.trim();
+                if (value) savePreference.mutate({ key, value });
+              }}
+            >
+              {saved[key] ? (
+                <CheckCircle2 className="h-3 w-3 text-emerald-500" />
+              ) : savePreference.isPending ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <><Save className="h-3 w-3 mr-1" /> Save</>
+              )}
+            </Button>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
 
 export default function Settings() {
   const { data: models, isLoading: modelsLoading } = useModels();
@@ -841,6 +922,10 @@ export default function Settings() {
               )}
             </CardContent>
           </Card>
+
+          {/* ── Memory Preferences ──────────────────────── */}
+          <MemoryPreferences />
+
         </div>
       </ScrollArea>
     </div>

--- a/server/controller/pipeline-controller.ts
+++ b/server/controller/pipeline-controller.ts
@@ -5,10 +5,14 @@ import type { PipelineStageConfig, WsEvent, SandboxFile, StageOutput } from "@sh
 import type { PipelineRun } from "@shared/schema";
 import { SandboxExecutor } from "../sandbox/executor";
 import { ThoughtTreeCollector } from "../pipeline/thought-tree-collector";
+import { MemoryExtractor } from "../memory/extractor";
+import { MemoryProvider } from "../memory/provider";
 
 export class PipelineController {
   private activeRuns: Map<string, AbortController> = new Map();
   private sandboxExecutor: SandboxExecutor;
+  private memoryExtractor: MemoryExtractor;
+  private memoryProvider: MemoryProvider;
 
   constructor(
     private storage: IStorage,
@@ -16,6 +20,8 @@ export class PipelineController {
     private wsManager: WsManager,
   ) {
     this.sandboxExecutor = new SandboxExecutor();
+    this.memoryExtractor = new MemoryExtractor();
+    this.memoryProvider = new MemoryProvider(storage);
   }
 
   async startRun(pipelineId: string, input: string): Promise<PipelineRun> {
@@ -121,6 +127,10 @@ export class PipelineController {
       }
     }
 
+    // Numeric run id for memory operations (hash the UUID string to a stable int)
+    const numericRunId = this.hashRunId(run.id);
+    const numericPipelineId = this.hashRunId(run.pipelineId);
+
     for (let i = startFromIndex; i < stages.length; i++) {
       if (signal.aborted) return;
 
@@ -172,6 +182,17 @@ export class PipelineController {
           input: stageInput,
         });
 
+        // Fetch relevant memories before execution
+        const relevantMemories = await this.memoryProvider.getRelevantMemories({
+          pipelineId: numericPipelineId,
+          runId: numericRunId,
+          teamId: stage.teamId,
+          maxTokenBudget: 2000,
+        });
+        const memoryContext = relevantMemories.length > 0
+          ? this.memoryProvider.formatForPrompt(relevantMemories)
+          : undefined;
+
         const context = {
           runId: run.id,
           stageIndex: i,
@@ -185,6 +206,7 @@ export class PipelineController {
             ? stage.privacySettings
             : undefined,
           sessionId: run.id,
+          memoryContext,
         };
 
         // Pass execution strategy (undefined = single, handled in BaseTeam)
@@ -199,6 +221,15 @@ export class PipelineController {
           collector.addFromLlmResponse(result.output.summary as string, stage.modelSlug);
         }
         const thoughtTree = collector.getTree();
+
+        // Extract and persist memories from stage output
+        const newMemories = await this.memoryExtractor.extractFromStageResult(
+          stage.teamId,
+          numericRunId,
+          numericPipelineId,
+          result.output ?? {},
+        );
+        await Promise.all(newMemories.map((m) => this.storage.upsertMemory(m)));
 
         // Check if team needs clarification
         if (result.questions && result.questions.length > 0) {
@@ -311,6 +342,7 @@ export class PipelineController {
             output: result.output,
             tokensUsed: result.tokensUsed,
             strategyResult: result.strategyResult ?? null,
+            memoriesUsed: relevantMemories.length,
           },
           timestamp: new Date().toISOString(),
         });
@@ -367,7 +399,9 @@ export class PipelineController {
       }
     }
 
-    // All stages complete
+    // All stages complete — decay unconfirmed memories
+    await this.memoryProvider.decayUnconfirmedMemories(numericRunId);
+
     const allOutputs = previousOutputs;
     await this.storage.updatePipelineRun(run.id, {
       status: "completed",
@@ -473,5 +507,14 @@ export class PipelineController {
 
   private broadcast(runId: string, event: WsEvent): void {
     this.wsManager.broadcastToRun(runId, event);
+  }
+
+  /**
+   * Converts a UUID string to a stable 32-bit integer for use as memory run/pipeline IDs.
+   * Uses the first 8 hex chars of the UUID (32-bit prefix).
+   */
+  private hashRunId(id: string): number {
+    const hex = id.replace(/-/g, "").slice(0, 8);
+    return parseInt(hex, 16) || 0;
   }
 }

--- a/server/memory/extractor.ts
+++ b/server/memory/extractor.ts
@@ -1,0 +1,187 @@
+import type { TeamId, InsertMemory, MemoryType, TeamMemoryHint } from "@shared/types";
+
+type ItemRecord = Record<string, unknown>;
+
+type StageRule = {
+  arrayPath?: string;
+  field?: string;
+  condition?: (item: ItemRecord) => boolean;
+  type: MemoryType;
+  keyFn: (item: ItemRecord, index: number) => string;
+  contentFn: (item: ItemRecord) => string;
+};
+
+const STAGE_RULES: Partial<Record<TeamId, StageRule[]>> = {
+  planning: [
+    {
+      arrayPath: "tasks",
+      type: "decision",
+      keyFn: (_item, i) => `task-${i}`,
+      contentFn: (item) => String(item.title ?? ""),
+    },
+    {
+      arrayPath: "risks",
+      type: "issue",
+      keyFn: (_item, i) => `risk-${i}`,
+      contentFn: (item) => String(item.description ?? ""),
+    },
+  ],
+  architecture: [
+    {
+      // techStack is an object — handled specially in extractByRules
+      field: "techStack",
+      type: "decision",
+      keyFn: (_item, _i) => "tech-stack",
+      contentFn: (item) => String(item.value ?? ""),
+    },
+    {
+      arrayPath: "components",
+      type: "fact",
+      keyFn: (item) => `component-${String(item.name ?? "unknown")}`,
+      contentFn: (item) => String(item.name ?? ""),
+    },
+  ],
+  development: [
+    {
+      arrayPath: "dependencies",
+      type: "dependency",
+      keyFn: (item) => `dep-${String(item.name ?? "unknown")}`,
+      contentFn: (item) => String(item.name ?? ""),
+    },
+  ],
+  testing: [
+    {
+      arrayPath: "issues",
+      condition: (item) => item.severity === "critical",
+      type: "issue",
+      keyFn: (_item, i) => `test-issue-${i}`,
+      contentFn: (item) => String(item.description ?? ""),
+    },
+  ],
+  code_review: [
+    {
+      arrayPath: "securityIssues",
+      type: "issue",
+      keyFn: (_item, i) => `security-${i}`,
+      contentFn: (item) => String(item.description ?? ""),
+    },
+  ],
+  deployment: [
+    {
+      field: "deploymentStrategy",
+      type: "decision",
+      keyFn: () => "deploy-strategy",
+      contentFn: (item) => String(item.value ?? ""),
+    },
+  ],
+};
+
+export class MemoryExtractor {
+  async extractFromStageResult(
+    teamId: TeamId,
+    runId: number,
+    pipelineId: number,
+    output: Record<string, unknown>,
+  ): Promise<InsertMemory[]> {
+    const ruleMemories = this.extractByRules(teamId, pipelineId, runId, output);
+    const hintMemories = this.extractModelHints(pipelineId, runId, output);
+    return [...ruleMemories, ...hintMemories];
+  }
+
+  private extractByRules(
+    teamId: TeamId,
+    pipelineId: number,
+    runId: number,
+    output: Record<string, unknown>,
+  ): InsertMemory[] {
+    const rules = STAGE_RULES[teamId];
+    if (!rules) return [];
+
+    const results: InsertMemory[] = [];
+    const source = `${teamId}/run-${runId}`;
+
+    for (const rule of rules) {
+      if (rule.arrayPath) {
+        const arr = output[rule.arrayPath];
+        if (!Array.isArray(arr)) continue;
+
+        arr.forEach((rawItem: unknown, i: number) => {
+          const item = rawItem as ItemRecord;
+          if (rule.condition && !rule.condition(item)) return;
+          const content = rule.contentFn(item);
+          if (!content) return;
+          results.push({
+            scope: "pipeline",
+            scopeId: String(pipelineId),
+            type: rule.type,
+            key: rule.keyFn(item, i),
+            content,
+            source,
+            createdByRunId: runId,
+          });
+        });
+      } else if (rule.field) {
+        const value = output[rule.field];
+        if (value === undefined || value === null) continue;
+
+        // techStack is a name→value object — emit one memory per key
+        if (rule.field === "techStack" && typeof value === "object" && !Array.isArray(value)) {
+          Object.entries(value as Record<string, unknown>).forEach(([name, v]) => {
+            results.push({
+              scope: "pipeline",
+              scopeId: String(pipelineId),
+              type: rule.type,
+              key: `tech-${name}`,
+              content: String(v ?? ""),
+              source,
+              createdByRunId: runId,
+            });
+          });
+        } else {
+          const item: ItemRecord = { value };
+          const content = rule.contentFn(item);
+          if (!content) continue;
+          results.push({
+            scope: "pipeline",
+            scopeId: String(pipelineId),
+            type: rule.type,
+            key: rule.keyFn(item, 0),
+            content,
+            source,
+            createdByRunId: runId,
+          });
+        }
+      }
+    }
+
+    return results;
+  }
+
+  private extractModelHints(
+    pipelineId: number,
+    runId: number,
+    output: Record<string, unknown>,
+  ): InsertMemory[] {
+    const rawHints = output.memories;
+    if (!Array.isArray(rawHints)) return [];
+
+    const source = `model-hints/run-${runId}`;
+    const results: InsertMemory[] = [];
+
+    for (const hint of rawHints) {
+      const h = hint as TeamMemoryHint;
+      if (!h.key || !h.content || !h.type) continue;
+      results.push({
+        scope: "pipeline",
+        scopeId: String(pipelineId),
+        type: h.type,
+        key: h.key,
+        content: h.content,
+        source,
+        createdByRunId: runId,
+      });
+    }
+
+    return results;
+  }
+}

--- a/server/memory/provider.ts
+++ b/server/memory/provider.ts
@@ -1,0 +1,103 @@
+import type { IStorage } from "../storage";
+import type { Memory, MemoryType } from "@shared/types";
+
+const SCOPE_WEIGHTS: Record<string, number> = {
+  pipeline: 0.8,
+  global: 0.4,
+  workspace: 0.6,
+  run: 1.0,
+};
+
+const CHARS_PER_TOKEN = 4;
+const DECAY_AMOUNT = 0.1;
+const STALE_THRESHOLD = 0.3;
+
+function recencyBoost(updatedAt: Date | null): number {
+  if (!updatedAt) return 0.5;
+  const ageMs = Date.now() - updatedAt.getTime();
+  const ageDays = ageMs / 86_400_000;
+  if (ageDays < 1) return 1.0;
+  if (ageDays < 7) return 0.9;
+  if (ageDays < 30) return 0.7;
+  return 0.5;
+}
+
+function scoreMemory(m: Memory): number {
+  const scopeWeight = SCOPE_WEIGHTS[m.scope] ?? 0.4;
+  return scopeWeight * m.confidence * recencyBoost(m.updatedAt);
+}
+
+export class MemoryProvider {
+  constructor(private storage: IStorage) {}
+
+  async getRelevantMemories(params: {
+    pipelineId: number;
+    runId: number;
+    teamId: string;
+    maxTokenBudget: number;
+  }): Promise<Memory[]> {
+    const [pipelineMems, globalMems] = await Promise.all([
+      this.storage.getMemories("pipeline", String(params.pipelineId)),
+      this.storage.getMemories("global"),
+    ]);
+
+    const all = [...pipelineMems, ...globalMems]
+      .filter((m) => m.confidence >= STALE_THRESHOLD)
+      .sort((a, b) => scoreMemory(b) - scoreMemory(a));
+
+    const budget = params.maxTokenBudget * CHARS_PER_TOKEN;
+    let used = 0;
+    const selected: Memory[] = [];
+
+    for (const m of all) {
+      const cost = m.content.length + m.key.length + 20;
+      if (used + cost > budget) break;
+      selected.push(m);
+      used += cost;
+    }
+
+    return selected;
+  }
+
+  formatForPrompt(memories: Memory[]): string {
+    const grouped: Partial<Record<MemoryType, Memory[]>> = {};
+
+    for (const m of memories) {
+      if (!grouped[m.type]) grouped[m.type] = [];
+      grouped[m.type]!.push(m);
+    }
+
+    const sectionTitles: Record<MemoryType, string> = {
+      decision: "Decisions",
+      fact: "Facts",
+      pattern: "Patterns",
+      preference: "Preferences",
+      issue: "Known Issues",
+      dependency: "Dependencies",
+    };
+
+    const sectionOrder: MemoryType[] = [
+      "decision", "fact", "pattern", "preference", "issue", "dependency",
+    ];
+
+    const lines: string[] = ["## Project Memory", ""];
+
+    for (const type of sectionOrder) {
+      const items = grouped[type];
+      if (!items || items.length === 0) continue;
+      lines.push(`**${sectionTitles[type]}:**`);
+      for (const m of items) {
+        const meta = `confidence: ${m.confidence.toFixed(1)}, source: ${m.source ?? "unknown"}`;
+        lines.push(`- [${m.key}] ${m.content} (${meta})`);
+      }
+      lines.push("");
+    }
+
+    return lines.join("\n").trimEnd();
+  }
+
+  async decayUnconfirmedMemories(runId: number): Promise<void> {
+    await this.storage.decayMemories(runId, DECAY_AMOUNT);
+    await this.storage.deleteStaleMemories(STALE_THRESHOLD);
+  }
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -13,6 +13,7 @@ import { registerGatewayRoutes } from "./routes/gateway";
 import { registerStrategyRoutes } from "./routes/strategies";
 import { registerPrivacyRoutes } from "./routes/privacy";
 import { registerStatsRoutes } from "./routes/stats";
+import { registerMemoryRoutes } from "./routes/memory";
 import { DEFAULT_MODELS, DEFAULT_PIPELINE_STAGES } from "@shared/constants";
 import { log } from "./index";
 
@@ -35,6 +36,7 @@ export async function registerRoutes(
   registerStrategyRoutes(app, storage);
   registerPrivacyRoutes(app);
   registerStatsRoutes(app, storage);
+  registerMemoryRoutes(app, storage);
 
   // Seed default models
   const existingModels = await storage.getModels();

--- a/server/routes/memory.ts
+++ b/server/routes/memory.ts
@@ -1,0 +1,154 @@
+import { Router } from "express";
+import { z } from "zod";
+import type { IStorage } from "../storage";
+import type { MemoryScope, MemoryType } from "@shared/types";
+
+const MEMORY_SCOPES = ["global", "workspace", "pipeline", "run"] as const;
+const MEMORY_TYPES = ["decision", "pattern", "fact", "preference", "issue", "dependency"] as const;
+
+const memoryBodySchema = z.object({
+  scope: z.enum(MEMORY_SCOPES),
+  scopeId: z.string().nullable().optional(),
+  type: z.enum(MEMORY_TYPES),
+  key: z.string().min(1).max(255),
+  content: z.string().min(1),
+  confidence: z.number().min(0).max(1).optional(),
+  tags: z.array(z.string()).optional(),
+  source: z.string().nullable().optional(),
+});
+
+const memoryUpdateSchema = z.object({
+  content: z.string().min(1).optional(),
+  confidence: z.number().min(0).max(1).optional(),
+});
+
+export function registerMemoryRoutes(app: Router, storage: IStorage): void {
+  // GET /api/memories — list all memories with optional filters
+  app.get("/api/memories", async (req, res) => {
+    try {
+      const { scope, type, q } = req.query as Record<string, string | undefined>;
+
+      if (q) {
+        const results = await storage.searchMemories(q, scope as MemoryScope | undefined);
+        return res.json(results);
+      }
+
+      if (scope) {
+        const results = await storage.getMemories(
+          scope as MemoryScope,
+          undefined,
+          type as MemoryType | undefined,
+        );
+        return res.json(results);
+      }
+
+      // Return all — fetch global + pipeline scopes
+      const [globalMems, pipelineMems, workspaceMems, runMems] = await Promise.all([
+        storage.getMemories("global"),
+        storage.getMemories("pipeline"),
+        storage.getMemories("workspace"),
+        storage.getMemories("run"),
+      ]);
+
+      const all = [...globalMems, ...pipelineMems, ...workspaceMems, ...runMems];
+      const filtered = type ? all.filter((m) => m.type === type) : all;
+      return res.json(filtered);
+    } catch {
+      return res.status(500).json({ error: "Failed to fetch memories" });
+    }
+  });
+
+  // GET /api/pipelines/:id/memories — memories for a specific pipeline
+  app.get("/api/pipelines/:id/memories", async (req, res) => {
+    try {
+      const results = await storage.getMemories("pipeline", req.params.id);
+      return res.json(results);
+    } catch {
+      return res.status(500).json({ error: "Failed to fetch pipeline memories" });
+    }
+  });
+
+  // POST /api/memories — create / upsert memory
+  app.post("/api/memories", async (req, res) => {
+    const parsed = memoryBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: parsed.error.flatten() });
+    }
+
+    try {
+      const memory = await storage.upsertMemory(parsed.data);
+      return res.status(201).json(memory);
+    } catch {
+      return res.status(500).json({ error: "Failed to upsert memory" });
+    }
+  });
+
+  // PUT /api/memories/:id — update content/confidence
+  app.put("/api/memories/:id", async (req, res) => {
+    const id = parseInt(req.params.id, 10);
+    if (isNaN(id)) {
+      return res.status(400).json({ error: "Invalid memory ID" });
+    }
+
+    const parsed = memoryUpdateSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: parsed.error.flatten() });
+    }
+
+    if (!parsed.data.content && parsed.data.confidence === undefined) {
+      return res.status(400).json({ error: "Provide content or confidence to update" });
+    }
+
+    try {
+      // Fetch existing to build upsert payload
+      const [existing] = await storage.searchMemories("", undefined).then((all) =>
+        all.filter((m) => m.id === id),
+      );
+
+      if (!existing) {
+        return res.status(404).json({ error: "Memory not found" });
+      }
+
+      const updated = await storage.upsertMemory({
+        scope: existing.scope,
+        scopeId: existing.scopeId,
+        type: existing.type,
+        key: existing.key,
+        content: parsed.data.content ?? existing.content,
+        confidence: parsed.data.confidence ?? existing.confidence,
+        source: existing.source,
+        tags: existing.tags ?? [],
+        createdByRunId: existing.createdByRunId ?? undefined,
+      });
+
+      return res.json(updated);
+    } catch {
+      return res.status(500).json({ error: "Failed to update memory" });
+    }
+  });
+
+  // DELETE /api/memories/stale — delete memories with confidence < 0.3
+  app.delete("/api/memories/stale", async (_req, res) => {
+    try {
+      const deleted = await storage.deleteStaleMemories(0.3);
+      return res.json({ deleted });
+    } catch {
+      return res.status(500).json({ error: "Failed to delete stale memories" });
+    }
+  });
+
+  // DELETE /api/memories/:id — delete a specific memory
+  app.delete("/api/memories/:id", async (req, res) => {
+    const id = parseInt(req.params.id, 10);
+    if (isNaN(id)) {
+      return res.status(400).json({ error: "Invalid memory ID" });
+    }
+
+    try {
+      await storage.deleteMemory(id);
+      return res.status(204).send();
+    } catch {
+      return res.status(500).json({ error: "Failed to delete memory" });
+    }
+  });
+}

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -1,9 +1,11 @@
-import { eq, desc, and, gte, lte, sql as drizzleSql } from "drizzle-orm";
+import { eq, desc, and, or, ilike, lt, ne, gte, lte, sql as drizzleSql } from "drizzle-orm";
 import { db } from "./db";
 import type { IStorage, LlmRequestFilters, LlmRequestStats, LlmStatsByModel, LlmStatsByProvider, LlmStatsByTeam, LlmTimelinePoint } from "./storage";
+import type { Memory, InsertMemory, MemoryScope, MemoryType } from "@shared/types";
 import {
   users, models, pipelines, pipelineRuns,
   stageExecutions, questions, chatMessages, llmRequests,
+  memories,
   type User, type InsertUser,
   type Model, type InsertModel,
   type Pipeline, type InsertPipeline,
@@ -416,5 +418,114 @@ export class PgStorage implements IStorage {
       tokens: r.tokens,
       costUsd: r.costUsd,
     }));
+  }
+
+  // ─── Memories ───────────────────────────────────────
+
+  private rowToMemory(row: typeof memories.$inferSelect): Memory {
+    return {
+      id: row.id,
+      scope: row.scope as Memory['scope'],
+      scopeId: row.scopeId ?? null,
+      type: row.type as Memory['type'],
+      key: row.key,
+      content: row.content,
+      source: row.source ?? null,
+      confidence: row.confidence,
+      tags: row.tags ?? [],
+      createdAt: row.createdAt ?? null,
+      updatedAt: row.updatedAt ?? null,
+      expiresAt: row.expiresAt ?? null,
+      createdByRunId: row.createdByRunId ?? null,
+    };
+  }
+
+  async getMemories(scope: MemoryScope, scopeId?: string | null, type?: MemoryType): Promise<Memory[]> {
+    const conditions = [eq(memories.scope, scope)];
+
+    if (scopeId !== undefined) {
+      conditions.push(scopeId === null
+        ? drizzleSql`${memories.scopeId} IS NULL`
+        : eq(memories.scopeId, scopeId));
+    }
+
+    if (type) {
+      conditions.push(eq(memories.type, type));
+    }
+
+    const rows = await db.select().from(memories).where(and(...conditions));
+    return rows.map((r) => this.rowToMemory(r));
+  }
+
+  async searchMemories(query: string, scope?: MemoryScope): Promise<Memory[]> {
+    const searchPattern = `%${query}%`;
+    const textMatch = or(
+      ilike(memories.key, searchPattern),
+      ilike(memories.content, searchPattern),
+    );
+
+    const condition = scope
+      ? and(textMatch, eq(memories.scope, scope))
+      : textMatch;
+
+    const rows = await db.select().from(memories).where(condition);
+    return rows.map((r) => this.rowToMemory(r));
+  }
+
+  async upsertMemory(insert: InsertMemory): Promise<Memory> {
+    const [row] = await db
+      .insert(memories)
+      .values({
+        scope: insert.scope,
+        scopeId: insert.scopeId ?? null,
+        type: insert.type,
+        key: insert.key,
+        content: insert.content,
+        source: insert.source ?? null,
+        confidence: insert.confidence ?? 1.0,
+        tags: insert.tags ?? [],
+        expiresAt: insert.expiresAt ?? null,
+        createdByRunId: insert.createdByRunId ?? null,
+      })
+      .onConflictDoUpdate({
+        target: [memories.scope, memories.scopeId, memories.key],
+        set: {
+          content: insert.content,
+          confidence: insert.confidence ?? 1.0,
+          source: insert.source ?? null,
+          updatedAt: new Date(),
+        },
+      })
+      .returning();
+    return this.rowToMemory(row);
+  }
+
+  async deleteMemory(id: number): Promise<void> {
+    await db.delete(memories).where(eq(memories.id, id));
+  }
+
+  async decayMemories(excludeRunId: number, decayAmount: number): Promise<number> {
+    const result = await db
+      .update(memories)
+      .set({
+        confidence: drizzleSql`${memories.confidence} - ${decayAmount}`,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          ne(memories.createdByRunId, excludeRunId),
+          drizzleSql`${memories.confidence} > ${decayAmount}`,
+        ),
+      )
+      .returning({ id: memories.id });
+    return result.length;
+  }
+
+  async deleteStaleMemories(threshold: number): Promise<number> {
+    const result = await db
+      .delete(memories)
+      .where(lt(memories.confidence, threshold))
+      .returning({ id: memories.id });
+    return result.length;
   }
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -16,6 +16,7 @@ import {
   type LlmRequest,
   type InsertLlmRequest,
 } from "@shared/schema";
+import type { Memory, InsertMemory, MemoryScope, MemoryType } from "@shared/types";
 import { randomUUID } from "crypto";
 import { PgStorage } from "./storage-pg";
 
@@ -130,6 +131,14 @@ export interface IStorage {
   getLlmStatsByProvider(): Promise<LlmStatsByProvider[]>;
   getLlmStatsByTeam(): Promise<LlmStatsByTeam[]>;
   getLlmTimeline(from: Date, to: Date, granularity: 'day' | 'week'): Promise<LlmTimelinePoint[]>;
+
+  // Memories
+  getMemories(scope: MemoryScope, scopeId?: string | null, type?: MemoryType): Promise<Memory[]>;
+  searchMemories(query: string, scope?: MemoryScope): Promise<Memory[]>;
+  upsertMemory(memory: InsertMemory): Promise<Memory>;
+  deleteMemory(id: number): Promise<void>;
+  decayMemories(excludeRunId: number, decayAmount: number): Promise<number>;
+  deleteStaleMemories(threshold: number): Promise<number>;
 }
 
 export class MemStorage implements IStorage {
@@ -142,6 +151,8 @@ export class MemStorage implements IStorage {
   private messages: Map<string, ChatMessage>;
   private llmRequestsMap: Map<number, LlmRequest>;
   private llmRequestIdSeq: number;
+  private memoriesMap: Map<number, Memory>;
+  private nextMemoryId: number;
 
   constructor() {
     this.users = new Map();
@@ -153,6 +164,8 @@ export class MemStorage implements IStorage {
     this.messages = new Map();
     this.llmRequestsMap = new Map();
     this.llmRequestIdSeq = 1;
+    this.memoriesMap = new Map();
+    this.nextMemoryId = 1;
   }
 
   // ─── Users ──────────────────────────────────────
@@ -611,6 +624,96 @@ export class MemStorage implements IStorage {
     }
 
     return Array.from(buckets.values()).sort((a, b) => a.date.localeCompare(b.date));
+  }
+
+  // ─── Memories ───────────────────────────────────
+
+  async getMemories(scope: MemoryScope, scopeId?: string | null, type?: MemoryType): Promise<Memory[]> {
+    return Array.from(this.memoriesMap.values()).filter((m) => {
+      if (m.scope !== scope) return false;
+      if (scopeId !== undefined && m.scopeId !== scopeId) return false;
+      if (type && m.type !== type) return false;
+      return true;
+    });
+  }
+
+  async searchMemories(query: string, scope?: MemoryScope): Promise<Memory[]> {
+    const lower = query.toLowerCase();
+    return Array.from(this.memoriesMap.values()).filter((m) => {
+      if (scope && m.scope !== scope) return false;
+      return (
+        m.key.toLowerCase().includes(lower) ||
+        m.content.toLowerCase().includes(lower)
+      );
+    });
+  }
+
+  async upsertMemory(insert: InsertMemory): Promise<Memory> {
+    const existing = Array.from(this.memoriesMap.values()).find(
+      (m) =>
+        m.scope === insert.scope &&
+        m.scopeId === (insert.scopeId ?? null) &&
+        m.key === insert.key,
+    );
+
+    if (existing) {
+      const updated: Memory = {
+        ...existing,
+        content: insert.content,
+        confidence: insert.confidence ?? existing.confidence,
+        source: insert.source ?? existing.source,
+        updatedAt: new Date(),
+      };
+      this.memoriesMap.set(existing.id, updated);
+      return updated;
+    }
+
+    const id = this.nextMemoryId++;
+    const now = new Date();
+    const memory: Memory = {
+      id,
+      scope: insert.scope,
+      scopeId: insert.scopeId ?? null,
+      type: insert.type,
+      key: insert.key,
+      content: insert.content,
+      source: insert.source ?? null,
+      confidence: insert.confidence ?? 1.0,
+      tags: insert.tags ?? [],
+      createdAt: now,
+      updatedAt: now,
+      expiresAt: insert.expiresAt ?? null,
+      createdByRunId: insert.createdByRunId ?? null,
+    };
+    this.memoriesMap.set(id, memory);
+    return memory;
+  }
+
+  async deleteMemory(id: number): Promise<void> {
+    this.memoriesMap.delete(id);
+  }
+
+  async decayMemories(excludeRunId: number, decayAmount: number): Promise<number> {
+    let count = 0;
+    for (const [id, m] of this.memoriesMap) {
+      if (m.createdByRunId !== excludeRunId) {
+        const updated = { ...m, confidence: m.confidence - decayAmount, updatedAt: new Date() };
+        this.memoriesMap.set(id, updated);
+        count++;
+      }
+    }
+    return count;
+  }
+
+  async deleteStaleMemories(threshold: number): Promise<number> {
+    let count = 0;
+    for (const [id, m] of this.memoriesMap) {
+      if (m.confidence < threshold) {
+        this.memoriesMap.delete(id);
+        count++;
+      }
+    }
+    return count;
   }
 }
 

--- a/server/teams/architecture.ts
+++ b/server/teams/architecture.ts
@@ -12,7 +12,7 @@ export class ArchitectureTeam extends BaseTeam {
       : input;
 
     return [
-      { role: "system", content: this.buildSystemMessage() },
+      { role: "system", content: this.buildSystemMessage(context) },
       {
         role: "user",
         content: `Design the architecture based on this planning output:\n\n${this.serializeInput(combined)}`,

--- a/server/teams/base.ts
+++ b/server/teams/base.ts
@@ -137,8 +137,12 @@ export abstract class BaseTeam {
     }
   }
 
-  protected buildSystemMessage(): string {
-    return this.config.systemPromptTemplate;
+  protected buildSystemMessage(context?: StageContext): string {
+    let base = this.config.systemPromptTemplate;
+    if (context?.memoryContext) {
+      base = `${base}\n\n${context.memoryContext}`;
+    }
+    return base;
   }
 
   protected serializeInput(input: Record<string, unknown>): string {

--- a/server/teams/code-review.ts
+++ b/server/teams/code-review.ts
@@ -15,7 +15,7 @@ export class CodeReviewTeam extends BaseTeam {
     };
 
     return [
-      { role: "system", content: this.buildSystemMessage() },
+      { role: "system", content: this.buildSystemMessage(context) },
       {
         role: "user",
         content: `Review the following code and tests for quality and security:\n\n${this.serializeInput(combined)}`,

--- a/server/teams/deployment.ts
+++ b/server/teams/deployment.ts
@@ -7,7 +7,7 @@ export class DeploymentTeam extends BaseTeam {
     context: StageContext,
   ): Array<{ role: string; content: string }> {
     return [
-      { role: "system", content: this.buildSystemMessage() },
+      { role: "system", content: this.buildSystemMessage(context) },
       {
         role: "user",
         content: `Generate deployment configurations based on all prior phase outputs:\n\n${this.serializeInput({ allOutputs: context.previousOutputs, ...input })}`,

--- a/server/teams/development.ts
+++ b/server/teams/development.ts
@@ -12,7 +12,7 @@ export class DevelopmentTeam extends BaseTeam {
       : input;
 
     return [
-      { role: "system", content: this.buildSystemMessage() },
+      { role: "system", content: this.buildSystemMessage(context) },
       {
         role: "user",
         content: `Generate production-ready code based on this architecture:\n\n${this.serializeInput(combined)}`,

--- a/server/teams/fact-check.ts
+++ b/server/teams/fact-check.ts
@@ -15,7 +15,7 @@ export class FactCheckTeam extends BaseTeam {
     const outputText = JSON.stringify(previousOutput, null, 2).slice(0, TRUNCATE_CHARS);
 
     return [
-      { role: "system", content: this.buildSystemMessage() },
+      { role: "system", content: this.buildSystemMessage(context) },
       {
         role: "user",
         content: `Fact-check the following pipeline stage output:\n\n\`\`\`json\n${outputText}\n\`\`\`\n\nUse your web search capability to verify claims, library versions, and check for security advisories.`,

--- a/server/teams/monitoring.ts
+++ b/server/teams/monitoring.ts
@@ -12,7 +12,7 @@ export class MonitoringTeam extends BaseTeam {
       : input;
 
     return [
-      { role: "system", content: this.buildSystemMessage() },
+      { role: "system", content: this.buildSystemMessage(context) },
       {
         role: "user",
         content: `Set up monitoring and observability for:\n\n${this.serializeInput(combined)}`,

--- a/server/teams/planning.ts
+++ b/server/teams/planning.ts
@@ -4,13 +4,13 @@ import type { StageContext } from "@shared/types";
 export class PlanningTeam extends BaseTeam {
   buildPrompt(
     input: Record<string, unknown>,
-    _context: StageContext,
+    context: StageContext,
   ): Array<{ role: string; content: string }> {
     const taskDescription =
       (input.taskDescription as string) ?? JSON.stringify(input);
 
     return [
-      { role: "system", content: this.buildSystemMessage() },
+      { role: "system", content: this.buildSystemMessage(context) },
       {
         role: "user",
         content: `Analyze and plan the following task:\n\n${taskDescription}`,

--- a/server/teams/testing.ts
+++ b/server/teams/testing.ts
@@ -12,7 +12,7 @@ export class TestingTeam extends BaseTeam {
       : input;
 
     return [
-      { role: "system", content: this.buildSystemMessage() },
+      { role: "system", content: this.buildSystemMessage(context) },
       {
         role: "user",
         content: `Generate comprehensive tests for the following code:\n\n${this.serializeInput(combined)}`,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -9,6 +9,7 @@ import {
   jsonb,
   serial,
   real,
+  unique,
 } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
@@ -265,3 +266,25 @@ export const insertLlmRequestSchema = createInsertSchema(llmRequests).omit({
 
 export type InsertLlmRequest = z.infer<typeof insertLlmRequestSchema>;
 export type LlmRequest = typeof llmRequests.$inferSelect;
+
+// ─── Memories ────────────────────────────────────────────────────────────────
+
+export const memories = pgTable("memories", {
+  id: serial("id").primaryKey(),
+  scope: text("scope").notNull(),
+  scopeId: text("scope_id"),
+  type: text("type").notNull(),
+  key: text("key").notNull(),
+  content: text("content").notNull(),
+  source: text("source"),
+  confidence: real("confidence").notNull().default(1.0),
+  tags: text("tags").array().default(sql`'{}'::text[]`),
+  createdAt: timestamp("created_at").defaultNow(),
+  updatedAt: timestamp("updated_at").defaultNow(),
+  expiresAt: timestamp("expires_at"),
+  createdByRunId: integer("created_by_run_id"),
+}, (table) => ({
+  scopeKeyUnique: unique().on(table.scope, table.scopeId, table.key),
+}));
+
+export type MemoryRow = typeof memories.$inferSelect;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -298,6 +298,7 @@ export interface StageContext {
   userAnswers?: Record<string, string>;
   privacySettings?: PrivacySettings;
   sessionId?: string;
+  memoryContext?: string;
 }
 
 export interface TeamResult {
@@ -393,3 +394,43 @@ export interface ThoughtNode {
 }
 
 export type ThoughtTree = ThoughtNode[];
+
+// ─── Memory Types ─────────────────────────────────────────────────────────────
+
+export type MemoryScope = 'global' | 'workspace' | 'pipeline' | 'run';
+export type MemoryType = 'decision' | 'pattern' | 'fact' | 'preference' | 'issue' | 'dependency';
+
+export interface Memory {
+  id: number;
+  scope: MemoryScope;
+  scopeId: string | null;
+  type: MemoryType;
+  key: string;
+  content: string;
+  source: string | null;
+  confidence: number;
+  tags: string[] | null;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+  expiresAt: Date | null;
+  createdByRunId: number | null;
+}
+
+export interface InsertMemory {
+  scope: MemoryScope;
+  scopeId?: string | null;
+  type: MemoryType;
+  key: string;
+  content: string;
+  source?: string | null;
+  confidence?: number;
+  tags?: string[];
+  expiresAt?: Date | null;
+  createdByRunId?: number | null;
+}
+
+export interface TeamMemoryHint {
+  key: string;
+  content: string;
+  type: MemoryType;
+}


### PR DESCRIPTION
## Summary

- **Persistent memory** stored in a `memories` table (scope/type/key unique constraint) with confidence scoring and expiry
- **Automatic extraction** after each stage: hard rules per team type (planning→decisions, architecture→techStack/components, development→dependencies, testing→critical issues, code_review→security issues, deployment→strategy) + optional model-provided `memories` hints in JSON output
- **Relevance-scored injection** before each stage: pipeline + global memories filtered by confidence >= 0.3, scored by scope weight × confidence × recency boost, fitted within a 2000-token budget and appended to system prompt
- **Confidence decay** after full run: memories not confirmed by the current run decay by 0.1; entries below 0.3 are purged

## Changes

### Backend
- `shared/schema.ts` — `memories` table with `real` confidence, `text[]` tags, unique on `(scope, scope_id, key)`
- `shared/types.ts` — `Memory`, `InsertMemory`, `TeamMemoryHint` types; `memoryContext?: string` on `StageContext`
- `server/storage.ts` — `IStorage` memory methods + `MemStorage` in-memory implementation
- `server/storage-pg.ts` — `PgStorage` with Drizzle `onConflictDoUpdate`, raw SQL decay, ILIKE search
- `server/memory/extractor.ts` — `MemoryExtractor` with per-stage rule table and model hint parsing
- `server/memory/provider.ts` — `MemoryProvider` with scoring formula, token-budget `formatForPrompt`, decay orchestration
- `server/controller/pipeline-controller.ts` — memory fetch before `team.execute()`, upsert after, decay after all stages; UUID→int hashing for memory IDs
- `server/teams/base.ts` — `buildSystemMessage(context?)` appends `memoryContext` when present
- `server/teams/*.ts` — all 8 team subclasses pass context to `buildSystemMessage`
- `server/routes/memory.ts` — `GET /api/memories`, `GET /api/pipelines/:id/memories`, `POST`, `PUT /:id`, `DELETE /:id`, `DELETE /stale`
- `server/routes.ts` — `registerMemoryRoutes` wired in

### Frontend
- `client/src/pages/Memory.tsx` — Memory page at `/memories`: search bar, scope/type filters, card grid with confidence bar and age, expandable content, add form, "Clear Stale" button
- `client/src/pages/Settings.tsx` — "Project Memory Preferences" card with 5 pre-populated rows that upsert global preference memories
- `client/src/components/layout/MainLayout.tsx` — Memory nav item (Brain icon)
- `client/src/App.tsx` — `/memories` route

## Test plan

- [ ] Start a pipeline run and verify memories are extracted and stored after each stage
- [ ] Run the same pipeline twice and verify second run receives memories from first in its system prompt
- [ ] Verify `upsertMemory` is idempotent — duplicate key+scope does not create duplicate rows
- [ ] Verify confidence decay: after a run completes, memories not touched by that run lose 0.1 confidence
- [ ] Verify stale memories (confidence < 0.3) are excluded from injection and cleaned up by `DELETE /api/memories/stale`
- [ ] Verify `formatForPrompt` respects token budget — run with many memories and check the injected context stays within 2000-token estimate
- [ ] Add a preference in Settings, start a pipeline, verify the preference appears in the Memory page and in stage output context
- [ ] Verify `/api/memories?q=` search returns relevant results
- [ ] Verify `DELETE /api/memories/:id` removes the entry