### PR TITLE
feat: Phase 3.1 — Tools, MCP & Knowledge Bases

### DIFF
--- a/client/src/components/pipeline/StageOutput.tsx
+++ b/client/src/components/pipeline/StageOutput.tsx
@@ -7,7 +7,8 @@ import StrategyViewer from "./StrategyViewer";
 import SandboxOutput from "./SandboxOutput";
 import ThoughtTree from "./ThoughtTree";
 import { CodeBlock } from "@/components/ui/CodeBlock";
-import type { StrategyResult, SandboxResult, ThoughtTree as ThoughtTreeType } from "@shared/types";
+import type { StrategyResult, SandboxResult, ThoughtTree as ThoughtTreeType, ToolCallLogEntry } from "@shared/types";
+import ToolCallLog from "./ToolCallLog";
 
 interface StageOutputProps {
   teamId: string;
@@ -16,6 +17,7 @@ interface StageOutputProps {
   strategyResult?: StrategyResult | null;
   isActive?: boolean;
   thoughtTree?: ThoughtTreeType | null;
+  toolCallLog?: ToolCallLogEntry[] | null;
 }
 
 export default function StageOutput({
@@ -25,6 +27,7 @@ export default function StageOutput({
   strategyResult,
   isActive,
   thoughtTree,
+  toolCallLog,
 }: StageOutputProps) {
   const [expanded, setExpanded] = useState(isActive ?? false);
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
@@ -160,6 +163,11 @@ export default function StageOutput({
           {/* Thought Tree */}
           {thoughtTree && thoughtTree.length > 0 && (
             <ThoughtTree nodes={thoughtTree} />
+          )}
+
+          {/* Tool call log */}
+          {toolCallLog && toolCallLog.length > 0 && (
+            <ToolCallLog entries={toolCallLog} />
           )}
 
           {/* Strategy intermediate outputs */}

--- a/client/src/components/pipeline/ToolCallLog.tsx
+++ b/client/src/components/pipeline/ToolCallLog.tsx
@@ -1,0 +1,103 @@
+import { useState } from "react";
+import { ChevronDown, ChevronRight, Clock, AlertCircle, CheckCircle2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ToolCallLogEntry } from "@shared/types";
+
+interface ToolCallLogProps {
+  entries: ToolCallLogEntry[];
+}
+
+function ToolCallEntry({ entry }: { entry: ToolCallLogEntry }) {
+  const [argsOpen, setArgsOpen] = useState(false);
+  const [resultOpen, setResultOpen] = useState(false);
+
+  const isError = entry.result.isError;
+
+  return (
+    <div className="border border-border rounded-md overflow-hidden text-xs">
+      {/* Header row */}
+      <div className="flex items-center gap-2 px-3 py-2 bg-muted/30">
+        {isError ? (
+          <AlertCircle className="h-3 w-3 text-destructive shrink-0" />
+        ) : (
+          <CheckCircle2 className="h-3 w-3 text-emerald-500 shrink-0" />
+        )}
+        <span className="font-mono font-medium text-foreground">{entry.call.name}</span>
+        <span className="text-muted-foreground">iteration {entry.iteration}</span>
+        <span className="ml-auto flex items-center gap-1 text-muted-foreground">
+          <Clock className="h-3 w-3" />
+          {entry.durationMs}ms
+        </span>
+      </div>
+
+      {/* Args section */}
+      <div className="border-t border-border">
+        <button
+          className="w-full flex items-center gap-1 px-3 py-1.5 text-muted-foreground hover:text-foreground hover:bg-muted/20 transition-colors"
+          onClick={() => setArgsOpen(!argsOpen)}
+        >
+          {argsOpen ? (
+            <ChevronDown className="h-3 w-3" />
+          ) : (
+            <ChevronRight className="h-3 w-3" />
+          )}
+          <span>Arguments</span>
+        </button>
+        {argsOpen && (
+          <div className="px-3 py-2 bg-muted/10 border-t border-border">
+            <pre className="whitespace-pre-wrap break-words text-xs font-mono text-foreground">
+              {JSON.stringify(entry.call.arguments, null, 2)}
+            </pre>
+          </div>
+        )}
+      </div>
+
+      {/* Result section */}
+      <div className="border-t border-border">
+        <button
+          className="w-full flex items-center gap-1 px-3 py-1.5 text-muted-foreground hover:text-foreground hover:bg-muted/20 transition-colors"
+          onClick={() => setResultOpen(!resultOpen)}
+        >
+          {resultOpen ? (
+            <ChevronDown className="h-3 w-3" />
+          ) : (
+            <ChevronRight className="h-3 w-3" />
+          )}
+          <span className={cn(isError ? "text-destructive" : "")}>
+            {isError ? "Error" : "Result"}
+          </span>
+        </button>
+        {resultOpen && (
+          <div className={cn(
+            "px-3 py-2 border-t border-border",
+            isError ? "bg-destructive/5" : "bg-muted/10",
+          )}>
+            <pre className={cn(
+              "whitespace-pre-wrap break-words text-xs font-mono",
+              isError ? "text-destructive" : "text-foreground",
+            )}>
+              {entry.result.content}
+            </pre>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function ToolCallLog({ entries }: ToolCallLogProps) {
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="space-y-1">
+      <p className="text-xs font-medium text-muted-foreground">
+        Tool Calls ({entries.length})
+      </p>
+      <div className="space-y-2">
+        {entries.map((entry, idx) => (
+          <ToolCallEntry key={idx} entry={entry} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/workflow/AgentNode.tsx
+++ b/client/src/components/workflow/AgentNode.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/lib/utils";
 import { SDLC_TEAMS, DEFAULT_TEMPERATURE, DEFAULT_MAX_TOKENS, MIN_TEMPERATURE, MAX_TEMPERATURE, TEMPERATURE_STEP } from "@shared/constants";
 import StrategyConfig from "./StrategyConfig";
 import SandboxConfig from "./SandboxConfig";
-import type { ExecutionStrategy, PrivacySettings, SandboxConfig as SandboxConfigType } from "@shared/types";
+import type { ExecutionStrategy, PrivacySettings, SandboxConfig as SandboxConfigType, StageToolConfig } from "@shared/types";
 
 interface ModelOption {
   label: string;
@@ -41,6 +41,8 @@ interface AgentNodeProps {
   onPrivacyChange: (id: string, settings: PrivacySettings) => void;
   sandboxConfig?: SandboxConfigType;
   onSandboxChange: (id: string, config: SandboxConfigType | undefined) => void;
+  toolConfig?: StageToolConfig;
+  onToolConfigChange: (id: string, config: StageToolConfig) => void;
   isLast: boolean;
 }
 
@@ -63,6 +65,18 @@ const DOT_COLOR_MAP: Record<string, string> = {
   cyan: "bg-cyan-500",
   rose: "bg-rose-500",
 };
+
+const DEFAULT_TEAM_TOOLS: Record<string, string[]> = {
+  planning:     ['web_search', 'knowledge_search', 'memory_search'],
+  architecture: ['web_search', 'knowledge_search', 'memory_search'],
+  development:  ['web_search', 'knowledge_search'],
+  testing:      ['knowledge_search'],
+  code_review:  ['web_search', 'knowledge_search', 'memory_search'],
+  deployment:   ['web_search', 'knowledge_search'],
+  monitoring:   ['web_search', 'knowledge_search'],
+};
+
+const ALL_BUILTIN_TOOLS = ['web_search', 'url_reader', 'knowledge_search', 'memory_search'];
 
 const DEFAULT_PRIVACY: PrivacySettings = {
   enabled: false,
@@ -93,6 +107,8 @@ export default function AgentNode({
   onPrivacyChange,
   sandboxConfig,
   onSandboxChange,
+  toolConfig,
+  onToolConfigChange,
   isLast,
 }: AgentNodeProps) {
   const team = SDLC_TEAMS[role as keyof typeof SDLC_TEAMS];
@@ -100,6 +116,7 @@ export default function AgentNode({
 
   const [promptExpanded, setPromptExpanded] = useState(false);
   const [advancedExpanded, setAdvancedExpanded] = useState(false);
+  const [toolsExpanded, setToolsExpanded] = useState(false);
   const [localPrompt, setLocalPrompt] = useState(systemPromptOverride ?? "");
   const [localMaxTokens, setLocalMaxTokens] = useState(
     String(maxTokens ?? DEFAULT_MAX_TOKENS),
@@ -324,6 +341,92 @@ export default function AgentNode({
             enabled={enabled}
             onChange={(s) => onStrategyChange(id, s)}
           />
+
+
+          {/* Tools Config */}
+          <div>
+            <button
+              type="button"
+              onClick={() => setToolsExpanded((prev) => !prev)}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              disabled={!enabled}
+            >
+              <span>Tools</span>
+              {toolsExpanded
+                ? <ChevronUp className="h-3 w-3 ml-1" />
+                : <ChevronDown className="h-3 w-3 ml-1" />}
+            </button>
+
+            {toolsExpanded && (
+              <div className="mt-3 space-y-3 p-3 rounded border border-border bg-muted/30">
+                <div className="flex items-center justify-between">
+                  <label className="text-xs font-medium text-muted-foreground">Enable tool calling</label>
+                  <Switch
+                    checked={toolConfig?.enabled ?? false}
+                    onCheckedChange={(checked) =>
+                      onToolConfigChange(id, {
+                        ...(toolConfig ?? { enabled: false }),
+                        enabled: checked,
+                        allowedTools: toolConfig?.allowedTools ?? (DEFAULT_TEAM_TOOLS[role] ?? []),
+                      })
+                    }
+                    disabled={!enabled}
+                  />
+                </div>
+
+                {(toolConfig?.enabled ?? false) && (
+                  <>
+                    <div>
+                      <label className="text-xs font-medium text-muted-foreground mb-1.5 block">Available Tools</label>
+                      <div className="space-y-1">
+                        {ALL_BUILTIN_TOOLS.map((toolName) => {
+                          const isAllowed = (toolConfig?.allowedTools ?? DEFAULT_TEAM_TOOLS[role] ?? []).includes(toolName);
+                          return (
+                            <div key={toolName} className="flex items-center justify-between">
+                              <span className="text-xs font-mono">{toolName}</span>
+                              <Switch
+                                checked={isAllowed}
+                                onCheckedChange={(checked) => {
+                                  const current = toolConfig?.allowedTools ?? DEFAULT_TEAM_TOOLS[role] ?? [];
+                                  const updated = checked
+                                    ? [...current, toolName]
+                                    : current.filter((t: string) => t !== toolName);
+                                  onToolConfigChange(id, { ...(toolConfig ?? { enabled: true }), allowedTools: updated });
+                                }}
+                                disabled={!enabled}
+                              />
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+
+                    <div>
+                      <div className="flex items-center justify-between mb-1">
+                        <label className="text-xs font-medium text-muted-foreground">
+                          Max tool calls
+                        </label>
+                        <span className="text-xs font-mono text-foreground">
+                          {toolConfig?.maxToolCalls ?? 10}
+                        </span>
+                      </div>
+                      <Slider
+                        min={1}
+                        max={10}
+                        step={1}
+                        value={[toolConfig?.maxToolCalls ?? 10]}
+                        onValueChange={([val]) =>
+                          onToolConfigChange(id, { ...(toolConfig ?? { enabled: true }), maxToolCalls: val })
+                        }
+                        disabled={!enabled}
+                        className="h-4"
+                      />
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
 
           {/* Sandbox Config */}
           <SandboxConfig

--- a/client/src/components/workflow/MultiAgentPipeline.tsx
+++ b/client/src/components/workflow/MultiAgentPipeline.tsx
@@ -7,7 +7,7 @@ import { Save, RotateCcw, Zap, Network } from "lucide-react";
 import AgentNode from "./AgentNode";
 import { usePipelines, useUpdatePipeline, useModels } from "@/hooks/use-pipeline";
 import { SDLC_TEAMS, TEAM_ORDER, STRATEGY_PRESETS, EXECUTION_STRATEGY_PRESETS } from "@shared/constants";
-import type { PipelineStageConfig, ExecutionStrategy, MoaStrategy, DebateStrategy, VotingStrategy, PrivacySettings, SandboxConfig } from "@shared/types";
+import type { PipelineStageConfig, ExecutionStrategy, MoaStrategy, DebateStrategy, VotingStrategy, PrivacySettings, SandboxConfig, StageToolConfig } from "@shared/types";
 
 interface MultiAgentPipelineProps {
   pipelineId?: string;
@@ -86,6 +86,13 @@ export default function MultiAgentPipeline({ pipelineId }: MultiAgentPipelinePro
   const updateSandbox = (teamId: string, config: SandboxConfig | undefined) => {
     setLocalStages(prev => prev.map(s =>
       s.teamId === teamId ? { ...s, sandbox: config } : s,
+    ));
+    setDirty(true);
+  };
+
+  const updateToolConfig = (teamId: string, config: StageToolConfig) => {
+    setLocalStages(prev => prev.map(s =>
+      s.teamId === teamId ? { ...s, tools: config } : s,
     ));
     setDirty(true);
   };
@@ -292,6 +299,8 @@ export default function MultiAgentPipeline({ pipelineId }: MultiAgentPipelinePro
                 onPrivacyChange={(_, settings) => updatePrivacy(stage.teamId, settings)}
                 sandboxConfig={stage.sandbox}
                 onSandboxChange={(_, cfg) => updateSandbox(stage.teamId, cfg)}
+                toolConfig={stage.tools}
+                onToolConfigChange={(_, cfg) => updateToolConfig(stage.teamId, cfg)}
                 isLast={idx === localStages.length - 1}
               />
             );

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -24,6 +24,9 @@ import {
   Eye,
   EyeOff,
   Brain,
+  Wrench,
+  Terminal,
+  Link2,
 } from "lucide-react";
 import {
   useModels,
@@ -157,6 +160,8 @@ export default function Settings() {
   const [probeType, setProbeType] = useState<"vllm" | "ollama">("ollama");
   const [probeResults, setProbeResults] = useState<unknown[] | null>(null);
   const [probeError, setProbeError] = useState<string | null>(null);
+  const [mcpForm, setMcpForm] = useState({ name: "", transport: "stdio", command: "", url: "", autoConnect: false });
+  const [mcpError, setMcpError] = useState<string | null>(null);
 
   // Per-provider test state: key → result or null (null = idle/loading)
   const [testResults, setTestResults] = useState<Partial<Record<CloudProvider, ProviderTestResult | null>>>({});
@@ -236,6 +241,78 @@ export default function Settings() {
       void qc.invalidateQueries({ queryKey: ["/api/gateway/status"] });
     },
   });
+
+
+  // MCP Servers
+  const { data: mcpServers, refetch: refetchMcpServers } = useQuery({
+    queryKey: ["/api/mcp/servers"],
+    queryFn: async () => {
+      const res = await fetch("/api/mcp/servers");
+      if (!res.ok) return [];
+      return res.json() as Promise<Array<Record<string, unknown>>>;
+    },
+  });
+
+  const { data: toolsStatus } = useQuery({
+    queryKey: ["/api/tools/status"],
+    queryFn: async () => {
+      const res = await fetch("/api/tools/status");
+      if (!res.ok) return {};
+      return res.json() as Promise<Record<string, { configured: boolean; keySource: string; premium?: boolean }>>;
+    },
+  });
+
+  const connectMcpServer = useMutation({
+    mutationFn: async (id: number) => {
+      const res = await fetch(`/api/mcp/servers/${id}/connect`, { method: "POST" });
+      return res.json();
+    },
+    onSuccess: () => void refetchMcpServers(),
+  });
+
+  const disconnectMcpServer = useMutation({
+    mutationFn: async (id: number) => {
+      const res = await fetch(`/api/mcp/servers/${id}/disconnect`, { method: "POST" });
+      return res.json();
+    },
+    onSuccess: () => void refetchMcpServers(),
+  });
+
+  const deleteMcpServer = useMutation({
+    mutationFn: async (id: number) => {
+      await fetch(`/api/mcp/servers/${id}`, { method: "DELETE" });
+    },
+    onSuccess: () => void refetchMcpServers(),
+  });
+
+  const addMcpServer = useMutation({
+    mutationFn: async (data: typeof mcpForm) => {
+      const res = await fetch("/api/mcp/servers", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: data.name,
+          transport: data.transport,
+          command: data.transport === "stdio" ? data.command || undefined : undefined,
+          url: data.transport !== "stdio" ? data.url || undefined : undefined,
+          autoConnect: data.autoConnect,
+          enabled: true,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json() as { error: unknown };
+        throw new Error(JSON.stringify(err.error));
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      setMcpForm({ name: "", transport: "stdio", command: "", url: "", autoConnect: false });
+      setMcpError(null);
+      void refetchMcpServers();
+    },
+    onError: (err: Error) => setMcpError(err.message),
+  });
+
 
   const modelList: Array<Record<string, unknown>> = Array.isArray(models) ? models as Array<Record<string, unknown>> : [];
   const registeredSlugs = new Set(modelList.map((m) => m.slug as string));
@@ -920,6 +997,182 @@ export default function Settings() {
                   ))}
                 </div>
               )}
+            </CardContent>
+          </Card>
+
+
+          {/* ── Tools & MCP ────────────────────────────── */}
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Wrench className="h-4 w-4" /> Tools & MCP
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {/* Built-in tools grid */}
+              <div>
+                <p className="text-xs font-medium text-muted-foreground mb-2">Built-in Tools</p>
+                <div className="grid grid-cols-2 gap-2">
+                  {[
+                    { name: "web_search", label: "Web Search", desc: (toolsStatus as Record<string, { keySource: string; premium?: boolean }> | undefined)?.web_search?.premium ? "Tavily (premium)" : "DuckDuckGo (fallback)" },
+                    { name: "url_reader", label: "URL Reader", desc: "Jina AI (free)" },
+                    { name: "knowledge_search", label: "Knowledge Search", desc: "Internal storage" },
+                    { name: "memory_search", label: "Memory Search", desc: "Internal storage" },
+                  ].map((tool) => (
+                    <div key={tool.name} className="flex items-start gap-2 p-3 rounded-lg border border-border bg-card">
+                      <CheckCircle2 className="h-4 w-4 text-emerald-500 shrink-0 mt-0.5" />
+                      <div className="min-w-0">
+                        <div className="text-xs font-medium font-mono">{tool.name}</div>
+                        <div className="text-xs text-muted-foreground">{tool.desc}</div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <p className="text-xs text-muted-foreground mt-2">
+                  Set <code className="font-mono bg-muted px-1 rounded">TAVILY_API_KEY</code> for premium web search results.
+                </p>
+              </div>
+
+              {/* MCP Servers */}
+              <div>
+                <p className="text-xs font-medium text-muted-foreground mb-2">MCP Servers</p>
+                {mcpServers && (mcpServers as Array<Record<string, unknown>>).length > 0 ? (
+                  <div className="space-y-2 mb-3">
+                    {(mcpServers as Array<Record<string, unknown>>).map((server) => (
+                      <div key={server.id as number} className="flex items-center gap-3 p-3 rounded-lg border border-border bg-card">
+                        <Terminal className="h-4 w-4 text-muted-foreground shrink-0" />
+                        <div className="flex-1 min-w-0">
+                          <div className="text-xs font-medium">{server.name as string}</div>
+                          <div className="text-xs text-muted-foreground font-mono">
+                            {server.transport as string}
+                            {server.command ? ` · ${server.command as string}` : ""}
+                            {server.url ? ` · ${server.url as string}` : ""}
+                          </div>
+                        </div>
+                        <Badge
+                          variant={server.connected ? "default" : "secondary"}
+                          className="text-[10px] shrink-0"
+                        >
+                          {server.connected ? "Connected" : "Disconnected"}
+                          {server.toolCount ? ` (${server.toolCount as number})` : ""}
+                        </Badge>
+                        {server.connected ? (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-7 text-xs shrink-0"
+                            onClick={() => disconnectMcpServer.mutate(server.id as number)}
+                            disabled={disconnectMcpServer.isPending}
+                          >
+                            Disconnect
+                          </Button>
+                        ) : (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-7 text-xs shrink-0"
+                            onClick={() => connectMcpServer.mutate(server.id as number)}
+                            disabled={connectMcpServer.isPending}
+                          >
+                            <Link2 className="h-3 w-3 mr-1" />
+                            Connect
+                          </Button>
+                        )}
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7 text-muted-foreground hover:text-destructive shrink-0"
+                          onClick={() => deleteMcpServer.mutate(server.id as number)}
+                        >
+                          <Trash2 className="h-3 w-3" />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-xs text-muted-foreground p-3 border border-dashed rounded-lg mb-3">
+                    No MCP servers configured.
+                  </div>
+                )}
+
+                {/* Add MCP Server Form */}
+                <div className="space-y-2 p-3 border border-border rounded-lg bg-muted/10">
+                  <p className="text-xs font-medium">Add MCP Server</p>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">Name</label>
+                      <Input
+                        className="h-7 text-xs"
+                        placeholder="my-mcp-server"
+                        value={mcpForm.name}
+                        onChange={(e) => setMcpForm((f) => ({ ...f, name: e.target.value }))}
+                      />
+                    </div>
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">Transport</label>
+                      <Select
+                        value={mcpForm.transport}
+                        onValueChange={(v) => setMcpForm((f) => ({ ...f, transport: v }))}
+                      >
+                        <SelectTrigger className="h-7 text-xs">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="stdio">stdio</SelectItem>
+                          <SelectItem value="sse">SSE</SelectItem>
+                          <SelectItem value="streamable-http">Streamable HTTP</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+                  {mcpForm.transport === "stdio" ? (
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">Command</label>
+                      <Input
+                        className="h-7 text-xs font-mono"
+                        placeholder="npx -y @modelcontextprotocol/server-filesystem /"
+                        value={mcpForm.command}
+                        onChange={(e) => setMcpForm((f) => ({ ...f, command: e.target.value }))}
+                      />
+                    </div>
+                  ) : (
+                    <div>
+                      <label className="text-xs text-muted-foreground mb-1 block">URL</label>
+                      <Input
+                        className="h-7 text-xs font-mono"
+                        placeholder="http://localhost:3001/mcp"
+                        value={mcpForm.url}
+                        onChange={(e) => setMcpForm((f) => ({ ...f, url: e.target.value }))}
+                      />
+                    </div>
+                  )}
+                  <div className="flex items-center gap-2">
+                    <Switch
+                      checked={mcpForm.autoConnect}
+                      onCheckedChange={(v) => setMcpForm((f) => ({ ...f, autoConnect: v }))}
+                    />
+                    <span className="text-xs text-muted-foreground">Auto-connect on save</span>
+                  </div>
+                  {mcpError && (
+                    <div className="text-xs text-destructive p-2 rounded border border-destructive/30 bg-destructive/5">
+                      {mcpError}
+                    </div>
+                  )}
+                  <Button
+                    size="sm"
+                    className="h-7 text-xs w-full"
+                    onClick={() => addMcpServer.mutate(mcpForm)}
+                    disabled={!mcpForm.name.trim() || addMcpServer.isPending}
+                  >
+                    {addMcpServer.isPending ? (
+                      <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                    ) : (
+                      <Plus className="h-3 w-3 mr-1" />
+                    )}
+                    Add Server
+                  </Button>
+                </div>
+              </div>
             </CardContent>
           </Card>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@google/generative-ai": "^0.24.1",
         "@hookform/resolvers": "^3.10.0",
         "@jridgewell/trace-mapping": "^0.3.25",
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-aspect-ratio": "^1.1.8",
@@ -1411,6 +1412,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@hookform/resolvers": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
@@ -1475,6 +1488,46 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -4321,6 +4374,39 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -4758,6 +4844,23 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cpu-features": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
@@ -4770,6 +4873,20 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/csstype": {
@@ -5357,6 +5474,27 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
@@ -5400,6 +5538,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express-session": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
@@ -5440,6 +5596,12 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-equals": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
@@ -5448,6 +5610,22 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -5698,6 +5876,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
+      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -5779,6 +5966,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -5803,6 +5999,12 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -5811,6 +6013,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -5844,6 +6055,18 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -6463,6 +6686,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
@@ -6585,6 +6817,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/postcss": {
@@ -7047,6 +7288,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -7210,6 +7460,27 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -8799,6 +9070,21 @@
         "@esbuild/win32-x64": "0.27.2"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/wouter": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/wouter/-/wouter-3.9.0.tgz",
@@ -8916,6 +9202,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     },
     "node_modules/zod-validation-error": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@google/generative-ai": "^0.24.1",
     "@hookform/resolvers": "^3.10.0",
     "@jridgewell/trace-mapping": "^0.3.25",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-aspect-ratio": "^1.1.8",

--- a/server/gateway/index.ts
+++ b/server/gateway/index.ts
@@ -1,5 +1,6 @@
 import type { IStorage } from "../storage";
-import type { GatewayRequest, GatewayResponse, ILLMProvider, ILLMProviderOptions, PrivacySettings, ProviderMessage } from "@shared/types";
+import { toolRegistry } from "../tools/index";
+import type { GatewayRequest, GatewayResponse, ILLMProvider, ILLMProviderOptions, PrivacySettings, ProviderMessage, ToolDefinition, ToolCallLogEntry } from "@shared/types";
 import { MockProvider } from "./providers/mock";
 import { VllmProvider } from "./providers/vllm";
 import { OllamaProvider } from "./providers/ollama";
@@ -171,7 +172,7 @@ export class Gateway {
     const privacy = privacyOptions?.privacy;
     const sessionId = privacyOptions?.sessionId ?? crypto.randomUUID();
 
-    let messages = request.messages;
+    let messages: ProviderMessage[] = request.messages as ProviderMessage[];
     if (this.shouldAnonymize(privacy)) {
       messages = request.messages.map((m) => ({
         ...m,
@@ -181,7 +182,7 @@ export class Gateway {
           privacy!.level,
           privacy!.vaultTtlMs,
         ).anonymizedText,
-      }));
+      })) as unknown as ProviderMessage[];
     }
 
     const start = Date.now();
@@ -247,7 +248,7 @@ export class Gateway {
     const privacy = privacyOptions?.privacy;
     const sessionId = privacyOptions?.sessionId ?? crypto.randomUUID();
 
-    let messages = request.messages;
+    let messages: ProviderMessage[] = request.messages as ProviderMessage[];
     if (this.shouldAnonymize(privacy)) {
       messages = request.messages.map((m) => ({
         ...m,
@@ -257,7 +258,7 @@ export class Gateway {
           privacy!.level,
           privacy!.vaultTtlMs,
         ).anonymizedText,
-      }));
+      })) as unknown as ProviderMessage[];
     }
 
     if (provider) {
@@ -304,6 +305,92 @@ export class Gateway {
     }
 
     return results;
+  }
+
+
+  /**
+   * Agentic tool loop: calls provider with tools, executes tool calls, feeds results back.
+   * Loops up to maxIterations (default 10) until provider stops calling tools.
+   */
+  async completeWithTools(params: {
+    modelSlug: string;
+    messages: ProviderMessage[];
+    tools: ToolDefinition[];
+    options?: ILLMProviderOptions;
+    maxIterations?: number;
+  }): Promise<{ content: string; tokensUsed: number; toolCallLog: ToolCallLogEntry[] }> {
+    const { modelSlug, tools, options } = params;
+    const maxIterations = params.maxIterations ?? 10;
+    const toolCallLog: ToolCallLogEntry[] = [];
+
+    const model = await this.storage.getModelBySlug(modelSlug);
+    const providerKey = model?.provider ?? 'mock';
+    const modelId = model?.modelId ?? model?.name ?? modelSlug;
+    const provider = this.getProvider(providerKey);
+
+    let messages: ProviderMessage[] = [...params.messages];
+    let totalTokensUsed = 0;
+    let iteration = 0;
+
+    while (iteration < maxIterations) {
+      iteration++;
+
+      let result: { content: string; tokensUsed: number; toolCalls?: import('@shared/types').ToolCall[]; finishReason?: 'stop' | 'tool_use' };
+
+      if (provider) {
+        result = await provider.complete(modelId, messages, {
+          ...options,
+          tools,
+          toolChoice: options?.toolChoice ?? 'auto',
+        });
+      } else {
+        const mockResult = await this.mockProvider.complete(
+          messages.map((m) => ({ role: m.role, content: 'content' in m ? m.content : '' })),
+          options,
+        );
+        result = { ...mockResult, finishReason: 'stop' as const };
+      }
+
+      totalTokensUsed += result.tokensUsed;
+
+      // If no tool calls or provider says stop, we're done
+      if (!result.toolCalls || result.toolCalls.length === 0 || result.finishReason !== 'tool_use') {
+        return { content: result.content, tokensUsed: totalTokensUsed, toolCallLog };
+      }
+
+      // Append assistant message with tool calls
+      messages.push({
+        role: 'assistant',
+        content: result.content,
+        toolCalls: result.toolCalls,
+      });
+
+      // Execute each tool call and collect results
+      for (const call of result.toolCalls) {
+        const callStart = Date.now();
+        const toolResult = await toolRegistry.execute(call);
+        const durationMs = Date.now() - callStart;
+
+        toolCallLog.push({
+          iteration,
+          call,
+          result: toolResult,
+          durationMs,
+        });
+
+        // Append tool result message
+        messages.push({
+          role: 'tool',
+          toolCallId: toolResult.toolCallId,
+          content: toolResult.content,
+        });
+      }
+    }
+
+    // Max iterations reached — return final content from last assistant message
+    const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant');
+    const content = lastAssistant && 'content' in lastAssistant ? lastAssistant.content : '';
+    return { content, tokensUsed: totalTokensUsed, toolCallLog };
   }
 
   async discoverFromEndpoint(

--- a/server/gateway/providers/claude.ts
+++ b/server/gateway/providers/claude.ts
@@ -1,5 +1,5 @@
 import Anthropic from "@anthropic-ai/sdk";
-import type { ILLMProvider, ILLMProviderOptions, ProviderMessage } from "@shared/types";
+import type { ILLMProvider, ILLMProviderOptions, ProviderMessage, ToolCall } from "@shared/types";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
@@ -26,6 +26,57 @@ async function withRetry<T>(fn: () => Promise<T>, label: string): Promise<T> {
   }
 }
 
+/** Convert our ProviderMessage format to Anthropic messages format. */
+function toAnthropicMessages(
+  messages: ProviderMessage[],
+): Array<Anthropic.Messages.MessageParam> {
+  const result: Anthropic.Messages.MessageParam[] = [];
+
+  for (const m of messages) {
+    if (m.role === "system") continue;
+
+    if (m.role === "tool") {
+      // Tool results go into a user message with tool_result content
+      result.push({
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: m.toolCallId,
+            content: m.content,
+          } as Anthropic.Messages.ToolResultBlockParam,
+        ],
+      });
+      continue;
+    }
+
+    if (m.role === "assistant" && m.toolCalls && m.toolCalls.length > 0) {
+      // Assistant with tool calls
+      const content: Anthropic.Messages.ContentBlock[] = [];
+      if (m.content) {
+        content.push({ type: "text", text: m.content } as Anthropic.Messages.TextBlock);
+      }
+      for (const tc of m.toolCalls) {
+        content.push({
+          type: "tool_use",
+          id: tc.id,
+          name: tc.name,
+          input: tc.arguments,
+        } as Anthropic.Messages.ToolUseBlock);
+      }
+      result.push({ role: "assistant", content });
+      continue;
+    }
+
+    result.push({
+      role: m.role as "user" | "assistant",
+      content: m.content,
+    });
+  }
+
+  return result;
+}
+
 export class ClaudeProvider implements ILLMProvider {
   private client: Anthropic;
 
@@ -43,23 +94,16 @@ export class ClaudeProvider implements ILLMProvider {
    */
   private extractSystem(messages: ProviderMessage[]): {
     system: string | undefined;
-    messages: Array<{ role: "user" | "assistant"; content: string }>;
+    messages: Array<Anthropic.Messages.MessageParam>;
   } {
     const systemParts = messages
       .filter((m) => m.role === "system")
       .map((m) => m.content)
       .join("\n");
 
-    const conversationMessages = messages
-      .filter((m) => m.role !== "system")
-      .map((m) => ({
-        role: m.role as "user" | "assistant",
-        content: m.content,
-      }));
-
     return {
       system: systemParts.length > 0 ? systemParts : undefined,
-      messages: conversationMessages,
+      messages: toAnthropicMessages(messages),
     };
   }
 
@@ -67,8 +111,27 @@ export class ClaudeProvider implements ILLMProvider {
     modelId: string,
     messages: ProviderMessage[],
     options?: ILLMProviderOptions,
-  ): Promise<{ content: string; tokensUsed: number }> {
+  ): Promise<{ content: string; tokensUsed: number; toolCalls?: ToolCall[]; finishReason?: 'stop' | 'tool_use' }> {
     const { system, messages: msgs } = this.extractSystem(messages);
+
+    // Build tools array for Anthropic API if provided
+    const anthropicTools: Anthropic.Messages.Tool[] | undefined =
+      options?.tools && options.tools.length > 0
+        ? options.tools.map((t) => ({
+            name: t.name,
+            description: t.description,
+            input_schema: t.inputSchema as Anthropic.Messages.Tool['input_schema'],
+          }))
+        : undefined;
+
+    const toolChoice: Anthropic.Messages.ToolChoiceAuto | Anthropic.Messages.ToolChoiceNone | Anthropic.Messages.ToolChoiceAny | undefined =
+      anthropicTools
+        ? options?.toolChoice === "none"
+          ? { type: "none" }
+          : options?.toolChoice === "required"
+          ? { type: "any" }
+          : { type: "auto" }
+        : undefined;
 
     const response = await withRetry(
       () =>
@@ -78,18 +141,36 @@ export class ClaudeProvider implements ILLMProvider {
           temperature: options?.temperature ?? 0.7,
           ...(system ? { system } : {}),
           messages: msgs,
+          ...(anthropicTools ? { tools: anthropicTools } : {}),
+          ...(toolChoice ? { tool_choice: toolChoice } : {}),
         }),
       `complete/${modelId}`,
     );
 
-    const content = response.content
-      .filter((block) => block.type === "text")
-      .map((block) => (block as { type: "text"; text: string }).text)
+    const textContent = response.content
+      .filter((block): block is Anthropic.Messages.TextBlock => block.type === "text")
+      .map((block) => block.text)
       .join("");
 
+    // Extract tool calls from response
+    const toolUseBlocks = response.content.filter(
+      (block): block is Anthropic.Messages.ToolUseBlock => block.type === "tool_use",
+    );
+
+    const toolCalls: ToolCall[] = toolUseBlocks.map((block) => ({
+      id: block.id,
+      name: block.name,
+      arguments: block.input as Record<string, unknown>,
+    }));
+
+    const finishReason: 'stop' | 'tool_use' =
+      response.stop_reason === "tool_use" ? "tool_use" : "stop";
+
     return {
-      content,
+      content: textContent,
       tokensUsed: (response.usage.input_tokens ?? 0) + (response.usage.output_tokens ?? 0),
+      toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+      finishReason,
     };
   }
 

--- a/server/gateway/providers/gemini.ts
+++ b/server/gateway/providers/gemini.ts
@@ -48,7 +48,7 @@ export class GeminiProvider implements ILLMProvider {
       .join("\n");
 
     const history: Content[] = messages
-      .filter((m) => m.role !== "system")
+      .filter((m) => m.role !== "system" && m.role !== "tool")
       .map((m) => ({
         role: m.role === "assistant" ? "model" : "user",
         parts: [{ text: m.content }],
@@ -64,7 +64,7 @@ export class GeminiProvider implements ILLMProvider {
     modelId: string,
     messages: ProviderMessage[],
     options?: ILLMProviderOptions,
-  ): Promise<{ content: string; tokensUsed: number }> {
+  ): Promise<{ content: string; tokensUsed: number; finishReason?: "stop" | "tool_use" }> {
     const { systemInstruction, history } = this.mapMessages(messages);
 
     // The last message must be the user turn; it's sent via sendMessage
@@ -92,7 +92,7 @@ export class GeminiProvider implements ILLMProvider {
     const content = response.text();
     const tokensUsed = response.usageMetadata?.totalTokenCount ?? 0;
 
-    return { content, tokensUsed };
+    return { content, tokensUsed, finishReason: "stop" as const };
   }
 
   async *stream(

--- a/server/gateway/providers/mock.ts
+++ b/server/gateway/providers/mock.ts
@@ -222,11 +222,11 @@ export class MockProvider {
   async complete(
     messages: Array<{ role: string; content: string }>,
     _options?: { maxTokens?: number },
-  ): Promise<{ content: string; tokensUsed: number }> {
+  ): Promise<{ content: string; tokensUsed: number; finishReason?: "stop" | "tool_use" }> {
     const team = detectTeam(messages);
     const input = extractUserInput(messages);
     const content = MOCK_RESPONSES[team](input);
-    return { content, tokensUsed: Math.floor(content.length / 4) };
+    return { content, tokensUsed: Math.floor(content.length / 4), finishReason: "stop" as const };
   }
 
   async *stream(

--- a/server/gateway/providers/ollama.ts
+++ b/server/gateway/providers/ollama.ts
@@ -44,7 +44,7 @@ export class OllamaProvider {
     model: string,
     messages: Array<{ role: string; content: string }>,
     options?: { maxTokens?: number; temperature?: number },
-  ): Promise<{ content: string; tokensUsed: number }> {
+  ): Promise<{ content: string; tokensUsed: number; finishReason?: "stop" | "tool_use" }> {
     const res = await fetch(`${this.baseUrl}/api/chat`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -73,6 +73,7 @@ export class OllamaProvider {
     return {
       content: data.message?.content ?? "",
       tokensUsed: (data.eval_count ?? 0) + (data.prompt_eval_count ?? 0),
+      finishReason: "stop" as const,
     };
   }
 

--- a/server/gateway/providers/openai-compatible.ts
+++ b/server/gateway/providers/openai-compatible.ts
@@ -1,7 +1,16 @@
-import type { ILLMProvider, ILLMProviderOptions, ProviderMessage } from "@shared/types";
+import type { ILLMProvider, ILLMProviderOptions, ProviderMessage, ToolCall } from "@shared/types";
+
+interface OpenAIToolCall {
+  id: string;
+  type: "function";
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
 
 interface OpenAIChoice {
-  message: { content: string };
+  message: { content: string | null; tool_calls?: OpenAIToolCall[] };
   finish_reason: string;
 }
 
@@ -48,6 +57,34 @@ async function fetchWithRetry(
   throw lastError ?? new Error("Request failed after retry");
 }
 
+/** Convert ProviderMessage[] to OpenAI chat messages format. */
+function toOpenAIMessages(messages: ProviderMessage[]): unknown[] {
+  return messages.map((m) => {
+    if (m.role === "tool") {
+      return {
+        role: "tool",
+        tool_call_id: m.toolCallId,
+        content: m.content,
+      };
+    }
+    if (m.role === "assistant" && m.toolCalls && m.toolCalls.length > 0) {
+      return {
+        role: "assistant",
+        content: m.content || null,
+        tool_calls: m.toolCalls.map((tc) => ({
+          id: tc.id,
+          type: "function",
+          function: {
+            name: tc.name,
+            arguments: JSON.stringify(tc.arguments),
+          },
+        })),
+      };
+    }
+    return { role: m.role, content: m.content };
+  });
+}
+
 export class OpenAICompatibleProvider implements ILLMProvider {
   constructor(
     protected readonly baseUrl: string,
@@ -67,20 +104,50 @@ export class OpenAICompatibleProvider implements ILLMProvider {
     modelId: string,
     messages: ProviderMessage[],
     options?: ILLMProviderOptions,
-  ): Promise<{ content: string; tokensUsed: number }> {
+  ): Promise<{ content: string; tokensUsed: number; toolCalls?: ToolCall[]; finishReason?: 'stop' | 'tool_use' }> {
     const timeoutMs = options?.timeoutMs ?? this.defaultTimeout;
+
+    // Build tools array for OpenAI API if provided
+    const openAiTools =
+      options?.tools && options.tools.length > 0
+        ? options.tools.map((t) => ({
+            type: "function" as const,
+            function: {
+              name: t.name,
+              description: t.description,
+              parameters: t.inputSchema,
+            },
+          }))
+        : undefined;
+
+    const toolChoice =
+      openAiTools
+        ? options?.toolChoice === "none"
+          ? "none"
+          : options?.toolChoice === "required"
+          ? "required"
+          : "auto"
+        : undefined;
+
+    const body: Record<string, unknown> = {
+      model: modelId,
+      messages: toOpenAIMessages(messages),
+      max_tokens: options?.maxTokens ?? 4096,
+      temperature: options?.temperature ?? 0.7,
+      stream: false,
+    };
+
+    if (openAiTools) {
+      body.tools = openAiTools;
+      body.tool_choice = toolChoice;
+    }
+
     const res = await fetchWithRetry(
       `${this.baseUrl}/v1/chat/completions`,
       {
         method: "POST",
         headers: this.buildHeaders(),
-        body: JSON.stringify({
-          model: modelId,
-          messages,
-          max_tokens: options?.maxTokens ?? 4096,
-          temperature: options?.temperature ?? 0.7,
-          stream: false,
-        }),
+        body: JSON.stringify(body),
       },
       timeoutMs,
     );
@@ -95,9 +162,32 @@ export class OpenAICompatibleProvider implements ILLMProvider {
       usage: { total_tokens: number };
     };
 
+    const choice = data.choices[0];
+    const content = choice?.message?.content ?? "";
+    const finishReason: 'stop' | 'tool_use' =
+      choice?.finish_reason === "tool_calls" ? "tool_use" : "stop";
+
+    // Extract tool calls if any
+    const rawToolCalls = choice?.message?.tool_calls ?? [];
+    const toolCalls: ToolCall[] = rawToolCalls.map((tc) => {
+      let args: Record<string, unknown> = {};
+      try {
+        args = JSON.parse(tc.function.arguments) as Record<string, unknown>;
+      } catch {
+        args = { _raw: tc.function.arguments };
+      }
+      return {
+        id: tc.id,
+        name: tc.function.name,
+        arguments: args,
+      };
+    });
+
     return {
-      content: data.choices[0]?.message?.content ?? "",
+      content,
       tokensUsed: data.usage?.total_tokens ?? 0,
+      toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+      finishReason,
     };
   }
 
@@ -114,7 +204,7 @@ export class OpenAICompatibleProvider implements ILLMProvider {
         headers: this.buildHeaders(),
         body: JSON.stringify({
           model: modelId,
-          messages,
+          messages: toOpenAIMessages(messages),
           max_tokens: options?.maxTokens ?? 4096,
           temperature: options?.temperature ?? 0.7,
           stream: true,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -14,6 +14,7 @@ import { registerStrategyRoutes } from "./routes/strategies";
 import { registerPrivacyRoutes } from "./routes/privacy";
 import { registerStatsRoutes } from "./routes/stats";
 import { registerMemoryRoutes } from "./routes/memory";
+import { registerToolRoutes } from "./routes/tools";
 import { DEFAULT_MODELS, DEFAULT_PIPELINE_STAGES } from "@shared/constants";
 import { log } from "./index";
 
@@ -37,6 +38,7 @@ export async function registerRoutes(
   registerPrivacyRoutes(app);
   registerStatsRoutes(app, storage);
   registerMemoryRoutes(app, storage);
+  registerToolRoutes(app, storage);
 
   // Seed default models
   const existingModels = await storage.getModels();

--- a/server/routes/tools.ts
+++ b/server/routes/tools.ts
@@ -1,0 +1,212 @@
+import type { Express } from "express";
+import { z } from "zod";
+import { toolRegistry } from "../tools/index";
+import { mcpClientManager } from "../tools/mcp-client";
+import type { IStorage } from "../storage";
+
+const createMcpServerSchema = z.object({
+  name: z.string().min(1).max(100),
+  transport: z.enum(["stdio", "sse", "streamable-http"]),
+  command: z.string().optional().nullable(),
+  args: z.array(z.string()).optional().nullable(),
+  url: z.string().url().optional().nullable(),
+  env: z.record(z.string()).optional().nullable(),
+  enabled: z.boolean().default(true),
+  autoConnect: z.boolean().default(false),
+});
+
+const updateMcpServerSchema = createMcpServerSchema.partial();
+
+const testToolSchema = z.object({
+  args: z.record(z.unknown()),
+});
+
+export function registerToolRoutes(app: Express, storage: IStorage): void {
+
+  // ─── Built-in Tools ─────────────────────────────────────────────────────────
+
+  /** GET /api/tools — all available tools (builtin + mcp) */
+  app.get("/api/tools", (_req, res) => {
+    const tools = toolRegistry.getAvailableTools();
+    res.json(tools);
+  });
+
+  /** GET /api/tools/status — configuration status of each tool */
+  app.get("/api/tools/status", (_req, res) => {
+    const hasTavily = !!process.env.TAVILY_API_KEY;
+
+    res.json({
+      web_search: {
+        configured: true,  // always available (fallback to DDG)
+        keySource: hasTavily ? "TAVILY_API_KEY" : "duckduckgo-fallback",
+        premium: hasTavily,
+      },
+      url_reader: {
+        configured: true,  // always available via Jina
+        keySource: "jina-ai-free",
+      },
+      knowledge_search: {
+        configured: true,
+        keySource: "internal-storage",
+      },
+      memory_search: {
+        configured: true,
+        keySource: "internal-storage",
+      },
+    });
+  });
+
+  /** POST /api/tools/:name/test — test a tool with given args */
+  app.post("/api/tools/:name/test", async (req, res) => {
+    const { name } = req.params as { name: string };
+    const parse = testToolSchema.safeParse(req.body);
+
+    if (!parse.success) {
+      return res.status(400).json({ error: parse.error.flatten() });
+    }
+
+    const toolDef = toolRegistry.getToolByName(name);
+    if (!toolDef) {
+      return res.status(404).json({ error: `Tool "${name}" not found` });
+    }
+
+    const call = {
+      id: crypto.randomUUID(),
+      name,
+      arguments: parse.data.args,
+    };
+
+    const result = await toolRegistry.execute(call);
+    return res.json(result);
+  });
+
+  // ─── MCP Servers ────────────────────────────────────────────────────────────
+
+  /** GET /api/mcp/servers — list all MCP server configs */
+  app.get("/api/mcp/servers", async (_req, res) => {
+    const servers = await storage.getMcpServers();
+    const connectionStatus = mcpClientManager.getStatus();
+
+    const enriched = servers.map((s) => ({
+      ...s,
+      // Never return env vars in API responses
+      env: undefined,
+      connected: !!connectionStatus[s.name]?.connected,
+      toolCount: connectionStatus[s.name]?.toolCount ?? s.toolCount,
+      connectionError: connectionStatus[s.name]?.error,
+    }));
+
+    res.json(enriched);
+  });
+
+  /** POST /api/mcp/servers — create a new MCP server config */
+  app.post("/api/mcp/servers", async (req, res) => {
+    const parse = createMcpServerSchema.safeParse(req.body);
+    if (!parse.success) {
+      return res.status(400).json({ error: parse.error.flatten() });
+    }
+
+    const data = parse.data;
+    const server = await storage.createMcpServer({
+      name: data.name,
+      transport: data.transport,
+      command: data.command ?? null,
+      args: data.args ?? null,
+      url: data.url ?? null,
+      env: data.env ?? null,
+      enabled: data.enabled,
+      autoConnect: data.autoConnect,
+      toolCount: 0,
+    });
+
+    // Auto-connect if requested
+    if (data.autoConnect && data.enabled) {
+      try {
+        await mcpClientManager.connect(server);
+        await storage.updateMcpServer(server.id, {
+          toolCount: mcpClientManager.getTools(data.name).length,
+          lastConnectedAt: new Date(),
+        });
+      } catch (err) {
+        console.warn(`[mcp] Auto-connect failed for "${data.name}":`, err);
+      }
+    }
+
+    return res.status(201).json({ ...server, env: undefined });
+  });
+
+  /** PUT /api/mcp/servers/:id — update a server config */
+  app.put("/api/mcp/servers/:id", async (req, res) => {
+    const id = parseInt(req.params.id as string, 10);
+    if (isNaN(id)) return res.status(400).json({ error: "Invalid server id" });
+
+    const parse = updateMcpServerSchema.safeParse(req.body);
+    if (!parse.success) {
+      return res.status(400).json({ error: parse.error.flatten() });
+    }
+
+    const existing = await storage.getMcpServer(id);
+    if (!existing) return res.status(404).json({ error: "Server not found" });
+
+    const updated = await storage.updateMcpServer(id, parse.data);
+    return res.json({ ...updated, env: undefined });
+  });
+
+  /** DELETE /api/mcp/servers/:id — delete a server config */
+  app.delete("/api/mcp/servers/:id", async (req, res) => {
+    const id = parseInt(req.params.id as string, 10);
+    if (isNaN(id)) return res.status(400).json({ error: "Invalid server id" });
+
+    const server = await storage.getMcpServer(id);
+    if (!server) return res.status(404).json({ error: "Server not found" });
+
+    // Disconnect if connected
+    await mcpClientManager.disconnect(server.name);
+    await storage.deleteMcpServer(id);
+    res.status(204).end();
+  });
+
+  /** POST /api/mcp/servers/:id/connect — connect to a server */
+  app.post("/api/mcp/servers/:id/connect", async (req, res) => {
+    const id = parseInt(req.params.id as string, 10);
+    if (isNaN(id)) return res.status(400).json({ error: "Invalid server id" });
+
+    const server = await storage.getMcpServer(id);
+    if (!server) return res.status(404).json({ error: "Server not found" });
+    if (!server.enabled) return res.status(400).json({ error: "Server is disabled" });
+
+    try {
+      await mcpClientManager.connect(server);
+      const toolCount = mcpClientManager.getTools(server.name).length;
+      await storage.updateMcpServer(id, { toolCount, lastConnectedAt: new Date() });
+      return res.json({ connected: true, toolCount });
+    } catch (err) {
+      const message = (err as Error).message;
+      return res.status(500).json({ connected: false, error: message });
+    }
+  });
+
+  /** POST /api/mcp/servers/:id/disconnect — disconnect from a server */
+  app.post("/api/mcp/servers/:id/disconnect", async (req, res) => {
+    const id = parseInt(req.params.id as string, 10);
+    if (isNaN(id)) return res.status(400).json({ error: "Invalid server id" });
+
+    const server = await storage.getMcpServer(id);
+    if (!server) return res.status(404).json({ error: "Server not found" });
+
+    await mcpClientManager.disconnect(server.name);
+    return res.json({ connected: false });
+  });
+
+  /** GET /api/mcp/servers/:id/tools — list tools from a specific server */
+  app.get("/api/mcp/servers/:id/tools", async (req, res) => {
+    const id = parseInt(req.params.id as string, 10);
+    if (isNaN(id)) return res.status(400).json({ error: "Invalid server id" });
+
+    const server = await storage.getMcpServer(id);
+    if (!server) return res.status(404).json({ error: "Server not found" });
+
+    const tools = mcpClientManager.getTools(server.name);
+    return res.json(tools);
+  });
+}

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -1,11 +1,12 @@
 import { eq, desc, and, or, ilike, lt, ne, gte, lte, sql as drizzleSql } from "drizzle-orm";
 import { db } from "./db";
 import type { IStorage, LlmRequestFilters, LlmRequestStats, LlmStatsByModel, LlmStatsByProvider, LlmStatsByTeam, LlmTimelinePoint } from "./storage";
-import type { Memory, InsertMemory, MemoryScope, MemoryType } from "@shared/types";
+import type { Memory, InsertMemory, MemoryScope, MemoryType, McpServerConfig } from "@shared/types";
 import {
   users, models, pipelines, pipelineRuns,
   stageExecutions, questions, chatMessages, llmRequests,
   memories,
+  mcpServers,
   type User, type InsertUser,
   type Model, type InsertModel,
   type Pipeline, type InsertPipeline,
@@ -528,4 +529,77 @@ export class PgStorage implements IStorage {
       .returning({ id: memories.id });
     return result.length;
   }
+  // ─── MCP Servers ────────────────────────────────────
+
+  private rowToMcpServer(row: typeof mcpServers.$inferSelect): McpServerConfig {
+    return {
+      id: row.id,
+      name: row.name,
+      transport: row.transport as McpServerConfig['transport'],
+      command: row.command ?? null,
+      args: (row.args as string[] | null) ?? null,
+      url: row.url ?? null,
+      env: (row.env as Record<string, string> | null) ?? null,
+      enabled: row.enabled,
+      autoConnect: row.autoConnect,
+      toolCount: row.toolCount ?? 0,
+      lastConnectedAt: row.lastConnectedAt ?? null,
+      createdAt: row.createdAt ?? null,
+    };
+  }
+
+  async getMcpServers(): Promise<McpServerConfig[]> {
+    const rows = await db.select().from(mcpServers).orderBy(mcpServers.name);
+    return rows.map((r) => this.rowToMcpServer(r));
+  }
+
+  async getMcpServer(id: number): Promise<McpServerConfig | undefined> {
+    const [row] = await db.select().from(mcpServers).where(eq(mcpServers.id, id));
+    return row ? this.rowToMcpServer(row) : undefined;
+  }
+
+  async createMcpServer(config: Omit<McpServerConfig, 'id'>): Promise<McpServerConfig> {
+    const [row] = await db
+      .insert(mcpServers)
+      .values({
+        name: config.name,
+        transport: config.transport,
+        command: config.command ?? null,
+        args: config.args ?? null,
+        url: config.url ?? null,
+        env: config.env ?? null,
+        enabled: config.enabled,
+        autoConnect: config.autoConnect,
+        toolCount: config.toolCount ?? 0,
+        lastConnectedAt: config.lastConnectedAt ?? null,
+      })
+      .returning();
+    return this.rowToMcpServer(row);
+  }
+
+  async updateMcpServer(id: number, updates: Partial<McpServerConfig>): Promise<McpServerConfig> {
+    const [row] = await db
+      .update(mcpServers)
+      .set({
+        ...(updates.name !== undefined && { name: updates.name }),
+        ...(updates.transport !== undefined && { transport: updates.transport }),
+        ...(updates.command !== undefined && { command: updates.command }),
+        ...(updates.args !== undefined && { args: updates.args }),
+        ...(updates.url !== undefined && { url: updates.url }),
+        ...(updates.env !== undefined && { env: updates.env }),
+        ...(updates.enabled !== undefined && { enabled: updates.enabled }),
+        ...(updates.autoConnect !== undefined && { autoConnect: updates.autoConnect }),
+        ...(updates.toolCount !== undefined && { toolCount: updates.toolCount }),
+        ...(updates.lastConnectedAt !== undefined && { lastConnectedAt: updates.lastConnectedAt }),
+      })
+      .where(eq(mcpServers.id, id))
+      .returning();
+    if (!row) throw new Error(`MCP server not found: ${id}`);
+    return this.rowToMcpServer(row);
+  }
+
+  async deleteMcpServer(id: number): Promise<void> {
+    await db.delete(mcpServers).where(eq(mcpServers.id, id));
+  }
+
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -16,7 +16,7 @@ import {
   type LlmRequest,
   type InsertLlmRequest,
 } from "@shared/schema";
-import type { Memory, InsertMemory, MemoryScope, MemoryType } from "@shared/types";
+import type { Memory, InsertMemory, MemoryScope, MemoryType, McpServerConfig } from "@shared/types";
 import { randomUUID } from "crypto";
 import { PgStorage } from "./storage-pg";
 
@@ -139,6 +139,13 @@ export interface IStorage {
   deleteMemory(id: number): Promise<void>;
   decayMemories(excludeRunId: number, decayAmount: number): Promise<number>;
   deleteStaleMemories(threshold: number): Promise<number>;
+
+  // MCP Servers
+  getMcpServers(): Promise<McpServerConfig[]>;
+  getMcpServer(id: number): Promise<McpServerConfig | undefined>;
+  createMcpServer(config: Omit<McpServerConfig, 'id'>): Promise<McpServerConfig>;
+  updateMcpServer(id: number, updates: Partial<McpServerConfig>): Promise<McpServerConfig>;
+  deleteMcpServer(id: number): Promise<void>;
 }
 
 export class MemStorage implements IStorage {
@@ -153,6 +160,8 @@ export class MemStorage implements IStorage {
   private llmRequestIdSeq: number;
   private memoriesMap: Map<number, Memory>;
   private nextMemoryId: number;
+  private mcpServersMap: Map<number, McpServerConfig>;
+  private nextMcpServerId: number;
 
   constructor() {
     this.users = new Map();
@@ -166,6 +175,8 @@ export class MemStorage implements IStorage {
     this.llmRequestIdSeq = 1;
     this.memoriesMap = new Map();
     this.nextMemoryId = 1;
+    this.mcpServersMap = new Map();
+    this.nextMcpServerId = 1;
   }
 
   // ─── Users ──────────────────────────────────────
@@ -715,6 +726,41 @@ export class MemStorage implements IStorage {
     }
     return count;
   }
+
+  // ─── MCP Servers ───────────────────────────────
+
+  async getMcpServers(): Promise<McpServerConfig[]> {
+    return Array.from(this.mcpServersMap.values()).filter((s) => true);
+  }
+
+  async getMcpServer(id: number): Promise<McpServerConfig | undefined> {
+    return this.mcpServersMap.get(id);
+  }
+
+  async createMcpServer(config: Omit<McpServerConfig, 'id'>): Promise<McpServerConfig> {
+    const id = this.nextMcpServerId++;
+    const server: McpServerConfig = {
+      ...config,
+      id,
+      toolCount: config.toolCount ?? 0,
+      createdAt: new Date(),
+    };
+    this.mcpServersMap.set(id, server);
+    return server;
+  }
+
+  async updateMcpServer(id: number, updates: Partial<McpServerConfig>): Promise<McpServerConfig> {
+    const server = this.mcpServersMap.get(id);
+    if (!server) throw new Error(`MCP server not found: ${id}`);
+    const updated = { ...server, ...updates };
+    this.mcpServersMap.set(id, updated);
+    return updated;
+  }
+
+  async deleteMcpServer(id: number): Promise<void> {
+    this.mcpServersMap.delete(id);
+  }
+
 }
 
 export const storage: IStorage = process.env.DATABASE_URL

--- a/server/teams/base.ts
+++ b/server/teams/base.ts
@@ -1,10 +1,21 @@
+import { toolRegistry } from "../tools/index";
 import type { Gateway } from "../gateway/index";
 import type { WsManager } from "../ws/manager";
-import type { TeamConfig, StageContext, TeamResult, ExecutionStrategy, ProviderMessage } from "@shared/types";
+import type { TeamConfig, StageContext, TeamResult, ExecutionStrategy, ProviderMessage, TeamId } from "@shared/types";
 import { StrategyExecutor } from "../services/strategy-executor";
 
 const CONTEXT_STAGES_TO_SHOW = 3;
 const CONTEXT_TRUNCATE_CHARS = 500;
+
+const DEFAULT_TEAM_TOOLS: Partial<Record<TeamId, string[]>> = {
+  planning:     ['web_search', 'knowledge_search', 'memory_search'],
+  architecture: ['web_search', 'knowledge_search', 'memory_search'],
+  development:  ['web_search', 'knowledge_search'],
+  testing:      ['knowledge_search'],
+  code_review:  ['web_search', 'knowledge_search', 'memory_search'],
+  deployment:   ['web_search', 'knowledge_search'],
+  monitoring:   ['web_search', 'knowledge_search'],
+};
 
 export abstract class BaseTeam {
   private strategyExecutor: StrategyExecutor;
@@ -32,7 +43,7 @@ export abstract class BaseTeam {
     context: StageContext,
     executionStrategy?: ExecutionStrategy,
   ): Promise<TeamResult> {
-    const messages = this.buildPrompt(input, context);
+    const messages: ProviderMessage[] = this.buildPrompt(input, context) as unknown as ProviderMessage[];
 
     const strategy = executionStrategy ?? { type: "single" as const };
 
@@ -47,6 +58,48 @@ export abstract class BaseTeam {
     messages: ProviderMessage[],
     context: StageContext,
   ): Promise<TeamResult> {
+    const toolConfig = context.stageConfig?.tools;
+    const defaultTools = DEFAULT_TEAM_TOOLS[this.config.id] ?? [];
+    const useTools = toolConfig?.enabled ?? defaultTools.length > 0;
+
+    if (useTools) {
+      // Filter tools per stage config
+      let allowedNames: string[] | undefined = toolConfig?.allowedTools ?? defaultTools;
+      const blockedNames = toolConfig?.blockedTools ?? [];
+      if (blockedNames.length > 0) {
+        allowedNames = allowedNames.filter((n) => !blockedNames.includes(n));
+      }
+
+      const tools = toolRegistry.getAvailableTools().filter(
+        (t) => allowedNames === undefined || allowedNames.includes(t.name),
+      );
+
+      if (tools.length > 0) {
+        const result = await this.gateway.completeWithTools({
+          modelSlug: context.modelSlug || this.config.defaultModelSlug,
+          messages,
+          tools,
+          options: {
+            temperature: context.temperature,
+            maxTokens: context.maxTokens,
+            toolChoice: toolConfig?.toolChoice ?? 'auto',
+          },
+          maxIterations: toolConfig?.maxToolCalls ?? 10,
+        });
+
+        const parsed = this.parseOutput(result.content);
+        const questions = this.extractQuestions(parsed);
+
+        return {
+          output: parsed,
+          tokensUsed: result.tokensUsed,
+          raw: result.content,
+          questions: questions.length > 0 ? questions : undefined,
+          toolCallLog: result.toolCallLog.length > 0 ? result.toolCallLog : undefined,
+        };
+      }
+    }
+
     const response = await this.gateway.complete(
       {
         modelSlug: context.modelSlug || this.config.defaultModelSlug,
@@ -102,7 +155,7 @@ export abstract class BaseTeam {
     context: StageContext,
   ): AsyncGenerator<string> {
     // Streaming always uses single model — intermediate strategy steps are WS events only
-    const messages = this.buildPrompt(input, context);
+    const messages: ProviderMessage[] = this.buildPrompt(input, context) as unknown as ProviderMessage[];
     yield* this.gateway.stream(
       {
         modelSlug: context.modelSlug || this.config.defaultModelSlug,

--- a/server/tools/builtin/knowledge-search.ts
+++ b/server/tools/builtin/knowledge-search.ts
@@ -1,0 +1,59 @@
+import type { ToolHandler } from "../registry";
+import { storage } from "../../storage";
+
+export const knowledgeSearchHandler: ToolHandler = {
+  definition: {
+    name: "knowledge_search",
+    description: "Search through previous pipeline runs and LLM responses stored in the system. Useful for finding prior analysis, past decisions, or previous outputs.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search query to find relevant past responses" },
+        limit: { type: "number", description: "Maximum number of results (default 5)", default: 5 },
+      },
+      required: ["query"],
+    },
+    source: "builtin",
+    tags: ["knowledge", "search", "history"],
+  },
+  async execute(args) {
+    const query = String(args.query ?? "").trim();
+    const limit = Math.min(Number(args.limit ?? 5), 20);
+
+    if (!query) return "Query cannot be empty.";
+
+    try {
+      // Try storage LLM requests search via ILIKE on response_content
+      const { rows } = await storage.getLlmRequests({
+        limit,
+        page: 1,
+      });
+
+      if (!rows || rows.length === 0) {
+        return "No previous pipeline responses found in knowledge base.";
+      }
+
+      const lower = query.toLowerCase();
+      const matching = rows.filter((r) =>
+        r.responseContent?.toLowerCase().includes(lower) ||
+        r.systemPrompt?.toLowerCase().includes(lower),
+      ).slice(0, limit);
+
+      if (matching.length === 0) {
+        return `No results found matching "${query}" in knowledge base.`;
+      }
+
+      return matching
+        .map((r, i) => {
+          const date = r.createdAt ? new Date(r.createdAt).toLocaleDateString() : "unknown date";
+          const preview = (r.responseContent ?? "").slice(0, 500);
+          return `### Result ${i + 1} (${r.modelSlug}, ${date})\n${preview}${preview.length >= 500 ? "..." : ""}`;
+        })
+        .join("\n\n");
+    } catch (err) {
+      // Fallback when PG not available
+      console.warn("[knowledge-search] Storage search failed:", err);
+      return `Knowledge base search unavailable: ${(err as Error).message}`;
+    }
+  },
+};

--- a/server/tools/builtin/memory-search.ts
+++ b/server/tools/builtin/memory-search.ts
@@ -1,0 +1,37 @@
+import type { ToolHandler } from "../registry";
+import { storage } from "../../storage";
+
+export const memorySearchHandler: ToolHandler = {
+  definition: {
+    name: "memory_search",
+    description: "Search project memories — decisions, patterns, known issues, preferences, and facts stored by previous pipeline runs.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Search query to find relevant memories" },
+      },
+      required: ["query"],
+    },
+    source: "builtin",
+    tags: ["memory", "search", "context"],
+  },
+  async execute(args) {
+    const query = String(args.query ?? "").trim();
+    if (!query) return "Query cannot be empty.";
+
+    try {
+      const memories = await storage.searchMemories(query);
+
+      if (memories.length === 0) {
+        return `No memories found matching "${query}".`;
+      }
+
+      return memories
+        .map((m) => `[${m.type}] ${m.key}: ${m.content} (confidence: ${m.confidence.toFixed(2)})`)
+        .join("\n");
+    } catch (err) {
+      console.warn("[memory-search] Memory search failed:", err);
+      return `Memory search unavailable: ${(err as Error).message}`;
+    }
+  },
+};

--- a/server/tools/builtin/url-reader.ts
+++ b/server/tools/builtin/url-reader.ts
@@ -1,0 +1,43 @@
+import type { ToolHandler } from "../registry";
+
+export const urlReaderHandler: ToolHandler = {
+  definition: {
+    name: "url_reader",
+    description: "Read and extract content from a web page URL. Returns clean markdown.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        url: { type: "string", description: "The URL to read" },
+      },
+      required: ["url"],
+    },
+    source: "builtin",
+    tags: ["web", "content"],
+  },
+  async execute(args) {
+    const url = String(args.url ?? "").trim();
+    if (!url) return "URL cannot be empty.";
+
+    // Basic URL validation — must start with http/https
+    if (!url.startsWith("http://") && !url.startsWith("https://")) {
+      return "Invalid URL: must start with http:// or https://";
+    }
+
+    const readerUrl = `https://r.jina.ai/${url}`;
+    const res = await fetch(readerUrl, {
+      headers: { Accept: "text/plain" },
+      signal: AbortSignal.timeout(20_000),
+    });
+
+    if (!res.ok) {
+      return `Failed to read URL (HTTP ${res.status}). The page may not be accessible.`;
+    }
+
+    const text = await res.text();
+    // Limit output to ~8000 chars to keep prompt size reasonable
+    if (text.length > 8000) {
+      return text.slice(0, 8000) + "\n\n[Content truncated at 8000 characters]";
+    }
+    return text || "Page returned no content.";
+  },
+};

--- a/server/tools/builtin/web-search.ts
+++ b/server/tools/builtin/web-search.ts
@@ -1,0 +1,110 @@
+import type { ToolHandler } from "../registry";
+
+interface TavilyResult {
+  title: string;
+  url: string;
+  content: string;
+}
+
+interface TavilyResponse {
+  results: TavilyResult[];
+}
+
+interface DdgResult {
+  FirstURL?: string;
+  Text?: string;
+}
+
+interface DdgResponse {
+  RelatedTopics?: DdgResult[];
+  Abstract?: string;
+  AbstractURL?: string;
+  AbstractText?: string;
+}
+
+async function searchWithTavily(query: string, limit: number): Promise<string> {
+  const apiKey = process.env.TAVILY_API_KEY;
+  if (!apiKey) throw new Error("No Tavily API key");
+
+  const res = await fetch("https://api.tavily.com/search", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      api_key: apiKey,
+      query,
+      max_results: limit,
+    }),
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Tavily API error ${res.status}: ${text}`);
+  }
+
+  const data = (await res.json()) as TavilyResponse;
+  const results = data.results ?? [];
+
+  if (results.length === 0) return "No results found.";
+
+  return results
+    .slice(0, limit)
+    .map((r) => `## [${r.title}](${r.url})\n${r.content}`)
+    .join("\n\n");
+}
+
+async function searchWithDuckDuckGo(query: string, limit: number): Promise<string> {
+  const url = `https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_html=1&skip_disambig=1`;
+
+  const res = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+  if (!res.ok) throw new Error(`DuckDuckGo API error ${res.status}`);
+
+  const data = (await res.json()) as DdgResponse;
+  const lines: string[] = [];
+
+  if (data.AbstractText && data.AbstractURL) {
+    lines.push(`## [Abstract](${data.AbstractURL})\n${data.AbstractText}`);
+  }
+
+  const topics = (data.RelatedTopics ?? []).filter((t) => t.FirstURL && t.Text);
+  for (const topic of topics.slice(0, limit - (lines.length > 0 ? 1 : 0))) {
+    lines.push(`## [${topic.Text ?? ""}](${topic.FirstURL ?? ""})\n${topic.Text ?? ""}`);
+  }
+
+  if (lines.length === 0) return "No results found via DuckDuckGo.";
+  return lines.join("\n\n");
+}
+
+export const webSearchHandler: ToolHandler = {
+  definition: {
+    name: "web_search",
+    description: "Search the internet for current information. Returns top results as formatted text.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "The search query" },
+        limit: { type: "number", description: "Maximum number of results (default 5)", default: 5 },
+      },
+      required: ["query"],
+    },
+    source: "builtin",
+    tags: ["search", "internet"],
+  },
+  async execute(args) {
+    const query = String(args.query ?? "");
+    const limit = Math.min(Number(args.limit ?? 5), 10);
+
+    if (!query.trim()) return "Query cannot be empty.";
+
+    try {
+      return await searchWithTavily(query, limit);
+    } catch (tavilyErr) {
+      console.warn(`[web-search] Tavily failed (${(tavilyErr as Error).message}), falling back to DuckDuckGo`);
+      try {
+        return await searchWithDuckDuckGo(query, limit);
+      } catch (ddgErr) {
+        return `Search failed. Tavily: ${(tavilyErr as Error).message}. DuckDuckGo: ${(ddgErr as Error).message}`;
+      }
+    }
+  },
+};

--- a/server/tools/index.ts
+++ b/server/tools/index.ts
@@ -1,0 +1,17 @@
+import { ToolRegistry } from "./registry";
+import { webSearchHandler } from "./builtin/web-search";
+import { urlReaderHandler } from "./builtin/url-reader";
+import { knowledgeSearchHandler } from "./builtin/knowledge-search";
+import { memorySearchHandler } from "./builtin/memory-search";
+
+// Singleton tool registry shared across the server process
+export const toolRegistry = new ToolRegistry();
+
+// Register all built-in tools
+toolRegistry.register(webSearchHandler);
+toolRegistry.register(urlReaderHandler);
+toolRegistry.register(knowledgeSearchHandler);
+toolRegistry.register(memorySearchHandler);
+
+export { ToolRegistry } from "./registry";
+export type { ToolHandler } from "./registry";

--- a/server/tools/mcp-client.ts
+++ b/server/tools/mcp-client.ts
@@ -1,0 +1,140 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import type { ToolDefinition, McpServerConfig } from "@shared/types";
+import { toolRegistry } from "./index";
+
+interface McpConnection {
+  client: Client;
+  tools: ToolDefinition[];
+  error?: string;
+}
+
+export class McpClientManager {
+  private connections: Map<string, McpConnection> = new Map();
+
+  async connect(config: McpServerConfig): Promise<void> {
+    // Disconnect existing connection for this server if any
+    if (this.connections.has(config.name)) {
+      await this.disconnect(config.name);
+    }
+
+    const client = new Client(
+      { name: "multiqlti-mcp-client", version: "1.0.0" },
+      { capabilities: {} },
+    );
+
+    let transport;
+    if (config.transport === "stdio") {
+      if (!config.command) {
+        throw new Error(`MCP server "${config.name}" requires a command for stdio transport`);
+      }
+      transport = new StdioClientTransport({
+        command: config.command,
+        args: config.args ?? [],
+        env: config.env ? { ...process.env, ...config.env } as Record<string, string> : undefined,
+      });
+    } else if (config.transport === "sse" || config.transport === "streamable-http") {
+      if (!config.url) {
+        throw new Error(`MCP server "${config.name}" requires a URL for ${config.transport} transport`);
+      }
+      transport = new SSEClientTransport(new URL(config.url));
+    } else {
+      throw new Error(`Unknown MCP transport: ${config.transport as string}`);
+    }
+
+    await client.connect(transport);
+
+    // Fetch the server's tool list
+    const { tools: mcpTools } = await client.listTools();
+
+    const toolDefs: ToolDefinition[] = (mcpTools ?? []).map((t) => ({
+      name: `${config.name}__${t.name}`,
+      description: t.description ?? `Tool "${t.name}" from MCP server "${config.name}"`,
+      inputSchema: (t.inputSchema ?? {}) as Record<string, unknown>,
+      source: "mcp" as const,
+      mcpServer: config.name,
+      tags: ["mcp"],
+    }));
+
+    // Register tools in the global registry
+    for (const def of toolDefs) {
+      const mcpToolName = def.name.slice(config.name.length + 2); // strip "serverName__" prefix
+      const serverName = config.name;
+      toolRegistry.register({
+        definition: def,
+        execute: async (args) => {
+          return this.callTool(serverName, mcpToolName, args);
+        },
+      });
+    }
+
+    this.connections.set(config.name, { client, tools: toolDefs });
+    console.log(`[mcp-client] Connected to "${config.name}" — ${toolDefs.length} tool(s) registered`);
+  }
+
+  async disconnect(serverName: string): Promise<void> {
+    const conn = this.connections.get(serverName);
+    if (!conn) return;
+
+    // Unregister all tools for this server
+    for (const def of conn.tools) {
+      toolRegistry.unregister(def.name);
+    }
+
+    try {
+      await conn.client.close();
+    } catch (err) {
+      console.warn(`[mcp-client] Error closing connection to "${serverName}":`, err);
+    }
+
+    this.connections.delete(serverName);
+    console.log(`[mcp-client] Disconnected from "${serverName}"`);
+  }
+
+  getTools(serverName?: string): ToolDefinition[] {
+    if (serverName) {
+      return this.connections.get(serverName)?.tools ?? [];
+    }
+    const all: ToolDefinition[] = [];
+    for (const conn of this.connections.values()) {
+      all.push(...conn.tools);
+    }
+    return all;
+  }
+
+  async callTool(serverName: string, toolName: string, args: Record<string, unknown>): Promise<string> {
+    const conn = this.connections.get(serverName);
+    if (!conn) {
+      throw new Error(`Not connected to MCP server "${serverName}"`);
+    }
+
+    const result = await conn.client.callTool({ name: toolName, arguments: args });
+
+    // Extract text content from result
+    const content = result.content ?? [];
+    if (Array.isArray(content)) {
+      const textParts = content
+        .filter((block): block is { type: "text"; text: string } => block.type === "text")
+        .map((block) => block.text);
+      return textParts.join("\n") || JSON.stringify(result);
+    }
+
+    return String(result);
+  }
+
+  getStatus(): Record<string, { connected: boolean; toolCount: number; error?: string }> {
+    const status: Record<string, { connected: boolean; toolCount: number; error?: string }> = {};
+    for (const [name, conn] of this.connections.entries()) {
+      status[name] = {
+        connected: true,
+        toolCount: conn.tools.length,
+        error: conn.error,
+      };
+    }
+    return status;
+  }
+}
+
+// Singleton instance
+export const mcpClientManager = new McpClientManager();

--- a/server/tools/registry.ts
+++ b/server/tools/registry.ts
@@ -1,0 +1,66 @@
+import type { ToolDefinition, ToolCall, ToolResult } from "@shared/types";
+
+export interface ToolHandler {
+  definition: ToolDefinition;
+  execute(args: Record<string, unknown>): Promise<string>;
+}
+
+export class ToolRegistry {
+  private tools: Map<string, ToolHandler> = new Map();
+
+  register(handler: ToolHandler): void {
+    this.tools.set(handler.definition.name, handler);
+  }
+
+  unregister(name: string): void {
+    this.tools.delete(name);
+  }
+
+  getAvailableTools(filter?: { tags?: string[]; source?: 'builtin' | 'mcp' }): ToolDefinition[] {
+    const all = Array.from(this.tools.values()).map((h) => h.definition);
+
+    if (!filter) return all;
+
+    return all.filter((def) => {
+      if (filter.source && def.source !== filter.source) return false;
+      if (filter.tags && filter.tags.length > 0) {
+        const defTags = def.tags ?? [];
+        if (!filter.tags.some((t) => defTags.includes(t))) return false;
+      }
+      return true;
+    });
+  }
+
+  getToolByName(name: string): ToolDefinition | undefined {
+    return this.tools.get(name)?.definition;
+  }
+
+  async execute(call: ToolCall): Promise<ToolResult> {
+    const handler = this.tools.get(call.name);
+
+    if (!handler) {
+      return {
+        toolCallId: call.id,
+        content: `Tool "${call.name}" not found in registry.`,
+        isError: true,
+      };
+    }
+
+    try {
+      const content = await handler.execute(call.arguments);
+      return {
+        toolCallId: call.id,
+        content,
+        isError: false,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[tool-registry] Tool "${call.name}" threw: ${message}`);
+      return {
+        toolCallId: call.id,
+        content: `Tool execution failed: ${message}`,
+        isError: true,
+      };
+    }
+  }
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -288,3 +288,28 @@ export const memories = pgTable("memories", {
 }));
 
 export type MemoryRow = typeof memories.$inferSelect;
+
+// ─── MCP Servers ─────────────────────────────────────────────────────────────
+
+export const mcpServers = pgTable("mcp_servers", {
+  id: serial("id").primaryKey(),
+  name: text("name").notNull().unique(),
+  transport: text("transport").notNull(),  // 'stdio' | 'sse' | 'streamable-http'
+  command: text("command"),
+  args: jsonb("args").$type<string[]>(),
+  url: text("url"),
+  env: jsonb("env").$type<Record<string, string>>(),
+  enabled: boolean("enabled").notNull().default(true),
+  autoConnect: boolean("auto_connect").notNull().default(false),
+  toolCount: integer("tool_count").default(0),
+  lastConnectedAt: timestamp("last_connected_at"),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
+export const insertMcpServerSchema = createInsertSchema(mcpServers).omit({
+  id: true,
+  createdAt: true,
+});
+
+export type InsertMcpServer = z.infer<typeof insertMcpServerSchema>;
+export type McpServerRow = typeof mcpServers.$inferSelect;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -267,6 +267,61 @@ export interface PrivacySettings {
   auditLog: boolean;    // default: true
 }
 
+// ─── Tool Types ───────────────────────────────────────────────────────────────
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;  // JSON Schema
+  source: 'builtin' | 'mcp';
+  mcpServer?: string;
+  tags?: string[];
+}
+
+export interface ToolCall {
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+export interface ToolResult {
+  toolCallId: string;
+  content: string;
+  isError?: boolean;
+}
+
+export interface ToolCallLogEntry {
+  iteration: number;
+  call: ToolCall;
+  result: ToolResult;
+  durationMs: number;
+}
+
+export interface StageToolConfig {
+  enabled: boolean;
+  allowedTools?: string[];
+  blockedTools?: string[];
+  maxToolCalls?: number;       // default 10
+  toolChoice?: 'auto' | 'none' | 'required';
+}
+
+// ─── MCP Server Config ────────────────────────────────────────────────────────
+
+export interface McpServerConfig {
+  id: number;
+  name: string;
+  transport: 'stdio' | 'sse' | 'streamable-http';
+  command?: string | null;
+  args?: string[] | null;
+  url?: string | null;
+  env?: Record<string, string> | null;
+  enabled: boolean;
+  autoConnect: boolean;
+  toolCount: number;
+  lastConnectedAt?: Date | null;
+  createdAt?: Date | null;
+}
+
 // ─── Pipeline Stage Config ────────────────────────────────────────────────────
 
 export interface PipelineStageConfig {
@@ -279,6 +334,7 @@ export interface PipelineStageConfig {
   executionStrategy?: ExecutionStrategy;
   privacySettings?: PrivacySettings;
   sandbox?: SandboxConfig;
+  tools?: StageToolConfig;
 }
 
 export interface StageOutput {
@@ -299,6 +355,7 @@ export interface StageContext {
   privacySettings?: PrivacySettings;
   sessionId?: string;
   memoryContext?: string;
+  stageConfig?: PipelineStageConfig;
 }
 
 export interface TeamResult {
@@ -307,9 +364,15 @@ export interface TeamResult {
   raw: string;
   questions?: string[];
   strategyResult?: StrategyResult;
+  toolCallLog?: ToolCallLogEntry[];
 }
 
-export type ProviderMessage = { role: string; content: string };
+// ─── Provider Message ─────────────────────────────────────────────────────────
+
+export type ProviderMessage =
+  | { role: 'system' | 'user'; content: string }
+  | { role: 'assistant'; content: string; toolCalls?: ToolCall[] }
+  | { role: 'tool'; toolCallId: string; content: string };
 
 export interface ILLMProviderOptions {
   maxTokens?: number;
@@ -322,17 +385,21 @@ export interface ILLMProviderOptions {
   stageExecutionId?: string;
   /** Team identifier for cost/usage grouping. */
   teamId?: string;
+  /** Tools to make available for this completion. */
+  tools?: ToolDefinition[];
+  /** How the model chooses tools. */
+  toolChoice?: 'auto' | 'none' | 'required';
 }
 
 export interface ILLMProvider {
   /**
-   * Non-streaming completion. Returns full content and token count.
+   * Non-streaming completion. Returns full content, token count, and optional tool calls.
    */
   complete(
     modelId: string,
     messages: ProviderMessage[],
     options?: ILLMProviderOptions,
-  ): Promise<{ content: string; tokensUsed: number }>;
+  ): Promise<{ content: string; tokensUsed: number; toolCalls?: ToolCall[]; finishReason?: 'stop' | 'tool_use' }>;
 
   /**
    * Streaming completion. Yields text delta chunks as they arrive.


### PR DESCRIPTION
## Summary

- **Agentic tool loop**: `Gateway.completeWithTools()` runs up to 10 iterations where the model calls tools, gets results appended, and continues until it produces a final text answer
- **4 built-in tools**: `web_search` (Tavily API with DuckDuckGo fallback), `url_reader` (Jina AI free tier), `knowledge_search` (previous pipeline outputs), `memory_search` (stored memories)
- **MCP client manager**: connect to any MCP server via stdio, SSE, or streamable-HTTP; tools auto-register into the global registry
- **Provider tool calling**: Claude (tool_use blocks), Grok/OpenAI-compatible (function calling), Gemini (skipped, returns stop)
- **Per-stage tool config**: each pipeline stage has a Tools tab (enable/disable, tool checklist, max iterations slider)
- **Settings UI**: Tools & MCP section shows built-in tool status and MCP server management with connect/disconnect
- **ToolCallLog component**: renders collapsible tool call history in StageOutput

## Key files

- `/server/tools/registry.ts` — ToolRegistry singleton
- `/server/tools/builtin/` — 4 built-in tool handlers
- `/server/tools/mcp-client.ts` — McpClientManager
- `/server/tools/index.ts` — exports singleton toolRegistry
- `/server/gateway/index.ts` — `completeWithTools()` agentic loop
- `/server/gateway/providers/claude.ts` — tool_use support
- `/server/gateway/providers/openai-compatible.ts` — function_calling support
- `/server/teams/base.ts` — routes to completeWithTools per DEFAULT_TEAM_TOOLS
- `/server/routes/tools.ts` — /api/tools and /api/mcp/servers endpoints
- `/client/src/components/pipeline/ToolCallLog.tsx` — tool call log UI
- `/shared/types.ts` — all new tool-related types

## Test plan

- [ ] Start server, confirm 4 built-in tools appear at `GET /api/tools`
- [ ] `POST /api/tools/web_search/test` with `{ "args": { "query": "latest TypeScript release" } }` returns results
- [ ] Run a pipeline with a Claude model and tool calling enabled — verify `toolCallLog` appears in stage output
- [ ] Add an MCP server via Settings UI, connect it, verify tools appear
- [ ] Max iterations respected — test with a mock that always returns tool_use (should cap at 10)
- [ ] Tool errors (isError: true) handled gracefully — loop continues, error content fed back to model
- [ ] `TAVILY_API_KEY` not set — DuckDuckGo fallback used

🤖 Generated with [Claude Code](https://claude.com/claude-code)