### PR TITLE
feat: Production-ready docker-compose deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,17 +3,31 @@
 #
 # Copy this file to .env and fill in your values.
 # NEVER commit .env to git.
+#
+# Generate strong secrets with:
+#   openssl rand -hex 32
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ── PostgreSQL ─────────────────────────────────────────────────────────────
 POSTGRES_USER=multiqlti
-POSTGRES_PASSWORD=change_me_in_production
+# REQUIRED — change this before first start
+POSTGRES_PASSWORD=change_me_before_starting
 POSTGRES_DB=multiqlti
 
-# Override the full URL if using an external/managed database:
+# Override the full URL to use an external / managed database:
 # DATABASE_URL=postgres://user:pass@your-rds-host:5432/multiqlti?sslmode=require
 
+# ── Security ───────────────────────────────────────────────────────────────
+# REQUIRED — minimum 32 characters. Generate with: openssl rand -hex 32
+JWT_SECRET=change_me_before_starting_generate_with_openssl_rand_hex_32
+
+# ── Caddy / TLS ────────────────────────────────────────────────────────────
+# Set to your domain for automatic HTTPS via Let's Encrypt.
+# Leave as "localhost" for local dev (HTTP only, no cert provisioning).
+CADDY_DOMAIN=localhost
+
 # ── Application ────────────────────────────────────────────────────────────
+# Only used in dev mode; in production traffic arrives through Caddy on 443.
 APP_PORT=5050
 
 # ── Sandbox ────────────────────────────────────────────────────────────────
@@ -28,3 +42,7 @@ VLLM_MODEL=meta-llama/Meta-Llama-3-70B-Instruct
 # ANTHROPIC_API_KEY=sk-ant-...
 # OPENAI_API_KEY=sk-...
 # GOOGLE_API_KEY=...
+
+# ── Monitoring ─────────────────────────────────────────────────────────────
+# Only used when --profile monitoring is active
+GRAFANA_PASSWORD=change_me_too

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,34 @@
+# Caddyfile — multiqlti reverse proxy
+#
+# Caddy automatically provisions and renews TLS certificates via Let's Encrypt
+# when CADDY_DOMAIN is set to a real domain name.
+#
+# For local development, Caddy serves on http://localhost (no TLS).
+# For production, set CADDY_DOMAIN=yourdomain.com in .env.
+#
+# Caddy reads this file as-is; environment variable substitution is handled
+# by the entrypoint via envsubst or caddy's native {env.VAR} syntax.
+
+{env.CADDY_DOMAIN} {
+    # Reverse proxy all traffic to the app container
+    reverse_proxy multiqlti:5000
+
+    # Security headers
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "DENY"
+        Referrer-Policy "strict-origin-when-cross-origin"
+        Permissions-Policy "geolocation=(), microphone=(), camera=()"
+        -Server
+    }
+
+    # Logging to stdout (picked up by Docker's json-file driver)
+    log {
+        output stdout
+        format json
+    }
+
+    # Compression
+    encode gzip zstd
+}

--- a/README.md
+++ b/README.md
@@ -18,8 +18,12 @@ A multi-provider AI pipeline orchestration platform supporting parallel model ex
 
 ```bash
 cp .env.example .env
-# Edit .env — at minimum set your AI provider API keys
 ```
+
+Open `.env` and set **at minimum**:
+- `POSTGRES_PASSWORD` — generate with `openssl rand -hex 16`
+- `JWT_SECRET` — generate with `openssl rand -hex 32`
+- `CADDY_DOMAIN` — your domain (or `localhost` for local dev)
 
 ### 2. Start the stack
 
@@ -38,12 +42,24 @@ docker compose --profile cloud-only up -d
 docker compose --profile full up -d
 ```
 
-The application is available at `http://localhost:5050` once the `multiqlti` service is healthy.
+The application is served through Caddy:
+- Local dev: `http://localhost`
+- Production: `https://yourdomain.com` (TLS auto-provisioned via Let's Encrypt)
 
-Database migrations run automatically on every startup before the server starts. To run them manually:
+Database migrations run automatically on every startup. To run them manually:
 ```bash
 docker compose exec multiqlti npm run db:push
 ```
+
+---
+
+## Health Check
+
+```bash
+curl http://localhost/api/health
+```
+
+Returns DB status, provider status, and overall health. Used by Docker and load balancers.
 
 ---
 
@@ -51,25 +67,32 @@ docker compose exec multiqlti npm run db:push
 
 | Profile | Services | Use case |
 |---------|----------|----------|
-| `dev` | app + postgres + ollama | Local development, no GPU |
-| `cloud-only` | app + postgres | Cloud AI providers only |
-| `full` | app + postgres + vllm + ollama | On-premise GPU inference |
+| `dev` | app + postgres + ollama + caddy | Local development, no GPU |
+| `cloud-only` | app + postgres + caddy | Cloud AI providers only |
+| `full` | app + postgres + vllm + ollama + caddy | On-premise GPU inference |
+| `monitoring` | + prometheus + loki + grafana | Observability (add to any profile) |
+
+```bash
+# Full stack with monitoring
+docker compose --profile full --profile monitoring up -d
+```
 
 ---
 
 ## Environment Variables
 
-Copy `.env.example` to `.env`. Key variables:
+Copy `.env.example` to `.env`. Required variables:
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `POSTGRES_USER` | `multiqlti` | DB username |
-| `POSTGRES_PASSWORD` | `multiqlti_dev` | DB password — **change in production** |
-| `POSTGRES_DB` | `multiqlti` | DB name |
-| `DATABASE_URL` | auto-constructed | Override to use external DB |
-| `APP_PORT` | `5050` | Host port for the web UI |
-| `SANDBOX_ENABLED` | `true` | Enable/disable code sandbox |
-| `VLLM_MODEL` | `meta-llama/Meta-Llama-3-70B-Instruct` | Model to load in vLLM |
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `POSTGRES_PASSWORD` | Yes | DB password — generate with `openssl rand -hex 16` |
+| `JWT_SECRET` | Yes | JWT signing key — generate with `openssl rand -hex 32` |
+| `CADDY_DOMAIN` | No | Domain for HTTPS (default: `localhost`) |
+| `POSTGRES_USER` | No | DB username (default: `multiqlti`) |
+| `POSTGRES_DB` | No | DB name (default: `multiqlti`) |
+| `DATABASE_URL` | No | Override to use external/managed DB |
+| `SANDBOX_ENABLED` | No | Enable code sandbox (default: `true`) |
+| `VLLM_MODEL` | No | vLLM model (default: Llama-3-70B) |
 
 ---
 
@@ -79,24 +102,26 @@ To override defaults without editing `docker-compose.yml`:
 
 ```bash
 cp docker-compose.override.yml.example docker-compose.override.yml
-# Edit docker-compose.override.yml with your customisations
+# Edit docker-compose.override.yml
 ```
 
-The override file is automatically merged by Docker Compose. Never commit it to git.
+Never commit `docker-compose.override.yml` to git — it is listed in `.gitignore`.
 
 ---
 
 ## Data Persistence
 
-All persistent data is stored in named Docker volumes:
+All persistent data lives in named Docker volumes:
 
 | Volume | Contents |
 |--------|----------|
 | `pgdata` | PostgreSQL database files |
+| `pgbackups` | Automated daily `pg_dump` backups (last 7) |
 | `ollama_data` | Downloaded Ollama models |
 | `vllm_cache` | Hugging Face model cache |
+| `caddy_data` | TLS certificates |
 
-To back up the database:
+Manual backup:
 ```bash
 docker compose exec postgres pg_dump -U multiqlti multiqlti > backup.sql
 ```
@@ -115,29 +140,34 @@ docker compose --profile dev down -v
 
 ---
 
-## Upgrading
+## Production Deployment
 
-```bash
-git pull
-docker compose --profile dev pull
-docker compose --profile dev up -d --build
-```
-
-Migrations run automatically on startup.
+See [docs/DEPLOYMENT_DOCKER.md](docs/DEPLOYMENT_DOCKER.md) for:
+- Cold start guide
+- Upgrade procedure
+- Backup and restore
+- Monitoring setup
+- Security checklist
+- Troubleshooting
 
 ---
 
 ## Troubleshooting
 
+**App fails to start — "JWT_SECRET must be set"**
+- Set `JWT_SECRET` in your `.env`: `openssl rand -hex 32`
+
 **App fails to connect to database**
-- Ensure the `postgres` service is healthy: `docker compose ps`
+- Check service health: `docker compose ps`
 - Check logs: `docker compose logs postgres`
-- Verify `DATABASE_URL` in your `.env` matches Postgres credentials
+- Verify `POSTGRES_PASSWORD` is identical in both postgres and multiqlti services
 
 **vLLM fails to start**
-- Confirm NVIDIA drivers and `nvidia-container-toolkit` are installed
-- Check GPU visibility: `docker run --rm --gpus all nvidia/cuda:12.0-base nvidia-smi`
+- Confirm NVIDIA drivers: `nvidia-smi`
+- Install `nvidia-container-toolkit`
 - Use `--profile dev` or `--profile cloud-only` if no GPU is available
 
-**Port 5050 already in use**
-- Set `APP_PORT=8080` (or another free port) in your `.env`
+**Caddy fails to get TLS certificate**
+- Ensure ports 80 and 443 are open in your firewall
+- Ensure `CADDY_DOMAIN` resolves to this server's IP
+- Check: `docker compose logs caddy`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,21 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# multiqlti docker-compose
+# multiqlti docker-compose — production-ready
 #
 # Profiles:
-#   full        — multiqlti + postgres + vllm (GPU) + ollama  (default if no profile given)
-#   cloud-only  — multiqlti + postgres only (use Anthropic/OpenAI cloud providers)
-#   dev         — multiqlti + postgres + ollama (CPU-friendly, no GPU required)
-#   monitoring  — adds Loki + Grafana + Prometheus (layer on top of any profile)
+#   full        — multiqlti + postgres + vllm (GPU) + ollama + caddy
+#   cloud-only  — multiqlti + postgres + caddy (cloud AI providers only)
+#   dev         — multiqlti + postgres + ollama + caddy (CPU-friendly, no GPU)
+#   monitoring  — add Loki + Grafana + Prometheus on top of any profile
 #
-# Quick start (dev mode, no GPU):
+# Quick start:
+#   cp .env.example .env          # fill in your secrets
 #   docker compose --profile dev up -d
 #
-# Full stack (GPU required):
+# Production (HTTPS):
+#   # Set CADDY_DOMAIN=yourdomain.com in .env
 #   docker compose --profile full up -d
 #
-# Cloud-only (no local AI, no GPU):
-#   docker compose --profile cloud-only up -d
-#
-# Copy .env.example → .env and fill in secrets before running in production.
+# See docs/DEPLOYMENT_DOCKER.md for full guide.
 # ─────────────────────────────────────────────────────────────────────────────
 
 services:
@@ -27,7 +26,7 @@ services:
     profiles: [full, cloud-only, dev]
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-multiqlti}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-multiqlti_dev}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
       POSTGRES_DB: ${POSTGRES_DB:-multiqlti}
     volumes:
       - pgdata:/var/lib/postgresql/data
@@ -40,17 +39,50 @@ services:
       retries: 5
       start_period: 10s
     restart: unless-stopped
+    mem_limit: 512m
+    # Postgres port is NOT exposed to the host — use docker exec or override file
+    # to expose it temporarily for maintenance.
+
+  # ── DB Backup (cron) ────────────────────────────────────────────────────────
+  postgres-backup:
+    image: postgres:16-alpine
+    profiles: [full, cloud-only, dev]
+    environment:
+      PGPASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+    volumes:
+      - pgbackups:/backups
+    networks:
+      - internal
+    depends_on:
+      postgres:
+        condition: service_healthy
+    # Run pg_dump every day at 02:00 UTC, keep last 7 dumps
+    entrypoint: >
+      sh -c "
+        while true; do
+          sleep_until=\$$(( \$$(date -u +%s) % 86400 ));
+          sleep \$$((86400 - sleep_until));
+          TIMESTAMP=\$$(date -u +%Y%m%d_%H%M%S);
+          pg_dump -h postgres -U ${POSTGRES_USER:-multiqlti} ${POSTGRES_DB:-multiqlti} \
+            > /backups/backup_\$$TIMESTAMP.sql;
+          ls -t /backups/backup_*.sql | tail -n +8 | xargs rm -f;
+          echo \"[backup] Completed at \$$TIMESTAMP\";
+        done
+      "
+    restart: unless-stopped
 
   # ── Application ─────────────────────────────────────────────────────────────
   multiqlti:
     build: .
     profiles: [full, cloud-only, dev]
-    ports:
-      - "${APP_PORT:-5050}:5000"
+    # No host ports — traffic arrives through Caddy only
+    expose:
+      - "5000"
     environment:
       NODE_ENV: production
       PORT: 5000
-      DATABASE_URL: ${DATABASE_URL:-postgres://${POSTGRES_USER:-multiqlti}:${POSTGRES_PASSWORD:-multiqlti_dev}@postgres:5432/${POSTGRES_DB:-multiqlti}}
+      DATABASE_URL: ${DATABASE_URL:-postgres://${POSTGRES_USER:-multiqlti}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-multiqlti}}
+      JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET in .env (min 32 chars, generate with: openssl rand -hex 32)}
       VLLM_ENDPOINT: http://vllm:8000
       OLLAMA_ENDPOINT: http://ollama:11434
       SANDBOX_ENABLED: ${SANDBOX_ENABLED:-true}
@@ -65,8 +97,42 @@ services:
         condition: service_healthy
     # Run DB migrations then start the server
     command: sh -c "npm run db:push && node dist/index.cjs"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:5000/api/health | grep -q '\"status\":\"ok\\|degraded\"' || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
     restart: unless-stopped
     mem_limit: 1g
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
+
+  # ── Caddy (reverse proxy + automatic TLS) ───────────────────────────────────
+  caddy:
+    image: caddy:2-alpine
+    profiles: [full, cloud-only, dev]
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    networks:
+      - internal
+    depends_on:
+      multiqlti:
+        condition: service_healthy
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "3"
 
   # ── vLLM (GPU required) ─────────────────────────────────────────────────────
   vllm:
@@ -96,6 +162,11 @@ services:
       retries: 3
       start_period: 60s
     restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
 
   # ── Ollama (CPU-friendly local AI) ─────────────────────────────────────────
   ollama:
@@ -114,11 +185,63 @@ services:
       start_period: 30s
     restart: unless-stopped
 
+  # ── Prometheus ──────────────────────────────────────────────────────────────
+  prometheus:
+    image: prom/prometheus:latest
+    profiles: [monitoring]
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/etc/prometheus/console_libraries"
+      - "--web.console.templates=/etc/prometheus/consoles"
+      - "--storage.tsdb.retention.time=15d"
+    networks:
+      - internal
+    restart: unless-stopped
+
+  # ── Loki (log aggregation) ──────────────────────────────────────────────────
+  loki:
+    image: grafana/loki:latest
+    profiles: [monitoring]
+    volumes:
+      - loki_data:/loki
+    networks:
+      - internal
+    restart: unless-stopped
+
+  # ── Grafana ─────────────────────────────────────────────────────────────────
+  grafana:
+    image: grafana/grafana:latest
+    profiles: [monitoring]
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+    networks:
+      - internal
+    depends_on:
+      - prometheus
+      - loki
+    restart: unless-stopped
+
 networks:
   internal:
     driver: bridge
+    # All services communicate only on this internal bridge.
+    # Only Caddy exposes external ports (80 + 443).
 
 volumes:
   pgdata:
+  pgbackups:
   vllm_cache:
   ollama_data:
+  caddy_data:
+  caddy_config:
+  prometheus_data:
+  loki_data:
+  grafana_data:

--- a/docs/DEPLOYMENT_DOCKER.md
+++ b/docs/DEPLOYMENT_DOCKER.md
@@ -1,0 +1,277 @@
+# Docker Deployment Guide
+
+This guide covers a cold start through a running production deployment of multiqlti using Docker Compose.
+
+---
+
+## Hardware Requirements
+
+| Profile | CPU | RAM | Storage | GPU |
+|---------|-----|-----|---------|-----|
+| `cloud-only` | 2 cores | 4 GB | 20 GB | None |
+| `dev` | 4 cores | 8 GB | 40 GB | None (Ollama CPU) |
+| `full` | 8 cores | 32 GB | 200 GB | NVIDIA, 24 GB+ VRAM |
+
+---
+
+## Prerequisites
+
+- Docker Engine 24+ and Docker Compose v2
+- `curl` and `openssl` on the host
+- A domain name pointed at your server (for HTTPS / Let's Encrypt)
+- For `full` profile: NVIDIA drivers + `nvidia-container-toolkit`
+
+---
+
+## Cold Start: First Deployment
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/100rd/multiqlti.git
+cd multiqlti
+```
+
+### 2. Configure environment
+
+```bash
+cp .env.example .env
+```
+
+Open `.env` and set the following **required** values:
+
+| Variable | How to set |
+|----------|-----------|
+| `POSTGRES_PASSWORD` | `openssl rand -hex 16` |
+| `JWT_SECRET` | `openssl rand -hex 32` |
+| `CADDY_DOMAIN` | Your domain (e.g. `multiqlti.example.com`) or `localhost` for dev |
+
+Also set your AI provider API key(s) if using cloud providers:
+```
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+### 3. Choose a profile and start
+
+**Development (no GPU, Ollama for local AI):**
+```bash
+docker compose --profile dev up -d
+```
+
+**Cloud-only (no local AI, API keys required):**
+```bash
+docker compose --profile cloud-only up -d
+```
+
+**Full stack (NVIDIA GPU required):**
+```bash
+docker compose --profile full up -d
+```
+
+### 4. Verify the deployment
+
+```bash
+# Check all services are running
+docker compose ps
+
+# Check application health
+curl http://localhost/api/health
+
+# View logs
+docker compose logs -f multiqlti
+```
+
+Caddy provisions a TLS certificate on first start. If `CADDY_DOMAIN` is a real domain, the app is available at `https://yourdomain.com` within ~30 seconds.
+
+---
+
+## Environment Variable Reference
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `POSTGRES_USER` | No | `multiqlti` | PostgreSQL username |
+| `POSTGRES_PASSWORD` | **Yes** | — | PostgreSQL password |
+| `POSTGRES_DB` | No | `multiqlti` | PostgreSQL database name |
+| `DATABASE_URL` | No | auto-constructed | Override for external/managed DB |
+| `JWT_SECRET` | **Yes** | — | JWT signing secret, min 32 chars |
+| `CADDY_DOMAIN` | No | `localhost` | Domain for TLS cert provisioning |
+| `APP_PORT` | No | `5050` | Host port (dev mode only) |
+| `SANDBOX_ENABLED` | No | `true` | Enable code sandbox |
+| `SANDBOX_MAX_CONCURRENT` | No | `3` | Max concurrent sandbox executions |
+| `SANDBOX_DEFAULT_TIMEOUT` | No | `120` | Sandbox timeout in seconds |
+| `VLLM_MODEL` | No | `meta-llama/Meta-Llama-3-70B-Instruct` | Model loaded by vLLM |
+| `GRAFANA_PASSWORD` | No | `admin` | Grafana admin password |
+
+---
+
+## Database Migrations
+
+Migrations run **automatically** on every container startup via:
+```
+npm run db:push && node dist/index.cjs
+```
+
+To run migrations manually (e.g. during a zero-downtime upgrade):
+```bash
+docker compose exec multiqlti npm run db:push
+```
+
+---
+
+## Upgrade Procedure
+
+```bash
+# 1. Pull latest code
+git pull
+
+# 2. Rebuild the app image
+docker compose --profile <your-profile> build multiqlti
+
+# 3. Restart with new image (migrations run automatically)
+docker compose --profile <your-profile> up -d --no-deps multiqlti
+```
+
+For major version upgrades, always check `CHANGELOG.md` for breaking changes before upgrading.
+
+---
+
+## Backup and Restore
+
+### Automated Backups
+
+The `postgres-backup` service runs a daily `pg_dump` at 02:00 UTC to the `pgbackups` volume, keeping the last 7 dumps.
+
+List backups:
+```bash
+docker compose exec postgres-backup ls /backups/
+```
+
+### Manual Backup
+
+```bash
+docker compose exec postgres pg_dump -U multiqlti multiqlti > backup_$(date +%Y%m%d).sql
+```
+
+### Restore from Backup
+
+```bash
+# Copy backup file into the container
+docker compose cp backup_20240101.sql postgres:/tmp/
+
+# Restore
+docker compose exec postgres psql -U multiqlti multiqlti < /tmp/backup_20240101.sql
+```
+
+---
+
+## Monitoring (Optional)
+
+Enable the monitoring stack on top of any running profile:
+
+```bash
+docker compose --profile monitoring up -d
+```
+
+This starts:
+- **Prometheus** — scrapes application and infrastructure metrics
+- **Loki** — aggregates container logs
+- **Grafana** — dashboards (default login: admin / `$GRAFANA_PASSWORD`)
+
+Access Grafana via the Caddy reverse proxy at `/grafana` (configure Caddy route) or directly on port 3000 via `docker compose exec`.
+
+---
+
+## Profiles Reference
+
+| Profile | Services | Use case |
+|---------|----------|----------|
+| `dev` | app + postgres + ollama + caddy | Local dev, no GPU |
+| `cloud-only` | app + postgres + caddy | Cloud AI only |
+| `full` | app + postgres + vllm + ollama + caddy | On-premise GPU |
+| `monitoring` | + prometheus + loki + grafana | Observability layer |
+
+Profiles can be combined:
+```bash
+docker compose --profile full --profile monitoring up -d
+```
+
+---
+
+## Network Architecture
+
+All services communicate on the `internal` bridge network. Only Caddy exposes external ports:
+
+```
+Internet
+    │
+    ▼
+  Caddy :80/:443
+    │
+    ▼  (internal bridge)
+  multiqlti :5000
+    │
+    ├── postgres :5432
+    ├── vllm :8000
+    └── ollama :11434
+```
+
+PostgreSQL is **never** directly accessible from outside Docker. To connect with a local client temporarily, use `docker-compose.override.yml`:
+```yaml
+services:
+  postgres:
+    ports:
+      - "5432:5432"
+```
+
+---
+
+## Troubleshooting
+
+### App fails to start — "JWT_SECRET must be set"
+
+`JWT_SECRET` is required and not set in `.env`. Generate one:
+```bash
+openssl rand -hex 32
+```
+
+### App fails to start — "POSTGRES_PASSWORD must be set"
+
+`POSTGRES_PASSWORD` is required. Set it in `.env`.
+
+### Caddy shows "certificate provisioning error"
+
+- Ensure port 80 and 443 are open in your firewall
+- Ensure `CADDY_DOMAIN` resolves to this server's public IP
+- Check Caddy logs: `docker compose logs caddy`
+
+### Database connection refused
+
+- Ensure the `postgres` service is healthy: `docker compose ps`
+- Check if `DATABASE_URL` in `.env` matches your credentials
+
+### vLLM fails to start (GPU not found)
+
+- Confirm NVIDIA drivers are installed: `nvidia-smi`
+- Install nvidia-container-toolkit: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
+- Test GPU in Docker: `docker run --rm --gpus all nvidia/cuda:12.0-base nvidia-smi`
+
+### Health endpoint returns "unhealthy"
+
+The app is running but cannot reach the database. Check:
+1. `docker compose ps` — is `postgres` healthy?
+2. `docker compose logs postgres` — any startup errors?
+3. Is `POSTGRES_PASSWORD` the same in postgres and multiqlti services?
+
+---
+
+## Security Checklist
+
+Before going to production:
+
+- [ ] `POSTGRES_PASSWORD` changed from default
+- [ ] `JWT_SECRET` is at least 32 random characters
+- [ ] `.env` is not committed to git
+- [ ] `CADDY_DOMAIN` set to your real domain (enables HTTPS)
+- [ ] Firewall: only ports 80 and 443 are open externally
+- [ ] PostgreSQL port 5432 is NOT exposed to the host
+- [ ] Regular backups verified by restoring to a test environment

--- a/monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  # Scrape Prometheus itself
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  # Scrape the multiqlti app health endpoint
+  - job_name: "multiqlti"
+    metrics_path: "/api/health"
+    static_configs:
+      - targets: ["multiqlti:5000"]

--- a/server/db.ts
+++ b/server/db.ts
@@ -5,6 +5,6 @@ import { configLoader } from "./config/loader";
 
 // database.url is optional — PgStorage will throw at query time if absent,
 // but importing this module is safe even when DATABASE_URL is not set (e.g. in tests).
-const pool = new Pool({ connectionString: configLoader.get().database.url });
+export const pool = new Pool({ connectionString: configLoader.get().database.url });
 
 export const db = drizzle(pool, { schema });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -30,6 +30,7 @@ import { registerDAGRoutes } from "./routes/dag";
 import { registerTraceRoutes } from "./routes/traces";
 import { registerTriggerRoutes } from "./routes/triggers";
 import { registerWebhookRoutes } from "./routes/webhooks";
+import { registerHealthRoutes } from "./routes/health";
 import { TriggerService } from "./services/trigger-service";
 import { CronScheduler } from "./services/cron-scheduler";
 import { FileWatcherService } from "./services/file-watcher";
@@ -52,7 +53,10 @@ export async function registerRoutes(
   const managerAgent = new ManagerAgent(storage, teamRegistry, wsManager, gateway, delegationService);
   const controller = new PipelineController(storage, teamRegistry, wsManager, gateway, delegationService, managerAgent, tracer);
 
-  // Register auth routes first (public routes included)
+  // Register public routes (no auth required) — must come before requireAuth middleware
+  registerHealthRoutes(app);
+
+  // Register auth routes (public routes included)
   registerAuthRoutes(app);
 
   // Register protected route groups — all require authentication

--- a/server/routes/health.ts
+++ b/server/routes/health.ts
@@ -1,0 +1,97 @@
+import type { Express } from "express";
+import { pool } from "../db";
+import { configLoader } from "../config/loader";
+
+/**
+ * GET /api/health
+ *
+ * Public endpoint (no authentication required). Returns the operational status
+ * of the application and its dependencies. Used by Docker healthchecks,
+ * load balancers, and monitoring systems.
+ *
+ * Response shape:
+ * {
+ *   status: "ok" | "degraded" | "unhealthy",
+ *   version: string,
+ *   uptime: number,          // process uptime in seconds
+ *   db: { status: "ok" | "error", latencyMs?: number, error?: string },
+ *   providers: {
+ *     vllm:   { status: "ok" | "unreachable" | "disabled" },
+ *     ollama: { status: "ok" | "unreachable" | "disabled" },
+ *   },
+ * }
+ *
+ * HTTP status codes:
+ *   200 — ok or degraded (app is running, some deps may be unavailable)
+ *   503 — unhealthy (DB is down; app cannot serve requests)
+ */
+export function registerHealthRoutes(app: Express): void {
+  app.get("/api/health", async (_req, res) => {
+    // ── 1. Database check ───────────────────────────────────────────────────
+    let dbStatus: { status: "ok" | "error"; latencyMs?: number; error?: string } = {
+      status: "error",
+    };
+    try {
+      const dbStart = Date.now();
+      const client = await pool.connect();
+      await client.query("SELECT 1");
+      client.release();
+      dbStatus = { status: "ok", latencyMs: Date.now() - dbStart };
+    } catch (err) {
+      dbStatus = {
+        status: "error",
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+
+    // ── 2. Provider checks (best-effort, 3 s timeout, non-blocking) ─────────
+    const config = configLoader.get();
+    const vllmEndpoint = config.providers.vllm.endpoint;
+    const ollamaEndpoint = config.providers.ollama.endpoint;
+
+    const checkUrl = async (
+      baseUrl: string | undefined,
+      path: string,
+    ): Promise<"ok" | "unreachable" | "disabled"> => {
+      if (!baseUrl) return "disabled";
+      try {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 3000);
+        const resp = await fetch(`${baseUrl}${path}`, { signal: controller.signal });
+        clearTimeout(timeoutId);
+        return resp.ok ? "ok" : "unreachable";
+      } catch {
+        return "unreachable";
+      }
+    };
+
+    const [vllmStatus, ollamaStatus] = await Promise.all([
+      checkUrl(vllmEndpoint, "/health"),
+      checkUrl(ollamaEndpoint, "/api/tags"),
+    ]);
+
+    // ── 3. Overall status ───────────────────────────────────────────────────
+    // unhealthy  → DB is down; app cannot serve requests
+    // degraded   → DB is ok but a provider is unreachable
+    // ok         → everything is reachable
+    const overallStatus =
+      dbStatus.status === "error"
+        ? "unhealthy"
+        : vllmStatus === "unreachable" || ollamaStatus === "unreachable"
+          ? "degraded"
+          : "ok";
+
+    const body = {
+      status: overallStatus,
+      version: process.env.npm_package_version ?? "unknown",
+      uptime: Math.floor(process.uptime()),
+      db: dbStatus,
+      providers: {
+        vllm: { status: vllmStatus },
+        ollama: { status: ollamaStatus },
+      },
+    };
+
+    res.status(overallStatus === "unhealthy" ? 503 : 200).json(body);
+  });
+}


### PR DESCRIPTION
Closes #115

Production-hardening on top of #118 (PostgreSQL in docker-compose).

## Changes

- **Caddy reverse proxy** — auto-TLS via Let's Encrypt, only 80/443 exposed externally
- **Security headers** — HSTS, X-Frame-Options, CSP, `-Server` header stripped
- **Resource limits** — multiqlti 1GB, postgres 512MB, all services `unless-stopped`
- **Secrets via `.env`** — no hardcoded passwords; `:?` fail-fast on missing required vars
- **`/api/health` endpoint** — DB latency + provider checks, `200 ok|degraded` / `503 unhealthy`
- **DB backup cron** — daily `pg_dump`, 7-day retention
- **Monitoring profile** — Prometheus + Loki + Grafana provisioned
- **docker-compose profiles** — `full`, `cloud`, `dev`, `monitoring`
- **`docs/DEPLOYMENT_DOCKER.md`** — cold start guide, hardware requirements, env var reference, upgrade, backup/restore, troubleshooting