### PR TITLE
fix(ci): add Postgres service for E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,24 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: multiqlti
+          POSTGRES_PASSWORD: multiqlti
+          POSTGRES_DB: multiqlti_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://multiqlti:multiqlti@localhost:5432/multiqlti_test
+      JWT_SECRET: e2e-test-secret-minimum-32-characters-long
+      NODE_ENV: test
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -42,6 +60,7 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - run: npm run db:push
       - run: npx playwright install chromium --with-deps
       - run: npm run test:e2e
       - uses: actions/upload-artifact@v4

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,6 +26,8 @@ export default defineConfig({
     env: {
       PORT: "3099",
       NODE_ENV: "test",
+      DATABASE_URL: process.env.DATABASE_URL ?? "",
+      JWT_SECRET: process.env.JWT_SECRET ?? "local-dev-secret-minimum-32-chars-long",
     },
   },
 });


### PR DESCRIPTION
Add PostgreSQL 16 service container to E2E job, set DATABASE_URL + JWT_SECRET env vars, run db:push before playwright. Fixes ECONNREFUSED crash when server starts without a database.