### PR TITLE
fix(db): register library migration in Drizzle journal

### DIFF
--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1742601600000,
       "tag": "0008_add_task_groups_trace_id",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1742688000000,
+      "tag": "0005_phase_7_library",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
Registers the `0005_phase_7_library` migration in the Drizzle journal so `library_channels` and `library_items` tables are created on fresh installs.

## Problem
`GET /api/library/items` and `GET /api/library/channels` returned 500 on fresh databases because the migration file existed but wasn't in `_journal.json`.

## Fix
Added journal entry for `0005_phase_7_library` (idx: 9).

## Verification
- Applied migration to running DB
- `GET /api/library/items` → 200 `[]`
- `GET /api/library/channels` → 200 `[]`