### PR TITLE
feat: phase 3 quality — approval gates, stage execution logging

### DIFF
--- a/client/src/components/workflow/AgentNode.tsx
+++ b/client/src/components/workflow/AgentNode.tsx
@@ -43,6 +43,8 @@ interface AgentNodeProps {
   onSandboxChange: (id: string, config: SandboxConfigType | undefined) => void;
   toolConfig?: StageToolConfig;
   onToolConfigChange: (id: string, config: StageToolConfig) => void;
+  approvalRequired?: boolean;
+  onApprovalChange: (id: string, value: boolean) => void;
   isLast: boolean;
 }
 
@@ -109,6 +111,8 @@ export default function AgentNode({
   onSandboxChange,
   toolConfig,
   onToolConfigChange,
+  approvalRequired = false,
+  onApprovalChange,
   isLast,
 }: AgentNodeProps) {
   const team = SDLC_TEAMS[role as keyof typeof SDLC_TEAMS];
@@ -434,6 +438,27 @@ export default function AgentNode({
             enabled={enabled}
             onChange={(cfg) => onSandboxChange(id, cfg)}
           />
+
+          {/* Approval Gate */}
+          <div className="pt-1 border-t border-border">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-1.5">
+                <label className="text-xs font-medium text-muted-foreground">
+                  Require approval before next stage
+                </label>
+              </div>
+              <Switch
+                checked={approvalRequired}
+                onCheckedChange={(checked) => onApprovalChange(id, checked)}
+                disabled={!enabled}
+              />
+            </div>
+            {approvalRequired && (
+              <p className="text-[10px] text-muted-foreground mt-1">
+                Pipeline will pause after this stage until a user approves the output.
+              </p>
+            )}
+          </div>
 
           {team && (
             <div className="p-2 rounded bg-muted/50 border border-border">

--- a/client/src/components/workflow/MultiAgentPipeline.tsx
+++ b/client/src/components/workflow/MultiAgentPipeline.tsx
@@ -97,6 +97,13 @@ export default function MultiAgentPipeline({ pipelineId }: MultiAgentPipelinePro
     setDirty(true);
   };
 
+  const updateApprovalRequired = (teamId: string, value: boolean) => {
+    setLocalStages(prev => prev.map(s =>
+      s.teamId === teamId ? { ...s, approvalRequired: value } : s,
+    ));
+    setDirty(true);
+  };
+
   const applyPreset = (presetId: string) => {
     const preset = STRATEGY_PRESETS.find(p => p.id === presetId);
     if (!preset) return;
@@ -307,6 +314,8 @@ export default function MultiAgentPipeline({ pipelineId }: MultiAgentPipelinePro
                 onSandboxChange={(_, cfg) => updateSandbox(stage.teamId, cfg)}
                 toolConfig={stage.tools}
                 onToolConfigChange={(_, cfg) => updateToolConfig(stage.teamId, cfg)}
+                approvalRequired={stage.approvalRequired ?? false}
+                onApprovalChange={(_, val) => updateApprovalRequired(stage.teamId, val)}
                 isLast={idx === localStages.length - 1}
               />
             );

--- a/server/controller/pipeline-controller.ts
+++ b/server/controller/pipeline-controller.ts
@@ -283,6 +283,7 @@ export class PipelineController {
         const context = {
           runId: run.id,
           stageIndex: i,
+          stageExecutionId: stageExec.id,
           modelSlug: stage.modelSlug,
           temperature: stage.temperature,
           maxTokens: stage.maxTokens,

--- a/server/routes/pipelines.ts
+++ b/server/routes/pipelines.ts
@@ -10,6 +10,7 @@ const PipelineStageConfigSchema = z.object({
   temperature: z.number().min(0).max(2).optional(),
   maxTokens: z.number().int().positive().max(100000).optional(),
   enabled: z.boolean(),
+  approvalRequired: z.boolean().optional(),
 });
 
 const CreatePipelineSchema = z.object({

--- a/server/teams/base.ts
+++ b/server/teams/base.ts
@@ -110,6 +110,11 @@ export abstract class BaseTeam {
       context.privacySettings
         ? { privacy: context.privacySettings, sessionId: context.sessionId }
         : undefined,
+      {
+        runId: context.runId,
+        stageExecutionId: context.stageExecutionId,
+        teamId: this.config.id,
+      },
     );
 
     const parsed = this.parseOutput(response.content);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -384,6 +384,7 @@ export interface StageOutput {
 export interface StageContext {
   runId: string;
   stageIndex: number;
+  stageExecutionId?: string;
   modelSlug?: string;
   temperature?: number;
   maxTokens?: number;
@@ -394,6 +395,7 @@ export interface StageContext {
   sessionId?: string;
   memoryContext?: string;
   stageConfig?: PipelineStageConfig;
+  variables?: Record<string, string>;
 }
 
 export interface TeamResult {


### PR DESCRIPTION
## Summary
- Add `approvalRequired` field to `PipelineStageConfigSchema` so per-stage approval gates persist through save/load cycles
- Pass `stageExecutionId` through pipeline context to `BaseTeam.execute()` for per-stage cost attribution
- Pass `loggingOptions` (`runId`, `stageExecutionId`, `teamId`) as third argument to `gateway.complete()` for LLM request linking
- Add per-stage approval gate toggle UI in pipeline builder (`AgentNode` + `MultiAgentPipeline`)

## Changes
- `server/routes/pipelines.ts`: `approvalRequired: z.boolean().optional()` added to `PipelineStageConfigSchema`
- `shared/types.ts`: `stageExecutionId?: string` and `variables?: Record<string, string>` added to `StageContext`
- `server/controller/pipeline-controller.ts`: `stageExecutionId: stageExec.id` wired into context
- `server/teams/base.ts`: logging options forwarded to gateway
- `client/src/components/workflow/AgentNode.tsx`: approval gate Switch UI + props
- `client/src/components/workflow/MultiAgentPipeline.tsx`: `updateApprovalRequired` handler

## Test plan
- [ ] TypeScript check passes
- [ ] Unit tests pass (217 tests)
- [ ] Integration tests pass
- [ ] Manual: configure a pipeline stage with approvalRequired=true, run pipeline, verify approval modal appears and pipeline pauses