### PR TITLE
fix: change SaveKeySchema field from 'apiKey' to 'key' to match API contract

### DIFF
--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -11,7 +11,7 @@ const CLOUD_PROVIDERS = ["anthropic", "google", "xai"] as const;
 type CloudProvider = (typeof CLOUD_PROVIDERS)[number];
 
 const SaveKeySchema = z.object({
-  apiKey: z.string().min(1, "apiKey must be non-empty"),
+  key: z.string().min(1, "key must be non-empty"),
 });
 
 /** Source of an active key: config value (env var / config.yaml) takes precedence over DB. */
@@ -66,7 +66,7 @@ export function registerSettingsRoutes(router: Router, gateway: Gateway) {
     }
 
     try {
-      const encrypted = encrypt(result.data.apiKey);
+      const encrypted = encrypt(result.data.key);
       const now = new Date();
 
       await db
@@ -78,7 +78,7 @@ export function registerSettingsRoutes(router: Router, gateway: Gateway) {
         });
 
       // Hot-reload the gateway with the new key
-      await gateway.reloadProvider(provider as CloudProvider, result.data.apiKey);
+      await gateway.reloadProvider(provider as CloudProvider, result.data.key);
 
       res.json({ ok: true, provider, source: "db" });
     } catch (e) {


### PR DESCRIPTION
## Fix

`POST /api/settings/providers/:provider/key` had its Zod schema expecting a field named `apiKey`, but the documented API contract (and the test plan) use `key`. Any request sending `{ "key": "sk-ant-..." }` would fail with 400 due to the schema mismatch.

Renamed the field in `SaveKeySchema` from `apiKey` to `key` and updated both handler references (`result.data.apiKey` → `result.data.key`).

## Testing

```bash
# Schema validation
node -e "
const { z } = require('zod');
const schema = z.object({ key: z.string().min(1) });
console.assert(schema.safeParse({ key: 'sk-test' }).success);
console.assert(!schema.safeParse({ apiKey: 'sk-test' }).success);
console.log('PASS');
"
```

`npm run check` passes (0 TypeScript errors).

With the fix applied, `POST /api/settings/providers/anthropic/key` with body `{"key":"sk-ant-test-123"}` returns 200 instead of 400.

Closes #23