### PR TITLE
fix: resolve issues #153-#157 — error feedback and security fixes

### DIFF
--- a/client/src/pages/Maintenance.tsx
+++ b/client/src/pages/Maintenance.tsx
@@ -10,6 +10,7 @@
 
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useToast } from "@/hooks/use-toast";
 import {
   Shield,
   ShieldAlert,
@@ -838,6 +839,7 @@ function ContainerScanSection({ findings }: { findings: ScoutFinding[] }) {
 const CATEGORISED_CATEGORIES = new Set(["cve_scan", "log_analysis", "container_scan"]);
 
 function ScansTab() {
+  const { toast } = useToast();
   const [expandedScan, setExpandedScan] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const qc = useQueryClient();
@@ -860,6 +862,8 @@ function ScansTab() {
         body: JSON.stringify({ action, scanId }),
       });
       await qc.invalidateQueries({ queryKey: ["/api/maintenance/scans"] });
+    } catch (err) {
+      toast({ variant: "destructive", title: "Action failed", description: (err as Error).message });
     } finally {
       setActionLoading(null);
     }

--- a/client/src/pages/PipelineRun.tsx
+++ b/client/src/pages/PipelineRun.tsx
@@ -341,35 +341,43 @@ export default function PipelineRun() {
           <p className="text-xs font-medium text-amber-800 mb-2">
             Waiting for approval before continuing
           </p>
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-3">
             {activeApprovals.map((approval) => (
-              <div key={approval.stageIndex} className="flex items-center gap-3">
+              <div key={approval.stageIndex} className="flex flex-col gap-1.5">
                 <span className="text-xs text-amber-700">
                   Stage {approval.stageIndex + 1} ({approval.teamId}) is awaiting approval
                 </span>
-                <Button
-                  size="sm"
-                  className="h-7 text-xs bg-emerald-600 hover:bg-emerald-700 text-white"
-                  disabled={approveMutation.isPending}
-                  onClick={() => approveMutation.mutate({ runId, stageIndex: approval.stageIndex })}
-                >
-                  <CheckCircle2 className="h-3 w-3 mr-1" />
-                  Approve
-                </Button>
-                <Button
-                  size="sm"
-                  variant="destructive"
-                  className="h-7 text-xs"
-                  disabled={rejectMutation.isPending}
-                  onClick={() => rejectMutation.mutate({
-                    runId,
-                    stageIndex: approval.stageIndex,
-                    reason: rejectReasonMap[approval.stageIndex],
-                  })}
-                >
-                  <XCircle className="h-3 w-3 mr-1" />
-                  Reject
-                </Button>
+                <div className="flex items-center gap-2">
+                  <Button
+                    size="sm"
+                    className="h-7 text-xs bg-emerald-600 hover:bg-emerald-700 text-white"
+                    disabled={approveMutation.isPending}
+                    onClick={() => approveMutation.mutate({ runId, stageIndex: approval.stageIndex })}
+                  >
+                    <CheckCircle2 className="h-3 w-3 mr-1" />
+                    Approve
+                  </Button>
+                  <input
+                    className="h-7 flex-1 rounded border border-amber-300 bg-white px-2 text-xs text-amber-900 placeholder:text-amber-400 focus:outline-none focus:ring-1 focus:ring-amber-400"
+                    placeholder="Rejection reason (optional)"
+                    value={rejectReasonMap[approval.stageIndex] ?? ""}
+                    onChange={(e) => setRejectReasonMap((prev) => ({ ...prev, [approval.stageIndex]: e.target.value }))}
+                  />
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    className="h-7 text-xs"
+                    disabled={rejectMutation.isPending}
+                    onClick={() => rejectMutation.mutate({
+                      runId,
+                      stageIndex: approval.stageIndex,
+                      reason: rejectReasonMap[approval.stageIndex],
+                    })}
+                  >
+                    <XCircle className="h-3 w-3 mr-1" />
+                    Reject
+                  </Button>
+                </div>
               </div>
             ))}
           </div>

--- a/client/src/pages/ProfileSettings.tsx
+++ b/client/src/pages/ProfileSettings.tsx
@@ -11,6 +11,7 @@ async function updateProfile(data: {
   name?: string;
   email?: string;
   password?: string;
+  currentPassword?: string;
 }): Promise<{ user: User }> {
   const res = await fetch("/api/auth/me", {
     method: "PUT",
@@ -82,9 +83,14 @@ export default function ProfileSettings() {
       return;
     }
 
+    if (!currentPassword) {
+      setError("Current password is required to set a new password.");
+      return;
+    }
+
     setSaving(true);
     try {
-      await updateProfile({ password: newPassword });
+      await updateProfile({ password: newPassword, currentPassword });
       setNewPassword("");
       setConfirmPassword("");
       setCurrentPassword("");

--- a/client/src/pages/Statistics.tsx
+++ b/client/src/pages/Statistics.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useToast } from "@/hooks/use-toast";
 import {
   AreaChart,
   Area,
@@ -313,6 +314,7 @@ function ModelTable() {
 // ─── Request Log ─────────────────────────────────────────────────────────────
 
 function RequestLog() {
+  const { toast } = useToast();
   const [page, setPage] = useState(1);
   const [modelFilter, setModelFilter] = useState("");
   const [providerFilter, setProviderFilter] = useState("");
@@ -352,7 +354,11 @@ function RequestLog() {
         status: statusFilter || undefined,
       }),
     });
-    if (!res.ok) return;
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ error: `HTTP ${res.status}` })) as { error?: string };
+      toast({ variant: "destructive", title: "Export failed", description: err.error ?? `HTTP ${res.status}` });
+      return;
+    }
     const blob = await res.blob();
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");

--- a/client/src/pages/Workspace.tsx
+++ b/client/src/pages/Workspace.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useRoute } from "wouter";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useToast } from "@/hooks/use-toast";
 import { RefreshCw, GitBranch, Eye, MessageSquare, Code2, Settings2, Network, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { FileTree } from "@/components/workspace/FileTree";
@@ -123,6 +124,7 @@ type MainView = "files" | "graph";
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function Workspace() {
+  const { toast } = useToast();
   const [, params] = useRoute<{ id: string }>("/workspaces/:id");
   const workspaceId = params?.id ?? "";
 
@@ -169,6 +171,7 @@ export default function Workspace() {
       qc.invalidateQueries({ queryKey: ["workspace", workspaceId] });
       qc.invalidateQueries({ queryKey: ["workspace-files", workspaceId] });
     },
+    onError: (err: Error) => toast({ variant: "destructive", title: "Sync failed", description: err.message }),
   });
 
   const loadDirContents = async (dirPath: string): Promise<FileEntry[]> => {
@@ -197,6 +200,8 @@ export default function Workspace() {
         { filePaths: [selectedFile], models: reviewModels },
       );
       setReviewResults(results);
+    } catch (err) {
+      toast({ variant: "destructive", title: "Review failed", description: (err as Error).message });
     } finally {
       setIsReviewing(false);
     }

--- a/client/src/pages/WorkspaceList.tsx
+++ b/client/src/pages/WorkspaceList.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useToast } from "@/hooks/use-toast";
 import { Link } from "wouter";
 import { FolderGit2, Plus, Trash2, RefreshCw, ExternalLink } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -191,6 +192,7 @@ function StatusBadge({ status }: { status: WorkspaceRow["status"] }) {
 // ─── Workspace card ───────────────────────────────────────────────────────────
 
 function WorkspaceCard({ workspace }: { workspace: WorkspaceRowWithIndex }) {
+  const { toast } = useToast();
   const qc = useQueryClient();
   const indexTrigger = useIndexTrigger(workspace.id);
 
@@ -198,11 +200,13 @@ function WorkspaceCard({ workspace }: { workspace: WorkspaceRowWithIndex }) {
     mutationFn: () =>
       fetch(`/api/workspaces/${workspace.id}`, { method: "DELETE", headers: buildAuthHeaders() }).then((r) => r.json()),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["workspaces"] }),
+    onError: (err: Error) => toast({ variant: "destructive", title: "Delete failed", description: err.message }),
   });
 
   const syncMutation = useMutation({
     mutationFn: () => postJson(`/api/workspaces/${workspace.id}/sync`, {}),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["workspaces"] }),
+    onError: (err: Error) => toast({ variant: "destructive", title: "Sync failed", description: err.message }),
   });
 
   return (

--- a/server/auth/service.ts
+++ b/server/auth/service.ts
@@ -92,6 +92,14 @@ class AuthService {
     return authStorage.getAllUsers();
   }
 
+  async verifyPassword(userId: string, password: string): Promise<boolean> {
+    const user = await authStorage.getUserById(userId);
+    if (!user) return false;
+    const hash = await authStorage.getPasswordHashByEmail(user.email);
+    if (!hash) return false;
+    return bcrypt.compare(password, hash);
+  }
+
   async updateUser(
     id: string,
     updates: { name?: string; email?: string; password?: string },

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -19,6 +19,7 @@ const updateMeSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   email: z.string().email().optional(),
   password: z.string().min(8).optional(),
+  currentPassword: z.string().optional(),
 });
 
 const updateRoleSchema = z.object({
@@ -111,8 +112,22 @@ export function registerAuthRoutes(app: Express): void {
       return;
     }
 
+    // Verify current password before allowing a password change
+    if (parsed.data.password) {
+      if (!parsed.data.currentPassword) {
+        res.status(400).json({ error: "Current password is required to set a new password" });
+        return;
+      }
+      const valid = await authService.verifyPassword(req.user.id, parsed.data.currentPassword);
+      if (!valid) {
+        res.status(403).json({ error: "Current password is incorrect" });
+        return;
+      }
+    }
+
     try {
-      const updated = await authService.updateUser(req.user.id, parsed.data);
+      const { currentPassword: _cp, ...updates } = parsed.data;
+      const updated = await authService.updateUser(req.user.id, updates);
       res.json({ user: updated });
     } catch (err) {
       const error = err as Error;


### PR DESCRIPTION
## Summary

Closes #153, #154, #155, #156, #157

### #153 — Reject stage button always sent `undefined` reason
Added an inline text input to the approval banner so users can type a rejection reason. The reason is now correctly passed to `rejectMutation`.

### #154 — Statistics export failures were silent
`handleExport()` previously returned silently on `!res.ok`. Now shows a destructive toast with the error message.

### #155 — Maintenance finding action errors swallowed
`handleAction()` in `ScansTab` had no catch block. Added `catch (err)` that surfaces the error via toast.

### #156 — Workspace/WorkspaceList no error feedback on sync/delete/review
Added `onError` toast handlers to `syncMutation` and `deleteMutation` in both `Workspace.tsx` and `WorkspaceList.tsx`, and a `catch` block in `handleReview`.

### #157 — ProfileSettings `currentPassword` never sent or verified (security fix)
**Frontend**: Added guard requiring `currentPassword` to be filled before submitting a password change. Sends it in the request body.

**Backend** (`server/routes/auth.ts`): Verifies `currentPassword` against the stored bcrypt hash before allowing the change. Returns 403 if incorrect.

**Backend** (`server/auth/service.ts`): Added `verifyPassword(userId, password)` method.

## Test plan

- [ ] Approve/reject a pipeline stage gate — rejection reason input appears, reason is sent to backend
- [ ] Trigger a stats export while unauthenticated — error toast appears
- [ ] Trigger a maintenance finding action that fails — error toast appears
- [ ] Delete/sync a workspace that fails — error toast appears
- [ ] Change password: leaving current password blank → validation error; wrong password → 403 error; correct password → success