### PR TITLE
feat(task-orchestrator): event-driven multi-model task coordination

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -30,6 +30,8 @@ import ProfileSettings from "@/pages/ProfileSettings";
 import Maintenance from "@/pages/Maintenance";
 import Skills from "@/pages/Skills";
 import SkillMarketplace from "@/pages/SkillMarketplace";
+import TaskGroupList from "@/pages/TaskGroupList";
+import TaskGroupPage from "@/pages/TaskGroup";
 
 function ProtectedRouter() {
   const { user, isLoading } = useAuth();
@@ -109,6 +111,12 @@ function ProtectedRouter() {
         )} />
         <Route path="/memories" component={() => (
           <ErrorBoundary><Memory /></ErrorBoundary>
+        )} />
+        <Route path="/task-groups/:id" component={() => (
+          <ErrorBoundary><TaskGroupPage /></ErrorBoundary>
+        )} />
+        <Route path="/task-groups" component={() => (
+          <ErrorBoundary><TaskGroupList /></ErrorBoundary>
         )} />
         <Route path="/maintenance" component={() => (
           <ErrorBoundary><Maintenance /></ErrorBoundary>

--- a/client/src/components/layout/MainLayout.tsx
+++ b/client/src/components/layout/MainLayout.tsx
@@ -17,6 +17,7 @@ import {
   Zap,
   Sparkles,
   Store,
+  ListChecks,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePendingQuestions } from "@/hooks/use-pipeline";
@@ -48,6 +49,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
       href: "/pipelines",
       badge: pendingCount > 0 ? pendingCount : undefined,
     },
+    { icon: ListChecks, label: "Task Groups", href: "/task-groups" },
     { icon: Zap, label: "Triggers", href: "/triggers" },
     { icon: FolderGit2, label: "Workspace", href: "/workspaces" },
     { icon: Sparkles, label: "Skills", href: "/skills" },

--- a/client/src/hooks/use-task-events.ts
+++ b/client/src/hooks/use-task-events.ts
@@ -1,0 +1,237 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { wsClient } from "@/lib/websocket";
+import type { WsEvent } from "@shared/types";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface TaskEventInfo {
+  name: string;
+  status: string;
+  executionMode?: string;
+  modelSlug?: string;
+  summary?: string;
+  error?: string;
+  pipelineRunId?: string;
+  dependsOn?: string[];
+  artifacts?: unknown[];
+  decisions?: string[];
+}
+
+export interface ActivityEntry {
+  type: string;
+  taskId?: string;
+  taskName?: string;
+  message: string;
+  timestamp: string;
+}
+
+export interface TaskGroupEventState {
+  groupStatus: string;
+  tasks: Map<string, TaskEventInfo>;
+  activity: ActivityEntry[];
+  completedCount: number;
+  totalCount: number;
+  runningCount: number;
+}
+
+// ─── Hook ───────────────────────────────────────────────────────────────────
+
+export function useTaskGroupEvents(groupId: string): TaskGroupEventState {
+  const [state, setState] = useState<TaskGroupEventState>({
+    groupStatus: "pending",
+    tasks: new Map(),
+    activity: [],
+    completedCount: 0,
+    totalCount: 0,
+    runningCount: 0,
+  });
+
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  const addActivity = (s: TaskGroupEventState, entry: Omit<ActivityEntry, "timestamp">, timestamp: string): ActivityEntry[] => {
+    return [...s.activity, { ...entry, timestamp }];
+  };
+
+  const handleEvent = useCallback((event: WsEvent) => {
+    if (event.runId !== groupId) return;
+    const s = stateRef.current;
+    const p = event.payload;
+
+    switch (event.type) {
+      case "task:created": {
+        const tasks = new Map(s.tasks);
+        tasks.set(p.taskId as string, {
+          name: p.name as string,
+          status: p.status as string,
+          dependsOn: p.dependsOn as string[],
+        });
+        setState({
+          ...s,
+          tasks,
+          totalCount: tasks.size,
+        });
+        break;
+      }
+
+      case "task:ready": {
+        const tasks = new Map(s.tasks);
+        const existing = tasks.get(p.taskId as string);
+        if (existing) tasks.set(p.taskId as string, { ...existing, status: "ready" });
+        setState({
+          ...s,
+          tasks,
+          activity: addActivity(s, {
+            type: "task:ready",
+            taskId: p.taskId as string,
+            taskName: p.name as string,
+            message: `Task "${p.name}" is ready to start`,
+          }, event.timestamp),
+        });
+        break;
+      }
+
+      case "task:started": {
+        const tasks = new Map(s.tasks);
+        const existing = tasks.get(p.taskId as string);
+        tasks.set(p.taskId as string, {
+          ...(existing ?? { name: p.name as string }),
+          name: p.name as string,
+          status: "running",
+          executionMode: p.executionMode as string,
+          modelSlug: p.modelSlug as string | undefined,
+        });
+        setState({
+          ...s,
+          tasks,
+          runningCount: s.runningCount + 1,
+          activity: addActivity(s, {
+            type: "task:started",
+            taskId: p.taskId as string,
+            taskName: p.name as string,
+            message: `Started "${p.name}" (${p.executionMode}${p.modelSlug ? ` / ${p.modelSlug}` : ""})`,
+          }, event.timestamp),
+        });
+        break;
+      }
+
+      case "task:progress": {
+        setState({
+          ...s,
+          activity: addActivity(s, {
+            type: "task:progress",
+            taskId: p.taskId as string,
+            taskName: p.name as string | undefined,
+            message: p.message as string,
+          }, event.timestamp),
+        });
+        break;
+      }
+
+      case "task:completed": {
+        const tasks = new Map(s.tasks);
+        const existing = tasks.get(p.taskId as string);
+        tasks.set(p.taskId as string, {
+          ...(existing ?? { name: p.name as string }),
+          name: p.name as string,
+          status: "completed",
+          summary: p.summary as string,
+          artifacts: p.artifacts as unknown[] | undefined,
+          decisions: p.decisions as string[] | undefined,
+        });
+        const newCompleted = s.completedCount + 1;
+        setState({
+          ...s,
+          tasks,
+          completedCount: newCompleted,
+          runningCount: Math.max(0, s.runningCount - 1),
+          activity: addActivity(s, {
+            type: "task:completed",
+            taskId: p.taskId as string,
+            taskName: p.name as string,
+            message: `Completed "${p.name}": ${p.summary}`,
+          }, event.timestamp),
+        });
+        break;
+      }
+
+      case "task:failed": {
+        const tasks = new Map(s.tasks);
+        const existing = tasks.get(p.taskId as string);
+        tasks.set(p.taskId as string, {
+          ...(existing ?? { name: p.name as string }),
+          name: p.name as string,
+          status: "failed",
+          error: p.error as string,
+        });
+        setState({
+          ...s,
+          tasks,
+          runningCount: Math.max(0, s.runningCount - 1),
+          activity: addActivity(s, {
+            type: "task:failed",
+            taskId: p.taskId as string,
+            taskName: p.name as string,
+            message: `Failed "${p.name}": ${p.error}`,
+          }, event.timestamp),
+        });
+        break;
+      }
+
+      case "taskgroup:started":
+        setState({
+          ...s,
+          groupStatus: "running",
+          totalCount: p.totalTasks as number,
+          activity: addActivity(s, {
+            type: "taskgroup:started",
+            message: `Task group started — ${p.totalTasks} tasks, ${p.readyTasks} ready`,
+          }, event.timestamp),
+        });
+        break;
+
+      case "taskgroup:progress":
+        setState({
+          ...s,
+          completedCount: p.completed as number,
+          runningCount: p.running as number,
+        });
+        break;
+
+      case "taskgroup:completed":
+        setState({
+          ...s,
+          groupStatus: "completed",
+          activity: addActivity(s, {
+            type: "taskgroup:completed",
+            message: `All tasks completed (${p.completedTasks}/${p.totalTasks})`,
+          }, event.timestamp),
+        });
+        break;
+
+      case "taskgroup:failed":
+        setState({
+          ...s,
+          groupStatus: "failed",
+          activity: addActivity(s, {
+            type: "taskgroup:failed",
+            message: `Task group failed: ${p.error}`,
+          }, event.timestamp),
+        });
+        break;
+    }
+  }, [groupId]);
+
+  useEffect(() => {
+    wsClient.connect();
+    wsClient.subscribe(groupId);
+    const unsub = wsClient.onAny(handleEvent);
+
+    return () => {
+      unsub();
+      wsClient.unsubscribe(groupId);
+    };
+  }, [groupId, handleEvent]);
+
+  return state;
+}

--- a/client/src/hooks/use-task-groups.ts
+++ b/client/src/hooks/use-task-groups.ts
@@ -1,0 +1,90 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiRequest } from "./use-pipeline";
+
+// ─── Queries ────────────────────────────────────────────────────────────────
+
+export function useTaskGroups() {
+  return useQuery({
+    queryKey: ["/api/task-groups"],
+    queryFn: () => apiRequest("GET", "/api/task-groups"),
+  });
+}
+
+export function useTaskGroup(id: string) {
+  return useQuery({
+    queryKey: ["/api/task-groups", id],
+    queryFn: () => apiRequest("GET", `/api/task-groups/${id}`),
+    enabled: !!id,
+    refetchInterval: 3000, // poll while viewing
+  });
+}
+
+// ─── Mutations ──────────────────────────────────────────────────────────────
+
+export function useCreateTaskGroup() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: {
+      name: string;
+      description: string;
+      input: string;
+      tasks: Array<{
+        name: string;
+        description: string;
+        executionMode?: "pipeline_run" | "direct_llm";
+        dependsOn?: string[];
+        pipelineId?: string;
+        modelSlug?: string;
+        teamId?: string;
+        input?: Record<string, unknown>;
+        sortOrder?: number;
+      }>;
+    }) => apiRequest("POST", "/api/task-groups", data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["/api/task-groups"] });
+    },
+  });
+}
+
+export function useStartTaskGroup() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => apiRequest("POST", `/api/task-groups/${id}/start`),
+    onSuccess: (_data, id) => {
+      qc.invalidateQueries({ queryKey: ["/api/task-groups", id] });
+      qc.invalidateQueries({ queryKey: ["/api/task-groups"] });
+    },
+  });
+}
+
+export function useCancelTaskGroup() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => apiRequest("POST", `/api/task-groups/${id}/cancel`),
+    onSuccess: (_data, id) => {
+      qc.invalidateQueries({ queryKey: ["/api/task-groups", id] });
+      qc.invalidateQueries({ queryKey: ["/api/task-groups"] });
+    },
+  });
+}
+
+export function useDeleteTaskGroup() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => apiRequest("DELETE", `/api/task-groups/${id}`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["/api/task-groups"] });
+    },
+  });
+}
+
+export function useRetryTask() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ groupId, taskId }: { groupId: string; taskId: string }) =>
+      apiRequest("POST", `/api/task-groups/${groupId}/tasks/${taskId}/retry`),
+    onSuccess: (_data, { groupId }) => {
+      qc.invalidateQueries({ queryKey: ["/api/task-groups", groupId] });
+    },
+  });
+}

--- a/client/src/pages/TaskGroup.tsx
+++ b/client/src/pages/TaskGroup.tsx
@@ -1,0 +1,239 @@
+import { useRoute } from "wouter";
+import { useTaskGroup, useStartTaskGroup, useCancelTaskGroup, useRetryTask } from "@/hooks/use-task-groups";
+import { useTaskGroupEvents } from "@/hooks/use-task-events";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Play, XCircle, RotateCcw, ArrowLeft, CheckCircle2, Clock, Loader2, AlertCircle, Ban } from "lucide-react";
+import { Link } from "wouter";
+import { useEffect, useRef } from "react";
+
+// ─── Status badges ──────────────────────────────────────────────────────────
+
+const statusConfig: Record<string, { color: string; icon: React.ReactNode }> = {
+  pending: { color: "bg-muted text-muted-foreground", icon: <Clock className="h-3 w-3" /> },
+  blocked: { color: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200", icon: <Clock className="h-3 w-3" /> },
+  ready: { color: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200", icon: <Play className="h-3 w-3" /> },
+  running: { color: "bg-blue-500 text-white", icon: <Loader2 className="h-3 w-3 animate-spin" /> },
+  completed: { color: "bg-green-600 text-white", icon: <CheckCircle2 className="h-3 w-3" /> },
+  failed: { color: "bg-red-600 text-white", icon: <AlertCircle className="h-3 w-3" /> },
+  cancelled: { color: "bg-gray-500 text-white", icon: <Ban className="h-3 w-3" /> },
+};
+
+function StatusBadge({ status }: { status: string }) {
+  const cfg = statusConfig[status] ?? statusConfig.pending;
+  return (
+    <Badge className={`${cfg.color} gap-1`}>
+      {cfg.icon}
+      {status}
+    </Badge>
+  );
+}
+
+// ─── Task Group Detail Page ─────────────────────────────────────────────────
+
+export default function TaskGroupPage() {
+  const [, params] = useRoute("/task-groups/:id");
+  const id = params?.id ?? "";
+
+  const { data, isLoading } = useTaskGroup(id);
+  const events = useTaskGroupEvents(id);
+  const startMutation = useStartTaskGroup();
+  const cancelMutation = useCancelTaskGroup();
+  const retryMutation = useRetryTask();
+  const activityEndRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll activity stream
+  useEffect(() => {
+    activityEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [events.activity.length]);
+
+  if (isLoading || !data) {
+    return <div className="p-6 text-muted-foreground">Loading...</div>;
+  }
+
+  const group = data as {
+    id: string;
+    name: string;
+    description: string;
+    status: string;
+    input: string;
+    output: unknown;
+    createdAt: string;
+    tasks: Array<{
+      id: string;
+      name: string;
+      description: string;
+      status: string;
+      executionMode: string;
+      modelSlug: string | null;
+      summary: string | null;
+      errorMessage: string | null;
+      dependsOn: string[];
+    }>;
+  };
+
+  // Merge WS events into task statuses for real-time display
+  const taskNameMap = new Map(group.tasks.map((t) => [t.id, t.name]));
+  const mergedTasks = group.tasks.map((t) => {
+    const wsInfo = events.tasks.get(t.id);
+    return {
+      ...t,
+      status: wsInfo?.status ?? t.status,
+      summary: wsInfo?.summary ?? t.summary,
+      error: wsInfo?.error ?? t.errorMessage,
+    };
+  });
+
+  const effectiveStatus = events.groupStatus !== "pending" ? events.groupStatus : group.status;
+  const canStart = effectiveStatus === "pending";
+  const canCancel = effectiveStatus === "running";
+
+  return (
+    <div className="p-6 max-w-6xl mx-auto space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <Link href="/task-groups">
+          <Button variant="ghost" size="icon">
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        </Link>
+        <div className="flex-1">
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-bold">{group.name}</h1>
+            <StatusBadge status={effectiveStatus} />
+          </div>
+          <p className="text-sm text-muted-foreground mt-1">{group.description}</p>
+        </div>
+        <div className="flex gap-2">
+          {canStart && (
+            <Button onClick={() => startMutation.mutate(id)} disabled={startMutation.isPending}>
+              <Play className="h-4 w-4 mr-2" />
+              Start
+            </Button>
+          )}
+          {canCancel && (
+            <Button variant="destructive" onClick={() => cancelMutation.mutate(id)} disabled={cancelMutation.isPending}>
+              <XCircle className="h-4 w-4 mr-2" />
+              Cancel
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Tasks panel */}
+        <div className="lg:col-span-2 space-y-3">
+          <h2 className="text-lg font-semibold">Tasks</h2>
+          {mergedTasks.map((t) => (
+            <Card key={t.id} className={t.status === "running" ? "border-blue-500/50" : ""}>
+              <CardHeader className="py-3 pb-1">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-sm font-medium">{t.name}</CardTitle>
+                  <div className="flex items-center gap-2">
+                    <StatusBadge status={t.status} />
+                    {t.status === "failed" && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 text-xs"
+                        onClick={() => retryMutation.mutate({ groupId: id, taskId: t.id })}
+                        disabled={retryMutation.isPending}
+                      >
+                        <RotateCcw className="h-3 w-3 mr-1" />
+                        Retry
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="py-2 space-y-1">
+                <p className="text-xs text-muted-foreground">{t.description}</p>
+                <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                  <span>{t.executionMode}</span>
+                  {t.modelSlug && <span>{t.modelSlug}</span>}
+                  {t.dependsOn.length > 0 && (
+                    <span>
+                      depends on: {t.dependsOn.map((d) => taskNameMap.get(d) ?? d.slice(0, 8)).join(", ")}
+                    </span>
+                  )}
+                </div>
+                {t.summary && (
+                  <div className="mt-2 p-2 bg-green-50 dark:bg-green-950 rounded text-xs text-green-800 dark:text-green-200">
+                    {t.summary}
+                  </div>
+                )}
+                {t.error && (
+                  <div className="mt-2 p-2 bg-red-50 dark:bg-red-950 rounded text-xs text-red-800 dark:text-red-200">
+                    {t.error}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        {/* Activity stream */}
+        <div className="space-y-3">
+          <h2 className="text-lg font-semibold">Activity</h2>
+          <Card>
+            <CardContent className="p-0">
+              <div className="max-h-[600px] overflow-y-auto p-3 space-y-2 font-mono text-xs">
+                {events.activity.length === 0 ? (
+                  <p className="text-muted-foreground text-center py-8">
+                    {effectiveStatus === "pending" ? "Start the group to see activity" : "No activity yet"}
+                  </p>
+                ) : (
+                  events.activity.map((entry, i) => (
+                    <div key={i} className="flex gap-2">
+                      <span className="text-muted-foreground shrink-0">
+                        {new Date(entry.timestamp).toLocaleTimeString()}
+                      </span>
+                      <span
+                        className={
+                          entry.type.includes("failed") ? "text-red-500" :
+                          entry.type.includes("completed") ? "text-green-500" :
+                          entry.type.includes("started") ? "text-blue-500" :
+                          "text-foreground"
+                        }
+                      >
+                        {entry.message}
+                      </span>
+                    </div>
+                  ))
+                )}
+                <div ref={activityEndRef} />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Progress summary */}
+          {effectiveStatus === "running" && (
+            <Card>
+              <CardContent className="py-3">
+                <div className="text-sm space-y-1">
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Completed</span>
+                    <span className="font-medium">{events.completedCount}/{events.totalCount || group.tasks.length}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Running</span>
+                    <span className="font-medium">{events.runningCount}</span>
+                  </div>
+                  <div className="w-full bg-muted rounded-full h-2 mt-2">
+                    <div
+                      className="bg-green-500 h-2 rounded-full transition-all"
+                      style={{
+                        width: `${((events.completedCount / (events.totalCount || group.tasks.length)) * 100) || 0}%`,
+                      }}
+                    />
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/TaskGroupList.tsx
+++ b/client/src/pages/TaskGroupList.tsx
@@ -1,0 +1,101 @@
+import { Link } from "wouter";
+import { useTaskGroups, useDeleteTaskGroup } from "@/hooks/use-task-groups";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Plus, Trash2, ListChecks } from "lucide-react";
+
+const statusColors: Record<string, string> = {
+  pending: "bg-muted text-muted-foreground",
+  running: "bg-blue-500 text-white",
+  completed: "bg-green-600 text-white",
+  failed: "bg-red-600 text-white",
+  cancelled: "bg-gray-500 text-white",
+};
+
+export default function TaskGroupList() {
+  const { data: groups, isLoading } = useTaskGroups();
+  const deleteMutation = useDeleteTaskGroup();
+
+  if (isLoading) {
+    return <div className="p-6 text-muted-foreground">Loading task groups...</div>;
+  }
+
+  const items = (groups ?? []) as Array<{
+    id: string;
+    name: string;
+    description: string;
+    status: string;
+    taskCount: number;
+    completedCount: number;
+    createdAt: string;
+  }>;
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Task Groups</h1>
+          <p className="text-muted-foreground text-sm mt-1">
+            Coordinate multi-model task execution with dependency graphs
+          </p>
+        </div>
+        <Link href="/task-groups/new">
+          <Button>
+            <Plus className="h-4 w-4 mr-2" />
+            New Task Group
+          </Button>
+        </Link>
+      </div>
+
+      {items.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center text-muted-foreground">
+            <ListChecks className="h-12 w-12 mx-auto mb-4 opacity-50" />
+            <p>No task groups yet. Create one to get started.</p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {items.map((g) => (
+            <Link key={g.id} href={`/task-groups/${g.id}`}>
+              <Card className="cursor-pointer hover:border-primary/50 transition-colors">
+                <CardHeader className="pb-2">
+                  <div className="flex items-center justify-between">
+                    <CardTitle className="text-base">{g.name}</CardTitle>
+                    <div className="flex items-center gap-2">
+                      <Badge className={statusColors[g.status] ?? "bg-muted"}>
+                        {g.status}
+                      </Badge>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 text-muted-foreground hover:text-red-500"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          if (confirm("Delete this task group?")) {
+                            deleteMutation.mutate(g.id);
+                          }
+                        }}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm text-muted-foreground line-clamp-2">{g.description}</p>
+                  <div className="flex items-center gap-4 mt-2 text-xs text-muted-foreground">
+                    <span>{g.completedCount}/{g.taskCount} tasks completed</span>
+                    <span>{new Date(g.createdAt).toLocaleDateString()}</span>
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/migrations/0000_abandoned_skrulls.sql
+++ b/migrations/0000_abandoned_skrulls.sql
@@ -1,0 +1,436 @@
+CREATE TABLE "anonymization_log" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"run_id" text,
+	"session_id" text NOT NULL,
+	"level" text NOT NULL,
+	"entities_found" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "anonymization_patterns" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"entity_type" text DEFAULT 'custom_pattern' NOT NULL,
+	"regex_pattern" text NOT NULL,
+	"severity" text DEFAULT 'high' NOT NULL,
+	"pseudonym_template" text,
+	"allowlist" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "argocd_config" (
+	"id" integer PRIMARY KEY DEFAULT 1 NOT NULL,
+	"server_url" text,
+	"token_enc" text,
+	"verify_ssl" boolean DEFAULT true NOT NULL,
+	"enabled" boolean DEFAULT false NOT NULL,
+	"mcp_server_id" integer,
+	"last_health_check_at" timestamp,
+	"health_status" text DEFAULT 'unknown' NOT NULL,
+	"health_error" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "auto_trigger_audit" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"scan_id" varchar NOT NULL,
+	"finding_id" varchar NOT NULL,
+	"pipeline_run_id" varchar NOT NULL,
+	"triggered_at" timestamp DEFAULT now() NOT NULL,
+	"triggered_by" varchar
+);
+--> statement-breakpoint
+CREATE TABLE "chat_messages" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"run_id" varchar,
+	"role" text NOT NULL,
+	"agent_team" text,
+	"model_slug" text,
+	"content" text NOT NULL,
+	"metadata" jsonb,
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "delegation_requests" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"run_id" varchar NOT NULL,
+	"from_stage" text NOT NULL,
+	"to_stage" text NOT NULL,
+	"task" text NOT NULL,
+	"context" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"priority" text DEFAULT 'blocking' NOT NULL,
+	"timeout" integer DEFAULT 30000 NOT NULL,
+	"depth" integer DEFAULT 0 NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"result" jsonb,
+	"error_message" text,
+	"started_at" timestamp DEFAULT now() NOT NULL,
+	"completed_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "llm_requests" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"run_id" varchar,
+	"stage_execution_id" varchar,
+	"model_slug" text NOT NULL,
+	"provider" text NOT NULL,
+	"messages" jsonb NOT NULL,
+	"system_prompt" text,
+	"temperature" real,
+	"max_tokens" integer,
+	"response_content" text DEFAULT '' NOT NULL,
+	"input_tokens" integer DEFAULT 0 NOT NULL,
+	"output_tokens" integer DEFAULT 0 NOT NULL,
+	"total_tokens" integer DEFAULT 0 NOT NULL,
+	"latency_ms" integer DEFAULT 0 NOT NULL,
+	"estimated_cost_usd" real,
+	"status" text DEFAULT 'success' NOT NULL,
+	"error_message" text,
+	"team_id" text,
+	"tags" jsonb DEFAULT '[]'::jsonb,
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "maintenance_policies" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"workspace_id" varchar,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"schedule" text DEFAULT '0 9 * * 1' NOT NULL,
+	"categories" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"severity_threshold" text DEFAULT 'high' NOT NULL,
+	"auto_merge" boolean DEFAULT false NOT NULL,
+	"notify_channels" jsonb DEFAULT '[]'::jsonb,
+	"auto_trigger_pipeline_id" varchar,
+	"auto_trigger_enabled" boolean DEFAULT false NOT NULL,
+	"log_source_config" jsonb,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "maintenance_scans" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"policy_id" varchar,
+	"workspace_id" varchar,
+	"status" text DEFAULT 'running' NOT NULL,
+	"findings" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"important_count" integer DEFAULT 0 NOT NULL,
+	"triggered_pipeline_id" varchar,
+	"started_at" timestamp DEFAULT now(),
+	"completed_at" timestamp,
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "manager_iterations" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"run_id" varchar NOT NULL,
+	"iteration_number" integer NOT NULL,
+	"decision" jsonb NOT NULL,
+	"team_result" text,
+	"tokens_used" integer DEFAULT 0 NOT NULL,
+	"decision_duration_ms" integer DEFAULT 0 NOT NULL,
+	"team_duration_ms" integer,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "manager_iterations_run_iteration_unique" UNIQUE("run_id","iteration_number")
+);
+--> statement-breakpoint
+CREATE TABLE "mcp_servers" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"transport" text NOT NULL,
+	"command" text,
+	"args" jsonb,
+	"url" text,
+	"env" jsonb,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"auto_connect" boolean DEFAULT false NOT NULL,
+	"tool_count" integer DEFAULT 0,
+	"last_connected_at" timestamp,
+	"created_at" timestamp DEFAULT now(),
+	CONSTRAINT "mcp_servers_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+CREATE TABLE "memories" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"scope" text NOT NULL,
+	"scope_id" text,
+	"type" text NOT NULL,
+	"key" text NOT NULL,
+	"content" text NOT NULL,
+	"source" text,
+	"confidence" real DEFAULT 1 NOT NULL,
+	"tags" text[] DEFAULT '{}'::text[],
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now(),
+	"expires_at" timestamp,
+	"created_by_run_id" integer,
+	CONSTRAINT "memories_scope_scope_id_key_unique" UNIQUE("scope","scope_id","key")
+);
+--> statement-breakpoint
+CREATE TABLE "models" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"slug" text NOT NULL,
+	"model_id" text,
+	"endpoint" text,
+	"provider" text DEFAULT 'mock' NOT NULL,
+	"context_limit" integer DEFAULT 4096 NOT NULL,
+	"capabilities" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now(),
+	CONSTRAINT "models_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+CREATE TABLE "pipeline_runs" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"pipeline_id" varchar NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"input" text NOT NULL,
+	"output" jsonb,
+	"current_stage_index" integer DEFAULT 0 NOT NULL,
+	"started_at" timestamp,
+	"completed_at" timestamp,
+	"triggered_by" text,
+	"dag_mode" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "pipelines" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"stages" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"dag" jsonb,
+	"created_by" varchar,
+	"owner_id" text,
+	"is_template" boolean DEFAULT false NOT NULL,
+	"manager_config" jsonb,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "provider_keys" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"provider" text NOT NULL,
+	"api_key_encrypted" text NOT NULL,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now(),
+	CONSTRAINT "provider_keys_provider_unique" UNIQUE("provider")
+);
+--> statement-breakpoint
+CREATE TABLE "questions" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"run_id" varchar NOT NULL,
+	"stage_execution_id" varchar NOT NULL,
+	"question" text NOT NULL,
+	"context" text,
+	"answer" text,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"created_at" timestamp DEFAULT now(),
+	"answered_at" timestamp
+);
+--> statement-breakpoint
+CREATE TABLE "sessions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"token" text NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "sessions_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+CREATE TABLE "skill_versions" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"skill_id" varchar NOT NULL,
+	"version" text NOT NULL,
+	"config" jsonb NOT NULL,
+	"changelog" text DEFAULT '' NOT NULL,
+	"created_by" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "skill_versions_skill_id_version_unique" UNIQUE("skill_id","version")
+);
+--> statement-breakpoint
+CREATE TABLE "skills" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"description" text DEFAULT '' NOT NULL,
+	"team_id" text NOT NULL,
+	"system_prompt_override" text DEFAULT '' NOT NULL,
+	"tools" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"model_preference" text,
+	"output_schema" jsonb,
+	"tags" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"is_builtin" boolean DEFAULT false NOT NULL,
+	"is_public" boolean DEFAULT true NOT NULL,
+	"created_by" text DEFAULT 'system' NOT NULL,
+	"version" text DEFAULT '1.0.0' NOT NULL,
+	"sharing" text DEFAULT 'public' NOT NULL,
+	"usage_count" integer DEFAULT 0 NOT NULL,
+	"forked_from" varchar,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "specialization_profiles" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"is_built_in" boolean DEFAULT false NOT NULL,
+	"assignments" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "stage_executions" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"run_id" varchar NOT NULL,
+	"stage_index" integer NOT NULL,
+	"team_id" text NOT NULL,
+	"model_slug" text NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"input" jsonb NOT NULL,
+	"output" jsonb,
+	"tokens_used" integer DEFAULT 0,
+	"started_at" timestamp,
+	"completed_at" timestamp,
+	"sandbox_result" jsonb,
+	"thought_tree" jsonb,
+	"approval_status" text,
+	"approved_at" timestamp,
+	"approved_by" text,
+	"rejection_reason" text,
+	"dag_stage_id" text,
+	"swarm_clone_results" jsonb,
+	"swarm_meta" jsonb,
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "task_groups" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"description" text NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"input" text NOT NULL,
+	"output" jsonb,
+	"created_by" text,
+	"started_at" timestamp,
+	"completed_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "tasks" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"group_id" varchar NOT NULL,
+	"name" text NOT NULL,
+	"description" text NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"execution_mode" text DEFAULT 'direct_llm' NOT NULL,
+	"depends_on" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"pipeline_id" varchar,
+	"pipeline_run_id" varchar,
+	"model_slug" text,
+	"team_id" text,
+	"input" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"output" jsonb,
+	"summary" text,
+	"artifacts" jsonb,
+	"decisions" jsonb,
+	"error_message" text,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"started_at" timestamp,
+	"completed_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "traces" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"trace_id" text NOT NULL,
+	"run_id" varchar NOT NULL,
+	"spans" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "traces_trace_id_unique" UNIQUE("trace_id")
+);
+--> statement-breakpoint
+CREATE TABLE "triggers" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"pipeline_id" varchar NOT NULL,
+	"type" text NOT NULL,
+	"config" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"secret_encrypted" text,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"last_triggered_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" text PRIMARY KEY NOT NULL,
+	"email" text NOT NULL,
+	"name" text NOT NULL,
+	"password_hash" text NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"role" text DEFAULT 'user' NOT NULL,
+	"last_login_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now(),
+	CONSTRAINT "users_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+CREATE TABLE "workspace_symbols" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"workspace_id" varchar NOT NULL,
+	"file_path" text NOT NULL,
+	"name" text NOT NULL,
+	"kind" text NOT NULL,
+	"line" integer NOT NULL,
+	"col" integer DEFAULT 0 NOT NULL,
+	"signature" text,
+	"file_hash" text NOT NULL,
+	"exported_from" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "workspace_symbols_unique" UNIQUE("workspace_id","file_path","name","kind")
+);
+--> statement-breakpoint
+CREATE TABLE "workspaces" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"type" text NOT NULL,
+	"path" text NOT NULL,
+	"branch" text DEFAULT 'main' NOT NULL,
+	"status" text DEFAULT 'active' NOT NULL,
+	"last_sync_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"owner_id" text,
+	"index_status" text DEFAULT 'idle' NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "argocd_config" ADD CONSTRAINT "argocd_config_mcp_server_id_mcp_servers_id_fk" FOREIGN KEY ("mcp_server_id") REFERENCES "public"."mcp_servers"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "auto_trigger_audit" ADD CONSTRAINT "auto_trigger_audit_scan_id_maintenance_scans_id_fk" FOREIGN KEY ("scan_id") REFERENCES "public"."maintenance_scans"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "auto_trigger_audit" ADD CONSTRAINT "auto_trigger_audit_triggered_by_users_id_fk" FOREIGN KEY ("triggered_by") REFERENCES "public"."users"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "maintenance_policies" ADD CONSTRAINT "maintenance_policies_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "maintenance_scans" ADD CONSTRAINT "maintenance_scans_policy_id_maintenance_policies_id_fk" FOREIGN KEY ("policy_id") REFERENCES "public"."maintenance_policies"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "maintenance_scans" ADD CONSTRAINT "maintenance_scans_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "manager_iterations" ADD CONSTRAINT "manager_iterations_run_id_pipeline_runs_id_fk" FOREIGN KEY ("run_id") REFERENCES "public"."pipeline_runs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pipeline_runs" ADD CONSTRAINT "pipeline_runs_triggered_by_users_id_fk" FOREIGN KEY ("triggered_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pipelines" ADD CONSTRAINT "pipelines_owner_id_users_id_fk" FOREIGN KEY ("owner_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "skill_versions" ADD CONSTRAINT "skill_versions_skill_id_skills_id_fk" FOREIGN KEY ("skill_id") REFERENCES "public"."skills"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "task_groups" ADD CONSTRAINT "task_groups_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "tasks" ADD CONSTRAINT "tasks_group_id_task_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."task_groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "traces" ADD CONSTRAINT "traces_run_id_pipeline_runs_id_fk" FOREIGN KEY ("run_id") REFERENCES "public"."pipeline_runs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "triggers" ADD CONSTRAINT "triggers_pipeline_id_pipelines_id_fk" FOREIGN KEY ("pipeline_id") REFERENCES "public"."pipelines"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "workspace_symbols" ADD CONSTRAINT "workspace_symbols_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "workspaces" ADD CONSTRAINT "workspaces_owner_id_users_id_fk" FOREIGN KEY ("owner_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "manager_iterations_run_id_idx" ON "manager_iterations" USING btree ("run_id");--> statement-breakpoint
+CREATE INDEX "skill_versions_skill_id_idx" ON "skill_versions" USING btree ("skill_id");--> statement-breakpoint
+CREATE INDEX "tasks_group_id_idx" ON "tasks" USING btree ("group_id");--> statement-breakpoint
+CREATE INDEX "tasks_status_idx" ON "tasks" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "traces_trace_id_idx" ON "traces" USING btree ("trace_id");--> statement-breakpoint
+CREATE INDEX "traces_run_id_idx" ON "traces" USING btree ("run_id");--> statement-breakpoint
+CREATE INDEX "triggers_pipeline_id_idx" ON "triggers" USING btree ("pipeline_id");--> statement-breakpoint
+CREATE INDEX "triggers_enabled_type_idx" ON "triggers" USING btree ("enabled","type");--> statement-breakpoint
+CREATE INDEX "workspace_symbols_name_idx" ON "workspace_symbols" USING btree ("workspace_id","name");--> statement-breakpoint
+CREATE INDEX "workspace_symbols_file_idx" ON "workspace_symbols" USING btree ("workspace_id","file_path");--> statement-breakpoint
+CREATE INDEX "workspace_symbols_kind_idx" ON "workspace_symbols" USING btree ("workspace_id","kind");

--- a/migrations/meta/0000_snapshot.json
+++ b/migrations/meta/0000_snapshot.json
@@ -1,0 +1,2920 @@
+{
+  "id": "499cd358-0a0b-4191-bed3-f7f55151cc74",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.anonymization_log": {
+      "name": "anonymization_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entities_found": {
+          "name": "entities_found",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.anonymization_patterns": {
+      "name": "anonymization_patterns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom_pattern'"
+        },
+        "regex_pattern": {
+          "name": "regex_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'high'"
+        },
+        "pseudonym_template": {
+          "name": "pseudonym_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowlist": {
+          "name": "allowlist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.argocd_config": {
+      "name": "argocd_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_enc": {
+          "name": "token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verify_ssl": {
+          "name": "verify_ssl",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_health_check_at": {
+          "name": "last_health_check_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "health_status": {
+          "name": "health_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "health_error": {
+          "name": "health_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "argocd_config_mcp_server_id_mcp_servers_id_fk": {
+          "name": "argocd_config_mcp_server_id_mcp_servers_id_fk",
+          "tableFrom": "argocd_config",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auto_trigger_audit": {
+      "name": "auto_trigger_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_id": {
+          "name": "finding_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pipeline_run_id": {
+          "name": "pipeline_run_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auto_trigger_audit_scan_id_maintenance_scans_id_fk": {
+          "name": "auto_trigger_audit_scan_id_maintenance_scans_id_fk",
+          "tableFrom": "auto_trigger_audit",
+          "tableTo": "maintenance_scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "auto_trigger_audit_triggered_by_users_id_fk": {
+          "name": "auto_trigger_audit_triggered_by_users_id_fk",
+          "tableFrom": "auto_trigger_audit",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_team": {
+          "name": "agent_team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_slug": {
+          "name": "model_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.delegation_requests": {
+      "name": "delegation_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_stage": {
+          "name": "from_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_stage": {
+          "name": "to_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blocking'"
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30000
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_requests": {
+      "name": "llm_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage_execution_id": {
+          "name": "stage_execution_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_slug": {
+          "name": "model_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_content": {
+          "name": "response_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'success'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_policies": {
+      "name": "maintenance_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0 9 * * 1'"
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "severity_threshold": {
+          "name": "severity_threshold",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'high'"
+        },
+        "auto_merge": {
+          "name": "auto_merge",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_channels": {
+          "name": "notify_channels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "auto_trigger_pipeline_id": {
+          "name": "auto_trigger_pipeline_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_trigger_enabled": {
+          "name": "auto_trigger_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "log_source_config": {
+          "name": "log_source_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "maintenance_policies_workspace_id_workspaces_id_fk": {
+          "name": "maintenance_policies_workspace_id_workspaces_id_fk",
+          "tableFrom": "maintenance_policies",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maintenance_scans": {
+      "name": "maintenance_scans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "findings": {
+          "name": "findings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "important_count": {
+          "name": "important_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "triggered_pipeline_id": {
+          "name": "triggered_pipeline_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "maintenance_scans_policy_id_maintenance_policies_id_fk": {
+          "name": "maintenance_scans_policy_id_maintenance_policies_id_fk",
+          "tableFrom": "maintenance_scans",
+          "tableTo": "maintenance_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "maintenance_scans_workspace_id_workspaces_id_fk": {
+          "name": "maintenance_scans_workspace_id_workspaces_id_fk",
+          "tableFrom": "maintenance_scans",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.manager_iterations": {
+      "name": "manager_iterations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iteration_number": {
+          "name": "iteration_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_result": {
+          "name": "team_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "decision_duration_ms": {
+          "name": "decision_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "team_duration_ms": {
+          "name": "team_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "manager_iterations_run_id_idx": {
+          "name": "manager_iterations_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "manager_iterations_run_id_pipeline_runs_id_fk": {
+          "name": "manager_iterations_run_id_pipeline_runs_id_fk",
+          "tableFrom": "manager_iterations",
+          "tableTo": "pipeline_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "manager_iterations_run_iteration_unique": {
+          "name": "manager_iterations_run_iteration_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "iteration_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args": {
+          "name": "args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env": {
+          "name": "env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_connect": {
+          "name": "auto_connect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tool_count": {
+          "name": "tool_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_connected_at": {
+          "name": "last_connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_servers_name_unique": {
+          "name": "mcp_servers_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memories": {
+      "name": "memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_run_id": {
+          "name": "created_by_run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "memories_scope_scope_id_key_unique": {
+          "name": "memories_scope_scope_id_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "scope",
+            "scope_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.models": {
+      "name": "models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mock'"
+        },
+        "context_limit": {
+          "name": "context_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 4096
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "models_slug_unique": {
+          "name": "models_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipeline_runs": {
+      "name": "pipeline_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_stage_index": {
+          "name": "current_stage_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by": {
+          "name": "triggered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dag_mode": {
+          "name": "dag_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pipeline_runs_triggered_by_users_id_fk": {
+          "name": "pipeline_runs_triggered_by_users_id_fk",
+          "tableFrom": "pipeline_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pipelines": {
+      "name": "pipelines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stages": {
+          "name": "stages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "dag": {
+          "name": "dag",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_template": {
+          "name": "is_template",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "manager_config": {
+          "name": "manager_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pipelines_owner_id_users_id_fk": {
+          "name": "pipelines_owner_id_users_id_fk",
+          "tableFrom": "pipelines",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_keys": {
+      "name": "provider_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "provider_keys_provider_unique": {
+          "name": "provider_keys_provider_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_execution_id": {
+          "name": "stage_execution_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill_versions": {
+      "name": "skill_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changelog": {
+          "name": "changelog",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "skill_versions_skill_id_idx": {
+          "name": "skill_versions_skill_id_idx",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skill_versions_skill_id_skills_id_fk": {
+          "name": "skill_versions_skill_id_skills_id_fk",
+          "tableFrom": "skill_versions",
+          "tableTo": "skills",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skill_versions_skill_id_version_unique": {
+          "name": "skill_versions_skill_id_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "skill_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt_override": {
+          "name": "system_prompt_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tools": {
+          "name": "tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "model_preference": {
+          "name": "model_preference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        },
+        "sharing": {
+          "name": "sharing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "forked_from": {
+          "name": "forked_from",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.specialization_profiles": {
+      "name": "specialization_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_built_in": {
+          "name": "is_built_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "assignments": {
+          "name": "assignments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stage_executions": {
+      "name": "stage_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage_index": {
+          "name": "stage_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_slug": {
+          "name": "model_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_result": {
+          "name": "sandbox_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thought_tree": {
+          "name": "thought_tree",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approval_status": {
+          "name": "approval_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dag_stage_id": {
+          "name": "dag_stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "swarm_clone_results": {
+          "name": "swarm_clone_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "swarm_meta": {
+          "name": "swarm_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_groups": {
+      "name": "task_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_groups_created_by_users_id_fk": {
+          "name": "task_groups_created_by_users_id_fk",
+          "tableFrom": "task_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "execution_mode": {
+          "name": "execution_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'direct_llm'"
+        },
+        "depends_on": {
+          "name": "depends_on",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_run_id": {
+          "name": "pipeline_run_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_slug": {
+          "name": "model_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifacts": {
+          "name": "artifacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decisions": {
+          "name": "decisions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_group_id_idx": {
+          "name": "tasks_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_group_id_task_groups_id_fk": {
+          "name": "tasks_group_id_task_groups_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "task_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traces": {
+      "name": "traces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spans": {
+          "name": "spans",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "traces_trace_id_idx": {
+          "name": "traces_trace_id_idx",
+          "columns": [
+            {
+              "expression": "trace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "traces_run_id_idx": {
+          "name": "traces_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "traces_run_id_pipeline_runs_id_fk": {
+          "name": "traces_run_id_pipeline_runs_id_fk",
+          "tableFrom": "traces",
+          "tableTo": "pipeline_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "traces_trace_id_unique": {
+          "name": "traces_trace_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.triggers": {
+      "name": "triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "pipeline_id": {
+          "name": "pipeline_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "secret_encrypted": {
+          "name": "secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "triggers_pipeline_id_idx": {
+          "name": "triggers_pipeline_id_idx",
+          "columns": [
+            {
+              "expression": "pipeline_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "triggers_enabled_type_idx": {
+          "name": "triggers_enabled_type_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "triggers_pipeline_id_pipelines_id_fk": {
+          "name": "triggers_pipeline_id_pipelines_id_fk",
+          "tableFrom": "triggers",
+          "tableTo": "pipelines",
+          "columnsFrom": [
+            "pipeline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_symbols": {
+      "name": "workspace_symbols",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "col": {
+          "name": "col",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exported_from": {
+          "name": "exported_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspace_symbols_name_idx": {
+          "name": "workspace_symbols_name_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_symbols_file_idx": {
+          "name": "workspace_symbols_file_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspace_symbols_kind_idx": {
+          "name": "workspace_symbols_kind_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_symbols_workspace_id_workspaces_id_fk": {
+          "name": "workspace_symbols_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspace_symbols",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspace_symbols_unique": {
+          "name": "workspace_symbols_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "file_path",
+            "name",
+            "kind"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_sync_at": {
+          "name": "last_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_status": {
+          "name": "index_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspaces_owner_id_users_id_fk": {
+          "name": "workspaces_owner_id_users_id_fk",
+          "tableFrom": "workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1773906837951,
+      "tag": "0000_abandoned_skrulls",
+      "breakpoints": true
+    }
+  ]
+}

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,10 +1,28 @@
 import { drizzle } from "drizzle-orm/node-postgres";
+import { migrate } from "drizzle-orm/node-postgres/migrator";
 import { Pool } from "pg";
 import * as schema from "@shared/schema";
 import { configLoader } from "./config/loader";
+import path from "path";
 
 // database.url is optional — PgStorage will throw at query time if absent,
 // but importing this module is safe even when DATABASE_URL is not set (e.g. in tests).
 export const pool = new Pool({ connectionString: configLoader.get().database.url });
 
 export const db = drizzle(pool, { schema });
+
+/**
+ * Run pending Drizzle migrations on startup.
+ * Safe to call multiple times — already-applied migrations are skipped.
+ * Resolves silently when DATABASE_URL is not set (MemStorage mode).
+ */
+export async function runMigrations(): Promise<void> {
+  if (!configLoader.get().database.url) return;
+  try {
+    await migrate(db, { migrationsFolder: path.resolve(import.meta.dirname ?? __dirname, "../migrations") });
+    console.log("[db] migrations applied");
+  } catch (err) {
+    console.error("[db] migration failed:", err);
+    throw err;
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,7 @@ const config = configLoader.load();
 
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
+import { runMigrations } from "./db";
 import { serveStatic } from "./static";
 import { createServer } from "http";
 
@@ -66,6 +67,9 @@ app.use((req, res, next) => {
 });
 
 (async () => {
+  // Apply pending database migrations before starting the server
+  await runMigrations();
+
   await registerRoutes(httpServer, app);
 
   app.use((err: unknown, _req: Request, res: Response, next: NextFunction) => {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -41,6 +41,8 @@ import { tracer } from "./tracing/tracer";
 import { DEFAULT_MODELS, DEFAULT_PIPELINE_STAGES } from "@shared/constants";
 import { log } from "./index";
 import { registerArgoCdSettingsRoutes, autoConnectArgoCdFromEnv } from "./routes/argocd-settings";
+import { registerTaskGroupRoutes } from "./routes/task-groups";
+import { TaskOrchestrator } from "./services/task-orchestrator";
 
 export async function registerRoutes(
   httpServer: Server,
@@ -85,6 +87,7 @@ export async function registerRoutes(
   app.use("/api/guardrails", requireAuth);
   app.use("/api/triggers", requireAuth);
   app.use("/api/traces", requireAuth);
+  app.use("/api/task-groups", requireAuth);
 
   // Register route implementations
   registerModelRoutes(app, storage);
@@ -108,6 +111,10 @@ export async function registerRoutes(
   registerDAGRoutes(app, storage);
   registerTraceRoutes(app, storage);
   registerArgoCdSettingsRoutes(app as unknown as Router);
+
+  // Task Orchestrator
+  const taskOrchestrator = new TaskOrchestrator(storage, wsManager, controller, gateway);
+  registerTaskGroupRoutes(app, storage, taskOrchestrator);
 
   // Phase 6.3 — Trigger subsystem
   let triggerService: TriggerService | null = null;

--- a/server/routes/task-groups.ts
+++ b/server/routes/task-groups.ts
@@ -1,0 +1,130 @@
+import { Router } from "express";
+import { z } from "zod";
+import type { IStorage } from "../storage";
+import type { TaskOrchestrator } from "../services/task-orchestrator";
+import { validateBody } from "../middleware/validate.js";
+
+// ─── Validation Schemas ─────────────────────────────────────────────────────
+
+const CreateTaskGroupSchema = z.object({
+  name: z.string().min(1).max(200),
+  description: z.string().min(1).max(5000),
+  input: z.string().min(1).max(50000),
+  tasks: z
+    .array(
+      z.object({
+        name: z.string().min(1).max(200),
+        description: z.string().min(1).max(5000),
+        executionMode: z.enum(["pipeline_run", "direct_llm"]).optional(),
+        dependsOn: z.array(z.string().max(200)).max(50).optional(),
+        pipelineId: z.string().max(100).optional(),
+        modelSlug: z.string().max(100).optional(),
+        teamId: z.string().max(100).optional(),
+        input: z.record(z.unknown()).optional(),
+        sortOrder: z.number().int().min(0).max(1000).optional(),
+      }),
+    )
+    .min(1)
+    .max(100),
+});
+
+// ─── Route Registration ─────────────────────────────────────────────────────
+
+export function registerTaskGroupRoutes(
+  router: Router,
+  storage: IStorage,
+  orchestrator: TaskOrchestrator,
+) {
+  // List all task groups
+  router.get("/api/task-groups", async (_req, res) => {
+    try {
+      const groups = await storage.getTaskGroups();
+      // Attach task counts
+      const result = await Promise.all(
+        groups.map(async (g) => {
+          const tasks = await storage.getTasksByGroup(g.id);
+          return {
+            ...g,
+            taskCount: tasks.length,
+            completedCount: tasks.filter((t) => t.status === "completed").length,
+          };
+        }),
+      );
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  // Get single task group with all tasks
+  router.get("/api/task-groups/:id", async (req, res) => {
+    try {
+      const group = await storage.getTaskGroup(req.params.id);
+      if (!group) return res.status(404).json({ error: "Task group not found" });
+      const tasks = await storage.getTasksByGroup(group.id);
+      res.json({ ...group, tasks });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  // Create task group with tasks
+  router.post("/api/task-groups", validateBody(CreateTaskGroupSchema), async (req, res) => {
+    try {
+      const body = req.body as z.infer<typeof CreateTaskGroupSchema>;
+      const userId = (req as unknown as { user?: { id: string } }).user?.id;
+      const result = await orchestrator.createTaskGroup({
+        ...body,
+        createdBy: userId,
+      });
+      res.status(201).json({ ...result.group, tasks: result.tasks });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  // Start task group execution
+  router.post("/api/task-groups/:id/start", async (req, res) => {
+    try {
+      await orchestrator.startGroup(req.params.id);
+      const group = await storage.getTaskGroup(req.params.id);
+      res.json(group);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(400).json({ error: message });
+    }
+  });
+
+  // Cancel task group
+  router.post("/api/task-groups/:id/cancel", async (req, res) => {
+    try {
+      await orchestrator.cancelGroup(req.params.id);
+      const group = await storage.getTaskGroup(req.params.id);
+      res.json(group);
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  // Delete task group
+  router.delete("/api/task-groups/:id", async (req, res) => {
+    try {
+      await storage.deleteTaskGroup(req.params.id);
+      res.status(204).end();
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  // Retry a failed task
+  router.post("/api/task-groups/:id/tasks/:taskId/retry", async (req, res) => {
+    try {
+      await orchestrator.retryTask(req.params.taskId);
+      const task = await storage.getTask(req.params.taskId);
+      res.json(task);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(400).json({ error: message });
+    }
+  });
+}

--- a/server/services/task-orchestrator.ts
+++ b/server/services/task-orchestrator.ts
@@ -1,0 +1,441 @@
+import type { IStorage } from "../storage";
+import type { WsManager } from "../ws/manager";
+import type { PipelineController } from "../controller/pipeline-controller";
+import type { Gateway } from "../gateway/index";
+import type { TaskGroupRow, TaskRow, InsertTaskGroup, InsertTask } from "@shared/schema";
+import type { WsEvent, TaskResult } from "@shared/types";
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const MAX_CONCURRENT_TASKS = 5;
+const PIPELINE_POLL_INTERVAL_MS = 2000;
+const PIPELINE_POLL_TIMEOUT_MS = 600_000; // 10 min
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface CreateTaskGroupParams {
+  name: string;
+  description: string;
+  input: string;
+  tasks: Array<{
+    name: string;
+    description: string;
+    executionMode?: "pipeline_run" | "direct_llm";
+    dependsOn?: string[]; // task names within this group
+    pipelineId?: string;
+    modelSlug?: string;
+    teamId?: string;
+    input?: Record<string, unknown>;
+    sortOrder?: number;
+  }>;
+  createdBy?: string;
+}
+
+// ─── Task Orchestrator ──────────────────────────────────────────────────────
+
+export class TaskOrchestrator {
+  constructor(
+    private storage: IStorage,
+    private wsManager: WsManager,
+    private pipelineController: PipelineController,
+    private gateway: Gateway,
+  ) {}
+
+  /**
+   * Create a task group with tasks. Resolves task name references in
+   * dependsOn to IDs and computes initial statuses (ready / blocked).
+   */
+  async createTaskGroup(params: CreateTaskGroupParams): Promise<{ group: TaskGroupRow; tasks: TaskRow[] }> {
+    const group = await this.storage.createTaskGroup({
+      name: params.name,
+      description: params.description,
+      input: params.input,
+      status: "pending",
+      createdBy: params.createdBy ?? null,
+    } as InsertTaskGroup);
+
+    // First pass: create all tasks with placeholder dependsOn
+    const nameToId = new Map<string, string>();
+    const createdTasks: TaskRow[] = [];
+
+    for (let i = 0; i < params.tasks.length; i++) {
+      const t = params.tasks[i];
+      const task = await this.storage.createTask({
+        groupId: group.id,
+        name: t.name,
+        description: t.description,
+        executionMode: t.executionMode ?? "direct_llm",
+        dependsOn: [], // populated in second pass
+        pipelineId: t.pipelineId ?? null,
+        modelSlug: t.modelSlug ?? null,
+        teamId: t.teamId ?? null,
+        input: t.input ?? {},
+        sortOrder: t.sortOrder ?? i,
+        status: "pending",
+      } as InsertTask);
+      nameToId.set(t.name, task.id);
+      createdTasks.push(task);
+    }
+
+    // Second pass: resolve name → id for dependsOn and set initial status
+    for (let i = 0; i < params.tasks.length; i++) {
+      const paramTask = params.tasks[i];
+      const dbTask = createdTasks[i];
+      const resolvedDeps = (paramTask.dependsOn ?? [])
+        .map((name) => nameToId.get(name))
+        .filter((id): id is string => !!id);
+
+      const status = resolvedDeps.length === 0 ? "ready" : "blocked";
+      const updated = await this.storage.updateTask(dbTask.id, {
+        dependsOn: resolvedDeps,
+        status,
+      });
+      createdTasks[i] = updated;
+
+      this.broadcast(group.id, {
+        type: "task:created",
+        runId: group.id,
+        payload: { taskId: dbTask.id, name: dbTask.name, status, dependsOn: resolvedDeps },
+        timestamp: new Date().toISOString(),
+      });
+    }
+
+    return { group, tasks: createdTasks };
+  }
+
+  /**
+   * Start executing a task group — kicks off all ready tasks.
+   */
+  async startGroup(groupId: string): Promise<void> {
+    const group = await this.storage.getTaskGroup(groupId);
+    if (!group) throw new Error(`TaskGroup ${groupId} not found`);
+    if (group.status !== "pending") throw new Error(`TaskGroup ${groupId} is already ${group.status}`);
+
+    await this.storage.updateTaskGroup(groupId, { status: "running", startedAt: new Date() });
+
+    const allTasks = await this.storage.getTasksByGroup(groupId);
+    const readyTasks = allTasks.filter((t) => t.status === "ready");
+
+    this.broadcast(groupId, {
+      type: "taskgroup:started",
+      runId: groupId,
+      payload: { totalTasks: allTasks.length, readyTasks: readyTasks.length },
+      timestamp: new Date().toISOString(),
+    });
+
+    // Launch ready tasks (up to concurrency limit)
+    const batch = readyTasks.slice(0, MAX_CONCURRENT_TASKS);
+    await Promise.allSettled(batch.map((t) => this.executeTask(t, group)));
+  }
+
+  /**
+   * Cancel the entire group.
+   */
+  async cancelGroup(groupId: string): Promise<void> {
+    const allTasks = await this.storage.getTasksByGroup(groupId);
+    for (const t of allTasks) {
+      if (t.status === "running" || t.status === "ready" || t.status === "blocked") {
+        await this.storage.updateTask(t.id, { status: "cancelled" });
+      }
+    }
+    await this.storage.updateTaskGroup(groupId, { status: "cancelled", completedAt: new Date() });
+
+    this.broadcast(groupId, {
+      type: "taskgroup:failed",
+      runId: groupId,
+      payload: { error: "Cancelled by user" },
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  /**
+   * Retry a failed task.
+   */
+  async retryTask(taskId: string): Promise<void> {
+    const task = await this.storage.getTask(taskId);
+    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (task.status !== "failed") throw new Error(`Task ${taskId} is ${task.status}, not failed`);
+
+    const group = await this.storage.getTaskGroup(task.groupId);
+    if (!group) throw new Error(`TaskGroup ${task.groupId} not found`);
+
+    // Reset group to running if it was failed
+    if (group.status === "failed") {
+      await this.storage.updateTaskGroup(group.id, { status: "running", completedAt: null });
+    }
+
+    await this.storage.updateTask(taskId, {
+      status: "ready",
+      output: null,
+      summary: null,
+      errorMessage: null,
+      startedAt: null,
+      completedAt: null,
+    });
+
+    const freshTask = (await this.storage.getTask(taskId))!;
+    await this.executeTask(freshTask, group);
+  }
+
+  // ─── Private: execution ───────────────────────────────────────────────────
+
+  private async executeTask(task: TaskRow, group: TaskGroupRow): Promise<void> {
+    await this.storage.updateTask(task.id, { status: "running", startedAt: new Date() });
+
+    this.broadcast(group.id, {
+      type: "task:started",
+      runId: group.id,
+      payload: {
+        taskId: task.id,
+        name: task.name,
+        executionMode: task.executionMode,
+        modelSlug: task.modelSlug,
+      },
+      timestamp: new Date().toISOString(),
+    });
+
+    try {
+      let result: TaskResult;
+
+      if (task.executionMode === "pipeline_run" && task.pipelineId) {
+        result = await this.executePipelineRun(task, group);
+      } else {
+        result = await this.executeDirectLlm(task, group);
+      }
+
+      await this.storage.updateTask(task.id, {
+        status: "completed",
+        output: result.output ?? null,
+        summary: result.summary,
+        artifacts: result.artifacts ?? null,
+        decisions: result.decisions ?? null,
+        completedAt: new Date(),
+      });
+
+      this.broadcast(group.id, {
+        type: "task:completed",
+        runId: group.id,
+        payload: {
+          taskId: task.id,
+          name: task.name,
+          summary: result.summary,
+          artifacts: result.artifacts,
+          decisions: result.decisions,
+        },
+        timestamp: new Date().toISOString(),
+      });
+
+      await this.onTaskCompleted(task);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      await this.onTaskFailed(task, errorMessage);
+    }
+  }
+
+  private async executeDirectLlm(task: TaskRow, group: TaskGroupRow): Promise<TaskResult> {
+    // Assemble context from completed dependency outputs
+    const allTasks = await this.storage.getTasksByGroup(group.id);
+    const depOutputs: Record<string, unknown> = {};
+    for (const depId of task.dependsOn as string[]) {
+      const dep = allTasks.find((t) => t.id === depId);
+      if (dep?.output) depOutputs[dep.name] = dep.output;
+    }
+
+    const systemPrompt = `You are completing a task as part of a larger task group.
+Task group: ${group.name}
+Overall objective: ${group.input}
+
+Your specific task: ${task.name}
+Description: ${task.description}
+
+${Object.keys(depOutputs).length > 0
+  ? `Results from prerequisite tasks:\n${JSON.stringify(depOutputs, null, 2)}`
+  : ""}
+
+Respond with a JSON object:
+{
+  "summary": "Brief summary of what was accomplished",
+  "output": { ... any structured output ... },
+  "decisions": ["key decision 1", "key decision 2"]
+}`;
+
+    const modelSlug = task.modelSlug ?? "mock";
+    const response = await this.gateway.complete({
+      modelSlug,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: typeof task.input === "string" ? task.input : JSON.stringify(task.input) },
+      ],
+      temperature: 0.7,
+      maxTokens: 4096,
+    });
+
+    // Try to parse structured response
+    try {
+      const parsed = JSON.parse(response.content);
+      return {
+        summary: parsed.summary ?? response.content.slice(0, 200),
+        output: parsed.output ?? { raw: response.content },
+        decisions: parsed.decisions ?? [],
+        artifacts: parsed.artifacts,
+      };
+    } catch {
+      return {
+        summary: response.content.slice(0, 200),
+        output: { raw: response.content },
+      };
+    }
+  }
+
+  private async executePipelineRun(task: TaskRow, group: TaskGroupRow): Promise<TaskResult> {
+    const inputText = typeof task.input === "string" ? task.input : JSON.stringify(task.input);
+    const run = await this.pipelineController.startRun(task.pipelineId!, inputText);
+
+    await this.storage.updateTask(task.id, { pipelineRunId: run.id });
+
+    // Poll for completion
+    const result = await this.pollRunCompletion(run.id);
+    return {
+      summary: typeof result === "string" ? result.slice(0, 200) : JSON.stringify(result).slice(0, 200),
+      output: typeof result === "object" && result !== null ? result as Record<string, unknown> : { raw: result },
+    };
+  }
+
+  private pollRunCompletion(runId: string): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const startTime = Date.now();
+
+      const poll = async () => {
+        const run = await this.storage.getPipelineRun(runId);
+        if (!run) {
+          reject(new Error(`Pipeline run ${runId} not found`));
+          return;
+        }
+
+        if (run.status === "completed") {
+          resolve(run.output);
+          return;
+        }
+        if (run.status === "failed" || run.status === "cancelled" || run.status === "rejected") {
+          reject(new Error(`Pipeline run ${runId} ended with status: ${run.status}`));
+          return;
+        }
+
+        if (Date.now() - startTime > PIPELINE_POLL_TIMEOUT_MS) {
+          reject(new Error(`Pipeline run ${runId} timed out after ${PIPELINE_POLL_TIMEOUT_MS}ms`));
+          return;
+        }
+
+        setTimeout(poll, PIPELINE_POLL_INTERVAL_MS);
+      };
+
+      poll();
+    });
+  }
+
+  // ─── Private: dependency resolution ───────────────────────────────────────
+
+  private async onTaskCompleted(task: TaskRow): Promise<void> {
+    const groupId = task.groupId;
+    const allTasks = await this.storage.getTasksByGroup(groupId);
+    const completedIds = new Set(allTasks.filter((t) => t.status === "completed").map((t) => t.id));
+
+    // Find blocked tasks that can now be unblocked
+    const newlyReady: TaskRow[] = [];
+    for (const t of allTasks) {
+      if (t.status !== "blocked") continue;
+      const deps = t.dependsOn as string[];
+      if (deps.every((depId) => completedIds.has(depId))) {
+        const updated = await this.storage.updateTask(t.id, { status: "ready" });
+        newlyReady.push(updated);
+        this.broadcast(groupId, {
+          type: "task:ready",
+          runId: groupId,
+          payload: { taskId: t.id, name: t.name },
+          timestamp: new Date().toISOString(),
+        });
+      }
+    }
+
+    // Broadcast progress
+    const completedCount = allTasks.filter((t) => t.status === "completed").length;
+    const runningCount = allTasks.filter((t) => t.status === "running").length;
+    this.broadcast(groupId, {
+      type: "taskgroup:progress",
+      runId: groupId,
+      payload: { completed: completedCount, total: allTasks.length, running: runningCount },
+      timestamp: new Date().toISOString(),
+    });
+
+    // Launch newly ready tasks
+    const group = (await this.storage.getTaskGroup(groupId))!;
+    const activeTasks = allTasks.filter((t) => t.status === "running").length;
+    const slotsAvailable = MAX_CONCURRENT_TASKS - activeTasks;
+    const batch = newlyReady.slice(0, Math.max(0, slotsAvailable));
+    await Promise.allSettled(batch.map((t) => this.executeTask(t, group)));
+
+    // Check if group is complete
+    await this.checkGroupCompletion(groupId);
+  }
+
+  private async onTaskFailed(task: TaskRow, error: string): Promise<void> {
+    await this.storage.updateTask(task.id, {
+      status: "failed",
+      errorMessage: error,
+      completedAt: new Date(),
+    });
+
+    this.broadcast(task.groupId, {
+      type: "task:failed",
+      runId: task.groupId,
+      payload: { taskId: task.id, name: task.name, error },
+      timestamp: new Date().toISOString(),
+    });
+
+    // Fail the group
+    await this.storage.updateTaskGroup(task.groupId, { status: "failed", completedAt: new Date() });
+
+    this.broadcast(task.groupId, {
+      type: "taskgroup:failed",
+      runId: task.groupId,
+      payload: { error, failedTaskId: task.id, failedTaskName: task.name },
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  private async checkGroupCompletion(groupId: string): Promise<void> {
+    const allTasks = await this.storage.getTasksByGroup(groupId);
+    const allDone = allTasks.every((t) => t.status === "completed" || t.status === "cancelled");
+    if (!allDone) return;
+
+    // Aggregate output
+    const summaries = allTasks
+      .filter((t) => t.status === "completed" && t.summary)
+      .map((t) => `- ${t.name}: ${t.summary}`);
+
+    const output = {
+      taskCount: allTasks.length,
+      completedCount: allTasks.filter((t) => t.status === "completed").length,
+      summaries: summaries.join("\n"),
+    };
+
+    await this.storage.updateTaskGroup(groupId, {
+      status: "completed",
+      output,
+      completedAt: new Date(),
+    });
+
+    this.broadcast(groupId, {
+      type: "taskgroup:completed",
+      runId: groupId,
+      payload: { totalTasks: allTasks.length, completedTasks: output.completedCount, output },
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  // ─── Private: WebSocket broadcast ─────────────────────────────────────────
+
+  private broadcast(groupId: string, event: WsEvent): void {
+    this.wsManager.broadcastToRun(groupId, event);
+  }
+}

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -31,6 +31,12 @@ import {
   type TriggerRow,
   type InsertTrace,
   type TraceRow,
+  taskGroups,
+  tasks,
+  type TaskGroupRow,
+  type InsertTaskGroup,
+  type TaskRow,
+  type InsertTask,
 } from "@shared/schema";
 import type { TraceSpan, SkillVersionRecord, MarketplaceSkill, MarketplaceFilters, InsertSkillVersion } from "@shared/types";
 
@@ -982,6 +988,66 @@ export class PgStorage implements IStorage {
     await db.update(traces)
       .set({ spans: spans as TraceRow["spans"], updatedAt: new Date() })
       .where(eq(traces.traceId, traceId));
+  }
+
+  // ─── Task Groups (Task Orchestrator) ────────────────────────────────────────
+
+  async getTaskGroups(): Promise<TaskGroupRow[]> {
+    return db.select().from(taskGroups).orderBy(desc(taskGroups.createdAt));
+  }
+
+  async getTaskGroup(id: string): Promise<TaskGroupRow | undefined> {
+    const [row] = await db.select().from(taskGroups).where(eq(taskGroups.id, id));
+    return row;
+  }
+
+  async createTaskGroup(data: InsertTaskGroup): Promise<TaskGroupRow> {
+    const [row] = await db.insert(taskGroups).values(data as typeof taskGroups.$inferInsert).returning();
+    return row;
+  }
+
+  async updateTaskGroup(id: string, updates: Partial<TaskGroupRow>): Promise<TaskGroupRow> {
+    const [row] = await db.update(taskGroups).set(updates).where(eq(taskGroups.id, id)).returning();
+    return row;
+  }
+
+  async deleteTaskGroup(id: string): Promise<void> {
+    await db.delete(taskGroups).where(eq(taskGroups.id, id));
+  }
+
+  // ─── Tasks (Task Orchestrator) ──────────────────────────────────────────────
+
+  async getTasksByGroup(groupId: string): Promise<TaskRow[]> {
+    return db.select().from(tasks)
+      .where(eq(tasks.groupId, groupId))
+      .orderBy(asc(tasks.sortOrder), asc(tasks.createdAt));
+  }
+
+  async getTask(id: string): Promise<TaskRow | undefined> {
+    const [row] = await db.select().from(tasks).where(eq(tasks.id, id));
+    return row;
+  }
+
+  async createTask(data: InsertTask): Promise<TaskRow> {
+    const [row] = await db.insert(tasks).values(data as typeof tasks.$inferInsert).returning();
+    return row;
+  }
+
+  async updateTask(id: string, updates: Partial<TaskRow>): Promise<TaskRow> {
+    const [row] = await db.update(tasks).set(updates).where(eq(tasks.id, id)).returning();
+    return row;
+  }
+
+  async getReadyTasks(groupId: string): Promise<TaskRow[]> {
+    return db.select().from(tasks)
+      .where(and(eq(tasks.groupId, groupId), eq(tasks.status, "ready")))
+      .orderBy(asc(tasks.sortOrder));
+  }
+
+  async getBlockedTasks(groupId: string): Promise<TaskRow[]> {
+    return db.select().from(tasks)
+      .where(and(eq(tasks.groupId, groupId), eq(tasks.status, "blocked")))
+      .orderBy(asc(tasks.sortOrder));
   }
 
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -28,6 +28,10 @@ import {
   type TraceRow,
   type SkillVersionRow,
   type InsertSkillVersion,
+  type TaskGroupRow,
+  type InsertTaskGroup,
+  type TaskRow,
+  type InsertTask,
 } from "@shared/schema";
 import type { Memory, InsertMemory, MemoryScope, MemoryType, McpServerConfig, TraceSpan, SkillVersionRecord, MarketplaceSkill, MarketplaceFilters, InsertSkillVersion as InsertSkillVersionType } from "@shared/types";
 import { randomUUID } from "crypto";
@@ -211,6 +215,20 @@ export interface IStorage {
   getTraces(limit?: number, offset?: number): Promise<TraceRow[]>;
   updateTraceSpans(traceId: string, spans: TraceSpan[]): Promise<void>;
 
+  // Task Groups (Task Orchestrator)
+  getTaskGroups(): Promise<TaskGroupRow[]>;
+  getTaskGroup(id: string): Promise<TaskGroupRow | undefined>;
+  createTaskGroup(data: InsertTaskGroup): Promise<TaskGroupRow>;
+  updateTaskGroup(id: string, updates: Partial<TaskGroupRow>): Promise<TaskGroupRow>;
+  deleteTaskGroup(id: string): Promise<void>;
+
+  // Tasks (Task Orchestrator)
+  getTasksByGroup(groupId: string): Promise<TaskRow[]>;
+  getTask(id: string): Promise<TaskRow | undefined>;
+  createTask(data: InsertTask): Promise<TaskRow>;
+  updateTask(id: string, updates: Partial<TaskRow>): Promise<TaskRow>;
+  getReadyTasks(groupId: string): Promise<TaskRow[]>;
+  getBlockedTasks(groupId: string): Promise<TaskRow[]>;
 }
 
 export class MemStorage implements IStorage {
@@ -1244,6 +1262,102 @@ export class MemStorage implements IStorage {
     const updated: TraceRow = { ...row, spans: spans as TraceSpan[], updatedAt: new Date() };
     this.tracesById.set(traceId, updated);
     this.tracesByRunId.set(row.runId, updated);
+  }
+
+  // ─── Task Groups (Task Orchestrator) — MemStorage stubs ─────────────────────
+
+  private taskGroupsMap = new Map<string, TaskGroupRow>();
+  private tasksMap = new Map<string, TaskRow>();
+
+  async getTaskGroups(): Promise<TaskGroupRow[]> {
+    return Array.from(this.taskGroupsMap.values()).sort(
+      (a, b) => (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0),
+    );
+  }
+
+  async getTaskGroup(id: string): Promise<TaskGroupRow | undefined> {
+    return this.taskGroupsMap.get(id);
+  }
+
+  async createTaskGroup(data: InsertTaskGroup): Promise<TaskGroupRow> {
+    const id = randomUUID();
+    const row: TaskGroupRow = { id, name: data.name, description: data.description, input: data.input, status: (data.status as TaskGroupRow["status"]) ?? "pending", output: data.output ?? null, createdBy: data.createdBy ?? null, startedAt: data.startedAt ?? null, completedAt: data.completedAt ?? null, createdAt: new Date() };
+    this.taskGroupsMap.set(id, row);
+    return row;
+  }
+
+  async updateTaskGroup(id: string, updates: Partial<TaskGroupRow>): Promise<TaskGroupRow> {
+    const existing = this.taskGroupsMap.get(id);
+    if (!existing) throw new Error(`TaskGroup ${id} not found`);
+    const updated = { ...existing, ...updates };
+    this.taskGroupsMap.set(id, updated);
+    return updated;
+  }
+
+  async deleteTaskGroup(id: string): Promise<void> {
+    this.taskGroupsMap.delete(id);
+    for (const [tid, t] of this.tasksMap) {
+      if (t.groupId === id) this.tasksMap.delete(tid);
+    }
+  }
+
+  async getTasksByGroup(groupId: string): Promise<TaskRow[]> {
+    return Array.from(this.tasksMap.values())
+      .filter((t) => t.groupId === groupId)
+      .sort((a, b) => a.sortOrder - b.sortOrder);
+  }
+
+  async getTask(id: string): Promise<TaskRow | undefined> {
+    return this.tasksMap.get(id);
+  }
+
+  async createTask(data: InsertTask): Promise<TaskRow> {
+    const id = randomUUID();
+    const row: TaskRow = {
+      id,
+      groupId: data.groupId,
+      name: data.name,
+      description: data.description,
+      status: (data.status as TaskRow["status"]) ?? "pending",
+      executionMode: (data.executionMode as TaskRow["executionMode"]) ?? "direct_llm",
+      dependsOn: data.dependsOn ?? [],
+      input: data.input ?? {},
+      sortOrder: data.sortOrder ?? 0,
+      pipelineId: data.pipelineId ?? null,
+      pipelineRunId: data.pipelineRunId ?? null,
+      modelSlug: data.modelSlug ?? null,
+      teamId: data.teamId ?? null,
+      output: data.output ?? null,
+      summary: data.summary ?? null,
+      artifacts: data.artifacts ?? null,
+      decisions: data.decisions ?? null,
+      errorMessage: data.errorMessage ?? null,
+      startedAt: data.startedAt ?? null,
+      completedAt: data.completedAt ?? null,
+      createdAt: new Date(),
+    };
+    this.tasksMap.set(id, row);
+    return row;
+  }
+
+  async updateTask(id: string, updates: Partial<TaskRow>): Promise<TaskRow> {
+    const existing = this.tasksMap.get(id);
+    if (!existing) throw new Error(`Task ${id} not found`);
+    const updated = { ...existing, ...updates };
+    this.tasksMap.set(id, updated);
+    return updated;
+  }
+
+  async getReadyTasks(groupId: string): Promise<TaskRow[]> {
+    return Array.from(this.tasksMap.values())
+      .filter((t) => t.groupId === groupId && t.status === "ready")
+      .sort((a, b) => a.sortOrder - b.sortOrder);
+  }
+
+  async getBlockedTasks(groupId: string): Promise<TaskRow[]> {
+    return Array.from(this.tasksMap.values())
+      .filter((t) => t.groupId === groupId && t.status === "blocked")
+      .sort((a, b) => a.sortOrder - b.sortOrder);
   }
 
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -743,3 +743,82 @@ export const insertWorkspaceSymbolSchema = createInsertSchema(workspaceSymbols).
 
 export type InsertWorkspaceSymbol = z.infer<typeof insertWorkspaceSymbolSchema>;
 export type WorkspaceSymbolRow = typeof workspaceSymbols.$inferSelect;
+
+// ─── Task Groups (Task Orchestrator) ────────────────────────────────────────
+
+export const TASK_GROUP_STATUSES = ["pending", "running", "completed", "failed", "cancelled"] as const;
+export type TaskGroupStatus = typeof TASK_GROUP_STATUSES[number];
+
+export const taskGroups = pgTable("task_groups", {
+  id: varchar("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()`),
+  name: text("name").notNull(),
+  description: text("description").notNull(),
+  status: text("status").notNull().default("pending").$type<TaskGroupStatus>(),
+  input: text("input").notNull(),
+  output: jsonb("output"),
+  createdBy: text("created_by").references(() => users.id, { onDelete: "set null" }),
+  startedAt: timestamp("started_at"),
+  completedAt: timestamp("completed_at"),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+});
+
+export const insertTaskGroupSchema = createInsertSchema(taskGroups).omit({
+  id: true,
+  createdAt: true,
+});
+
+export type InsertTaskGroup = z.infer<typeof insertTaskGroupSchema>;
+export type TaskGroupRow = typeof taskGroups.$inferSelect;
+
+// ─── Tasks (Task Orchestrator) ──────────────────────────────────────────────
+
+export const TASK_STATUSES = ["pending", "blocked", "ready", "running", "completed", "failed", "cancelled"] as const;
+export type TaskStatus = typeof TASK_STATUSES[number];
+
+export const TASK_EXECUTION_MODES = ["pipeline_run", "direct_llm"] as const;
+export type TaskExecutionMode = typeof TASK_EXECUTION_MODES[number];
+
+export const tasks = pgTable(
+  "tasks",
+  {
+    id: varchar("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    groupId: varchar("group_id")
+      .notNull()
+      .references(() => taskGroups.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    description: text("description").notNull(),
+    status: text("status").notNull().default("pending").$type<TaskStatus>(),
+    executionMode: text("execution_mode").notNull().default("direct_llm").$type<TaskExecutionMode>(),
+    dependsOn: jsonb("depends_on").notNull().default(sql`'[]'::jsonb`).$type<string[]>(),
+    pipelineId: varchar("pipeline_id"),
+    pipelineRunId: varchar("pipeline_run_id"),
+    modelSlug: text("model_slug"),
+    teamId: text("team_id"),
+    input: jsonb("input").notNull().default(sql`'{}'::jsonb`),
+    output: jsonb("output"),
+    summary: text("summary"),
+    artifacts: jsonb("artifacts").$type<Record<string, unknown>[]>(),
+    decisions: jsonb("decisions").$type<string[]>(),
+    errorMessage: text("error_message"),
+    sortOrder: integer("sort_order").notNull().default(0),
+    startedAt: timestamp("started_at"),
+    completedAt: timestamp("completed_at"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (table) => ({
+    groupIdIdx: index("tasks_group_id_idx").on(table.groupId),
+    statusIdx: index("tasks_status_idx").on(table.status),
+  }),
+);
+
+export const insertTaskSchema = createInsertSchema(tasks).omit({
+  id: true,
+  createdAt: true,
+});
+
+export type InsertTask = z.infer<typeof insertTaskSchema>;
+export type TaskRow = typeof tasks.$inferSelect;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -300,7 +300,18 @@ export type WsEventType =
   | "workspace:index_start"
   | "workspace:index_progress"
   | "workspace:index_complete"
-  | "workspace:index_error";
+  | "workspace:index_error"
+  // ─── Task Orchestrator Events ───────────────────────────────────────────────
+  | "task:created"
+  | "task:ready"
+  | "task:started"
+  | "task:progress"
+  | "task:completed"
+  | "task:failed"
+  | "taskgroup:started"
+  | "taskgroup:progress"
+  | "taskgroup:completed"
+  | "taskgroup:failed";
 
 export interface WsEvent {
   type: WsEventType;
@@ -1429,6 +1440,21 @@ export interface InsertSkillVersion {
   config: SkillVersionConfig;
   changelog: string;
   createdBy: string;
+}
+
+// ─── Platform Version Types ────────────────────────────────────────────────────
+
+// ─── Task Orchestrator Types ───────────────────────────────────────────────
+
+export type TaskGroupStatus = "pending" | "running" | "completed" | "failed" | "cancelled";
+export type TaskStatus = "pending" | "blocked" | "ready" | "running" | "completed" | "failed" | "cancelled";
+export type TaskExecutionMode = "pipeline_run" | "direct_llm";
+
+export interface TaskResult {
+  summary: string;
+  artifacts?: Record<string, unknown>[];
+  decisions?: string[];
+  output?: Record<string, unknown>;
 }
 
 // ─── Platform Version Types ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Task Orchestrator** — new module above pipelines that coordinates large tasks split across multiple models/agents
- **Event-driven dependency graph** — tasks complete → dependents auto-unblock → execute (up to 5 concurrent)
- **Real-time activity stream** — 10 new WebSocket events for live progress tracking
- **Auto-migrate on startup** — `drizzle-orm/migrator` runs pending migrations before server starts

## What's included

### Backend
- `task_groups` + `tasks` DB tables with indexes (Drizzle schema)
- `TaskOrchestrator` service — dependency resolution, `direct_llm` and `pipeline_run` execution modes
- REST API: `POST/GET/DELETE /api/task-groups`, `POST .../start`, `POST .../cancel`, `POST .../tasks/:id/retry`
- IStorage + PgStorage + MemStorage implementations
- Server auto-migration via `runMigrations()` in `server/db.ts`

### Frontend
- `useTaskGroups` / `useTaskGroupEvents` hooks (React Query + WebSocket)
- `TaskGroupList` page — list with status badges, task counts
- `TaskGroup` detail page — task list with dependency info, activity stream, progress bar
- Sidebar nav link (ListChecks icon)

## How it works

```
POST /api/task-groups  →  create group + tasks with dependsOn (by name)
POST /api/task-groups/:id/start  →  launch all ready tasks
                                     ↓
                              task:started WS event
                              task:completed WS event → resolve blocked tasks
                              taskgroup:completed WS event
```

## Test plan

- [ ] Create task group via API with 3-4 tasks and dependencies
- [ ] Start group — verify ready tasks execute, blocked tasks wait
- [ ] Verify WebSocket events arrive on frontend
- [ ] Verify dependent tasks unblock after prerequisites complete
- [ ] Test retry of failed task
- [ ] Verify auto-migration on fresh DB startup
- [ ] `npx tsc --noEmit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)