### PR TITLE
fix: add auth header to Maintenance page apiFetch helper

### DIFF
--- a/client/src/pages/Maintenance.tsx
+++ b/client/src/pages/Maintenance.tsx
@@ -119,10 +119,16 @@ interface AutoTriggerAuditRecord {
 
 // ─── API Helpers ──────────────────────────────────────────────────────────────
 
+function getAuthToken(): string | null {
+  return localStorage.getItem("auth_token");
+}
+
 async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = getAuthToken();
+  const authHeaders: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
   const res = await fetch(path, {
     ...init,
-    headers: { "Content-Type": "application/json", ...init?.headers },
+    headers: { "Content-Type": "application/json", ...authHeaders, ...init?.headers },
   });
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: "Unknown error" }));


### PR DESCRIPTION
## Summary

The Maintenance page `apiFetch` helper was sending requests without an `Authorization` header, causing all authenticated endpoints (`/api/maintenance/policies`, `/api/maintenance/scans/trigger`, etc.) to return **401 Unauthorized**.

**Root cause**: Same pattern as the previously fixed Memory.tsx bug — a local `fetch` wrapper that didn't forward the JWT from `localStorage`.

**Fix**: Added `getAuthToken()` helper and inject `Authorization: Bearer <token>` header alongside `Content-Type` in every `apiFetch` call.

## Test plan

- [ ] Navigate to `/maintenance`
- [ ] Create a new maintenance policy — should succeed (no longer 401)
- [ ] Trigger a scan — should succeed
- [ ] All other maintenance API calls should work while authenticated