### PR TITLE
fix(e2e): authenticate before each E2E test

### DIFF
--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -1,0 +1,56 @@
+import type { Page } from "@playwright/test";
+import { request } from "@playwright/test";
+
+const ADMIN_EMAIL = "e2e@multiqlti.test";
+const ADMIN_PASSWORD = "e2e-test-password-secure";
+const ADMIN_NAME = "E2E Admin";
+
+let cachedToken: string | null = null;
+
+/**
+ * Ensure the admin user exists and return a valid auth token.
+ * Registers on first call (when no users exist), logs in on subsequent calls.
+ * Token is cached for the lifetime of the test worker process.
+ */
+export async function getAuthToken(baseURL: string): Promise<string> {
+  if (cachedToken) return cachedToken;
+
+  const ctx = await request.newContext({ baseURL });
+
+  const statusRes = await ctx.get("/api/auth/status");
+  const { hasUsers } = (await statusRes.json()) as { hasUsers: boolean };
+
+  if (!hasUsers) {
+    await ctx.post("/api/auth/register", {
+      data: { email: ADMIN_EMAIL, name: ADMIN_NAME, password: ADMIN_PASSWORD },
+    });
+  }
+
+  const loginRes = await ctx.post("/api/auth/login", {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+  });
+  const { token } = (await loginRes.json()) as { token: string };
+
+  await ctx.dispose();
+  cachedToken = token;
+  return token;
+}
+
+/**
+ * Authenticate the Playwright page:
+ * - Sets `auth_token` in localStorage so the React app considers the session active.
+ * - Sets `Authorization` header on all future page.request calls.
+ */
+export async function loginPage(page: Page, baseURL: string): Promise<void> {
+  const token = await getAuthToken(baseURL);
+
+  // Set extra HTTP header on the page context so page.request calls include auth.
+  await page.setExtraHTTPHeaders({ Authorization: `Bearer ${token}` });
+
+  // Navigate to login page first so the origin is available for localStorage.
+  await page.goto("/login");
+  await page.waitForLoadState("networkidle");
+
+  // Set token in localStorage so React auth context considers user logged in.
+  await page.evaluate((t) => localStorage.setItem("auth_token", t), token);
+}

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,13 +1,16 @@
 import { test, expect } from "@playwright/test";
+import { loginPage } from "./helpers/auth";
 
 test.describe("Navigation", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    await loginPage(page, testInfo.project.use.baseURL ?? "http://localhost:3099");
+  });
+
   test("root path renders the dashboard or redirects to a main page", async ({ page }) => {
     await page.goto("/");
-
-    // Wait for the app to load — should not be on login page
     await page.waitForLoadState("networkidle");
 
-    // Should not be redirected to /login
+    // Should not be redirected to /login (user is authenticated)
     expect(page.url()).not.toContain("/login");
   });
 
@@ -15,7 +18,6 @@ test.describe("Navigation", () => {
     await page.goto("/pipelines");
     await page.waitForLoadState("networkidle");
 
-    // Page should be accessible without login redirect
     expect(page.url()).toContain("/pipelines");
   });
 
@@ -23,12 +25,8 @@ test.describe("Navigation", () => {
     await page.goto("/pipelines");
     await page.waitForLoadState("networkidle");
 
-    // The seeded default pipeline template should appear
-    // Just check the page renders without errors
     const body = await page.locator("body").textContent();
     expect(body).toBeTruthy();
-
-    // Should not show an error boundary crash message
     expect(body).not.toContain("Something went wrong");
   });
 

--- a/tests/e2e/pipeline-crud.spec.ts
+++ b/tests/e2e/pipeline-crud.spec.ts
@@ -1,6 +1,11 @@
 import { test, expect } from "@playwright/test";
+import { loginPage } from "./helpers/auth";
 
 test.describe("Pipeline CRUD", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    await loginPage(page, testInfo.project.use.baseURL ?? "http://localhost:3099");
+  });
+
   test("pipeline list page renders without errors", async ({ page }) => {
     await page.goto("/pipelines");
     await page.waitForLoadState("networkidle");
@@ -11,11 +16,10 @@ test.describe("Pipeline CRUD", () => {
   });
 
   test("navigating to a pipeline detail page works", async ({ page }) => {
-    // First get a pipeline id from the API
     const response = await page.request.get("/api/pipelines");
     expect(response.status()).toBe(200);
 
-    const pipelines = await response.json() as Array<{ id: string; name: string }>;
+    const pipelines = (await response.json()) as Array<{ id: string; name: string }>;
 
     if (pipelines.length > 0) {
       const pipeline = pipelines[0];
@@ -32,23 +36,19 @@ test.describe("Pipeline CRUD", () => {
   });
 
   test("creating a pipeline via API and then navigating to it", async ({ page }) => {
-    // Create pipeline via API
     const createRes = await page.request.post("/api/pipelines", {
       data: {
         name: "E2E Test Pipeline",
         description: "Created by E2E test",
-        stages: [
-          { teamId: "planning", modelSlug: "mock", enabled: true },
-        ],
+        stages: [{ teamId: "planning", modelSlug: "mock", enabled: true }],
       },
     });
     expect(createRes.status()).toBe(201);
 
-    const pipeline = await createRes.json() as { id: string; name: string };
+    const pipeline = (await createRes.json()) as { id: string; name: string };
     expect(pipeline.id).toBeTruthy();
     expect(pipeline.name).toBe("E2E Test Pipeline");
 
-    // Navigate to the pipeline detail page
     await page.goto(`/pipelines/${pipeline.id}`);
     await page.waitForLoadState("networkidle");
 

--- a/tests/e2e/run-execution.spec.ts
+++ b/tests/e2e/run-execution.spec.ts
@@ -1,8 +1,12 @@
 import { test, expect } from "@playwright/test";
+import { loginPage } from "./helpers/auth";
 
 test.describe("Run Execution", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    await loginPage(page, testInfo.project.use.baseURL ?? "http://localhost:3099");
+  });
+
   test("starting a run via API returns a run id", async ({ page }) => {
-    // Create a minimal pipeline
     const pipelineRes = await page.request.post("/api/pipelines", {
       data: {
         name: "E2E Run Test Pipeline",
@@ -10,59 +14,54 @@ test.describe("Run Execution", () => {
       },
     });
     expect(pipelineRes.status()).toBe(201);
-    const pipeline = await pipelineRes.json() as { id: string };
+    const pipeline = (await pipelineRes.json()) as { id: string };
 
-    // Start a run
     const runRes = await page.request.post("/api/runs", {
       data: { pipelineId: pipeline.id, input: "Build a REST API for a blog" },
     });
     expect(runRes.status()).toBe(201);
 
-    const run = await runRes.json() as { id: string; status: string };
+    const run = (await runRes.json()) as { id: string; status: string };
     expect(run.id).toBeTruthy();
     expect(run.status).toBeTruthy();
   });
 
   test("run detail is accessible via GET", async ({ page }) => {
-    // Create pipeline and start run
     const pipelineRes = await page.request.post("/api/pipelines", {
       data: {
         name: "E2E Run Detail Test",
         stages: [{ teamId: "planning", modelSlug: "mock", enabled: true }],
       },
     });
-    const pipeline = await pipelineRes.json() as { id: string };
+    const pipeline = (await pipelineRes.json()) as { id: string };
 
     const runRes = await page.request.post("/api/runs", {
       data: { pipelineId: pipeline.id, input: "Create a user management system" },
     });
-    const run = await runRes.json() as { id: string };
+    const run = (await runRes.json()) as { id: string };
 
-    // Fetch run details
     const getRes = await page.request.get(`/api/runs/${run.id}`);
     expect(getRes.status()).toBe(200);
 
-    const runDetail = await getRes.json() as { id: string; stages: unknown[] };
+    const runDetail = (await getRes.json()) as { id: string; stages: unknown[] };
     expect(runDetail.id).toBe(run.id);
     expect(Array.isArray(runDetail.stages)).toBe(true);
   });
 
   test("navigating to a run page works without errors", async ({ page }) => {
-    // Create pipeline and start run
     const pipelineRes = await page.request.post("/api/pipelines", {
       data: {
         name: "E2E Run Navigation Test",
         stages: [{ teamId: "planning", modelSlug: "mock", enabled: true }],
       },
     });
-    const pipeline = await pipelineRes.json() as { id: string };
+    const pipeline = (await pipelineRes.json()) as { id: string };
 
     const runRes = await page.request.post("/api/runs", {
       data: { pipelineId: pipeline.id, input: "Design a payment service" },
     });
-    const run = await runRes.json() as { id: string };
+    const run = (await runRes.json()) as { id: string };
 
-    // Navigate to the run page
     await page.goto(`/runs/${run.id}`);
     await page.waitForLoadState("networkidle");
 


### PR DESCRIPTION
E2E specs were written before auth was added. Add loginPage() helper that registers/logs in via API and sets auth_token in localStorage + Authorization header on page.request calls. Apply beforeEach to all three spec files.