### PR TITLE
fix: strip HTML tags from pipeline name and description to prevent stored XSS

### DIFF
--- a/server/routes/pipelines.ts
+++ b/server/routes/pipelines.ts
@@ -12,8 +12,8 @@ const PipelineStageConfigSchema = z.object({
 });
 
 const CreatePipelineSchema = z.object({
-  name: z.string().min(1).max(100),
-  description: z.string().optional(),
+  name: z.string().min(1).max(100).transform((s) => s.replace(/<[^>]*>/g, "").trim()),
+  description: z.string().optional().transform((s) => s?.replace(/<[^>]*>/g, "").trim()),
   stages: z.array(PipelineStageConfigSchema).default([]),
   createdBy: z.string().optional(),
   isTemplate: z.boolean().optional(),


### PR DESCRIPTION
## Fix

`CreatePipelineSchema` (and via inheritance `UpdatePipelineSchema`) accepted raw HTML in the `name` and `description` fields, which were stored unmodified. A value like `<script>alert(1)</script>` would be stored as-is and could be rendered in the browser, enabling stored XSS.

Added `.transform((s) => s.replace(/<[^>]*>/g, '').trim())` to both `name` and `description` fields. The transform runs after Zod validation, stripping all angle-bracket markup while preserving the text content:

- `<script>alert(1)</script>` → `alert(1)` (script tags removed)
- `hello <b>world</b>` → `hello world` (formatting tags removed)
- `SDLC Pipeline v2` → `SDLC Pipeline v2` (unchanged)

Since `UpdatePipelineSchema = CreatePipelineSchema.partial()`, the same sanitization applies to PATCH requests.

## Testing

```bash
# POST with XSS payload
curl -s -X POST /api/pipelines \
  -H "Content-Type: application/json" \
  -d '{"name":"<script>alert(1)</script>"}'
# Stored name: "alert(1)" — no script tags
```

`npm run check` passes (0 TypeScript errors).
All 49 vitest unit/integration tests pass.

Closes #25