### PR TITLE
feat(settings): platform version dashboard — component versions panel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,9 @@ COPY shared/ ./shared/
 
 EXPOSE 5000
 
+ARG BUILD_DATE=dev
+ARG GIT_COMMIT=dev
+ENV BUILD_DATE=$BUILD_DATE
+ENV GIT_COMMIT=$GIT_COMMIT
+
 CMD ["node", "dist/index.cjs"]

--- a/client/src/components/settings/VersionInfoPanel.tsx
+++ b/client/src/components/settings/VersionInfoPanel.tsx
@@ -1,0 +1,194 @@
+import { useQueryClient, useQuery } from "@tanstack/react-query";
+import { Copy, RefreshCw } from "lucide-react";
+import { apiRequest } from "@/hooks/use-pipeline";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import type { VersionsResponse } from "@shared/types";
+
+// ─── Badge helper ─────────────────────────────────────────────────────────────
+
+type BadgeVariant = "present" | "dev" | "na";
+
+function versionBadgeVariant(version: string | null | undefined): BadgeVariant {
+  if (version === null || version === undefined) return "na";
+  if (version === "dev") return "dev";
+  return "present";
+}
+
+const BADGE_CLASSES: Record<BadgeVariant, string> = {
+  present: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  dev: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  na: "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-500",
+};
+
+interface VersionBadgeProps {
+  version: string | null | undefined;
+}
+
+function VersionBadge({ version }: VersionBadgeProps) {
+  const variant = versionBadgeVariant(version);
+  const label = version ?? "N/A";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded px-2 py-0.5 text-xs font-mono font-medium",
+        BADGE_CLASSES[variant],
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+// ─── Copy button ──────────────────────────────────────────────────────────────
+
+interface CopyButtonProps {
+  value: string | null | undefined;
+}
+
+function CopyButton({ value }: CopyButtonProps) {
+  if (!value || value === "N/A") return null;
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(value).catch(() => {
+      // clipboard API unavailable — silently ignore
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+      aria-label={`Copy ${value}`}
+      title="Copy to clipboard"
+    >
+      <Copy className="h-3.5 w-3.5" />
+    </button>
+  );
+}
+
+// ─── Single version row ───────────────────────────────────────────────────────
+
+interface VersionRowProps {
+  label: string;
+  version: string | null | undefined;
+}
+
+function VersionRow({ label, version }: VersionRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-2 py-1.5 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <div className="flex items-center gap-1.5">
+        <VersionBadge version={version} />
+        <CopyButton value={version} />
+      </div>
+    </div>
+  );
+}
+
+// ─── Loading skeleton ─────────────────────────────────────────────────────────
+
+function VersionRowSkeleton() {
+  return (
+    <div className="flex items-center justify-between gap-2 py-1.5">
+      <Skeleton className="h-4 w-32" />
+      <Skeleton className="h-5 w-16 rounded" />
+    </div>
+  );
+}
+
+// ─── Section divider ──────────────────────────────────────────────────────────
+
+function GroupLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mt-4 mb-1 first:mt-0">
+      {children}
+    </p>
+  );
+}
+
+// ─── Main panel ───────────────────────────────────────────────────────────────
+
+export function VersionInfoPanel() {
+  const qc = useQueryClient();
+
+  const { data, isLoading, isError } = useQuery<VersionsResponse>({
+    queryKey: ["versions"],
+    queryFn: () => apiRequest("GET", "/api/settings/versions") as Promise<VersionsResponse>,
+    staleTime: 60_000, // 1 minute — versions don't change mid-session
+  });
+
+  const handleRefresh = () => {
+    qc.invalidateQueries({ queryKey: ["versions"] });
+  };
+
+  return (
+    <div className="p-4 space-y-1">
+      {/* Header row with Refresh button */}
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs text-muted-foreground">
+          Live component versions and build metadata.
+        </p>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 text-xs gap-1.5"
+          onClick={handleRefresh}
+          disabled={isLoading}
+          aria-label="Refresh version information"
+        >
+          <RefreshCw className={cn("h-3 w-3", isLoading && "animate-spin")} />
+          Refresh
+        </Button>
+      </div>
+
+      {isError && (
+        <p className="text-xs text-destructive py-2">
+          Failed to load version information. Check server connectivity.
+        </p>
+      )}
+
+      {/* Platform group */}
+      <GroupLabel>Platform</GroupLabel>
+
+      {isLoading ? (
+        <>
+          <VersionRowSkeleton />
+          <VersionRowSkeleton />
+          <VersionRowSkeleton />
+          <VersionRowSkeleton />
+          <VersionRowSkeleton />
+        </>
+      ) : data ? (
+        <>
+          <VersionRow label="Frontend" version={data.platform.frontend} />
+          <VersionRow label="Backend" version={data.platform.backend} />
+          <VersionRow label="Node.js" version={data.platform.node} />
+          <VersionRow label="Build Date" version={data.platform.buildDate} />
+          <VersionRow label="Git Commit" version={data.platform.gitCommit} />
+        </>
+      ) : null}
+
+      {/* Connected services group */}
+      <GroupLabel>Connected Services</GroupLabel>
+
+      {isLoading ? (
+        <>
+          <VersionRowSkeleton />
+          <VersionRowSkeleton />
+          <VersionRowSkeleton />
+          <VersionRowSkeleton />
+        </>
+      ) : data ? (
+        <>
+          <VersionRow label="Docker Engine" version={data.runtimes.docker} />
+          <VersionRow label="vLLM" version={data.runtimes.vllm} />
+          <VersionRow label="Ollama" version={data.runtimes.ollama} />
+          <VersionRow label="PostgreSQL" version={data.database.postgres} />
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -28,6 +28,7 @@ import {
   Link2,
   Shield,
   ShieldCheck,
+  Info,
 } from "lucide-react";
 import {
   useModels,
@@ -44,6 +45,7 @@ import { cn } from "@/lib/utils";
 import { useQueryClient, useMutation, useQuery } from "@tanstack/react-query";
 import { ArgocdSettings } from "@/components/settings/ArgocdSettings";
 import { SettingsSection } from "@/components/settings/SettingsSection";
+import { VersionInfoPanel } from "@/components/settings/VersionInfoPanel";
 
 type CloudProvider = "anthropic" | "google" | "xai";
 
@@ -1412,6 +1414,17 @@ export default function Settings() {
             defaultOpen={false}
           >
             <MemoryPreferences noCard />
+          </SettingsSection>
+
+          {/* ── 11. Version Information ────────────────── */}
+          <SettingsSection
+            title="Version Information"
+            icon={<Info className="h-5 w-5" />}
+            shortDescription="Installed component versions and build info"
+            longDescription="Shows versions of the frontend, backend, Node.js runtime, Docker engine, local LLM runtimes (vLLM, Ollama), and the connected PostgreSQL database. Build date and git commit are shown when the platform is deployed via Docker."
+            defaultOpen={false}
+          >
+            <VersionInfoPanel />
           </SettingsSection>
 
         </div>

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -1,11 +1,15 @@
 import { Router } from "express";
 import { z } from "zod";
 import { eq } from "drizzle-orm";
+import { spawnSync } from "child_process";
+import { readFileSync } from "fs";
+import { resolve } from "path";
 import { db } from "../db";
 import { providerKeys } from "@shared/schema";
 import { encrypt, decrypt } from "../crypto";
 import type { Gateway } from "../gateway/index";
 import { configLoader } from "../config/loader";
+import type { VersionsResponse } from "@shared/types";
 
 const CLOUD_PROVIDERS = ["anthropic", "google", "xai"] as const;
 type CloudProvider = (typeof CLOUD_PROVIDERS)[number];
@@ -24,6 +28,94 @@ function getKeySource(provider: CloudProvider): "env" | "db" | "none" {
   };
   if (configKeys[provider]) return "env";
   return "none"; // updated to "db" by caller if DB row exists
+}
+
+// ─── Version probe helpers ────────────────────────────────────────────────────
+
+/** Read the version field from the root package.json. Cached at module load. */
+let _pkgVersion: string | undefined;
+function getPackageVersion(): string {
+  if (_pkgVersion !== undefined) return _pkgVersion;
+  try {
+    const pkgPath = resolve(process.cwd(), "package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version?: string };
+    _pkgVersion = pkg.version ?? "unknown";
+  } catch {
+    _pkgVersion = "unknown";
+  }
+  return _pkgVersion;
+}
+
+/** Probe docker version via spawnSync. Returns null when binary is not found or times out. */
+export function probeDockerVersion(): string | null {
+  try {
+    const result = spawnSync("docker", ["version", "--format", "{{.Server.Version}}"], {
+      timeout: 3000,
+      encoding: "utf-8",
+    });
+    if (result.status !== 0 || result.error || !result.stdout) return null;
+    const version = result.stdout.trim();
+    return version.length > 0 ? version : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Probe vLLM version via HTTP. Returns null on any error. */
+export async function probeVllmVersion(): Promise<string | null> {
+  const baseUrl = process.env.VLLM_BASE_URL;
+  if (!baseUrl) return null;
+  try {
+    const res = await fetch(`${baseUrl}/version`, {
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { version?: string };
+    return data.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Probe Ollama version via HTTP. Returns null on any error. */
+export async function probeOllamaVersion(): Promise<string | null> {
+  const baseUrl = process.env.OLLAMA_BASE_URL ?? "http://localhost:11434";
+  try {
+    const res = await fetch(`${baseUrl}/api/version`, {
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { version?: string };
+    return data.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract a clean semver string from a full PostgreSQL version string.
+ * e.g. "PostgreSQL 16.1 on x86_64-pc-linux-gnu, ..." → "16.1"
+ * Returns null when the input is not a recognisable version string.
+ */
+export function extractPostgresVersion(raw: string): string | null {
+  // Match patterns like "16.1", "15.4", "14.10" — major.minor only
+  const match = raw.match(/\bPostgreSQL\s+(\d+\.\d+)/i);
+  if (match) return match[1];
+  // Fallback: bare semver-like token
+  const bare = raw.match(/(\d+\.\d+(?:\.\d+)?)/);
+  return bare ? bare[1] : null;
+}
+
+/** Probe PostgreSQL version via the DB connection. Returns null on any error. */
+async function probePostgresVersion(): Promise<string | null> {
+  try {
+    const { sql } = await import("drizzle-orm");
+    const rows = (await db.execute(sql`SELECT version()`)) as unknown as Array<{ version?: string }>;
+    const raw = rows[0]?.version ?? "";
+    return extractPostgresVersion(raw);
+  } catch {
+    return null;
+  }
 }
 
 export function registerSettingsRoutes(router: Router, gateway: Gateway) {
@@ -104,6 +196,43 @@ export function registerSettingsRoutes(router: Router, gateway: Gateway) {
     } catch (e) {
       res.status(500).json({ error: (e as Error).message });
     }
+  });
+
+  /**
+   * GET /api/settings/versions — live component version report.
+   *
+   * Uses Promise.allSettled so every probe failure is isolated — this endpoint
+   * will NEVER return 500 due to an unavailable downstream service.
+   */
+  router.get("/api/settings/versions", async (_req, res) => {
+    const pkgVersion = getPackageVersion();
+
+    const [dockerResult, vllmResult, ollamaResult, pgResult] = await Promise.allSettled([
+      Promise.resolve(probeDockerVersion()),
+      probeVllmVersion(),
+      probeOllamaVersion(),
+      probePostgresVersion(),
+    ]);
+
+    const response: VersionsResponse = {
+      platform: {
+        frontend: pkgVersion,
+        backend: pkgVersion,
+        node: process.version,
+        buildDate: process.env.BUILD_DATE ?? "dev",
+        gitCommit: process.env.GIT_COMMIT ?? "dev",
+      },
+      runtimes: {
+        docker: dockerResult.status === "fulfilled" ? dockerResult.value : null,
+        vllm: vllmResult.status === "fulfilled" ? vllmResult.value : null,
+        ollama: ollamaResult.status === "fulfilled" ? ollamaResult.value : null,
+      },
+      database: {
+        postgres: pgResult.status === "fulfilled" ? pgResult.value : null,
+      },
+    };
+
+    res.json(response);
   });
 }
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1430,3 +1430,23 @@ export interface InsertSkillVersion {
   changelog: string;
   createdBy: string;
 }
+
+// ─── Platform Version Types ────────────────────────────────────────────────────
+
+export interface VersionsResponse {
+  platform: {
+    frontend: string;
+    backend: string;
+    node: string;
+    buildDate: string;
+    gitCommit: string;
+  };
+  runtimes: {
+    docker: string | null;
+    vllm: string | null;
+    ollama: string | null;
+  };
+  database: {
+    postgres: string | null;
+  };
+}

--- a/tests/integration/settings-versions.test.ts
+++ b/tests/integration/settings-versions.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Integration tests for GET /api/settings/versions
+ *
+ * The endpoint uses Promise.allSettled internally, so it MUST always return
+ * 200 regardless of which external services (Docker, vLLM, Ollama, Postgres)
+ * are available.
+ *
+ * The DB mock and spawnSync mock ensure no real side-effects occur in CI.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import request from "supertest";
+import express from "express";
+import { createServer } from "http";
+import type { Express } from "express";
+import type { User } from "../../shared/types.js";
+import type { VersionsResponse } from "../../shared/types.js";
+
+const TEST_ADMIN_USER: User = {
+  id: "test-user-id",
+  email: "test@example.com",
+  name: "Test User",
+  isActive: true,
+  role: "admin",
+  lastLoginAt: null,
+  createdAt: new Date(0),
+};
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("../../server/db.js", () => ({
+  db: {
+    select: () => ({ from: () => Promise.resolve([]) }),
+    insert: () => ({ values: () => ({ onConflictDoUpdate: () => Promise.resolve() }) }),
+    delete: () => ({ where: () => Promise.resolve() }),
+    execute: () => Promise.resolve([{ version: "PostgreSQL 16.1 on x86_64-pc-linux-gnu" }]),
+  },
+}));
+
+vi.mock("../../server/crypto.js", () => ({
+  encrypt: (v: string) => `enc:${v}`,
+  decrypt: (v: string) => v.replace(/^enc:/, ""),
+}));
+
+// Mock child_process so we can control docker probe behaviour
+vi.mock("child_process", () => ({
+  spawnSync: vi.fn(() => ({
+    status: 0,
+    stdout: "24.0.5\n",
+    stderr: "",
+    error: undefined,
+  })),
+}));
+
+// ─── Test suite ───────────────────────────────────────────────────────────────
+
+describe("GET /api/settings/versions", () => {
+  let app: Express;
+  let closeApp: () => Promise<void>;
+
+  beforeAll(async () => {
+    const { registerSettingsRoutes } = await import("../../server/routes/settings.js");
+    const { Gateway } = await import("../../server/gateway/index.js");
+    const { MemStorage } = await import("../../server/storage.js");
+
+    const storage = new MemStorage();
+    const gateway = new Gateway(storage);
+    const httpServer = createServer();
+
+    const appInstance = express();
+    appInstance.use(express.json());
+    // Inject auth user so requireAuth passes (not used here, but good practice)
+    appInstance.use((req, _res, next) => {
+      req.user = TEST_ADMIN_USER;
+      next();
+    });
+
+    registerSettingsRoutes(appInstance as unknown as import("express").Router, gateway);
+
+    app = appInstance;
+    closeApp = () =>
+      new Promise<void>((resolve) => {
+        httpServer.close(() => resolve());
+      });
+  });
+
+  afterAll(async () => {
+    await closeApp();
+  });
+
+  // ─── Shape validation ───────────────────────────────────────────────────────
+
+  it("returns HTTP 200", async () => {
+    const res = await request(app).get("/api/settings/versions");
+    expect(res.status).toBe(200);
+  });
+
+  it("returns JSON content-type", async () => {
+    const res = await request(app).get("/api/settings/versions");
+    expect(res.headers["content-type"]).toMatch(/json/);
+  });
+
+  it("response has platform, runtimes, database top-level keys", async () => {
+    const res = await request(app).get("/api/settings/versions");
+    const body = res.body as VersionsResponse;
+    expect(body).toHaveProperty("platform");
+    expect(body).toHaveProperty("runtimes");
+    expect(body).toHaveProperty("database");
+  });
+
+  it("platform contains all expected fields", async () => {
+    const res = await request(app).get("/api/settings/versions");
+    const { platform } = res.body as VersionsResponse;
+    expect(typeof platform.frontend).toBe("string");
+    expect(typeof platform.backend).toBe("string");
+    expect(typeof platform.node).toBe("string");
+    expect(typeof platform.buildDate).toBe("string");
+    expect(typeof platform.gitCommit).toBe("string");
+  });
+
+  it("runtimes contains docker, vllm, ollama (string or null)", async () => {
+    const res = await request(app).get("/api/settings/versions");
+    const { runtimes } = res.body as VersionsResponse;
+    expect(runtimes).toHaveProperty("docker");
+    expect(runtimes).toHaveProperty("vllm");
+    expect(runtimes).toHaveProperty("ollama");
+    // Each must be a string or null
+    for (const v of [runtimes.docker, runtimes.vllm, runtimes.ollama]) {
+      expect(v === null || typeof v === "string").toBe(true);
+    }
+  });
+
+  it("database contains postgres (string or null)", async () => {
+    const res = await request(app).get("/api/settings/versions");
+    const { database } = res.body as VersionsResponse;
+    expect(database).toHaveProperty("postgres");
+    expect(database.postgres === null || typeof database.postgres === "string").toBe(true);
+  });
+
+  it("node version starts with 'v'", async () => {
+    const res = await request(app).get("/api/settings/versions");
+    const { platform } = res.body as VersionsResponse;
+    expect(platform.node).toMatch(/^v\d+\.\d+/);
+  });
+
+  it("docker returns version string from mocked spawnSync", async () => {
+    const res = await request(app).get("/api/settings/versions");
+    const { runtimes } = res.body as VersionsResponse;
+    // Our mock returns "24.0.5\n" — endpoint should strip whitespace
+    expect(runtimes.docker).toBe("24.0.5");
+  });
+});

--- a/tests/unit/settings/version-probes.test.ts
+++ b/tests/unit/settings/version-probes.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Unit tests for the version probe functions exported from server/routes/settings.ts
+ *
+ * These tests run in isolation — no real network calls or child processes are spawned.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ─── Mocks declared before any imports ───────────────────────────────────────
+
+vi.mock("../../../server/db.js", () => ({
+  db: {
+    select: () => ({ from: () => Promise.resolve([]) }),
+    insert: () => ({ values: () => ({ onConflictDoUpdate: () => Promise.resolve() }) }),
+    delete: () => ({ where: () => Promise.resolve() }),
+    execute: () => Promise.resolve([]),
+  },
+}));
+
+vi.mock("../../../server/crypto.js", () => ({
+  encrypt: (v: string) => `enc:${v}`,
+  decrypt: (v: string) => v.replace(/^enc:/, ""),
+}));
+
+const { mockSpawnSync } = vi.hoisted(() => {
+  return { mockSpawnSync: vi.fn() };
+});
+
+vi.mock("child_process", () => ({
+  spawnSync: mockSpawnSync,
+}));
+
+// ─── Imports ──────────────────────────────────────────────────────────────────
+
+import {
+  probeDockerVersion,
+  probeVllmVersion,
+  probeOllamaVersion,
+  extractPostgresVersion,
+} from "../../../server/routes/settings.js";
+
+// ─── extractPostgresVersion ───────────────────────────────────────────────────
+
+describe("extractPostgresVersion", () => {
+  it("extracts major.minor from a full PostgreSQL version string", () => {
+    const raw = "PostgreSQL 16.1 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 12.3.0, 64-bit";
+    expect(extractPostgresVersion(raw)).toBe("16.1");
+  });
+
+  it("extracts version from shorter string", () => {
+    expect(extractPostgresVersion("PostgreSQL 15.4")).toBe("15.4");
+  });
+
+  it("returns null for an unrecognisable string", () => {
+    expect(extractPostgresVersion("some random text")).toBeNull();
+  });
+
+  it("handles empty string", () => {
+    expect(extractPostgresVersion("")).toBeNull();
+  });
+
+  it("is case-insensitive", () => {
+    expect(extractPostgresVersion("postgresql 14.10 on linux")).toBe("14.10");
+  });
+});
+
+// ─── probeDockerVersion ───────────────────────────────────────────────────────
+
+describe("probeDockerVersion", () => {
+  beforeEach(() => {
+    mockSpawnSync.mockReset();
+  });
+
+  it("returns trimmed version string when docker is available", () => {
+    mockSpawnSync.mockReturnValue({
+      status: 0,
+      stdout: "24.0.5\n",
+      stderr: "",
+      error: undefined,
+    });
+    expect(probeDockerVersion()).toBe("24.0.5");
+  });
+
+  it("returns null when binary is not found (spawnSync error)", () => {
+    mockSpawnSync.mockReturnValue({
+      status: null,
+      stdout: "",
+      stderr: "",
+      error: new Error("ENOENT"),
+    });
+    expect(probeDockerVersion()).toBeNull();
+  });
+
+  it("returns null when exit status is non-zero", () => {
+    mockSpawnSync.mockReturnValue({
+      status: 1,
+      stdout: "",
+      stderr: "Cannot connect to Docker daemon",
+      error: undefined,
+    });
+    expect(probeDockerVersion()).toBeNull();
+  });
+
+  it("returns null when stdout is empty", () => {
+    mockSpawnSync.mockReturnValue({
+      status: 0,
+      stdout: "",
+      stderr: "",
+      error: undefined,
+    });
+    expect(probeDockerVersion()).toBeNull();
+  });
+
+  it("returns null when spawnSync throws", () => {
+    mockSpawnSync.mockImplementation(() => {
+      throw new Error("Unexpected error");
+    });
+    expect(probeDockerVersion()).toBeNull();
+  });
+});
+
+// ─── probeVllmVersion ────────────────────────────────────────────────────────
+
+describe("probeVllmVersion", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.unstubAllGlobals();
+  });
+
+  it("returns null when VLLM_BASE_URL is not set", async () => {
+    delete process.env.VLLM_BASE_URL;
+    const result = await probeVllmVersion();
+    expect(result).toBeNull();
+  });
+
+  it("returns version string on successful fetch", async () => {
+    process.env.VLLM_BASE_URL = "http://localhost:8000";
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ version: "0.4.1" }),
+    });
+    const result = await probeVllmVersion();
+    expect(result).toBe("0.4.1");
+  });
+
+  it("returns null on fetch error", async () => {
+    process.env.VLLM_BASE_URL = "http://localhost:8000";
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Network error"));
+    const result = await probeVllmVersion();
+    expect(result).toBeNull();
+  });
+
+  it("returns null when response is not ok", async () => {
+    process.env.VLLM_BASE_URL = "http://localhost:8000";
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({}),
+    });
+    const result = await probeVllmVersion();
+    expect(result).toBeNull();
+  });
+
+  it("returns null when version field is missing from response", async () => {
+    process.env.VLLM_BASE_URL = "http://localhost:8000";
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    const result = await probeVllmVersion();
+    expect(result).toBeNull();
+  });
+});
+
+// ─── probeOllamaVersion ───────────────────────────────────────────────────────
+
+describe("probeOllamaVersion", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.unstubAllGlobals();
+  });
+
+  it("returns version string on successful fetch", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ version: "0.1.27" }),
+    });
+    const result = await probeOllamaVersion();
+    expect(result).toBe("0.1.27");
+  });
+
+  it("returns null on fetch error", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Connection refused"));
+    const result = await probeOllamaVersion();
+    expect(result).toBeNull();
+  });
+
+  it("uses OLLAMA_BASE_URL env var when set", async () => {
+    process.env.OLLAMA_BASE_URL = "http://custom-ollama:11434";
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ version: "0.2.0" }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+    await probeOllamaVersion();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://custom-ollama:11434/api/version",
+      expect.any(Object),
+    );
+  });
+
+  it("returns null when response is not ok", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({}),
+    });
+    const result = await probeOllamaVersion();
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `GET /api/settings/versions` endpoint under the existing `requireAuth`-protected `/api/settings` prefix, returning a `VersionsResponse` with live versions of all platform components
- Adds `VersionInfoPanel` React component (`client/src/components/settings/VersionInfoPanel.tsx`) with per-row version badges, copy-to-clipboard, and a Refresh button
- Wires `VersionInfoPanel` into `Settings.tsx` as collapsible section 11 ("Version Information", `defaultOpen={false}`)
- Adds `BUILD_DATE` / `GIT_COMMIT` `ARG`/`ENV` to the production Dockerfile stage
- Adds `VersionsResponse` interface to `shared/types.ts`

## Technical details

- All external probes (Docker, vLLM, Ollama, PostgreSQL) are run with `Promise.allSettled` — endpoint never returns 500 due to an unavailable service
- Docker: `spawnSync` with 3 s timeout, null on any error
- vLLM: `fetch` with `AbortSignal.timeout(2000)`, requires `VLLM_BASE_URL` env var
- Ollama: `fetch` with `AbortSignal.timeout(2000)`, defaults to `http://localhost:11434`
- PostgreSQL: `SELECT version()` via Drizzle, extracts semver only (strips OS build info)
- Badge colours: green (present/deployed), yellow (dev), gray (N/A)
- Zero TypeScript errors (`npm run check` clean)

## Test plan

- [x] `tests/integration/settings-versions.test.ts` — 8 tests: HTTP 200, JSON shape, all top-level keys present, docker version from mock, node version format
- [x] `tests/unit/settings/version-probes.test.ts` — 19 tests: `extractPostgresVersion` edge cases, docker probe null on ENOENT/non-zero exit/empty stdout/thrown error, vLLM probe null on missing env var/fetch error/non-ok/missing field, Ollama probe null on fetch error/non-ok + custom base URL
- [x] Full test suite: 1624 tests across 88 files, all passing

Closes #150