### PR TITLE
fix: raise email severity to high so standard mode anonymizes emails

### DIFF
--- a/server/privacy/classifier.ts
+++ b/server/privacy/classifier.ts
@@ -82,7 +82,7 @@ const BUILTIN_PATTERNS: PatternDefinition[] = [
   },
   {
     type: "email",
-    severity: "medium",
+    severity: "high",
     patterns: [/[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/gi],
   },
   {


### PR DESCRIPTION
## Fix

The `email` pattern in `DataClassifier` was classified as `medium` severity. The `standard` anonymization level only masks entities with severity `high` or above (`minSeverityForLevel` returns `SEVERITY_RANK.high` for standard). This meant emails were detected and listed in `entitiesFound` but were never replaced in the `anonymized` text.

Email addresses are PII and must be protected in standard mode. Changed email severity from `medium` to `high`, consistent with other personal-data entity types (`ip_address`, `git_url`, `docker_image`, `domain`).

The `generatePseudonym` function for `email` was already correct — it preserves the local part and replaces the domain with `example.com` (e.g. `user@company.com` → `user@example.com`).

## Testing

```
Input:      Contact user@company.com for help
Anonymized: Contact user@example.com for help
```

`npm run check` passes (0 TypeScript errors).
All 49 vitest unit/integration tests pass.

Closes #13