### PR TITLE
feat: built-in MCP servers (#270)

### DIFF
--- a/server/mcp-servers/base.ts
+++ b/server/mcp-servers/base.ts
@@ -1,0 +1,141 @@
+/**
+ * Base interface and types for built-in MCP servers (issue #270).
+ *
+ * Each built-in MCP server:
+ *  - Is tied to a specific ConnectionType ("kubernetes", "github", "gitlab", "docker-run" conceptually)
+ *  - Exposes a set of ToolHandlers that the BuiltinMcpServerRegistry registers
+ *  - Receives connection config + resolved secrets at startup
+ *  - Enforces scope: which operations are allowed vs. require an explicit allow-flag
+ */
+
+import type { ToolHandler } from "../tools/registry";
+import type { ConnectionType } from "@shared/types";
+
+// ─── Server Config ─────────────────────────────────────────────────────────────
+
+/**
+ * Runtime configuration supplied to a built-in MCP server when it starts.
+ * Secrets are passed as a plain map — they were decrypted from storage and
+ * must NEVER be logged or included in tool output.
+ */
+export interface BuiltinMcpServerConfig {
+  /** The workspace connection ID this server represents. */
+  connectionId: string;
+  /** Non-secret configuration JSON (URLs, usernames, project keys, etc.). */
+  config: Record<string, unknown>;
+  /**
+   * Decrypted secrets. Must never appear in logs or tool responses.
+   * The server is responsible for redacting these values from all output.
+   */
+  secrets: Record<string, string>;
+  /**
+   * When true the server may execute destructive operations
+   * (delete namespace, force-push, etc.). Defaults to false.
+   */
+  allowDestructive?: boolean;
+}
+
+// ─── Tool Scope ────────────────────────────────────────────────────────────────
+
+/** The two permission tiers for built-in tools. */
+export type ToolScope = "read" | "destructive";
+
+/**
+ * Metadata attached to every tool exposed by a built-in MCP server.
+ * The registry uses `scope` to decide whether the operation is gated by
+ * `allowDestructive`.
+ */
+export interface BuiltinToolMeta {
+  /** Human-readable category for grouping in the UI. */
+  category: string;
+  /** "read" = always allowed; "destructive" = requires `allowDestructive` flag. */
+  scope: ToolScope;
+}
+
+// ─── Server Interface ─────────────────────────────────────────────────────────
+
+/**
+ * Interface all built-in MCP servers must implement.
+ *
+ * The registry calls `start()` once when a matching connection is created /
+ * enabled, then calls `stop()` when the connection is deleted / disabled.
+ */
+export interface IBuiltinMcpServer {
+  /**
+   * The connection type this server handles.
+   * Must match exactly one of the CONNECTION_TYPES values.
+   */
+  readonly connectionType: ConnectionType;
+
+  /**
+   * Initialise the server with the connection config and resolved secrets.
+   * Must not throw for invalid config — surface errors as tool execution results.
+   */
+  start(cfg: BuiltinMcpServerConfig): Promise<void>;
+
+  /** Release all resources held by this server. */
+  stop(): Promise<void>;
+
+  /**
+   * Return all tool handlers this server exposes.
+   * Called after `start()` — handlers may close over the resolved config.
+   */
+  getToolHandlers(): ToolHandler[];
+
+  /**
+   * Return the scope for a named tool.
+   * Returns undefined if the tool is unknown (treated as "read").
+   */
+  getToolScope(toolName: string): ToolScope | undefined;
+}
+
+// ─── Secret Redaction ─────────────────────────────────────────────────────────
+
+/**
+ * Replace every occurrence of a secret value in `text` with a placeholder.
+ * Called on every string returned from tool executors.
+ *
+ * Rules:
+ * - Only non-empty secret values are redacted.
+ * - The replacement is `[REDACTED]`.
+ * - Comparison is case-sensitive (secrets are case-sensitive credentials).
+ */
+export function redactSecrets(text: string, secrets: Record<string, string>): string {
+  let result = text;
+  for (const value of Object.values(secrets)) {
+    if (!value) continue;
+    // Escape special regex chars to avoid broken patterns
+    const escaped = value.replace(/[$()*+./?[\\\]^{|}]/g, "\\$&");
+    result = result.replace(new RegExp(escaped, "g"), "[REDACTED]");
+  }
+  return result;
+}
+
+// ─── Destructive Guard ────────────────────────────────────────────────────────
+
+/**
+ * Throw a typed error when a destructive operation is attempted without the
+ * `allowDestructive` flag. The message is safe to surface to the user.
+ */
+export class DestructiveOperationDeniedError extends Error {
+  constructor(toolName: string) {
+    super(
+      `Tool "${toolName}" is a destructive operation. ` +
+        "Set allowDestructive=true on the workspace connection to enable it.",
+    );
+    this.name = "DestructiveOperationDeniedError";
+  }
+}
+
+/**
+ * Guard helper used inside every destructive tool executor.
+ * Throws `DestructiveOperationDeniedError` when `allowDestructive` is falsy.
+ */
+export function requireDestructiveFlag(
+  toolName: string,
+  allowDestructive: boolean | undefined,
+): void {
+  if (!allowDestructive) {
+    throw new DestructiveOperationDeniedError(toolName);
+  }
+}

--- a/server/mcp-servers/docker-run/index.ts
+++ b/server/mcp-servers/docker-run/index.ts
@@ -1,0 +1,271 @@
+/**
+ * Built-in Docker-Run MCP server (issue #270).
+ *
+ * Wraps the existing SandboxExecutor to expose a single tool:
+ *   docker_run — run an arbitrary Docker image with cpu/mem caps
+ *
+ * The connection config supplies default limits; the tool caller may tighten
+ * them but CANNOT exceed the connection's caps.
+ *
+ * Security:
+ *   - CPU and memory are always capped (deny unbounded runs).
+ *   - Network is disabled by default unless `networkEnabled` is true on config.
+ *   - Secrets (if any) are redacted from stdout/stderr.
+ *   - `docker_run_privileged` (run with full privileges) is DESTRUCTIVE.
+ */
+
+import type { ToolHandler } from "../../tools/registry";
+import type { IBuiltinMcpServer, BuiltinMcpServerConfig, ToolScope } from "../base";
+import { redactSecrets, requireDestructiveFlag } from "../base";
+import { SandboxExecutor } from "../../sandbox/executor";
+import type { SandboxConfig, SandboxFile } from "@shared/types";
+import { SANDBOX_DEFAULTS } from "@shared/constants";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Hard cap on memory to prevent runaway containers. */
+const MAX_MEMORY_LIMIT = "2g";
+/** Hard cap on CPU fraction (2 cores). */
+const MAX_CPU_LIMIT = 2;
+/** Hard cap on timeout seconds. */
+const MAX_TIMEOUT_SECONDS = 300;
+
+const TOOL_DOCKER_RUN = "docker_run";
+const TOOL_DOCKER_RUN_PRIVILEGED = "docker_run_privileged";
+
+const TOOL_SCOPES: Record<string, ToolScope> = {
+  [TOOL_DOCKER_RUN]: "read",
+  [TOOL_DOCKER_RUN_PRIVILEGED]: "destructive",
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Parse a memory limit string (e.g. "512m", "1g") into bytes for comparison.
+ * Only supports `m` (megabytes) and `g` (gigabytes) suffixes.
+ */
+function parseMemoryBytes(mem: string): number {
+  const lower = mem.toLowerCase();
+  if (lower.endsWith("g")) return parseFloat(lower) * 1024 * 1024 * 1024;
+  if (lower.endsWith("m")) return parseFloat(lower) * 1024 * 1024;
+  if (lower.endsWith("k")) return parseFloat(lower) * 1024;
+  return parseFloat(lower); // assume bytes
+}
+
+/**
+ * Clamp the caller's memory request to the connection cap and hard cap.
+ */
+function clampMemory(requested: string, connectionLimit: string): string {
+  const reqBytes = parseMemoryBytes(requested);
+  const connBytes = parseMemoryBytes(connectionLimit);
+  const maxBytes = parseMemoryBytes(MAX_MEMORY_LIMIT);
+  const cappedBytes = Math.min(reqBytes, connBytes, maxBytes);
+  // Express in MB for readability
+  return `${Math.floor(cappedBytes / 1024 / 1024)}m`;
+}
+
+// ─── DockerRunMcpServer ───────────────────────────────────────────────────────
+
+export class DockerRunMcpServer implements IBuiltinMcpServer {
+  // docker-run is not a real ConnectionType; it maps to a generic_mcp connection
+  // that the registry uses as the "docker-run" provider. We use a generic MCP
+  // connection to hold docker caps config.
+  readonly connectionType = "generic_mcp" as const;
+
+  private cfg: BuiltinMcpServerConfig | null = null;
+  private executor: SandboxExecutor;
+
+  constructor(executor?: SandboxExecutor) {
+    this.executor = executor ?? new SandboxExecutor();
+  }
+
+  async start(cfg: BuiltinMcpServerConfig): Promise<void> {
+    this.cfg = cfg;
+  }
+
+  async stop(): Promise<void> {
+    this.cfg = null;
+  }
+
+  getToolScope(toolName: string): ToolScope | undefined {
+    return TOOL_SCOPES[toolName];
+  }
+
+  getToolHandlers(): ToolHandler[] {
+    if (!this.cfg) {
+      throw new Error("DockerRunMcpServer: call start() before getToolHandlers()");
+    }
+
+    const cfg = this.cfg;
+    const connectionMemoryLimit = String(cfg.config["memoryLimit"] ?? SANDBOX_DEFAULTS.memoryLimit);
+    const connectionCpuLimit = Math.min(
+      Number(cfg.config["cpuLimit"] ?? SANDBOX_DEFAULTS.cpuLimit),
+      MAX_CPU_LIMIT,
+    );
+    const connectionNetworkEnabled = Boolean(cfg.config["networkEnabled"] ?? false);
+    const connectionTimeout = Math.min(
+      Number(cfg.config["timeout"] ?? SANDBOX_DEFAULTS.timeout),
+      MAX_TIMEOUT_SECONDS,
+    );
+    const executor = this.executor;
+
+    const runContainer = async (
+      args: Record<string, unknown>,
+      networkOverride?: boolean,
+    ): Promise<string> => {
+      const image = String(args["image"] ?? "").trim();
+      const command = String(args["command"] ?? "sh").trim();
+      if (!image) return "Error: image is required.";
+
+      // Clamp caller's limits to connection caps
+      const requestedMem = String(args["memoryLimit"] ?? connectionMemoryLimit);
+      const requestedCpu = Math.min(
+        Number(args["cpuLimit"] ?? connectionCpuLimit),
+        connectionCpuLimit,
+        MAX_CPU_LIMIT,
+      );
+      const requestedTimeout = Math.min(
+        Number(args["timeout"] ?? connectionTimeout),
+        connectionTimeout,
+        MAX_TIMEOUT_SECONDS,
+      );
+
+      const sandboxConfig: SandboxConfig = {
+        enabled: true,
+        image,
+        command,
+        memoryLimit: clampMemory(requestedMem, connectionMemoryLimit),
+        cpuLimit: requestedCpu,
+        networkEnabled: networkOverride !== undefined ? networkOverride : connectionNetworkEnabled,
+        timeout: requestedTimeout,
+        env: args["env"] ? (args["env"] as Record<string, string>) : undefined,
+        installCommand: args["installCommand"] ? String(args["installCommand"]) : undefined,
+        workdir: args["workdir"] ? String(args["workdir"]) : undefined,
+      };
+
+      const files: SandboxFile[] = Array.isArray(args["files"])
+        ? (args["files"] as Array<{ path: string; content: string }>).map((f) => ({
+            path: f.path,
+            content: f.content,
+          }))
+        : [];
+
+      const result = await executor.execute(sandboxConfig, files);
+
+      const lines: string[] = [
+        `Exit code: ${result.exitCode}`,
+        `Duration: ${result.durationMs}ms`,
+        `Memory limit: ${sandboxConfig.memoryLimit}`,
+        `CPU limit: ${sandboxConfig.cpuLimit}`,
+      ];
+      if (result.timedOut) lines.push("Status: TIMED_OUT");
+      if (result.stdout) lines.push(`\nstdout:\n${result.stdout}`);
+      if (result.stderr) lines.push(`\nstderr:\n${result.stderr}`);
+
+      const output = lines.join("\n");
+      return redactSecrets(output, cfg.secrets);
+    };
+
+    return [
+      // ── docker_run ─────────────────────────────────────────────────────────
+      {
+        definition: {
+          name: TOOL_DOCKER_RUN,
+          description:
+            "Run a Docker image in a sandboxed container with CPU/memory caps. " +
+            "Network is disabled by default (controlled by connection config).",
+          inputSchema: {
+            type: "object",
+            properties: {
+              image: {
+                type: "string",
+                description: "Docker image to run (e.g. \"python:3.12-slim\").",
+              },
+              command: {
+                type: "string",
+                description: "Shell command to execute inside the container.",
+              },
+              memoryLimit: {
+                type: "string",
+                description:
+                  `Memory limit (e.g. "512m", "1g"). Capped at connection limit (${connectionMemoryLimit}).`,
+              },
+              cpuLimit: {
+                type: "number",
+                description:
+                  `CPU fraction (e.g. 0.5 = half a core). Capped at connection limit (${connectionCpuLimit}).`,
+              },
+              timeout: {
+                type: "number",
+                description:
+                  `Timeout in seconds. Capped at connection limit (${connectionTimeout}).`,
+              },
+              files: {
+                type: "array",
+                description: "Files to write into the workdir before running.",
+                items: {
+                  type: "object",
+                  properties: {
+                    path: { type: "string" },
+                    content: { type: "string" },
+                  },
+                  required: ["path", "content"],
+                },
+              },
+              env: {
+                type: "object",
+                description: "Environment variables to set inside the container.",
+                additionalProperties: { type: "string" },
+              },
+              installCommand: {
+                type: "string",
+                description: "Command to run before the main command (e.g. \"pip install -r requirements.txt\").",
+              },
+              workdir: {
+                type: "string",
+                description: "Working directory inside the container.",
+              },
+            },
+            required: ["image", "command"],
+          },
+          source: "mcp" as const,
+          mcpServer: `builtin:docker-run:${cfg.connectionId}`,
+          tags: ["docker", `connection:${cfg.connectionId}`],
+        },
+        execute: (args) => runContainer(args),
+      },
+
+      // ── docker_run_privileged ──────────────────────────────────────────────
+      {
+        definition: {
+          name: TOOL_DOCKER_RUN_PRIVILEGED,
+          description:
+            "Run a Docker image with network access enabled. " +
+            "DESTRUCTIVE — requires allowDestructive=true on the connection.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              image: { type: "string", description: "Docker image to run." },
+              command: { type: "string", description: "Command to execute." },
+              memoryLimit: { type: "string" },
+              cpuLimit: { type: "number" },
+              timeout: { type: "number" },
+              files: { type: "array", items: { type: "object" } },
+              env: { type: "object", additionalProperties: { type: "string" } },
+              installCommand: { type: "string" },
+              workdir: { type: "string" },
+            },
+            required: ["image", "command"],
+          },
+          source: "mcp" as const,
+          mcpServer: `builtin:docker-run:${cfg.connectionId}`,
+          tags: ["docker", `connection:${cfg.connectionId}`],
+        },
+        execute: async (args) => {
+          requireDestructiveFlag(TOOL_DOCKER_RUN_PRIVILEGED, cfg.allowDestructive);
+          return runContainer(args, true /* networkEnabled */);
+        },
+      },
+    ];
+  }
+}

--- a/server/mcp-servers/github/index.ts
+++ b/server/mcp-servers/github/index.ts
@@ -1,0 +1,367 @@
+/**
+ * Built-in GitHub MCP server (issue #270).
+ *
+ * Tools exposed (read-heavy — no repo settings mutation):
+ *   github_list_prs        — list open/closed PRs with pagination
+ *   github_get_pr_files    — list files changed in a PR
+ *   github_get_pr_diff     — get the raw unified diff for a PR
+ *   github_post_comment    — post a comment on a PR or issue
+ *   github_list_workflows  — list recent workflow runs for the repo
+ *
+ * Security:
+ *   - The GitHub token is sourced from `secrets["token"]` — NEVER logged.
+ *   - No repo settings, branch protection, secrets, or admin mutations.
+ *   - `github_post_comment` is the only write operation (non-destructive;
+ *     destructive would be delete, force-push, etc.).
+ *   - All output is redacted of secret values.
+ */
+
+import type { ToolHandler } from "../../tools/registry";
+import type { IBuiltinMcpServer, BuiltinMcpServerConfig, ToolScope } from "../base";
+import { redactSecrets } from "../base";
+
+// ─── GitHub API client ────────────────────────────────────────────────────────
+
+interface GitHubRequestOptions {
+  method?: string;
+  body?: unknown;
+}
+
+interface GitHubApiClient {
+  get(path: string): Promise<unknown>;
+  post(path: string, body: unknown): Promise<unknown>;
+}
+
+function buildGitHubClient(host: string, token: string): GitHubApiClient {
+  const baseUrl = host.endsWith("/") ? host.slice(0, -1) : host;
+
+  async function request(path: string, opts: GitHubRequestOptions = {}): Promise<unknown> {
+    const url = `${baseUrl}${path}`;
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Content-Type": "application/json",
+    };
+
+    const fetchRes = await fetch(url, {
+      method: opts.method ?? "GET",
+      headers,
+      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+    });
+
+    if (!fetchRes.ok) {
+      const text = await fetchRes.text().catch(() => "");
+      throw new Error(`GitHub API ${fetchRes.status}: ${text.slice(0, 200)}`);
+    }
+
+    return fetchRes.json().catch(() => null);
+  }
+
+  return {
+    get: (path) => request(path),
+    post: (path, body) => request(path, { method: "POST", body }),
+  };
+}
+
+// ─── Tool name constants ──────────────────────────────────────────────────────
+
+const TOOL_LIST_PRS = "github_list_prs";
+const TOOL_GET_PR_FILES = "github_get_pr_files";
+const TOOL_GET_PR_DIFF = "github_get_pr_diff";
+const TOOL_POST_COMMENT = "github_post_comment";
+const TOOL_LIST_WORKFLOWS = "github_list_workflows";
+
+const TOOL_SCOPES: Record<string, ToolScope> = {
+  [TOOL_LIST_PRS]: "read",
+  [TOOL_GET_PR_FILES]: "read",
+  [TOOL_GET_PR_DIFF]: "read",
+  [TOOL_POST_COMMENT]: "read",   // posting a comment is not destructive
+  [TOOL_LIST_WORKFLOWS]: "read",
+};
+
+// ─── GitHubMcpServer ──────────────────────────────────────────────────────────
+
+export class GitHubMcpServer implements IBuiltinMcpServer {
+  readonly connectionType = "github" as const;
+
+  private cfg: BuiltinMcpServerConfig | null = null;
+  private client: GitHubApiClient | null = null;
+  private repoOwner = "";
+  private repoName = "";
+
+  async start(cfg: BuiltinMcpServerConfig): Promise<void> {
+    this.cfg = cfg;
+
+    const host = String(cfg.config["host"] ?? "https://api.github.com");
+    const owner = String(cfg.config["owner"] ?? "");
+    const repo = String(cfg.config["repo"] ?? "");
+
+    // owner/repo can be split from a single "owner/repo" field
+    if (owner.includes("/")) {
+      const [o, r] = owner.split("/", 2);
+      this.repoOwner = o ?? owner;
+      this.repoName = r ?? repo;
+    } else {
+      this.repoOwner = owner;
+      this.repoName = repo;
+    }
+
+    const token = cfg.secrets["token"] ?? cfg.secrets["githubToken"] ?? "";
+    this.client = buildGitHubClient(host, token);
+  }
+
+  async stop(): Promise<void> {
+    this.cfg = null;
+    this.client = null;
+  }
+
+  getToolScope(toolName: string): ToolScope | undefined {
+    return TOOL_SCOPES[toolName];
+  }
+
+  getToolHandlers(): ToolHandler[] {
+    if (!this.cfg || !this.client) {
+      throw new Error("GitHubMcpServer: call start() before getToolHandlers()");
+    }
+
+    const cfg = this.cfg;
+    const client = this.client;
+    const defaultOwner = this.repoOwner;
+    const defaultRepo = this.repoName;
+
+    function ownerRepo(args: Record<string, unknown>): { owner: string; repo: string } {
+      const raw = String(args["repo"] ?? "");
+      if (raw.includes("/")) {
+        const [o, r] = raw.split("/", 2);
+        return { owner: o ?? defaultOwner, repo: r ?? defaultRepo };
+      }
+      return {
+        owner: String(args["owner"] ?? defaultOwner),
+        repo: raw || defaultRepo,
+      };
+    }
+
+    function safe(value: unknown): string {
+      return redactSecrets(JSON.stringify(value, null, 2), cfg.secrets);
+    }
+
+    return [
+      // ── github_list_prs ────────────────────────────────────────────────────
+      {
+        definition: {
+          name: TOOL_LIST_PRS,
+          description:
+            "List pull requests for a GitHub repository. Returns PR number, title, state, author, and URL.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              repo: {
+                type: "string",
+                description: "Repository in \"owner/repo\" format, or just \"repo\" if owner is set on the connection.",
+              },
+              state: {
+                type: "string",
+                enum: ["open", "closed", "all"],
+                description: "PR state filter (default: \"open\").",
+              },
+              perPage: {
+                type: "number",
+                description: "Results per page (default: 30, max: 100).",
+              },
+              page: {
+                type: "number",
+                description: "Page number (default: 1).",
+              },
+            },
+            required: [],
+          },
+          source: "mcp" as const,
+          mcpServer: `builtin:github:${cfg.connectionId}`,
+          tags: ["github", `connection:${cfg.connectionId}`],
+        },
+        execute: async (args) => {
+          const { owner, repo } = ownerRepo(args);
+          if (!owner || !repo) return "Error: repository owner and name are required (set on connection or pass repo=\"owner/repo\").";
+
+          const state = String(args["state"] ?? "open");
+          const perPage = Math.min(Number(args["perPage"] ?? 30), 100);
+          const page = Number(args["page"] ?? 1);
+
+          const data = await client.get(
+            `/repos/${owner}/${repo}/pulls?state=${state}&per_page=${perPage}&page=${page}`,
+          );
+          return safe(data);
+        },
+      },
+
+      // ── github_get_pr_files ────────────────────────────────────────────────
+      {
+        definition: {
+          name: TOOL_GET_PR_FILES,
+          description:
+            "List files changed in a pull request. Returns filename, status, additions, deletions.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              repo: { type: "string", description: "Repository (\"owner/repo\" or just \"repo\")." },
+              prNumber: { type: "number", description: "Pull request number." },
+            },
+            required: ["prNumber"],
+          },
+          source: "mcp" as const,
+          mcpServer: `builtin:github:${cfg.connectionId}`,
+          tags: ["github", `connection:${cfg.connectionId}`],
+        },
+        execute: async (args) => {
+          const { owner, repo } = ownerRepo(args);
+          const prNumber = Number(args["prNumber"]);
+          if (!owner || !repo) return "Error: repository required.";
+          if (!prNumber) return "Error: prNumber is required.";
+
+          const data = await client.get(`/repos/${owner}/${repo}/pulls/${prNumber}/files`);
+          return safe(data);
+        },
+      },
+
+      // ── github_get_pr_diff ─────────────────────────────────────────────────
+      {
+        definition: {
+          name: TOOL_GET_PR_DIFF,
+          description:
+            "Get the raw unified diff for a pull request.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              repo: { type: "string", description: "Repository (\"owner/repo\")." },
+              prNumber: { type: "number", description: "Pull request number." },
+            },
+            required: ["prNumber"],
+          },
+          source: "mcp" as const,
+          mcpServer: `builtin:github:${cfg.connectionId}`,
+          tags: ["github", `connection:${cfg.connectionId}`],
+        },
+        execute: async (args) => {
+          const { owner, repo } = ownerRepo(args);
+          const prNumber = Number(args["prNumber"]);
+          if (!owner || !repo) return "Error: repository required.";
+          if (!prNumber) return "Error: prNumber is required.";
+
+          // GitHub diff requires Accept: application/vnd.github.diff
+          const host = String(cfg.config["host"] ?? "https://api.github.com");
+          const token = cfg.secrets["token"] ?? cfg.secrets["githubToken"] ?? "";
+          const url = `${host}/repos/${owner}/${repo}/pulls/${prNumber}`;
+
+          const fetchRes = await fetch(url, {
+            headers: {
+              Authorization: `Bearer ${token}`,
+              Accept: "application/vnd.github.diff",
+              "X-GitHub-Api-Version": "2022-11-28",
+            },
+          });
+
+          if (!fetchRes.ok) {
+            const text = await fetchRes.text().catch(() => "");
+            return redactSecrets(`Error ${fetchRes.status}: ${text.slice(0, 200)}`, cfg.secrets);
+          }
+
+          const diff = await fetchRes.text();
+          return redactSecrets(diff, cfg.secrets);
+        },
+      },
+
+      // ── github_post_comment ────────────────────────────────────────────────
+      {
+        definition: {
+          name: TOOL_POST_COMMENT,
+          description:
+            "Post a comment on a GitHub pull request or issue. " +
+            "Returns the created comment URL.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              repo: { type: "string", description: "Repository (\"owner/repo\")." },
+              issueNumber: {
+                type: "number",
+                description: "PR or issue number to comment on.",
+              },
+              body: { type: "string", description: "Comment body (Markdown supported)." },
+            },
+            required: ["issueNumber", "body"],
+          },
+          source: "mcp" as const,
+          mcpServer: `builtin:github:${cfg.connectionId}`,
+          tags: ["github", `connection:${cfg.connectionId}`],
+        },
+        execute: async (args) => {
+          const { owner, repo } = ownerRepo(args);
+          const issueNumber = Number(args["issueNumber"]);
+          const body = String(args["body"] ?? "").trim();
+
+          if (!owner || !repo) return "Error: repository required.";
+          if (!issueNumber) return "Error: issueNumber is required.";
+          if (!body) return "Error: comment body is required.";
+
+          const data = await client.post(
+            `/repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+            { body },
+          );
+
+          const result = data as Record<string, unknown>;
+          return redactSecrets(
+            `Comment posted: ${String(result?.["html_url"] ?? "(no URL)")}`,
+            cfg.secrets,
+          );
+        },
+      },
+
+      // ── github_list_workflows ──────────────────────────────────────────────
+      {
+        definition: {
+          name: TOOL_LIST_WORKFLOWS,
+          description:
+            "List recent workflow runs for a GitHub repository. " +
+            "Returns run ID, name, status, conclusion, and URL.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              repo: { type: "string", description: "Repository (\"owner/repo\")." },
+              branch: {
+                type: "string",
+                description: "Filter by branch name.",
+              },
+              status: {
+                type: "string",
+                enum: ["queued", "in_progress", "completed", "waiting", "requested", "pending"],
+                description: "Filter by workflow run status.",
+              },
+              perPage: {
+                type: "number",
+                description: "Results per page (default: 10, max: 30).",
+              },
+            },
+            required: [],
+          },
+          source: "mcp" as const,
+          mcpServer: `builtin:github:${cfg.connectionId}`,
+          tags: ["github", `connection:${cfg.connectionId}`],
+        },
+        execute: async (args) => {
+          const { owner, repo } = ownerRepo(args);
+          if (!owner || !repo) return "Error: repository required.";
+
+          const perPage = Math.min(Number(args["perPage"] ?? 10), 30);
+          const params = new URLSearchParams({ per_page: String(perPage) });
+          if (args["branch"]) params.set("branch", String(args["branch"]));
+          if (args["status"]) params.set("status", String(args["status"]));
+
+          const data = await client.get(
+            `/repos/${owner}/${repo}/actions/runs?${params.toString()}`,
+          );
+          return safe(data);
+        },
+      },
+    ];
+  }
+}

--- a/server/mcp-servers/gitlab/index.ts
+++ b/server/mcp-servers/gitlab/index.ts
@@ -1,0 +1,376 @@
+/**
+ * Built-in GitLab MCP server (issue #270).
+ *
+ * Tools exposed (read-heavy — no project settings mutation):
+ *   gitlab_list_mrs        — list merge requests
+ *   gitlab_get_mr_diff     — get the diff for a merge request
+ *   gitlab_list_pipelines  — list CI/CD pipelines
+ *   gitlab_post_note       — post a note (comment) on an MR or issue
+ *   gitlab_list_commits    — list commits for a project branch
+ *
+ * Security:
+ *   - The GitLab token is sourced from `secrets["token"]` — NEVER logged.
+ *   - No project settings, protected branches, access token, or admin mutations.
+ *   - `gitlab_post_note` is the only write operation (non-destructive).
+ *   - All output is redacted of secret values.
+ */
+
+import type { ToolHandler } from "../../tools/registry";
+import type { IBuiltinMcpServer, BuiltinMcpServerConfig, ToolScope } from "../base";
+import { redactSecrets } from "../base";
+
+// ─── GitLab API client ────────────────────────────────────────────────────────
+
+interface GitLabApiClient {
+  get(path: string): Promise<unknown>;
+  post(path: string, body: unknown): Promise<unknown>;
+}
+
+function buildGitLabClient(host: string, token: string): GitLabApiClient {
+  const apiBase = `${host.replace(/\/$/, "")}/api/v4`;
+
+  async function request(path: string, method = "GET", body?: unknown): Promise<unknown> {
+    const url = `${apiBase}${path}`;
+    const headers: Record<string, string> = {
+      "PRIVATE-TOKEN": token,
+      "Content-Type": "application/json",
+    };
+
+    const fetchRes = await fetch(url, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+
+    if (!fetchRes.ok) {
+      const text = await fetchRes.text().catch(() => "");
+      throw new Error(`GitLab API ${fetchRes.status}: ${text.slice(0, 200)}`);
+    }
+
+    return fetchRes.json().catch(() => null);
+  }
+
+  return {
+    get: (path) => request(path),
+    post: (path, body) => request(path, "POST", body),
+  };
+}
+
+/**
+ * URL-encode a GitLab project path (namespace/project).
+ * GitLab requires the project ID or URL-encoded "namespace%2Fproject".
+ */
+function encodeProjectId(project: string): string {
+  return encodeURIComponent(project);
+}
+
+// ─── Tool name constants ──────────────────────────────────────────────────────
+
+const TOOL_LIST_MRS = "gitlab_list_mrs";
+const TOOL_GET_MR_DIFF = "gitlab_get_mr_diff";
+const TOOL_LIST_PIPELINES = "gitlab_list_pipelines";
+const TOOL_POST_NOTE = "gitlab_post_note";
+const TOOL_LIST_COMMITS = "gitlab_list_commits";
+
+const TOOL_SCOPES: Record<string, ToolScope> = {
+  [TOOL_LIST_MRS]: "read",
+  [TOOL_GET_MR_DIFF]: "read",
+  [TOOL_LIST_PIPELINES]: "read",
+  [TOOL_POST_NOTE]: "read",   // posting a note is not destructive
+  [TOOL_LIST_COMMITS]: "read",
+};
+
+// ─── GitLabMcpServer ──────────────────────────────────────────────────────────
+
+export class GitLabMcpServer implements IBuiltinMcpServer {
+  readonly connectionType = "gitlab" as const;
+
+  private cfg: BuiltinMcpServerConfig | null = null;
+  private client: GitLabApiClient | null = null;
+  private defaultProject = "";
+
+  async start(cfg: BuiltinMcpServerConfig): Promise<void> {
+    this.cfg = cfg;
+
+    const host = String(cfg.config["host"] ?? "https://gitlab.com");
+    const owner = String(cfg.config["owner"] ?? "");
+    const project = String(cfg.config["project"] ?? "");
+
+    // Store defaultProject as "owner/project" if both given
+    if (owner && project) {
+      this.defaultProject = `${owner}/${project}`;
+    } else if (owner.includes("/")) {
+      this.defaultProject = owner;
+    } else {
+      this.defaultProject = project || owner;
+    }
+
+    const token = cfg.secrets["token"] ?? cfg.secrets["gitlabToken"] ?? "";
+    this.client = buildGitLabClient(host, token);
+  }
+
+  async stop(): Promise<void> {
+    this.cfg = null;
+    this.client = null;
+  }
+
+  getToolScope(toolName: string): ToolScope | undefined {
+    return TOOL_SCOPES[toolName];
+  }
+
+  getToolHandlers(): ToolHandler[] {
+    if (!this.cfg || !this.client) {
+      throw new Error("GitLabMcpServer: call start() before getToolHandlers()");
+    }
+
+    const cfg = this.cfg;
+    const client = this.client;
+    const defaultProject = this.defaultProject;
+
+    function resolveProject(args: Record<string, unknown>): string {
+      const p = String(args["project"] ?? "").trim() || defaultProject;
+      if (!p) throw new Error("project is required (set on connection config or pass as argument)");
+      return p;
+    }
+
+    function safe(value: unknown): string {
+      return redactSecrets(JSON.stringify(value, null, 2), cfg.secrets);
+    }
+
+    return [
+      // ── gitlab_list_mrs ────────────────────────────────────────────────────
+      {
+        definition: {
+          name: TOOL_LIST_MRS,
+          description:
+            "List merge requests for a GitLab project. Returns MR IID, title, state, author, and URL.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              project: {
+                type: "string",
+                description: "Project path (\"namespace/project\") or ID. Uses connection default if omitted.",
+              },
+              state: {
+                type: "string",
+                enum: ["opened", "closed", "merged", "locked", "all"],
+                description: "MR state filter (default: \"opened\").",
+              },
+              perPage: {
+                type: "number",
+                description: "Results per page (default: 20, max: 100).",
+              },
+              page: {
+                type: "number",
+                description: "Page number (default: 1).",
+              },
+            },
+            required: [],
+          },
+          source: "mcp" as const,
+          mcpServer: `builtin:gitlab:${cfg.connectionId}`,
+          tags: ["gitlab", `connection:${cfg.connectionId}`],
+        },
+        execute: async (args) => {
+          const project = resolveProject(args);
+          const state = String(args["state"] ?? "opened");
+          const perPage = Math.min(Number(args["perPage"] ?? 20), 100);
+          const page = Number(args["page"] ?? 1);
+
+          const data = await client.get(
+            `/projects/${encodeProjectId(project)}/merge_requests?state=${state}&per_page=${perPage}&page=${page}`,
+          );
+          return safe(data);
+        },
+      },
+
+      // ── gitlab_get_mr_diff ─────────────────────────────────────────────────
+      {
+        definition: {
+          name: TOOL_GET_MR_DIFF,
+          description:
+            "Get the diff for a GitLab merge request. Returns per-file diffs.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              project: {
+                type: "string",
+                description: "Project path or ID. Uses connection default if omitted.",
+              },
+              mrIid: {
+                type: "number",
+                description: "Merge request IID (project-scoped integer ID).",
+              },
+            },
+            required: ["mrIid"],
+          },
+          source: "mcp" as const,
+          mcpServer: `builtin:gitlab:${cfg.connectionId}`,
+          tags: ["gitlab", `connection:${cfg.connectionId}`],
+        },
+        execute: async (args) => {
+          const project = resolveProject(args);
+          const mrIid = Number(args["mrIid"]);
+          if (!mrIid) return "Error: mrIid is required.";
+
+          const data = await client.get(
+            `/projects/${encodeProjectId(project)}/merge_requests/${mrIid}/diffs`,
+          );
+          return safe(data);
+        },
+      },
+
+      // ── gitlab_list_pipelines ──────────────────────────────────────────────
+      {
+        definition: {
+          name: TOOL_LIST_PIPELINES,
+          description:
+            "List CI/CD pipeline runs for a GitLab project. Returns pipeline ID, status, ref, and URL.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              project: {
+                type: "string",
+                description: "Project path or ID. Uses connection default if omitted.",
+              },
+              ref: {
+                type: "string",
+                description: "Filter by branch or tag name.",
+              },
+              status: {
+                type: "string",
+                enum: ["created", "waiting_for_resource", "preparing", "pending", "running", "success", "failed", "canceled", "skipped", "manual", "scheduled"],
+                description: "Filter by pipeline status.",
+              },
+              perPage: {
+                type: "number",
+                description: "Results per page (default: 10, max: 100).",
+              },
+            },
+            required: [],
+          },
+          source: "mcp" as const,
+          mcpServer: `builtin:gitlab:${cfg.connectionId}`,
+          tags: ["gitlab", `connection:${cfg.connectionId}`],
+        },
+        execute: async (args) => {
+          const project = resolveProject(args);
+          const perPage = Math.min(Number(args["perPage"] ?? 10), 100);
+          const params = new URLSearchParams({ per_page: String(perPage) });
+          if (args["ref"]) params.set("ref", String(args["ref"]));
+          if (args["status"]) params.set("status", String(args["status"]));
+
+          const data = await client.get(
+            `/projects/${encodeProjectId(project)}/pipelines?${params.toString()}`,
+          );
+          return safe(data);
+        },
+      },
+
+      // ── gitlab_post_note ───────────────────────────────────────────────────
+      {
+        definition: {
+          name: TOOL_POST_NOTE,
+          description:
+            "Post a note (comment) on a GitLab merge request or issue. Returns the created note URL.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              project: {
+                type: "string",
+                description: "Project path or ID. Uses connection default if omitted.",
+              },
+              resourceType: {
+                type: "string",
+                enum: ["merge_requests", "issues"],
+                description: "Resource type to comment on (default: \"merge_requests\").",
+              },
+              resourceIid: {
+                type: "number",
+                description: "MR or issue IID.",
+              },
+              body: {
+                type: "string",
+                description: "Note body (Markdown supported).",
+              },
+            },
+            required: ["resourceIid", "body"],
+          },
+          source: "mcp" as const,
+          mcpServer: `builtin:gitlab:${cfg.connectionId}`,
+          tags: ["gitlab", `connection:${cfg.connectionId}`],
+        },
+        execute: async (args) => {
+          const project = resolveProject(args);
+          const resourceType = String(args["resourceType"] ?? "merge_requests");
+          const resourceIid = Number(args["resourceIid"]);
+          const body = String(args["body"] ?? "").trim();
+
+          if (!resourceIid) return "Error: resourceIid is required.";
+          if (!body) return "Error: note body is required.";
+
+          const data = await client.post(
+            `/projects/${encodeProjectId(project)}/${resourceType}/${resourceIid}/notes`,
+            { body },
+          );
+
+          const result = data as Record<string, unknown>;
+          const noteId = String(result?.["id"] ?? "");
+          return redactSecrets(
+            `Note posted (id: ${noteId}) on ${resourceType} #${resourceIid}`,
+            cfg.secrets,
+          );
+        },
+      },
+
+      // ── gitlab_list_commits ────────────────────────────────────────────────
+      {
+        definition: {
+          name: TOOL_LIST_COMMITS,
+          description:
+            "List commits for a GitLab project branch. Returns commit SHA, title, author, and timestamp.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              project: {
+                type: "string",
+                description: "Project path or ID. Uses connection default if omitted.",
+              },
+              ref: {
+                type: "string",
+                description: "Branch, tag, or commit SHA (default: default branch).",
+              },
+              perPage: {
+                type: "number",
+                description: "Results per page (default: 20, max: 100).",
+              },
+              page: {
+                type: "number",
+                description: "Page number (default: 1).",
+              },
+            },
+            required: [],
+          },
+          source: "mcp" as const,
+          mcpServer: `builtin:gitlab:${cfg.connectionId}`,
+          tags: ["gitlab", `connection:${cfg.connectionId}`],
+        },
+        execute: async (args) => {
+          const project = resolveProject(args);
+          const perPage = Math.min(Number(args["perPage"] ?? 20), 100);
+          const page = Number(args["page"] ?? 1);
+          const params = new URLSearchParams({
+            per_page: String(perPage),
+            page: String(page),
+          });
+          if (args["ref"]) params.set("ref_name", String(args["ref"]));
+
+          const data = await client.get(
+            `/projects/${encodeProjectId(project)}/repository/commits?${params.toString()}`,
+          );
+          return safe(data);
+        },
+      },
+    ];
+  }
+}

--- a/server/mcp-servers/kubernetes/index.ts
+++ b/server/mcp-servers/kubernetes/index.ts
@@ -1,0 +1,362 @@
+/**
+ * Built-in Kubernetes MCP server (issue #270).
+ *
+ * Tools exposed:
+ *   k8s_deploy_manifest      — apply a YAML manifest to the run namespace
+ *   k8s_apply_helm_chart     — install/upgrade a Helm release in the run namespace
+ *   k8s_port_forward_check   — port-forward a pod and perform a basic HTTP health check
+ *   k8s_get_logs             — tail N lines of pod logs
+ *   k8s_delete_namespace     — delete the run namespace (DESTRUCTIVE)
+ *
+ * Namespace scoping: every tool is scoped to `cfg.config.namespace`.
+ *
+ * Security:
+ *   - kubeconfig / token secrets are never included in tool output.
+ *   - `k8s_delete_namespace` requires `allowDestructive=true`.
+ *   - All commands run via `child_process.spawn` — no shell interpolation.
+ */
+
+import { spawn } from "child_process";
+import type { ToolHandler } from "../../tools/registry";
+import type { IBuiltinMcpServer, BuiltinMcpServerConfig, ToolScope } from "../base";
+import { redactSecrets, requireDestructiveFlag } from "../base";
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+interface SpawnResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+function runCommand(
+  cmd: string,
+  args: string[],
+  stdinData?: string,
+): Promise<SpawnResult> {
+  return new Promise((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    const proc = spawn(cmd, args, { stdio: ["pipe", "pipe", "pipe"] });
+    proc.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });
+    proc.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
+    proc.on("close", (code) => resolve({ stdout, stderr, exitCode: code ?? 1 }));
+    proc.on("error", (err) => resolve({ stdout, stderr: err.message, exitCode: 1 }));
+    if (stdinData !== undefined) {
+      proc.stdin.write(stdinData);
+    }
+    proc.stdin.end();
+  });
+}
+
+function kubectlArgs(kubeconfigPath: string | undefined, ...rest: string[]): string[] {
+  return kubeconfigPath ? ["--kubeconfig", kubeconfigPath, ...rest] : [...rest];
+}
+
+function helmArgs(kubeconfigPath: string | undefined, ...rest: string[]): string[] {
+  return kubeconfigPath ? ["--kubeconfig", kubeconfigPath, ...rest] : [...rest];
+}
+
+function validateNamespace(ns: string): string {
+  if (!/^[a-z0-9][a-z0-9-]{0,251}[a-z0-9]$|^[a-z0-9]$/.test(ns)) {
+    throw new Error(
+      `Invalid namespace "${ns}". Must match Kubernetes naming rules.`,
+    );
+  }
+  return ns;
+}
+
+function formatResult(result: SpawnResult): string {
+  if (result.exitCode === 0) return result.stdout || "(no output)";
+  return `Error (exit ${result.exitCode}): ${result.stderr || result.stdout}`;
+}
+
+// ─── Tool name constants ──────────────────────────────────────────────────────
+
+const TOOL_DEPLOY_MANIFEST = "k8s_deploy_manifest";
+const TOOL_APPLY_HELM = "k8s_apply_helm_chart";
+const TOOL_PORT_FORWARD_CHECK = "k8s_port_forward_check";
+const TOOL_GET_LOGS = "k8s_get_logs";
+const TOOL_DELETE_NAMESPACE = "k8s_delete_namespace";
+
+const TOOL_SCOPES: Record<string, ToolScope> = {
+  [TOOL_DEPLOY_MANIFEST]: "read",
+  [TOOL_APPLY_HELM]: "read",
+  [TOOL_PORT_FORWARD_CHECK]: "read",
+  [TOOL_GET_LOGS]: "read",
+  [TOOL_DELETE_NAMESPACE]: "destructive",
+};
+
+// ─── KubernetesMcpServer ──────────────────────────────────────────────────────
+
+export class KubernetesMcpServer implements IBuiltinMcpServer {
+  readonly connectionType = "kubernetes" as const;
+
+  private cfg: BuiltinMcpServerConfig | null = null;
+  private namespace = "default";
+  private kubeconfigPath: string | undefined = undefined;
+
+  async start(cfg: BuiltinMcpServerConfig): Promise<void> {
+    this.cfg = cfg;
+    const rawNs = String(cfg.config["namespace"] ?? "default");
+    this.namespace = validateNamespace(rawNs);
+    this.kubeconfigPath = cfg.secrets["kubeconfigPath"] ?? undefined;
+  }
+
+  async stop(): Promise<void> {
+    this.cfg = null;
+  }
+
+  getToolScope(toolName: string): ToolScope | undefined {
+    return TOOL_SCOPES[toolName];
+  }
+
+  getToolHandlers(): ToolHandler[] {
+    if (!this.cfg) {
+      throw new Error("KubernetesMcpServer: call start() before getToolHandlers()");
+    }
+
+    const cfg = this.cfg;
+    const ns = this.namespace;
+    const kc = this.kubeconfigPath;
+
+    return [
+      // ── k8s_deploy_manifest ────────────────────────────────────────────────
+      {
+        definition: {
+          name: TOOL_DEPLOY_MANIFEST,
+          description:
+            "Apply a Kubernetes YAML manifest to the scoped namespace. " +
+            "Returns kubectl apply output.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              manifest: {
+                type: "string",
+                description: "YAML manifest content to apply.",
+              },
+            },
+            required: ["manifest"],
+          },
+          source: "mcp" as const,
+          mcpServer: `builtin:kubernetes:${cfg.connectionId}`,
+          tags: ["kubernetes", `connection:${cfg.connectionId}`],
+        },
+        execute: async (args) => {
+          const manifest = String(args["manifest"] ?? "");
+          if (!manifest.trim()) return "Error: manifest is empty.";
+
+          const result = await runCommand(
+            "kubectl",
+            kubectlArgs(kc, "apply", "--namespace", ns, "-f", "-"),
+            manifest,
+          );
+          return redactSecrets(formatResult(result), cfg.secrets);
+        },
+      },
+
+      // ── k8s_apply_helm_chart ───────────────────────────────────────────────
+      {
+        definition: {
+          name: TOOL_APPLY_HELM,
+          description:
+            "Install or upgrade a Helm chart in the scoped namespace. " +
+            "Returns helm upgrade output.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              releaseName: { type: "string", description: "Helm release name." },
+              chart: {
+                type: "string",
+                description: "Chart reference (repo/chart or local path).",
+              },
+              valuesYaml: {
+                type: "string",
+                description: "Optional Helm values as YAML string.",
+              },
+              version: {
+                type: "string",
+                description: "Optional chart version.",
+              },
+            },
+            required: ["releaseName", "chart"],
+          },
+          source: "mcp" as const,
+          mcpServer: `builtin:kubernetes:${cfg.connectionId}`,
+          tags: ["kubernetes", `connection:${cfg.connectionId}`],
+        },
+        execute: async (args) => {
+          const releaseName = String(args["releaseName"] ?? "").trim();
+          const chart = String(args["chart"] ?? "").trim();
+          if (!releaseName || !chart) {
+            return "Error: releaseName and chart are required.";
+          }
+
+          const baseArgs = [
+            "upgrade", "--install",
+            releaseName, chart,
+            "--namespace", ns,
+            "--create-namespace",
+          ];
+
+          if (args["version"]) baseArgs.push("--version", String(args["version"]));
+
+          const valuesYaml = args["valuesYaml"] ? String(args["valuesYaml"]) : undefined;
+          if (valuesYaml) baseArgs.push("-f", "-");
+
+          const result = await runCommand(
+            "helm",
+            helmArgs(kc, ...baseArgs),
+            valuesYaml,
+          );
+          return redactSecrets(formatResult(result), cfg.secrets);
+        },
+      },
+
+      // ── k8s_port_forward_check ─────────────────────────────────────────────
+      {
+        definition: {
+          name: TOOL_PORT_FORWARD_CHECK,
+          description:
+            "Start a kubectl port-forward for a pod and perform an HTTP health check. " +
+            "Returns health status and response body.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              podName: { type: "string", description: "Pod name to port-forward." },
+              targetPort: {
+                type: "number",
+                description: "Container port to forward.",
+              },
+              healthPath: {
+                type: "string",
+                description: "HTTP path for health check (default: \"/health\").",
+              },
+            },
+            required: ["podName", "targetPort"],
+          },
+          source: "mcp" as const,
+          mcpServer: `builtin:kubernetes:${cfg.connectionId}`,
+          tags: ["kubernetes", `connection:${cfg.connectionId}`],
+        },
+        execute: async (args) => {
+          const podName = String(args["podName"] ?? "").trim();
+          const targetPort = Number(args["targetPort"] ?? 0);
+          const healthPath = String(args["healthPath"] ?? "/health");
+
+          if (!podName || targetPort <= 0) {
+            return "Error: podName and a positive targetPort are required.";
+          }
+
+          // Use a local port above 30000 to avoid privilege requirements
+          const localPort = 30000 + (targetPort % 10000);
+
+          const pfArgs = kubectlArgs(
+            kc,
+            "port-forward", `pod/${podName}`,
+            `${localPort}:${targetPort}`,
+            "--namespace", ns,
+          );
+
+          const pfProc = spawn("kubectl", pfArgs, { stdio: ["ignore", "pipe", "pipe"] });
+
+          try {
+            // Wait for the port-forward to become ready
+            await new Promise<void>((resolve) => setTimeout(resolve, 1500));
+
+            const curlResult = await runCommand("curl", [
+              "-sf", "--max-time", "5",
+              `http://localhost:${localPort}${healthPath}`,
+            ]);
+
+            const status = curlResult.exitCode === 0 ? "HEALTHY" : "UNHEALTHY";
+            const body = curlResult.stdout.trim() || curlResult.stderr.trim() || "(empty)";
+            return redactSecrets(
+              `Status: ${status}\nPod: ${podName}\nPath: ${healthPath}\nResponse: ${body}`,
+              cfg.secrets,
+            );
+          } finally {
+            pfProc.kill("SIGTERM");
+          }
+        },
+      },
+
+      // ── k8s_get_logs ──────────────────────────────────────────────────────
+      {
+        definition: {
+          name: TOOL_GET_LOGS,
+          description:
+            "Fetch the last N lines of logs from a pod in the scoped namespace.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              podName: { type: "string", description: "Pod name." },
+              containerName: {
+                type: "string",
+                description: "Container name (needed for multi-container pods).",
+              },
+              tail: {
+                type: "number",
+                description: "Number of lines to return (default: 100, max: 1000).",
+              },
+            },
+            required: ["podName"],
+          },
+          source: "mcp" as const,
+          mcpServer: `builtin:kubernetes:${cfg.connectionId}`,
+          tags: ["kubernetes", `connection:${cfg.connectionId}`],
+        },
+        execute: async (args) => {
+          const podName = String(args["podName"] ?? "").trim();
+          if (!podName) return "Error: podName is required.";
+
+          const tail = Math.min(Number(args["tail"] ?? 100), 1000);
+          const logArgs = ["logs", podName, "--namespace", ns, `--tail=${tail}`];
+          if (args["containerName"]) logArgs.push("-c", String(args["containerName"]));
+
+          const result = await runCommand("kubectl", kubectlArgs(kc, ...logArgs));
+          return redactSecrets(formatResult(result), cfg.secrets);
+        },
+      },
+
+      // ── k8s_delete_namespace ──────────────────────────────────────────────
+      {
+        definition: {
+          name: TOOL_DELETE_NAMESPACE,
+          description:
+            "Delete the scoped namespace and all resources within it. " +
+            "DESTRUCTIVE — requires allowDestructive=true on the connection.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              confirm: {
+                type: "string",
+                description: "Must be \"DELETE\" to confirm the destructive operation.",
+              },
+            },
+            required: ["confirm"],
+          },
+          source: "mcp" as const,
+          mcpServer: `builtin:kubernetes:${cfg.connectionId}`,
+          tags: ["kubernetes", `connection:${cfg.connectionId}`],
+        },
+        execute: async (args) => {
+          requireDestructiveFlag(TOOL_DELETE_NAMESPACE, cfg.allowDestructive);
+
+          if (String(args["confirm"]) !== "DELETE") {
+            return 'Error: confirm must be the string "DELETE" to proceed.';
+          }
+
+          const result = await runCommand(
+            "kubectl",
+            kubectlArgs(kc, "delete", "namespace", ns, "--ignore-not-found"),
+          );
+          const output = result.exitCode === 0
+            ? `Namespace "${ns}" deleted.\n${result.stdout}`
+            : formatResult(result);
+          return redactSecrets(output, cfg.secrets);
+        },
+      },
+    ];
+  }
+}

--- a/server/mcp-servers/registry.ts
+++ b/server/mcp-servers/registry.ts
@@ -1,0 +1,223 @@
+/**
+ * Built-in MCP Server Registry (issue #270).
+ *
+ * Manages the lifecycle of built-in MCP servers:
+ *  - Auto-spawns when a matching workspace connection is created/enabled.
+ *  - Terminates when the connection is deleted/disabled.
+ *  - Registers / unregisters tool handlers in the global ToolRegistry.
+ *
+ * The registry maps ConnectionType → server factory function. When a connection
+ * arrives it looks up the factory, instantiates the server, calls start(), and
+ * registers the returned tool handlers.
+ *
+ * Secrets are provided at spawn time — they come from the caller (connection
+ * route / storage) and are NEVER stored in this registry after tool handlers
+ * are built. Once handlers close over the config, the registry holds no
+ * plaintext secrets.
+ */
+
+import type { ConnectionType } from "@shared/types";
+import type { ToolRegistry } from "../tools/registry";
+import type { IBuiltinMcpServer, BuiltinMcpServerConfig } from "./base";
+import { KubernetesMcpServer } from "./kubernetes/index";
+import { DockerRunMcpServer } from "./docker-run/index";
+import { GitHubMcpServer } from "./github/index";
+import { GitLabMcpServer } from "./gitlab/index";
+
+// ─── Factory Registry ─────────────────────────────────────────────────────────
+
+/**
+ * A factory that creates a fresh built-in MCP server instance.
+ * Each connection gets its own isolated server instance.
+ */
+type ServerFactory = () => IBuiltinMcpServer;
+
+/**
+ * Tag appended to all tools registered by a built-in MCP server so we can
+ * bulk-unregister them when the connection is removed.
+ */
+const BUILTIN_TAG_PREFIX = "builtin-mcp:";
+
+// ─── Runtime entry ────────────────────────────────────────────────────────────
+
+interface ActiveServer {
+  server: IBuiltinMcpServer;
+  /** Names of all tool handlers registered for this connection. */
+  toolNames: string[];
+}
+
+// ─── BuiltinMcpServerRegistry ────────────────────────────────────────────────
+
+export class BuiltinMcpServerRegistry {
+  private readonly factories: Map<string, ServerFactory> = new Map();
+  private readonly active: Map<string, ActiveServer> = new Map();
+  private readonly toolRegistry: ToolRegistry;
+
+  constructor(toolRegistry: ToolRegistry) {
+    this.toolRegistry = toolRegistry;
+    this.registerDefaultFactories();
+  }
+
+  // ── Default factories ────────────────────────────────────────────────────
+
+  private registerDefaultFactories(): void {
+    this.registerFactory("kubernetes", () => new KubernetesMcpServer());
+    // docker-run capability is surfaced via a generic_mcp connection whose
+    // config includes "provider": "docker-run"
+    this.registerFactory("generic_mcp", () => new DockerRunMcpServer());
+    this.registerFactory("github", () => new GitHubMcpServer());
+    this.registerFactory("gitlab", () => new GitLabMcpServer());
+  }
+
+  // ── Factory management ───────────────────────────────────────────────────
+
+  /**
+   * Register (or replace) the factory for a connection type.
+   * Used in tests to inject mocked server instances.
+   */
+  registerFactory(connectionType: string, factory: ServerFactory): void {
+    this.factories.set(connectionType, factory);
+  }
+
+  /** Returns true if a factory exists for the given connection type. */
+  hasFactory(connectionType: string): boolean {
+    return this.factories.has(connectionType);
+  }
+
+  // ── Lifecycle ────────────────────────────────────────────────────────────
+
+  /**
+   * Spawn a built-in MCP server for the given connection.
+   *
+   * If a server is already running for `connectionId` it is stopped first
+   * (idempotent — safe to call when a connection is updated).
+   *
+   * @param connectionType — the type of connection (must match a registered factory)
+   * @param connectionId   — unique connection ID (used as the tool tag namespace)
+   * @param config         — non-secret configuration JSON from the connection record
+   * @param secrets        — decrypted secrets (MUST NOT be stored beyond this call)
+   * @param allowDestructive — whether destructive tools are permitted
+   */
+  async spawn(
+    connectionType: ConnectionType | string,
+    connectionId: string,
+    config: Record<string, unknown>,
+    secrets: Record<string, string>,
+    allowDestructive = false,
+  ): Promise<void> {
+    // Stop any existing server for this connection
+    if (this.active.has(connectionId)) {
+      await this.terminate(connectionId);
+    }
+
+    const factory = this.factories.get(connectionType);
+    if (!factory) {
+      // No built-in server for this connection type — silently skip
+      return;
+    }
+
+    const server = factory();
+
+    const serverCfg: BuiltinMcpServerConfig = {
+      connectionId,
+      config,
+      secrets,
+      allowDestructive,
+    };
+
+    await server.start(serverCfg);
+
+    const handlers = server.getToolHandlers();
+    const toolNames: string[] = [];
+
+    for (const handler of handlers) {
+      // Add a builtin-mcp tag for bulk-unregistration tracking
+      const tagsWithBuiltin = [
+        ...(handler.definition.tags ?? []),
+        `${BUILTIN_TAG_PREFIX}${connectionId}`,
+      ];
+      const patchedDefinition = { ...handler.definition, tags: tagsWithBuiltin };
+
+      this.toolRegistry.register({
+        ...handler,
+        definition: patchedDefinition,
+      });
+
+      toolNames.push(handler.definition.name);
+    }
+
+    this.active.set(connectionId, { server, toolNames });
+  }
+
+  /**
+   * Terminate the built-in MCP server for the given connection and unregister
+   * all its tool handlers.
+   */
+  async terminate(connectionId: string): Promise<void> {
+    const entry = this.active.get(connectionId);
+    if (!entry) return;
+
+    for (const name of entry.toolNames) {
+      this.toolRegistry.unregister(name);
+    }
+
+    try {
+      await entry.server.stop();
+    } catch (err) {
+      // Log but do not rethrow — we always want cleanup to succeed
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[builtin-mcp-registry] Error stopping server for ${connectionId}: ${msg}`);
+    }
+
+    this.active.delete(connectionId);
+  }
+
+  /**
+   * Terminate all active built-in MCP servers.
+   * Called on process shutdown.
+   */
+  async terminateAll(): Promise<void> {
+    const ids = Array.from(this.active.keys());
+    await Promise.all(ids.map((id) => this.terminate(id)));
+  }
+
+  // ── Inspection ───────────────────────────────────────────────────────────
+
+  /** Returns true if a server is currently active for the given connection ID. */
+  isActive(connectionId: string): boolean {
+    return this.active.has(connectionId);
+  }
+
+  /** Returns the list of tool names registered for a given connection ID. */
+  getRegisteredToolNames(connectionId: string): string[] {
+    return this.active.get(connectionId)?.toolNames ?? [];
+  }
+
+  /** Returns all currently active connection IDs. */
+  getActiveConnectionIds(): string[] {
+    return Array.from(this.active.keys());
+  }
+}
+
+// ─── Singleton ────────────────────────────────────────────────────────────────
+
+// Lazily initialized — avoids circular import issues at module load time.
+// Callers use `getBuiltinMcpRegistry()` rather than importing the instance directly.
+let _registry: BuiltinMcpServerRegistry | null = null;
+
+export function getBuiltinMcpRegistry(): BuiltinMcpServerRegistry {
+  if (!_registry) {
+    // Import toolRegistry here to avoid circular dep at module load time
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { toolRegistry } = require("../tools/index") as { toolRegistry: ToolRegistry };
+    _registry = new BuiltinMcpServerRegistry(toolRegistry);
+  }
+  return _registry;
+}
+
+/**
+ * Reset the singleton — only used in tests.
+ */
+export function _resetBuiltinMcpRegistry(): void {
+  _registry = null;
+}

--- a/server/tools/mcp-client.ts
+++ b/server/tools/mcp-client.ts
@@ -1,8 +1,9 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
-import type { ToolDefinition, McpServerConfig } from "@shared/types";
+import type { ToolDefinition, McpServerConfig, ConnectionType } from "@shared/types";
 import { toolRegistry } from "./index";
+import { BuiltinMcpServerRegistry } from "../mcp-servers/registry";
 
 interface McpConnection {
   client: Client;
@@ -12,6 +13,59 @@ interface McpConnection {
 
 export class McpClientManager {
   private connections: Map<string, McpConnection> = new Map();
+  private builtinRegistry: BuiltinMcpServerRegistry;
+
+  constructor(builtinRegistry?: BuiltinMcpServerRegistry) {
+    this.builtinRegistry = builtinRegistry ?? new BuiltinMcpServerRegistry(toolRegistry);
+  }
+
+  // ── Built-in MCP server integration ────────────────────────────────────────
+
+  /**
+   * Spawn a built-in MCP server for a workspace connection.
+   * Called when a connection is created or enabled.
+   *
+   * @param connectionType — e.g. "kubernetes", "github", "gitlab", "generic_mcp"
+   * @param connectionId   — unique connection ID from the workspace connection record
+   * @param config         — non-secret config JSON
+   * @param secrets        — decrypted secrets (MUST NOT be stored after this call)
+   * @param allowDestructive — whether destructive tools are enabled
+   */
+  async spawnBuiltinServer(
+    connectionType: ConnectionType | string,
+    connectionId: string,
+    config: Record<string, unknown>,
+    secrets: Record<string, string>,
+    allowDestructive = false,
+  ): Promise<void> {
+    if (!this.builtinRegistry.hasFactory(connectionType)) {
+      return; // No built-in server for this type — skip silently
+    }
+    await this.builtinRegistry.spawn(
+      connectionType,
+      connectionId,
+      config,
+      secrets,
+      allowDestructive,
+    );
+    const toolNames = this.builtinRegistry.getRegisteredToolNames(connectionId);
+    console.log(
+      `[mcp-client] Built-in server spawned for connection "${connectionId}" ` +
+      `(type: ${connectionType}) — ${toolNames.length} tool(s) registered`,
+    );
+  }
+
+  /**
+   * Terminate the built-in MCP server for a workspace connection.
+   * Called when a connection is deleted or disabled.
+   */
+  async terminateBuiltinServer(connectionId: string): Promise<void> {
+    if (!this.builtinRegistry.isActive(connectionId)) return;
+    await this.builtinRegistry.terminate(connectionId);
+    console.log(`[mcp-client] Built-in server terminated for connection "${connectionId}"`);
+  }
+
+  // ── External MCP server management ─────────────────────────────────────────
 
   async connect(config: McpServerConfig): Promise<void> {
     // Disconnect existing connection for this server if any
@@ -133,6 +187,11 @@ export class McpClientManager {
       };
     }
     return status;
+  }
+
+  /** Returns the underlying built-in server registry for inspection in tests. */
+  getBuiltinRegistry(): BuiltinMcpServerRegistry {
+    return this.builtinRegistry;
   }
 }
 

--- a/tests/unit/builtin-mcp-servers.test.ts
+++ b/tests/unit/builtin-mcp-servers.test.ts
@@ -1,0 +1,1235 @@
+/**
+ * Comprehensive unit tests for built-in MCP servers (issue #270).
+ *
+ * Covers:
+ *  1. base.ts — redactSecrets, requireDestructiveFlag, DestructiveOperationDeniedError
+ *  2. KubernetesMcpServer — all 5 tools, namespace scoping, destructive guard
+ *  3. DockerRunMcpServer  — docker_run tool, CPU/mem capping, docker_run_privileged guard
+ *  4. GitHubMcpServer     — all 5 tools, comment posting, error handling
+ *  5. GitLabMcpServer     — all 5 tools, note posting, project encoding
+ *  6. BuiltinMcpServerRegistry — spawn/terminate lifecycle, tool registration/unregistration
+ *  7. McpClientManager.spawnBuiltinServer / terminateBuiltinServer integration
+ *  8. Security: no secrets in output, destructive ops require allow-flag
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+// ── base.ts ───────────────────────────────────────────────────────────────────
+
+import {
+  redactSecrets,
+  requireDestructiveFlag,
+  DestructiveOperationDeniedError,
+} from "../../server/mcp-servers/base";
+
+describe("redactSecrets()", () => {
+  it("replaces a single secret value with [REDACTED]", () => {
+    const result = redactSecrets("token: mySecretToken123", {
+      token: "mySecretToken123",
+    });
+    expect(result).toBe("token: [REDACTED]");
+  });
+
+  it("replaces multiple occurrences of the same secret", () => {
+    const result = redactSecrets("abc abc abc", { val: "abc" });
+    expect(result).toBe("[REDACTED] [REDACTED] [REDACTED]");
+  });
+
+  it("replaces multiple distinct secrets", () => {
+    const result = redactSecrets("user=admin pass=hunter2", {
+      user: "admin",
+      pass: "hunter2",
+    });
+    expect(result).toContain("[REDACTED]");
+    expect(result).not.toContain("admin");
+    expect(result).not.toContain("hunter2");
+  });
+
+  it("leaves text unchanged when secrets map is empty", () => {
+    const result = redactSecrets("no secrets here", {});
+    expect(result).toBe("no secrets here");
+  });
+
+  it("ignores empty-string secret values", () => {
+    const result = redactSecrets("text", { empty: "" });
+    expect(result).toBe("text");
+  });
+
+  it("handles regex special chars in secret values", () => {
+    const secret = "p@ss$w0rd(special)";
+    const result = redactSecrets(`password: ${secret}`, { pw: secret });
+    expect(result).toBe("password: [REDACTED]");
+  });
+});
+
+describe("requireDestructiveFlag()", () => {
+  it("does not throw when allowDestructive is true", () => {
+    expect(() => requireDestructiveFlag("my_tool", true)).not.toThrow();
+  });
+
+  it("throws DestructiveOperationDeniedError when flag is false", () => {
+    expect(() => requireDestructiveFlag("my_tool", false)).toThrow(
+      DestructiveOperationDeniedError,
+    );
+  });
+
+  it("throws when flag is undefined", () => {
+    expect(() => requireDestructiveFlag("my_tool", undefined)).toThrow(
+      DestructiveOperationDeniedError,
+    );
+  });
+
+  it("error message mentions the tool name", () => {
+    try {
+      requireDestructiveFlag("dangerous_op", false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(DestructiveOperationDeniedError);
+      expect((err as Error).message).toContain("dangerous_op");
+    }
+  });
+});
+
+// ── KubernetesMcpServer ───────────────────────────────────────────────────────
+
+import { KubernetesMcpServer } from "../../server/mcp-servers/kubernetes/index";
+import type { BuiltinMcpServerConfig } from "../../server/mcp-servers/base";
+
+function makeK8sConfig(overrides: Partial<BuiltinMcpServerConfig> = {}): BuiltinMcpServerConfig {
+  return {
+    connectionId: "conn-k8s-test",
+    config: { namespace: "test-ns" },
+    secrets: { kubeconfigPath: "/fake/kubeconfig" },
+    allowDestructive: false,
+    ...overrides,
+  };
+}
+
+describe("KubernetesMcpServer", () => {
+  let server: KubernetesMcpServer;
+
+  beforeEach(() => {
+    server = new KubernetesMcpServer();
+  });
+
+  it("has connectionType 'kubernetes'", () => {
+    expect(server.connectionType).toBe("kubernetes");
+  });
+
+  it("throws if getToolHandlers() called before start()", () => {
+    expect(() => server.getToolHandlers()).toThrow(/start\(\)/);
+  });
+
+  it("start() initialises with given namespace", async () => {
+    await server.start(makeK8sConfig());
+    const handlers = server.getToolHandlers();
+    expect(handlers.length).toBe(5);
+  });
+
+  it("all 5 tool names are defined", async () => {
+    await server.start(makeK8sConfig());
+    const names = server.getToolHandlers().map((h) => h.definition.name);
+    expect(names).toContain("k8s_deploy_manifest");
+    expect(names).toContain("k8s_apply_helm_chart");
+    expect(names).toContain("k8s_port_forward_check");
+    expect(names).toContain("k8s_get_logs");
+    expect(names).toContain("k8s_delete_namespace");
+  });
+
+  it("tool definitions have source='mcp'", async () => {
+    await server.start(makeK8sConfig());
+    for (const h of server.getToolHandlers()) {
+      expect(h.definition.source).toBe("mcp");
+    }
+  });
+
+  it("tool definitions include connection tag", async () => {
+    await server.start(makeK8sConfig());
+    for (const h of server.getToolHandlers()) {
+      expect(h.definition.tags).toContain("connection:conn-k8s-test");
+    }
+  });
+
+  it("getToolScope('k8s_delete_namespace') returns 'destructive'", async () => {
+    await server.start(makeK8sConfig());
+    expect(server.getToolScope("k8s_delete_namespace")).toBe("destructive");
+  });
+
+  it("getToolScope('k8s_get_logs') returns 'read'", async () => {
+    await server.start(makeK8sConfig());
+    expect(server.getToolScope("k8s_get_logs")).toBe("read");
+  });
+
+  it("getToolScope(unknown) returns undefined", async () => {
+    await server.start(makeK8sConfig());
+    expect(server.getToolScope("unknown_tool")).toBeUndefined();
+  });
+
+  it("stop() clears state — getToolHandlers() throws after stop", async () => {
+    await server.start(makeK8sConfig());
+    await server.stop();
+    expect(() => server.getToolHandlers()).toThrow();
+  });
+
+  describe("k8s_deploy_manifest", () => {
+    it("returns error for empty manifest", async () => {
+      await server.start(makeK8sConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "k8s_deploy_manifest")!;
+      // Empty manifest guard triggers before any spawn call
+      const result = await handler.execute({ manifest: "   " });
+      expect(result).toMatch(/empty/i);
+    });
+  });
+
+  describe("k8s_delete_namespace — destructive guard", () => {
+    it("rejects without allowDestructive flag", async () => {
+      await server.start(makeK8sConfig({ allowDestructive: false }));
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "k8s_delete_namespace")!;
+
+      await expect(handler.execute({ confirm: "DELETE" })).rejects.toThrow(
+        DestructiveOperationDeniedError,
+      );
+    });
+
+    it("rejects with wrong confirm string even when allowDestructive=true", async () => {
+      await server.start(makeK8sConfig({ allowDestructive: true }));
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "k8s_delete_namespace")!;
+      // Wrong confirm string guard triggers before any spawn call
+      const result = await handler.execute({ confirm: "WRONG" });
+      expect(result).toMatch(/confirm/i);
+    });
+  });
+
+  describe("k8s_get_logs — tail capped at 1000", () => {
+    it("requires podName", async () => {
+      await server.start(makeK8sConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "k8s_get_logs")!;
+      const result = await handler.execute({ podName: "" });
+      expect(result).toMatch(/podName is required/i);
+    });
+  });
+
+  describe("k8s_port_forward_check", () => {
+    it("returns error for missing targetPort", async () => {
+      await server.start(makeK8sConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "k8s_port_forward_check")!;
+      const result = await handler.execute({ podName: "my-pod", targetPort: 0 });
+      expect(result).toMatch(/required/i);
+    });
+
+    it("returns error for missing podName", async () => {
+      await server.start(makeK8sConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "k8s_port_forward_check")!;
+      const result = await handler.execute({ podName: "", targetPort: 8080 });
+      expect(result).toMatch(/required/i);
+    });
+  });
+
+  describe("k8s_apply_helm_chart", () => {
+    it("returns error when releaseName is missing", async () => {
+      await server.start(makeK8sConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "k8s_apply_helm_chart")!;
+      const result = await handler.execute({ releaseName: "", chart: "stable/nginx" });
+      expect(result).toMatch(/required/i);
+    });
+
+    it("returns error when chart is missing", async () => {
+      await server.start(makeK8sConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "k8s_apply_helm_chart")!;
+      const result = await handler.execute({ releaseName: "my-app", chart: "" });
+      expect(result).toMatch(/required/i);
+    });
+  });
+
+  describe("secret redaction", () => {
+    it("secrets are not present in error output", async () => {
+      await server.start(makeK8sConfig({ secrets: { kubeconfigPath: "/secret/path", apiToken: "supersecrettoken" } }));
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "k8s_get_logs")!;
+      // We cannot check spawn output in unit tests without actually running kubectl,
+      // but we verify the handler closure holds the secrets reference for redaction
+      // by checking the tool definition does NOT contain secrets inline.
+      expect(JSON.stringify(handler.definition)).not.toContain("supersecrettoken");
+    });
+  });
+});
+
+// ── DockerRunMcpServer ────────────────────────────────────────────────────────
+
+import { DockerRunMcpServer } from "../../server/mcp-servers/docker-run/index";
+import { SandboxExecutor } from "../../server/sandbox/executor";
+import type { SandboxResult } from "../../shared/types";
+
+function makeDockerConfig(overrides: Partial<BuiltinMcpServerConfig> = {}): BuiltinMcpServerConfig {
+  return {
+    connectionId: "conn-docker-test",
+    config: {
+      memoryLimit: "512m",
+      cpuLimit: 1,
+      networkEnabled: false,
+      timeout: 60,
+    },
+    secrets: {},
+    allowDestructive: false,
+    ...overrides,
+  };
+}
+
+function makeSuccessResult(): SandboxResult {
+  return {
+    exitCode: 0,
+    stdout: "Hello from container\n",
+    stderr: "",
+    durationMs: 120,
+    timedOut: false,
+    artifacts: [],
+    image: "alpine:3.18",
+    command: "echo hello",
+  };
+}
+
+describe("DockerRunMcpServer", () => {
+  let server: DockerRunMcpServer;
+  let mockExecutor: SandboxExecutor;
+
+  beforeEach(() => {
+    mockExecutor = {
+      isAvailable: vi.fn().mockResolvedValue(true),
+      execute: vi.fn().mockResolvedValue(makeSuccessResult()),
+    } as unknown as SandboxExecutor;
+
+    server = new DockerRunMcpServer(mockExecutor);
+  });
+
+  it("has connectionType 'generic_mcp'", () => {
+    expect(server.connectionType).toBe("generic_mcp");
+  });
+
+  it("throws if getToolHandlers() called before start()", () => {
+    expect(() => server.getToolHandlers()).toThrow(/start\(\)/);
+  });
+
+  it("exposes docker_run and docker_run_privileged tools", async () => {
+    await server.start(makeDockerConfig());
+    const names = server.getToolHandlers().map((h) => h.definition.name);
+    expect(names).toContain("docker_run");
+    expect(names).toContain("docker_run_privileged");
+  });
+
+  it("docker_run scope is 'read'", async () => {
+    await server.start(makeDockerConfig());
+    expect(server.getToolScope("docker_run")).toBe("read");
+  });
+
+  it("docker_run_privileged scope is 'destructive'", async () => {
+    await server.start(makeDockerConfig());
+    expect(server.getToolScope("docker_run_privileged")).toBe("destructive");
+  });
+
+  it("docker_run returns error when image is missing", async () => {
+    await server.start(makeDockerConfig());
+    const handler = server.getToolHandlers().find((h) => h.definition.name === "docker_run")!;
+    const result = await handler.execute({ image: "", command: "echo hi" });
+    expect(result).toMatch(/image is required/i);
+  });
+
+  it("docker_run calls executor.execute() with correct image/command", async () => {
+    await server.start(makeDockerConfig());
+    const handler = server.getToolHandlers().find((h) => h.definition.name === "docker_run")!;
+
+    await handler.execute({ image: "alpine:3.18", command: "echo hello" });
+
+    expect(mockExecutor.execute).toHaveBeenCalledOnce();
+    const [config] = (mockExecutor.execute as ReturnType<typeof vi.fn>).mock.calls[0] as [import("../../shared/types").SandboxConfig, unknown[]];
+    expect(config.image).toBe("alpine:3.18");
+    expect(config.command).toBe("echo hello");
+  });
+
+  it("docker_run caps memory at connection limit", async () => {
+    await server.start(makeDockerConfig({ config: { memoryLimit: "256m", cpuLimit: 0.5, timeout: 30 } }));
+    const handler = server.getToolHandlers().find((h) => h.definition.name === "docker_run")!;
+
+    // Caller requests 1g — should be capped to 256m
+    await handler.execute({ image: "alpine", command: "echo", memoryLimit: "1g" });
+
+    const [config] = (mockExecutor.execute as ReturnType<typeof vi.fn>).mock.calls[0] as [import("../../shared/types").SandboxConfig, unknown[]];
+    const memBytes = parseInt(config.memoryLimit ?? "0");
+    // memoryLimit is returned as Xm strings; 256m → 256
+    expect(parseInt(config.memoryLimit ?? "0")).toBeLessThanOrEqual(256);
+  });
+
+  it("docker_run caps CPU at connection limit", async () => {
+    await server.start(makeDockerConfig({ config: { memoryLimit: "512m", cpuLimit: 0.5, timeout: 30 } }));
+    const handler = server.getToolHandlers().find((h) => h.definition.name === "docker_run")!;
+
+    // Caller requests 4.0 CPUs — capped to 0.5
+    await handler.execute({ image: "alpine", command: "echo", cpuLimit: 4.0 });
+
+    const [config] = (mockExecutor.execute as ReturnType<typeof vi.fn>).mock.calls[0] as [import("../../shared/types").SandboxConfig, unknown[]];
+    expect(config.cpuLimit).toBeLessThanOrEqual(0.5);
+  });
+
+  it("docker_run caps timeout at connection limit", async () => {
+    await server.start(makeDockerConfig({ config: { memoryLimit: "512m", cpuLimit: 1, timeout: 30 } }));
+    const handler = server.getToolHandlers().find((h) => h.definition.name === "docker_run")!;
+
+    // Caller requests 9999 seconds — capped to 30
+    await handler.execute({ image: "alpine", command: "echo", timeout: 9999 });
+
+    const [config] = (mockExecutor.execute as ReturnType<typeof vi.fn>).mock.calls[0] as [import("../../shared/types").SandboxConfig, unknown[]];
+    expect(config.timeout).toBeLessThanOrEqual(30);
+  });
+
+  it("docker_run output includes exit code and duration", async () => {
+    await server.start(makeDockerConfig());
+    const handler = server.getToolHandlers().find((h) => h.definition.name === "docker_run")!;
+    const result = await handler.execute({ image: "alpine", command: "echo hi" });
+    expect(result).toMatch(/exit code/i);
+    expect(result).toMatch(/duration/i);
+  });
+
+  it("docker_run output includes stdout from executor", async () => {
+    await server.start(makeDockerConfig());
+    const handler = server.getToolHandlers().find((h) => h.definition.name === "docker_run")!;
+    const result = await handler.execute({ image: "alpine", command: "echo hi" });
+    expect(result).toContain("Hello from container");
+  });
+
+  it("docker_run_privileged rejects without allowDestructive flag", async () => {
+    await server.start(makeDockerConfig({ allowDestructive: false }));
+    const handler = server.getToolHandlers().find((h) => h.definition.name === "docker_run_privileged")!;
+    await expect(handler.execute({ image: "alpine", command: "echo" })).rejects.toThrow(
+      DestructiveOperationDeniedError,
+    );
+  });
+
+  it("docker_run_privileged succeeds with allowDestructive=true", async () => {
+    await server.start(makeDockerConfig({ allowDestructive: true }));
+    const handler = server.getToolHandlers().find((h) => h.definition.name === "docker_run_privileged")!;
+    const result = await handler.execute({ image: "alpine", command: "echo" });
+    expect(result).toContain("Exit code");
+  });
+
+  it("docker_run_privileged enables network", async () => {
+    await server.start(makeDockerConfig({ allowDestructive: true, config: { memoryLimit: "512m", cpuLimit: 1, timeout: 60, networkEnabled: false } }));
+    const handler = server.getToolHandlers().find((h) => h.definition.name === "docker_run_privileged")!;
+    await handler.execute({ image: "alpine", command: "echo" });
+
+    const [config] = (mockExecutor.execute as ReturnType<typeof vi.fn>).mock.calls[0] as [import("../../shared/types").SandboxConfig, unknown[]];
+    expect(config.networkEnabled).toBe(true);
+  });
+
+  it("secrets are not present in tool output", async () => {
+    await server.start(makeDockerConfig({ secrets: { apiKey: "secret-key-xyz" } }));
+    const handler = server.getToolHandlers().find((h) => h.definition.name === "docker_run")!;
+
+    // Inject secret into stdout to simulate a leaky container
+    (mockExecutor.execute as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ...makeSuccessResult(),
+      stdout: "API KEY: secret-key-xyz\n",
+    });
+
+    const result = await handler.execute({ image: "alpine", command: "echo" });
+    expect(result).not.toContain("secret-key-xyz");
+    expect(result).toContain("[REDACTED]");
+  });
+
+  it("timedOut flag is shown in output", async () => {
+    (mockExecutor.execute as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ...makeSuccessResult(),
+      timedOut: true,
+      exitCode: 1,
+    });
+    await server.start(makeDockerConfig());
+    const handler = server.getToolHandlers().find((h) => h.definition.name === "docker_run")!;
+    const result = await handler.execute({ image: "alpine", command: "sleep 9999" });
+    expect(result).toMatch(/timed_out/i);
+  });
+});
+
+// ── GitHubMcpServer ───────────────────────────────────────────────────────────
+
+import { GitHubMcpServer } from "../../server/mcp-servers/github/index";
+
+function makeGitHubConfig(overrides: Partial<BuiltinMcpServerConfig> = {}): BuiltinMcpServerConfig {
+  return {
+    connectionId: "conn-gh-test",
+    config: {
+      host: "https://api.github.com",
+      owner: "test-owner",
+      repo: "test-repo",
+    },
+    secrets: { token: "ghp_supersecrettoken" },
+    allowDestructive: false,
+    ...overrides,
+  };
+}
+
+describe("GitHubMcpServer", () => {
+  let server: GitHubMcpServer;
+
+  beforeEach(() => {
+    server = new GitHubMcpServer();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("has connectionType 'github'", () => {
+    expect(server.connectionType).toBe("github");
+  });
+
+  it("throws if getToolHandlers() called before start()", () => {
+    expect(() => server.getToolHandlers()).toThrow(/start\(\)/);
+  });
+
+  it("exposes 5 tool handlers after start()", async () => {
+    await server.start(makeGitHubConfig());
+    expect(server.getToolHandlers()).toHaveLength(5);
+  });
+
+  it("all tools have source='mcp'", async () => {
+    await server.start(makeGitHubConfig());
+    for (const h of server.getToolHandlers()) {
+      expect(h.definition.source).toBe("mcp");
+    }
+  });
+
+  it("all tools are tagged with connection ID", async () => {
+    await server.start(makeGitHubConfig());
+    for (const h of server.getToolHandlers()) {
+      expect(h.definition.tags).toContain("connection:conn-gh-test");
+    }
+  });
+
+  it("all tools have scope 'read'", async () => {
+    await server.start(makeGitHubConfig());
+    const names = server.getToolHandlers().map((h) => h.definition.name);
+    for (const name of names) {
+      expect(server.getToolScope(name)).toBe("read");
+    }
+  });
+
+  it("stop() clears state", async () => {
+    await server.start(makeGitHubConfig());
+    await server.stop();
+    expect(() => server.getToolHandlers()).toThrow();
+  });
+
+  describe("github_list_prs", () => {
+    it("returns error when no owner/repo configured", async () => {
+      await server.start({
+        ...makeGitHubConfig(),
+        config: { host: "https://api.github.com" }, // no owner/repo
+      });
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "github_list_prs")!;
+      const result = await handler.execute({});
+      expect(result).toMatch(/required/i);
+    });
+
+    it("calls GitHub API with correct endpoint", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [{ number: 1, title: "Test PR" }],
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitHubConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "github_list_prs")!;
+      await handler.execute({});
+
+      const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain("/repos/test-owner/test-repo/pulls");
+      expect((opts.headers as Record<string, string>)["Authorization"]).toContain("Bearer");
+    });
+
+    it("token is NOT in Authorization header output", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitHubConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "github_list_prs")!;
+      const result = await handler.execute({});
+      expect(result).not.toContain("ghp_supersecrettoken");
+    });
+
+    it("returns error string on non-ok response", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        text: async () => "Forbidden",
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitHubConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "github_list_prs")!;
+      await expect(handler.execute({})).rejects.toThrow("403");
+    });
+  });
+
+  describe("github_get_pr_files", () => {
+    it("returns error for missing prNumber", async () => {
+      await server.start(makeGitHubConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "github_get_pr_files")!;
+      const result = await handler.execute({});
+      expect(result).toMatch(/required/i);
+    });
+
+    it("calls correct endpoint with prNumber", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitHubConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "github_get_pr_files")!;
+      await handler.execute({ prNumber: 42 });
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toContain("/pulls/42/files");
+    });
+  });
+
+  describe("github_get_pr_diff", () => {
+    it("returns error for missing prNumber", async () => {
+      await server.start(makeGitHubConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "github_get_pr_diff")!;
+      const result = await handler.execute({});
+      expect(result).toMatch(/required/i);
+    });
+
+    it("uses diff Accept header", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: async () => "diff --git a/file.ts b/file.ts\n",
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitHubConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "github_get_pr_diff")!;
+      await handler.execute({ prNumber: 7 });
+
+      const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect((opts.headers as Record<string, string>)["Accept"]).toContain("diff");
+    });
+
+    it("token is not present in diff output", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: async () => "diff content here\n",
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitHubConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "github_get_pr_diff")!;
+      const result = await handler.execute({ prNumber: 7 });
+      expect(result).not.toContain("ghp_supersecrettoken");
+    });
+  });
+
+  describe("github_post_comment", () => {
+    it("returns error for missing issueNumber", async () => {
+      await server.start(makeGitHubConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "github_post_comment")!;
+      const result = await handler.execute({ body: "hello" });
+      expect(result).toMatch(/required/i);
+    });
+
+    it("returns error for empty body", async () => {
+      await server.start(makeGitHubConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "github_post_comment")!;
+      const result = await handler.execute({ issueNumber: 1, body: "" });
+      expect(result).toMatch(/required/i);
+    });
+
+    it("POSTs to issues/comments endpoint", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: 123, html_url: "https://github.com/test-owner/test-repo/issues/5#issuecomment-123" }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitHubConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "github_post_comment")!;
+      const result = await handler.execute({ issueNumber: 5, body: "Great work!" });
+
+      const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain("/issues/5/comments");
+      expect(opts.method).toBe("POST");
+      expect(result).toContain("Comment posted");
+    });
+  });
+
+  describe("github_list_workflows", () => {
+    it("calls workflows/runs endpoint", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ workflow_runs: [] }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitHubConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "github_list_workflows")!;
+      await handler.execute({});
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toContain("/actions/runs");
+    });
+
+    it("caps perPage at 30", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ workflow_runs: [] }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitHubConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "github_list_workflows")!;
+      await handler.execute({ perPage: 1000 });
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toContain("per_page=30");
+    });
+  });
+
+  describe("owner/repo from args overrides connection default", () => {
+    it("uses args repo when provided as owner/repo", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitHubConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "github_list_prs")!;
+      await handler.execute({ repo: "another-org/another-repo" });
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toContain("/repos/another-org/another-repo/pulls");
+    });
+  });
+});
+
+// ── GitLabMcpServer ───────────────────────────────────────────────────────────
+
+import { GitLabMcpServer } from "../../server/mcp-servers/gitlab/index";
+
+function makeGitLabConfig(overrides: Partial<BuiltinMcpServerConfig> = {}): BuiltinMcpServerConfig {
+  return {
+    connectionId: "conn-gl-test",
+    config: {
+      host: "https://gitlab.com",
+      owner: "test-group",
+      project: "test-project",
+    },
+    secrets: { token: "glpat-supersecret" },
+    allowDestructive: false,
+    ...overrides,
+  };
+}
+
+describe("GitLabMcpServer", () => {
+  let server: GitLabMcpServer;
+
+  beforeEach(() => {
+    server = new GitLabMcpServer();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("has connectionType 'gitlab'", () => {
+    expect(server.connectionType).toBe("gitlab");
+  });
+
+  it("throws if getToolHandlers() called before start()", () => {
+    expect(() => server.getToolHandlers()).toThrow(/start\(\)/);
+  });
+
+  it("exposes 5 tools after start()", async () => {
+    await server.start(makeGitLabConfig());
+    expect(server.getToolHandlers()).toHaveLength(5);
+  });
+
+  it("all tools tagged with connection ID", async () => {
+    await server.start(makeGitLabConfig());
+    for (const h of server.getToolHandlers()) {
+      expect(h.definition.tags).toContain("connection:conn-gl-test");
+    }
+  });
+
+  it("all tools have scope 'read'", async () => {
+    await server.start(makeGitLabConfig());
+    for (const h of server.getToolHandlers()) {
+      expect(server.getToolScope(h.definition.name)).toBe("read");
+    }
+  });
+
+  it("stop() clears state", async () => {
+    await server.start(makeGitLabConfig());
+    await server.stop();
+    expect(() => server.getToolHandlers()).toThrow();
+  });
+
+  describe("gitlab_list_mrs", () => {
+    it("calls correct API endpoint", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitLabConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "gitlab_list_mrs")!;
+      await handler.execute({});
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toContain("/projects/");
+      expect(url).toContain("/merge_requests");
+    });
+
+    it("project path is URL-encoded in the request", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitLabConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "gitlab_list_mrs")!;
+      await handler.execute({});
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      // test-group/test-project → test-group%2Ftest-project
+      expect(url).toContain("test-group%2Ftest-project");
+    });
+
+    it("token is not present in output", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [{ iid: 1, title: "MR title" }],
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitLabConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "gitlab_list_mrs")!;
+      const result = await handler.execute({});
+      expect(result).not.toContain("glpat-supersecret");
+    });
+  });
+
+  describe("gitlab_get_mr_diff", () => {
+    it("returns error for missing mrIid", async () => {
+      await server.start(makeGitLabConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "gitlab_get_mr_diff")!;
+      const result = await handler.execute({});
+      expect(result).toMatch(/required/i);
+    });
+
+    it("calls diffs endpoint with correct mrIid", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitLabConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "gitlab_get_mr_diff")!;
+      await handler.execute({ mrIid: 42 });
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toContain("/merge_requests/42/diffs");
+    });
+  });
+
+  describe("gitlab_list_pipelines", () => {
+    it("calls pipelines endpoint", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitLabConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "gitlab_list_pipelines")!;
+      await handler.execute({});
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toContain("/pipelines");
+    });
+
+    it("adds ref param when provided", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitLabConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "gitlab_list_pipelines")!;
+      await handler.execute({ ref: "main" });
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toContain("ref=main");
+    });
+  });
+
+  describe("gitlab_post_note", () => {
+    it("returns error for missing resourceIid", async () => {
+      await server.start(makeGitLabConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "gitlab_post_note")!;
+      const result = await handler.execute({ body: "a comment" });
+      expect(result).toMatch(/required/i);
+    });
+
+    it("returns error for empty body", async () => {
+      await server.start(makeGitLabConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "gitlab_post_note")!;
+      const result = await handler.execute({ resourceIid: 1, body: "" });
+      expect(result).toMatch(/required/i);
+    });
+
+    it("POSTs to merge_requests/notes endpoint by default", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: 9, body: "note" }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitLabConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "gitlab_post_note")!;
+      const result = await handler.execute({ resourceIid: 3, body: "LGTM" });
+
+      const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain("/merge_requests/3/notes");
+      expect(opts.method).toBe("POST");
+      expect(result).toContain("Note posted");
+    });
+
+    it("POSTs to issues/notes when resourceType='issues'", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: 10, body: "note" }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitLabConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "gitlab_post_note")!;
+      await handler.execute({ resourceType: "issues", resourceIid: 7, body: "Thanks!" });
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toContain("/issues/7/notes");
+    });
+
+    it("token is not present in output", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: 1 }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitLabConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "gitlab_post_note")!;
+      const result = await handler.execute({ resourceIid: 1, body: "hi" });
+      expect(result).not.toContain("glpat-supersecret");
+    });
+  });
+
+  describe("gitlab_list_commits", () => {
+    it("calls repository/commits endpoint", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitLabConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "gitlab_list_commits")!;
+      await handler.execute({});
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toContain("/repository/commits");
+    });
+
+    it("adds ref_name param when ref is provided", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitLabConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "gitlab_list_commits")!;
+      await handler.execute({ ref: "develop" });
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toContain("ref_name=develop");
+    });
+  });
+
+  describe("project arg overrides connection default", () => {
+    it("uses project from args when provided", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [],
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await server.start(makeGitLabConfig());
+      const handler = server.getToolHandlers().find((h) => h.definition.name === "gitlab_list_mrs")!;
+      await handler.execute({ project: "other-group/other-project" });
+
+      const [url] = mockFetch.mock.calls[0] as [string];
+      expect(url).toContain("other-group%2Fother-project");
+    });
+  });
+});
+
+// ── BuiltinMcpServerRegistry ──────────────────────────────────────────────────
+
+import { BuiltinMcpServerRegistry } from "../../server/mcp-servers/registry";
+import { ToolRegistry } from "../../server/tools/registry";
+import type { IBuiltinMcpServer } from "../../server/mcp-servers/base";
+import type { ToolHandler } from "../../server/tools/registry";
+
+function makeToolHandler(name: string): ToolHandler {
+  return {
+    definition: {
+      name,
+      description: `Test tool ${name}`,
+      inputSchema: {},
+      source: "mcp",
+      tags: [`connection:test-conn`],
+    },
+    execute: vi.fn().mockResolvedValue(`result-${name}`),
+  };
+}
+
+function makeMockServer(tools: ToolHandler[]): IBuiltinMcpServer {
+  return {
+    connectionType: "kubernetes",
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    getToolHandlers: vi.fn().mockReturnValue(tools),
+    getToolScope: vi.fn().mockReturnValue("read"),
+  };
+}
+
+describe("BuiltinMcpServerRegistry", () => {
+  let toolRegistry: ToolRegistry;
+  let registry: BuiltinMcpServerRegistry;
+
+  beforeEach(() => {
+    toolRegistry = new ToolRegistry();
+    registry = new BuiltinMcpServerRegistry(toolRegistry);
+  });
+
+  it("hasFactory returns true for built-in connection types", () => {
+    expect(registry.hasFactory("kubernetes")).toBe(true);
+    expect(registry.hasFactory("github")).toBe(true);
+    expect(registry.hasFactory("gitlab")).toBe(true);
+    expect(registry.hasFactory("generic_mcp")).toBe(true);
+  });
+
+  it("hasFactory returns false for unknown type", () => {
+    expect(registry.hasFactory("aws")).toBe(false);
+    expect(registry.hasFactory("jira")).toBe(false);
+  });
+
+  it("spawn registers tools in the tool registry", async () => {
+    const mockServer = makeMockServer([
+      makeToolHandler("tool_a"),
+      makeToolHandler("tool_b"),
+    ]);
+    registry.registerFactory("kubernetes", () => mockServer);
+
+    await registry.spawn("kubernetes", "conn-123", {}, {});
+
+    expect(toolRegistry.getToolByName("tool_a")).toBeDefined();
+    expect(toolRegistry.getToolByName("tool_b")).toBeDefined();
+  });
+
+  it("spawn calls server.start() with correct config", async () => {
+    const mockServer = makeMockServer([makeToolHandler("tool_x")]);
+    registry.registerFactory("kubernetes", () => mockServer);
+
+    const config = { namespace: "my-ns" };
+    const secrets = { kubeconfigPath: "/path" };
+    await registry.spawn("kubernetes", "conn-abc", config, secrets, true);
+
+    expect(mockServer.start).toHaveBeenCalledWith({
+      connectionId: "conn-abc",
+      config,
+      secrets,
+      allowDestructive: true,
+    });
+  });
+
+  it("terminate unregisters all tools and calls server.stop()", async () => {
+    const mockServer = makeMockServer([makeToolHandler("my_tool")]);
+    registry.registerFactory("kubernetes", () => mockServer);
+
+    await registry.spawn("kubernetes", "conn-xyz", {}, {});
+    expect(toolRegistry.getToolByName("my_tool")).toBeDefined();
+
+    await registry.terminate("conn-xyz");
+    expect(toolRegistry.getToolByName("my_tool")).toBeUndefined();
+    expect(mockServer.stop).toHaveBeenCalled();
+  });
+
+  it("isActive returns true after spawn, false after terminate", async () => {
+    const mockServer = makeMockServer([makeToolHandler("t1")]);
+    registry.registerFactory("github", () => mockServer);
+
+    expect(registry.isActive("conn-test")).toBe(false);
+    await registry.spawn("github", "conn-test", {}, {});
+    expect(registry.isActive("conn-test")).toBe(true);
+    await registry.terminate("conn-test");
+    expect(registry.isActive("conn-test")).toBe(false);
+  });
+
+  it("getRegisteredToolNames returns tool names for active connection", async () => {
+    const mockServer = makeMockServer([
+      makeToolHandler("t_one"),
+      makeToolHandler("t_two"),
+    ]);
+    registry.registerFactory("gitlab", () => mockServer);
+
+    await registry.spawn("gitlab", "conn-gl", {}, {});
+    const names = registry.getRegisteredToolNames("conn-gl");
+    expect(names).toContain("t_one");
+    expect(names).toContain("t_two");
+  });
+
+  it("getRegisteredToolNames returns empty array for unknown connection", () => {
+    const names = registry.getRegisteredToolNames("nonexistent");
+    expect(names).toEqual([]);
+  });
+
+  it("spawn is idempotent — re-spawning terminates old server first", async () => {
+    const mockServer1 = makeMockServer([makeToolHandler("tool_v1")]);
+    const mockServer2 = makeMockServer([makeToolHandler("tool_v2")]);
+    let callCount = 0;
+    registry.registerFactory("kubernetes", () => {
+      callCount++;
+      return callCount === 1 ? mockServer1 : mockServer2;
+    });
+
+    await registry.spawn("kubernetes", "conn-re", {}, {});
+    expect(toolRegistry.getToolByName("tool_v1")).toBeDefined();
+
+    await registry.spawn("kubernetes", "conn-re", {}, {});
+    // Old server stopped, old tools gone
+    expect(mockServer1.stop).toHaveBeenCalled();
+    expect(toolRegistry.getToolByName("tool_v1")).toBeUndefined();
+    // New server active
+    expect(toolRegistry.getToolByName("tool_v2")).toBeDefined();
+  });
+
+  it("terminateAll stops all active servers", async () => {
+    const serverA = makeMockServer([makeToolHandler("ta")]);
+    const serverB = makeMockServer([makeToolHandler("tb")]);
+    let i = 0;
+    registry.registerFactory("kubernetes", () => (i++ === 0 ? serverA : serverB));
+
+    await registry.spawn("kubernetes", "conn-a", {}, {});
+    registry.registerFactory("github", () => serverB);
+    await registry.spawn("github", "conn-b", {}, {});
+
+    await registry.terminateAll();
+
+    expect(serverA.stop).toHaveBeenCalled();
+    expect(serverB.stop).toHaveBeenCalled();
+    expect(registry.getActiveConnectionIds()).toEqual([]);
+  });
+
+  it("skips spawn for unknown connection type (no factory)", async () => {
+    const before = toolRegistry.getAvailableTools().length;
+    await registry.spawn("aws", "conn-aws", {}, {}); // no factory registered
+    const after = toolRegistry.getAvailableTools().length;
+    expect(after).toBe(before); // nothing registered
+  });
+
+  it("terminate on non-active connection is a no-op", async () => {
+    await expect(registry.terminate("nonexistent-conn")).resolves.not.toThrow();
+  });
+
+  it("tools get builtin-mcp tag added by registry", async () => {
+    const handler = makeToolHandler("tagged_tool");
+    handler.definition.tags = ["kubernetes", "connection:conn-tag"];
+    const mockServer = makeMockServer([handler]);
+    registry.registerFactory("kubernetes", () => mockServer);
+
+    await registry.spawn("kubernetes", "conn-tag", {}, {});
+
+    const def = toolRegistry.getToolByName("tagged_tool");
+    expect(def?.tags).toContain("builtin-mcp:conn-tag");
+  });
+});
+
+// ── McpClientManager — built-in integration ───────────────────────────────────
+
+import { McpClientManager } from "../../server/tools/mcp-client";
+
+describe("McpClientManager — built-in server integration", () => {
+  let toolRegistry: ToolRegistry;
+  let builtinRegistry: BuiltinMcpServerRegistry;
+  let manager: McpClientManager;
+
+  beforeEach(() => {
+    toolRegistry = new ToolRegistry();
+    builtinRegistry = new BuiltinMcpServerRegistry(toolRegistry);
+    manager = new McpClientManager(builtinRegistry);
+  });
+
+  it("spawnBuiltinServer() silently skips unknown connection type", async () => {
+    await expect(
+      manager.spawnBuiltinServer("aws", "conn-aws", {}, {}),
+    ).resolves.not.toThrow();
+  });
+
+  it("spawnBuiltinServer() activates a server for github type", async () => {
+    const mockServer = makeMockServer([makeToolHandler("gh_list_prs_test")]);
+    builtinRegistry.registerFactory("github", () => mockServer);
+
+    await manager.spawnBuiltinServer("github", "conn-gh-mgr", {}, {});
+
+    expect(builtinRegistry.isActive("conn-gh-mgr")).toBe(true);
+  });
+
+  it("terminateBuiltinServer() stops the server and unregisters tools", async () => {
+    const mockServer = makeMockServer([makeToolHandler("gl_list_mrs_test")]);
+    builtinRegistry.registerFactory("gitlab", () => mockServer);
+
+    await manager.spawnBuiltinServer("gitlab", "conn-gl-mgr", {}, {});
+    await manager.terminateBuiltinServer("conn-gl-mgr");
+
+    expect(builtinRegistry.isActive("conn-gl-mgr")).toBe(false);
+    expect(mockServer.stop).toHaveBeenCalled();
+  });
+
+  it("terminateBuiltinServer() is a no-op for non-active connection", async () => {
+    await expect(manager.terminateBuiltinServer("nonexistent")).resolves.not.toThrow();
+  });
+
+  it("getBuiltinRegistry() returns the registry instance", () => {
+    expect(manager.getBuiltinRegistry()).toBe(builtinRegistry);
+  });
+
+  it("spawnBuiltinServer with allowDestructive passes flag to registry", async () => {
+    const mockServer = makeMockServer([makeToolHandler("k8s_tool")]);
+    const startSpy = mockServer.start as ReturnType<typeof vi.fn>;
+    builtinRegistry.registerFactory("kubernetes", () => mockServer);
+
+    await manager.spawnBuiltinServer("kubernetes", "conn-k8s-destr", {}, {}, true);
+
+    const callArg = startSpy.mock.calls[0][0] as BuiltinMcpServerConfig;
+    expect(callArg.allowDestructive).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- 4 built-in MCP servers: `kubernetes`, `docker-run`, `github`, `gitlab`
- Auto-spawn/terminate lifecycle tied to workspace connections via `BuiltinMcpServerRegistry`
- Tool-level scope enforcement: `read` vs `destructive` per tool
- Destructive ops (delete namespace, privileged docker run) require explicit `allowDestructive=true` on the connection
- Namespace scoping for k8s — all tools constrained to per-connection namespace
- Sandbox limits for docker (cpu/mem/timeout capped to connection config; caller cannot exceed)
- No secrets in logs or tool output — `redactSecrets()` applied to every tool response

## Tools by server

| Server | Tools | Destructive |
|--------|-------|-------------|
| `kubernetes` | deploy_manifest, apply_helm_chart, port_forward_check, get_logs, **delete_namespace** | delete_namespace |
| `docker-run` | docker_run, **docker_run_privileged** | docker_run_privileged |
| `github` | list_prs, get_pr_files, get_pr_diff, post_comment, list_workflows | none |
| `gitlab` | list_mrs, get_mr_diff, list_pipelines, post_note, list_commits | none |

## Files changed
- `server/mcp-servers/base.ts` — base interface, `redactSecrets`, `requireDestructiveFlag`
- `server/mcp-servers/kubernetes/index.ts`
- `server/mcp-servers/docker-run/index.ts`
- `server/mcp-servers/github/index.ts`
- `server/mcp-servers/gitlab/index.ts`
- `server/mcp-servers/registry.ts` — lifecycle manager
- `server/tools/mcp-client.ts` — `spawnBuiltinServer`/`terminateBuiltinServer` integration

Closes #270

## Test plan
- [x] 108 new unit tests in `tests/unit/builtin-mcp-servers.test.ts`
- [x] All tools tested against mocked upstreams (fetch / SandboxExecutor)
- [x] Scope enforcement: destructive ops reject without allow-flag
- [x] Lifecycle: spawn registers tools, terminate unregisters them
- [x] Re-spawn is idempotent (terminates old server first)
- [x] `terminateAll` stops all active servers
- [x] Secret redaction: token values not present in any tool output
- [x] Input validation: empty manifest, missing IDs, wrong confirm string
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 2859/2859 tests pass (137 files)