### PR TITLE
fix(health): treat vllm and lmstudio as optional providers

### DIFF
--- a/server/routes/health.ts
+++ b/server/routes/health.ts
@@ -88,12 +88,12 @@ export function registerHealthRoutes(app: Express): void {
 
     // ── 3. Overall status ───────────────────────────────────────────────────
     // unhealthy  → DB is down; app cannot serve requests
-    // degraded   → DB is ok but a provider is unreachable
-    // ok         → everything is reachable
+    // degraded   → DB is ok but ollama (core local provider) is unreachable
+    // ok         → DB and ollama are reachable (vllm/lmstudio are optional)
     const overallStatus =
       dbStatus.status === "error"
         ? "unhealthy"
-        : vllmStatus === "unreachable" || ollamaStatus === "unreachable" || lmstudioStatus === "unreachable"
+        : ollamaStatus === "unreachable"
           ? "degraded"
           : "ok";
 


### PR DESCRIPTION
## Summary
vllm and lmstudio no longer cause "degraded" health status when unreachable.

## Problem
Health endpoint reported `"degraded"` on dev profile because vllm endpoint is configured in docker-compose but the vllm container only runs in the `full` profile (GPU required). This made the platform appear unhealthy even when everything relevant was working.

## Fix
Only ollama (the core local provider in dev profile) affects overall health status. vllm and lmstudio are treated as optional — their individual statuses are still visible to authenticated users for debugging.

| Provider | Profile | Affects health? |
|----------|---------|----------------|
| ollama | dev, full | Yes |
| vllm | full only | No (optional) |
| lmstudio | external | No (optional) |

## Verification
```
# Before: {"status":"degraded"}
# After:  {"status":"ok"}
```
Authenticated detailed view still shows `vllm: "unreachable"` for debugging.