### PR TITLE
fix: send correct field name "key" when saving provider API key

### DIFF
--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -375,7 +375,7 @@ export default function Settings() {
 
   const saveKey = useMutation({
     mutationFn: async ({ provider, apiKey }: { provider: CloudProvider; apiKey: string }) => {
-      return apiRequest("POST", `/api/settings/providers/${provider}/key`, { apiKey });
+      return apiRequest("POST", `/api/settings/providers/${provider}/key`, { key: apiKey });
     },
     onSuccess: (_data, { provider }) => {
       setKeyInputs((prev) => ({ ...prev, [provider]: "" }));


### PR DESCRIPTION
## Summary

- Fixes a field name mismatch in the `saveKey` mutation in `Settings.tsx`
- The frontend was sending `{ apiKey }` but the backend `SaveKeySchema` expects `{ key }`
- This caused 100% of API key save attempts to return 400 Validation failed

## Change

Single character change in `client/src/pages/Settings.tsx`:

```ts
// Before
return apiRequest("POST", `/api/settings/providers/${provider}/key`, { apiKey });

// After
return apiRequest("POST", `/api/settings/providers/${provider}/key`, { key: apiKey });
```

## Test Plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` (vitest) — 86 test files, 1594 tests passed

Closes #138