### PR TITLE
fix(db): handle 42P07 when db:push precedes runMigrations

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -15,13 +15,23 @@ export const db = drizzle(pool, { schema });
  * Run pending Drizzle migrations on startup.
  * Safe to call multiple times — already-applied migrations are skipped.
  * Resolves silently when DATABASE_URL is not set (MemStorage mode).
+ *
+ * If the schema was already created via `drizzle-kit push`, migrations
+ * will fail with "relation already exists" (42P07). We treat this as a
+ * non-fatal condition: the schema is already up-to-date.
  */
 export async function runMigrations(): Promise<void> {
   if (!configLoader.get().database.url) return;
   try {
     await migrate(db, { migrationsFolder: path.resolve(import.meta.dirname ?? __dirname, "../migrations") });
     console.log("[db] migrations applied");
-  } catch (err) {
+  } catch (err: unknown) {
+    const pgErr = err as { code?: string };
+    if (pgErr.code === "42P07") {
+      // "relation already exists" — schema was created by `drizzle-kit push`
+      console.log("[db] schema already up-to-date (created via push), skipping migrations");
+      return;
+    }
     console.error("[db] migration failed:", err);
     throw err;
   }


### PR DESCRIPTION
## Summary

- CI E2E job runs `drizzle-kit push` then starts the Playwright webserver, which calls `runMigrations()` on startup
- Migration 0000 attempts `CREATE TABLE "anonymization_log"` on tables already created by `push` → Postgres error **42P07** ("relation already exists") → server crash → all E2E tests fail
- Fix: catch 42P07 in `runMigrations()` and treat it as non-fatal — the schema is already up-to-date

## Root Cause

`drizzle-kit push` and `drizzle-orm/migrator` are mutually exclusive strategies:
- `push` syncs schema directly from code → no journal entries
- `migrate()` reads journal → tries to apply migration 0000 → table already exists → crash

## Test plan

- [ ] CI E2E job passes (was failing on every push to main)
- [ ] Nightly pipeline E2E step passes
- [ ] Local `npm run test:e2e` with DATABASE_URL set still works
- [ ] Server startup without DATABASE_URL still skips migrations silently

Fixes actions/runs/23399234455