### PR TITLE
fix: resolve 6 QA-identified bugs (#195-#200)

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -20,7 +20,9 @@ ${CADDY_DOMAIN} {
         X-Frame-Options "DENY"
         Referrer-Policy "strict-origin-when-cross-origin"
         Permissions-Policy "geolocation=(), microphone=(), camera=()"
+        Content-Security-Policy "default-src 'self'; script-src 'self'; connect-src 'self' wss:; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; frame-ancestors 'none'"
         -Server
+        -X-Powered-By
     }
 
     # Logging to stdout (picked up by Docker's json-file driver)

--- a/migrations/0008_add_task_groups_trace_id.sql
+++ b/migrations/0008_add_task_groups_trace_id.sql
@@ -1,0 +1,3 @@
+-- Add missing trace_id column to task_groups table
+-- Referenced by Drizzle schema (shared/schema.ts) but absent from DB
+ALTER TABLE task_groups ADD COLUMN IF NOT EXISTS trace_id text;

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "drizzle-zod": "^0.7.0",
         "embla-carousel-react": "^8.6.0",
         "express": "^5.0.1",
+        "express-rate-limit": "^8.3.1",
         "express-session": "^1.18.1",
         "framer-motion": "^12.23.24",
         "input-otp": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",
     "express": "^5.0.1",
+    "express-rate-limit": "^8.3.1",
     "express-session": "^1.18.1",
     "framer-motion": "^12.23.24",
     "input-otp": "^1.4.2",

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,6 +11,7 @@ import { serveStatic } from "./static";
 import { createServer } from "http";
 
 const app = express();
+app.disable("x-powered-by");
 const httpServer = createServer(app);
 
 declare module "http" {
@@ -84,6 +85,11 @@ app.use((req, res, next) => {
     }
 
     return res.status(status).json({ message });
+  });
+
+  // Catch-all for unmatched /api/* routes — return JSON 404 instead of SPA HTML
+  app.all("/api/{*path}", (_req: Request, res: Response) => {
+    res.status(404).json({ error: "Not Found" });
   });
 
   // importantly only setup vite in development and after

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -1,8 +1,18 @@
 import type { Express } from "express";
 import { z } from "zod";
+import rateLimit from "express-rate-limit";
 import { authService } from "../auth/service";
 import { requireAuth, requireRole } from "../auth/middleware";
 import { USER_ROLES } from "@shared/schema";
+
+const loginLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 5,
+  message: { error: "Too many login attempts, please try again later" },
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => req.ip ?? "unknown",
+});
 
 const registerSchema = z.object({
   email: z.string().email(),
@@ -24,6 +34,13 @@ const updateMeSchema = z.object({
 
 const updateRoleSchema = z.object({
   role: z.enum(USER_ROLES),
+});
+
+const adminUpdateUserSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  email: z.string().email().optional(),
+  role: z.enum(USER_ROLES).optional(),
+  isActive: z.boolean().optional(),
 });
 
 export function registerAuthRoutes(app: Express): void {
@@ -60,8 +77,8 @@ export function registerAuthRoutes(app: Express): void {
     }
   });
 
-  // Public: login
-  app.post("/api/auth/login", async (req, res) => {
+  // Public: login (rate-limited)
+  app.post("/api/auth/login", loginLimiter, async (req, res) => {
     const parsed = loginSchema.safeParse(req.body);
     if (!parsed.success) {
       res.status(400).json({ error: "Invalid input", details: parsed.error.flatten() });
@@ -166,6 +183,73 @@ export function registerAuthRoutes(app: Express): void {
       const error = err as Error;
       if (error.message === "User not found") {
         res.status(404).json({ error: "User not found" });
+        return;
+      }
+      throw err;
+    }
+  });
+
+  // Admin: update a user (name, email, role, isActive)
+  app.patch("/api/users/:id", requireAuth, requireRole("admin"), async (req, res) => {
+    const parsed = adminUpdateUserSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: "Invalid input", details: parsed.error.flatten() });
+      return;
+    }
+
+    const updates = parsed.data;
+    if (Object.keys(updates).length === 0) {
+      res.status(400).json({ error: "No fields to update" });
+      return;
+    }
+
+    // Prevent admin from changing their own role
+    if (req.user?.id === req.params["id"] && updates.role && updates.role !== "admin") {
+      res.status(400).json({ error: "Cannot change your own role" });
+      return;
+    }
+
+    try {
+      const userId = req.params["id"] as string;
+      let updated;
+
+      // Apply profile updates (name, email)
+      if (updates.name !== undefined || updates.email !== undefined) {
+        updated = await authService.updateUser(userId, {
+          name: updates.name,
+          email: updates.email,
+        });
+      }
+
+      // Apply role change
+      if (updates.role !== undefined) {
+        updated = await authService.updateUserRole(userId, updates.role);
+      }
+
+      // Apply active status change
+      if (updates.isActive === false) {
+        updated = await authService.deactivateUser(userId);
+      }
+
+      if (!updated) {
+        // Fetch current state if no mutations were applied
+        const users = await authService.getAllUsers();
+        updated = users.find((u) => u.id === userId);
+        if (!updated) {
+          res.status(404).json({ error: "User not found" });
+          return;
+        }
+      }
+
+      res.json({ user: updated });
+    } catch (err) {
+      const error = err as Error;
+      if (error.message === "User not found") {
+        res.status(404).json({ error: "User not found" });
+        return;
+      }
+      if (error.message?.includes("unique") || error.message?.includes("duplicate")) {
+        res.status(409).json({ error: "Email already in use" });
         return;
       }
       throw err;

--- a/server/routes/health.ts
+++ b/server/routes/health.ts
@@ -1,6 +1,7 @@
 import type { Express } from "express";
 import { pool } from "../db";
 import { configLoader } from "../config/loader";
+import { authService } from "../auth/service";
 
 /**
  * GET /api/health
@@ -26,7 +27,19 @@ import { configLoader } from "../config/loader";
  *   503 — unhealthy (DB is down; app cannot serve requests)
  */
 export function registerHealthRoutes(app: Express): void {
-  app.get("/api/health", async (_req, res) => {
+  app.get("/api/health", async (req, res) => {
+    // Check if caller is authenticated (optional — unauthenticated gets minimal response)
+    let isAuthenticated = false;
+    const authHeader = req.headers.authorization;
+    if (authHeader?.startsWith("Bearer ")) {
+      try {
+        await authService.validateToken(authHeader.slice(7));
+        isAuthenticated = true;
+      } catch {
+        // Not authenticated — serve minimal response
+      }
+    }
+
     // ── 1. Database check ───────────────────────────────────────────────────
     let dbStatus: { status: "ok" | "error"; latencyMs?: number; error?: string } = {
       status: "error",
@@ -84,6 +97,15 @@ export function registerHealthRoutes(app: Express): void {
           ? "degraded"
           : "ok";
 
+    const statusCode = overallStatus === "unhealthy" ? 503 : 200;
+
+    if (!isAuthenticated) {
+      // Minimal response for unauthenticated callers — no internal topology
+      res.status(statusCode).json({ status: overallStatus });
+      return;
+    }
+
+    // Full response for authenticated users
     const body = {
       status: overallStatus,
       version: process.env.npm_package_version ?? "unknown",
@@ -96,6 +118,6 @@ export function registerHealthRoutes(app: Express): void {
       },
     };
 
-    res.status(overallStatus === "unhealthy" ? 503 : 200).json(body);
+    res.status(statusCode).json(body);
   });
 }


### PR DESCRIPTION
## Summary
Fixes all 6 bugs identified during comprehensive QA testing of the platform.

### Fixes included

| Issue | Severity | Fix |
|-------|----------|-----|
| #195 | Critical | Add missing `trace_id` column to `task_groups` table via migration |
| #196 | High | Add `/api/*` catch-all 404 handler before SPA fallback — 19 routes now return proper JSON 404 instead of HTML |
| #197 | Medium | Add `express-rate-limit` on `/api/auth/login` — 5 attempts/min/IP |
| #198 | Medium | Add `Content-Security-Policy` header via Caddy, remove `X-Powered-By` in both Caddy and Express |
| #199 | Medium | Implement `PATCH /api/users/:id` for admin user management (name, email, role, isActive) |
| #200 | Low | Health endpoint returns minimal `{"status":"ok"}` for unauthenticated callers, full details only for authenticated users |

### Files changed
- `migrations/0008_add_task_groups_trace_id.sql` — new migration
- `server/index.ts` — API 404 catch-all + disable x-powered-by
- `server/routes/auth.ts` — rate limiter + PATCH users endpoint
- `server/routes/health.ts` — conditional response based on auth
- `Caddyfile` — CSP header + strip X-Powered-By
- `package.json` — add `express-rate-limit` dependency

### Verification
All 6 fixes were verified against the running Docker platform:
- [x] `GET /api/task-groups` → 200 `[]` (was 500)
- [x] `GET /api/guardrails` → 404 JSON (was 200 HTML)
- [x] Login rate limiting → 429 after 5 attempts (was unlimited)
- [x] CSP header present, X-Powered-By removed
- [x] `PATCH /api/users/:id` → 200 with updated user (was HTML)
- [x] Health unauthenticated → `{"status":"degraded"}` only (was full topology)

## Test plan
- [x] Verified each fix against running platform
- [ ] Run existing E2E test suite
- [ ] Security team review of CSP policy