### PR TITLE
fix: Maintenance Autopilot toggle fails with 401 in Settings

### DIFF
--- a/client/src/hooks/use-pipeline.ts
+++ b/client/src/hooks/use-pipeline.ts
@@ -5,7 +5,7 @@ function getAuthToken(): string | null {
   return localStorage.getItem("auth_token");
 }
 
-async function apiRequest(method: string, url: string, body?: unknown) {
+export async function apiRequest(method: string, url: string, body?: unknown) {
   const headers: Record<string, string> = {};
   if (body) headers["Content-Type"] = "application/json";
   const token = getAuthToken();

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -39,6 +39,7 @@ import {
   useDiscoverProviderModels,
   useProbeEndpoint,
   useCreateModel,
+  apiRequest,
 } from "@/hooks/use-pipeline";
 import { cn } from "@/lib/utils";
 import { useQueryClient, useMutation, useQuery } from "@tanstack/react-query";
@@ -100,11 +101,8 @@ function MaintenanceSettings() {
 
   const { data: policies, isLoading } = useQuery<MaintenancePolicySummary[]>({
     queryKey: ["/api/maintenance/policies"],
-    queryFn: async () => {
-      const res = await fetch("/api/maintenance/policies");
-      if (!res.ok) return [];
-      return res.json() as Promise<MaintenancePolicySummary[]>;
-    },
+    queryFn: () =>
+      apiRequest("GET", "/api/maintenance/policies") as Promise<MaintenancePolicySummary[]>,
   });
 
   const firstPolicy = policies?.[0] ?? null;
@@ -113,48 +111,27 @@ function MaintenanceSettings() {
   const [severity, setSeverity] = useState<string>("high");
 
   const createPolicy = useMutation({
-    mutationFn: async () => {
-      const res = await fetch("/api/maintenance/policies", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          enabled: true,
-          schedule,
-          severityThreshold: severity,
-          categories: [],
-          autoMerge: false,
-          notifyChannels: [],
-        }),
-      });
-      if (!res.ok) throw new Error("Failed to create policy");
-      return res.json();
-    },
+    mutationFn: () =>
+      apiRequest("POST", "/api/maintenance/policies", {
+        enabled: true,
+        schedule,
+        severityThreshold: severity,
+        categories: [],
+        autoMerge: false,
+        notifyChannels: [],
+      }),
     onSuccess: () => void qc.invalidateQueries({ queryKey: ["/api/maintenance/policies"] }),
   });
 
   const togglePolicy = useMutation({
-    mutationFn: async ({ id, enabled }: { id: string; enabled: boolean }) => {
-      const res = await fetch(`/api/maintenance/policies/${id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ enabled }),
-      });
-      if (!res.ok) throw new Error("Failed to update policy");
-      return res.json();
-    },
+    mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
+      apiRequest("PUT", `/api/maintenance/policies/${id}`, { enabled }),
     onSuccess: () => void qc.invalidateQueries({ queryKey: ["/api/maintenance/policies"] }),
   });
 
   const updatePolicy = useMutation({
-    mutationFn: async ({ id, schedule: s, severityThreshold }: { id: string; schedule: string; severityThreshold: string }) => {
-      const res = await fetch(`/api/maintenance/policies/${id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ schedule: s, severityThreshold }),
-      });
-      if (!res.ok) throw new Error("Failed to update policy");
-      return res.json();
-    },
+    mutationFn: ({ id, schedule: s, severityThreshold }: { id: string; schedule: string; severityThreshold: string }) =>
+      apiRequest("PUT", `/api/maintenance/policies/${id}`, { schedule: s, severityThreshold }),
     onSuccess: () => void qc.invalidateQueries({ queryKey: ["/api/maintenance/policies"] }),
   });
 


### PR DESCRIPTION
## Summary

- All 4 `fetch()` calls in `MaintenanceSettings` were unauthenticated, causing 401 responses from `/api/maintenance/*` routes (which are guarded by `requireAuth` middleware)
- Added `export` to `apiRequest` in `use-pipeline.ts` so it can be imported by consumers outside the hook file
- Replaced the 4 raw `fetch()` calls with `apiRequest`, which reads the Bearer token from `localStorage` and attaches it as an `Authorization` header

## Files changed

- `client/src/hooks/use-pipeline.ts` — exported `apiRequest`
- `client/src/pages/Settings.tsx` — imported `apiRequest`, replaced 4 raw fetch calls

## Test plan

- [ ] `npx tsc --noEmit` passes with 0 errors (verified locally)
- [ ] Open Settings → Autopilot section while logged in: toggle no longer shows empty state
- [ ] Enable toggle: no "Failed to create policy" error; policy is created in DB
- [ ] Disable toggle: PUT request succeeds with 200
- [ ] Schedule/severity changes: PUT request succeeds with 200