### PR TITLE
fix(models): fix PATCH/DELETE routing and duplicate slug handling

### DIFF
--- a/server/routes/models.ts
+++ b/server/routes/models.ts
@@ -17,6 +17,14 @@ const CreateModelSchema = z.object({
 
 const UpdateModelSchema = CreateModelSchema.partial();
 
+async function resolveModel(storage: IStorage, idOrSlug: string) {
+  // Try slug first (more common in URLs), then fall back to UUID
+  const bySlug = await storage.getModelBySlug(idOrSlug);
+  if (bySlug) return bySlug;
+  const models = await storage.getModels();
+  return models.find((m) => m.id === idOrSlug) ?? null;
+}
+
 export function registerModelRoutes(router: Router, storage: IStorage) {
   router.get("/api/models", async (_req, res) => {
     const models = await storage.getModels();
@@ -42,11 +50,19 @@ export function registerModelRoutes(router: Router, storage: IStorage) {
         issues: result.error.issues.map((i) => ({ path: i.path, message: i.message })),
       });
     }
-    const model = await storage.createModel(result.data);
-    res.status(201).json(model);
+    try {
+      const model = await storage.createModel(result.data);
+      res.status(201).json(model);
+    } catch (e) {
+      const msg = (e as Error).message ?? "";
+      if (msg.includes("unique") || msg.includes("duplicate")) {
+        return res.status(409).json({ error: "A model with this slug already exists" });
+      }
+      throw e;
+    }
   });
 
-  router.patch("/api/models/:id", async (req, res) => {
+  router.patch("/api/models/:idOrSlug", async (req, res) => {
     const result = UpdateModelSchema.safeParse(req.body);
     if (!result.success) {
       return res.status(400).json({
@@ -55,16 +71,20 @@ export function registerModelRoutes(router: Router, storage: IStorage) {
       });
     }
     try {
-      const model = await storage.updateModel(req.params.id, result.data);
-      res.json(model);
+      const model = await resolveModel(storage, req.params.idOrSlug);
+      if (!model) return res.status(404).json({ error: "Model not found" });
+      const updated = await storage.updateModel(model.id, result.data);
+      res.json(updated);
     } catch (e) {
       res.status(404).json({ error: (e as Error).message });
     }
   });
 
-  router.delete("/api/models/:id", async (req, res) => {
+  router.delete("/api/models/:idOrSlug", async (req, res) => {
     try {
-      await storage.deleteModel(req.params.id);
+      const model = await resolveModel(storage, req.params.idOrSlug);
+      if (!model) return res.status(404).json({ error: "Model not found" });
+      await storage.deleteModel(model.id);
       res.status(204).end();
     } catch (e) {
       res.status(404).json({ error: (e as Error).message });


### PR DESCRIPTION
## Summary
Fixes 3 model CRUD bugs found during comprehensive QA testing.

| Issue | Bug | Fix |
|-------|-----|-----|
| #217 | PATCH always returns 404 | Resolve by slug or UUID |
| #218 | DELETE is no-op | Resolve by slug or UUID |
| #219 | Duplicate slug returns 500 | Catch constraint violation, return 409 |

## Root Cause
GET uses `/api/models/:slug` but PATCH/DELETE used `/api/models/:id` with `eq(models.id, id)`. Users naturally pass the slug from GET responses, which never matches a UUID.

## Verification
```
PATCH /api/models/delete-test → 200 (was 404)
DELETE /api/models/delete-test → 204, then GET → 404 (was no-op)
POST duplicate slug → 409 (was 500)
```