### PR TITLE
fix: return sandbox presets as array with id field instead of keyed object

### DIFF
--- a/server/routes/sandbox.ts
+++ b/server/routes/sandbox.ts
@@ -21,7 +21,11 @@ export function registerSandboxRoutes(router: Router): void {
   });
 
   router.get("/api/sandbox/presets", (_req, res) => {
-    res.json(SANDBOX_IMAGE_PRESETS);
+    const presets = Object.entries(SANDBOX_IMAGE_PRESETS).map(([id, preset]) => ({
+      id,
+      ...preset,
+    }));
+    res.json(presets);
   });
 
   router.post("/api/sandbox/test", async (req, res) => {


### PR DESCRIPTION
## Fix

`GET /api/sandbox/presets` was returning `SANDBOX_IMAGE_PRESETS` directly — a plain object keyed by preset name (e.g. `{ "node": {...}, "python": {...} }`). The expected response shape is an array where each element includes an `id` field.

Fixed by converting with `Object.entries().map()` to produce:
```json
[
  { "id": "node", "image": "node:20-alpine", ... },
  { "id": "python", "image": "python:3.12-slim", ... },
  ...
]
```

## Testing

```bash
# Verify shape
node -e "
const { SANDBOX_IMAGE_PRESETS } = require('./shared/constants');
const presets = Object.entries(SANDBOX_IMAGE_PRESETS).map(([id, p]) => ({ id, ...p }));
console.assert(Array.isArray(presets));
console.assert(presets[0].id === 'node');
console.log('PASS — array with', presets.length, 'items');
"
```

`npm run check` passes (0 TypeScript errors).

Closes #22