### PR TITLE
fix(docker): add git to production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN npm run build
 
 # ── Production ────────────────────────────────────
 FROM base AS production
+RUN apk add --no-cache git
 ENV NODE_ENV=production
 ENV PORT=5000
 


### PR DESCRIPTION
## Summary
Adds `git` to the production Docker image so remote workspace cloning works.

## Problem
Creating a remote workspace failed with `spawn git ENOENT` — the `node:20-alpine` production stage had no `git` binary, but `WorkspaceManager.cloneRemote()` shells out to `git clone`.

## Fix
```dockerfile
RUN apk add --no-cache git
```

## Verification
- Rebuilt container, confirmed `which git` → `/usr/bin/git`
- Created remote workspace from `https://github.com/100rd/multiqlti`
- Status transitioned: `syncing` → `active`, `indexStatus: ready`