### PR TITLE
fix: provider Test Connection calls real API, not MockProvider

### DIFF
--- a/server/gateway/index.ts
+++ b/server/gateway/index.ts
@@ -292,6 +292,25 @@ export class Gateway {
     return this.anonymizer;
   }
 
+  /**
+   * Test a cloud provider's API key by making a minimal real call directly to
+   * the registered provider instance — bypasses model-slug DB lookup which
+   * would otherwise fall back to MockProvider for unknown slugs.
+   */
+  async testProvider(providerKey: string): Promise<void> {
+    const provider = this.registry.get(providerKey);
+    if (!provider) throw new Error("Provider not configured");
+
+    const testModelIds: Record<string, string> = {
+      anthropic: "claude-haiku-4-5-20251001",
+      google: "gemini-1.5-flash",
+      xai: "grok-beta",
+    };
+
+    const modelId = testModelIds[providerKey] ?? providerKey;
+    await provider.complete(modelId, [{ role: "user", content: "ping" }], { maxTokens: 5 });
+  }
+
   getStatus() {
     const providers = configLoader.get().providers;
     return {

--- a/server/routes/gateway.ts
+++ b/server/routes/gateway.ts
@@ -100,11 +100,7 @@ export function registerGatewayRoutes(router: Router, gateway: Gateway) {
 
     const start = Date.now();
     try {
-      await gateway.complete({
-        modelSlug: `__test__${provider}`,
-        messages: [{ role: "user", content: "ping" }],
-        maxTokens: 5,
-      });
+      await gateway.testProvider(provider);
       res.json({ ok: true, latencyMs: Date.now() - start });
     } catch (e) {
       res.json({ ok: false, error: (e as Error).message });

--- a/tests/unit/gateway.test.ts
+++ b/tests/unit/gateway.test.ts
@@ -188,3 +188,45 @@ describe("MockProvider", () => {
     });
   });
 });
+
+// ─── Gateway.testProvider() ────────────────────────────────────────────────
+
+describe("Gateway.testProvider()", () => {
+  it("throws when provider is not registered", async () => {
+    // Minimal Gateway stub with empty registry
+    const { Gateway } = await import("../../server/gateway/index.js");
+    const fakeStorage = {
+      getModelBySlug: async () => null,
+      createLlmRequest: async () => {},
+    } as unknown as import("../../server/storage.js").IStorage;
+
+    const gw = new Gateway(fakeStorage);
+    await expect(gw.testProvider("anthropic")).rejects.toThrow("Provider not configured");
+  });
+
+  it("calls the real provider's complete() — does NOT fall back to MockProvider", async () => {
+    const { Gateway } = await import("../../server/gateway/index.js");
+    const calls: string[] = [];
+
+    const fakeProvider = {
+      complete: async (modelId: string) => {
+        calls.push(modelId);
+        return { content: "pong", tokensUsed: 1 };
+      },
+      stream: async function* () { yield ""; },
+    };
+
+    const fakeStorage = {
+      getModelBySlug: async () => null,
+      createLlmRequest: async () => {},
+    } as unknown as import("../../server/storage.js").IStorage;
+
+    const gw = new Gateway(fakeStorage);
+    // Inject fake provider directly into the registry
+    (gw as unknown as { registry: Map<string, unknown> }).registry.set("anthropic", fakeProvider);
+
+    await gw.testProvider("anthropic");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBe("claude-haiku-4-5-20251001");
+  });
+});


### PR DESCRIPTION
## Problem

Clicking **Test Connection** for any cloud provider (Claude, Gemini, Grok) always returned ✅ — even with a completely random/invalid API key.

### Root cause

The test endpoint in `server/routes/gateway.ts` called:
```ts
await gateway.complete({ modelSlug: "__test__anthropic", ... })
```

`gateway.complete()` resolves the provider via `storage.getModelBySlug("__test__anthropic")` — which returns `null` (no DB record with that slug) — causing a silent fallback to `providerKey = "mock"`. **MockProvider was running the test, not the real Claude/Gemini/Grok provider.** MockProvider always succeeds.

## Fix

Added `Gateway.testProvider(providerKey)` which:
1. Looks up the provider **directly from the registry** (no model slug, no DB lookup)
2. Calls `provider.complete()` with the correct cloud model ID for that provider
3. Throws the real API error (e.g. `401 authentication_error`) when the key is invalid

Updated the test route to call `gateway.testProvider(provider)` instead.

| Provider | Test model used |
|----------|----------------|
| anthropic | `claude-haiku-4-5-20251001` |
| google | `gemini-1.5-flash` |
| xai | `grok-beta` |

## Tests

Added 2 unit tests to `tests/unit/gateway.test.ts`:
- Throws `"Provider not configured"` when provider not in registry
- Calls the real provider's `complete()` with the correct model ID (not MockProvider)