### PR TITLE
feat: provider unit tests with mocked SDKs (T-200/201/202)

### DIFF
--- a/tests/unit/providers/claude.test.ts
+++ b/tests/unit/providers/claude.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Unit tests for ClaudeProvider.
+ *
+ * All Anthropic SDK calls are mocked — no real API calls are made.
+ * Tests verify:
+ *   - complete() returns correct { content, tokensUsed } structure
+ *   - stream() yields correct text chunks
+ *   - System message extraction: role:"system" → top-level `system` param
+ *   - Error handling: invalid API key / auth error → surfaces clear error
+ *   - Error handling: rate limit (429) → surfaced clearly (no SDK-level retry)
+ *   - Retry on 502/503/504 (single retry via withRetry)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Mock the Anthropic SDK before importing the provider ────────────────────
+// We need the mock to expose `mockCreate` and `mockStream` so tests can
+// control return values. We do this via a module-level variable captured
+// in the factory closure.
+
+const mockCreate = vi.fn();
+const mockStream = vi.fn();
+
+vi.mock("@anthropic-ai/sdk", () => {
+  class MockAnthropic {
+    messages = {
+      create: mockCreate,
+      stream: mockStream,
+    };
+    constructor(_opts: unknown) {}
+  }
+  return { default: MockAnthropic };
+});
+
+// Import after mocking so the provider picks up the mock
+import { ClaudeProvider } from "../../../server/gateway/providers/claude.js";
+import type { ProviderMessage } from "../../../shared/types.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeTextBlock(text: string) {
+  return { type: "text" as const, text };
+}
+
+function makeToolUseBlock(id: string, name: string, input: Record<string, unknown>) {
+  return { type: "tool_use" as const, id, name, input };
+}
+
+function makeCompleteResponse(
+  text: string,
+  inputTokens = 10,
+  outputTokens = 20,
+  stopReason: string = "end_turn",
+) {
+  return {
+    content: [makeTextBlock(text)],
+    usage: { input_tokens: inputTokens, output_tokens: outputTokens },
+    stop_reason: stopReason,
+  };
+}
+
+const SYSTEM_MESSAGES: ProviderMessage[] = [
+  { role: "system", content: "You are a helpful assistant." },
+  { role: "user", content: "Hello!" },
+];
+
+const USER_ONLY_MESSAGES: ProviderMessage[] = [
+  { role: "user", content: "What is 2+2?" },
+];
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("ClaudeProvider — complete()", () => {
+  let provider: ClaudeProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new ClaudeProvider("sk-ant-test-key");
+  });
+
+  it("returns correct { content, tokensUsed } structure", async () => {
+    mockCreate.mockResolvedValueOnce(makeCompleteResponse("Hello there!", 15, 25));
+
+    const result = await provider.complete("claude-3-haiku-20240307", USER_ONLY_MESSAGES);
+
+    expect(result.content).toBe("Hello there!");
+    expect(result.tokensUsed).toBe(40); // 15 + 25
+    expect(result.finishReason).toBe("stop");
+  });
+
+  it("returns empty toolCalls when no tool use blocks are present", async () => {
+    mockCreate.mockResolvedValueOnce(makeCompleteResponse("Just text"));
+
+    const result = await provider.complete("claude-3-haiku-20240307", USER_ONLY_MESSAGES);
+
+    expect(result.toolCalls).toBeUndefined();
+  });
+
+  it("returns toolCalls when response contains tool_use blocks", async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [
+        makeTextBlock("I'll search for that."),
+        makeToolUseBlock("call-1", "search", { query: "test" }),
+      ],
+      usage: { input_tokens: 10, output_tokens: 30 },
+      stop_reason: "tool_use",
+    });
+
+    const result = await provider.complete("claude-3-haiku-20240307", USER_ONLY_MESSAGES);
+
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls![0].name).toBe("search");
+    expect(result.toolCalls![0].arguments).toEqual({ query: "test" });
+    expect(result.finishReason).toBe("tool_use");
+  });
+
+  it("extracts system messages as top-level system param", async () => {
+    mockCreate.mockResolvedValueOnce(makeCompleteResponse("response"));
+
+    await provider.complete("claude-3-haiku-20240307", SYSTEM_MESSAGES);
+
+    const callArgs = mockCreate.mock.calls[0][0] as { system?: string; messages: unknown[] };
+    expect(callArgs.system).toBe("You are a helpful assistant.");
+    // The messages array should NOT contain the system message
+    const msgs = callArgs.messages as Array<{ role: string }>;
+    expect(msgs.every((m) => m.role !== "system")).toBe(true);
+  });
+
+  it("omits system param when no system messages are present", async () => {
+    mockCreate.mockResolvedValueOnce(makeCompleteResponse("response"));
+
+    await provider.complete("claude-3-haiku-20240307", USER_ONLY_MESSAGES);
+
+    const callArgs = mockCreate.mock.calls[0][0] as { system?: string };
+    expect(callArgs.system).toBeUndefined();
+  });
+
+  it("concatenates multiple system messages", async () => {
+    const messages: ProviderMessage[] = [
+      { role: "system", content: "Part one." },
+      { role: "system", content: "Part two." },
+      { role: "user", content: "Hello" },
+    ];
+    mockCreate.mockResolvedValueOnce(makeCompleteResponse("ok"));
+
+    await provider.complete("claude-3-haiku-20240307", messages);
+
+    const callArgs = mockCreate.mock.calls[0][0] as { system?: string };
+    expect(callArgs.system).toBe("Part one.\nPart two.");
+  });
+
+  it("surfaces authentication error with clear message", async () => {
+    const authError = Object.assign(new Error("401 Unauthorized: invalid API key"), {
+      status: 401,
+    });
+    mockCreate.mockRejectedValueOnce(authError);
+
+    await expect(
+      provider.complete("claude-3-haiku-20240307", USER_ONLY_MESSAGES),
+    ).rejects.toThrow(/invalid API key|401/i);
+  });
+
+  it("surfaces rate limit error without swallowing message", async () => {
+    const rateLimitError = Object.assign(new Error("429 Too Many Requests: rate limit exceeded"), {
+      status: 429,
+    });
+    mockCreate.mockRejectedValueOnce(rateLimitError);
+
+    await expect(
+      provider.complete("claude-3-haiku-20240307", USER_ONLY_MESSAGES),
+    ).rejects.toThrow(/rate limit|429/i);
+  });
+
+  it("retries once on 503 and returns result on second attempt", async () => {
+    const serverError = Object.assign(new Error("503 Service Unavailable"), { status: 503 });
+    mockCreate
+      .mockRejectedValueOnce(serverError)
+      .mockResolvedValueOnce(makeCompleteResponse("retry worked"));
+
+    const result = await provider.complete("claude-3-haiku-20240307", USER_ONLY_MESSAGES);
+
+    expect(result.content).toBe("retry worked");
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after second attempt also fails with 503", async () => {
+    const serverError = Object.assign(new Error("503 Service Unavailable"), { status: 503 });
+    mockCreate.mockRejectedValue(serverError);
+
+    await expect(
+      provider.complete("claude-3-haiku-20240307", USER_ONLY_MESSAGES),
+    ).rejects.toThrow("503");
+  });
+});
+
+describe("ClaudeProvider — stream()", () => {
+  let provider: ClaudeProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new ClaudeProvider("sk-ant-test-key");
+  });
+
+  function makeStreamEvents(texts: string[]) {
+    const events = texts.map((text) => ({
+      type: "content_block_delta" as const,
+      delta: { type: "text_delta" as const, text },
+    }));
+
+    return {
+      [Symbol.asyncIterator]: async function* () {
+        // Emit a non-text event first to ensure it's ignored
+        yield { type: "message_start" as const };
+        for (const event of events) {
+          yield event;
+        }
+      },
+    };
+  }
+
+  it("yields correct text chunks", async () => {
+    const fakeStream = makeStreamEvents(["Hello", " world", "!"]);
+    mockStream.mockReturnValueOnce(fakeStream);
+
+    const chunks: string[] = [];
+    for await (const chunk of provider.stream("claude-3-haiku-20240307", USER_ONLY_MESSAGES)) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(["Hello", " world", "!"]);
+  });
+
+  it("ignores non-text-delta events and only yields text chunks", async () => {
+    const fakeStream = makeStreamEvents(["Only text"]);
+    mockStream.mockReturnValueOnce(fakeStream);
+
+    const chunks: string[] = [];
+    for await (const chunk of provider.stream("claude-3-haiku-20240307", USER_ONLY_MESSAGES)) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(["Only text"]);
+  });
+
+  it("yields no chunks when stream has no text-delta events", async () => {
+    const emptyStream = {
+      [Symbol.asyncIterator]: async function* () {
+        yield { type: "message_start" as const };
+      },
+    };
+    mockStream.mockReturnValueOnce(emptyStream);
+
+    const chunks: string[] = [];
+    for await (const chunk of provider.stream("claude-3-haiku-20240307", USER_ONLY_MESSAGES)) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(0);
+  });
+
+  it("extracts system message in streaming calls", async () => {
+    const fakeStream = makeStreamEvents(["ok"]);
+    mockStream.mockReturnValueOnce(fakeStream);
+
+    for await (const _ of provider.stream("claude-3-haiku-20240307", SYSTEM_MESSAGES)) {
+      // consume
+    }
+
+    const callArgs = mockStream.mock.calls[0][0] as { system?: string };
+    expect(callArgs.system).toBe("You are a helpful assistant.");
+  });
+});

--- a/tests/unit/providers/gemini.test.ts
+++ b/tests/unit/providers/gemini.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Unit tests for GeminiProvider.
+ *
+ * The @google/generative-ai SDK is mocked — no real API calls are made.
+ * Tests verify:
+ *   - complete() returns correct { content, tokensUsed } structure
+ *   - stream() yields correct text chunks
+ *   - Role mapping: "assistant" → "model" in chat history
+ *   - System message extraction: role:"system" → systemInstruction config
+ *   - Error handling: invalid API key → surfaces clear error
+ *   - Error handling: rate limit → surfaced clearly
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Mock @google/generative-ai before importing provider ────────────────────
+
+const mockSendMessage = vi.fn();
+const mockSendMessageStream = vi.fn();
+const mockStartChat = vi.fn().mockReturnValue({
+  sendMessage: mockSendMessage,
+  sendMessageStream: mockSendMessageStream,
+});
+const mockGetGenerativeModel = vi.fn().mockReturnValue({
+  startChat: mockStartChat,
+});
+
+vi.mock("@google/generative-ai", () => {
+  class MockGoogleGenerativeAI {
+    getGenerativeModel = mockGetGenerativeModel;
+    constructor(_apiKey: string) {}
+  }
+  return { GoogleGenerativeAI: MockGoogleGenerativeAI };
+});
+
+// Import after mocking
+import { GeminiProvider } from "../../../server/gateway/providers/gemini.js";
+import type { ProviderMessage } from "../../../shared/types.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function setupStreamChunks(chunks: string[]) {
+  const chunkIterator = async function* () {
+    for (const text of chunks) {
+      yield { text: () => text };
+    }
+  };
+  mockSendMessageStream.mockResolvedValue({ stream: chunkIterator() });
+}
+
+const USER_MESSAGES: ProviderMessage[] = [
+  { role: "user", content: "What is 2+2?" },
+];
+
+const SYSTEM_WITH_USER: ProviderMessage[] = [
+  { role: "system", content: "You are a math tutor." },
+  { role: "user", content: "What is 2+2?" },
+];
+
+const CONVERSATION: ProviderMessage[] = [
+  { role: "user", content: "Hi" },
+  { role: "assistant", content: "Hello!" },
+  { role: "user", content: "How are you?" },
+];
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("GeminiProvider — complete()", () => {
+  let provider: GeminiProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset return values after clearAllMocks
+    mockStartChat.mockReturnValue({
+      sendMessage: mockSendMessage,
+      sendMessageStream: mockSendMessageStream,
+    });
+    mockGetGenerativeModel.mockReturnValue({ startChat: mockStartChat });
+    provider = new GeminiProvider("AIza-test-key");
+  });
+
+  it("returns correct { content, tokensUsed } structure", async () => {
+    mockSendMessage.mockResolvedValueOnce({
+      response: {
+        text: () => "4",
+        usageMetadata: { totalTokenCount: 42 },
+      },
+    });
+
+    const result = await provider.complete("gemini-2.0-flash", USER_MESSAGES);
+
+    expect(result.content).toBe("4");
+    expect(result.tokensUsed).toBe(42);
+    expect(result.finishReason).toBe("stop");
+  });
+
+  it("returns 0 tokensUsed when usageMetadata is absent", async () => {
+    mockSendMessage.mockResolvedValueOnce({
+      response: {
+        text: () => "answer",
+        usageMetadata: undefined,
+      },
+    });
+
+    const result = await provider.complete("gemini-2.0-flash", USER_MESSAGES);
+
+    expect(result.tokensUsed).toBe(0);
+  });
+
+  it("passes system message as systemInstruction", async () => {
+    mockSendMessage.mockResolvedValueOnce({
+      response: { text: () => "ok", usageMetadata: { totalTokenCount: 10 } },
+    });
+
+    await provider.complete("gemini-2.0-flash", SYSTEM_WITH_USER);
+
+    const modelConfig = mockGetGenerativeModel.mock.calls[0][0] as {
+      systemInstruction?: string;
+    };
+    expect(modelConfig.systemInstruction).toBe("You are a math tutor.");
+  });
+
+  it("omits systemInstruction when no system messages are present", async () => {
+    mockSendMessage.mockResolvedValueOnce({
+      response: { text: () => "ok", usageMetadata: { totalTokenCount: 5 } },
+    });
+
+    await provider.complete("gemini-2.0-flash", USER_MESSAGES);
+
+    const modelConfig = mockGetGenerativeModel.mock.calls[0][0] as {
+      systemInstruction?: string;
+    };
+    expect(modelConfig.systemInstruction).toBeUndefined();
+  });
+
+  it("maps assistant role to model in chat history", async () => {
+    mockSendMessage.mockResolvedValueOnce({
+      response: { text: () => "fine", usageMetadata: { totalTokenCount: 10 } },
+    });
+
+    await provider.complete("gemini-2.0-flash", CONVERSATION);
+
+    const chatConfig = mockStartChat.mock.calls[0][0] as {
+      history: Array<{ role: string; parts: Array<{ text: string }> }>;
+    };
+
+    // The last user message is sent via sendMessage, so history has 2 entries
+    expect(chatConfig.history).toHaveLength(2);
+    expect(chatConfig.history[0].role).toBe("user");
+    expect(chatConfig.history[1].role).toBe("model"); // "assistant" → "model"
+  });
+
+  it("surfaces authentication error with clear message", async () => {
+    mockSendMessage.mockRejectedValueOnce(
+      new Error("API_KEY_INVALID: invalid API key"),
+    );
+
+    await expect(
+      provider.complete("gemini-2.0-flash", USER_MESSAGES),
+    ).rejects.toThrow(/invalid API key|API_KEY_INVALID/i);
+  });
+
+  it("surfaces rate limit error without swallowing message", async () => {
+    mockSendMessage.mockRejectedValueOnce(
+      new Error("429 Too Many Requests: quota exceeded"),
+    );
+
+    await expect(
+      provider.complete("gemini-2.0-flash", USER_MESSAGES),
+    ).rejects.toThrow(/429|quota exceeded/i);
+  });
+
+  it("retries once on 503 error and returns result", async () => {
+    mockSendMessage
+      .mockRejectedValueOnce(new Error("503 Service Unavailable"))
+      .mockResolvedValueOnce({
+        response: {
+          text: () => "retry worked",
+          usageMetadata: { totalTokenCount: 20 },
+        },
+      });
+
+    const result = await provider.complete("gemini-2.0-flash", USER_MESSAGES);
+
+    expect(result.content).toBe("retry worked");
+    expect(mockSendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws when no user message is present", async () => {
+    const systemOnlyMessages: ProviderMessage[] = [
+      { role: "system", content: "You are a bot." },
+    ];
+
+    await expect(
+      provider.complete("gemini-2.0-flash", systemOnlyMessages),
+    ).rejects.toThrow(/no user message/i);
+  });
+});
+
+describe("GeminiProvider — stream()", () => {
+  let provider: GeminiProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStartChat.mockReturnValue({
+      sendMessage: mockSendMessage,
+      sendMessageStream: mockSendMessageStream,
+    });
+    mockGetGenerativeModel.mockReturnValue({ startChat: mockStartChat });
+    provider = new GeminiProvider("AIza-test-key");
+  });
+
+  it("yields correct text chunks from stream", async () => {
+    setupStreamChunks(["Hello", " world", "!"]);
+
+    const chunks: string[] = [];
+    for await (const chunk of provider.stream("gemini-2.0-flash", USER_MESSAGES)) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(["Hello", " world", "!"]);
+  });
+
+  it("skips empty string chunks", async () => {
+    setupStreamChunks(["non-empty", "", "also non-empty"]);
+
+    const chunks: string[] = [];
+    for await (const chunk of provider.stream("gemini-2.0-flash", USER_MESSAGES)) {
+      chunks.push(chunk);
+    }
+
+    // GeminiProvider: `if (text) yield text` — empty string is skipped
+    expect(chunks).toEqual(["non-empty", "also non-empty"]);
+  });
+
+  it("yields no chunks when stream is empty", async () => {
+    setupStreamChunks([]);
+
+    const chunks: string[] = [];
+    for await (const chunk of provider.stream("gemini-2.0-flash", USER_MESSAGES)) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(0);
+  });
+
+  it("passes systemInstruction in streaming calls", async () => {
+    setupStreamChunks(["ok"]);
+
+    for await (const _ of provider.stream("gemini-2.0-flash", SYSTEM_WITH_USER)) {
+      // consume
+    }
+
+    const modelConfig = mockGetGenerativeModel.mock.calls[0][0] as {
+      systemInstruction?: string;
+    };
+    expect(modelConfig.systemInstruction).toBe("You are a math tutor.");
+  });
+});

--- a/tests/unit/providers/grok.test.ts
+++ b/tests/unit/providers/grok.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Unit tests for GrokProvider.
+ *
+ * GrokProvider extends OpenAICompatibleProvider and uses the global fetch API
+ * for all HTTP calls. We mock `global.fetch` to avoid real network requests.
+ *
+ * Tests verify:
+ *   - complete() returns correct { content, tokensUsed } structure
+ *   - stream() yields correct text chunks from SSE events
+ *   - Error handling: invalid API key (401) → surfaces clear error
+ *   - Error handling: rate limit (429) → surfaced clearly
+ *   - Retry on 502/503/504: single retry, success on second attempt
+ *   - Retry on 502/503/504: both attempts fail → throws
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { MockInstance } from "vitest";
+
+// Import the provider (it uses global fetch, which we will mock)
+import { GrokProvider } from "../../../server/gateway/providers/grok.js";
+import type { ProviderMessage } from "../../../shared/types.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const USER_MESSAGES: ProviderMessage[] = [
+  { role: "user", content: "Tell me a joke." },
+];
+
+const CONVERSATION: ProviderMessage[] = [
+  { role: "user", content: "Hi" },
+  { role: "assistant", content: "Hello!" },
+  { role: "user", content: "How are you?" },
+];
+
+/** Build a minimal OpenAI-format JSON response body. */
+function makeCompletionBody(content: string, totalTokens = 50): string {
+  return JSON.stringify({
+    choices: [
+      {
+        message: { content, tool_calls: undefined },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { total_tokens: totalTokens },
+  });
+}
+
+/** Build a successful JSON response. */
+function makeOkResponse(body: string): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Build an error Response object. Note: each call creates a fresh Response. */
+function makeErrorResponse(status: number, body = "error"): Response {
+  return new Response(body, { status });
+}
+
+/** Build a ReadableStream from an array of SSE data lines. */
+function makeSSEStream(lines: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const line of lines) {
+        controller.enqueue(encoder.encode(line + "\n"));
+      }
+      controller.close();
+    },
+  });
+}
+
+/** Create a streaming Response with given SSE chunks. */
+function makeStreamResponse(chunks: string[], done = true): Response {
+  const sseLines: string[] = [];
+  for (const chunk of chunks) {
+    sseLines.push(`data: ${JSON.stringify({ choices: [{ delta: { content: chunk } }] })}`);
+    sseLines.push("");
+  }
+  if (done) {
+    sseLines.push("data: [DONE]");
+    sseLines.push("");
+  }
+
+  return new Response(makeSSEStream(sseLines), {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("GrokProvider — complete()", () => {
+  let provider: GrokProvider;
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    provider = new GrokProvider("xai-test-key");
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns correct { content, tokensUsed } structure", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      makeOkResponse(makeCompletionBody("Why don't scientists trust atoms?", 75)),
+    );
+
+    const result = await provider.complete("grok-3", USER_MESSAGES);
+
+    expect(result.content).toBe("Why don't scientists trust atoms?");
+    expect(result.tokensUsed).toBe(75);
+    expect(result.finishReason).toBe("stop");
+  });
+
+  it("returns empty string content when choices is empty", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      makeOkResponse(JSON.stringify({
+        choices: [],
+        usage: { total_tokens: 0 },
+      })),
+    );
+
+    const result = await provider.complete("grok-3", USER_MESSAGES);
+
+    expect(result.content).toBe("");
+  });
+
+  it("includes Authorization header with Bearer token", async () => {
+    fetchSpy.mockResolvedValueOnce(makeOkResponse(makeCompletionBody("ok")));
+
+    await provider.complete("grok-3", USER_MESSAGES);
+
+    const [_url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer xai-test-key");
+  });
+
+  it("posts to the xAI completions endpoint", async () => {
+    fetchSpy.mockResolvedValueOnce(makeOkResponse(makeCompletionBody("ok")));
+
+    await provider.complete("grok-3", USER_MESSAGES);
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("api.x.ai");
+    expect(url).toContain("/v1/chat/completions");
+  });
+
+  it("surfaces 401 authentication error with clear message", async () => {
+    fetchSpy.mockResolvedValueOnce(makeErrorResponse(401, "invalid API key"));
+
+    await expect(
+      provider.complete("grok-3", USER_MESSAGES),
+    ).rejects.toThrow(/401|invalid API key/i);
+  });
+
+  it("surfaces 429 rate limit error without swallowing message", async () => {
+    fetchSpy.mockResolvedValueOnce(makeErrorResponse(429, "rate limit exceeded"));
+
+    await expect(
+      provider.complete("grok-3", USER_MESSAGES),
+    ).rejects.toThrow(/429|rate limit/i);
+  });
+
+  it("retries once on 503 and returns result on second attempt", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(makeErrorResponse(503, "Service Unavailable"))
+      .mockResolvedValueOnce(makeOkResponse(makeCompletionBody("retry worked", 30)));
+
+    const result = await provider.complete("grok-3", USER_MESSAGES);
+
+    expect(result.content).toBe("retry worked");
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after second attempt also fails with 502", async () => {
+    // Use mockImplementation to create fresh Response each time
+    fetchSpy.mockImplementation(async () => makeErrorResponse(502, "Bad Gateway"));
+
+    await expect(
+      provider.complete("grok-3", USER_MESSAGES),
+    ).rejects.toThrow(/502|Bad Gateway/i);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries once on 504 and throws if both fail", async () => {
+    fetchSpy.mockImplementation(async () => makeErrorResponse(504, "Gateway Timeout"));
+
+    await expect(
+      provider.complete("grok-3", USER_MESSAGES),
+    ).rejects.toThrow(/504/i);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("sends conversation history in correct OpenAI message format", async () => {
+    fetchSpy.mockResolvedValueOnce(makeOkResponse(makeCompletionBody("fine")));
+
+    await provider.complete("grok-3", CONVERSATION);
+
+    const [_url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    expect(body.messages[0].role).toBe("user");
+    expect(body.messages[1].role).toBe("assistant");
+    expect(body.messages[2].role).toBe("user");
+  });
+});
+
+describe("GrokProvider — stream()", () => {
+  let provider: GrokProvider;
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    provider = new GrokProvider("xai-test-key");
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("yields correct text chunks from SSE stream", async () => {
+    fetchSpy.mockResolvedValueOnce(makeStreamResponse(["Hello", " world", "!"]));
+
+    const chunks: string[] = [];
+    for await (const chunk of provider.stream("grok-3", USER_MESSAGES)) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(["Hello", " world", "!"]);
+  });
+
+  it("stops at [DONE] sentinel and does not yield extra chunks", async () => {
+    fetchSpy.mockResolvedValueOnce(makeStreamResponse(["only", " these"]));
+
+    const chunks: string[] = [];
+    for await (const chunk of provider.stream("grok-3", USER_MESSAGES)) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(["only", " these"]);
+  });
+
+  it("yields empty result when stream has no content chunks", async () => {
+    fetchSpy.mockResolvedValueOnce(makeStreamResponse([]));
+
+    const chunks: string[] = [];
+    for await (const chunk of provider.stream("grok-3", USER_MESSAGES)) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(0);
+  });
+
+  it("surfaces stream error for non-200 status", async () => {
+    fetchSpy.mockResolvedValueOnce(makeErrorResponse(401, "unauthorized"));
+
+    await expect(async () => {
+      for await (const _ of provider.stream("grok-3", USER_MESSAGES)) {
+        // consume
+      }
+    }).rejects.toThrow(/401|unauthorized/i);
+  });
+
+  it("sets stream: true in request body", async () => {
+    fetchSpy.mockResolvedValueOnce(makeStreamResponse(["ok"]));
+
+    for await (const _ of provider.stream("grok-3", USER_MESSAGES)) {
+      // consume
+    }
+
+    const [_url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as { stream: boolean };
+    expect(body.stream).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Add unit tests for all three cloud LLM providers. All SDKs are mocked — no real API calls are made.

- **`tests/unit/providers/claude.test.ts`** (14 tests) — ClaudeProvider: response structure, system message extraction to top-level `system` param, multiple system messages concatenated, tool call extraction, auth/rate-limit error surfacing, 503 retry behavior (single retry via `withRetry`)
- **`tests/unit/providers/gemini.test.ts`** (13 tests) — GeminiProvider: response structure, `assistant` → `model` role mapping, `systemInstruction` extraction, absent `usageMetadata` handling, auth/rate-limit errors, 503 retry, empty-chunk skipping, no-user-message guard
- **`tests/unit/providers/grok.test.ts`** (15 tests) — GrokProvider: response structure, Bearer auth header, xAI endpoint URL, auth/rate-limit error surfacing, 502/503/504 retry logic (fresh Response per attempt), SSE chunk parsing, `[DONE]` sentinel, conversation history format

## Test plan

- [ ] `npm run check` — zero TypeScript errors
- [ ] `npm test` — 141 tests pass (99 prior + 42 new)
- [ ] No real API calls (all SDKs mocked with vi.mock / vi.spyOn)