### PR TITLE
fix: validate customPatterns regex in privacy test endpoint — return 400 on invalid pattern

### DIFF
--- a/server/privacy/anonymizer.ts
+++ b/server/privacy/anonymizer.ts
@@ -6,6 +6,7 @@ import type {
   EntityType,
 } from "@shared/types";
 import { DataClassifier } from "./classifier";
+import type { CustomPattern } from "./classifier";
 
 // Severity ordering for level-based filtering
 const SEVERITY_RANK: Record<EntitySeverity, number> = {
@@ -138,6 +139,7 @@ export class AnonymizerService {
     sessionId: string,
     level: AnonymizationLevel,
     ttlMs = 3_600_000,
+    customPatterns?: CustomPattern[],
   ): AnonymizationResult {
     if (level === "off") {
       return { anonymizedText: text, sessionId, entitiesFound: [] };
@@ -146,7 +148,7 @@ export class AnonymizerService {
     this.getOrCreateSession(sessionId);
     this.scheduleExpiry(sessionId, ttlMs);
 
-    const entities = this.classifier.classify(text);
+    const entities = this.classifier.classify(text, customPatterns);
     const minRank = this.minSeverityForLevel(level);
 
     // Filter by severity threshold

--- a/server/privacy/classifier.ts
+++ b/server/privacy/classifier.ts
@@ -7,7 +7,7 @@ interface PatternDefinition {
   allowlist?: string[];
 }
 
-interface CustomPattern {
+export interface CustomPattern {
   type: EntityType;
   severity: EntitySeverity;
   pattern: RegExp;

--- a/server/routes/privacy.ts
+++ b/server/routes/privacy.ts
@@ -13,9 +13,20 @@ import { configLoader } from "../config/loader";
 
 const anonymizer = new AnonymizerService();
 
+const customPatternItemSchema = z.object({
+  name: z.string().min(1).max(100),
+  pattern: z.string().min(1).refine(
+    (p) => { try { new RegExp(p); return true; } catch { return false; } },
+    { message: "Invalid regular expression" },
+  ),
+  replacement: z.string().optional(),
+  severity: z.enum(["critical", "high", "medium", "low"]).default("high"),
+});
+
 const testSchema = z.object({
   text: z.string().min(1),
   level: z.enum(["off", "standard", "strict"]),
+  customPatterns: z.array(customPatternItemSchema).optional(),
 });
 
 const createPatternSchema = insertAnonymizationPatternSchema.extend({
@@ -39,14 +50,27 @@ export function registerPrivacyRoutes(router: Router): void {
       return res.status(400).json({ error: parsed.error.flatten() });
     }
 
-    const { text, level } = parsed.data;
+    const { text, level, customPatterns } = parsed.data;
 
     if (level === "off") {
       return res.json({ anonymized: text, entities: [] });
     }
 
+    // Convert validated custom patterns to the format expected by DataClassifier
+    const classifierCustomPatterns = customPatterns?.map((cp) => ({
+      type: "custom_pattern" as const,
+      severity: cp.severity,
+      pattern: new RegExp(cp.pattern, "g"),
+    }));
+
     const sessionId = crypto.randomUUID();
-    const result = anonymizer.anonymize(text, sessionId, level as AnonymizationLevel);
+    const result = anonymizer.anonymize(
+      text,
+      sessionId,
+      level as AnonymizationLevel,
+      undefined,
+      classifierCustomPatterns,
+    );
     anonymizer.clearSession(sessionId);
 
     return res.json({


### PR DESCRIPTION
## Fix

`POST /api/privacy/test` had no `customPatterns` field in its Zod schema. Requests including `customPatterns` with an invalid regex string would succeed with 200 because the unknown field was silently stripped by Zod, and the invalid pattern was never evaluated.

### Changes

1. Added `customPatterns` array to `testSchema` with a `.refine()` that validates each `pattern` string compiles as a valid `RegExp`. Invalid patterns now return 400.

2. Threaded `customPatterns` through to the anonymizer and classifier:
   - Exported `CustomPattern` interface from `classifier.ts`
   - Added optional `customPatterns` parameter to `AnonymizerService.anonymize()`
   - Converted validated patterns to `RegExp` objects in the route handler before calling `anonymizer.anonymize()`

## Testing

```bash
# Invalid regex → 400
curl -s -o /dev/null -w "%{http_code}" -X POST /api/privacy/test \
  -H "Content-Type: application/json" \
  -d '{"text":"test","level":"standard","customPatterns":[{"name":"bad","pattern":"[invalid("}]}'
# Output: 400

# Valid regex → 200
curl -s -o /dev/null -w "%{http_code}" -X POST /api/privacy/test \
  -H "Content-Type: application/json" \
  -d '{"text":"test","level":"standard","customPatterns":[{"name":"good","pattern":"hello\\w+"}]}'
# Output: 200
```

`npm run check` passes (0 TypeScript errors).
All 49 vitest unit/integration tests pass.

Closes #12