### PR TITLE
feat(skills): per-model skill assignment — bind skills to specific LLM models

### DIFF
--- a/client/src/components/skills/ModelSkillsTab.tsx
+++ b/client/src/components/skills/ModelSkillsTab.tsx
@@ -1,0 +1,368 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Cpu, Plus, Trash2, X } from "lucide-react";
+import { DEFAULT_MODELS } from "@shared/constants";
+import { useSkills } from "@/hooks/use-skills";
+import {
+  useModelSkills,
+  useModelsWithSkills,
+  useBindSkillToModel,
+  useUnbindSkillFromModel,
+} from "@/hooks/use-model-skill-bindings";
+import { useToast } from "@/hooks/use-toast";
+import type { Skill } from "@shared/schema";
+
+// ─── Known models catalogue ───────────────────────────────────────────────────
+
+interface KnownModel {
+  id: string;
+  label: string;
+  provider: string;
+}
+
+const CATALOGUE: KnownModel[] = DEFAULT_MODELS.map((m) => ({
+  id: "modelId" in m && m.modelId ? (m.modelId as string) : m.slug,
+  label: m.name,
+  provider: m.provider,
+}));
+
+const CATALOGUE_BY_PROVIDER: Record<string, KnownModel[]> = {};
+for (const model of CATALOGUE) {
+  (CATALOGUE_BY_PROVIDER[model.provider] ??= []).push(model);
+}
+const PROVIDER_ORDER = ["anthropic", "google", "xai", "mock"] as const;
+
+// ─── Add-Skill Dialog ─────────────────────────────────────────────────────────
+
+interface AddSkillDialogProps {
+  modelId: string;
+  boundSkillIds: Set<string>;
+  open: boolean;
+  onClose: () => void;
+}
+
+function AddSkillDialog({ modelId, boundSkillIds, open, onClose }: AddSkillDialogProps) {
+  const { toast } = useToast();
+  const { data: allSkills = [] } = useSkills();
+  const bind = useBindSkillToModel();
+  const [selectedSkillId, setSelectedSkillId] = useState("");
+
+  const available = allSkills.filter((s) => !boundSkillIds.has(s.id));
+
+  function handleClose() {
+    setSelectedSkillId("");
+    onClose();
+  }
+
+  async function handleAdd() {
+    if (!selectedSkillId) return;
+    try {
+      await bind.mutateAsync({ modelId, skillId: selectedSkillId });
+      toast({ title: "Skill bound to model" });
+      handleClose();
+    } catch (err) {
+      toast({
+        title: "Failed to bind skill",
+        description: err instanceof Error ? err.message : "Unknown error",
+        variant: "destructive",
+      });
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && handleClose()}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="text-base">Add Skill to Model</DialogTitle>
+        </DialogHeader>
+        <div className="py-2">
+          <p className="text-xs text-muted-foreground mb-3">
+            Select a skill to bind to <span className="font-mono font-medium text-foreground">{modelId}</span>.
+          </p>
+          {available.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-4">
+              All available skills are already bound.
+            </p>
+          ) : (
+            <Select value={selectedSkillId} onValueChange={setSelectedSkillId}>
+              <SelectTrigger className="h-8 text-sm">
+                <SelectValue placeholder="Select a skill..." />
+              </SelectTrigger>
+              <SelectContent>
+                {available.map((s) => (
+                  <SelectItem key={s.id} value={s.id}>
+                    <span>{s.name}</span>
+                    {s.teamId && (
+                      <span className="ml-2 text-xs text-muted-foreground">({s.teamId})</span>
+                    )}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+        <DialogFooter className="gap-2">
+          <Button variant="ghost" size="sm" onClick={handleClose} disabled={bind.isPending}>
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleAdd}
+            disabled={!selectedSkillId || bind.isPending || available.length === 0}
+          >
+            {bind.isPending ? "Binding..." : "Add Skill"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─── Model Skill Row ──────────────────────────────────────────────────────────
+
+interface ModelSkillRowProps {
+  skill: Skill;
+  modelId: string;
+}
+
+function ModelSkillRow({ skill, modelId }: ModelSkillRowProps) {
+  const { toast } = useToast();
+  const unbind = useUnbindSkillFromModel();
+
+  async function handleUnbind() {
+    if (!confirm(`Remove skill "${skill.name}" from this model?`)) return;
+    try {
+      await unbind.mutateAsync({ modelId, skillId: skill.id });
+      toast({ title: "Skill unbound" });
+    } catch (err) {
+      toast({
+        title: "Failed to unbind skill",
+        description: err instanceof Error ? err.message : "Unknown error",
+        variant: "destructive",
+      });
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-between px-3 py-2 rounded-md border border-border bg-card hover:bg-muted/30 transition-colors">
+      <div className="min-w-0">
+        <p className="text-sm font-medium truncate">{skill.name}</p>
+        {skill.description && (
+          <p className="text-xs text-muted-foreground truncate">{skill.description}</p>
+        )}
+        <div className="flex flex-wrap gap-1 mt-1">
+          {(skill.tags as string[]).slice(0, 3).map((tag) => (
+            <Badge key={tag} variant="secondary" className="text-[10px] px-1.5 py-0">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+      </div>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-7 w-7 text-muted-foreground hover:text-destructive shrink-0 ml-2"
+        onClick={handleUnbind}
+        disabled={unbind.isPending}
+        aria-label="Unbind skill"
+      >
+        <X className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+}
+
+// ─── Model Panel ──────────────────────────────────────────────────────────────
+
+interface ModelPanelProps {
+  modelId: string;
+  label: string;
+}
+
+function ModelPanel({ modelId, label }: ModelPanelProps) {
+  const { data: boundSkills = [], isLoading } = useModelSkills(modelId);
+  const [addOpen, setAddOpen] = useState(false);
+  const boundSkillIds = new Set(boundSkills.map((s) => s.id));
+
+  return (
+    <div className="rounded-lg border border-border bg-card">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+        <div>
+          <p className="text-sm font-semibold">{label}</p>
+          <p className="text-xs font-mono text-muted-foreground">{modelId}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">
+            {boundSkills.length} skill{boundSkills.length !== 1 ? "s" : ""}
+          </span>
+          <Button size="sm" variant="outline" className="gap-1.5 h-7 text-xs" onClick={() => setAddOpen(true)}>
+            <Plus className="h-3 w-3" />
+            Add
+          </Button>
+        </div>
+      </div>
+
+      <div className="p-3 space-y-2">
+        {isLoading ? (
+          <>
+            <Skeleton className="h-12 rounded-md" />
+            <Skeleton className="h-12 rounded-md" />
+          </>
+        ) : boundSkills.length === 0 ? (
+          <p className="text-xs text-muted-foreground text-center py-4">
+            No skills bound to this model yet.
+          </p>
+        ) : (
+          boundSkills.map((skill) => (
+            <ModelSkillRow key={skill.id} skill={skill} modelId={modelId} />
+          ))
+        )}
+      </div>
+
+      <AddSkillDialog
+        modelId={modelId}
+        boundSkillIds={boundSkillIds}
+        open={addOpen}
+        onClose={() => setAddOpen(false)}
+      />
+    </div>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+export function ModelSkillsTab() {
+  const { data: activeModelIds = [], isLoading: loadingActive } = useModelsWithSkills();
+  const [selectedModelId, setSelectedModelId] = useState<string>("");
+  const [addModelOpen, setAddModelOpen] = useState(false);
+  const [newModelId, setNewModelId] = useState("");
+
+  // Derive which models are "shown" — union of models with bindings + manually added
+  const [manuallyAdded, setManuallyAdded] = useState<string[]>([]);
+  const shownModelIds = Array.from(new Set([...activeModelIds, ...manuallyAdded])).sort();
+
+  function modelLabel(modelId: string): string {
+    const found = CATALOGUE.find((m) => m.id === modelId);
+    return found ? found.label : modelId;
+  }
+
+  function handleAddModel() {
+    const id = selectedModelId || newModelId.trim();
+    if (!id) return;
+    if (!shownModelIds.includes(id)) {
+      setManuallyAdded((prev) => [...prev, id]);
+    }
+    setSelectedModelId("");
+    setNewModelId("");
+    setAddModelOpen(false);
+  }
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Sub-header */}
+      <div className="flex items-center justify-between px-6 py-3 border-b border-border shrink-0">
+        <div className="flex items-center gap-2">
+          <Cpu className="h-4 w-4 text-muted-foreground" />
+          <span className="text-sm font-medium">Model-Specific Skills</span>
+          <span className="text-xs text-muted-foreground">
+            Bind skills to run automatically for a given LLM model
+          </span>
+        </div>
+        <Button size="sm" variant="outline" className="gap-1.5 h-8 text-xs" onClick={() => setAddModelOpen(true)}>
+          <Plus className="h-3 w-3" />
+          Add Model
+        </Button>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto px-6 py-4">
+        {loadingActive ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-32 rounded-lg" />
+            ))}
+          </div>
+        ) : shownModelIds.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <Cpu className="h-8 w-8 text-muted-foreground/40 mb-3" />
+            <p className="text-sm text-muted-foreground">No model skill bindings yet.</p>
+            <p className="text-xs text-muted-foreground mt-1">
+              Add a model to start assigning skills to it.
+            </p>
+            <Button size="sm" className="mt-4 gap-1.5" onClick={() => setAddModelOpen(true)}>
+              <Plus className="h-3.5 w-3.5" />
+              Add Model
+            </Button>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {shownModelIds.map((modelId) => (
+              <ModelPanel key={modelId} modelId={modelId} label={modelLabel(modelId)} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Add Model Dialog */}
+      <Dialog open={addModelOpen} onOpenChange={(o) => { if (!o) { setAddModelOpen(false); setSelectedModelId(""); setNewModelId(""); } }}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle className="text-base">Add Model</DialogTitle>
+          </DialogHeader>
+          <div className="py-2 space-y-3">
+            <div>
+              <p className="text-xs text-muted-foreground mb-2">Select a known model:</p>
+              <Select value={selectedModelId} onValueChange={(v) => { setSelectedModelId(v); setNewModelId(""); }}>
+                <SelectTrigger className="h-8 text-sm">
+                  <SelectValue placeholder="Choose a model..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {PROVIDER_ORDER.map((provider) => {
+                    const models = CATALOGUE_BY_PROVIDER[provider];
+                    if (!models?.length) return null;
+                    return (
+                      <SelectGroup key={provider}>
+                        <SelectLabel className="text-[10px] uppercase">{provider}</SelectLabel>
+                        {models.map((m) => (
+                          <SelectItem key={m.id} value={m.id}>
+                            {m.label}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter className="gap-2">
+            <Button variant="ghost" size="sm" onClick={() => { setAddModelOpen(false); setSelectedModelId(""); setNewModelId(""); }}>
+              Cancel
+            </Button>
+            <Button size="sm" onClick={handleAddModel} disabled={!selectedModelId && !newModelId.trim()}>
+              Add
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/client/src/hooks/use-model-skill-bindings.ts
+++ b/client/src/hooks/use-model-skill-bindings.ts
@@ -1,0 +1,82 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import type { Skill } from "@shared/schema";
+
+function getAuthToken(): string | null {
+  return localStorage.getItem("auth_token");
+}
+
+async function apiRequest<T>(method: string, url: string, body?: unknown): Promise<T> {
+  const headers: Record<string, string> = {};
+  if (body !== undefined) headers["Content-Type"] = "application/json";
+  const token = getAuthToken();
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
+  const res = await fetch(url, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }));
+    throw new Error((err as { error?: string }).error ?? res.statusText);
+  }
+  if (res.status === 204) return null as T;
+  return res.json() as Promise<T>;
+}
+
+// ─── Query Key Factories ──────────────────────────────────────────────────────
+
+function modelSkillsKey(modelId?: string): unknown[] {
+  if (modelId) return ["/api/skills/models", modelId];
+  return ["/api/skills/models"];
+}
+
+// ─── Read Hooks ───────────────────────────────────────────────────────────────
+
+/** List all model IDs that have at least one skill binding. */
+export function useModelsWithSkills() {
+  return useQuery<string[]>({
+    queryKey: ["/api/skills/models"],
+    queryFn: () => apiRequest<string[]>("GET", "/api/skills/models"),
+  });
+}
+
+/** List all skills bound to a specific model ID. */
+export function useModelSkills(modelId: string) {
+  return useQuery<Skill[]>({
+    queryKey: modelSkillsKey(modelId),
+    queryFn: () => apiRequest<Skill[]>("GET", `/api/skills/models/${encodeURIComponent(modelId)}`),
+    enabled: Boolean(modelId),
+  });
+}
+
+// ─── Mutation Hooks ───────────────────────────────────────────────────────────
+
+export interface BindSkillPayload {
+  modelId: string;
+  skillId: string;
+}
+
+export function useBindSkillToModel() {
+  const qc = useQueryClient();
+  return useMutation<unknown, Error, BindSkillPayload>({
+    mutationFn: ({ modelId, skillId }) =>
+      apiRequest("POST", `/api/skills/models/${encodeURIComponent(modelId)}/${encodeURIComponent(skillId)}`),
+    onSuccess: (_data, { modelId }) => {
+      qc.invalidateQueries({ queryKey: modelSkillsKey(modelId) });
+      qc.invalidateQueries({ queryKey: ["/api/skills/models"] });
+    },
+  });
+}
+
+export function useUnbindSkillFromModel() {
+  const qc = useQueryClient();
+  return useMutation<unknown, Error, BindSkillPayload>({
+    mutationFn: ({ modelId, skillId }) =>
+      apiRequest("DELETE", `/api/skills/models/${encodeURIComponent(modelId)}/${encodeURIComponent(skillId)}`),
+    onSuccess: (_data, { modelId }) => {
+      qc.invalidateQueries({ queryKey: modelSkillsKey(modelId) });
+      qc.invalidateQueries({ queryKey: ["/api/skills/models"] });
+    },
+  });
+}

--- a/client/src/pages/Skills.tsx
+++ b/client/src/pages/Skills.tsx
@@ -21,7 +21,8 @@ import {
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { Sparkles, Upload, Download, Plus, Users } from "lucide-react";
+import { Sparkles, Upload, Download, Plus, Users, Cpu } from "lucide-react";
+import { ModelSkillsTab } from "@/components/skills/ModelSkillsTab";
 import { cn } from "@/lib/utils";
 import { SDLC_TEAMS } from "@shared/constants";
 import {
@@ -164,6 +165,7 @@ function CreateTeamDialog({ open, onClose }: CreateTeamDialogProps) {
 
 export default function Skills() {
   const { toast } = useToast();
+  const [activeTab, setActiveTab] = useState<"library" | "model-skills">("library");
   const { data: skills = [], isLoading, error } = useSkills();
   const { data: customTeams = [] } = useSkillTeams();
   const deleteSkill = useDeleteSkill();
@@ -333,6 +335,42 @@ export default function Skills() {
         </div>
       </div>
 
+      {/* Tab Switcher */}
+      <div className="flex items-center gap-1 px-6 py-0 border-b border-border shrink-0">
+        <button
+          type="button"
+          onClick={() => setActiveTab("library")}
+          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+            activeTab === "library"
+              ? "border-primary text-foreground"
+              : "border-transparent text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          <span className="flex items-center gap-1.5">
+            <Sparkles className="h-3.5 w-3.5" />
+            Library
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab("model-skills")}
+          className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+            activeTab === "model-skills"
+              ? "border-primary text-foreground"
+              : "border-transparent text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          <span className="flex items-center gap-1.5">
+            <Cpu className="h-3.5 w-3.5" />
+            Model Skills
+          </span>
+        </button>
+      </div>
+
+      {activeTab === "model-skills" ? (
+        <ModelSkillsTab />
+      ) : (
+      <>
       {/* Filters */}
       <div className="flex items-center gap-3 px-6 py-3 border-b border-border shrink-0 flex-wrap">
         {/* Search */}
@@ -471,6 +509,11 @@ export default function Skills() {
         )}
       </div>
 
+      </>
+      )}
+
+      {activeTab === "library" && (
+      <>
       {/* Skill Detail Modal (view only) */}
       <SkillLibraryDetailModal
         skill={viewingSkill ?? null}
@@ -502,6 +545,8 @@ export default function Skills() {
         open={createTeamOpen}
         onClose={() => setCreateTeamOpen(false)}
       />
+      </>
+      )}
     </div>
   );
 }

--- a/migrations/0006_model_skill_bindings.sql
+++ b/migrations/0006_model_skill_bindings.sql
@@ -1,0 +1,13 @@
+-- Phase 6.17 — Per-model skill assignment
+-- Creates model_skill_bindings table linking LLM model IDs to skills.
+
+CREATE TABLE IF NOT EXISTS "model_skill_bindings" (
+  "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "model_id" text NOT NULL,
+  "skill_id" varchar NOT NULL REFERENCES "skills"("id") ON DELETE CASCADE,
+  "created_by" text REFERENCES "users"("id"),
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  CONSTRAINT "model_skill_bindings_model_id_skill_id_unique" UNIQUE("model_id", "skill_id")
+);
+
+CREATE INDEX IF NOT EXISTS "model_skill_bindings_model_id_idx" ON "model_skill_bindings" ("model_id");

--- a/server/controller/pipeline-controller.ts
+++ b/server/controller/pipeline-controller.ts
@@ -1020,22 +1020,52 @@ export class PipelineController {
   }
 
   /**
-   * If the stage has a skillId, load that skill and merge its settings into
-   * the stage config (skill values act as fallbacks — explicit stage settings win).
+   * Applies skill settings to a stage config.
+   *
+   * Resolution order:
+   * 1. Model-specific skill bindings (per-model wins): if the stage's modelSlug
+   *    has bindings in model_skill_bindings, those skills are merged first.
+   * 2. Stage-level skillId (existing behaviour): if the stage has a skillId,
+   *    that skill's settings are merged on top.
+   *
+   * Within each merge pass, explicit stage settings always win over skill
+   * fallbacks (so stage.systemPromptOverride is appended, not replaced).
    */
   private async applySkill(stage: PipelineStageConfig): Promise<PipelineStageConfig> {
-    if (!stage.skillId) return stage;
+    let resolved = { ...stage };
 
-    const skill = await this.storage.getSkill(stage.skillId);
-    if (!skill) return stage;
+    // Step 1 — model-specific skill bindings
+    if (stage.modelSlug) {
+      const modelSkills = await this.storage.resolveSkillsForModel(stage.modelSlug);
+      for (const skill of modelSkills) {
+        resolved = this.mergeSkillIntoStage(resolved, skill);
+      }
+    }
 
+    // Step 2 — stage-level skillId (existing behaviour, takes precedence)
+    if (stage.skillId) {
+      const skill = await this.storage.getSkill(stage.skillId);
+      if (skill) {
+        resolved = this.mergeSkillIntoStage(resolved, skill);
+      }
+    }
+
+    return resolved;
+  }
+
+  /**
+   * Merges a single skill's settings into a stage config.
+   * Explicit stage settings always win; skill values act as fallbacks.
+   */
+  private mergeSkillIntoStage(
+    stage: PipelineStageConfig,
+    skill: import("@shared/schema").Skill,
+  ): PipelineStageConfig {
     return {
       ...stage,
       modelSlug: stage.modelSlug || skill.modelPreference || stage.modelSlug,
       systemPromptOverride: stage.systemPromptOverride
-        ? `${skill.systemPromptOverride}
-
-${stage.systemPromptOverride}`
+        ? `${skill.systemPromptOverride}\n\n${stage.systemPromptOverride}`
         : skill.systemPromptOverride || stage.systemPromptOverride,
       tools: stage.tools
         ? {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -43,6 +43,7 @@ import { log } from "./index";
 import { registerArgoCdSettingsRoutes, autoConnectArgoCdFromEnv } from "./routes/argocd-settings";
 import { registerTaskGroupRoutes } from "./routes/task-groups";
 import { registerSkillTeamRoutes } from "./routes/skill-teams";
+import { registerModelSkillBindingRoutes } from "./routes/model-skill-bindings";
 import { registerTaskTraceRoutes } from "./routes/task-traces";
 import { registerTrackerRoutes } from "./routes/tracker";
 import { TaskOrchestrator } from "./services/task-orchestrator";
@@ -113,6 +114,7 @@ export async function registerRoutes(
   registerSettingsRoutes(app as unknown as Router, gateway);
   registerMaintenanceRoutes(app as unknown as Router);
   registerSpecializationRoutes(app, storage);
+  registerModelSkillBindingRoutes(app, storage);
   registerSkillRoutes(app, storage);
   registerGuardrailRoutes(app, storage, gateway);
   registerDelegationRoutes(app, storage);

--- a/server/routes/model-skill-bindings.ts
+++ b/server/routes/model-skill-bindings.ts
@@ -1,0 +1,160 @@
+import type { Express, Request, Response } from "express";
+import { z } from "zod";
+import type { IStorage } from "../storage";
+import type { InsertModelSkillBinding } from "@shared/schema";
+import { DEFAULT_MODELS } from "@shared/constants";
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+/**
+ * Allowed model IDs: the modelId field from DEFAULT_MODELS plus any
+ * slug-based identifiers. We build a Set of accepted values at startup.
+ *
+ * Pattern prefixes are also accepted for self-hosted (ollama/*, vllm/*).
+ */
+const KNOWN_MODEL_ID_SET = new Set<string>(
+  DEFAULT_MODELS.flatMap((m) => {
+    const ids: string[] = [m.slug];
+    if ("modelId" in m && m.modelId) ids.push(m.modelId as string);
+    return ids;
+  }),
+);
+
+const DYNAMIC_MODEL_PATTERNS: RegExp[] = [
+  /^ollama\/.+/,
+  /^vllm\/.+/,
+];
+
+function isValidModelId(modelId: string): boolean {
+  if (KNOWN_MODEL_ID_SET.has(modelId)) return true;
+  return DYNAMIC_MODEL_PATTERNS.some((p) => p.test(modelId));
+}
+
+const ModelIdParamSchema = z.string().min(1).max(200).refine(
+  (v) => isValidModelId(v),
+  { message: "Unknown or disallowed model ID" },
+);
+
+const SkillIdParamSchema = z.string().uuid({ message: "skillId must be a valid UUID" });
+
+// ─── Helper ──────────────────────────────────────────────────────────────────
+
+function isOwnerOrAdmin(skillCreatedBy: string, req: Request): boolean {
+  const user = req.user;
+  if (!user) return false;
+  if (user.role === "admin") return true;
+  return skillCreatedBy === user.id;
+}
+
+// ─── Route Registration ──────────────────────────────────────────────────────
+
+export function registerModelSkillBindingRoutes(app: Express, storage: IStorage): void {
+  /**
+   * GET /api/skills/models
+   * List all distinct model IDs that have at least one skill binding.
+   * Requires auth (enforced by middleware in routes.ts).
+   */
+  app.get("/api/skills/models", async (_req: Request, res: Response) => {
+    const modelIds = await storage.getModelsWithSkillBindings();
+    res.json(modelIds);
+  });
+
+  /**
+   * GET /api/skills/models/:modelId
+   * List all skills bound to the given model.
+   */
+  app.get("/api/skills/models/:modelId", async (req: Request, res: Response) => {
+    const parsed = ModelIdParamSchema.safeParse(req.params.modelId);
+    if (!parsed.success) {
+      return res.status(400).json({ error: parsed.error.errors[0]?.message ?? "Invalid modelId" });
+    }
+
+    const skills = await storage.resolveSkillsForModel(parsed.data);
+    res.json(skills);
+  });
+
+  /**
+   * POST /api/skills/models/:modelId/:skillId
+   * Bind a skill to a model.
+   * Requires: admin OR skill owner.
+   */
+  app.post("/api/skills/models/:modelId/:skillId", async (req: Request, res: Response) => {
+    const modelParsed = ModelIdParamSchema.safeParse(req.params.modelId);
+    if (!modelParsed.success) {
+      return res.status(400).json({ error: modelParsed.error.errors[0]?.message ?? "Invalid modelId" });
+    }
+
+    const skillParsed = SkillIdParamSchema.safeParse(req.params.skillId);
+    if (!skillParsed.success) {
+      return res.status(400).json({ error: skillParsed.error.errors[0]?.message ?? "Invalid skillId" });
+    }
+
+    // Verify skill exists (returns 404 rather than FK 500)
+    const skill = await storage.getSkill(skillParsed.data);
+    if (!skill) {
+      return res.status(404).json({ error: "Skill not found" });
+    }
+
+    // Authorization: admin or owner
+    if (!isOwnerOrAdmin(skill.createdBy, req)) {
+      return res.status(403).json({ error: "Forbidden -- must be skill owner or admin" });
+    }
+
+    try {
+      const data: InsertModelSkillBinding = {
+        modelId: modelParsed.data,
+        skillId: skillParsed.data,
+        createdBy: req.user?.id ?? null,
+      };
+      const binding = await storage.createModelSkillBinding(data);
+      res.status(201).json(binding);
+    } catch (err) {
+      // Unique constraint violation → 409
+      const code = (err as NodeJS.ErrnoException).code;
+      const message = err instanceof Error ? err.message : "";
+      if (code === "23505" || message.includes("unique") || message.includes("Unique")) {
+        return res.status(409).json({ error: "Skill is already bound to this model" });
+      }
+      throw err;
+    }
+  });
+
+  /**
+   * DELETE /api/skills/models/:modelId/:skillId
+   * Unbind a skill from a model.
+   * Requires: admin OR skill owner.
+   */
+  app.delete("/api/skills/models/:modelId/:skillId", async (req: Request, res: Response) => {
+    const modelParsed = ModelIdParamSchema.safeParse(req.params.modelId);
+    if (!modelParsed.success) {
+      return res.status(400).json({ error: modelParsed.error.errors[0]?.message ?? "Invalid modelId" });
+    }
+
+    const skillParsed = SkillIdParamSchema.safeParse(req.params.skillId);
+    if (!skillParsed.success) {
+      return res.status(400).json({ error: skillParsed.error.errors[0]?.message ?? "Invalid skillId" });
+    }
+
+    // Verify skill exists
+    const skill = await storage.getSkill(skillParsed.data);
+    if (!skill) {
+      return res.status(404).json({ error: "Skill not found" });
+    }
+
+    // Authorization: admin or owner
+    if (!isOwnerOrAdmin(skill.createdBy, req)) {
+      return res.status(403).json({ error: "Forbidden -- must be skill owner or admin" });
+    }
+
+    try {
+      await storage.deleteModelSkillBinding(modelParsed.data, skillParsed.data);
+      res.status(204).end();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "";
+      if (message.includes("not found")) {
+        return res.status(404).json({ error: "Binding not found" });
+      }
+      throw err;
+    }
+  });
+}

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -12,6 +12,7 @@ import {
   skills,
   skillVersions,
   skillTeams,
+  modelSkillBindings,
   triggers,
   managerIterations,
   traces,
@@ -45,6 +46,8 @@ import {
   type InsertTaskTrace,
   type TrackerConnectionRow,
   type InsertTrackerConnection,
+  type ModelSkillBinding,
+  type InsertModelSkillBinding,
 } from "@shared/schema";
 import type { TraceSpan, SkillVersionRecord, MarketplaceSkill, MarketplaceFilters, InsertSkillVersion } from "@shared/types";
 
@@ -1115,6 +1118,53 @@ export class PgStorage implements IStorage {
 
   async deleteTrackerConnection(id: string): Promise<void> {
     await db.delete(trackerConnections).where(eq(trackerConnections.id, id));
+  }
+
+  // ─── Model Skill Bindings (Phase 6.17) ──────────────────────────────────────
+
+  async getModelSkillBindings(modelId: string): Promise<ModelSkillBinding[]> {
+    return db.select().from(modelSkillBindings)
+      .where(eq(modelSkillBindings.modelId, modelId))
+      .orderBy(asc(modelSkillBindings.createdAt));
+  }
+
+  async getModelsWithSkillBindings(): Promise<string[]> {
+    const rows = await db
+      .selectDistinct({ modelId: modelSkillBindings.modelId })
+      .from(modelSkillBindings)
+      .orderBy(asc(modelSkillBindings.modelId));
+    return rows.map((r) => r.modelId);
+  }
+
+  async createModelSkillBinding(data: InsertModelSkillBinding): Promise<ModelSkillBinding> {
+    const [row] = await db.insert(modelSkillBindings)
+      .values(data as typeof modelSkillBindings.$inferInsert)
+      .returning();
+    return row;
+  }
+
+  async deleteModelSkillBinding(modelId: string, skillId: string): Promise<void> {
+    const result = await db.delete(modelSkillBindings)
+      .where(
+        and(
+          eq(modelSkillBindings.modelId, modelId),
+          eq(modelSkillBindings.skillId, skillId),
+        ),
+      )
+      .returning();
+    if (result.length === 0) {
+      throw new Error(`Binding not found for model ${modelId} skill ${skillId}`);
+    }
+  }
+
+  async resolveSkillsForModel(modelId: string): Promise<Skill[]> {
+    const rows = await db
+      .select({ skill: skills })
+      .from(modelSkillBindings)
+      .innerJoin(skills, eq(modelSkillBindings.skillId, skills.id))
+      .where(eq(modelSkillBindings.modelId, modelId))
+      .orderBy(asc(modelSkillBindings.createdAt));
+    return rows.map((r) => r.skill);
   }
 
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -38,6 +38,8 @@ import {
   type InsertTrackerConnection,
   type SkillTeam,
   type InsertSkillTeam,
+  type ModelSkillBinding,
+  type InsertModelSkillBinding,
 } from "@shared/schema";
 import type { Memory, InsertMemory, MemoryScope, MemoryType, McpServerConfig, TraceSpan, TaskTraceSpan, SkillVersionRecord, MarketplaceSkill, MarketplaceFilters, InsertSkillVersion as InsertSkillVersionType } from "@shared/types";
 import { randomUUID } from "crypto";
@@ -251,6 +253,13 @@ export interface IStorage {
   getTrackerConnection(id: string): Promise<TrackerConnectionRow | undefined>;
   createTrackerConnection(data: InsertTrackerConnection): Promise<TrackerConnectionRow>;
   deleteTrackerConnection(id: string): Promise<void>;
+
+  // Model Skill Bindings (Phase 6.17)
+  getModelSkillBindings(modelId: string): Promise<ModelSkillBinding[]>;
+  getModelsWithSkillBindings(): Promise<string[]>;
+  createModelSkillBinding(data: InsertModelSkillBinding): Promise<ModelSkillBinding>;
+  deleteModelSkillBinding(modelId: string, skillId: string): Promise<void>;
+  resolveSkillsForModel(modelId: string): Promise<Skill[]>;
 }
 
 export class MemStorage implements IStorage {
@@ -1483,6 +1492,68 @@ export class MemStorage implements IStorage {
 
   async deleteTrackerConnection(id: string): Promise<void> {
     this.trackerConnectionsMap.delete(id);
+  }
+
+
+  // ─── Model Skill Bindings ────────────────────────────────────────────────
+
+  private modelSkillBindingsMap: Map<string, ModelSkillBinding> = new Map();
+
+  async getModelSkillBindings(modelId: string): Promise<ModelSkillBinding[]> {
+    return Array.from(this.modelSkillBindingsMap.values()).filter(
+      (b) => b.modelId === modelId,
+    );
+  }
+
+  async getModelsWithSkillBindings(): Promise<string[]> {
+    const modelIds = new Set<string>();
+    for (const b of this.modelSkillBindingsMap.values()) {
+      modelIds.add(b.modelId);
+    }
+    return Array.from(modelIds).sort();
+  }
+
+  async createModelSkillBinding(data: InsertModelSkillBinding): Promise<ModelSkillBinding> {
+    // Check uniqueness
+    const duplicate = Array.from(this.modelSkillBindingsMap.values()).find(
+      (b) => b.modelId === data.modelId && b.skillId === data.skillId,
+    );
+    if (duplicate) {
+      const err = new Error("Unique constraint violation: model_skill_bindings_model_id_skill_id_unique");
+      (err as NodeJS.ErrnoException).code = "23505";
+      throw err;
+    }
+    const id = randomUUID();
+    const binding: ModelSkillBinding = {
+      id,
+      modelId: data.modelId,
+      skillId: data.skillId,
+      createdBy: data.createdBy ?? null,
+      createdAt: new Date(),
+    };
+    this.modelSkillBindingsMap.set(id, binding);
+    return binding;
+  }
+
+  async deleteModelSkillBinding(modelId: string, skillId: string): Promise<void> {
+    for (const [key, binding] of this.modelSkillBindingsMap.entries()) {
+      if (binding.modelId === modelId && binding.skillId === skillId) {
+        this.modelSkillBindingsMap.delete(key);
+        return;
+      }
+    }
+    throw new Error(`Binding not found for model ${modelId} skill ${skillId}`);
+  }
+
+  async resolveSkillsForModel(modelId: string): Promise<Skill[]> {
+    const bindings = await this.getModelSkillBindings(modelId);
+    if (bindings.length === 0) return [];
+    const result: Skill[] = [];
+    for (const b of bindings) {
+      const skill = this.skillsMap.get(b.skillId);
+      if (skill) result.push(skill);
+    }
+    return result;
   }
 
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -903,3 +903,20 @@ export const insertTrackerConnectionSchema = createInsertSchema(trackerConnectio
 
 export type InsertTrackerConnection = z.infer<typeof insertTrackerConnectionSchema>;
 export type TrackerConnectionRow = typeof trackerConnections.$inferSelect;
+
+// ─── Model Skill Bindings (Phase 6.17) ───────────────────────────────────────
+
+export const modelSkillBindings = pgTable("model_skill_bindings", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  modelId: text("model_id").notNull(),
+  skillId: varchar("skill_id").notNull().references(() => skills.id, { onDelete: "cascade" }),
+  createdBy: text("created_by").references(() => users.id),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+}, (t) => ({
+  uniqueModelSkill: unique().on(t.modelId, t.skillId),
+  modelIdIdx: index("model_skill_bindings_model_id_idx").on(t.modelId),
+}));
+
+export const insertModelSkillBindingSchema = createInsertSchema(modelSkillBindings).omit({ id: true, createdAt: true });
+export type InsertModelSkillBinding = z.infer<typeof insertModelSkillBindingSchema>;
+export type ModelSkillBinding = typeof modelSkillBindings.$inferSelect;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1539,3 +1539,18 @@ export interface TaskTraceSpan {
   durationMs?: number;
   metadata: TaskTraceSpanMetadata;
 }
+
+// ─── Model Skill Binding Types (Phase 6.17) ───────────────────────────────────
+
+export interface ModelSkillBinding {
+  id: string;
+  modelId: string;
+  skillId: string;
+  createdBy: string | null;
+  createdAt: Date;
+}
+
+export interface ModelWithSkills {
+  modelId: string;
+  skills: import("./schema.js").Skill[];
+}

--- a/tests/integration/model-skill-bindings-api.test.ts
+++ b/tests/integration/model-skill-bindings-api.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Integration tests for Phase 6.17 — Model Skill Bindings API.
+ *
+ * Covers:
+ * - POST   /api/skills/models/:modelId/:skillId → 201
+ * - GET    /api/skills/models/:modelId          → lists bound skills
+ * - GET    /api/skills/models                   → lists model IDs with bindings
+ * - DELETE /api/skills/models/:modelId/:skillId → 204
+ * - 409 on duplicate bind
+ * - 403 when non-owner/non-admin tries to bind
+ * - 404 when skill doesn't exist
+ * - 400 for invalid modelId
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import express from "express";
+import { createServer } from "http";
+import { MemStorage } from "../../server/storage.js";
+import { registerSkillRoutes } from "../../server/routes/skills.js";
+import { registerModelSkillBindingRoutes } from "../../server/routes/model-skill-bindings.js";
+import type { User } from "../../shared/types.js";
+
+const ADMIN_USER: User = {
+  id: "admin-id",
+  email: "admin@test.com",
+  name: "Admin",
+  isActive: true,
+  role: "admin",
+  lastLoginAt: null,
+  createdAt: new Date(0),
+};
+
+const REGULAR_USER: User = {
+  id: "regular-id",
+  email: "user@test.com",
+  name: "Regular",
+  isActive: true,
+  role: "user",
+  lastLoginAt: null,
+  createdAt: new Date(0),
+};
+
+function buildApp(user: User = ADMIN_USER) {
+  const storage = new MemStorage();
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.user = user;
+    next();
+  });
+  registerModelSkillBindingRoutes(app, storage);
+  registerSkillRoutes(app, storage);
+  return { app, storage };
+}
+
+describe("Model Skill Bindings API", () => {
+  let app: express.Express;
+  let storage: MemStorage;
+  let closeServer: () => Promise<void>;
+  let skillId: string;
+
+  const MODEL_ID = "claude-sonnet-4-6"; // valid model ID from DEFAULT_MODELS
+
+  beforeAll(async () => {
+    ({ app, storage } = buildApp(ADMIN_USER));
+    const httpServer = createServer(app);
+    closeServer = () => new Promise<void>((r) => httpServer.close(() => r()));
+
+    // Create a skill to use in tests
+    const res = await request(app)
+      .post("/api/skills")
+      .send({
+        name: "TestSkill",
+        description: "A test skill",
+        teamId: "development",
+        systemPromptOverride: "You are a test assistant.",
+        tools: [],
+        tags: ["test"],
+        isPublic: true,
+      });
+    expect(res.status).toBe(201);
+    skillId = (res.body as { id: string }).id;
+  });
+
+  afterAll(async () => {
+    await closeServer();
+  });
+
+  // ─── POST bind ──────────────────────────────────────────────────────────────
+
+  it("POST /api/skills/models/:modelId/:skillId → 201", async () => {
+    const res = await request(app).post(`/api/skills/models/${MODEL_ID}/${skillId}`);
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ modelId: MODEL_ID, skillId });
+  });
+
+  it("POST → 409 on duplicate bind", async () => {
+    const res = await request(app).post(`/api/skills/models/${MODEL_ID}/${skillId}`);
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/already bound/i);
+  });
+
+  // ─── GET model skills ────────────────────────────────────────────────────────
+
+  it("GET /api/skills/models/:modelId → lists bound skills", async () => {
+    const res = await request(app).get(`/api/skills/models/${MODEL_ID}`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect((res.body as { id: string }[])[0].id).toBe(skillId);
+  });
+
+  // ─── GET models with bindings ────────────────────────────────────────────────
+
+  it("GET /api/skills/models → lists model IDs with bindings", async () => {
+    const res = await request(app).get("/api/skills/models");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body as string[]).toContain(MODEL_ID);
+  });
+
+  // ─── DELETE unbind ───────────────────────────────────────────────────────────
+
+  it("DELETE /api/skills/models/:modelId/:skillId → 204", async () => {
+    const res = await request(app).delete(`/api/skills/models/${MODEL_ID}/${skillId}`);
+    expect(res.status).toBe(204);
+
+    // Verify binding is gone
+    const checkRes = await request(app).get(`/api/skills/models/${MODEL_ID}`);
+    expect(checkRes.status).toBe(200);
+    expect(checkRes.body as unknown[]).toHaveLength(0);
+  });
+
+  it("DELETE non-existent binding → 404", async () => {
+    const res = await request(app).delete(`/api/skills/models/${MODEL_ID}/${skillId}`);
+    expect(res.status).toBe(404);
+  });
+
+  // ─── 404 for non-existent skill ──────────────────────────────────────────────
+
+  it("POST with unknown skillId → 404", async () => {
+    const fakeSkillId = "00000000-0000-0000-0000-000000000000";
+    const res = await request(app).post(`/api/skills/models/${MODEL_ID}/${fakeSkillId}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/not found/i);
+  });
+
+  // ─── 400 for invalid model ID ────────────────────────────────────────────────
+
+  it("POST with unknown/invalid modelId → 400", async () => {
+    const res = await request(app).post(`/api/skills/models/INVALID-MODEL-XYZ/${skillId}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/model/i);
+  });
+
+  it("GET with unknown modelId → 400", async () => {
+    const res = await request(app).get("/api/skills/models/TOTALLY-FAKE-MODEL");
+    expect(res.status).toBe(400);
+  });
+
+  // ─── 403 for non-owner/non-admin ─────────────────────────────────────────────
+
+  it("non-owner user cannot bind skill created by another user", async () => {
+    // Build an app where the current user is REGULAR_USER but the skill is owned by ADMIN_USER.
+    // We do this by: build a single-storage app that injects admin first to create the skill,
+    // then manually creates a request with the regular user injected.
+    const sharedStorage = new MemStorage();
+
+    // Build admin app using shared storage
+    const adminApp = express();
+    adminApp.use(express.json());
+    adminApp.use((_req, _res, next) => { _req.user = ADMIN_USER; next(); });
+    registerModelSkillBindingRoutes(adminApp, sharedStorage);
+    registerSkillRoutes(adminApp, sharedStorage);
+
+    // Build regular user app using same storage
+    const userApp = express();
+    userApp.use(express.json());
+    userApp.use((_req, _res, next) => { _req.user = REGULAR_USER; next(); });
+    registerModelSkillBindingRoutes(userApp, sharedStorage);
+    registerSkillRoutes(userApp, sharedStorage);
+
+    // Admin creates a skill
+    const createRes = await request(adminApp).post("/api/skills").send({
+      name: "AdminOwnedSkill2",
+      description: "Owned by admin",
+      teamId: "development",
+      systemPromptOverride: "",
+      tools: [],
+      tags: [],
+      isPublic: true,
+    });
+    expect(createRes.status).toBe(201);
+    const adminSkillId = (createRes.body as { id: string }).id;
+
+    // Regular user tries to bind admin's skill — should be forbidden
+    const res = await request(userApp).post(`/api/skills/models/${MODEL_ID}/${adminSkillId}`);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/forbidden/i);
+  });
+
+  it("owner can bind their own skill", async () => {
+    // Create skill as regular user (createdBy = "regular-id")
+    const { app: userApp, storage: userStorage } = buildApp(REGULAR_USER);
+
+    const createRes = await request(userApp).post("/api/skills").send({
+      name: "UserOwnedSkill",
+      description: "Owned by regular user",
+      teamId: "development",
+      systemPromptOverride: "",
+      tools: [],
+      tags: [],
+      isPublic: true,
+    });
+    expect(createRes.status).toBe(201);
+    const userSkillId = (createRes.body as { id: string }).id;
+
+    // Regular user can bind their own skill
+    const bindRes = await request(userApp).post(`/api/skills/models/${MODEL_ID}/${userSkillId}`);
+    expect(bindRes.status).toBe(201);
+  });
+});
+
+// ─── Pipeline integration: skill resolution ────────────────────────────────
+
+describe("Pipeline: model-specific skill resolution via MemStorage", () => {
+  it("resolveSkillsForModel returns empty array for model with no bindings (global fallback)", async () => {
+    const { storage } = buildApp();
+    const skills = await storage.resolveSkillsForModel("grok-3");
+    expect(skills).toEqual([]);
+  });
+
+  it("resolveSkillsForModel returns bound skills for model with bindings", async () => {
+    const { app, storage } = buildApp(ADMIN_USER);
+
+    // Create a skill
+    const createRes = await request(app).post("/api/skills").send({
+      name: "PipelineSkill",
+      description: "Used by pipeline",
+      teamId: "development",
+      systemPromptOverride: "Pipeline helper",
+      tools: ["read_file"],
+      tags: [],
+      isPublic: true,
+    });
+    expect(createRes.status).toBe(201);
+    const sid = (createRes.body as { id: string }).id;
+
+    // Bind it to grok-3
+    const bindRes = await request(app).post(`/api/skills/models/grok-3/${sid}`);
+    expect(bindRes.status).toBe(201);
+
+    // Resolve — should return the bound skill
+    const resolved = await storage.resolveSkillsForModel("grok-3");
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].name).toBe("PipelineSkill");
+
+    // Different model — no bindings → empty (global fallback)
+    const fallback = await storage.resolveSkillsForModel("claude-sonnet-4-6");
+    expect(fallback).toHaveLength(0);
+  });
+});

--- a/tests/unit/skills/model-skill-resolution.test.ts
+++ b/tests/unit/skills/model-skill-resolution.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for per-model skill resolution logic.
+ *
+ * Verifies:
+ * - Model-specific bindings are returned when present
+ * - Global fallback (empty array) when no bindings exist for a model
+ * - MemStorage correctly enforces unique constraint
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { MemStorage } from "../../../server/storage.js";
+import type { InsertSkill } from "../../../shared/schema.js";
+
+function makeSkill(name: string): InsertSkill {
+  return {
+    id: undefined as unknown as string,
+    name,
+    description: `${name} description`,
+    teamId: "development",
+    systemPromptOverride: `You are ${name}.`,
+    tools: [],
+    modelPreference: null,
+    outputSchema: null,
+    tags: [name.toLowerCase()],
+    isBuiltin: false,
+    isPublic: true,
+    createdBy: "user-1",
+    version: "1.0.0",
+    sharing: "public",
+  };
+}
+
+describe("model skill resolution — MemStorage", () => {
+  let storage: MemStorage;
+
+  beforeEach(() => {
+    storage = new MemStorage();
+  });
+
+  it("returns empty array when no bindings exist for a model", async () => {
+    const skills = await storage.resolveSkillsForModel("claude-sonnet-4-5");
+    expect(skills).toEqual([]);
+  });
+
+  it("returns bound skills after binding", async () => {
+    const skill = await storage.createSkill(makeSkill("Coder"));
+    await storage.createModelSkillBinding({
+      modelId: "claude-sonnet-4-5",
+      skillId: skill.id,
+      createdBy: "user-1",
+    });
+
+    const resolved = await storage.resolveSkillsForModel("claude-sonnet-4-5");
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].name).toBe("Coder");
+  });
+
+  it("returns only skills for the specified model, not others", async () => {
+    const skillA = await storage.createSkill(makeSkill("SkillA"));
+    const skillB = await storage.createSkill(makeSkill("SkillB"));
+
+    await storage.createModelSkillBinding({
+      modelId: "claude-sonnet-4-5",
+      skillId: skillA.id,
+      createdBy: "user-1",
+    });
+    await storage.createModelSkillBinding({
+      modelId: "grok-3",
+      skillId: skillB.id,
+      createdBy: "user-1",
+    });
+
+    const forClaude = await storage.resolveSkillsForModel("claude-sonnet-4-5");
+    const forGrok = await storage.resolveSkillsForModel("grok-3");
+
+    expect(forClaude).toHaveLength(1);
+    expect(forClaude[0].name).toBe("SkillA");
+
+    expect(forGrok).toHaveLength(1);
+    expect(forGrok[0].name).toBe("SkillB");
+  });
+
+  it("returns multiple skills bound to same model", async () => {
+    const skillA = await storage.createSkill(makeSkill("Alpha"));
+    const skillB = await storage.createSkill(makeSkill("Beta"));
+
+    await storage.createModelSkillBinding({ modelId: "gemini-2.0-flash", skillId: skillA.id, createdBy: null });
+    await storage.createModelSkillBinding({ modelId: "gemini-2.0-flash", skillId: skillB.id, createdBy: null });
+
+    const resolved = await storage.resolveSkillsForModel("gemini-2.0-flash");
+    expect(resolved).toHaveLength(2);
+    const names = resolved.map((s) => s.name).sort();
+    expect(names).toEqual(["Alpha", "Beta"]);
+  });
+
+  it("throws on duplicate binding (unique constraint)", async () => {
+    const skill = await storage.createSkill(makeSkill("Dup"));
+    await storage.createModelSkillBinding({ modelId: "grok-3", skillId: skill.id, createdBy: null });
+
+    await expect(
+      storage.createModelSkillBinding({ modelId: "grok-3", skillId: skill.id, createdBy: null }),
+    ).rejects.toThrow(/unique/i);
+  });
+
+  it("removes binding on delete", async () => {
+    const skill = await storage.createSkill(makeSkill("Removable"));
+    await storage.createModelSkillBinding({ modelId: "claude-sonnet-4-5", skillId: skill.id, createdBy: null });
+
+    await storage.deleteModelSkillBinding("claude-sonnet-4-5", skill.id);
+    const resolved = await storage.resolveSkillsForModel("claude-sonnet-4-5");
+    expect(resolved).toHaveLength(0);
+  });
+
+  it("getModelsWithSkillBindings returns distinct model IDs", async () => {
+    const s1 = await storage.createSkill(makeSkill("S1"));
+    const s2 = await storage.createSkill(makeSkill("S2"));
+
+    await storage.createModelSkillBinding({ modelId: "grok-3", skillId: s1.id, createdBy: null });
+    await storage.createModelSkillBinding({ modelId: "claude-sonnet-4-5", skillId: s2.id, createdBy: null });
+
+    const modelIds = await storage.getModelsWithSkillBindings();
+    expect(modelIds).toContain("grok-3");
+    expect(modelIds).toContain("claude-sonnet-4-5");
+    expect(new Set(modelIds).size).toBe(modelIds.length); // no duplicates
+  });
+
+  it("global fallback: resolveSkillsForModel returns empty for unbound model", async () => {
+    const skill = await storage.createSkill(makeSkill("Bound"));
+    await storage.createModelSkillBinding({ modelId: "grok-3", skillId: skill.id, createdBy: null });
+
+    // Different model — should return empty (global fallback is caller's responsibility)
+    const unbound = await storage.resolveSkillsForModel("gemini-2.0-flash");
+    expect(unbound).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `model_skill_bindings` table + Drizzle migration so skills can be attached to specific LLM model IDs
- REST API (`GET`/`POST`/`DELETE /api/skills/models/:modelId/:skillId`) with auth, modelId validation, and owner/admin authorization
- Pipeline controller now resolves model-specific skills first, then falls back to stage-level `skillId` and the global pool
- Frontend "Model Skills" tab on the Skills page with per-model skill cards, bind/unbind UI

## Test plan

- [ ] `npx vitest run tests/unit/skills/model-skill-resolution.test.ts` — 8 unit tests (MemStorage uniqueness, fallback, multi-skill)
- [ ] `npx vitest run tests/integration/model-skill-bindings-api.test.ts` — 13 integration tests (201/204/400/403/404/409)
- [ ] `npx vitest run` — 1569 existing tests pass (no regressions)
- [ ] `npx tsc --noEmit` — zero type errors

Closes #162