### PR TITLE
fix: workspace file routes wildcard for Express 5

### DIFF
--- a/server/routes/workspaces.ts
+++ b/server/routes/workspaces.ts
@@ -164,7 +164,7 @@ export function registerWorkspaceRoutes(router: Router, gateway: Gateway): void 
     }
   });
 
-  router.get("/api/workspaces/:id/files/*", async (req: Request, res: Response) => {
+  router.get("/api/workspaces/:id/files/*path", async (req: Request, res: Response) => {
     const row = await getWorkspaceById(String(req.params.id), res);
     if (!row) return;
 
@@ -179,7 +179,7 @@ export function registerWorkspaceRoutes(router: Router, gateway: Gateway): void 
     }
   });
 
-  router.put("/api/workspaces/:id/files/*", async (req: Request, res: Response) => {
+  router.put("/api/workspaces/:id/files/*path", async (req: Request, res: Response) => {
     const row = await getWorkspaceById(String(req.params.id), res);
     if (!row) return;
 
@@ -201,7 +201,7 @@ export function registerWorkspaceRoutes(router: Router, gateway: Gateway): void 
     }
   });
 
-  router.delete("/api/workspaces/:id/files/*", async (req: Request, res: Response) => {
+  router.delete("/api/workspaces/:id/files/*path", async (req: Request, res: Response) => {
     const row = await getWorkspaceById(String(req.params.id), res);
     if (!row) return;
 


### PR DESCRIPTION
Express 5 / path-to-regexp v8 requires named wildcards. Replace `/files/*` with `/files/*path` on all three file operation routes.