### PR TITLE
fix: add missing auth headers to 8 pages/hooks (full UI audit)

### DIFF
--- a/client/src/hooks/useIndexTrigger.ts
+++ b/client/src/hooks/useIndexTrigger.ts
@@ -9,8 +9,17 @@ export interface IndexTriggerResponse {
 
 // ─── Hook ─────────────────────────────────────────────────────────────────────
 
+function getAuthToken(): string | null {
+  return localStorage.getItem("auth_token");
+}
+
 async function triggerIndex(workspaceId: string): Promise<IndexTriggerResponse> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/index`, { method: "POST" });
+  const token = getAuthToken();
+  const authHeaders: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
+  const res = await fetch(`/api/workspaces/${workspaceId}/index`, {
+    method: "POST",
+    headers: authHeaders,
+  });
   if (!res.ok) {
     const body = await res.json().catch(() => ({ error: "Request failed" }));
     throw new Error((body as { error: string }).error ?? "Request failed");

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -15,11 +15,6 @@ interface StatsSummary {
 function useStatsSummary() {
   return useQuery<StatsSummary>({
     queryKey: ["/api/stats/summary"],
-    queryFn: async () => {
-      const res = await fetch("/api/stats/summary");
-      if (!res.ok) throw new Error("Failed to load stats");
-      return res.json() as Promise<StatsSummary>;
-    },
     refetchInterval: 30_000,
   });
 }

--- a/client/src/pages/Privacy.tsx
+++ b/client/src/pages/Privacy.tsx
@@ -195,10 +195,6 @@ function PatternsTable() {
 
   const { data: patterns = [] } = useQuery<CustomPattern[]>({
     queryKey: ["/api/privacy/patterns"],
-    queryFn: async () => {
-      const res = await fetch("/api/privacy/patterns");
-      return res.json();
-    },
   });
 
   const createMutation = useMutation({

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -276,21 +276,14 @@ function MemoryPreferences({ noCard = false }: MemoryPreferencesProps) {
   const [saved, setSaved] = useState<Record<string, boolean>>({});
 
   const savePreference = useMutation({
-    mutationFn: async ({ key, value }: { key: string; value: string }) => {
-      const res = await fetch("/api/memories", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          scope: "global",
-          type: "preference",
-          key,
-          content: value,
-          confidence: 1.0,
-        }),
-      });
-      if (!res.ok) throw new Error("Failed to save preference");
-      return res.json();
-    },
+    mutationFn: ({ key, value }: { key: string; value: string }) =>
+      apiRequest("POST", "/api/memories", {
+        scope: "global",
+        type: "preference",
+        key,
+        content: value,
+        confidence: 1.0,
+      }),
     onSuccess: (_data, { key }) => {
       setSaved((prev) => ({ ...prev, [key]: true }));
       void qc.invalidateQueries({ queryKey: ["/api/memories"] });

--- a/client/src/pages/Statistics.tsx
+++ b/client/src/pages/Statistics.tsx
@@ -63,8 +63,17 @@ interface RequestsResponse {
 
 // ─── Fetchers ────────────────────────────────────────────────────────────────
 
-async function fetchJson<T>(url: string): Promise<T> {
-  const res = await fetch(url);
+function getAuthToken(): string | null {
+  return localStorage.getItem("auth_token");
+}
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const token = getAuthToken();
+  const authHeaders: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
+  const res = await fetch(url, {
+    ...init,
+    headers: { ...authHeaders, ...init?.headers },
+  });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return res.json();
 }
@@ -332,9 +341,11 @@ function RequestLog() {
   const totalPages = data ? Math.ceil(data.total / 50) : 1;
 
   async function handleExport(format: "csv" | "json") {
+    const token = getAuthToken();
+    const authHeaders: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
     const res = await fetch(`/api/stats/export?format=${format}`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...authHeaders },
       body: JSON.stringify({
         model: modelFilter || undefined,
         provider: providerFilter || undefined,

--- a/client/src/pages/Workspace.tsx
+++ b/client/src/pages/Workspace.tsx
@@ -23,8 +23,17 @@ type WorkspaceRowWithIndex = WorkspaceRow & { indexStatus?: WorkspaceIndexStatus
 
 // ─── API helpers ─────────────────────────────────────────────────────────────
 
+function getAuthToken(): string | null {
+  return localStorage.getItem("auth_token");
+}
+
+function buildAuthHeaders(): Record<string, string> {
+  const token = getAuthToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 async function fetchJson<T>(url: string): Promise<T> {
-  const res = await fetch(url);
+  const res = await fetch(url, { headers: buildAuthHeaders() });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return res.json();
 }
@@ -32,7 +41,7 @@ async function fetchJson<T>(url: string): Promise<T> {
 async function postJson<T>(url: string, body: unknown): Promise<T> {
   const res = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...buildAuthHeaders() },
     body: JSON.stringify(body),
   });
   if (!res.ok) {

--- a/client/src/pages/WorkspaceList.tsx
+++ b/client/src/pages/WorkspaceList.tsx
@@ -13,8 +13,17 @@ type WorkspaceRowWithIndex = WorkspaceRow & { indexStatus?: WorkspaceIndexStatus
 
 // ─── API helpers ─────────────────────────────────────────────────────────────
 
+function getAuthToken(): string | null {
+  return localStorage.getItem("auth_token");
+}
+
+function buildAuthHeaders(): Record<string, string> {
+  const token = getAuthToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 async function fetchJson<T>(url: string): Promise<T> {
-  const res = await fetch(url);
+  const res = await fetch(url, { headers: buildAuthHeaders() });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return res.json();
 }
@@ -22,7 +31,7 @@ async function fetchJson<T>(url: string): Promise<T> {
 async function postJson<T>(url: string, body: unknown): Promise<T> {
   const res = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...buildAuthHeaders() },
     body: JSON.stringify(body),
   });
   if (!res.ok) {
@@ -187,7 +196,7 @@ function WorkspaceCard({ workspace }: { workspace: WorkspaceRowWithIndex }) {
 
   const deleteMutation = useMutation({
     mutationFn: () =>
-      fetch(`/api/workspaces/${workspace.id}`, { method: "DELETE" }).then((r) => r.json()),
+      fetch(`/api/workspaces/${workspace.id}`, { method: "DELETE", headers: buildAuthHeaders() }).then((r) => r.json()),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["workspaces"] }),
   });
 


### PR DESCRIPTION
## Summary

Full UI audit found 8 pages/hooks sending unauthenticated API requests. All `fetch()` calls without `Authorization: Bearer` headers were returning 401 on every page load.

## Files fixed

| File | Issue |
|------|-------|
| `Dashboard.tsx` | `useStatsSummary` custom queryFn used raw `fetch()` — dropped in favor of default queryClient queryFn |
| `Statistics.tsx` | `fetchJson()` helper + export `POST` had no auth header |
| `Workspace.tsx` | `fetchJson()` + `postJson()` helpers had no auth header |
| `WorkspaceList.tsx` | `fetchJson()`, `postJson()`, and inline `DELETE` had no auth header |
| `useIndexTrigger.ts` | `triggerIndex()` POST had no auth header |
| `Settings.tsx` | `savePreference` mutation used raw `fetch()` — replaced with `apiRequest` |
| `Privacy.tsx` | `GET /api/privacy/patterns` queryFn used raw `fetch()` — dropped in favor of default |

## Pattern

Safe pattern (already auth-aware): `apiRequest()` from `@/lib/queryClient` or the default React Query queryFn via `queryKey` alone.

Risky pattern (now fixed): local `fetchJson()`/`postJson()`/`apiFetch()` wrappers or inline `fetch()` without `Authorization` header.

## Test plan

- [ ] Log in and navigate to Dashboard — stats load without 401
- [ ] Navigate to Statistics — all charts and tables load
- [ ] Navigate to Workspaces — list, create, sync, delete, index all work
- [ ] Navigate to Settings → Memory Preferences — saving a preference succeeds
- [ ] Navigate to Privacy → Custom Patterns — patterns list loads and create/delete works