### PR TITLE
fix: Triggers page shows error when TRIGGER_SECRET_KEY not set

### DIFF
--- a/client/src/hooks/use-triggers.ts
+++ b/client/src/hooks/use-triggers.ts
@@ -17,8 +17,12 @@ async function apiRequest(method: string, url: string, body?: unknown): Promise<
     body: body ? JSON.stringify(body) : undefined,
   });
   if (!res.ok) {
-    const err = await res.json().catch(() => ({ message: res.statusText }));
-    throw new Error((err as { message?: string }).message || res.statusText);
+    const err = await res.json().catch(() => ({ error: res.statusText })) as { message?: string; error?: string; disabled?: boolean };
+    const message = err.message ?? err.error ?? res.statusText;
+    const error = new Error(message) as Error & { disabled?: boolean; status?: number };
+    error.disabled = err.disabled ?? false;
+    error.status = res.status;
+    throw error;
   }
   if (res.status === 204) return null;
   return res.json();

--- a/client/src/pages/TriggersPage.tsx
+++ b/client/src/pages/TriggersPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Zap, Plus, Loader2 } from "lucide-react";
+import { Zap, Plus, Loader2, ZapOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { TriggerCard } from "@/components/triggers/TriggerCard";
 import { TriggerForm } from "@/components/triggers/TriggerForm";
@@ -20,6 +20,7 @@ export default function TriggersPage() {
   const [formOpen, setFormOpen] = useState(false);
   const [editingTrigger, setEditingTrigger] = useState<PipelineTrigger | undefined>();
 
+  const subsystemDisabled = (error as (Error & { disabled?: boolean }) | null)?.disabled === true || (error as (Error & { status?: number }) | null)?.status === 503;
   const triggerList: PipelineTrigger[] = Array.isArray(triggers) ? triggers : [];
   const pipelines: Pipeline[] = Array.isArray(pipelinesData) ? pipelinesData : [];
 
@@ -56,7 +57,7 @@ export default function TriggersPage() {
           size="sm"
           className="h-8 text-xs"
           onClick={handleAdd}
-          disabled={pipelines.length === 0}
+          disabled={pipelines.length === 0 || subsystemDisabled}
         >
           <Plus className="h-3 w-3 mr-2" />
           Add Trigger
@@ -72,10 +73,20 @@ export default function TriggersPage() {
           </div>
         )}
 
-        {error && (
+        {error && !subsystemDisabled && (
           <div className="flex items-center justify-center py-16">
             <p className="text-sm text-destructive">
               Failed to load triggers: {error.message}
+            </p>
+          </div>
+        )}
+
+        {subsystemDisabled && (
+          <div className="flex flex-col items-center justify-center py-20 text-center">
+            <ZapOff className="h-10 w-10 text-muted-foreground/40 mb-4" />
+            <p className="text-sm font-medium text-muted-foreground">Trigger subsystem is not configured</p>
+            <p className="text-xs text-muted-foreground mt-1 max-w-xs">
+              Set the <code className="font-mono bg-muted px-1 rounded">TRIGGER_SECRET_KEY</code> environment variable to enable webhooks, schedules, and event triggers.
             </p>
           </div>
         )}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -146,8 +146,18 @@ export async function registerRoutes(
 
     log("[triggers] Trigger subsystem started", "triggers");
   } catch (e) {
-    // TriggerCrypto throws if TRIGGER_SECRET_KEY is absent — subsystem is disabled
+    // TriggerCrypto throws if TRIGGER_SECRET_KEY is absent — subsystem is disabled.
+    // Register stub routes so the UI receives JSON instead of Express's HTML 404.
     log(`[triggers] Trigger subsystem disabled: ${(e as Error).message}`, "triggers");
+    app.get("/api/triggers", (_req, res) => {
+      res.status(503).json({ error: "Trigger subsystem is disabled (TRIGGER_SECRET_KEY not configured)", disabled: true });
+    });
+    app.get("/api/pipelines/:pipelineId/triggers", (_req, res) => {
+      res.status(503).json({ error: "Trigger subsystem is disabled (TRIGGER_SECRET_KEY not configured)", disabled: true });
+    });
+    app.use("/api/triggers/:id", (_req, res) => {
+      res.status(503).json({ error: "Trigger subsystem is disabled (TRIGGER_SECRET_KEY not configured)", disabled: true });
+    });
   }
 
   // Graceful shutdown


### PR DESCRIPTION
## Root Cause

`TriggerCrypto` throws in its constructor when `TRIGGER_SECRET_KEY` is not set. This causes the entire trigger subsystem `try` block in `routes.ts` to abort **before** `registerTriggerRoutes()` is called. All requests to `/api/triggers` hit no Express handler and get a **HTML 404** response. The frontend hook fails to parse this as JSON and shows a generic error.

## Changes

### `server/routes.ts`
In the `catch` block, register stub GET routes for `/api/triggers`, `/api/pipelines/:id/triggers`, and `/api/triggers/:id` that return:
```json
{ "error": "Trigger subsystem is disabled (TRIGGER_SECRET_KEY not configured)", "disabled": true }
```
with HTTP 503, instead of leaving the routes unregistered.

### `client/src/hooks/use-triggers.ts`
- Parse both `err.error` and `err.message` (backend uses `error`, not `message`)
- Attach `disabled` and `status` properties to thrown errors so callers can distinguish "subsystem off" from real failures

### `client/src/pages/TriggersPage.tsx`
- Detect `disabled=true` or `status=503` responses
- Render a helpful empty state: _"Set the `TRIGGER_SECRET_KEY` environment variable to enable webhooks, schedules, and event triggers"_
- Disable "Add Trigger" button when subsystem is off
- Red error banner only shown for actual request failures

## Before / After

| Before | After |
|--------|-------|
| Red error: "Failed to load triggers: Not Found" | Gray empty state with env var hint |
| HTML 404 from Express | JSON 503 with `disabled: true` |

## Test plan

- [ ] Without `TRIGGER_SECRET_KEY` set: `/triggers` shows the "not configured" empty state, no red error
- [ ] With `TRIGGER_SECRET_KEY` set: `/triggers` works normally (empty list or trigger cards)
- [ ] "Add Trigger" button is disabled when subsystem is off