### PR TITLE
feat: Phase 4 — Code Workspace with multi-model parallel review

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,6 +17,8 @@ import Settings from "@/pages/Settings";
 import Privacy from "@/pages/Privacy";
 import Statistics from "@/pages/Statistics";
 import Memory from "@/pages/Memory";
+import WorkspaceList from "@/pages/WorkspaceList";
+import Workspace from "@/pages/Workspace";
 
 function Router() {
   return (
@@ -42,6 +44,12 @@ function Router() {
         </Route>
         <Route path="/runs/:runId" component={() => (
           <ErrorBoundary><PipelineRun /></ErrorBoundary>
+        )} />
+        <Route path="/workspaces" component={() => (
+          <ErrorBoundary><WorkspaceList /></ErrorBoundary>
+        )} />
+        <Route path="/workspaces/:id" component={() => (
+          <ErrorBoundary><Workspace /></ErrorBoundary>
         )} />
         <Route path="/settings" component={() => (
           <ErrorBoundary><Settings /></ErrorBoundary>

--- a/client/src/components/layout/MainLayout.tsx
+++ b/client/src/components/layout/MainLayout.tsx
@@ -10,6 +10,7 @@ import {
   ShieldCheck,
   BarChart3,
   Brain,
+  FolderGit2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePendingQuestions } from "@/hooks/use-pipeline";
@@ -32,6 +33,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
       href: "/pipelines",
       badge: pendingCount > 0 ? pendingCount : undefined,
     },
+    { icon: FolderGit2, label: "Workspace", href: "/workspaces" },
     { icon: BarChart3, label: "Statistics", href: "/stats" },
     { icon: Brain, label: "Memory", href: "/memories" },
     { icon: ShieldCheck, label: "Privacy", href: "/privacy" },

--- a/client/src/components/workspace/ChatPanel.tsx
+++ b/client/src/components/workspace/ChatPanel.tsx
@@ -1,0 +1,165 @@
+import { useState, useRef, useEffect } from "react";
+import { Send } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface Message {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  model?: string;
+}
+
+interface ChatPanelProps {
+  workspaceId: string;
+  modelSlug: string;
+  contextFilePaths?: string[];
+}
+
+async function sendChat(
+  workspaceId: string,
+  message: string,
+  modelSlug: string,
+  filePaths: string[],
+): Promise<string> {
+  const res = await fetch(`/api/workspaces/${workspaceId}/chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      message,
+      modelSlug,
+      context: filePaths.length > 0 ? { filePaths } : undefined,
+    }),
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: "Request failed" }));
+    throw new Error((err as { error: string }).error ?? "Request failed");
+  }
+
+  const data = await res.json() as { reply: string };
+  return data.reply;
+}
+
+export function ChatPanel({ workspaceId, modelSlug, contextFilePaths = [] }: ChatPanelProps) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+  const [isSending, setIsSending] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const handleSend = async () => {
+    const text = input.trim();
+    if (!text || isSending) return;
+
+    const userMsg: Message = { id: crypto.randomUUID(), role: "user", content: text };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput("");
+    setIsSending(true);
+
+    try {
+      const reply = await sendChat(workspaceId, text, modelSlug, contextFilePaths);
+      const assistantMsg: Message = {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        content: reply,
+        model: modelSlug,
+      };
+      setMessages((prev) => [...prev, assistantMsg]);
+    } catch (err) {
+      const errMsg: Message = {
+        id: crypto.randomUUID(),
+        role: "assistant",
+        content: `Error: ${(err as Error).message}`,
+        model: modelSlug,
+      };
+      setMessages((prev) => [...prev, errMsg]);
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto p-3 space-y-3">
+        {messages.length === 0 && (
+          <div className="flex items-center justify-center h-24">
+            <p className="text-xs text-muted-foreground text-center">
+              Ask about the code in this workspace.
+              {contextFilePaths.length > 0 && (
+                <> {contextFilePaths.length} file(s) in context.</>
+              )}
+            </p>
+          </div>
+        )}
+
+        {messages.map((msg) => (
+          <div
+            key={msg.id}
+            className={cn(
+              "flex",
+              msg.role === "user" ? "justify-end" : "justify-start",
+            )}
+          >
+            <div
+              className={cn(
+                "max-w-[85%] rounded-lg px-3 py-2 text-xs",
+                msg.role === "user"
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-muted text-foreground",
+              )}
+            >
+              {msg.role === "assistant" && msg.model && (
+                <span className="block text-[10px] font-mono font-semibold mb-1 opacity-60">
+                  {msg.model}
+                </span>
+              )}
+              <pre className="whitespace-pre-wrap font-sans">{msg.content}</pre>
+            </div>
+          </div>
+        ))}
+
+        {isSending && (
+          <div className="flex justify-start">
+            <div className="bg-muted rounded-lg px-3 py-2 text-xs text-muted-foreground">
+              Thinking...
+            </div>
+          </div>
+        )}
+
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Input */}
+      <div className="border-t border-border p-3 shrink-0">
+        <div className="flex gap-2 items-end">
+          <textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask about the code... (Enter to send)"
+            rows={2}
+            className="flex-1 resize-none text-xs px-3 py-2 rounded-md border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+          <button
+            onClick={handleSend}
+            disabled={!input.trim() || isSending}
+            className="shrink-0 p-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+          >
+            <Send className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/workspace/CodeViewer.tsx
+++ b/client/src/components/workspace/CodeViewer.tsx
@@ -1,0 +1,66 @@
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+
+interface CodeViewerProps {
+  content: string;
+  filePath: string;
+  className?: string;
+}
+
+function getLanguageClass(filePath: string): string {
+  const ext = filePath.split(".").pop()?.toLowerCase() ?? "";
+  const map: Record<string, string> = {
+    ts: "language-typescript",
+    tsx: "language-typescript",
+    js: "language-javascript",
+    jsx: "language-javascript",
+    py: "language-python",
+    go: "language-go",
+    rs: "language-rust",
+    json: "language-json",
+    yaml: "language-yaml",
+    yml: "language-yaml",
+    toml: "language-toml",
+    css: "language-css",
+    html: "language-html",
+    md: "language-markdown",
+  };
+  return map[ext] ?? "language-plaintext";
+}
+
+export function CodeViewer({ content, filePath, className }: CodeViewerProps) {
+  const lines = useMemo(() => content.split("\n"), [content]);
+  const langClass = getLanguageClass(filePath);
+
+  return (
+    <div className={cn("flex flex-col h-full overflow-hidden", className)}>
+      <div className="flex items-center justify-between px-3 py-1.5 border-b border-border bg-muted/30 shrink-0">
+        <span className="text-xs font-mono text-muted-foreground truncate">{filePath}</span>
+        <span className="text-[10px] text-muted-foreground ml-2 shrink-0">
+          {lines.length} lines
+        </span>
+      </div>
+
+      <div className="flex-1 overflow-auto">
+        <div className={cn("flex font-mono text-xs", langClass)}>
+          {/* Line numbers */}
+          <div
+            className="select-none text-right pr-4 pl-3 py-3 text-muted-foreground/50 border-r border-border bg-muted/20 shrink-0"
+            aria-hidden="true"
+          >
+            {lines.map((_, i) => (
+              <div key={i} className="leading-5">
+                {i + 1}
+              </div>
+            ))}
+          </div>
+
+          {/* Code content */}
+          <pre className="flex-1 py-3 px-4 overflow-x-auto whitespace-pre leading-5 text-foreground">
+            <code>{content}</code>
+          </pre>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/workspace/FileTree.tsx
+++ b/client/src/components/workspace/FileTree.tsx
@@ -1,0 +1,176 @@
+import { useState } from "react";
+import { ChevronRight, ChevronDown, Folder, FolderOpen, File } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { FileEntry } from "@shared/types";
+
+interface FileTreeProps {
+  entries: FileEntry[];
+  workspaceId: string;
+  selectedPath: string | null;
+  onSelect: (path: string) => void;
+  onLoadDir?: (path: string) => Promise<FileEntry[]>;
+}
+
+interface TreeNode {
+  entry: FileEntry;
+  children?: TreeNode[];
+  isOpen: boolean;
+  isLoaded: boolean;
+}
+
+function buildTree(entries: FileEntry[]): TreeNode[] {
+  return entries.map((entry) => ({
+    entry,
+    children: entry.type === "directory" ? [] : undefined,
+    isOpen: false,
+    isLoaded: false,
+  }));
+}
+
+interface NodeProps {
+  node: TreeNode;
+  depth: number;
+  selectedPath: string | null;
+  onSelect: (path: string) => void;
+  onToggle: (path: string) => void;
+}
+
+function TreeNode({ node, depth, selectedPath, onSelect, onToggle }: NodeProps) {
+  const isDir = node.entry.type === "directory";
+  const isSelected = selectedPath === node.entry.path;
+
+  const handleClick = () => {
+    if (isDir) {
+      onToggle(node.entry.path);
+    } else {
+      onSelect(node.entry.path);
+    }
+  };
+
+  return (
+    <div>
+      <div
+        className={cn(
+          "flex items-center gap-1.5 px-2 py-1 text-xs cursor-pointer rounded-sm transition-colors",
+          isSelected
+            ? "bg-primary/15 text-primary"
+            : "hover:bg-muted/50 text-foreground",
+        )}
+        style={{ paddingLeft: `${depth * 12 + 8}px` }}
+        onClick={handleClick}
+      >
+        {isDir ? (
+          <>
+            <span className="text-muted-foreground w-3 h-3 flex-shrink-0">
+              {node.isOpen ? (
+                <ChevronDown className="h-3 w-3" />
+              ) : (
+                <ChevronRight className="h-3 w-3" />
+              )}
+            </span>
+            {node.isOpen ? (
+              <FolderOpen className="h-3.5 w-3.5 text-amber-400 flex-shrink-0" />
+            ) : (
+              <Folder className="h-3.5 w-3.5 text-amber-400 flex-shrink-0" />
+            )}
+          </>
+        ) : (
+          <>
+            <span className="w-3 flex-shrink-0" />
+            <File className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+          </>
+        )}
+        <span className="truncate">{node.entry.name}</span>
+      </div>
+
+      {isDir && node.isOpen && node.children && (
+        <div>
+          {node.children.map((child) => (
+            <TreeNode
+              key={child.entry.path}
+              node={child}
+              depth={depth + 1}
+              selectedPath={selectedPath}
+              onSelect={onSelect}
+              onToggle={onToggle}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function FileTree({ entries, workspaceId, selectedPath, onSelect, onLoadDir }: FileTreeProps) {
+  const [nodes, setNodes] = useState<TreeNode[]>(() => buildTree(entries));
+
+  const handleToggle = async (path: string) => {
+    setNodes((prev) => toggleNode(prev, path));
+
+    if (onLoadDir) {
+      const node = findNode(nodes, path);
+      if (node && !node.isLoaded) {
+        const children = await onLoadDir(path);
+        setNodes((prev) => setChildren(prev, path, buildTree(children)));
+      }
+    }
+  };
+
+  // Re-sync when entries change
+  if (nodes.length === 0 && entries.length > 0) {
+    setNodes(buildTree(entries));
+  }
+
+  return (
+    <div className="select-none">
+      {nodes.map((node) => (
+        <TreeNode
+          key={node.entry.path}
+          node={node}
+          depth={0}
+          selectedPath={selectedPath}
+          onSelect={onSelect}
+          onToggle={handleToggle}
+        />
+      ))}
+      {nodes.length === 0 && (
+        <p className="text-xs text-muted-foreground px-3 py-4">No files found</p>
+      )}
+    </div>
+  );
+}
+
+function findNode(nodes: TreeNode[], path: string): TreeNode | null {
+  for (const node of nodes) {
+    if (node.entry.path === path) return node;
+    if (node.children) {
+      const found = findNode(node.children, path);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function toggleNode(nodes: TreeNode[], path: string): TreeNode[] {
+  return nodes.map((node) => {
+    if (node.entry.path === path) {
+      return { ...node, isOpen: !node.isOpen };
+    }
+    if (node.children) {
+      return { ...node, children: toggleNode(node.children, path) };
+    }
+    return node;
+  });
+}
+
+function setChildren(nodes: TreeNode[], path: string, children: TreeNode[]): TreeNode[] {
+  return nodes.map((node) => {
+    if (node.entry.path === path) {
+      return { ...node, children, isLoaded: true };
+    }
+    if (node.children) {
+      return { ...node, children: setChildren(node.children, path, children) };
+    }
+    return node;
+  });
+}

--- a/client/src/components/workspace/ReviewPanel.tsx
+++ b/client/src/components/workspace/ReviewPanel.tsx
@@ -1,0 +1,117 @@
+import { cn } from "@/lib/utils";
+import type { ReviewResult, ReviewIssue } from "@shared/types";
+
+interface ReviewPanelProps {
+  results: Record<string, ReviewResult>;
+  isLoading?: boolean;
+}
+
+const severityConfig: Record<ReviewIssue["severity"], { label: string; classes: string }> = {
+  error: { label: "Error", classes: "bg-red-500/10 text-red-500 border-red-500/20" },
+  warning: { label: "Warn", classes: "bg-amber-500/10 text-amber-500 border-amber-500/20" },
+  info: { label: "Info", classes: "bg-blue-500/10 text-blue-500 border-blue-500/20" },
+};
+
+function SeverityBadge({ severity }: { severity: ReviewIssue["severity"] }) {
+  const { label, classes } = severityConfig[severity];
+  return (
+    <span className={cn("text-[10px] font-semibold px-1.5 py-0.5 rounded border", classes)}>
+      {label}
+    </span>
+  );
+}
+
+function IssueCard({ issue }: { issue: ReviewIssue }) {
+  return (
+    <div className="rounded-md border border-border bg-muted/20 p-2.5 space-y-1">
+      <div className="flex items-start gap-2">
+        <SeverityBadge severity={issue.severity} />
+        <span className="text-xs text-muted-foreground font-mono">
+          {issue.file}
+          {issue.line ? `:${issue.line}` : ""}
+        </span>
+      </div>
+      <p className="text-xs text-foreground">{issue.message}</p>
+      {issue.suggestion && (
+        <p className="text-[11px] text-muted-foreground italic">{issue.suggestion}</p>
+      )}
+    </div>
+  );
+}
+
+function ModelReview({ result }: { result: ReviewResult }) {
+  const errorCount = result.issues.filter((i) => i.severity === "error").length;
+  const warnCount = result.issues.filter((i) => i.severity === "warning").length;
+  const infoCount = result.issues.filter((i) => i.severity === "info").length;
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-3 space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs font-mono font-semibold text-primary truncate">{result.model}</span>
+        <div className="flex gap-1 shrink-0">
+          {errorCount > 0 && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-red-500/10 text-red-500 font-semibold">
+              {errorCount}E
+            </span>
+          )}
+          {warnCount > 0 && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-500 font-semibold">
+              {warnCount}W
+            </span>
+          )}
+          {infoCount > 0 && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-500 font-semibold">
+              {infoCount}I
+            </span>
+          )}
+        </div>
+      </div>
+
+      <p className="text-xs text-muted-foreground leading-relaxed">{result.summary}</p>
+
+      {result.issues.length > 0 && (
+        <div className="space-y-1.5">
+          {result.issues.map((issue, idx) => (
+            <IssueCard key={idx} issue={issue} />
+          ))}
+        </div>
+      )}
+
+      {result.issues.length === 0 && (
+        <p className="text-[11px] text-muted-foreground italic">No issues found</p>
+      )}
+    </div>
+  );
+}
+
+export function ReviewPanel({ results, isLoading }: ReviewPanelProps) {
+  const entries = Object.values(results);
+
+  if (isLoading) {
+    return (
+      <div className="p-4 space-y-3">
+        {[1, 2].map((i) => (
+          <div key={i} className="rounded-lg border border-border bg-card p-3 animate-pulse h-24" />
+        ))}
+      </div>
+    );
+  }
+
+  if (entries.length === 0) {
+    return (
+      <div className="p-4 flex flex-col items-center justify-center h-32 text-center">
+        <p className="text-xs text-muted-foreground">
+          Select files and click "Review" to run multi-model code analysis.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-3 space-y-3 overflow-y-auto">
+      {entries.map((result) => (
+        <ModelReview key={result.model} result={result} />
+      ))}
+    </div>
+  );
+}

--- a/client/src/pages/Workspace.tsx
+++ b/client/src/pages/Workspace.tsx
@@ -1,0 +1,319 @@
+import { useState } from "react";
+import { useRoute } from "wouter";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { RefreshCw, GitBranch, Eye, MessageSquare, Code2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { FileTree } from "@/components/workspace/FileTree";
+import { CodeViewer } from "@/components/workspace/CodeViewer";
+import { ReviewPanel } from "@/components/workspace/ReviewPanel";
+import { ChatPanel } from "@/components/workspace/ChatPanel";
+import type { WorkspaceRow } from "@shared/schema";
+import type { FileEntry, GitStatus, ReviewResult } from "@shared/types";
+import type { Model } from "@shared/schema";
+
+// ─── API helpers ─────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+
+async function postJson<T>(url: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: "Request failed" }));
+    throw new Error((err as { error: string }).error ?? "Request failed");
+  }
+  return res.json();
+}
+
+// ─── Panel tab ────────────────────────────────────────────────────────────────
+
+type RightPanel = "chat" | "review";
+
+// ─── Status indicator ─────────────────────────────────────────────────────────
+
+function GitStatusBadge({ status }: { status: GitStatus }) {
+  const total = status.modified.length + status.staged.length + status.untracked.length;
+  return (
+    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+      <GitBranch className="h-3.5 w-3.5" />
+      <span className="font-mono">{status.branch}</span>
+      {total > 0 && (
+        <span className="bg-amber-500/10 text-amber-500 px-1.5 py-0.5 rounded text-[10px] font-semibold">
+          {total} changed
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ─── Model selector ───────────────────────────────────────────────────────────
+
+interface ModelSelectorProps {
+  models: Model[];
+  selected: string[];
+  onChange: (slugs: string[]) => void;
+  single?: boolean;
+}
+
+function ModelSelector({ models, selected, onChange, single }: ModelSelectorProps) {
+  const active = models.filter((m) => m.isActive);
+
+  const toggle = (slug: string) => {
+    if (single) {
+      onChange([slug]);
+      return;
+    }
+    if (selected.includes(slug)) {
+      onChange(selected.filter((s) => s !== slug));
+    } else {
+      onChange([...selected, slug]);
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {active.map((m) => (
+        <button
+          key={m.slug}
+          onClick={() => toggle(m.slug)}
+          className={cn(
+            "text-[10px] px-2 py-0.5 rounded border transition-colors font-mono",
+            selected.includes(m.slug)
+              ? "bg-primary text-primary-foreground border-primary"
+              : "border-border text-muted-foreground hover:border-primary/50",
+          )}
+        >
+          {m.slug}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function Workspace() {
+  const [, params] = useRoute<{ id: string }>("/workspaces/:id");
+  const workspaceId = params?.id ?? "";
+
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const [fileContent, setFileContent] = useState<string>("");
+  const [rightPanel, setRightPanel] = useState<RightPanel>("chat");
+  const [reviewModels, setReviewModels] = useState<string[]>([]);
+  const [chatModel, setChatModel] = useState<string[]>([]);
+  const [reviewResults, setReviewResults] = useState<Record<string, ReviewResult>>({});
+  const [isReviewing, setIsReviewing] = useState(false);
+  const qc = useQueryClient();
+
+  const { data: workspace } = useQuery<WorkspaceRow>({
+    queryKey: ["workspace", workspaceId],
+    queryFn: () => fetchJson(`/api/workspaces/${workspaceId}`),
+    enabled: !!workspaceId,
+  });
+
+  const { data: files } = useQuery<FileEntry[]>({
+    queryKey: ["workspace-files", workspaceId],
+    queryFn: () => fetchJson(`/api/workspaces/${workspaceId}/files`),
+    enabled: !!workspaceId,
+  });
+
+  const { data: gitStatus } = useQuery<GitStatus>({
+    queryKey: ["workspace-git-status", workspaceId],
+    queryFn: () => fetchJson(`/api/workspaces/${workspaceId}/git/status`),
+    enabled: !!workspaceId,
+  });
+
+  const { data: models } = useQuery<Model[]>({
+    queryKey: ["models"],
+    queryFn: () => fetchJson("/api/models"),
+  });
+
+  const syncMutation = useMutation({
+    mutationFn: () => postJson(`/api/workspaces/${workspaceId}/sync`, {}),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["workspace", workspaceId] });
+      qc.invalidateQueries({ queryKey: ["workspace-files", workspaceId] });
+    },
+  });
+
+  const loadDirContents = async (dirPath: string): Promise<FileEntry[]> => {
+    return fetchJson(`/api/workspaces/${workspaceId}/files?path=${encodeURIComponent(dirPath)}`);
+  };
+
+  const handleFileSelect = async (filePath: string) => {
+    setSelectedFile(filePath);
+    try {
+      const data = await fetchJson<{ path: string; content: string }>(
+        `/api/workspaces/${workspaceId}/files/${encodeURIComponent(filePath)}`,
+      );
+      setFileContent(data.content);
+    } catch {
+      setFileContent("[Could not read file]");
+    }
+  };
+
+  const handleReview = async () => {
+    if (!selectedFile || reviewModels.length === 0) return;
+    setIsReviewing(true);
+    setRightPanel("review");
+    try {
+      const results = await postJson<Record<string, ReviewResult>>(
+        `/api/workspaces/${workspaceId}/review`,
+        { filePaths: [selectedFile], models: reviewModels },
+      );
+      setReviewResults(results);
+    } finally {
+      setIsReviewing(false);
+    }
+  };
+
+  if (!workspace) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <p className="text-sm text-muted-foreground">Loading workspace...</p>
+      </div>
+    );
+  }
+
+  const activeModels = models?.filter((m) => m.isActive) ?? [];
+  const chatModelSlug = chatModel[0] ?? activeModels[0]?.slug ?? "";
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      {/* Top bar */}
+      <div className="h-14 border-b border-border flex items-center gap-4 px-4 shrink-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <Code2 className="h-4 w-4 text-primary shrink-0" />
+          <span className="text-sm font-semibold truncate">{workspace.name}</span>
+        </div>
+
+        {gitStatus && <GitStatusBadge status={gitStatus} />}
+
+        <div className="ml-auto flex items-center gap-2">
+          {workspace.type === "remote" && (
+            <button
+              onClick={() => syncMutation.mutate()}
+              disabled={syncMutation.isPending || workspace.status === "syncing"}
+              className="flex items-center gap-1 text-xs px-2 py-1 rounded border border-border text-muted-foreground hover:border-primary/50 disabled:opacity-50 transition-colors"
+            >
+              <RefreshCw className={cn("h-3 w-3", syncMutation.isPending && "animate-spin")} />
+              Sync
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Main layout: file tree | code viewer | right panel */}
+      <div className="flex-1 flex overflow-hidden">
+        {/* File tree */}
+        <div className="w-56 border-r border-border flex flex-col shrink-0 overflow-hidden">
+          <div className="px-3 py-2 border-b border-border">
+            <p className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">Files</p>
+          </div>
+          <div className="flex-1 overflow-y-auto py-1">
+            <FileTree
+              entries={files ?? []}
+              workspaceId={workspaceId}
+              selectedPath={selectedFile}
+              onSelect={handleFileSelect}
+              onLoadDir={loadDirContents}
+            />
+          </div>
+        </div>
+
+        {/* Code viewer */}
+        <div className="flex-1 flex flex-col overflow-hidden border-r border-border">
+          {selectedFile && fileContent ? (
+            <CodeViewer content={fileContent} filePath={selectedFile} className="flex-1" />
+          ) : (
+            <div className="flex-1 flex items-center justify-center">
+              <p className="text-xs text-muted-foreground">Select a file to view</p>
+            </div>
+          )}
+        </div>
+
+        {/* Right panel */}
+        <div className="w-96 flex flex-col overflow-hidden shrink-0">
+          {/* Panel tabs */}
+          <div className="border-b border-border flex items-center gap-1 px-3 py-1.5">
+            <button
+              onClick={() => setRightPanel("chat")}
+              className={cn(
+                "flex items-center gap-1.5 text-xs px-2.5 py-1 rounded transition-colors",
+                rightPanel === "chat"
+                  ? "bg-primary/10 text-primary"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <MessageSquare className="h-3 w-3" />
+              Chat
+            </button>
+            <button
+              onClick={() => setRightPanel("review")}
+              className={cn(
+                "flex items-center gap-1.5 text-xs px-2.5 py-1 rounded transition-colors",
+                rightPanel === "review"
+                  ? "bg-primary/10 text-primary"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <Eye className="h-3 w-3" />
+              Review
+            </button>
+          </div>
+
+          {/* Model pickers + review trigger */}
+          <div className="border-b border-border px-3 py-2 space-y-2">
+            {rightPanel === "review" ? (
+              <>
+                <p className="text-[10px] text-muted-foreground uppercase tracking-wider">Review models</p>
+                <ModelSelector
+                  models={activeModels}
+                  selected={reviewModels}
+                  onChange={setReviewModels}
+                />
+                <button
+                  onClick={handleReview}
+                  disabled={!selectedFile || reviewModels.length === 0 || isReviewing}
+                  className="w-full text-xs py-1.5 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+                >
+                  {isReviewing ? "Reviewing..." : "Run Review"}
+                </button>
+              </>
+            ) : (
+              <>
+                <p className="text-[10px] text-muted-foreground uppercase tracking-wider">Chat model</p>
+                <ModelSelector
+                  models={activeModels}
+                  selected={chatModel}
+                  onChange={setChatModel}
+                  single
+                />
+              </>
+            )}
+          </div>
+
+          {/* Panel content */}
+          <div className="flex-1 overflow-hidden">
+            {rightPanel === "review" ? (
+              <ReviewPanel results={reviewResults} isLoading={isReviewing} />
+            ) : (
+              <ChatPanel
+                workspaceId={workspaceId}
+                modelSlug={chatModelSlug}
+                contextFilePaths={selectedFile ? [selectedFile] : []}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/WorkspaceList.tsx
+++ b/client/src/pages/WorkspaceList.tsx
@@ -1,0 +1,306 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Link } from "wouter";
+import { FolderGit2, Plus, Trash2, RefreshCw, ExternalLink } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { WorkspaceRow } from "@shared/schema";
+
+// ─── API helpers ─────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+
+async function postJson<T>(url: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: "Request failed" }));
+    throw new Error((err as { error: string }).error ?? "Request failed");
+  }
+  return res.json();
+}
+
+// ─── Connect form ─────────────────────────────────────────────────────────────
+
+interface ConnectFormProps {
+  onDone: () => void;
+}
+
+function ConnectForm({ onDone }: ConnectFormProps) {
+  const [type, setType] = useState<"local" | "remote">("local");
+  const [localPath, setLocalPath] = useState("");
+  const [remoteUrl, setRemoteUrl] = useState("");
+  const [branch, setBranch] = useState("main");
+  const [name, setName] = useState("");
+  const [error, setError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const qc = useQueryClient();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setIsSubmitting(true);
+
+    try {
+      if (type === "local") {
+        await postJson("/api/workspaces", { type: "local", path: localPath, name: name || undefined });
+      } else {
+        await postJson("/api/workspaces", {
+          type: "remote",
+          url: remoteUrl,
+          branch: branch || "main",
+          name: name || undefined,
+        });
+      }
+      await qc.invalidateQueries({ queryKey: ["workspaces"] });
+      onDone();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="flex gap-2">
+        {(["local", "remote"] as const).map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => setType(t)}
+            className={cn(
+              "text-xs px-3 py-1.5 rounded border transition-colors capitalize",
+              type === t
+                ? "bg-primary text-primary-foreground border-primary"
+                : "border-border text-muted-foreground hover:border-primary/50",
+            )}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {type === "local" ? (
+        <div>
+          <label className="text-xs text-muted-foreground">Local path</label>
+          <input
+            type="text"
+            value={localPath}
+            onChange={(e) => setLocalPath(e.target.value)}
+            placeholder="/Users/you/projects/myapp"
+            required
+            className="mt-1 w-full text-xs px-3 py-2 rounded-md border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
+      ) : (
+        <>
+          <div>
+            <label className="text-xs text-muted-foreground">Repository URL (https://)</label>
+            <input
+              type="url"
+              value={remoteUrl}
+              onChange={(e) => setRemoteUrl(e.target.value)}
+              placeholder="https://github.com/owner/repo"
+              required
+              className="mt-1 w-full text-xs px-3 py-2 rounded-md border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+          <div>
+            <label className="text-xs text-muted-foreground">Branch</label>
+            <input
+              type="text"
+              value={branch}
+              onChange={(e) => setBranch(e.target.value)}
+              placeholder="main"
+              className="mt-1 w-full text-xs px-3 py-2 rounded-md border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+        </>
+      )}
+
+      <div>
+        <label className="text-xs text-muted-foreground">Name (optional)</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="My Project"
+          className="mt-1 w-full text-xs px-3 py-2 rounded-md border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+        />
+      </div>
+
+      {error && <p className="text-xs text-red-500">{error}</p>}
+
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="text-xs px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+        >
+          {isSubmitting ? "Connecting..." : "Connect"}
+        </button>
+        <button
+          type="button"
+          onClick={onDone}
+          className="text-xs px-4 py-2 rounded-md border border-border text-muted-foreground hover:border-primary/50 transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ─── Status badge ─────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: WorkspaceRow["status"] }) {
+  const config = {
+    active: "bg-green-500/10 text-green-500",
+    syncing: "bg-amber-500/10 text-amber-500",
+    error: "bg-red-500/10 text-red-500",
+  };
+  return (
+    <span className={cn("text-[10px] px-1.5 py-0.5 rounded font-medium capitalize", config[status])}>
+      {status}
+    </span>
+  );
+}
+
+// ─── Workspace card ───────────────────────────────────────────────────────────
+
+function WorkspaceCard({ workspace }: { workspace: WorkspaceRow }) {
+  const qc = useQueryClient();
+
+  const deleteMutation = useMutation({
+    mutationFn: () =>
+      fetch(`/api/workspaces/${workspace.id}`, { method: "DELETE" }).then((r) => r.json()),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["workspaces"] }),
+  });
+
+  const syncMutation = useMutation({
+    mutationFn: () => postJson(`/api/workspaces/${workspace.id}/sync`, {}),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["workspaces"] }),
+  });
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <FolderGit2 className="h-4 w-4 text-primary shrink-0" />
+          <div className="min-w-0">
+            <p className="text-sm font-medium truncate">{workspace.name}</p>
+            <p className="text-xs text-muted-foreground font-mono truncate">{workspace.path}</p>
+          </div>
+        </div>
+        <StatusBadge status={workspace.status} />
+      </div>
+
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <span className="capitalize">{workspace.type}</span>
+        <span>·</span>
+        <span className="font-mono">{workspace.branch}</span>
+        {workspace.lastSyncAt && (
+          <>
+            <span>·</span>
+            <span>synced {new Date(workspace.lastSyncAt).toLocaleString()}</span>
+          </>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Link href={`/workspaces/${workspace.id}`}>
+          <button className="flex items-center gap-1 text-xs px-2.5 py-1.5 rounded border border-primary text-primary hover:bg-primary/10 transition-colors">
+            <ExternalLink className="h-3 w-3" />
+            Open
+          </button>
+        </Link>
+
+        {workspace.type === "remote" && (
+          <button
+            onClick={() => syncMutation.mutate()}
+            disabled={syncMutation.isPending || workspace.status === "syncing"}
+            className="flex items-center gap-1 text-xs px-2.5 py-1.5 rounded border border-border text-muted-foreground hover:border-primary/50 disabled:opacity-50 transition-colors"
+          >
+            <RefreshCw className={cn("h-3 w-3", syncMutation.isPending && "animate-spin")} />
+            Sync
+          </button>
+        )}
+
+        <button
+          onClick={() => {
+            if (confirm(`Remove workspace "${workspace.name}"?`)) deleteMutation.mutate();
+          }}
+          disabled={deleteMutation.isPending}
+          className="flex items-center gap-1 text-xs px-2.5 py-1.5 rounded border border-border text-muted-foreground hover:border-red-500/50 hover:text-red-500 disabled:opacity-50 transition-colors ml-auto"
+        >
+          <Trash2 className="h-3 w-3" />
+          Remove
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function WorkspaceList() {
+  const [showForm, setShowForm] = useState(false);
+
+  const { data: workspaceList, isLoading } = useQuery<WorkspaceRow[]>({
+    queryKey: ["workspaces"],
+    queryFn: () => fetchJson("/api/workspaces"),
+  });
+
+  return (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      <div className="h-16 border-b border-border flex items-center justify-between px-6 shrink-0">
+        <h1 className="text-base font-semibold">Code Workspaces</h1>
+        <button
+          onClick={() => setShowForm(true)}
+          className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Connect Workspace
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-6 space-y-4">
+        {showForm && (
+          <div className="rounded-lg border border-border bg-card p-5">
+            <h2 className="text-sm font-medium mb-4">Connect a Workspace</h2>
+            <ConnectForm onDone={() => setShowForm(false)} />
+          </div>
+        )}
+
+        {isLoading ? (
+          <div className="grid gap-3">
+            {[1, 2].map((i) => (
+              <div key={i} className="rounded-lg border border-border bg-card p-4 animate-pulse h-28" />
+            ))}
+          </div>
+        ) : !workspaceList || workspaceList.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-48 text-center">
+            <FolderGit2 className="h-10 w-10 text-muted-foreground/30 mb-3" />
+            <p className="text-sm text-muted-foreground">No workspaces connected yet.</p>
+            <p className="text-xs text-muted-foreground mt-1">
+              Connect a local path or clone a remote repository to get started.
+            </p>
+          </div>
+        ) : (
+          <div className="grid gap-3">
+            {workspaceList.map((ws) => (
+              <WorkspaceCard key={ws.id} workspace={ws} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "react-hook-form": "^7.66.0",
         "react-resizable-panels": "^2.1.9",
         "recharts": "^2.15.4",
+        "simple-git": "^3.33.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
@@ -1489,6 +1490,21 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.27.1",
@@ -7552,6 +7568,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-git": {
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.33.0.tgz",
+      "integrity": "sha512-D4V/tGC2sjsoNhoMybKyGoE+v8A60hRawKQ1iFRA1zwuDgGZCBJ4ByOzZ5J8joBbi4Oam0qiPH+GhzmSBwbJng==",
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
     },
     "node_modules/sonner": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "react-hook-form": "^7.66.0",
     "react-resizable-panels": "^2.1.9",
     "recharts": "^2.15.4",
+    "simple-git": "^3.33.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -15,6 +15,7 @@ import { registerPrivacyRoutes } from "./routes/privacy";
 import { registerStatsRoutes } from "./routes/stats";
 import { registerMemoryRoutes } from "./routes/memory";
 import { registerToolRoutes } from "./routes/tools";
+import { registerWorkspaceRoutes } from "./routes/workspaces";
 import { DEFAULT_MODELS, DEFAULT_PIPELINE_STAGES } from "@shared/constants";
 import { log } from "./index";
 
@@ -39,6 +40,7 @@ export async function registerRoutes(
   registerStatsRoutes(app, storage);
   registerMemoryRoutes(app, storage);
   registerToolRoutes(app, storage);
+  registerWorkspaceRoutes(app, gateway);
 
   // Seed default models
   const existingModels = await storage.getModels();

--- a/server/routes/workspaces.ts
+++ b/server/routes/workspaces.ts
@@ -1,0 +1,352 @@
+import { type Router, type Request, type Response } from "express";
+import { z } from "zod";
+import { db } from "../db";
+import { workspaces } from "@shared/schema";
+import { eq } from "drizzle-orm";
+import type { WorkspaceRow } from "@shared/schema";
+import { WorkspaceManager } from "../workspace/manager";
+import { CodeChatService } from "../workspace/code-chat";
+import type { Gateway } from "../gateway/index";
+
+// ─── Validation schemas ───────────────────────────────────────────────────────
+
+const ConnectWorkspaceSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("local"),
+    path: z.string().min(1),
+    name: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal("remote"),
+    url: z.string().url().startsWith("https://"),
+    branch: z.string().optional(),
+    name: z.string().optional(),
+  }),
+]);
+
+const WriteFileSchema = z.object({
+  content: z.string(),
+  confirmed: z.boolean().optional(),
+});
+
+const CommitSchema = z.object({
+  message: z.string().min(1).max(500),
+});
+
+const BranchSchema = z.object({
+  name: z.string().min(1).max(200).regex(/^[a-zA-Z0-9_/.-]+$/, "Invalid branch name"),
+});
+
+const ReviewSchema = z.object({
+  filePaths: z.array(z.string().min(1)).min(1).max(20),
+  models: z.array(z.string().min(1)).min(1).max(10),
+  prompt: z.string().max(1000).optional(),
+});
+
+const ChatSchema = z.object({
+  message: z.string().min(1).max(10000),
+  modelSlug: z.string().min(1),
+  context: z
+    .object({
+      filePaths: z.array(z.string()).optional(),
+      selection: z.object({ content: z.string() }).optional(),
+    })
+    .optional(),
+});
+
+// ─── Route registration ───────────────────────────────────────────────────────
+
+export function registerWorkspaceRoutes(router: Router, gateway: Gateway): void {
+  const manager = new WorkspaceManager();
+  const codeChatService = new CodeChatService(gateway);
+
+  // ── Workspace CRUD ──────────────────────────────────────────────────────────
+
+  router.get("/api/workspaces", async (_req, res) => {
+    const rows = await db.select().from(workspaces).orderBy(workspaces.createdAt);
+    res.json(rows);
+  });
+
+  router.get("/api/workspaces/:id", async (req, res) => {
+    const [row] = await db.select().from(workspaces).where(eq(workspaces.id, req.params.id));
+    if (!row) return res.status(404).json({ error: "Workspace not found" });
+    res.json(row);
+  });
+
+  router.post("/api/workspaces", async (req, res) => {
+    const parsed = ConnectWorkspaceSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: parsed.error.message });
+    }
+
+    try {
+      if (parsed.data.type === "local") {
+        const { id, name, path: localPath } = await manager.connectLocal(
+          parsed.data.path,
+          parsed.data.name,
+        );
+        const [row] = await db
+          .insert(workspaces)
+          .values({ id, name, type: "local", path: localPath, branch: "main", status: "active" })
+          .returning();
+        return res.status(201).json(row);
+      }
+
+      // Remote
+      const id = crypto.randomUUID();
+      const name = parsed.data.name ?? new URL(parsed.data.url).pathname.split("/").pop() ?? id;
+      const branch = parsed.data.branch ?? "main";
+
+      const [row] = await db
+        .insert(workspaces)
+        .values({ id, name, type: "remote", path: parsed.data.url, branch, status: "syncing" })
+        .returning();
+
+      // Clone in background, update status when done
+      manager
+        .cloneRemote(parsed.data.url, id, branch)
+        .then(() =>
+          db.update(workspaces).set({ status: "active" }).where(eq(workspaces.id, id)),
+        )
+        .catch(() =>
+          db.update(workspaces).set({ status: "error" }).where(eq(workspaces.id, id)),
+        );
+
+      return res.status(201).json(row);
+    } catch (err) {
+      return res.status(400).json({ error: (err as Error).message });
+    }
+  });
+
+  router.delete("/api/workspaces/:id", async (req, res) => {
+    const [row] = await db.select().from(workspaces).where(eq(workspaces.id, req.params.id));
+    if (!row) return res.status(404).json({ error: "Workspace not found" });
+
+    await db.delete(workspaces).where(eq(workspaces.id, req.params.id));
+
+    if (row.type === "remote") {
+      await manager.removeClone(row.id).catch(() => undefined);
+    }
+
+    res.json({ message: "Workspace disconnected" });
+  });
+
+  router.post("/api/workspaces/:id/sync", async (req, res) => {
+    const row = await getWorkspaceById(String(req.params.id), res);
+    if (!row) return;
+
+    try {
+      await db.update(workspaces).set({ status: "syncing" }).where(eq(workspaces.id, row.id));
+      await manager.sync(row);
+      await db
+        .update(workspaces)
+        .set({ status: "active", lastSyncAt: new Date() })
+        .where(eq(workspaces.id, row.id));
+      res.json({ message: "Workspace synced" });
+    } catch (err) {
+      await db.update(workspaces).set({ status: "error" }).where(eq(workspaces.id, row.id));
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // ── File Operations ─────────────────────────────────────────────────────────
+
+  router.get("/api/workspaces/:id/files", async (req, res) => {
+    const row = await getWorkspaceById(String(req.params.id), res);
+    if (!row) return;
+
+    try {
+      const subpath = typeof req.query.path === "string" ? req.query.path : "";
+      const entries = await manager.listFiles(row, subpath);
+      res.json(entries);
+    } catch (err) {
+      res.status(400).json({ error: (err as Error).message });
+    }
+  });
+
+  router.get("/api/workspaces/:id/files/*", async (req: Request, res: Response) => {
+    const row = await getWorkspaceById(String(req.params.id), res);
+    if (!row) return;
+
+    const filePath = extractFilePathFromUrl(req.path, String(req.params.id));
+    if (!filePath) return res.status(400).json({ error: "File path required" });
+
+    try {
+      const content = await manager.readFile(row, filePath);
+      res.json({ path: filePath, content });
+    } catch (err) {
+      res.status(400).json({ error: (err as Error).message });
+    }
+  });
+
+  router.put("/api/workspaces/:id/files/*", async (req: Request, res: Response) => {
+    const row = await getWorkspaceById(String(req.params.id), res);
+    if (!row) return;
+
+    const filePath = extractFilePathFromUrl(req.path, String(req.params.id));
+    if (!filePath) return res.status(400).json({ error: "File path required" });
+
+    const parsed = WriteFileSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: parsed.error.message });
+
+    if (parsed.data.confirmed !== true) {
+      return res.status(400).json({ error: "File writes require confirmed: true" });
+    }
+
+    try {
+      await manager.writeFile(row, filePath, parsed.data.content);
+      res.json({ message: "File updated" });
+    } catch (err) {
+      res.status(400).json({ error: (err as Error).message });
+    }
+  });
+
+  router.delete("/api/workspaces/:id/files/*", async (req: Request, res: Response) => {
+    const row = await getWorkspaceById(String(req.params.id), res);
+    if (!row) return;
+
+    const filePath = extractFilePathFromUrl(req.path, String(req.params.id));
+    if (!filePath) return res.status(400).json({ error: "File path required" });
+
+    try {
+      await manager.deleteFile(row, filePath);
+      res.json({ message: "File deleted" });
+    } catch (err) {
+      res.status(400).json({ error: (err as Error).message });
+    }
+  });
+
+  // ── Git Operations ──────────────────────────────────────────────────────────
+
+  router.get("/api/workspaces/:id/git/status", async (req, res) => {
+    const row = await getWorkspaceById(String(req.params.id), res);
+    if (!row) return;
+
+    try {
+      const status = await manager.gitStatus(row);
+      res.json(status);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  router.get("/api/workspaces/:id/git/diff", async (req, res) => {
+    const row = await getWorkspaceById(String(req.params.id), res);
+    if (!row) return;
+
+    try {
+      const diff = await manager.gitDiff(row);
+      res.json({ diff });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  router.post("/api/workspaces/:id/git/commit", async (req, res) => {
+    const row = await getWorkspaceById(String(req.params.id), res);
+    if (!row) return;
+
+    const parsed = CommitSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: parsed.error.message });
+
+    try {
+      await manager.gitCommit(row, parsed.data.message);
+      res.json({ message: "Committed" });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  router.post("/api/workspaces/:id/git/branch", async (req, res) => {
+    const row = await getWorkspaceById(String(req.params.id), res);
+    if (!row) return;
+
+    const parsed = BranchSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: parsed.error.message });
+
+    try {
+      await manager.gitBranch(row, parsed.data.name);
+      res.json({ message: `Branch '${parsed.data.name}' created and checked out` });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  router.get("/api/workspaces/:id/git/log", async (req, res) => {
+    const row = await getWorkspaceById(String(req.params.id), res);
+    if (!row) return;
+
+    const limit = Math.min(parseInt(String(req.query.limit ?? "20"), 10) || 20, 100);
+
+    try {
+      const log = await manager.gitLog(row, limit);
+      res.json(log);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // ── AI Operations ───────────────────────────────────────────────────────────
+
+  router.post("/api/workspaces/:id/review", async (req, res) => {
+    const row = await getWorkspaceById(String(req.params.id), res);
+    if (!row) return;
+
+    const parsed = ReviewSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: parsed.error.message });
+
+    try {
+      const results = await codeChatService.reviewCode(
+        row,
+        parsed.data.filePaths,
+        parsed.data.models,
+        parsed.data.prompt,
+      );
+      res.json(Object.fromEntries(results));
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  router.post("/api/workspaces/:id/chat", async (req, res) => {
+    const row = await getWorkspaceById(String(req.params.id), res);
+    if (!row) return;
+
+    const parsed = ChatSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: parsed.error.message });
+
+    try {
+      const reply = await codeChatService.chat(
+        row,
+        parsed.data.message,
+        parsed.data.modelSlug,
+        parsed.data.context,
+      );
+      res.json({ reply });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function getWorkspaceById(id: string, res: Response): Promise<WorkspaceRow | null> {
+  const [row] = await db.select().from(workspaces).where(eq(workspaces.id, id));
+  if (!row) {
+    res.status(404).json({ error: "Workspace not found" });
+    return null;
+  }
+  return row;
+}
+
+/**
+ * Extract the file path from the URL path.
+ * E.g. /api/workspaces/{id}/files/src/index.ts  -> "src/index.ts"
+ */
+function extractFilePathFromUrl(reqPath: string, workspaceId: string): string | null {
+  const prefix = `/api/workspaces/${workspaceId}/files/`;
+  if (!reqPath.startsWith(prefix)) return null;
+  const fp = reqPath.slice(prefix.length);
+  return fp.length > 0 ? decodeURIComponent(fp) : null;
+}

--- a/server/workspace/code-chat.ts
+++ b/server/workspace/code-chat.ts
@@ -1,0 +1,163 @@
+import type { Gateway } from "../gateway/index";
+import type { WorkspaceRow } from "@shared/schema";
+import type { ReviewResult, ReviewIssue, CodeChange } from "@shared/types";
+import { WorkspaceManager } from "./manager";
+
+const REVIEW_SYSTEM_PROMPT = `You are an expert code reviewer. Analyze the provided code and return a JSON response with the following structure:
+{
+  "issues": [
+    {
+      "severity": "error" | "warning" | "info",
+      "file": "<filename>",
+      "line": <optional line number>,
+      "message": "<issue description>",
+      "suggestion": "<optional fix suggestion>"
+    }
+  ],
+  "summary": "<brief overall assessment>"
+}
+Only return valid JSON, no markdown fences.`;
+
+export class CodeChatService {
+  private manager: WorkspaceManager;
+
+  constructor(private gateway: Gateway) {
+    this.manager = new WorkspaceManager();
+  }
+
+  async reviewCode(
+    workspace: WorkspaceRow,
+    filePaths: string[],
+    models: string[],
+    prompt?: string,
+  ): Promise<Map<string, ReviewResult>> {
+    const fileContents = await this.loadFiles(workspace, filePaths);
+    const userMessage = this.buildReviewMessage(fileContents, prompt);
+    const results = new Map<string, ReviewResult>();
+
+    await Promise.all(
+      models.map(async (modelSlug) => {
+        try {
+          const response = await this.gateway.complete({
+            modelSlug,
+            messages: [
+              { role: "system", content: REVIEW_SYSTEM_PROMPT },
+              { role: "user", content: userMessage },
+            ],
+            maxTokens: 2048,
+          });
+
+          const result = this.parseReviewResponse(response.content, modelSlug);
+          results.set(modelSlug, result);
+        } catch (err) {
+          results.set(modelSlug, {
+            model: modelSlug,
+            issues: [],
+            summary: `Review failed: ${(err as Error).message}`,
+          });
+        }
+      }),
+    );
+
+    return results;
+  }
+
+  async chat(
+    workspace: WorkspaceRow,
+    message: string,
+    modelSlug: string,
+    context?: { filePaths?: string[]; selection?: { content: string } },
+  ): Promise<string> {
+    const contextParts: string[] = [];
+
+    if (context?.filePaths?.length) {
+      const fileContents = await this.loadFiles(workspace, context.filePaths);
+      contextParts.push(fileContents);
+    }
+
+    if (context?.selection?.content) {
+      contextParts.push(`Selected code:\n\`\`\`\n${context.selection.content}\n\`\`\``);
+    }
+
+    const systemPrompt = [
+      "You are an expert software engineer helping with code in a workspace.",
+      contextParts.length > 0 ? `\n\nContext:\n${contextParts.join("\n\n")}` : "",
+    ]
+      .filter(Boolean)
+      .join("");
+
+    const response = await this.gateway.complete({
+      modelSlug,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: message },
+      ],
+      maxTokens: 4096,
+    });
+
+    return response.content;
+  }
+
+  async applyChange(workspace: WorkspaceRow, filePath: string, change: CodeChange): Promise<void> {
+    const content = await this.manager.readFile(workspace, filePath);
+    const lines = content.split("\n");
+    const updated = this.applyLineChange(lines, change);
+    await this.manager.writeFile(workspace, filePath, updated.join("\n"));
+  }
+
+  private applyLineChange(lines: string[], change: CodeChange): string[] {
+    const result = [...lines];
+    const start = change.startLine - 1;
+
+    if (change.type === "replace") {
+      const end = (change.endLine ?? change.startLine) - 1;
+      const newLines = (change.content ?? "").split("\n");
+      result.splice(start, end - start + 1, ...newLines);
+    } else if (change.type === "insert") {
+      const newLines = (change.content ?? "").split("\n");
+      result.splice(start, 0, ...newLines);
+    } else if (change.type === "delete") {
+      const end = (change.endLine ?? change.startLine) - 1;
+      result.splice(start, end - start + 1);
+    }
+
+    return result;
+  }
+
+  private async loadFiles(workspace: WorkspaceRow, filePaths: string[]): Promise<string> {
+    const parts: string[] = [];
+    for (const fp of filePaths) {
+      try {
+        const content = await this.manager.readFile(workspace, fp);
+        parts.push(`// File: ${fp}\n${content}`);
+      } catch {
+        parts.push(`// File: ${fp}\n// [Could not read file]`);
+      }
+    }
+    return parts.join("\n\n");
+  }
+
+  private buildReviewMessage(fileContents: string, prompt?: string): string {
+    const lines = ["Review the following code:"];
+    if (prompt) lines.push(`Focus on: ${prompt}`);
+    lines.push("", fileContents);
+    return lines.join("\n");
+  }
+
+  private parseReviewResponse(content: string, modelSlug: string): ReviewResult {
+    try {
+      const raw = JSON.parse(content) as { issues?: ReviewIssue[]; summary?: string };
+      return {
+        model: modelSlug,
+        issues: Array.isArray(raw.issues) ? raw.issues : [],
+        summary: typeof raw.summary === "string" ? raw.summary : "No summary provided",
+      };
+    } catch {
+      return {
+        model: modelSlug,
+        issues: [],
+        summary: content.slice(0, 500),
+      };
+    }
+  }
+}

--- a/server/workspace/manager.ts
+++ b/server/workspace/manager.ts
@@ -1,0 +1,186 @@
+import path from "path";
+import fs from "fs/promises";
+import { simpleGit } from "simple-git";
+import type { FileEntry, GitStatus } from "@shared/types";
+import type { WorkspaceRow } from "@shared/schema";
+
+const WORKSPACE_DATA_DIR = path.resolve("data/workspaces");
+const MAX_FILE_SIZE_BYTES = 1_048_576; // 1 MB
+const MAX_CLONE_SIZE_BYTES = 500 * 1_048_576; // 500 MB
+const SKIP_DIRS = new Set(["node_modules", ".git", "dist", ".next", "__pycache__"]);
+const ALLOWED_WRITE_EXTENSIONS = new Set([
+  ".ts", ".js", ".tsx", ".jsx", ".py", ".go", ".rs",
+  ".md", ".json", ".yaml", ".yml", ".toml", ".css", ".html",
+]);
+
+export class WorkspaceManager {
+  private resolveRoot(workspace: WorkspaceRow): string {
+    if (workspace.type === "local") return workspace.path;
+    return path.join(WORKSPACE_DATA_DIR, workspace.id);
+  }
+
+  private guardPath(root: string, filePath: string): string {
+    const resolved = path.resolve(root, filePath);
+    if (!resolved.startsWith(path.resolve(root) + path.sep) && resolved !== path.resolve(root)) {
+      throw new Error("Path traversal attempt blocked");
+    }
+    return resolved;
+  }
+
+  async connectLocal(localPath: string, name?: string): Promise<{ id: string; name: string; path: string }> {
+    await fs.access(localPath);
+    const resolvedPath = path.resolve(localPath);
+    const workspaceName = name ?? path.basename(resolvedPath);
+    return { id: crypto.randomUUID(), name: workspaceName, path: resolvedPath };
+  }
+
+  async cloneRemote(
+    url: string,
+    workspaceId: string,
+    branch = "main",
+  ): Promise<void> {
+    if (!url.startsWith("https://")) {
+      throw new Error("Only https:// git URLs are allowed");
+    }
+    await fs.mkdir(path.join(WORKSPACE_DATA_DIR, workspaceId), { recursive: true });
+    const dest = path.join(WORKSPACE_DATA_DIR, workspaceId);
+    const git = simpleGit();
+    await git.clone(url, dest, ["--depth", "1", "--branch", branch]);
+    await this.checkCloneSize(dest);
+  }
+
+  private async checkCloneSize(dir: string): Promise<void> {
+    const total = await this.dirSize(dir);
+    if (total > MAX_CLONE_SIZE_BYTES) {
+      await fs.rm(dir, { recursive: true, force: true });
+      throw new Error("Cloned repository exceeds 500 MB size limit");
+    }
+  }
+
+  private async dirSize(dir: string): Promise<number> {
+    let total = 0;
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        total += await this.dirSize(full);
+      } else {
+        const stat = await fs.stat(full);
+        total += stat.size;
+      }
+    }
+    return total;
+  }
+
+  async sync(workspace: WorkspaceRow): Promise<void> {
+    if (workspace.type !== "remote") {
+      throw new Error("Only remote workspaces can be synced");
+    }
+    const root = this.resolveRoot(workspace);
+    const git = simpleGit(root);
+    await git.pull();
+  }
+
+  async listFiles(workspace: WorkspaceRow, subpath = ""): Promise<FileEntry[]> {
+    const root = this.resolveRoot(workspace);
+    const target = subpath ? this.guardPath(root, subpath) : root;
+    return this.readDir(root, target);
+  }
+
+  private async readDir(root: string, dir: string): Promise<FileEntry[]> {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    const result: FileEntry[] = [];
+
+    for (const entry of entries) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      const rel = path.relative(root, full);
+
+      if (entry.isDirectory()) {
+        result.push({ name: entry.name, path: rel, type: "directory" });
+      } else {
+        const stat = await fs.stat(full);
+        result.push({ name: entry.name, path: rel, type: "file", size: stat.size });
+      }
+    }
+
+    return result.sort((a, b) => {
+      if (a.type !== b.type) return a.type === "directory" ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+  }
+
+  async readFile(workspace: WorkspaceRow, filePath: string): Promise<string> {
+    const root = this.resolveRoot(workspace);
+    const full = this.guardPath(root, filePath);
+    const stat = await fs.stat(full);
+    if (stat.size > MAX_FILE_SIZE_BYTES) {
+      throw new Error(`File exceeds 1 MB limit (${stat.size} bytes)`);
+    }
+    return fs.readFile(full, "utf-8");
+  }
+
+  async writeFile(workspace: WorkspaceRow, filePath: string, content: string): Promise<void> {
+    const ext = path.extname(filePath).toLowerCase();
+    if (!ALLOWED_WRITE_EXTENSIONS.has(ext)) {
+      throw new Error(`File extension '${ext}' is not allowed for writes`);
+    }
+    const root = this.resolveRoot(workspace);
+    const full = this.guardPath(root, filePath);
+    await fs.writeFile(full, content, "utf-8");
+  }
+
+  async deleteFile(workspace: WorkspaceRow, filePath: string): Promise<void> {
+    const root = this.resolveRoot(workspace);
+    const full = this.guardPath(root, filePath);
+    await fs.unlink(full);
+  }
+
+  async gitStatus(workspace: WorkspaceRow): Promise<GitStatus> {
+    const root = this.resolveRoot(workspace);
+    const git = simpleGit(root);
+    const status = await git.status();
+    return {
+      branch: status.current ?? "unknown",
+      modified: status.modified,
+      staged: status.staged,
+      untracked: status.not_added,
+    };
+  }
+
+  async gitDiff(workspace: WorkspaceRow): Promise<string> {
+    const root = this.resolveRoot(workspace);
+    const git = simpleGit(root);
+    return git.diff();
+  }
+
+  async gitCommit(workspace: WorkspaceRow, message: string): Promise<void> {
+    const root = this.resolveRoot(workspace);
+    const git = simpleGit(root);
+    await git.add(".");
+    await git.commit(message);
+  }
+
+  async gitBranch(workspace: WorkspaceRow, branchName: string): Promise<void> {
+    const root = this.resolveRoot(workspace);
+    const git = simpleGit(root);
+    await git.checkoutLocalBranch(branchName);
+  }
+
+  async gitLog(workspace: WorkspaceRow, limit = 20): Promise<Array<{ hash: string; message: string; date: string; author: string }>> {
+    const root = this.resolveRoot(workspace);
+    const git = simpleGit(root);
+    const log = await git.log({ maxCount: limit });
+    return log.all.map((entry) => ({
+      hash: entry.hash.slice(0, 8),
+      message: entry.message,
+      date: entry.date,
+      author: entry.author_name,
+    }));
+  }
+
+  async removeClone(workspaceId: string): Promise<void> {
+    const dir = path.join(WORKSPACE_DATA_DIR, workspaceId);
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -318,3 +318,26 @@ export const insertMcpServerSchema = createInsertSchema(mcpServers).omit({
 
 export type InsertMcpServer = z.infer<typeof insertMcpServerSchema>;
 export type McpServerRow = typeof mcpServers.$inferSelect;
+
+// ─── Workspaces ──────────────────────────────────────────────────────────────
+
+export const workspaces = pgTable("workspaces", {
+  id: varchar("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()`),
+  name: text("name").notNull(),
+  type: text("type").notNull().$type<"local" | "remote">(),
+  path: text("path").notNull(),
+  branch: text("branch").notNull().default("main"),
+  status: text("status").notNull().default("active").$type<"active" | "syncing" | "error">(),
+  lastSyncAt: timestamp("last_sync_at"),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+});
+
+export const insertWorkspaceSchema = createInsertSchema(workspaces).omit({
+  id: true,
+  createdAt: true,
+});
+
+export type InsertWorkspace = z.infer<typeof insertWorkspaceSchema>;
+export type WorkspaceRow = typeof workspaces.$inferSelect;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -509,3 +509,57 @@ export interface TeamMemoryHint {
   content: string;
   type: MemoryType;
 }
+
+// ─── Workspace Types ──────────────────────────────────────────────────────────
+
+export interface Workspace {
+  id: string;
+  name: string;
+  type: "local" | "remote";
+  path: string;
+  branch: string;
+  status: "active" | "syncing" | "error";
+  lastSyncAt: Date | null;
+  createdAt: Date;
+}
+
+export interface FileEntry {
+  name: string;
+  path: string;
+  type: "file" | "directory";
+  size?: number;
+}
+
+export interface GitStatus {
+  branch: string;
+  modified: string[];
+  staged: string[];
+  untracked: string[];
+}
+
+export interface CodeSelection {
+  startLine: number;
+  endLine: number;
+  content: string;
+}
+
+export interface CodeChange {
+  type: "replace" | "insert" | "delete";
+  startLine: number;
+  endLine?: number;
+  content?: string;
+}
+
+export interface ReviewIssue {
+  severity: "error" | "warning" | "info";
+  file: string;
+  line?: number;
+  message: string;
+  suggestion?: string;
+}
+
+export interface ReviewResult {
+  model: string;
+  issues: ReviewIssue[];
+  summary: string;
+}


### PR DESCRIPTION
## Summary

- Adds a full Code Workspace feature: connect local directories or clone remote git repos, browse files, view code, and run multiple AI models simultaneously for parallel code review
- Implements secure file access (path traversal blocked, 1 MB read limit, extension allowlist for writes, `confirmed: true` gate on AI-generated writes)
- All git operations use `simple-git` — no `child_process.exec` with user strings

## What's in this PR

### Backend

| File | Purpose |
|------|---------|
| `shared/types.ts` | Workspace, FileEntry, GitStatus, CodeChange, ReviewIssue, ReviewResult types |
| `shared/schema.ts` | `workspaces` Drizzle/PostgreSQL table |
| `server/workspace/manager.ts` | WorkspaceManager: file tree, read/write, git ops, path traversal protection |
| `server/workspace/code-chat.ts` | CodeChatService: parallel multi-model review, context-aware chat, change application |
| `server/routes/workspaces.ts` | 16 REST endpoints — CRUD, files, git, review, chat (Zod-validated) |
| `server/routes.ts` | Register workspace routes |

### Frontend

| File | Purpose |
|------|---------|
| `client/src/pages/WorkspaceList.tsx` | Connect/list workspaces with local/remote form |
| `client/src/pages/Workspace.tsx` | 3-panel workspace view (file tree, code, chat/review) |
| `client/src/components/workspace/FileTree.tsx` | Collapsible recursive file tree |
| `client/src/components/workspace/CodeViewer.tsx` | Line-numbered read-only code display |
| `client/src/components/workspace/ReviewPanel.tsx` | Multi-model results with severity badges |
| `client/src/components/workspace/ChatPanel.tsx` | Model-tagged chat with file context |
| `client/src/App.tsx` | Added `/workspaces` and `/workspaces/:id` routes |
| `client/src/components/layout/MainLayout.tsx` | Added Workspace nav item |

### Security properties enforced

- Path traversal: `path.resolve` + `startsWith` check on every file op
- Remote URLs: only `https://` allowed; `file://` and `ssh://` rejected
- Clone size limit: 500 MB (auto-deletes on exceed)
- File read limit: 1 MB per file
- Write extension allowlist: `.ts .js .tsx .jsx .py .go .rs .md .json .yaml .yml .toml .css .html`
- AI-generated writes: require `confirmed: true` in request body
- All git ops: `simple-git` only, no shell injection surface

## Test plan

- [ ] Connect a local workspace path, browse file tree, view a file
- [ ] Open Chat panel, select a model, ask a question about the open file
- [ ] Open Review panel, select 2+ models, click "Run Review", verify side-by-side results with severity badges
- [ ] Connect a remote repo (https://), verify it shows as "syncing" then "active"
- [ ] Verify path traversal is blocked: PUT /api/workspaces/:id/files/../../etc/passwd returns 400
- [ ] Verify write without `confirmed:true` returns 400
- [ ] Run `npm run db:push` to create the `workspaces` table
- [ ] Run `npm run build` — confirms 0 TS errors and clean build