### PR TITLE
feat: Phase 3.4 — Governance Gates (approval gates + run export)

### DIFF
--- a/client/src/components/pipeline/StageProgress.tsx
+++ b/client/src/components/pipeline/StageProgress.tsx
@@ -51,6 +51,11 @@ const statusConfig: Record<
     color: "text-muted-foreground",
     bg: "bg-muted",
   },
+  awaiting_approval: {
+    icon: <Pause className="h-3.5 w-3.5" />,
+    color: "text-amber-600",
+    bg: "bg-amber-500/20",
+  },
 };
 
 export default function StageProgress({

--- a/client/src/hooks/use-pipeline.ts
+++ b/client/src/hooks/use-pipeline.ts
@@ -300,3 +300,51 @@ export function useDeleteModel() {
     },
   });
 }
+
+// ─── Approval Gates ─────────────────────────────
+
+export function useApproveStage() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ runId, stageIndex, approvedBy }: { runId: string; stageIndex: number; approvedBy?: string }) =>
+      apiRequest("POST", `/api/runs/${runId}/stages/${stageIndex}/approve`, { approvedBy }),
+    onSuccess: (_data, vars) => {
+      qc.invalidateQueries({ queryKey: ["/api/runs", vars.runId] });
+    },
+  });
+}
+
+export function useRejectStage() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ runId, stageIndex, reason }: { runId: string; stageIndex: number; reason?: string }) =>
+      apiRequest("POST", `/api/runs/${runId}/stages/${stageIndex}/reject`, { reason }),
+    onSuccess: (_data, vars) => {
+      qc.invalidateQueries({ queryKey: ["/api/runs", vars.runId] });
+    },
+  });
+}
+
+// ─── Export ─────────────────────────────────────
+
+export function useExportRun() {
+  return useMutation({
+    mutationFn: async ({ runId, format }: { runId: string; format: "markdown" | "zip" }) => {
+      const res = await fetch(`/api/runs/${runId}/export?format=${format}`);
+      if (!res.ok) {
+        const errText = await res.text().catch(() => res.statusText);
+        throw new Error(errText || res.statusText);
+      }
+      const blob = await res.blob();
+      const contentDisposition = res.headers.get("Content-Disposition") ?? "";
+      const filenameMatch = contentDisposition.match(/filename="([^"]+)"/);
+      const filename = filenameMatch?.[1] ?? (format === "zip" ? "export.zip" : "report.md");
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      a.click();
+      URL.revokeObjectURL(url);
+    },
+  });
+}

--- a/client/src/hooks/use-websocket.ts
+++ b/client/src/hooks/use-websocket.ts
@@ -27,6 +27,12 @@ export function useWebSocket(runId?: string) {
   return { lastEvent, isConnected };
 }
 
+export interface PendingApproval {
+  stageIndex: number;
+  stageExecutionId: string;
+  teamId: string;
+}
+
 export interface PipelineEventState {
   status: RunStatus;
   stages: Map<
@@ -53,6 +59,7 @@ export interface PipelineEventState {
     content: string;
     agentTeam?: string;
   }>;
+  pendingApprovals: PendingApproval[];
 }
 
 export function usePipelineEvents(runId: string): PipelineEventState {
@@ -62,6 +69,7 @@ export function usePipelineEvents(runId: string): PipelineEventState {
     currentStageIndex: 0,
     questions: [],
     messages: [],
+    pendingApprovals: [],
   });
 
   const stateRef = useRef(state);
@@ -125,6 +133,63 @@ export function usePipelineEvents(runId: string): PipelineEventState {
           status: "failed",
         });
         setState({ ...s, stages });
+        break;
+      }
+
+      case "stage:awaiting_approval": {
+        const stageIndex = event.payload.stageIndex as number;
+        const stages = new Map(s.stages);
+        const existing = stages.get(stageIndex);
+        stages.set(stageIndex, {
+          teamId: existing?.teamId ?? (event.payload.teamId as string),
+          modelSlug: existing?.modelSlug ?? "",
+          status: "awaiting_approval",
+          output: existing?.output,
+          tokensUsed: existing?.tokensUsed,
+        });
+        const approval: PendingApproval = {
+          stageIndex,
+          stageExecutionId: event.stageExecutionId ?? "",
+          teamId: event.payload.teamId as string,
+        };
+        setState({
+          ...s,
+          stages,
+          status: "paused",
+          pendingApprovals: [...s.pendingApprovals.filter((a) => a.stageIndex !== stageIndex), approval],
+        });
+        break;
+      }
+
+      case "stage:approved": {
+        const stageIndex = event.payload.stageIndex as number;
+        const stages = new Map(s.stages);
+        const existing = stages.get(stageIndex);
+        if (existing) {
+          stages.set(stageIndex, { ...existing, status: "completed" });
+        }
+        setState({
+          ...s,
+          stages,
+          status: "running",
+          pendingApprovals: s.pendingApprovals.filter((a) => a.stageIndex !== stageIndex),
+        });
+        break;
+      }
+
+      case "stage:rejected": {
+        const stageIndex = event.payload.stageIndex as number;
+        const stages = new Map(s.stages);
+        const existing = stages.get(stageIndex);
+        if (existing) {
+          stages.set(stageIndex, { ...existing, status: "failed" });
+        }
+        setState({
+          ...s,
+          stages,
+          status: "rejected" as RunStatus,
+          pendingApprovals: s.pendingApprovals.filter((a) => a.stageIndex !== stageIndex),
+        });
         break;
       }
 

--- a/client/src/pages/PipelineRun.tsx
+++ b/client/src/pages/PipelineRun.tsx
@@ -1,5 +1,6 @@
+import { useState } from "react";
 import { useParams } from "wouter";
-import { usePipelineRun, useCancelRun } from "@/hooks/use-pipeline";
+import { usePipelineRun, useCancelRun, useApproveStage, useRejectStage, useExportRun } from "@/hooks/use-pipeline";
 import { usePipelineEvents } from "@/hooks/use-websocket";
 import StageProgress from "@/components/pipeline/StageProgress";
 import QuestionPanel from "@/components/pipeline/QuestionPanel";
@@ -8,7 +9,13 @@ import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Badge } from "@/components/ui/badge";
-import { StopCircle, ArrowLeft, Loader2 } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { StopCircle, ArrowLeft, Loader2, CheckCircle2, XCircle, Download, ChevronDown } from "lucide-react";
 import { Link } from "wouter";
 import { SDLC_TEAMS } from "@shared/constants";
 import type { PipelineStageConfig } from "@shared/types";
@@ -21,6 +28,7 @@ const statusColors: Record<string, string> = {
   completed: "bg-emerald-500/20 text-emerald-700",
   failed: "bg-red-500/20 text-red-700",
   cancelled: "bg-muted text-muted-foreground",
+  rejected: "bg-red-500/20 text-red-700",
 };
 
 export default function PipelineRun() {
@@ -28,7 +36,12 @@ export default function PipelineRun() {
   const runId = params.runId ?? "";
   const { data: run, isLoading } = usePipelineRun(runId);
   const cancelMutation = useCancelRun();
+  const approveMutation = useApproveStage();
+  const rejectMutation = useRejectStage();
+  const exportMutation = useExportRun();
   const pipelineEvents = usePipelineEvents(runId);
+
+  const [rejectReasonMap, setRejectReasonMap] = useState<Record<number, string>>({});
 
   if (isLoading) {
     return (
@@ -55,6 +68,7 @@ export default function PipelineRun() {
     status: string;
     output: Record<string, unknown> | null;
     tokensUsed: number;
+    approvalStatus?: string | null;
   }>;
 
   // Merge WS live data with server data for stages
@@ -76,6 +90,18 @@ export default function PipelineRun() {
     ? pipelineEvents.questions
     : (run.questions ?? []);
 
+  const { pendingApprovals } = pipelineEvents;
+
+  // Derive approvals from server data if WS hasn't emitted events yet
+  const serverPendingApprovals = pipelineStages
+    .filter((s) => s.status === "awaiting_approval" && s.approvalStatus === "pending")
+    .map((s) => ({ stageIndex: s.stageIndex, stageExecutionId: s.id, teamId: s.teamId }));
+
+  const activeApprovals = pendingApprovals.length > 0 ? pendingApprovals : serverPendingApprovals;
+
+  const isActiveRun = status === "running" || status === "paused";
+  const isTerminal = status === "completed" || status === "failed" || status === "cancelled" || status === "rejected";
+
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
@@ -92,7 +118,7 @@ export default function PipelineRun() {
               {run.input?.length > 60 ? "..." : ""}
             </h2>
             <div className="flex items-center gap-2 mt-0.5">
-              <Badge className={cn("text-[10px] h-4 px-1.5", statusColors[status])}>
+              <Badge className={cn("text-[10px] h-4 px-1.5", statusColors[status] ?? "bg-muted text-muted-foreground")}>
                 {status}
               </Badge>
               <span className="text-[10px] text-muted-foreground">
@@ -101,18 +127,102 @@ export default function PipelineRun() {
             </div>
           </div>
         </div>
-        {(status === "running" || status === "paused") && (
-          <Button
-            variant="destructive"
-            size="sm"
-            className="h-8 text-xs"
-            onClick={() => cancelMutation.mutate(runId)}
-            disabled={cancelMutation.isPending}
-          >
-            <StopCircle className="h-3 w-3 mr-1" /> Cancel
-          </Button>
-        )}
+
+        <div className="flex items-center gap-2">
+          {/* Export button — always visible */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-8 text-xs gap-1"
+                disabled={exportMutation.isPending}
+              >
+                {exportMutation.isPending
+                  ? <Loader2 className="h-3 w-3 animate-spin" />
+                  : <Download className="h-3 w-3" />}
+                Export
+                <ChevronDown className="h-3 w-3" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => exportMutation.mutate({ runId, format: "markdown" })}
+              >
+                Markdown Report
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => exportMutation.mutate({ runId, format: "zip" })}
+              >
+                ZIP (report + code)
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          {/* Cancel button */}
+          {isActiveRun && (
+            <Button
+              variant="destructive"
+              size="sm"
+              className="h-8 text-xs"
+              onClick={() => cancelMutation.mutate(runId)}
+              disabled={cancelMutation.isPending}
+            >
+              <StopCircle className="h-3 w-3 mr-1" /> Cancel
+            </Button>
+          )}
+        </div>
       </div>
+
+      {/* Approval Gate Banner */}
+      {activeApprovals.length > 0 && (
+        <div className="border-b border-amber-200 bg-amber-50 px-6 py-3 shrink-0">
+          <p className="text-xs font-medium text-amber-800 mb-2">
+            Waiting for approval before continuing
+          </p>
+          <div className="flex flex-col gap-2">
+            {activeApprovals.map((approval) => (
+              <div key={approval.stageIndex} className="flex items-center gap-3">
+                <span className="text-xs text-amber-700">
+                  Stage {approval.stageIndex + 1} ({approval.teamId}) is awaiting approval
+                </span>
+                <Button
+                  size="sm"
+                  className="h-7 text-xs bg-emerald-600 hover:bg-emerald-700 text-white"
+                  disabled={approveMutation.isPending}
+                  onClick={() => approveMutation.mutate({ runId, stageIndex: approval.stageIndex })}
+                >
+                  <CheckCircle2 className="h-3 w-3 mr-1" />
+                  Approve
+                </Button>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  className="h-7 text-xs"
+                  disabled={rejectMutation.isPending}
+                  onClick={() => rejectMutation.mutate({
+                    runId,
+                    stageIndex: approval.stageIndex,
+                    reason: rejectReasonMap[approval.stageIndex],
+                  })}
+                >
+                  <XCircle className="h-3 w-3 mr-1" />
+                  Reject
+                </Button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Rejection notice */}
+      {status === "rejected" && (
+        <div className="border-b border-red-200 bg-red-50 px-6 py-3 shrink-0">
+          <p className="text-xs text-red-700">
+            This pipeline run was rejected at a governance gate and did not complete.
+          </p>
+        </div>
+      )}
 
       {/* Content */}
       <div className="flex-1 flex overflow-hidden">
@@ -180,6 +290,12 @@ export default function PipelineRun() {
                   {status === "failed" && (
                     <div className="p-4 rounded-lg border border-red-500/30 bg-red-500/5 text-sm text-red-700">
                       Pipeline failed. Check the stage outputs for details.
+                    </div>
+                  )}
+                  {status === "rejected" && (
+                    <div className="p-4 rounded-lg border border-red-500/30 bg-red-500/5 text-sm text-red-700">
+                      Pipeline rejected at a governance gate.{" "}
+                      {completedStages.length} stages completed before rejection.
                     </div>
                   )}
                 </div>

--- a/server/controller/pipeline-controller.ts
+++ b/server/controller/pipeline-controller.ts
@@ -8,8 +8,14 @@ import { ThoughtTreeCollector } from "../pipeline/thought-tree-collector";
 import { MemoryExtractor } from "../memory/extractor";
 import { MemoryProvider } from "../memory/provider";
 
+interface ApprovalHandle {
+  resolve: (approved: boolean) => void;
+  reason?: string;
+}
+
 export class PipelineController {
   private activeRuns: Map<string, AbortController> = new Map();
+  private pendingApprovals: Map<string, ApprovalHandle> = new Map();
   private sandboxExecutor: SandboxExecutor;
   private memoryExtractor: MemoryExtractor;
   private memoryProvider: MemoryProvider;
@@ -105,6 +111,80 @@ export class PipelineController {
     }
 
     return files;
+  }
+
+  /** Returns a promise that resolves to true (approved) or false (rejected). */
+  private waitForApproval(approvalKey: string): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      this.pendingApprovals.set(approvalKey, { resolve });
+    });
+  }
+
+  private makeApprovalKey(runId: string, stageIndex: number): string {
+    return `${runId}::${stageIndex}`;
+  }
+
+  async approveStage(runId: string, stageIndex: number, approvedBy?: string): Promise<void> {
+    const key = this.makeApprovalKey(runId, stageIndex);
+    const handle = this.pendingApprovals.get(key);
+    if (!handle) throw new Error(`No pending approval for run ${runId} stage ${stageIndex}`);
+
+    this.pendingApprovals.delete(key);
+
+    // Update DB
+    const executions = await this.storage.getStageExecutions(runId);
+    const stageExec = executions.find((e) => e.stageIndex === stageIndex);
+    if (stageExec) {
+      await this.storage.updateStageExecution(stageExec.id, {
+        approvalStatus: "approved",
+        approvedAt: new Date(),
+        approvedBy: approvedBy ?? null,
+      });
+    }
+
+    // Update run back to running
+    await this.storage.updatePipelineRun(runId, { status: "running" });
+
+    this.broadcast(runId, {
+      type: "stage:approved",
+      runId,
+      payload: { stageIndex, approvedBy: approvedBy ?? null },
+      timestamp: new Date().toISOString(),
+    });
+
+    handle.resolve(true);
+  }
+
+  async rejectStage(runId: string, stageIndex: number, reason?: string): Promise<void> {
+    const key = this.makeApprovalKey(runId, stageIndex);
+    const handle = this.pendingApprovals.get(key);
+    if (!handle) throw new Error(`No pending approval for run ${runId} stage ${stageIndex}`);
+
+    this.pendingApprovals.delete(key);
+
+    // Update DB
+    const executions = await this.storage.getStageExecutions(runId);
+    const stageExec = executions.find((e) => e.stageIndex === stageIndex);
+    if (stageExec) {
+      await this.storage.updateStageExecution(stageExec.id, {
+        approvalStatus: "rejected",
+        rejectionReason: reason ?? null,
+      });
+    }
+
+    await this.storage.updatePipelineRun(runId, {
+      status: "rejected",
+      completedAt: new Date(),
+    });
+
+    this.broadcast(runId, {
+      type: "stage:rejected",
+      runId,
+      payload: { stageIndex, reason: reason ?? null },
+      timestamp: new Date().toISOString(),
+    });
+
+    handle.resolve(false);
   }
 
   private async executeStages(
@@ -367,6 +447,40 @@ export class PipelineController {
           content: result.output.summary as string ?? `${stage.teamId} stage completed.`,
           metadata: { stageIndex: i, output: result.output },
         });
+
+        // ─── Approval Gate ────────────────────────────────────────────────────
+        if (stage.approvalRequired) {
+          const approvalKey = this.makeApprovalKey(run.id, i);
+
+          await this.storage.updateStageExecution(stageExec.id, {
+            status: "awaiting_approval",
+            approvalStatus: "pending",
+          });
+          await this.storage.updatePipelineRun(run.id, { status: "paused" });
+
+          this.broadcast(run.id, {
+            type: "stage:awaiting_approval",
+            runId: run.id,
+            stageExecutionId: stageExec.id,
+            payload: { stageIndex: i, teamId: stage.teamId },
+            timestamp: new Date().toISOString(),
+          });
+
+          if (signal.aborted) return;
+
+          const approved = await this.waitForApproval(approvalKey);
+
+          if (!approved) {
+            // run status already set to rejected in rejectStage()
+            this.activeRuns.delete(run.id);
+            return;
+          }
+
+          // Continue — restore stage status to completed
+          await this.storage.updateStageExecution(stageExec.id, {
+            status: "completed",
+          });
+        }
       } catch (error) {
         const errMsg =
           error instanceof Error ? error.message : "Unknown error";
@@ -459,6 +573,14 @@ export class PipelineController {
     if (abort) {
       abort.abort();
       this.activeRuns.delete(runId);
+    }
+
+    // Resolve any pending approval as rejected to unblock the promise
+    for (const [key, handle] of this.pendingApprovals) {
+      if (key.startsWith(`${runId}::`)) {
+        this.pendingApprovals.delete(key);
+        handle.resolve(false);
+      }
     }
 
     await this.storage.updatePipelineRun(runId, {

--- a/server/routes/runs.ts
+++ b/server/routes/runs.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { z } from "zod";
 import type { IStorage } from "../storage";
 import type { PipelineController } from "../controller/pipeline-controller";
+import { generateMarkdownReport, generateZipExport } from "../services/export-service";
 
 const CreateRunSchema = z.object({
   pipelineId: z.string().min(1, "pipelineId is required"),
@@ -11,6 +12,16 @@ const CreateRunSchema = z.object({
 const AnswerQuestionSchema = z.object({
   answer: z.string().min(1, "answer is required"),
 });
+
+const ApproveStageSchema = z.object({
+  approvedBy: z.string().max(200).optional(),
+});
+
+const RejectStageSchema = z.object({
+  reason: z.string().max(500).optional(),
+});
+
+const ExportFormatSchema = z.enum(["markdown", "zip"]);
 
 export function registerRunRoutes(
   router: Router,
@@ -87,5 +98,79 @@ export function registerRunRoutes(
     } catch (e) {
       res.status(400).json({ error: (e as Error).message });
     }
+  });
+
+  // ─── Approval Gates ────────────────────────────────────────────────────────
+
+  router.post("/api/runs/:id/stages/:stageIndex/approve", async (req, res) => {
+    const stageIndex = parseInt(req.params.stageIndex, 10);
+    if (isNaN(stageIndex) || stageIndex < 0) {
+      return res.status(400).json({ error: "Invalid stageIndex" });
+    }
+
+    const parsed = ApproveStageSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: parsed.error.message });
+    }
+
+    try {
+      await controller.approveStage(req.params.id, stageIndex, parsed.data.approvedBy);
+      res.json({ message: "Stage approved" });
+    } catch (e) {
+      res.status(400).json({ error: (e as Error).message });
+    }
+  });
+
+  router.post("/api/runs/:id/stages/:stageIndex/reject", async (req, res) => {
+    const stageIndex = parseInt(req.params.stageIndex, 10);
+    if (isNaN(stageIndex) || stageIndex < 0) {
+      return res.status(400).json({ error: "Invalid stageIndex" });
+    }
+
+    const parsed = RejectStageSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: parsed.error.message });
+    }
+
+    try {
+      await controller.rejectStage(req.params.id, stageIndex, parsed.data.reason);
+      res.json({ message: "Stage rejected" });
+    } catch (e) {
+      res.status(400).json({ error: (e as Error).message });
+    }
+  });
+
+  // ─── Export ───────────────────────────────────────────────────────────────
+
+  router.get("/api/runs/:id/export", async (req, res) => {
+    const formatResult = ExportFormatSchema.safeParse(req.query.format);
+    if (!formatResult.success) {
+      return res.status(400).json({ error: "format must be 'markdown' or 'zip'" });
+    }
+    const format = formatResult.data;
+
+    const run = await storage.getPipelineRun(req.params.id);
+    if (!run) return res.status(404).json({ error: "Run not found" });
+
+    const pipeline = await storage.getPipeline(run.pipelineId);
+    if (!pipeline) return res.status(404).json({ error: "Pipeline not found" });
+
+    const stages = await storage.getStageExecutions(run.id);
+    const runSlug = run.id.slice(0, 8);
+
+    if (format === "markdown") {
+      const markdown = generateMarkdownReport(run, stages, pipeline);
+      res.setHeader("Content-Type", "text/markdown; charset=utf-8");
+      res.setHeader("Content-Disposition", `attachment; filename="run-${runSlug}-report.md"`);
+      res.send(markdown);
+      return;
+    }
+
+    // ZIP
+    const zipBuffer = generateZipExport(run, stages, pipeline);
+    res.setHeader("Content-Type", "application/zip");
+    res.setHeader("Content-Disposition", `attachment; filename="run-${runSlug}-export.zip"`);
+    res.setHeader("Content-Length", zipBuffer.length);
+    res.send(zipBuffer);
   });
 }

--- a/server/services/export-service.ts
+++ b/server/services/export-service.ts
@@ -1,0 +1,315 @@
+import type { PipelineRun, StageExecution, Pipeline } from "@shared/schema";
+
+// ─── Markdown Export ──────────────────────────────────────────────────────────
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remaining = seconds % 60;
+  return `${minutes}m ${remaining}s`;
+}
+
+function formatTimestamp(date: Date | null | string): string {
+  if (!date) return "N/A";
+  return new Date(date).toISOString().replace("T", " ").slice(0, 19) + " UTC";
+}
+
+export function generateMarkdownReport(
+  run: PipelineRun,
+  stages: StageExecution[],
+  pipeline: Pipeline,
+): string {
+  const completedStages = stages.filter((s) => s.status === "completed");
+  const totalTokens = stages.reduce((sum, s) => sum + (s.tokensUsed ?? 0), 0);
+
+  const durationMs =
+    run.startedAt && run.completedAt
+      ? new Date(run.completedAt).getTime() - new Date(run.startedAt).getTime()
+      : 0;
+
+  const lines: string[] = [
+    `# Pipeline Run Report`,
+    ``,
+    `## Executive Summary`,
+    ``,
+    `| Field | Value |`,
+    `|-------|-------|`,
+    `| Pipeline | ${pipeline.name} |`,
+    `| Run ID | \`${run.id}\` |`,
+    `| Status | ${run.status} |`,
+    `| Total Tokens | ${totalTokens.toLocaleString()} |`,
+    `| Duration | ${durationMs > 0 ? formatDuration(durationMs) : "N/A"} |`,
+    `| Started | ${formatTimestamp(run.startedAt)} |`,
+    `| Completed | ${formatTimestamp(run.completedAt)} |`,
+    `| Stages Completed | ${completedStages.length} / ${stages.filter((s) => s.status !== "skipped").length} |`,
+    ``,
+  ];
+
+  // Model breakdown
+  const modelBreakdown = new Map<string, { tokens: number; stages: number }>();
+  for (const stage of completedStages) {
+    const existing = modelBreakdown.get(stage.modelSlug) ?? { tokens: 0, stages: 0 };
+    existing.tokens += stage.tokensUsed ?? 0;
+    existing.stages++;
+    modelBreakdown.set(stage.modelSlug, existing);
+  }
+
+  if (modelBreakdown.size > 0) {
+    lines.push(`## Model Breakdown`, ``);
+    lines.push(`| Model | Stages | Tokens |`);
+    lines.push(`|-------|--------|--------|`);
+    for (const [model, stats] of modelBreakdown) {
+      lines.push(`| ${model} | ${stats.stages} | ${stats.tokens.toLocaleString()} |`);
+    }
+    lines.push(``);
+  }
+
+  // Timeline
+  lines.push(`## Timeline`, ``);
+  lines.push(`| # | Team | Status | Tokens | Started | Completed |`);
+  lines.push(`|---|------|--------|--------|---------|-----------|`);
+  for (const stage of stages) {
+    lines.push(
+      `| ${stage.stageIndex + 1} | ${stage.teamId} | ${stage.status} | ${(stage.tokensUsed ?? 0).toLocaleString()} | ${formatTimestamp(stage.startedAt)} | ${formatTimestamp(stage.completedAt)} |`,
+    );
+  }
+  lines.push(``);
+
+  // Per-stage outputs
+  lines.push(`## Stage Outputs`, ``);
+  for (const stage of completedStages) {
+    const output = stage.output as Record<string, unknown> | null;
+    lines.push(`### Stage ${stage.stageIndex + 1}: ${stage.teamId}`);
+    lines.push(``);
+    lines.push(`- **Model**: ${stage.modelSlug}`);
+    lines.push(`- **Tokens**: ${(stage.tokensUsed ?? 0).toLocaleString()}`);
+    lines.push(``);
+
+    if (output) {
+      const summary = output.summary as string | undefined;
+      if (summary) {
+        lines.push(`#### Summary`, ``);
+        lines.push(summary, ``);
+      }
+
+      const rawContent = output.raw as string | undefined;
+      if (rawContent && rawContent !== summary) {
+        lines.push(`#### Full Output`, ``, rawContent, ``);
+      }
+    }
+  }
+
+  // Input
+  lines.push(`## Input`, ``, run.input, ``);
+
+  return lines.join("\n");
+}
+
+// ─── Code Block Extraction ───────────────────────────────────────────────────
+
+interface CodeBlock {
+  lang: string;
+  content: string;
+  stageIndex: number;
+  blockIndex: number;
+}
+
+const CODE_BLOCK_RE = /```(\w*)\n([\s\S]*?)```/g;
+
+const LANG_TO_EXT: Record<string, string> = {
+  typescript: "ts",
+  javascript: "js",
+  python: "py",
+  go: "go",
+  rust: "rs",
+  java: "java",
+  bash: "sh",
+  shell: "sh",
+  sh: "sh",
+  yaml: "yaml",
+  yml: "yml",
+  json: "json",
+  sql: "sql",
+  html: "html",
+  css: "css",
+  markdown: "md",
+  md: "md",
+  dockerfile: "dockerfile",
+  tf: "tf",
+};
+
+function extractCodeBlocks(stages: StageExecution[]): CodeBlock[] {
+  const blocks: CodeBlock[] = [];
+  for (const stage of stages) {
+    if (stage.status !== "completed") continue;
+    const output = stage.output as Record<string, unknown> | null;
+    if (!output) continue;
+
+    const text = (output.raw as string) ?? JSON.stringify(output);
+    let match: RegExpExecArray | null;
+    let blockIndex = 0;
+    const re = new RegExp(CODE_BLOCK_RE.source, "g");
+    while ((match = re.exec(text)) !== null) {
+      const lang = match[1] ?? "";
+      const content = match[2] ?? "";
+      if (content.trim().length > 0) {
+        blocks.push({ lang: lang.toLowerCase(), content, stageIndex: stage.stageIndex, blockIndex });
+        blockIndex++;
+      }
+    }
+  }
+  return blocks;
+}
+
+// ─── Minimal ZIP Builder ──────────────────────────────────────────────────────
+// Implements ZIP format (PKZIP spec) with STORE compression (no deflate).
+
+function uint16LE(n: number): Buffer {
+  const b = Buffer.allocUnsafe(2);
+  b.writeUInt16LE(n, 0);
+  return b;
+}
+
+function uint32LE(n: number): Buffer {
+  const b = Buffer.allocUnsafe(4);
+  b.writeUInt32LE(n, 0);
+  return b;
+}
+
+function dosDateTime(d: Date): { date: number; time: number } {
+  const date =
+    ((d.getFullYear() - 1980) << 9) | ((d.getMonth() + 1) << 5) | d.getDate();
+  const time =
+    (d.getHours() << 11) | (d.getMinutes() << 5) | Math.floor(d.getSeconds() / 2);
+  return { date, time };
+}
+
+function crc32(buf: Buffer): number {
+  const TABLE = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let c = i;
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    TABLE[i] = c;
+  }
+  let crc = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) {
+    crc = TABLE[(crc ^ buf[i]) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+interface ZipEntry {
+  name: string;
+  data: Buffer;
+}
+
+function buildZip(entries: ZipEntry[]): Buffer {
+  const now = new Date();
+  const { date: dosDate, time: dosTime } = dosDateTime(now);
+
+  const localHeaders: Buffer[] = [];
+  const centralDirs: Buffer[] = [];
+  const offsets: number[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const nameBuffer = Buffer.from(entry.name, "utf8");
+    const crc = crc32(entry.data);
+    const size = entry.data.length;
+
+    // Local file header (signature 0x04034b50)
+    const local = Buffer.concat([
+      Buffer.from([0x50, 0x4b, 0x03, 0x04]), // signature
+      uint16LE(20),          // version needed: 2.0
+      uint16LE(0),           // flags
+      uint16LE(0),           // compression: STORE
+      uint16LE(dosTime),
+      uint16LE(dosDate),
+      uint32LE(crc),
+      uint32LE(size),        // compressed size
+      uint32LE(size),        // uncompressed size
+      uint16LE(nameBuffer.length),
+      uint16LE(0),           // extra field length
+      nameBuffer,
+      entry.data,
+    ]);
+
+    offsets.push(offset);
+    localHeaders.push(local);
+    offset += local.length;
+  }
+
+  // Central directory
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    const nameBuffer = Buffer.from(entry.name, "utf8");
+    const crc = crc32(entry.data);
+    const size = entry.data.length;
+
+    const cd = Buffer.concat([
+      Buffer.from([0x50, 0x4b, 0x01, 0x02]), // signature
+      uint16LE(20),           // version made by
+      uint16LE(20),           // version needed
+      uint16LE(0),            // flags
+      uint16LE(0),            // compression: STORE
+      uint16LE(dosTime),
+      uint16LE(dosDate),
+      uint32LE(crc),
+      uint32LE(size),
+      uint32LE(size),
+      uint16LE(nameBuffer.length),
+      uint16LE(0),            // extra length
+      uint16LE(0),            // comment length
+      uint16LE(0),            // disk start
+      uint16LE(0),            // internal attr
+      uint32LE(0),            // external attr
+      uint32LE(offsets[i]),   // local header offset
+      nameBuffer,
+    ]);
+    centralDirs.push(cd);
+  }
+
+  const centralDirBuffer = Buffer.concat(centralDirs);
+  const centralDirSize = centralDirBuffer.length;
+  const centralDirOffset = offset;
+
+  // End of central directory record
+  const eocd = Buffer.concat([
+    Buffer.from([0x50, 0x4b, 0x05, 0x06]), // signature
+    uint16LE(0),                             // disk number
+    uint16LE(0),                             // start disk
+    uint16LE(entries.length),                // entries on disk
+    uint16LE(entries.length),                // total entries
+    uint32LE(centralDirSize),
+    uint32LE(centralDirOffset),
+    uint16LE(0),                             // comment length
+  ]);
+
+  return Buffer.concat([...localHeaders, centralDirBuffer, eocd]);
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export function generateZipExport(
+  run: PipelineRun,
+  stages: StageExecution[],
+  pipeline: Pipeline,
+): Buffer {
+  const markdown = generateMarkdownReport(run, stages, pipeline);
+  const entries: ZipEntry[] = [
+    { name: "report.md", data: Buffer.from(markdown, "utf8") },
+  ];
+
+  const codeBlocks = extractCodeBlocks(stages);
+  for (const block of codeBlocks) {
+    const ext = (LANG_TO_EXT[block.lang] ?? block.lang) || "txt";
+    const fileName = `stage-${block.stageIndex + 1}-code-${block.blockIndex + 1}.${ext}`;
+    entries.push({ name: fileName, data: Buffer.from(block.content, "utf8") });
+  }
+
+  return buildZip(entries);
+}

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -359,6 +359,10 @@ export class MemStorage implements IStorage {
       completedAt: insert.completedAt ?? null,
       sandboxResult: insert.sandboxResult ?? null,
       thoughtTree: insert.thoughtTree ?? null,
+      approvalStatus: insert.approvalStatus ?? null,
+      approvedAt: insert.approvedAt ?? null,
+      approvedBy: insert.approvedBy ?? null,
+      rejectionReason: insert.rejectionReason ?? null,
       createdAt: new Date(),
     };
     this.stages.set(id, stage);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -125,6 +125,11 @@ export const stageExecutions = pgTable("stage_executions", {
   completedAt: timestamp("completed_at"),
   sandboxResult: jsonb("sandbox_result"),
   thoughtTree: jsonb("thought_tree"),
+  // ─── Approval Gate Fields ───────────────────────
+  approvalStatus: text("approval_status"),  // 'pending' | 'approved' | 'rejected'
+  approvedAt: timestamp("approved_at"),
+  approvedBy: text("approved_by"),
+  rejectionReason: text("rejection_reason"),
   createdAt: timestamp("created_at").defaultNow(),
 });
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -14,7 +14,8 @@ export type RunStatus =
   | "paused"
   | "completed"
   | "failed"
-  | "cancelled";
+  | "cancelled"
+  | "rejected";
 
 export type StageStatus =
   | "pending"
@@ -22,7 +23,10 @@ export type StageStatus =
   | "paused"
   | "completed"
   | "failed"
-  | "skipped";
+  | "skipped"
+  | "awaiting_approval";
+
+export type ApprovalStatus = "pending" | "approved" | "rejected";
 
 export type QuestionStatus = "pending" | "answered" | "dismissed";
 
@@ -181,6 +185,9 @@ export type WsEventType =
   | "stage:progress"
   | "stage:completed"
   | "stage:failed"
+  | "stage:awaiting_approval"
+  | "stage:approved"
+  | "stage:rejected"
   | "question:asked"
   | "question:answered"
   | "chat:message"
@@ -331,6 +338,7 @@ export interface PipelineStageConfig {
   temperature?: number;
   maxTokens?: number;
   enabled: boolean;
+  approvalRequired?: boolean;
   executionStrategy?: ExecutionStrategy;
   privacySettings?: PrivacySettings;
   sandbox?: SandboxConfig;


### PR DESCRIPTION
## Summary

- **Approval gates per stage**: any pipeline stage can now require human approval before the pipeline continues. After a stage completes, if `approvalRequired: true` is set, the pipeline pauses and emits a `stage:awaiting_approval` WS event. Operators click Approve or Reject in the UI; on reject the run status becomes `rejected` and execution stops.
- **Run export**: `GET /api/runs/:id/export?format=markdown` downloads a Markdown report (executive summary, model breakdown, timeline, per-stage outputs); `?format=zip` downloads a ZIP with the report plus all extracted code blocks as individual files. ZIP is implemented using Node built-ins only — no new dependencies.
- **DB migration**: four new columns on `stage_executions` — `approval_status`, `approved_at`, `approved_by`, `rejection_reason`. Apply with `npm run db:push`.

## Changes

### Shared
- `shared/types.ts` — `approvalRequired?` on `PipelineStageConfig`, new `ApprovalStatus` type, `awaiting_approval` added to `StageStatus`, `rejected` added to `RunStatus`, three new WS event types
- `shared/schema.ts` — four approval columns on `stage_executions`

### Server
- `server/controller/pipeline-controller.ts` — promise-based approval gate; `approveStage()` / `rejectStage()` public methods; cancel cleans up pending approval promises
- `server/routes/runs.ts` — approve, reject, and export routes with Zod validation
- `server/services/export-service.ts` — Markdown generator and minimal ZIP builder (PKZIP STORE format, pure Node.js)
- `server/storage.ts` — `MemStorage.createStageExecution` includes new approval fields

### Client
- `client/src/hooks/use-websocket.ts` — handles `stage:awaiting_approval`, `stage:approved`, `stage:rejected` events; tracks `pendingApprovals` list
- `client/src/hooks/use-pipeline.ts` — `useApproveStage`, `useRejectStage`, `useExportRun` hooks
- `client/src/pages/PipelineRun.tsx` — approval banner with Approve/Reject buttons, Export dropdown, rejection status messaging
- `client/src/components/pipeline/StageProgress.tsx` — `awaiting_approval` status entry with amber styling

## Test plan

- [ ] Create a pipeline with `approvalRequired: true` on at least one stage; run it and confirm the pipeline pauses with the approval banner visible
- [ ] Click Approve — pipeline continues to the next stage
- [ ] Click Reject — run status changes to `rejected`, pipeline does not continue
- [ ] Cancel a run that is awaiting approval — confirm no memory leak (promise resolves)
- [ ] Export a completed run as Markdown — check the file downloads with the correct report structure
- [ ] Export a completed run as ZIP — check the archive contains `report.md` and any code blocks as separate files
- [ ] `npm run db:push` applies the schema migration without errors
- [ ] `npm run check` and `npm run build` pass