### PR TITLE
fix(migration): use varchar/text instead of uuid in 0007_git_skill_sources

### DIFF
--- a/migrations/0007_git_skill_sources.sql
+++ b/migrations/0007_git_skill_sources.sql
@@ -2,7 +2,7 @@
 -- Phase: Git Skill Sources (issue #161)
 
 CREATE TABLE IF NOT EXISTS "git_skill_sources" (
-  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "id" varchar PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
   "name" text NOT NULL,
   "repo_url" text NOT NULL,
   "branch" text NOT NULL DEFAULT 'main',
@@ -10,14 +10,15 @@ CREATE TABLE IF NOT EXISTS "git_skill_sources" (
   "sync_on_start" boolean NOT NULL DEFAULT false,
   "last_synced_at" timestamp,
   "last_error" text,
-  "created_by" uuid REFERENCES "users"("id"),
+  "encrypted_pat" text,
+  "created_by" text REFERENCES "users"("id"),
   "created_at" timestamp NOT NULL DEFAULT now()
 );
 
 -- Add source tracking columns to skills table
 ALTER TABLE "skills"
   ADD COLUMN IF NOT EXISTS "source_type" text NOT NULL DEFAULT 'manual',
-  ADD COLUMN IF NOT EXISTS "git_source_id" uuid REFERENCES "git_skill_sources"("id") ON DELETE SET NULL;
+  ADD COLUMN IF NOT EXISTS "git_source_id" varchar REFERENCES "git_skill_sources"("id") ON DELETE SET NULL;
 
 -- Index for efficient lookup of skills by git source
 CREATE INDEX IF NOT EXISTS "skills_git_source_id_idx" ON "skills"("git_source_id");


### PR DESCRIPTION
## Summary
- Migration `0007_git_skill_sources` declared `created_by uuid` and `id uuid`, but `users.id` is `text` and the rest of the codebase uses `varchar` for IDs
- The FK type mismatch caused the `CREATE TABLE` to fail silently inside Drizzle's migrator, so `source_type`/`git_source_id` columns were never added to `skills`
- App crashed on startup with `column "source_type" does not exist` in a crash loop

## Fix
- Changed `created_by` from `uuid` to `text` (matches `users.id`)
- Changed `id` from `uuid` to `varchar` with `gen_random_uuid()::text` default (matches all other tables)
- Changed `git_source_id` FK from `uuid` to `varchar` (matches new `git_skill_sources.id`)
- Added missing `encrypted_pat` column (present in schema.ts but absent from migration)

## Test plan
- [ ] Fresh DB: all migrations apply cleanly, app starts healthy
- [ ] Existing DB: `0007` applies without error after `0005`/`0006`