### PR TITLE
fix: route all process.env reads through ConfigLoader (Phase 0 gap)

### DIFF
--- a/server/config/loader.ts
+++ b/server/config/loader.ts
@@ -74,6 +74,7 @@ const ENV_MAPPINGS: EnvMapping[] = [
   { envKey: "XAI_API_KEY",      configPath: ["providers", "xai", "apiKey"],             kind: "string"  },
   { envKey: "VLLM_ENDPOINT",    configPath: ["providers", "vllm", "endpoint"],          kind: "string"  },
   { envKey: "OLLAMA_ENDPOINT",  configPath: ["providers", "ollama", "endpoint"],        kind: "string"  },
+  { envKey: "TAVILY_API_KEY",   configPath: ["providers", "tavily", "apiKey"],          kind: "string"  },
   { envKey: "SANDBOX_ENABLED",  configPath: ["features", "sandbox", "enabled"],         kind: "boolean" },
   { envKey: "ENCRYPTION_KEY",   configPath: ["encryption", "key"],                      kind: "string"  },
 
@@ -86,6 +87,7 @@ const ENV_MAPPINGS: EnvMapping[] = [
   { envKey: "MULTI_PROVIDERS_XAI_API_KEY",           configPath: ["providers", "xai", "apiKey"],                  kind: "string"  },
   { envKey: "MULTI_PROVIDERS_VLLM_ENDPOINT",         configPath: ["providers", "vllm", "endpoint"],               kind: "string"  },
   { envKey: "MULTI_PROVIDERS_OLLAMA_ENDPOINT",       configPath: ["providers", "ollama", "endpoint"],             kind: "string"  },
+  { envKey: "MULTI_PROVIDERS_TAVILY_API_KEY",        configPath: ["providers", "tavily", "apiKey"],               kind: "string"  },
   { envKey: "MULTI_FEATURES_SANDBOX_ENABLED",        configPath: ["features", "sandbox", "enabled"],              kind: "boolean" },
   { envKey: "MULTI_ENCRYPTION_KEY",                  configPath: ["encryption", "key"],                           kind: "string"  },
 ];

--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -22,6 +22,7 @@ export const ConfigSchema = z.object({
     xai: z.object({ apiKey: z.string().optional() }).default({}),
     vllm: z.object({ endpoint: z.string().url().optional() }).default({}),
     ollama: z.object({ endpoint: z.string().url().optional() }).default({}),
+    tavily: z.object({ apiKey: z.string().optional() }).default({}),
   }).default({}),
   features: z.object({
     sandbox: z.object({

--- a/server/index.ts
+++ b/server/index.ts
@@ -98,7 +98,7 @@ app.use((req, res, next) => {
     {
       port,
       host: "0.0.0.0",
-      ...(process.env.NODE_ENV === "production" && { reusePort: true }),
+      ...(config.server.nodeEnv === "production" && { reusePort: true }),
     },
     () => {
       log(`serving on port ${port}`);

--- a/server/routes/tools.ts
+++ b/server/routes/tools.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { toolRegistry } from "../tools/index";
 import { mcpClientManager } from "../tools/mcp-client";
 import type { IStorage } from "../storage";
+import { configLoader } from "../config/loader";
 
 const createMcpServerSchema = z.object({
   name: z.string().min(1).max(100),
@@ -33,7 +34,7 @@ export function registerToolRoutes(app: Express, storage: IStorage): void {
 
   /** GET /api/tools/status — configuration status of each tool */
   app.get("/api/tools/status", (_req, res) => {
-    const hasTavily = !!process.env.TAVILY_API_KEY;
+    const hasTavily = !!configLoader.get().providers.tavily?.apiKey;
 
     res.json({
       web_search: {

--- a/server/tools/builtin/web-search.ts
+++ b/server/tools/builtin/web-search.ts
@@ -1,4 +1,5 @@
 import type { ToolHandler } from "../registry";
+import { configLoader } from "../../config/loader";
 
 interface TavilyResult {
   title: string;
@@ -23,7 +24,7 @@ interface DdgResponse {
 }
 
 async function searchWithTavily(query: string, limit: number): Promise<string> {
-  const apiKey = process.env.TAVILY_API_KEY;
+  const apiKey = configLoader.get().providers.tavily?.apiKey;
   if (!apiKey) throw new Error("No Tavily API key");
 
   const res = await fetch("https://api.tavily.com/search", {


### PR DESCRIPTION
## Summary

Closes the two remaining Phase 0 gaps identified in the config audit — all `process.env` reads now flow through the validated `ConfigLoader` layer.

### Files changed

**`server/config/schema.ts`**
- Added `tavily: z.object({ apiKey: z.string().optional() }).default({})` to the `providers` section, matching the pattern used by every other provider.

**`server/config/loader.ts`**
- Added two new `ENV_MAPPINGS` entries so `TAVILY_API_KEY` (legacy) and `MULTI_PROVIDERS_TAVILY_API_KEY` (MULTI_\* prefixed) are ingested and validated at startup alongside all other provider keys.

**`server/tools/builtin/web-search.ts`**
- Replaced `process.env.TAVILY_API_KEY` with `configLoader.get().providers.tavily?.apiKey`.

**`server/routes/tools.ts`**
- Replaced `process.env.TAVILY_API_KEY` with `configLoader.get().providers.tavily?.apiKey` in the `/api/tools/status` handler.

**`server/index.ts`**
- Replaced `process.env.NODE_ENV === "production"` in the `httpServer.listen` options with `config.server.nodeEnv === "production"`. The `config` object was already in scope (loaded at the top of the file via `configLoader.load()`).

### Why

Phase 0 goal: every runtime configuration value is loaded once at startup, validated by Zod, and served from `ConfigLoader`. Scattered `process.env` reads bypass validation and are invisible to the config diff/audit tooling. These were the last two remaining gaps.

## Test plan

- [x] `npm run check` — zero TypeScript errors
- [x] `npm test` — 477 tests pass across 31 test files