### PR TITLE
fix: resolve remaining Settings page bugs #143-#147

### DIFF
--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -374,7 +374,7 @@ export default function Settings() {
   const [showKey, setShowKey] = useState<Partial<Record<CloudProvider, boolean>>>({});
 
   // Load provider key metadata from DB
-  const { data: providerStatuses, refetch: refetchProviderStatuses } = useQuery<ProviderStatus[]>({
+  const { data: providerStatuses, isLoading: providerStatusesLoading, refetch: refetchProviderStatuses } = useQuery<ProviderStatus[]>({
     queryKey: ["/api/settings/providers"],
     queryFn: async () => {
       return apiRequest("GET", "/api/settings/providers").catch(() => [] as ProviderStatus[]);
@@ -598,6 +598,11 @@ export default function Settings() {
                     <div className="text-xs text-muted-foreground font-mono">
                       {(gatewayStatus as Record<string, unknown>)?.vllmEndpoint as string ?? "Not configured"}
                     </div>
+                    {!(gatewayStatus as Record<string, unknown>)?.vllmEndpoint && (
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Set via <code className="font-mono">VLLM_ENDPOINT</code> environment variable
+                      </p>
+                    )}
                   </div>
                 </div>
                 <div className="flex items-center gap-3 p-3 rounded-lg border border-border">
@@ -611,6 +616,11 @@ export default function Settings() {
                     <div className="text-xs text-muted-foreground font-mono">
                       {(gatewayStatus as Record<string, unknown>)?.ollamaEndpoint as string ?? "Not configured"}
                     </div>
+                    {!(gatewayStatus as Record<string, unknown>)?.ollamaEndpoint && (
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Set via <code className="font-mono">OLLAMA_ENDPOINT</code> environment variable
+                      </p>
+                    )}
                   </div>
                 </div>
               </div>
@@ -669,7 +679,7 @@ export default function Settings() {
                               Saved in DB
                             </Badge>
                           )}
-                          {source === "env" && (
+                          {!providerStatusesLoading && source === "env" && (
                             <Badge variant="outline" className="text-[10px] text-muted-foreground">
                               From env var
                             </Badge>
@@ -778,6 +788,12 @@ export default function Settings() {
                         </Button>
                       )}
                     </div>
+                    {(saveKey.isError && (saveKey.variables as { provider: CloudProvider })?.provider === key) && (
+                      <p className="text-xs text-destructive mt-1">{(saveKey.error as Error)?.message}</p>
+                    )}
+                    {(removeKey.isError && removeKey.variables === key) && (
+                      <p className="text-xs text-destructive mt-1">{(removeKey.error as Error)?.message}</p>
+                    )}
                   </div>
                 );
               })}
@@ -1171,7 +1187,7 @@ export default function Settings() {
                             if (!window.confirm(`Delete model "${model.name}"? This cannot be undone.`)) return;
                             deleteModel.mutate(model.id as string);
                           }}
-                          disabled={deleteModel.isPending}
+                          disabled={deleteModel.isPending && deleteModel.variables === model.id}
                         >
                           <Trash2 className="h-4 w-4" />
                         </Button>

--- a/server/routes/tools.ts
+++ b/server/routes/tools.ts
@@ -63,7 +63,9 @@ export function registerToolRoutes(app: Express, storage: IStorage): void {
     const parse = testToolSchema.safeParse(req.body);
 
     if (!parse.success) {
-      return res.status(400).json({ error: parse.error.flatten() });
+      return res.status(400).json({
+        error: parse.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).filter(Boolean).join("; ") || "Validation failed",
+      });
     }
 
     const toolDef = toolRegistry.getToolByName(name);
@@ -104,7 +106,9 @@ export function registerToolRoutes(app: Express, storage: IStorage): void {
   app.post("/api/mcp/servers", async (req, res) => {
     const parse = createMcpServerSchema.safeParse(req.body);
     if (!parse.success) {
-      return res.status(400).json({ error: parse.error.flatten() });
+      return res.status(400).json({
+        error: parse.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).filter(Boolean).join("; ") || "Validation failed",
+      });
     }
 
     const data = parse.data;
@@ -143,7 +147,9 @@ export function registerToolRoutes(app: Express, storage: IStorage): void {
 
     const parse = updateMcpServerSchema.safeParse(req.body);
     if (!parse.success) {
-      return res.status(400).json({ error: parse.error.flatten() });
+      return res.status(400).json({
+        error: parse.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).filter(Boolean).join("; ") || "Validation failed",
+      });
     }
 
     const existing = await storage.getMcpServer(id);


### PR DESCRIPTION
## Summary

Fixes 5 remaining Settings page bugs from the settings audit:

- **#143** — vLLM/Ollama "Not configured" rows now show `VLLM_ENDPOINT`/`OLLAMA_ENDPOINT` env var hints so users know how to enable them
- **#144** — Cloud Providers card now renders `saveKey` and `removeKey` error messages when API operations fail
- **#145** — Source badge (`From env var`) is only rendered after provider statuses finish loading, preventing stale display on initial load
- **#146** — MCP tools route now returns readable Zod validation errors (e.g. `"name: Required; url: Invalid url"`) instead of the unreadable `flatten()` output
- **#147** — Delete button pending state is scoped to the specific model row being deleted, preventing all rows from showing a spinner

## Test plan

- [ ] Add vLLM/Ollama endpoints via env vars and verify the hint disappears once configured
- [ ] Submit an invalid API key for a cloud provider and verify the error message is shown
- [ ] Reload Settings and verify "From env var" badge only appears after the status loads
- [ ] Submit a malformed MCP tool call and verify the error message is readable
- [ ] Delete a model and verify only that row's button shows the spinner