### PR TITLE
feat: collapsible Settings sections with short/long descriptions

### DIFF
--- a/client/src/components/settings/ArgocdSettings.tsx
+++ b/client/src/components/settings/ArgocdSettings.tsx
@@ -92,9 +92,13 @@ function TestResultPanel({ result }: { result: ArgoCdTestResult }) {
   );
 }
 
-// ─── Main Component ───────────────────────────────────────────────────────────
+// ─── Inner content (shared between noCard and Card modes) ─────────────────────
 
-export function ArgocdSettings() {
+interface ArgocdSettingsContentProps {
+  className?: string;
+}
+
+function ArgocdSettingsContent({ className }: ArgocdSettingsContentProps) {
   const { data: config, isLoading } = useArgoCdConfig();
   const saveConfig = useSaveArgoCdConfig();
   const deleteConfig = useDeleteArgoCdConfig();
@@ -156,6 +160,207 @@ export function ArgocdSettings() {
   }
 
   return (
+    <div className={cn("space-y-4", className)}>
+      {/* Status Row */}
+      {!isLoading && (
+        <div className="flex items-center gap-3">
+          <StatusBadge status={config?.healthStatus} />
+          {config?.lastHealthCheckAt && (
+            <span className="text-xs text-muted-foreground">
+              Last checked: {new Date(config.lastHealthCheckAt).toLocaleString()}
+            </span>
+          )}
+          {config?.source === "env" && (
+            <Badge variant="secondary" className="text-xs">via env vars</Badge>
+          )}
+        </div>
+      )}
+
+      {/* Health error */}
+      {config?.healthStatus === "error" && config.healthError && (
+        <div className="p-2 rounded-md bg-red-50 border border-red-200 text-xs text-red-700">
+          {config.healthError}
+        </div>
+      )}
+
+      {/* Form */}
+      <div className="space-y-3">
+        {/* Server URL */}
+        <div className="space-y-1">
+          <Label htmlFor="argocd-server-url">ArgoCD Server URL</Label>
+          <Input
+            id="argocd-server-url"
+            type="url"
+            placeholder={config?.serverUrl ?? "https://argocd.example.com"}
+            value={serverUrl}
+            onChange={(e) => setServerUrl(e.target.value)}
+            disabled={config?.source === "env"}
+          />
+          {config?.source === "env" && (
+            <p className="text-xs text-muted-foreground">Configured via ARGOCD_SERVER_URL environment variable.</p>
+          )}
+        </div>
+
+        {/* Auth Token */}
+        <div className="space-y-1">
+          <Label htmlFor="argocd-token">Authentication Token</Label>
+          <div className="relative">
+            <Input
+              id="argocd-token"
+              type={showToken ? "text" : "password"}
+              placeholder={isConfigured ? "••••••••  (leave blank to keep existing token)" : "Enter ArgoCD API token"}
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              className="pr-10"
+              disabled={config?.source === "env"}
+            />
+            <Button
+              variant="ghost"
+              size="icon"
+              type="button"
+              className="absolute right-0 top-0 h-full px-3"
+              onClick={() => setShowToken((v) => !v)}
+              tabIndex={-1}
+            >
+              {showToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Token is stored encrypted (AES-256-GCM). Leave blank to keep the existing token.
+          </p>
+        </div>
+
+        {/* Verify SSL */}
+        <div className="flex items-center gap-2">
+          <Switch
+            id="argocd-verify-ssl"
+            checked={verifySsl}
+            onCheckedChange={setVerifySsl}
+            disabled={config?.source === "env"}
+          />
+          <Label htmlFor="argocd-verify-ssl" className="cursor-pointer">
+            Verify SSL Certificate
+          </Label>
+          {!verifySsl && (
+            <Badge variant="outline" className="text-yellow-600 border-yellow-300 text-xs">
+              SSL disabled — use only for development
+            </Badge>
+          )}
+        </div>
+
+        {/* Enabled */}
+        <div className="flex items-center gap-2">
+          <Switch
+            id="argocd-enabled"
+            checked={enabled}
+            onCheckedChange={setEnabled}
+            disabled={config?.source === "env"}
+          />
+          <Label htmlFor="argocd-enabled" className="cursor-pointer">
+            Enable ArgoCD integration
+          </Label>
+        </div>
+      </div>
+
+      {/* Action Buttons */}
+      {config?.source !== "env" && (
+        <div className="flex gap-2 pt-2">
+          <Button
+            onClick={handleSave}
+            disabled={isSaving || isDeleting}
+            size="sm"
+            className={cn(saveConfig.isSuccess && "bg-green-600 hover:bg-green-700")}
+          >
+            {isSaving ? (
+              <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+            ) : (
+              <Save className="h-4 w-4 mr-1" />
+            )}
+            {isSaving ? "Saving…" : saveConfig.isSuccess ? "Saved" : "Save"}
+          </Button>
+
+          <Button
+            variant="outline"
+            onClick={handleTest}
+            disabled={isTesting || isDeleting || (!isConfigured && !serverUrl.trim())}
+            size="sm"
+          >
+            {isTesting ? (
+              <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+            ) : (
+              <Plug className="h-4 w-4 mr-1" />
+            )}
+            {isTesting ? "Testing…" : "Test Connection"}
+          </Button>
+
+          {isConfigured && (
+            <Button
+              variant="ghost"
+              onClick={handleDelete}
+              disabled={isSaving || isDeleting}
+              size="sm"
+              className="text-destructive hover:text-destructive"
+            >
+              {isDeleting ? (
+                <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+              ) : (
+                <Trash2 className="h-4 w-4 mr-1" />
+              )}
+              Remove
+            </Button>
+          )}
+        </div>
+      )}
+
+      {/* env override test button */}
+      {config?.source === "env" && (
+        <Button
+          variant="outline"
+          onClick={handleTest}
+          disabled={isTesting}
+          size="sm"
+        >
+          {isTesting ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <Plug className="h-4 w-4 mr-1" />}
+          Test Connection
+        </Button>
+      )}
+
+      {/* Error from save */}
+      {saveConfig.isError && (
+        <p className="text-sm text-red-600">{saveConfig.error.message}</p>
+      )}
+
+      {/* Test Result */}
+      {testResult && <TestResultPanel result={testResult} />}
+
+      {/* Info note */}
+      <div className="pt-2 border-t text-xs text-muted-foreground space-y-1">
+        <p>
+          When connected, the <strong>Infrastructure Monitor</strong> built-in skill becomes available in pipeline stages.
+          All K8s resource names are masked before being sent to the LLM.
+        </p>
+        <p>
+          Environment variables: <code className="bg-muted px-1 rounded">ARGOCD_SERVER_URL</code>,{" "}
+          <code className="bg-muted px-1 rounded">ARGOCD_TOKEN</code>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ─── Public export ────────────────────────────────────────────────────────────
+
+interface ArgocdSettingsProps {
+  /** When true, renders content only (no Card wrapper). Use inside SettingsSection. */
+  noCard?: boolean;
+}
+
+export function ArgocdSettings({ noCard = false }: ArgocdSettingsProps) {
+  if (noCard) {
+    return <ArgocdSettingsContent className="p-4" />;
+  }
+
+  return (
     <Card>
       <CardHeader className="pb-3">
         <CardTitle className="text-base flex items-center gap-2">
@@ -168,190 +373,8 @@ export function ArgocdSettings() {
         </CardDescription>
       </CardHeader>
 
-      <CardContent className="space-y-4">
-        {/* Status Row */}
-        {!isLoading && (
-          <div className="flex items-center gap-3">
-            <StatusBadge status={config?.healthStatus} />
-            {config?.lastHealthCheckAt && (
-              <span className="text-xs text-muted-foreground">
-                Last checked: {new Date(config.lastHealthCheckAt).toLocaleString()}
-              </span>
-            )}
-            {config?.source === "env" && (
-              <Badge variant="secondary" className="text-xs">via env vars</Badge>
-            )}
-          </div>
-        )}
-
-        {/* Health error */}
-        {config?.healthStatus === "error" && config.healthError && (
-          <div className="p-2 rounded-md bg-red-50 border border-red-200 text-xs text-red-700">
-            {config.healthError}
-          </div>
-        )}
-
-        {/* Form */}
-        <div className="space-y-3">
-          {/* Server URL */}
-          <div className="space-y-1">
-            <Label htmlFor="argocd-server-url">ArgoCD Server URL</Label>
-            <Input
-              id="argocd-server-url"
-              type="url"
-              placeholder={config?.serverUrl ?? "https://argocd.example.com"}
-              value={serverUrl}
-              onChange={(e) => setServerUrl(e.target.value)}
-              disabled={config?.source === "env"}
-            />
-            {config?.source === "env" && (
-              <p className="text-xs text-muted-foreground">Configured via ARGOCD_SERVER_URL environment variable.</p>
-            )}
-          </div>
-
-          {/* Auth Token */}
-          <div className="space-y-1">
-            <Label htmlFor="argocd-token">Authentication Token</Label>
-            <div className="relative">
-              <Input
-                id="argocd-token"
-                type={showToken ? "text" : "password"}
-                placeholder={isConfigured ? "••••••••  (leave blank to keep existing token)" : "Enter ArgoCD API token"}
-                value={token}
-                onChange={(e) => setToken(e.target.value)}
-                className="pr-10"
-                disabled={config?.source === "env"}
-              />
-              <Button
-                variant="ghost"
-                size="icon"
-                type="button"
-                className="absolute right-0 top-0 h-full px-3"
-                onClick={() => setShowToken((v) => !v)}
-                tabIndex={-1}
-              >
-                {showToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-              </Button>
-            </div>
-            <p className="text-xs text-muted-foreground">
-              Token is stored encrypted (AES-256-GCM). Leave blank to keep the existing token.
-            </p>
-          </div>
-
-          {/* Verify SSL */}
-          <div className="flex items-center gap-2">
-            <Switch
-              id="argocd-verify-ssl"
-              checked={verifySsl}
-              onCheckedChange={setVerifySsl}
-              disabled={config?.source === "env"}
-            />
-            <Label htmlFor="argocd-verify-ssl" className="cursor-pointer">
-              Verify SSL Certificate
-            </Label>
-            {!verifySsl && (
-              <Badge variant="outline" className="text-yellow-600 border-yellow-300 text-xs">
-                SSL disabled — use only for development
-              </Badge>
-            )}
-          </div>
-
-          {/* Enabled */}
-          <div className="flex items-center gap-2">
-            <Switch
-              id="argocd-enabled"
-              checked={enabled}
-              onCheckedChange={setEnabled}
-              disabled={config?.source === "env"}
-            />
-            <Label htmlFor="argocd-enabled" className="cursor-pointer">
-              Enable ArgoCD integration
-            </Label>
-          </div>
-        </div>
-
-        {/* Action Buttons */}
-        {config?.source !== "env" && (
-          <div className="flex gap-2 pt-2">
-            <Button
-              onClick={handleSave}
-              disabled={isSaving || isDeleting}
-              size="sm"
-              className={cn(saveConfig.isSuccess && "bg-green-600 hover:bg-green-700")}
-            >
-              {isSaving ? (
-                <Loader2 className="h-4 w-4 mr-1 animate-spin" />
-              ) : (
-                <Save className="h-4 w-4 mr-1" />
-              )}
-              {isSaving ? "Saving…" : saveConfig.isSuccess ? "Saved" : "Save"}
-            </Button>
-
-            <Button
-              variant="outline"
-              onClick={handleTest}
-              disabled={isTesting || isDeleting || (!isConfigured && !serverUrl.trim())}
-              size="sm"
-            >
-              {isTesting ? (
-                <Loader2 className="h-4 w-4 mr-1 animate-spin" />
-              ) : (
-                <Plug className="h-4 w-4 mr-1" />
-              )}
-              {isTesting ? "Testing…" : "Test Connection"}
-            </Button>
-
-            {isConfigured && (
-              <Button
-                variant="ghost"
-                onClick={handleDelete}
-                disabled={isSaving || isDeleting}
-                size="sm"
-                className="text-destructive hover:text-destructive"
-              >
-                {isDeleting ? (
-                  <Loader2 className="h-4 w-4 mr-1 animate-spin" />
-                ) : (
-                  <Trash2 className="h-4 w-4 mr-1" />
-                )}
-                Remove
-              </Button>
-            )}
-          </div>
-        )}
-
-        {/* env override test button */}
-        {config?.source === "env" && (
-          <Button
-            variant="outline"
-            onClick={handleTest}
-            disabled={isTesting}
-            size="sm"
-          >
-            {isTesting ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <Plug className="h-4 w-4 mr-1" />}
-            Test Connection
-          </Button>
-        )}
-
-        {/* Error from save */}
-        {saveConfig.isError && (
-          <p className="text-sm text-red-600">{saveConfig.error.message}</p>
-        )}
-
-        {/* Test Result */}
-        {testResult && <TestResultPanel result={testResult} />}
-
-        {/* Info note */}
-        <div className="pt-2 border-t text-xs text-muted-foreground space-y-1">
-          <p>
-            When connected, the <strong>Infrastructure Monitor</strong> built-in skill becomes available in pipeline stages.
-            All K8s resource names are masked before being sent to the LLM.
-          </p>
-          <p>
-            Environment variables: <code className="bg-muted px-1 rounded">ARGOCD_SERVER_URL</code>,{" "}
-            <code className="bg-muted px-1 rounded">ARGOCD_TOKEN</code>
-          </p>
-        </div>
+      <CardContent>
+        <ArgocdSettingsContent />
       </CardContent>
     </Card>
   );

--- a/client/src/components/settings/SettingsSection.tsx
+++ b/client/src/components/settings/SettingsSection.tsx
@@ -1,0 +1,121 @@
+import { type ReactNode, useState, useEffect, useCallback } from "react";
+import { ChevronDown, Info } from "lucide-react";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+interface SettingsSectionProps {
+  /** Unique key used for localStorage persistence. Derived as kebab-case of title if not provided. */
+  storageKey?: string;
+  title: string;
+  icon: ReactNode;
+  shortDescription: string;
+  longDescription: string;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}
+
+function toStorageKey(title: string): string {
+  return `settings-section-${title.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "")}`;
+}
+
+export function SettingsSection({
+  storageKey,
+  title,
+  icon,
+  shortDescription,
+  longDescription,
+  defaultOpen = false,
+  children,
+}: SettingsSectionProps) {
+  const key = storageKey ?? toStorageKey(title);
+
+  const [open, setOpen] = useState<boolean>(() => {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored !== null) return stored === "true";
+    } catch {
+      // localStorage unavailable (SSR, private mode)
+    }
+    return defaultOpen;
+  });
+
+  // Persist open/closed state whenever it changes
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, String(open));
+    } catch {
+      // ignore
+    }
+  }, [key, open]);
+
+  const handleOpenChange = useCallback((next: boolean) => {
+    setOpen(next);
+  }, []);
+
+  return (
+    <Collapsible open={open} onOpenChange={handleOpenChange}>
+      <div className="rounded-lg border border-border bg-card shadow-sm">
+        {/* Header row */}
+        <div className="flex items-center gap-3 px-4 py-3">
+          {/* Clickable area: takes up most of the row */}
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="flex flex-1 items-center gap-3 text-left min-w-0 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded"
+              aria-expanded={open}
+              aria-controls={`settings-section-content-${key}`}
+            >
+              <span className="shrink-0 text-muted-foreground group-hover:text-foreground transition-colors">
+                {icon}
+              </span>
+              <span className="font-semibold text-sm leading-tight">{title}</span>
+              <span className="text-xs text-muted-foreground truncate min-w-0 hidden sm:block">
+                {shortDescription}
+              </span>
+              <ChevronDown
+                className={cn(
+                  "ml-auto h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200",
+                  open && "rotate-180",
+                )}
+              />
+            </button>
+          </CollapsibleTrigger>
+
+          {/* Info popover button — does NOT propagate click to collapse trigger */}
+          <Popover>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className="shrink-0 text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 rounded"
+                aria-label={`More information about ${title}`}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Info className="h-3.5 w-3.5" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent
+              side="top"
+              align="end"
+              className="w-80 text-xs leading-relaxed"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <p className="font-medium mb-1">{title}</p>
+              <p className="text-muted-foreground">{longDescription}</p>
+            </PopoverContent>
+          </Popover>
+        </div>
+
+        {/* Collapsible content */}
+        <CollapsibleContent
+          id={`settings-section-content-${key}`}
+          className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down"
+        >
+          <div className="border-t border-border">
+            {children}
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+}

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Switch } from "@/components/ui/switch";
@@ -44,6 +43,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useQueryClient, useMutation, useQuery } from "@tanstack/react-query";
 import { ArgocdSettings } from "@/components/settings/ArgocdSettings";
+import { SettingsSection } from "@/components/settings/SettingsSection";
 
 type CloudProvider = "anthropic" | "google" | "xai";
 
@@ -96,7 +96,12 @@ interface MaintenancePolicySummary {
   severityThreshold: string;
 }
 
-function MaintenanceSettings() {
+interface MaintenanceSettingsProps {
+  /** When true, renders content only without a Card wrapper. Use inside SettingsSection. */
+  noCard?: boolean;
+}
+
+function MaintenanceSettings({ noCard = false }: MaintenanceSettingsProps) {
   const qc = useQueryClient();
 
   const { data: policies, isLoading } = useQuery<MaintenancePolicySummary[]>({
@@ -137,136 +142,154 @@ function MaintenanceSettings() {
 
   const isEnabled = firstPolicy?.enabled ?? false;
 
+  const inner = (
+    <div className={cn("space-y-4", noCard ? "p-4" : "")}>
+      <p className="text-xs text-muted-foreground">
+        Automatically scan workspaces for dependency updates, security advisories, and license issues.
+        Configure and manage scans in detail from the{" "}
+        <a href="/maintenance" className="text-primary underline underline-offset-2">
+          Maintenance
+        </a>{" "}
+        page.
+      </p>
+
+      {isLoading ? (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="h-3 w-3 animate-spin" />
+          Loading...
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {/* Enable/disable toggle */}
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium">Enable Autopilot</p>
+              <p className="text-xs text-muted-foreground">
+                {firstPolicy
+                  ? isEnabled
+                    ? "Autopilot is active — scans run on schedule"
+                    : "Autopilot is paused"
+                  : "No policy configured yet"}
+              </p>
+            </div>
+            <Switch
+              checked={isEnabled}
+              onCheckedChange={(checked) => {
+                if (firstPolicy) {
+                  togglePolicy.mutate({ id: firstPolicy.id, enabled: checked });
+                } else if (checked) {
+                  createPolicy.mutate();
+                }
+              }}
+              disabled={togglePolicy.isPending || createPolicy.isPending}
+            />
+          </div>
+
+          {/* Schedule selector */}
+          <div className="flex items-center gap-3">
+            <label className="text-xs font-medium w-32 shrink-0">Default Schedule</label>
+            <Select
+              value={firstPolicy?.schedule ?? schedule}
+              onValueChange={(val) => {
+                setSchedule(val);
+                if (firstPolicy) {
+                  updatePolicy.mutate({ id: firstPolicy.id, schedule: val, severityThreshold: firstPolicy.severityThreshold });
+                }
+              }}
+            >
+              <SelectTrigger className="h-8 text-xs flex-1">
+                <SelectValue placeholder="Select schedule" />
+              </SelectTrigger>
+              <SelectContent>
+                {SCHEDULE_PRESETS.map((p) => (
+                  <SelectItem key={p.value} value={p.value} className="text-xs">
+                    {p.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Severity threshold selector */}
+          <div className="flex items-center gap-3">
+            <label className="text-xs font-medium w-32 shrink-0">Severity Threshold</label>
+            <Select
+              value={firstPolicy?.severityThreshold ?? severity}
+              onValueChange={(val) => {
+                setSeverity(val);
+                if (firstPolicy) {
+                  updatePolicy.mutate({ id: firstPolicy.id, schedule: firstPolicy.schedule, severityThreshold: val });
+                }
+              }}
+            >
+              <SelectTrigger className="h-8 text-xs flex-1">
+                <SelectValue placeholder="Select threshold" />
+              </SelectTrigger>
+              <SelectContent>
+                {SEVERITY_OPTIONS.map((s) => (
+                  <SelectItem key={s} value={s} className="text-xs capitalize">
+                    {s}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {(togglePolicy.isError || createPolicy.isError || updatePolicy.isError) && (
+            <p className="text-xs text-destructive">
+              {((togglePolicy.error ?? createPolicy.error ?? updatePolicy.error) as Error).message}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
+  if (noCard) return inner;
+
+  // Legacy standalone card render (backward-compat for any direct usage)
   return (
-    <Card>
-      <CardHeader className="pb-3">
-        <CardTitle className="text-base flex items-center gap-2">
+    <div className="rounded-lg border border-border bg-card shadow-sm">
+      <div className="px-4 py-3 border-b border-border">
+        <p className="text-base font-semibold flex items-center gap-2">
           {isEnabled ? (
             <ShieldCheck className="h-4 w-4 text-green-500" />
           ) : (
             <Shield className="h-4 w-4 text-muted-foreground" />
           )}
           Maintenance Autopilot
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <p className="text-xs text-muted-foreground">
-          Automatically scan workspaces for dependency updates, security advisories, and license issues.
-          Configure and manage scans in detail from the{" "}
-          <a href="/maintenance" className="text-primary underline underline-offset-2">
-            Maintenance
-          </a>{" "}
-          page.
         </p>
-
-        {isLoading ? (
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <Loader2 className="h-3 w-3 animate-spin" />
-            Loading...
-          </div>
-        ) : (
-          <div className="space-y-4">
-            {/* Enable/disable toggle */}
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-sm font-medium">Enable Autopilot</p>
-                <p className="text-xs text-muted-foreground">
-                  {firstPolicy
-                    ? isEnabled
-                      ? "Autopilot is active — scans run on schedule"
-                      : "Autopilot is paused"
-                    : "No policy configured yet"}
-                </p>
-              </div>
-              <Switch
-                checked={isEnabled}
-                onCheckedChange={(checked) => {
-                  if (firstPolicy) {
-                    togglePolicy.mutate({ id: firstPolicy.id, enabled: checked });
-                  } else if (checked) {
-                    createPolicy.mutate();
-                  }
-                }}
-                disabled={togglePolicy.isPending || createPolicy.isPending}
-              />
-            </div>
-
-            {/* Schedule selector */}
-            <div className="flex items-center gap-3">
-              <label className="text-xs font-medium w-32 shrink-0">Default Schedule</label>
-              <Select
-                value={firstPolicy?.schedule ?? schedule}
-                onValueChange={(val) => {
-                  setSchedule(val);
-                  if (firstPolicy) {
-                    updatePolicy.mutate({ id: firstPolicy.id, schedule: val, severityThreshold: firstPolicy.severityThreshold });
-                  }
-                }}
-              >
-                <SelectTrigger className="h-8 text-xs flex-1">
-                  <SelectValue placeholder="Select schedule" />
-                </SelectTrigger>
-                <SelectContent>
-                  {SCHEDULE_PRESETS.map((p) => (
-                    <SelectItem key={p.value} value={p.value} className="text-xs">
-                      {p.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            {/* Severity threshold selector */}
-            <div className="flex items-center gap-3">
-              <label className="text-xs font-medium w-32 shrink-0">Severity Threshold</label>
-              <Select
-                value={firstPolicy?.severityThreshold ?? severity}
-                onValueChange={(val) => {
-                  setSeverity(val);
-                  if (firstPolicy) {
-                    updatePolicy.mutate({ id: firstPolicy.id, schedule: firstPolicy.schedule, severityThreshold: val });
-                  }
-                }}
-              >
-                <SelectTrigger className="h-8 text-xs flex-1">
-                  <SelectValue placeholder="Select threshold" />
-                </SelectTrigger>
-                <SelectContent>
-                  {SEVERITY_OPTIONS.map((s) => (
-                    <SelectItem key={s} value={s} className="text-xs capitalize">
-                      {s}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            {(togglePolicy.isError || createPolicy.isError || updatePolicy.isError) && (
-              <p className="text-xs text-destructive">
-                {((togglePolicy.error ?? createPolicy.error ?? updatePolicy.error) as Error).message}
-              </p>
-            )}
-          </div>
-        )}
-      </CardContent>
-    </Card>
+      </div>
+      {inner}
+    </div>
   );
 }
 
-function MemoryPreferences() {
+interface MemoryPreferencesProps {
+  /** When true, renders content only without a Card wrapper. Use inside SettingsSection. */
+  noCard?: boolean;
+}
+
+function MemoryPreferences({ noCard = false }: MemoryPreferencesProps) {
   const qc = useQueryClient();
   const [values, setValues] = useState<Record<string, string>>({});
   const [saved, setSaved] = useState<Record<string, boolean>>({});
 
   const savePreference = useMutation({
     mutationFn: async ({ key, value }: { key: string; value: string }) => {
-      return apiRequest("POST", "/api/memories", {
-        scope: "global",
-        type: "preference",
-        key,
-        content: value,
-        confidence: 1.0,
+      const res = await fetch("/api/memories", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          scope: "global",
+          type: "preference",
+          key,
+          content: value,
+          confidence: 1.0,
+        }),
       });
+      if (!res.ok) throw new Error("Failed to save preference");
+      return res.json();
     },
     onSuccess: (_data, { key }) => {
       setSaved((prev) => ({ ...prev, [key]: true }));
@@ -275,47 +298,54 @@ function MemoryPreferences() {
     },
   });
 
+  const inner = (
+    <div className={cn("space-y-3", noCard ? "p-4" : "")}>
+      <p className="text-xs text-muted-foreground">
+        These preferences are stored as global memories and injected into every pipeline stage, helping the AI make consistent decisions aligned with your preferences.
+      </p>
+      {PREFERENCE_ROWS.map(({ key, label, placeholder }) => (
+        <div key={key} className="flex items-center gap-3">
+          <label className="text-xs font-medium w-44 shrink-0">{label}</label>
+          <Input
+            className="h-8 text-xs flex-1"
+            placeholder={placeholder}
+            value={values[key] ?? ""}
+            onChange={(e) => setValues((prev) => ({ ...prev, [key]: e.target.value }))}
+          />
+          <Button
+            size="sm"
+            className="h-8 text-xs shrink-0"
+            disabled={!values[key]?.trim() || savePreference.isPending}
+            onClick={() => {
+              const value = values[key]?.trim();
+              if (value) savePreference.mutate({ key, value });
+            }}
+          >
+            {saved[key] ? (
+              <CheckCircle2 className="h-3 w-3 text-emerald-500" />
+            ) : savePreference.isPending ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <><Save className="h-3 w-3 mr-1" /> Save</>
+            )}
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+
+  if (noCard) return inner;
+
+  // Legacy standalone card render
   return (
-    <Card>
-      <CardHeader className="pb-3">
-        <CardTitle className="text-base flex items-center gap-2">
+    <div className="rounded-lg border border-border bg-card shadow-sm">
+      <div className="px-4 py-3 border-b border-border">
+        <p className="text-base font-semibold flex items-center gap-2">
           <Brain className="h-4 w-4" /> Project Memory Preferences
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        <p className="text-xs text-muted-foreground">
-          These preferences are stored as global memories and injected into every pipeline stage, helping the AI make consistent decisions aligned with your preferences.
         </p>
-        {PREFERENCE_ROWS.map(({ key, label, placeholder }) => (
-          <div key={key} className="flex items-center gap-3">
-            <label className="text-xs font-medium w-44 shrink-0">{label}</label>
-            <Input
-              className="h-8 text-xs flex-1"
-              placeholder={placeholder}
-              value={values[key] ?? ""}
-              onChange={(e) => setValues((prev) => ({ ...prev, [key]: e.target.value }))}
-            />
-            <Button
-              size="sm"
-              className="h-8 text-xs shrink-0"
-              disabled={!values[key]?.trim() || savePreference.isPending}
-              onClick={() => {
-                const value = values[key]?.trim();
-                if (value) savePreference.mutate({ key, value });
-              }}
-            >
-              {saved[key] ? (
-                <CheckCircle2 className="h-3 w-3 text-emerald-500" />
-              ) : savePreference.isPending ? (
-                <Loader2 className="h-3 w-3 animate-spin" />
-              ) : (
-                <><Save className="h-3 w-3 mr-1" /> Save</>
-              )}
-            </Button>
-          </div>
-        ))}
-      </CardContent>
-    </Card>
+      </div>
+      {inner}
+    </div>
   );
 }
 
@@ -541,15 +571,17 @@ export default function Settings() {
       </div>
 
       <ScrollArea className="flex-1">
-        <div className="max-w-4xl mx-auto p-6 space-y-6">
-          {/* ── Gateway Status ─────────────────────────── */}
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-base flex items-center gap-2">
-                <Globe className="h-4 w-4" /> Gateway Status
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
+        <div className="max-w-4xl mx-auto p-6 space-y-3">
+
+          {/* ── 1. Gateway Status ──────────────────────────── */}
+          <SettingsSection
+            title="Gateway Status"
+            icon={<Server className="h-4 w-4" />}
+            shortDescription="Live connection status for all configured model providers."
+            longDescription="Shows real-time connectivity for each configured provider. Green = reachable and authenticated. Yellow = key configured but not tested. Red = unreachable or auth failed. Refresh to re-check."
+            defaultOpen={true}
+          >
+            <div className="p-4">
               <div className="grid grid-cols-2 gap-4">
                 <div className="flex items-center gap-3 p-3 rounded-lg border border-border">
                   {gatewayStatus?.vllm ? (
@@ -578,17 +610,18 @@ export default function Settings() {
                   </div>
                 </div>
               </div>
-            </CardContent>
-          </Card>
+            </div>
+          </SettingsSection>
 
-          {/* ── Cloud Providers ────────────────────────── */}
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-base flex items-center gap-2">
-                <Cloud className="h-4 w-4" /> Cloud Providers
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3">
+          {/* ── 2. Cloud Providers ─────────────────────────── */}
+          <SettingsSection
+            title="Cloud Providers"
+            icon={<Cloud className="h-4 w-4" />}
+            shortDescription="API keys for Claude (Anthropic), Gemini (Google), and Grok (xAI)."
+            longDescription="API keys are encrypted (AES-256) before storage. Keys from environment variables (ANTHROPIC_API_KEY, GOOGLE_API_KEY, XAI_API_KEY) always take precedence and cannot be edited from the UI. Delete a DB key to fall back to env var or disable the provider."
+            defaultOpen={true}
+          >
+            <div className="p-4 space-y-3">
               {CLOUD_PROVIDERS.map(({ key, name, envVar }) => {
                 const isConfigured: boolean = !!(gatewayStatus as Record<string, unknown>)?.[key];
                 const testResult = testResults[key];
@@ -744,16 +777,19 @@ export default function Settings() {
                   </div>
                 );
               })}
-            </CardContent>
-          </Card>
+            </div>
+          </SettingsSection>
 
-          {/* ── Discover from Connected Providers ──────── */}
-          <Card>
-            <CardHeader className="pb-3">
-              <div className="flex items-center justify-between">
-                <CardTitle className="text-base flex items-center gap-2">
-                  <Search className="h-4 w-4" /> Discover Models from Providers
-                </CardTitle>
+          {/* ── 3. Discover Models ─────────────────────────── */}
+          <SettingsSection
+            title="Discover Models"
+            icon={<Search className="h-4 w-4" />}
+            shortDescription="Auto-detect available models from connected providers."
+            longDescription="Queries the provider's model list endpoint and imports available models into the registry. Only works when the provider's API key is configured and valid."
+            defaultOpen={false}
+          >
+            <div className="p-4 space-y-4">
+              <div className="flex justify-end">
                 <Button
                   variant="outline"
                   size="sm"
@@ -769,8 +805,7 @@ export default function Settings() {
                   Refresh
                 </Button>
               </div>
-            </CardHeader>
-            <CardContent className="space-y-4">
+
               {/* vLLM discovered */}
               {(discovered as Record<string, { available: boolean; error?: string; models: unknown[] }>)?.vllm?.available && (
                 <div>
@@ -881,17 +916,18 @@ export default function Settings() {
                   <code className="font-mono text-xs bg-muted px-1 py-0.5 rounded">OLLAMA_ENDPOINT</code> environment variables, or use the probe tool below.
                 </div>
               )}
-            </CardContent>
-          </Card>
+            </div>
+          </SettingsSection>
 
-          {/* ── Probe Custom Endpoint ──────────────────── */}
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-base flex items-center gap-2">
-                <Plug className="h-4 w-4" /> Probe Custom Endpoint
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
+          {/* ── 4. Probe Endpoint ──────────────────────────── */}
+          <SettingsSection
+            title="Probe Endpoint"
+            icon={<Globe className="h-4 w-4" />}
+            shortDescription="Test a custom vLLM or Ollama endpoint before registering."
+            longDescription="Send a test request to any HTTP endpoint to verify it's running a compatible LLM API (OpenAI-compatible, vLLM, or Ollama format). Use this before adding a custom local model."
+            defaultOpen={false}
+          >
+            <div className="p-4 space-y-4">
               <div className="flex items-end gap-3">
                 <div className="flex-1">
                   <label className="text-xs font-medium text-muted-foreground mb-1 block">Endpoint URL</label>
@@ -973,18 +1009,18 @@ export default function Settings() {
                   })}
                 </div>
               )}
-            </CardContent>
-          </Card>
+            </div>
+          </SettingsSection>
 
-
-          {/* ── Add Model Manually ──────────────────────── */}
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-base flex items-center gap-2">
-                <Plus className="h-4 w-4" /> Add Model Manually
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3">
+          {/* ── 5. Add Model ───────────────────────────────── */}
+          <SettingsSection
+            title="Add Model"
+            icon={<Plus className="h-4 w-4" />}
+            shortDescription="Manually register a model with a custom slug and endpoint."
+            longDescription="Register any OpenAI-compatible, vLLM, or Ollama endpoint as a model. The slug must be unique and is used for pipeline stage assignment. Provider type determines which SDK is used."
+            defaultOpen={false}
+          >
+            <div className="p-4 space-y-3">
               <p className="text-xs text-muted-foreground">
                 Add non-discoverable models such as private vLLM or Ollama deployments.
               </p>
@@ -1053,20 +1089,23 @@ export default function Settings() {
                   Add Model
                 </Button>
               </div>
-            </CardContent>
-          </Card>
+            </div>
+          </SettingsSection>
 
-          {/* ── Registered Models ──────────────────────── */}
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-base flex items-center gap-2">
-                <Cpu className="h-4 w-4" /> Registered Models
-                <Badge variant="secondary" className="ml-1 text-[10px]">
-                  {modelList.length}
+          {/* ── 6. Registered Models ───────────────────────── */}
+          <SettingsSection
+            title="Registered Models"
+            icon={<Cpu className="h-4 w-4" />}
+            shortDescription="All models available for pipeline stage assignment."
+            longDescription="All models available for assignment to pipeline stages. Includes cloud models (Claude, Gemini, Grok), local models (vLLM, Ollama), and mock models for testing. Delete removes from the registry but does not affect running pipelines."
+            defaultOpen={true}
+          >
+            <div className="p-4">
+              <div className="flex items-center gap-2 mb-3">
+                <Badge variant="secondary" className="text-[10px]">
+                  {modelList.length} registered
                 </Badge>
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
+              </div>
               {modelsLoading ? (
                 <div className="flex items-center gap-2 text-sm text-muted-foreground py-4">
                   <Loader2 className="h-4 w-4 animate-spin" /> Loading models...
@@ -1134,18 +1173,18 @@ export default function Settings() {
                   ))}
                 </div>
               )}
-            </CardContent>
-          </Card>
+            </div>
+          </SettingsSection>
 
-
-          {/* ── Tools & MCP ────────────────────────────── */}
-          <Card>
-            <CardHeader className="pb-3">
-              <CardTitle className="text-base flex items-center gap-2">
-                <Wrench className="h-4 w-4" /> Tools & MCP
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
+          {/* ── 7. Tools & MCP ─────────────────────────────── */}
+          <SettingsSection
+            title="Tools & MCP"
+            icon={<Plug className="h-4 w-4" />}
+            shortDescription="Connect external MCP servers and built-in tools."
+            longDescription="Model Context Protocol servers extend agent capabilities with external tools (web search, file access, databases). Built-in tools (Tavily, etc.) require their own API keys. MCP servers must be running and reachable at the configured URL."
+            defaultOpen={false}
+          >
+            <div className="p-4 space-y-4">
               {/* Built-in tools grid */}
               <div>
                 <p className="text-xs font-medium text-muted-foreground mb-2">Built-in Tools</p>
@@ -1310,17 +1349,41 @@ export default function Settings() {
                   </Button>
                 </div>
               </div>
-            </CardContent>
-          </Card>
+            </div>
+          </SettingsSection>
 
-          {/* ── Infrastructure: ArgoCD ──────────────── */}
-          <ArgocdSettings />
+          {/* ── 8. ArgoCD ──────────────────────────────────── */}
+          <SettingsSection
+            title="ArgoCD"
+            icon={<Server className="h-4 w-4" />}
+            shortDescription="GitOps deployment integration via ArgoCD."
+            longDescription="Connect to an ArgoCD instance to manage GitOps deployments directly from multiqlti pipelines. Requires ArgoCD server URL and an API token with application read/sync permissions."
+            defaultOpen={false}
+          >
+            <ArgocdSettings noCard />
+          </SettingsSection>
 
-          {/* ── Maintenance Autopilot ───────────────────── */}
-          <MaintenanceSettings />
+          {/* ── 9. Maintenance Autopilot ───────────────────── */}
+          <SettingsSection
+            title="Maintenance Autopilot"
+            icon={<Shield className="h-4 w-4" />}
+            shortDescription="Scheduled scanning for dependency updates and security advisories."
+            longDescription="Runs automated scans on a cron schedule to detect outdated dependencies, CVEs, license issues, and config drift. Findings appear in the Maintenance page. Scans use the Development team's configured model."
+            defaultOpen={false}
+          >
+            <MaintenanceSettings noCard />
+          </SettingsSection>
 
-          {/* ── Memory Preferences ──────────────────────── */}
-          <MemoryPreferences />
+          {/* ── 10. Memory Preferences ─────────────────────── */}
+          <SettingsSection
+            title="Memory Preferences"
+            icon={<Brain className="h-4 w-4" />}
+            shortDescription="Persistent AI preferences injected into pipeline stage prompts."
+            longDescription="These preferences are injected into every pipeline stage's system prompt as context. Use them to encode your team's standards, preferred technologies, and coding style so agents consistently produce on-brand output."
+            defaultOpen={false}
+          >
+            <MemoryPreferences noCard />
+          </SettingsSection>
 
         </div>
       </ScrollArea>


### PR DESCRIPTION
## Summary

- Add `SettingsSection` component (`client/src/components/settings/SettingsSection.tsx`) — a collapsible container built on `@radix-ui/react-collapsible` with a header row (icon + title + short description + info popover + chevron), localStorage-persisted open/closed state per section, and smooth CSS transition via `tw-animate-css`
- Wrap all 10 Settings sections: Gateway Status, Cloud Providers, Discover Models, Probe Endpoint, Add Model, Registered Models, Tools & MCP, ArgoCD, Maintenance Autopilot, Memory Preferences
- Add `noCard?: boolean` prop to `ArgocdSettings`, `MaintenanceSettings`, and `MemoryPreferences` so they render content without a nested `<Card>` wrapper when used inside `SettingsSection`
- Pure frontend change — no backend modifications, no new dependencies

## API

```tsx
<SettingsSection
  title="Cloud Providers"
  icon={<Cloud className="h-4 w-4" />}
  shortDescription="API keys for Claude, Gemini, and Grok."
  longDescription="Full explanation shown in the ⓘ popover..."
  defaultOpen={false}        // initial state when no localStorage value
>
  {/* section content */}
</SettingsSection>
```

- Clicking the header row toggles collapse
- Clicking ⓘ opens a Popover with `longDescription` — does NOT toggle collapse (click is stopped at the button)
- `localStorage` key: `settings-section-{kebab-case-title}`

## Test plan

- [ ] Each section can be expanded and collapsed by clicking its header
- [ ] ⓘ button opens the info popover without toggling collapse state
- [ ] Open/closed state survives a page refresh (check localStorage)
- [ ] `defaultOpen={true}` sections (Gateway Status, Cloud Providers, Registered Models) are open on first visit
- [ ] All existing functionality (save API keys, probe endpoints, add models, MCP servers, ArgoCD, maintenance, memory) still works
- [ ] `npx tsc --noEmit` — 0 errors
- [ ] `npm test` — 1596 tests pass