### PR TITLE
feat: Phase 4.5 PR4 — Maintenance Analytics (MTTR, trends, recommendations)

### DIFF
--- a/server/maintenance/analytics.ts
+++ b/server/maintenance/analytics.ts
@@ -1,0 +1,364 @@
+/**
+ * Maintenance Analytics Engine — Phase 4.5 PR 4
+ *
+ * Computes derived metrics from maintenance scan history:
+ *   - MTTR (Mean Time to Remediate)
+ *   - Health score trend projection
+ *   - Category breakdown and heatmaps
+ *   - Actionable recommendations
+ *
+ * All functions are pure (no DB calls) — the caller fetches data and passes it in.
+ * This makes testing straightforward without mocking.
+ */
+
+import type {
+  ScoutFinding,
+  MaintenanceScan,
+  MaintenancePolicy,
+  HealthScore,
+  Recommendation,
+  MaintenanceCategory,
+  MaintenanceSeverity,
+} from "@shared/types";
+
+// ─── MTTR ─────────────────────────────────────────────────────────────────────
+
+const SEVERITY_WEIGHT: Record<MaintenanceSeverity, number> = {
+  critical: 5,
+  high: 4,
+  medium: 3,
+  low: 2,
+  info: 1,
+};
+
+/**
+ * Compute mean time to remediate in hours.
+ *
+ * A finding is "remediated" when its status changes from "open" to "actioned"
+ * or "dismissed". Since individual findings don't track timestamps, we
+ * approximate MTTR as the average time between the scan that introduced a
+ * finding and the scan where it disappeared.
+ *
+ * Simplified model: compare open findings across consecutive scans. A finding
+ * is resolved when its id no longer appears in open findings in a later scan.
+ */
+export function computeMttr(scans: MaintenanceScan[]): number {
+  if (scans.length < 2) return 0;
+
+  // Sort ascending by startedAt
+  const sorted = [...scans].sort(
+    (a, b) => new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime(),
+  );
+
+  let totalHours = 0;
+  let resolvedCount = 0;
+
+  for (let i = 0; i < sorted.length - 1; i++) {
+    const scanA = sorted[i];
+    const scanB = sorted[i + 1];
+
+    if (!scanA.completedAt || !scanB.startedAt) continue;
+
+    const openInA = new Set(
+      ((scanA.findings as ScoutFinding[]) ?? [])
+        .filter((f) => f.status === "open")
+        .map((f) => f.id),
+    );
+
+    const openInB = new Set(
+      ((scanB.findings as ScoutFinding[]) ?? [])
+        .filter((f) => f.status === "open")
+        .map((f) => f.id),
+    );
+
+    // Findings that were open in A but not open in B are resolved
+    for (const id of openInA) {
+      if (!openInB.has(id)) {
+        const scanAEnd = new Date(scanA.completedAt).getTime();
+        const scanBStart = new Date(scanB.startedAt).getTime();
+        const deltaHours = (scanBStart - scanAEnd) / 3_600_000;
+        if (deltaHours >= 0) {
+          totalHours += deltaHours;
+          resolvedCount++;
+        }
+      }
+    }
+  }
+
+  if (resolvedCount === 0) return 0;
+  return Math.round((totalHours / resolvedCount) * 10) / 10;
+}
+
+// ─── Category Breakdown ───────────────────────────────────────────────────────
+
+export interface CategoryBreakdown {
+  category: MaintenanceCategory;
+  open: number;
+  actioned: number;
+  dismissed: number;
+  total: number;
+  highestSeverity: MaintenanceSeverity | null;
+}
+
+/**
+ * Aggregate finding counts by category across all provided scans.
+ */
+export function computeCategoryBreakdown(scans: MaintenanceScan[]): CategoryBreakdown[] {
+  const map = new Map<MaintenanceCategory, CategoryBreakdown>();
+
+  for (const scan of scans) {
+    const findings = (scan.findings as ScoutFinding[]) ?? [];
+    for (const f of findings) {
+      const existing = map.get(f.category) ?? {
+        category: f.category,
+        open: 0,
+        actioned: 0,
+        dismissed: 0,
+        total: 0,
+        highestSeverity: null,
+      };
+
+      if (f.status === "open") existing.open++;
+      else if (f.status === "actioned") existing.actioned++;
+      else if (f.status === "dismissed") existing.dismissed++;
+      existing.total++;
+
+      // Track highest severity seen
+      if (
+        !existing.highestSeverity ||
+        SEVERITY_WEIGHT[f.severity] > SEVERITY_WEIGHT[existing.highestSeverity]
+      ) {
+        existing.highestSeverity = f.severity;
+      }
+
+      map.set(f.category, existing);
+    }
+  }
+
+  return Array.from(map.values()).sort((a, b) => b.open - a.open);
+}
+
+// ─── Score History ────────────────────────────────────────────────────────────
+
+export interface ScoreSample {
+  scanId: string;
+  completedAt: Date;
+  score: number;
+  openCount: number;
+}
+
+/**
+ * Build a time-series of health scores from completed scans.
+ * Uses the same deduction formula as the health route.
+ */
+export function computeScoreHistory(scans: MaintenanceScan[]): ScoreSample[] {
+  return scans
+    .filter((s) => s.status === "completed" && s.completedAt)
+    .sort((a, b) => new Date(a.completedAt!).getTime() - new Date(b.completedAt!).getTime())
+    .map((s) => {
+      const findings = (s.findings as ScoutFinding[]) ?? [];
+      const open = findings.filter((f) => f.status === "open");
+      const deductions = Math.min(
+        60,
+        open.filter((f) => f.severity === "critical").length * 20 +
+          open.filter((f) => f.severity === "high").length * 10 +
+          open.filter((f) => f.severity === "medium").length * 3 +
+          open.filter((f) => f.severity === "low").length * 1,
+      );
+      return {
+        scanId: s.id,
+        completedAt: new Date(s.completedAt!),
+        score: Math.max(0, Math.min(100, 100 - deductions)),
+        openCount: open.length,
+      };
+    });
+}
+
+// ─── Trend Projection ─────────────────────────────────────────────────────────
+
+export interface TrendProjection {
+  projectedScore: number;
+  projectedAt: Date;
+  confidence: "high" | "medium" | "low";
+}
+
+/**
+ * Project the health score 30 days forward using linear regression
+ * on the last N score samples.
+ */
+export function projectTrend(
+  history: ScoreSample[],
+  daysAhead = 30,
+  sampleCount = 10,
+): TrendProjection | null {
+  if (history.length < 2) return null;
+
+  const samples = history.slice(-sampleCount);
+  const n = samples.length;
+
+  // Convert timestamps to days-since-first-sample
+  const t0 = samples[0].completedAt.getTime();
+  const xs = samples.map((s) => (s.completedAt.getTime() - t0) / 86_400_000);
+  const ys = samples.map((s) => s.score);
+
+  // Simple least-squares linear regression
+  const sumX = xs.reduce((a, b) => a + b, 0);
+  const sumY = ys.reduce((a, b) => a + b, 0);
+  const sumXY = xs.reduce((acc, x, i) => acc + x * ys[i], 0);
+  const sumXX = xs.reduce((acc, x) => acc + x * x, 0);
+
+  const denominator = n * sumXX - sumX * sumX;
+  if (denominator === 0) return null;
+
+  const slope = (n * sumXY - sumX * sumY) / denominator;
+  const intercept = (sumY - slope * sumX) / n;
+
+  const lastX = xs[xs.length - 1];
+  const projectedX = lastX + daysAhead;
+  const projectedScore = Math.max(0, Math.min(100, slope * projectedX + intercept));
+
+  const confidence: TrendProjection["confidence"] =
+    n >= 8 ? "high" : n >= 4 ? "medium" : "low";
+
+  const projectedAt = new Date(samples[samples.length - 1].completedAt.getTime() + daysAhead * 86_400_000);
+
+  return {
+    projectedScore: Math.round(projectedScore * 10) / 10,
+    projectedAt,
+    confidence,
+  };
+}
+
+// ─── Recommendations ──────────────────────────────────────────────────────────
+
+/**
+ * Generate actionable recommendations from scan history and policy settings.
+ * Returns an array sorted by priority (high → low).
+ */
+export function generateRecommendations(
+  policy: MaintenancePolicy,
+  recentScans: MaintenanceScan[],
+): Recommendation[] {
+  const recommendations: Recommendation[] = [];
+
+  const completedScans = recentScans.filter((s) => s.status === "completed");
+  const allFindings = completedScans.flatMap((s) => (s.findings as ScoutFinding[]) ?? []);
+  const openFindings = allFindings.filter((f) => f.status === "open");
+
+  // Recommendation: increase scan frequency if scans are infrequent
+  if (completedScans.length > 0 && completedScans[0].completedAt) {
+    const latestScan = completedScans
+      .filter((s) => s.completedAt)
+      .sort((a, b) => new Date(b.completedAt!).getTime() - new Date(a.completedAt!).getTime())[0];
+
+    if (latestScan?.completedAt) {
+      const ageMs = Date.now() - new Date(latestScan.completedAt).getTime();
+      const ageDays = ageMs / 86_400_000;
+
+      if (ageDays > 14) {
+        recommendations.push({
+          type: "increase_frequency",
+          message: `Last scan was ${Math.round(ageDays)} days ago. Consider changing the schedule from "${policy.schedule}" to a more frequent interval to stay ahead of issues.`,
+          priority: "high",
+          actionable: true,
+          suggestedChange: { schedule: "0 9 * * 1" }, // weekly
+        });
+      }
+    }
+  }
+
+  // Recommendation: enable unconfigured high-value categories
+  const enabledCategoryNames = new Set(policy.categories.filter((c) => c.enabled).map((c) => c.category));
+  const highValueCategories: MaintenanceCategory[] = ["security_advisory", "dependency_update", "license_compliance"];
+
+  for (const cat of highValueCategories) {
+    if (!enabledCategoryNames.has(cat)) {
+      recommendations.push({
+        type: "enable_category",
+        message: `The "${cat}" scanner is not enabled. Enabling it will improve security posture and dependency hygiene.`,
+        priority: "medium",
+        actionable: true,
+        suggestedChange: {
+          categories: [
+            ...policy.categories,
+            { category: cat, enabled: true, severity: "high" },
+          ],
+        },
+      });
+    }
+  }
+
+  // Recommendation: stale open findings
+  const criticalOpen = openFindings.filter((f) => f.severity === "critical" || f.severity === "high");
+  if (criticalOpen.length > 5) {
+    recommendations.push({
+      type: "review_stale",
+      message: `There are ${criticalOpen.length} critical/high severity open findings that have not been actioned. Review and triage to improve the health score.`,
+      priority: "high",
+      actionable: true,
+    });
+  }
+
+  // Recommendation: upgrade severity threshold if too permissive
+  if (policy.severityThreshold === "low" || policy.severityThreshold === "info") {
+    recommendations.push({
+      type: "upgrade_threshold",
+      message: `The severity threshold is set to "${policy.severityThreshold}". Tightening it to "medium" or "high" will surface more meaningful issues and reduce noise.`,
+      priority: "low",
+      actionable: true,
+      suggestedChange: { severityThreshold: "medium" },
+    });
+  }
+
+  // Sort by priority
+  const priorityOrder = { high: 0, medium: 1, low: 2 };
+  return recommendations.sort((a, b) => priorityOrder[a.priority] - priorityOrder[b.priority]);
+}
+
+// ─── Full Analytics Report ────────────────────────────────────────────────────
+
+export interface AnalyticsReport {
+  mttrHours: number;
+  categoryBreakdown: CategoryBreakdown[];
+  scoreHistory: ScoreSample[];
+  projection: TrendProjection | null;
+  recommendations: Recommendation[];
+  openByCategory: Partial<Record<MaintenanceCategory, number>>;
+  totalOpen: number;
+  totalActioned: number;
+  totalDismissed: number;
+}
+
+/**
+ * Compute a full analytics report for a workspace's scan history.
+ */
+export function computeAnalyticsReport(
+  policy: MaintenancePolicy,
+  scans: MaintenanceScan[],
+): AnalyticsReport {
+  const categoryBreakdown = computeCategoryBreakdown(scans);
+  const scoreHistory = computeScoreHistory(scans);
+  const projection = projectTrend(scoreHistory);
+  const mttrHours = computeMttr(scans);
+  const recommendations = generateRecommendations(policy, scans);
+
+  const allFindings = scans.flatMap((s) => (s.findings as ScoutFinding[]) ?? []);
+  const openByCategory: Partial<Record<MaintenanceCategory, number>> = {};
+  for (const breakdown of categoryBreakdown) {
+    if (breakdown.open > 0) {
+      openByCategory[breakdown.category] = breakdown.open;
+    }
+  }
+
+  return {
+    mttrHours,
+    categoryBreakdown,
+    scoreHistory,
+    projection,
+    recommendations,
+    openByCategory,
+    totalOpen: allFindings.filter((f) => f.status === "open").length,
+    totalActioned: allFindings.filter((f) => f.status === "actioned").length,
+    totalDismissed: allFindings.filter((f) => f.status === "dismissed").length,
+  };
+}

--- a/server/routes/maintenance.ts
+++ b/server/routes/maintenance.ts
@@ -7,7 +7,9 @@ import type {
   MaintenanceCategoryConfig,
   ScoutFinding,
   HealthScore,
+  MaintenancePolicy,
 } from "@shared/types";
+import { computeAnalyticsReport } from "../maintenance/analytics";
 
 // ─── Validation Schemas ───────────────────────────────────────────────────────
 
@@ -415,4 +417,63 @@ export function registerMaintenanceRoutes(router: Router): void {
       res.status(500).json({ error: (err as Error).message });
     }
   });
+
+  // ── Analytics ─────────────────────────────────────────────────────────────────
+
+  router.get("/api/maintenance/analytics/:workspaceId", async (req, res) => {
+    try {
+      const workspaceId = req.params.workspaceId;
+
+      const [policies, scans] = await Promise.all([
+        db
+          .select()
+          .from(maintenancePolicies)
+          .where(eq(maintenancePolicies.workspaceId, workspaceId)),
+        db
+          .select()
+          .from(maintenanceScans)
+          .where(
+            and(
+              eq(maintenanceScans.workspaceId, workspaceId),
+              eq(maintenanceScans.status, "completed"),
+            ),
+          )
+          .orderBy(desc(maintenanceScans.completedAt)),
+      ]);
+
+      // Use the first policy for recommendation context, or a sensible default
+      const policy: MaintenancePolicy = policies[0]
+        ? {
+            id: policies[0].id,
+            workspaceId: policies[0].workspaceId ?? null,
+            enabled: policies[0].enabled,
+            schedule: policies[0].schedule,
+            categories: (policies[0].categories as MaintenancePolicy["categories"]) ?? [],
+            severityThreshold: policies[0].severityThreshold as MaintenancePolicy["severityThreshold"],
+            autoMerge: policies[0].autoMerge,
+            notifyChannels: (policies[0].notifyChannels as string[]) ?? [],
+            createdAt: policies[0].createdAt ?? new Date(),
+            updatedAt: policies[0].updatedAt ?? new Date(),
+          }
+        : {
+            id: "",
+            workspaceId,
+            enabled: false,
+            schedule: "0 9 * * 1",
+            categories: [],
+            severityThreshold: "high",
+            autoMerge: false,
+            notifyChannels: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          };
+
+      const report = computeAnalyticsReport(policy, scans as import("@shared/types").MaintenanceScan[]);
+
+      res.json(report);
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
 }

--- a/tests/unit/maintenance/analytics.test.ts
+++ b/tests/unit/maintenance/analytics.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Unit tests for the Maintenance Analytics Engine (Phase 4.5 PR 4).
+ *
+ * Pure functions — no mocking needed.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  computeMttr,
+  computeCategoryBreakdown,
+  computeScoreHistory,
+  projectTrend,
+  generateRecommendations,
+  computeAnalyticsReport,
+} from "../../../server/maintenance/analytics";
+import type { MaintenanceScan, MaintenancePolicy, ScoutFinding } from "@shared/types";
+
+// ─── Test Data Helpers ────────────────────────────────────────────────────────
+
+function makeScan(
+  id: string,
+  findings: Partial<ScoutFinding>[],
+  status: "completed" | "running" | "failed" = "completed",
+  daysAgo = 0,
+): MaintenanceScan {
+  const now = new Date();
+  const started = new Date(now.getTime() - daysAgo * 86_400_000 - 3_600_000);
+  const completed = new Date(now.getTime() - daysAgo * 86_400_000);
+
+  return {
+    id,
+    policyId: "policy-1",
+    workspaceId: "ws-1",
+    status,
+    findings: findings.map((f, i) => ({
+      id: f.id ?? `finding-${id}-${i}`,
+      scanId: id,
+      category: f.category ?? "dependency_update",
+      severity: f.severity ?? "medium",
+      title: f.title ?? `Finding ${i}`,
+      description: f.description ?? "desc",
+      currentValue: f.currentValue ?? "old",
+      recommendedValue: f.recommendedValue ?? "new",
+      effort: f.effort ?? "small",
+      references: f.references ?? [],
+      autoFixable: f.autoFixable ?? false,
+      complianceRefs: f.complianceRefs ?? [],
+      status: f.status ?? "open",
+    })) as ScoutFinding[],
+    importantCount: findings.filter((f) => f.severity === "critical" || f.severity === "high").length,
+    triggeredPipelineId: null,
+    startedAt: started,
+    completedAt: status === "completed" ? completed : null,
+    createdAt: started,
+  };
+}
+
+const basePolicy: MaintenancePolicy = {
+  id: "policy-1",
+  workspaceId: "ws-1",
+  enabled: true,
+  schedule: "0 9 * * 1",
+  categories: [
+    { category: "security_advisory", enabled: true, severity: "high" },
+    { category: "dependency_update", enabled: true, severity: "medium" },
+  ],
+  severityThreshold: "medium",
+  autoMerge: false,
+  notifyChannels: [],
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+};
+
+// ─── computeMttr ─────────────────────────────────────────────────────────────
+
+describe("computeMttr", () => {
+  it("returns 0 with fewer than 2 scans", () => {
+    expect(computeMttr([])).toBe(0);
+    expect(computeMttr([makeScan("s1", [])])).toBe(0);
+  });
+
+  it("returns 0 when no findings are resolved between scans", () => {
+    const scan1 = makeScan("s1", [{ id: "f1", status: "open" }], "completed", 2);
+    const scan2 = makeScan("s2", [{ id: "f1", status: "open" }], "completed", 1);
+    expect(computeMttr([scan1, scan2])).toBe(0);
+  });
+
+  it("calculates positive MTTR when a finding is resolved", () => {
+    const scan1 = makeScan("s1", [{ id: "f1", status: "open" }], "completed", 10);
+    const scan2 = makeScan("s2", [], "completed", 3); // f1 resolved
+    const mttr = computeMttr([scan1, scan2]);
+    expect(mttr).toBeGreaterThan(0);
+  });
+
+  it("returns 0 when scans lack completedAt", () => {
+    const scan1 = makeScan("s1", [{ id: "f1", status: "open" }], "running", 5);
+    const scan2 = makeScan("s2", [], "completed", 1);
+    // scan1 has no completedAt because it's running
+    expect(typeof computeMttr([scan1, scan2])).toBe("number");
+  });
+});
+
+// ─── computeCategoryBreakdown ─────────────────────────────────────────────────
+
+describe("computeCategoryBreakdown", () => {
+  it("returns empty array for no scans", () => {
+    expect(computeCategoryBreakdown([])).toEqual([]);
+  });
+
+  it("aggregates findings by category", () => {
+    const scan = makeScan("s1", [
+      { category: "dependency_update", severity: "high", status: "open" },
+      { category: "dependency_update", severity: "medium", status: "actioned" },
+      { category: "security_advisory", severity: "critical", status: "open" },
+    ]);
+
+    const breakdown = computeCategoryBreakdown([scan]);
+    const depUpdate = breakdown.find((b) => b.category === "dependency_update");
+    const secAdvisory = breakdown.find((b) => b.category === "security_advisory");
+
+    expect(depUpdate).toBeDefined();
+    expect(depUpdate?.open).toBe(1);
+    expect(depUpdate?.actioned).toBe(1);
+    expect(depUpdate?.total).toBe(2);
+
+    expect(secAdvisory?.open).toBe(1);
+    expect(secAdvisory?.highestSeverity).toBe("critical");
+  });
+
+  it("sorts by open count descending", () => {
+    const scan = makeScan("s1", [
+      { category: "license_compliance", status: "open" },
+      { category: "dependency_update", status: "open" },
+      { category: "dependency_update", status: "open" },
+    ]);
+
+    const breakdown = computeCategoryBreakdown([scan]);
+    expect(breakdown[0].category).toBe("dependency_update");
+  });
+
+  it("tracks highest severity per category", () => {
+    const scan = makeScan("s1", [
+      { category: "security_advisory", severity: "low", status: "open" },
+      { category: "security_advisory", severity: "critical", status: "open" },
+      { category: "security_advisory", severity: "medium", status: "open" },
+    ]);
+
+    const [item] = computeCategoryBreakdown([scan]);
+    expect(item.highestSeverity).toBe("critical");
+  });
+});
+
+// ─── computeScoreHistory ──────────────────────────────────────────────────────
+
+describe("computeScoreHistory", () => {
+  it("returns empty array for no completed scans", () => {
+    const running = makeScan("s1", [], "running");
+    expect(computeScoreHistory([running])).toEqual([]);
+  });
+
+  it("computes score 100 for scans with no open findings", () => {
+    const scan = makeScan("s1", [{ status: "actioned" }]);
+    const [sample] = computeScoreHistory([scan]);
+    expect(sample.score).toBe(100);
+  });
+
+  it("deducts points for open findings by severity", () => {
+    const scan = makeScan("s1", [
+      { severity: "critical", status: "open" },
+      { severity: "critical", status: "open" },
+    ]);
+    const [sample] = computeScoreHistory([scan]);
+    // 2 × 20 = 40 deduction → score = 60
+    expect(sample.score).toBe(60);
+  });
+
+  it("caps deductions at 60", () => {
+    const findings = Array.from({ length: 10 }, (_, i) => ({
+      id: `f${i}`,
+      severity: "critical" as const,
+      status: "open" as const,
+    }));
+    const scan = makeScan("s1", findings);
+    const [sample] = computeScoreHistory([scan]);
+    // 10 × 20 = 200 but capped at 60 → score = 40
+    expect(sample.score).toBe(40);
+  });
+
+  it("returns samples sorted by completedAt ascending", () => {
+    const scan1 = makeScan("s1", [], "completed", 5);
+    const scan2 = makeScan("s2", [], "completed", 1);
+    const history = computeScoreHistory([scan2, scan1]); // pass in reverse order
+    expect(history[0].scanId).toBe("s1");
+    expect(history[1].scanId).toBe("s2");
+  });
+});
+
+// ─── projectTrend ─────────────────────────────────────────────────────────────
+
+describe("projectTrend", () => {
+  it("returns null for empty or single-sample history", () => {
+    expect(projectTrend([])).toBeNull();
+
+    const history = computeScoreHistory([makeScan("s1", [])]);
+    expect(projectTrend(history)).toBeNull();
+  });
+
+  it("returns a projection with score in [0, 100]", () => {
+    const scans = Array.from({ length: 5 }, (_, i) =>
+      makeScan(`s${i}`, [{ severity: "medium", status: "open" }], "completed", (4 - i) * 7),
+    );
+    const history = computeScoreHistory(scans);
+    const projection = projectTrend(history);
+
+    expect(projection).not.toBeNull();
+    expect(projection!.projectedScore).toBeGreaterThanOrEqual(0);
+    expect(projection!.projectedScore).toBeLessThanOrEqual(100);
+  });
+
+  it("returns low confidence for 2 samples", () => {
+    const scans = [makeScan("s1", [], "completed", 14), makeScan("s2", [], "completed", 7)];
+    const history = computeScoreHistory(scans);
+    const projection = projectTrend(history);
+    expect(projection?.confidence).toBe("low");
+  });
+
+  it("returns high confidence for 8+ samples", () => {
+    const scans = Array.from({ length: 10 }, (_, i) =>
+      makeScan(`s${i}`, [], "completed", (9 - i) * 7),
+    );
+    const history = computeScoreHistory(scans);
+    const projection = projectTrend(history);
+    expect(projection?.confidence).toBe("high");
+  });
+
+  it("projectedAt is approximately daysAhead from last sample", () => {
+    const scans = [makeScan("s1", [], "completed", 14), makeScan("s2", [], "completed", 7)];
+    const history = computeScoreHistory(scans);
+    const projection = projectTrend(history, 30);
+    expect(projection).not.toBeNull();
+    const diff = projection!.projectedAt.getTime() - history[history.length - 1].completedAt.getTime();
+    // Should be approximately 30 days
+    expect(Math.round(diff / 86_400_000)).toBe(30);
+  });
+});
+
+// ─── generateRecommendations ──────────────────────────────────────────────────
+
+describe("generateRecommendations", () => {
+  it("returns recommendations sorted by priority (high before medium)", () => {
+    const stalePolicy: MaintenancePolicy = {
+      ...basePolicy,
+      categories: [], // no categories enabled → multiple medium recs
+      schedule: "@weekly",
+    };
+    const oldScan = makeScan("s1", [], "completed", 30); // very old scan
+    const recs = generateRecommendations(stalePolicy, [oldScan]);
+
+    const priorities = recs.map((r) => r.priority);
+    for (let i = 1; i < priorities.length; i++) {
+      const prev = { high: 0, medium: 1, low: 2 }[priorities[i - 1]] ?? 0;
+      const curr = { high: 0, medium: 1, low: 2 }[priorities[i]] ?? 0;
+      expect(prev).toBeLessThanOrEqual(curr);
+    }
+  });
+
+  it("recommends increasing frequency when last scan is old", () => {
+    const oldScan = makeScan("s1", [], "completed", 20);
+    const recs = generateRecommendations(basePolicy, [oldScan]);
+    const freqRec = recs.find((r) => r.type === "increase_frequency");
+    expect(freqRec).toBeDefined();
+    expect(freqRec?.priority).toBe("high");
+  });
+
+  it("recommends enabling high-value categories when missing", () => {
+    const policyNoCats: MaintenancePolicy = { ...basePolicy, categories: [] };
+    const scan = makeScan("s1", [], "completed", 1);
+    const recs = generateRecommendations(policyNoCats, [scan]);
+    const catRecs = recs.filter((r) => r.type === "enable_category");
+    expect(catRecs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("recommends reviewing stale findings when critical open count is high", () => {
+    const criticalFindings = Array.from({ length: 8 }, (_, i) => ({
+      id: `f${i}`,
+      severity: "critical" as const,
+      status: "open" as const,
+    }));
+    const scan = makeScan("s1", criticalFindings, "completed", 1);
+    const recs = generateRecommendations(basePolicy, [scan]);
+    const staleRec = recs.find((r) => r.type === "review_stale");
+    expect(staleRec).toBeDefined();
+    expect(staleRec?.priority).toBe("high");
+  });
+
+  it("recommends upgrading threshold when set to low/info", () => {
+    const lenientPolicy: MaintenancePolicy = { ...basePolicy, severityThreshold: "info" };
+    const recs = generateRecommendations(lenientPolicy, []);
+    const threshRec = recs.find((r) => r.type === "upgrade_threshold");
+    expect(threshRec).toBeDefined();
+  });
+
+  it("returns empty recommendations for a healthy policy with recent scans", () => {
+    const healthyPolicy: MaintenancePolicy = {
+      ...basePolicy,
+      categories: [
+        { category: "security_advisory", enabled: true, severity: "high" },
+        { category: "dependency_update", enabled: true, severity: "medium" },
+        { category: "license_compliance", enabled: true, severity: "medium" },
+      ],
+      severityThreshold: "high",
+    };
+    const recentScan = makeScan("s1", [], "completed", 1);
+    const recs = generateRecommendations(healthyPolicy, [recentScan]);
+    expect(recs.length).toBe(0);
+  });
+});
+
+// ─── computeAnalyticsReport ───────────────────────────────────────────────────
+
+describe("computeAnalyticsReport", () => {
+  it("returns a complete report with all fields", () => {
+    const scans = [
+      makeScan("s1", [{ severity: "high", status: "open" }], "completed", 7),
+      makeScan("s2", [{ severity: "medium", status: "actioned" }], "completed", 1),
+    ];
+
+    const report = computeAnalyticsReport(basePolicy, scans);
+
+    expect(typeof report.mttrHours).toBe("number");
+    expect(Array.isArray(report.categoryBreakdown)).toBe(true);
+    expect(Array.isArray(report.scoreHistory)).toBe(true);
+    expect(Array.isArray(report.recommendations)).toBe(true);
+    expect(typeof report.totalOpen).toBe("number");
+    expect(typeof report.totalActioned).toBe("number");
+    expect(typeof report.totalDismissed).toBe("number");
+    expect(typeof report.openByCategory).toBe("object");
+  });
+
+  it("counts open/actioned/dismissed correctly", () => {
+    const scan = makeScan("s1", [
+      { status: "open" },
+      { status: "open" },
+      { status: "actioned" },
+      { status: "dismissed" },
+    ]);
+
+    const report = computeAnalyticsReport(basePolicy, [scan]);
+    expect(report.totalOpen).toBe(2);
+    expect(report.totalActioned).toBe(1);
+    expect(report.totalDismissed).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the analytics engine that derives actionable insights from scan history.

- **`server/maintenance/analytics.ts`**: Pure functions with no DB dependencies
  - `computeMttr()`: mean-time-to-remediate in hours (tracks resolved finding IDs across scans)
  - `computeCategoryBreakdown()`: counts open/actioned/dismissed per category with highest severity
  - `computeScoreHistory()`: time-series of health scores from completed scans
  - `projectTrend()`: 30-day linear regression projection with confidence levels (low/medium/high)
  - `generateRecommendations()`: priority-sorted actionable suggestions covering frequency, categories, stale findings, and threshold tuning
  - `computeAnalyticsReport()`: aggregate wrapper combining all metrics

- **Route addition** (`server/routes/maintenance.ts`):
  - `GET /api/maintenance/analytics/:workspaceId` — full analytics report

- **`tests/unit/maintenance/analytics.test.ts`**: 26 unit tests, all pure (no mocking needed)

## Test plan

- [x] `npm run check` — zero new TypeScript errors
- [x] `npx vitest run` — 429 tests pass (baseline 281; 1 pre-existing failure)
- [x] All 26 analytics unit tests pass
- [x] MTTR returns 0 when no findings resolved between scans
- [x] Score capped at 100, deductions capped at 60
- [x] Trend projection returns null for < 2 samples
- [x] Recommendations sorted high → medium → low
- [x] Healthy policy with recent scan generates zero recommendations