### PR TITLE
fix: register sandbox routes and protect with requireAuth

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -17,6 +17,7 @@ import { registerMemoryRoutes } from "./routes/memory";
 import { registerToolRoutes } from "./routes/tools";
 import { registerWorkspaceRoutes } from "./routes/workspaces";
 import { registerAuthRoutes } from "./routes/auth";
+import { registerSandboxRoutes } from "./routes/sandbox";
 import { requireAuth } from "./auth/middleware";
 import { DEFAULT_MODELS, DEFAULT_PIPELINE_STAGES } from "@shared/constants";
 import { log } from "./index";
@@ -51,6 +52,7 @@ export async function registerRoutes(
   app.use("/api/tools", requireAuth);
   app.use("/api/providers", requireAuth);
   app.use("/api/teams", requireAuth);
+  app.use("/api/sandbox", requireAuth);
 
   // Register route implementations
   registerModelRoutes(app, storage);
@@ -64,6 +66,7 @@ export async function registerRoutes(
   registerMemoryRoutes(app, storage);
   registerToolRoutes(app, storage);
   registerWorkspaceRoutes(app, gateway);
+  registerSandboxRoutes(app as unknown as Router);
 
   // Seed default models
   const existingModels = await storage.getModels();


### PR DESCRIPTION
## Fix

`registerSandboxRoutes` was implemented in `server/routes/sandbox.ts` but was never imported or called in `server/routes.ts`. As a result, all `/api/sandbox/*` endpoints returned an HTML 404 page (caught by the Vite catch-all) instead of JSON.

Added the import, applied `requireAuth` middleware to the `/api/sandbox` path prefix, and called `registerSandboxRoutes` alongside the existing route registrations.

## Testing

`npm run check` passes (0 TypeScript errors).
All 49 vitest unit/integration tests pass.

With the server running, `/api/sandbox/status` and `/api/sandbox/presets` now return JSON instead of HTML.

Closes #11