### PR TITLE
feat: ephemeral K8s test environment stage (#272)

### DIFF
--- a/server/maintenance/ephemeral-janitor.ts
+++ b/server/maintenance/ephemeral-janitor.ts
@@ -1,0 +1,275 @@
+/**
+ * Ephemeral Namespace Janitor (issue #272).
+ *
+ * Background job that finds Kubernetes namespaces created by the
+ * e2e_kubernetes pipeline stage and deletes those whose TTL has expired.
+ *
+ * Identification criteria (both must be true):
+ *   - Label  `ephemeral=true`
+ *   - Annotation `multiqlti.io/delete-after` is a parseable ISO timestamp
+ *     that is now in the past
+ *
+ * Safety rules:
+ *   - Only touches namespaces with the `ephemeral=true` label — never
+ *     deletes user-managed namespaces.
+ *   - Dry-run mode returns what would be deleted without taking action.
+ *
+ * Metric: `janitorResult.namespacesByAge` — array of
+ *   `{ namespace, ageHours, expired }` for observability dashboards.
+ *
+ * The `CommandRunner` interface allows injecting a test double without needing
+ * to mock `child_process`.
+ */
+
+import { spawn } from "child_process";
+import type { CommandRunner, CommandResult } from "../pipeline/stages/e2e-kubernetes";
+
+// ─── Re-export CommandRunner from the stage module for convenience ─────────────
+export type { CommandRunner, CommandResult };
+
+// ─── Production runner ────────────────────────────────────────────────────────
+
+class SpawnCommandRunner implements CommandRunner {
+  run(
+    cmd: string,
+    args: string[],
+  ): Promise<CommandResult> {
+    return new Promise((resolve) => {
+      let stdout = "";
+      let stderr = "";
+      const proc = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+      proc.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });
+      proc.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
+      proc.on("close", (code) => resolve({ stdout, stderr, exitCode: code ?? 1 }));
+      proc.on("error", (err) => resolve({ stdout, stderr: err.message, exitCode: 1 }));
+    });
+  }
+}
+
+const defaultRunner: CommandRunner = new SpawnCommandRunner();
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+function kubectlArgs(kubeconfigPath: string | undefined, ...rest: string[]): string[] {
+  return kubeconfigPath ? ["--kubeconfig", kubeconfigPath, ...rest] : [...rest];
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface NamespaceAgeEntry {
+  namespace: string;
+  /** Floating-point hours since namespace creation */
+  ageHours: number;
+  /** True when `delete-after` annotation is in the past */
+  expired: boolean;
+  deleteAfter: string | null;
+}
+
+export interface JanitorRunResult {
+  scanned: number;
+  deleted: string[];
+  errors: Array<{ namespace: string; error: string }>;
+  namespacesByAge: NamespaceAgeEntry[];
+  dryRun: boolean;
+  ranAt: Date;
+}
+
+export interface JanitorOptions {
+  /** Path to kubeconfig file. Undefined = use in-cluster config. */
+  kubeconfigPath?: string;
+  /** When true, log what would be deleted but do not actually delete. Default false. */
+  dryRun?: boolean;
+  /**
+   * Custom label selector used to find ephemeral namespaces.
+   * Default: "ephemeral=true"
+   */
+  labelSelector?: string;
+  /**
+   * Injectable command runner for testing.
+   * Defaults to the spawn-backed production runner.
+   */
+  runner?: CommandRunner;
+}
+
+// ─── Janitor implementation ────────────────────────────────────────────────────
+
+/**
+ * List namespaces matching the ephemeral label selector and return
+ * their metadata (name, delete-after annotation, creation timestamp).
+ */
+export async function listEphemeralNamespaces(
+  kubeconfigPath: string | undefined,
+  labelSelector: string,
+  runner: CommandRunner,
+): Promise<Array<{ name: string; deleteAfter: string | null; creationTimestamp: string | null }>> {
+  const result = await runner.run(
+    "kubectl",
+    kubectlArgs(
+      kubeconfigPath,
+      "get", "namespaces",
+      "--selector", labelSelector,
+      "-o",
+      "jsonpath={range .items[*]}{.metadata.name}|{.metadata.annotations.multiqlti\\.io/delete-after}|{.metadata.creationTimestamp}\\n{end}",
+    ),
+  );
+
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Failed to list ephemeral namespaces: ${result.stderr}`,
+    );
+  }
+
+  return result.stdout
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => {
+      const parts = line.split("|");
+      return {
+        name: parts[0] ?? "",
+        deleteAfter: parts[1] || null,
+        creationTimestamp: parts[2] || null,
+      };
+    })
+    .filter((ns) => ns.name.length > 0);
+}
+
+/**
+ * Delete a single namespace. Returns true on success, false on error.
+ */
+export async function deleteNamespace(
+  namespace: string,
+  kubeconfigPath: string | undefined,
+  runner: CommandRunner,
+): Promise<{ success: boolean; error?: string }> {
+  const result = await runner.run(
+    "kubectl",
+    kubectlArgs(kubeconfigPath, "delete", "namespace", namespace, "--ignore-not-found"),
+  );
+
+  if (result.exitCode !== 0) {
+    return { success: false, error: result.stderr.trim() || "unknown error" };
+  }
+  return { success: true };
+}
+
+/**
+ * Compute the age of a namespace in hours from its creation timestamp.
+ */
+function computeAgeHours(creationTimestamp: string | null): number {
+  if (!creationTimestamp) return 0;
+  const created = new Date(creationTimestamp);
+  if (isNaN(created.getTime())) return 0;
+  return (Date.now() - created.getTime()) / (1000 * 60 * 60);
+}
+
+/**
+ * Determine whether a namespace has exceeded its TTL based on the
+ * `multiqlti.io/delete-after` annotation.
+ */
+function isExpired(deleteAfter: string | null): boolean {
+  if (!deleteAfter) return false;
+  const ts = new Date(deleteAfter);
+  if (isNaN(ts.getTime())) return false;
+  return Date.now() > ts.getTime();
+}
+
+/**
+ * Main janitor function. Scans all ephemeral namespaces, deletes those whose
+ * TTL has expired, and returns a structured result for metrics/logging.
+ */
+export async function runEphemeralJanitor(
+  opts: JanitorOptions = {},
+): Promise<JanitorRunResult> {
+  const {
+    kubeconfigPath,
+    dryRun = false,
+    labelSelector = "ephemeral=true",
+    runner = defaultRunner,
+  } = opts;
+
+  const ranAt = new Date();
+  const deleted: string[] = [];
+  const errors: Array<{ namespace: string; error: string }> = [];
+  const namespacesByAge: NamespaceAgeEntry[] = [];
+
+  const namespaces = await listEphemeralNamespaces(kubeconfigPath, labelSelector, runner);
+
+  for (const ns of namespaces) {
+    const ageHours = computeAgeHours(ns.creationTimestamp);
+    const expired = isExpired(ns.deleteAfter);
+
+    namespacesByAge.push({
+      namespace: ns.name,
+      ageHours,
+      expired,
+      deleteAfter: ns.deleteAfter,
+    });
+
+    if (!expired) continue;
+
+    if (dryRun) {
+      // Record as "would delete" without acting
+      deleted.push(ns.name);
+      continue;
+    }
+
+    const outcome = await deleteNamespace(ns.name, kubeconfigPath, runner);
+    if (outcome.success) {
+      deleted.push(ns.name);
+    } else {
+      errors.push({ namespace: ns.name, error: outcome.error ?? "unknown error" });
+    }
+  }
+
+  return {
+    scanned: namespaces.length,
+    deleted,
+    errors,
+    namespacesByAge,
+    dryRun,
+    ranAt,
+  };
+}
+
+// ─── Scheduled janitor ─────────────────────────────────────────────────────────
+
+export interface ScheduledJanitorHandle {
+  stop: () => void;
+  lastResult: () => JanitorRunResult | null;
+}
+
+/**
+ * Start a recurring janitor that runs every `intervalMs` milliseconds.
+ * Returns a handle with `stop()` and `lastResult()`.
+ *
+ * Errors during a run are captured in `lastResult().errors` — they do not
+ * crash the background loop.
+ */
+export function startScheduledJanitor(
+  opts: JanitorOptions & { intervalMs: number },
+): ScheduledJanitorHandle {
+  let lastResult: JanitorRunResult | null = null;
+  let stopped = false;
+
+  const run = (): void => {
+    void runEphemeralJanitor(opts).then((result) => {
+      lastResult = result;
+    }).catch(() => {
+      // Non-fatal: errors are surfaced via lastResult.errors in the next run
+    });
+  };
+
+  // Run immediately on start, then repeat
+  run();
+  const interval = setInterval(() => {
+    if (!stopped) run();
+  }, opts.intervalMs);
+
+  return {
+    stop: () => {
+      stopped = true;
+      clearInterval(interval);
+    },
+    lastResult: () => lastResult,
+  };
+}

--- a/server/pipeline/stages/e2e-kubernetes.ts
+++ b/server/pipeline/stages/e2e-kubernetes.ts
@@ -1,0 +1,699 @@
+/**
+ * Ephemeral Kubernetes Test Environment Stage (issue #272).
+ *
+ * Stage type: e2e_kubernetes
+ *
+ * Lifecycle:
+ *   1. Validate inputs + guardrails
+ *   2. Create namespace `mq-run-<runId>` with labels (ephemeral=true, ttl=hours)
+ *   3. Apply namespace-level ResourceQuota + NetworkPolicy (default-deny egress)
+ *   4. Deploy app via Helm (workspace chart or bundled generic chart)
+ *   5. Wait for rollout readiness (deployment rollout, endpoints, custom command)
+ *   6. Run test command in a test pod — capture stdout/stderr + exit code
+ *   7. Collect artifacts: test logs, rendered Helm manifest, pod events on failure
+ *   8. Teardown:  success → delete immediately (configurable)
+ *                 failure → leave namespace with TTL annotation for janitor
+ *
+ * Security guardrails (enforced before any cluster interaction):
+ *   - No privileged containers
+ *   - No hostNetwork
+ *   - No hostPath volumes
+ *   - Egress locked to default-deny unless `allowedEgressHosts` declared
+ *
+ * All cluster commands are executed via `child_process.spawn` — no shell
+ * interpolation, no string-concatenated kubectl/helm arguments.
+ *
+ * The `CommandRunner` interface allows injecting a test double for unit tests
+ * without needing to mock the `child_process` module.
+ */
+
+import { spawn } from "child_process";
+import type {
+  E2eKubernetesStageConfig,
+  E2eKubernetesResult,
+  E2eKubernetesArtifacts,
+} from "@shared/types";
+
+// ─── Command runner abstraction ───────────────────────────────────────────────
+
+export interface CommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/**
+ * Dependency-injectable command runner.
+ * Production code uses `defaultCommandRunner`; tests inject a fake.
+ */
+export interface CommandRunner {
+  run(
+    cmd: string,
+    args: string[],
+    opts?: { stdinData?: string; timeoutMs?: number },
+  ): Promise<CommandResult>;
+}
+
+/** Production command runner backed by child_process.spawn. */
+export class SpawnCommandRunner implements CommandRunner {
+  run(
+    cmd: string,
+    args: string[],
+    opts: { stdinData?: string; timeoutMs?: number } = {},
+  ): Promise<CommandResult> {
+    return new Promise((resolve) => {
+      let stdout = "";
+      let stderr = "";
+      let timedOut = false;
+
+      const proc = spawn(cmd, args, { stdio: ["pipe", "pipe", "pipe"] });
+      proc.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });
+      proc.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
+
+      const timer = opts.timeoutMs
+        ? setTimeout(() => {
+            timedOut = true;
+            proc.kill("SIGKILL");
+          }, opts.timeoutMs)
+        : null;
+
+      proc.on("close", (code) => {
+        if (timer) clearTimeout(timer);
+        if (timedOut) {
+          resolve({ stdout, stderr: `Timed out after ${opts.timeoutMs}ms`, exitCode: 124 });
+        } else {
+          resolve({ stdout, stderr, exitCode: code ?? 1 });
+        }
+      });
+
+      proc.on("error", (err) => {
+        if (timer) clearTimeout(timer);
+        resolve({ stdout, stderr: err.message, exitCode: 1 });
+      });
+
+      if (opts.stdinData !== undefined) {
+        proc.stdin.write(opts.stdinData);
+      }
+      proc.stdin.end();
+    });
+  }
+}
+
+/** Singleton production runner. Tests pass their own instance. */
+export const defaultCommandRunner: CommandRunner = new SpawnCommandRunner();
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function kubectlArgs(kubeconfigPath: string | undefined, ...rest: string[]): string[] {
+  return kubeconfigPath ? ["--kubeconfig", kubeconfigPath, ...rest] : [...rest];
+}
+
+function helmArgs(kubeconfigPath: string | undefined, ...rest: string[]): string[] {
+  return kubeconfigPath ? ["--kubeconfig", kubeconfigPath, ...rest] : [...rest];
+}
+
+/**
+ * Validate a Kubernetes namespace name.
+ * DNS label rules: lowercase alphanumeric and hyphens, 1–253 chars.
+ */
+function validateNamespaceName(ns: string): void {
+  if (!/^[a-z0-9][a-z0-9-]{0,251}[a-z0-9]$|^[a-z0-9]$/.test(ns)) {
+    throw new E2eKubernetesError(
+      `Invalid namespace name "${ns}". Must match Kubernetes DNS label rules.`,
+    );
+  }
+}
+
+/**
+ * Sanitize a pipeline run ID into a safe Kubernetes name segment.
+ * Keep lowercase alphanumeric and hyphens only, truncate to 50 chars.
+ */
+export function buildNamespaceName(runId: string): string {
+  const sanitized = runId
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 50);
+
+  return `mq-run-${sanitized}`;
+}
+
+// ─── Errors ───────────────────────────────────────────────────────────────────
+
+export class E2eKubernetesError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "E2eKubernetesError";
+  }
+}
+
+export class E2eGuardrailError extends E2eKubernetesError {
+  constructor(violation: string) {
+    super(`Security guardrail violation: ${violation}`);
+    this.name = "E2eGuardrailError";
+  }
+}
+
+export class E2eReadinessTimeoutError extends E2eKubernetesError {
+  constructor(check: string, timeoutMs: number) {
+    super(`Readiness check "${check}" did not pass within ${timeoutMs}ms`);
+    this.name = "E2eReadinessTimeoutError";
+  }
+}
+
+// ─── Guardrail Validation ─────────────────────────────────────────────────────
+
+/**
+ * Validate the stage config against security guardrails before any cluster
+ * interaction. Throws E2eGuardrailError on the first violation found.
+ *
+ * Guardrails enforced:
+ *   - testPodSpec.securityContext.privileged must not be true
+ *   - testPodSpec.hostNetwork must not be true
+ *   - testPodSpec.volumes must not contain hostPath entries
+ */
+export function enforceGuardrails(cfg: E2eKubernetesStageConfig): void {
+  const pod = cfg.testPodSpec;
+  if (!pod) return;
+
+  // Privileged container check
+  const containers = [
+    ...(pod.containers ?? []),
+    ...(pod.initContainers ?? []),
+  ];
+  for (const container of containers) {
+    const privileged = container?.securityContext?.privileged;
+    if (privileged === true) {
+      throw new E2eGuardrailError(
+        `Container "${container.name ?? "(unnamed)"}" requests privileged mode — denied.`,
+      );
+    }
+  }
+
+  // Host network check
+  if (pod.hostNetwork === true) {
+    throw new E2eGuardrailError("hostNetwork: true is not permitted in ephemeral test pods.");
+  }
+
+  // hostPath volume check
+  const volumes = pod.volumes ?? [];
+  for (const vol of volumes) {
+    if (vol?.hostPath !== undefined && vol.hostPath !== null) {
+      throw new E2eGuardrailError(
+        `Volume "${vol.name ?? "(unnamed)"}" uses hostPath — denied.`,
+      );
+    }
+  }
+}
+
+// ─── Namespace manifest builders ──────────────────────────────────────────────
+
+/** Builds the Namespace manifest YAML with ephemeral labels and TTL annotation. */
+export function buildNamespaceManifest(
+  namespace: string,
+  runId: string,
+  ttlHours: number,
+): string {
+  const deleteAfter = new Date(Date.now() + ttlHours * 60 * 60 * 1000).toISOString();
+  return [
+    "apiVersion: v1",
+    "kind: Namespace",
+    "metadata:",
+    `  name: ${namespace}`,
+    "  labels:",
+    "    ephemeral: \"true\"",
+    `    mq-run-id: "${runId}"`,
+    `    ttl-hours: "${ttlHours}"`,
+    "  annotations:",
+    `    multiqlti.io/delete-after: "${deleteAfter}"`,
+  ].join("\n");
+}
+
+/**
+ * Builds a ResourceQuota manifest for the namespace.
+ * Defaults: 2 CPU, 2Gi memory, 10 pods.
+ */
+export function buildResourceQuotaManifest(
+  namespace: string,
+  quota: E2eKubernetesStageConfig["resourceQuota"],
+): string {
+  const cpu = quota?.limitCpu ?? "2";
+  const memory = quota?.limitMemory ?? "2Gi";
+  const pods = quota?.maxPods ?? 10;
+
+  return [
+    "apiVersion: v1",
+    "kind: ResourceQuota",
+    "metadata:",
+    "  name: mq-ephemeral-quota",
+    `  namespace: ${namespace}`,
+    "spec:",
+    "  hard:",
+    `    limits.cpu: "${cpu}"`,
+    `    limits.memory: "${memory}"`,
+    `    pods: "${pods}"`,
+  ].join("\n");
+}
+
+/**
+ * Builds a default-deny egress NetworkPolicy.
+ * If allowedEgressHosts contains entries they become Egress rules.
+ * Ingress is unrestricted within the namespace to allow pod-to-pod communication.
+ */
+export function buildNetworkPolicyManifest(
+  namespace: string,
+  allowedEgressHosts: string[] = [],
+): string {
+  const lines = [
+    "apiVersion: networking.k8s.io/v1",
+    "kind: NetworkPolicy",
+    "metadata:",
+    "  name: mq-default-deny-egress",
+    `  namespace: ${namespace}`,
+    "spec:",
+    "  podSelector: {}",
+    "  policyTypes:",
+    "  - Egress",
+  ];
+
+  if (allowedEgressHosts.length > 0) {
+    lines.push("  egress:");
+    for (const host of allowedEgressHosts) {
+      lines.push("  - to:");
+      lines.push("    - ipBlock:");
+      lines.push(`        cidr: ${host}`);
+    }
+  }
+  // When allowedEgressHosts is empty, no egress stanza = block all egress.
+
+  return lines.join("\n");
+}
+
+// ─── Kubernetes operations ─────────────────────────────────────────────────────
+
+/** Create the namespace and apply the quota + network policy. */
+async function bootstrapNamespace(
+  namespace: string,
+  runId: string,
+  cfg: E2eKubernetesStageConfig,
+  kubeconfigPath: string | undefined,
+  runner: CommandRunner,
+): Promise<void> {
+  const nsManifest = buildNamespaceManifest(namespace, runId, cfg.ttlHours ?? 4);
+  const quotaManifest = buildResourceQuotaManifest(namespace, cfg.resourceQuota);
+  const netpolManifest = buildNetworkPolicyManifest(
+    namespace,
+    cfg.allowedEgressHosts ?? [],
+  );
+
+  const combined = [nsManifest, "---", quotaManifest, "---", netpolManifest].join("\n");
+
+  const result = await runner.run(
+    "kubectl",
+    kubectlArgs(kubeconfigPath, "apply", "-f", "-"),
+    { stdinData: combined },
+  );
+
+  if (result.exitCode !== 0) {
+    throw new E2eKubernetesError(
+      `Failed to bootstrap namespace "${namespace}": ${result.stderr}`,
+    );
+  }
+}
+
+/** Deploy via Helm chart. Returns rendered manifest (helm get manifest). */
+async function helmDeploy(
+  namespace: string,
+  releaseName: string,
+  chart: string,
+  valuesYaml: string | undefined,
+  kubeconfigPath: string | undefined,
+  runner: CommandRunner,
+  timeoutMs = 120_000,
+): Promise<string> {
+  const args = [
+    "upgrade", "--install",
+    releaseName, chart,
+    "--namespace", namespace,
+    "--wait",
+    "--timeout", `${Math.ceil(timeoutMs / 1000)}s`,
+  ];
+
+  const result = await runner.run(
+    "helm",
+    helmArgs(kubeconfigPath, ...args),
+    { stdinData: valuesYaml, timeoutMs: timeoutMs + 10_000 },
+  );
+
+  if (result.exitCode !== 0) {
+    throw new E2eKubernetesError(
+      `Helm deploy failed for release "${releaseName}": ${result.stderr}`,
+    );
+  }
+
+  // Capture rendered manifest for artifacts
+  const manifestResult = await runner.run(
+    "helm",
+    helmArgs(kubeconfigPath, "get", "manifest", releaseName, "--namespace", namespace),
+  );
+
+  return manifestResult.exitCode === 0 ? manifestResult.stdout : "(manifest unavailable)";
+}
+
+/**
+ * Wait for rollout of a deployment to complete.
+ * Uses `kubectl rollout status` which blocks until ready or times out.
+ */
+async function waitForRollout(
+  namespace: string,
+  deploymentName: string,
+  kubeconfigPath: string | undefined,
+  runner: CommandRunner,
+  timeoutMs: number,
+): Promise<void> {
+  const result = await runner.run(
+    "kubectl",
+    kubectlArgs(
+      kubeconfigPath,
+      "rollout", "status",
+      `deployment/${deploymentName}`,
+      "--namespace", namespace,
+      "--timeout", `${Math.ceil(timeoutMs / 1000)}s`,
+    ),
+    { timeoutMs: timeoutMs + 5_000 },
+  );
+
+  if (result.exitCode !== 0) {
+    throw new E2eReadinessTimeoutError("deployment rollout", timeoutMs);
+  }
+}
+
+/**
+ * Verify at least one ready endpoint exists for a given service.
+ */
+async function waitForEndpoints(
+  namespace: string,
+  serviceName: string,
+  kubeconfigPath: string | undefined,
+  runner: CommandRunner,
+  pollIntervalMs: number,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const result = await runner.run(
+      "kubectl",
+      kubectlArgs(
+        kubeconfigPath,
+        "get", "endpoints", serviceName,
+        "--namespace", namespace,
+        "-o", "jsonpath={.subsets[0].addresses[0].ip}",
+      ),
+    );
+
+    if (result.exitCode === 0 && result.stdout.trim().length > 0) {
+      return;
+    }
+
+    await new Promise<void>((r) => setTimeout(r, pollIntervalMs));
+  }
+
+  throw new E2eReadinessTimeoutError("service endpoints", timeoutMs);
+}
+
+/**
+ * Execute the custom readiness command in a test pod.
+ * Returns when the command exits 0.
+ */
+async function runReadinessCommand(
+  namespace: string,
+  image: string,
+  command: string[],
+  kubeconfigPath: string | undefined,
+  runner: CommandRunner,
+  timeoutMs: number,
+): Promise<void> {
+  const result = await runner.run(
+    "kubectl",
+    kubectlArgs(
+      kubeconfigPath,
+      "run", "mq-readiness-check",
+      `--image=${image}`,
+      "--namespace", namespace,
+      "--restart=Never",
+      "--rm",
+      "--attach",
+      "--command", "--",
+      ...command,
+    ),
+    { timeoutMs },
+  );
+
+  if (result.exitCode !== 0) {
+    throw new E2eReadinessTimeoutError("custom command", timeoutMs);
+  }
+}
+
+/**
+ * Run the test command in a short-lived test pod.
+ * Returns stdout, stderr, and exitCode.
+ */
+async function runTestPod(
+  namespace: string,
+  testImage: string,
+  testCommand: string[],
+  kubeconfigPath: string | undefined,
+  runner: CommandRunner,
+  timeoutMs: number,
+): Promise<CommandResult> {
+  const podName = `mq-test-${Date.now().toString(36)}`;
+
+  return runner.run(
+    "kubectl",
+    kubectlArgs(
+      kubeconfigPath,
+      "run", podName,
+      `--image=${testImage}`,
+      "--namespace", namespace,
+      "--restart=Never",
+      "--rm",
+      "--attach",
+      "--command", "--",
+      ...testCommand,
+    ),
+    { timeoutMs },
+  );
+}
+
+/** Collect pod events for the namespace — useful for failure diagnostics. */
+async function getPodEvents(
+  namespace: string,
+  kubeconfigPath: string | undefined,
+  runner: CommandRunner,
+): Promise<string> {
+  const result = await runner.run(
+    "kubectl",
+    kubectlArgs(
+      kubeconfigPath,
+      "get", "events",
+      "--namespace", namespace,
+      "--sort-by=.lastTimestamp",
+    ),
+  );
+  return result.stdout || "(no events)";
+}
+
+/** Delete the namespace immediately. */
+async function deleteNamespace(
+  namespace: string,
+  kubeconfigPath: string | undefined,
+  runner: CommandRunner,
+): Promise<void> {
+  await runner.run(
+    "kubectl",
+    kubectlArgs(kubeconfigPath, "delete", "namespace", namespace, "--ignore-not-found"),
+  );
+}
+
+/** Annotate the namespace with a delete-after timestamp (TTL mode). */
+async function annotateWithTtl(
+  namespace: string,
+  ttlHours: number,
+  kubeconfigPath: string | undefined,
+  runner: CommandRunner,
+): Promise<void> {
+  const deleteAfter = new Date(Date.now() + ttlHours * 60 * 60 * 1000).toISOString();
+  await runner.run(
+    "kubectl",
+    kubectlArgs(
+      kubeconfigPath,
+      "annotate", "namespace", namespace,
+      `multiqlti.io/delete-after=${deleteAfter}`,
+      "--overwrite",
+    ),
+  );
+}
+
+// ─── Readiness orchestration ──────────────────────────────────────────────────
+
+async function waitForReadiness(
+  namespace: string,
+  cfg: E2eKubernetesStageConfig,
+  kubeconfigPath: string | undefined,
+  runner: CommandRunner,
+): Promise<void> {
+  const readiness = cfg.readiness;
+  if (!readiness) return;
+
+  const timeoutMs = readiness.timeoutMs ?? 120_000;
+  const pollIntervalMs = readiness.pollIntervalMs ?? 3_000;
+
+  if (readiness.deploymentName) {
+    await waitForRollout(namespace, readiness.deploymentName, kubeconfigPath, runner, timeoutMs);
+  }
+
+  if (readiness.serviceName) {
+    await waitForEndpoints(namespace, readiness.serviceName, kubeconfigPath, runner, pollIntervalMs, timeoutMs);
+  }
+
+  if (readiness.command && readiness.command.length > 0) {
+    const image = readiness.commandImage ?? cfg.testImage;
+    await runReadinessCommand(namespace, image, readiness.command, kubeconfigPath, runner, timeoutMs);
+  }
+}
+
+// ─── Stage entry point ─────────────────────────────────────────────────────────
+
+/**
+ * Run an ephemeral Kubernetes test environment stage.
+ *
+ * @param runId          Pipeline run ID used to derive the namespace name
+ * @param cfg            Stage configuration
+ * @param kubeconfigPath Path to kubeconfig file (undefined = use in-cluster config)
+ * @param runner         Command runner (defaults to spawn-backed production runner)
+ */
+export async function runE2eKubernetesStage(
+  runId: string,
+  cfg: E2eKubernetesStageConfig,
+  kubeconfigPath?: string,
+  runner: CommandRunner = defaultCommandRunner,
+): Promise<E2eKubernetesResult> {
+  // ── 1. Validate inputs ─────────────────────────────────────────────────────
+  if (!cfg.imageRef?.trim()) {
+    throw new E2eKubernetesError("imageRef is required for e2e_kubernetes stage.");
+  }
+  if (!cfg.testImage?.trim()) {
+    throw new E2eKubernetesError("testImage is required for e2e_kubernetes stage.");
+  }
+  if (!cfg.testCommand || cfg.testCommand.length === 0) {
+    throw new E2eKubernetesError("testCommand must be a non-empty array.");
+  }
+
+  // ── 2. Enforce security guardrails ─────────────────────────────────────────
+  enforceGuardrails(cfg);
+
+  // ── 3. Derive namespace name ───────────────────────────────────────────────
+  const namespace = buildNamespaceName(runId);
+  validateNamespaceName(namespace);
+
+  const ttlHours = cfg.ttlHours ?? 4;
+  const helmChart = cfg.helmChart ?? "stable/nginx";
+  const releaseName =
+    cfg.releaseName ??
+    `mq-${runId
+      .slice(0, 20)
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "")}`;
+  const helmTimeoutMs = cfg.helmTimeoutMs ?? 120_000;
+  const testTimeoutMs = cfg.testTimeoutMs ?? 60_000;
+
+  let helmManifest = "(not captured)";
+  let testStdout = "";
+  let testStderr = "";
+  let testExitCode = -1;
+  let podEvents: string | undefined;
+  let success = false;
+
+  try {
+    // ── 4. Bootstrap namespace (NS + ResourceQuota + NetworkPolicy) ───────────
+    await bootstrapNamespace(namespace, runId, cfg, kubeconfigPath, runner);
+
+    // ── 5. Deploy via Helm ────────────────────────────────────────────────────
+    helmManifest = await helmDeploy(
+      namespace,
+      releaseName,
+      helmChart,
+      cfg.helmValues,
+      kubeconfigPath,
+      runner,
+      helmTimeoutMs,
+    );
+
+    // ── 6. Wait for readiness ─────────────────────────────────────────────────
+    await waitForReadiness(namespace, cfg, kubeconfigPath, runner);
+
+    // ── 7. Run test command in test pod ───────────────────────────────────────
+    const testResult = await runTestPod(
+      namespace,
+      cfg.testImage,
+      cfg.testCommand,
+      kubeconfigPath,
+      runner,
+      testTimeoutMs,
+    );
+
+    testStdout = testResult.stdout;
+    testStderr = testResult.stderr;
+    testExitCode = testResult.exitCode;
+    success = testExitCode === 0;
+
+    // ── 8a. Collect pod events on failure ─────────────────────────────────────
+    if (!success) {
+      podEvents = await getPodEvents(namespace, kubeconfigPath, runner);
+    }
+  } catch (err) {
+    // Capture events for any unexpected error during setup
+    podEvents = await getPodEvents(namespace, kubeconfigPath, runner).catch(
+      () => "(events unavailable)",
+    );
+
+    // Re-throw so the pipeline can record the failure
+    throw err;
+  } finally {
+    // ── 8b. Teardown ──────────────────────────────────────────────────────────
+    if (success) {
+      const deleteOnSuccess = cfg.deleteOnSuccess !== false; // default true
+      if (deleteOnSuccess) {
+        await deleteNamespace(namespace, kubeconfigPath, runner).catch(() => {
+          // Non-fatal: janitor will clean it up
+        });
+      } else {
+        await annotateWithTtl(namespace, ttlHours, kubeconfigPath, runner).catch(() => {});
+      }
+    } else {
+      // Failure: leave namespace alive with TTL annotation for debugging
+      await annotateWithTtl(namespace, ttlHours, kubeconfigPath, runner).catch(() => {});
+    }
+  }
+
+  // ── 9. Build artifact record ───────────────────────────────────────────────
+  const artifacts: E2eKubernetesArtifacts = {
+    testLogs: testStdout + (testStderr ? `\n--- stderr ---\n${testStderr}` : ""),
+    helmManifest,
+    ...(podEvents !== undefined ? { podEvents } : {}),
+  };
+
+  return {
+    namespace,
+    success,
+    testExitCode,
+    testStdout,
+    testStderr,
+    artifacts,
+    ttlHours,
+  };
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -2064,3 +2064,153 @@ export interface RecordMcpToolCallInput {
   durationMs: number;
   startedAt?: Date;
 }
+
+// ── E2E Kubernetes Stage Types (issue #272) ───────────────────────────────────
+
+/**
+ * Resource quota limits for an ephemeral namespace.
+ * All values follow Kubernetes resource notation (e.g. "2", "500m" for CPU;
+ * "2Gi", "512Mi" for memory).
+ */
+export interface EphemeralNamespaceQuota {
+  /** CPU limit for the entire namespace (default "2"). */
+  limitCpu?: string;
+  /** Memory limit for the entire namespace (default "2Gi"). */
+  limitMemory?: string;
+  /** Maximum pod count for the entire namespace (default 10). */
+  maxPods?: number;
+}
+
+/**
+ * Readiness check configuration.
+ * Checks are performed in order: deployment rollout → endpoints → custom command.
+ * Any single check failure aborts the stage.
+ */
+export interface ReadinessConfig {
+  /** Kubernetes Deployment name to wait for (kubectl rollout status). */
+  deploymentName?: string;
+  /** Service name whose Endpoints must have at least one ready address. */
+  serviceName?: string;
+  /** Arbitrary command to run in a short-lived pod; exit 0 = ready. */
+  command?: string[];
+  /** Image to use when running `command`. Defaults to `testImage`. */
+  commandImage?: string;
+  /** Maximum milliseconds to wait for any single check (default 120_000). */
+  timeoutMs?: number;
+  /** Polling interval for endpoint checks (default 3_000). */
+  pollIntervalMs?: number;
+}
+
+/**
+ * Minimal pod spec subset used for security guardrail validation.
+ * Mirrors the subset of the Kubernetes PodSpec we inspect; additional fields
+ * are passed through untouched.
+ */
+export interface EphemeralPodSpec {
+  hostNetwork?: boolean;
+  volumes?: Array<{
+    name?: string;
+    hostPath?: unknown;
+    [key: string]: unknown;
+  }>;
+  containers?: Array<{
+    name?: string;
+    securityContext?: { privileged?: boolean; [key: string]: unknown };
+    [key: string]: unknown;
+  }>;
+  initContainers?: Array<{
+    name?: string;
+    securityContext?: { privileged?: boolean; [key: string]: unknown };
+    [key: string]: unknown;
+  }>;
+}
+
+/**
+ * Configuration for the `e2e_kubernetes` pipeline stage type.
+ */
+export interface E2eKubernetesStageConfig {
+  /** Docker image reference to deploy (e.g. "registry/app:sha256-..."). */
+  imageRef: string;
+  /**
+   * Helm chart reference. Can be:
+   *   - A repo/chart reference (e.g. "stable/nginx")
+   *   - A local chart path (e.g. "./helm/my-chart")
+   * Default: "stable/nginx" (generic bundled chart).
+   */
+  helmChart?: string;
+  /** Helm release name. Defaults to "mq-<runId-prefix>". */
+  releaseName?: string;
+  /** Optional Helm values as a YAML string. */
+  helmValues?: string;
+  /**
+   * TTL in hours for failed-run namespaces. The janitor uses this value.
+   * Default: 4 hours.
+   */
+  ttlHours?: number;
+  /**
+   * When true (default), the namespace is deleted immediately after a
+   * successful test run. When false, the namespace is preserved until the
+   * TTL expires.
+   */
+  deleteOnSuccess?: boolean;
+  /**
+   * Image used to run the test command in the test pod.
+   * Must be a valid, pullable Docker image reference.
+   */
+  testImage: string;
+  /**
+   * Command and arguments to execute in the test pod.
+   * Exit code 0 = test passed; any other exit code = test failed.
+   */
+  testCommand: string[];
+  /** Readiness checks to perform before running the test command. */
+  readiness?: ReadinessConfig;
+  /** Namespace resource quota overrides. */
+  resourceQuota?: EphemeralNamespaceQuota;
+  /**
+   * CIDR blocks that should be allowed in the egress NetworkPolicy.
+   * Default: empty (deny all egress).
+   */
+  allowedEgressHosts?: string[];
+  /**
+   * Optional pod spec for the test pod — used for guardrail validation.
+   * Privileged containers, hostNetwork, and hostPath volumes are denied.
+   */
+  testPodSpec?: EphemeralPodSpec;
+  /** Timeout in ms for the Helm deploy (default 120_000). */
+  helmTimeoutMs?: number;
+  /** Timeout in ms for the test pod execution (default 60_000). */
+  testTimeoutMs?: number;
+}
+
+/**
+ * Artifacts collected during the e2e_kubernetes stage run.
+ */
+export interface E2eKubernetesArtifacts {
+  /** Combined test stdout + stderr from the test pod. */
+  testLogs: string;
+  /** Rendered Helm manifest (from `helm get manifest`). */
+  helmManifest: string;
+  /** Pod events for the namespace — populated on failure for diagnostics. */
+  podEvents?: string;
+}
+
+/**
+ * Result returned by the e2e_kubernetes stage after completion.
+ */
+export interface E2eKubernetesResult {
+  /** Fully qualified namespace that was created (e.g. "mq-run-abc123"). */
+  namespace: string;
+  /** True when the test command exited with code 0. */
+  success: boolean;
+  /** Raw exit code from the test command (-1 if not reached). */
+  testExitCode: number;
+  /** Standard output from the test pod. */
+  testStdout: string;
+  /** Standard error from the test pod. */
+  testStderr: string;
+  /** Collected artifacts for storage/display. */
+  artifacts: E2eKubernetesArtifacts;
+  /** TTL used for the namespace (hours). */
+  ttlHours: number;
+}

--- a/tests/unit/e2e-kubernetes-stage.test.ts
+++ b/tests/unit/e2e-kubernetes-stage.test.ts
@@ -1,0 +1,925 @@
+/**
+ * Comprehensive unit tests for the ephemeral Kubernetes test environment stage
+ * and the ephemeral janitor (issue #272).
+ *
+ * All kubectl/helm invocations are intercepted by an injected `FakeRunner` so no
+ * cluster is needed.
+ *
+ * Sections:
+ *  1.  buildNamespaceName — safe namespace name derivation
+ *  2.  enforceGuardrails — privileged, hostNetwork, hostPath rejections
+ *  3.  buildNamespaceManifest — correct labels and TTL annotation
+ *  4.  buildResourceQuotaManifest — CPU/memory/pod defaults and overrides
+ *  5.  buildNetworkPolicyManifest — default-deny and allowed-egress
+ *  6.  runE2eKubernetesStage — validation (missing fields, guardrail rejection)
+ *  7.  runE2eKubernetesStage — success lifecycle
+ *  8.  runE2eKubernetesStage — failure lifecycle
+ *  9.  runE2eKubernetesStage — teardown behaviour
+ * 10.  runE2eKubernetesStage — artifact capture
+ * 11.  runEphemeralJanitor — expired namespace deleted, non-expired preserved
+ * 12.  runEphemeralJanitor — dry-run mode
+ * 13.  runEphemeralJanitor — label selector safety
+ * 14.  runEphemeralJanitor — error handling
+ * 15.  startScheduledJanitor — stop/lastResult lifecycle
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ─── Module under test ────────────────────────────────────────────────────────
+
+import {
+  buildNamespaceName,
+  enforceGuardrails,
+  buildNamespaceManifest,
+  buildResourceQuotaManifest,
+  buildNetworkPolicyManifest,
+  runE2eKubernetesStage,
+  E2eGuardrailError,
+  E2eKubernetesError,
+} from "../../server/pipeline/stages/e2e-kubernetes";
+
+import type { CommandRunner, CommandResult } from "../../server/pipeline/stages/e2e-kubernetes";
+
+import {
+  runEphemeralJanitor,
+  startScheduledJanitor,
+} from "../../server/maintenance/ephemeral-janitor";
+
+import type {
+  E2eKubernetesStageConfig,
+  EphemeralPodSpec,
+} from "@shared/types";
+
+// ─── Fake command runner ──────────────────────────────────────────────────────
+
+/**
+ * A fake CommandRunner that returns pre-programmed responses in order.
+ * Also records all calls for assertion.
+ */
+class FakeRunner implements CommandRunner {
+  private responses: CommandResult[];
+  private index = 0;
+  readonly calls: Array<{ cmd: string; args: string[]; stdinData?: string }> = [];
+
+  constructor(responses: CommandResult[] = []) {
+    this.responses = responses;
+  }
+
+  run(cmd: string, args: string[], opts?: { stdinData?: string }): Promise<CommandResult> {
+    this.calls.push({ cmd, args: [...args], stdinData: opts?.stdinData });
+    const resp = this.responses[Math.min(this.index, this.responses.length - 1)] ?? {
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    };
+    this.index++;
+    return Promise.resolve({ ...resp });
+  }
+
+  /** Convenience: check whether a call with given cmd+arg was made. */
+  wasCalledWith(cmd: string, ...args: string[]): boolean {
+    return this.calls.some(
+      (c) => c.cmd === cmd && args.every((a) => c.args.includes(a)),
+    );
+  }
+}
+
+/** Create a runner that returns `ok` (exitCode 0) for every call. */
+function okRunner(n = 20): FakeRunner {
+  return new FakeRunner(
+    Array.from({ length: n }, () => ({ stdout: "ok", stderr: "", exitCode: 0 })),
+  );
+}
+
+/** Build a minimal valid stage config with optional overrides. */
+function makeStageCfg(overrides: Partial<E2eKubernetesStageConfig> = {}): E2eKubernetesStageConfig {
+  return {
+    imageRef: "registry/myapp:sha256-abc",
+    testImage: "alpine:3.18",
+    testCommand: ["sh", "-c", "echo test-passed"],
+    helmChart: "stable/nginx",
+    ttlHours: 2,
+    ...overrides,
+  };
+}
+
+// ─── 1. buildNamespaceName ────────────────────────────────────────────────────
+
+describe("buildNamespaceName()", () => {
+  it("prefixes with mq-run-", () => {
+    expect(buildNamespaceName("abc123")).toMatch(/^mq-run-/);
+  });
+
+  it("lowercases the runId", () => {
+    const result = buildNamespaceName("RunABC-123");
+    expect(result).toBe(result.toLowerCase());
+  });
+
+  it("replaces non-alphanumeric non-hyphen chars with hyphens", () => {
+    const result = buildNamespaceName("run_id.with.dots_and_underscores");
+    expect(result).not.toMatch(/[._]/);
+  });
+
+  it("collapses consecutive hyphens into one", () => {
+    const result = buildNamespaceName("run---multiple---hyphens");
+    expect(result).not.toMatch(/--/);
+  });
+
+  it("truncates long runIds so the final name fits within Kubernetes limits", () => {
+    const longId = "a".repeat(200);
+    const result = buildNamespaceName(longId);
+    // "mq-run-" (7) + max 50 chars = 57
+    expect(result.length).toBeLessThanOrEqual(60);
+  });
+
+  it("produces a valid Kubernetes DNS label from a UUID-like ID", () => {
+    const result = buildNamespaceName("550e8400-e29b-41d4-a716-446655440000");
+    expect(result).toMatch(/^mq-run-[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+  });
+
+  it("preserves existing lowercase alphanumeric chars", () => {
+    const result = buildNamespaceName("run123");
+    expect(result).toBe("mq-run-run123");
+  });
+});
+
+// ─── 2. enforceGuardrails ─────────────────────────────────────────────────────
+
+describe("enforceGuardrails()", () => {
+  function makeCfg(podSpec?: EphemeralPodSpec): E2eKubernetesStageConfig {
+    return {
+      imageRef: "registry/app:latest",
+      testImage: "alpine:3.18",
+      testCommand: ["echo", "ok"],
+      testPodSpec: podSpec,
+    };
+  }
+
+  it("passes when no testPodSpec is supplied", () => {
+    expect(() => enforceGuardrails({ imageRef: "x", testImage: "x", testCommand: ["x"] })).not.toThrow();
+  });
+
+  it("passes for a safe minimal pod spec", () => {
+    expect(() => enforceGuardrails(makeCfg({ containers: [{ name: "app" }] }))).not.toThrow();
+  });
+
+  it("rejects a container with privileged: true", () => {
+    const cfg = makeCfg({
+      containers: [{ name: "exploit", securityContext: { privileged: true } }],
+    });
+    expect(() => enforceGuardrails(cfg)).toThrow(E2eGuardrailError);
+    expect(() => enforceGuardrails(cfg)).toThrow(/privileged/i);
+  });
+
+  it("rejects an initContainer with privileged: true", () => {
+    const cfg = makeCfg({
+      initContainers: [{ name: "init-evil", securityContext: { privileged: true } }],
+    });
+    expect(() => enforceGuardrails(cfg)).toThrow(E2eGuardrailError);
+  });
+
+  it("passes when privileged is explicitly false", () => {
+    const cfg = makeCfg({
+      containers: [{ name: "app", securityContext: { privileged: false } }],
+    });
+    expect(() => enforceGuardrails(cfg)).not.toThrow();
+  });
+
+  it("rejects hostNetwork: true", () => {
+    const cfg = makeCfg({ hostNetwork: true });
+    expect(() => enforceGuardrails(cfg)).toThrow(E2eGuardrailError);
+    expect(() => enforceGuardrails(cfg)).toThrow(/hostNetwork/i);
+  });
+
+  it("passes when hostNetwork is false", () => {
+    const cfg = makeCfg({ hostNetwork: false });
+    expect(() => enforceGuardrails(cfg)).not.toThrow();
+  });
+
+  it("rejects a hostPath volume", () => {
+    const cfg = makeCfg({
+      volumes: [{ name: "host-vol", hostPath: { path: "/etc" } }],
+    });
+    expect(() => enforceGuardrails(cfg)).toThrow(E2eGuardrailError);
+    expect(() => enforceGuardrails(cfg)).toThrow(/hostPath/i);
+  });
+
+  it("passes for emptyDir volumes", () => {
+    const cfg = makeCfg({
+      volumes: [{ name: "tmp", emptyDir: {} }],
+    });
+    expect(() => enforceGuardrails(cfg)).not.toThrow();
+  });
+
+  it("error message includes the container name on privileged violation", () => {
+    try {
+      enforceGuardrails(
+        makeCfg({ containers: [{ name: "badactor", securityContext: { privileged: true } }] }),
+      );
+      expect.fail("should have thrown");
+    } catch (err) {
+      expect((err as Error).message).toContain("badactor");
+    }
+  });
+
+  it("E2eGuardrailError is a subclass of E2eKubernetesError", () => {
+    const cfg = makeCfg({ hostNetwork: true });
+    try {
+      enforceGuardrails(cfg);
+    } catch (err) {
+      expect(err).toBeInstanceOf(E2eKubernetesError);
+      expect(err).toBeInstanceOf(E2eGuardrailError);
+    }
+  });
+});
+
+// ─── 3. buildNamespaceManifest ────────────────────────────────────────────────
+
+describe("buildNamespaceManifest()", () => {
+  it("includes the ephemeral=true label", () => {
+    expect(buildNamespaceManifest("mq-run-abc", "abc", 4)).toContain('ephemeral: "true"');
+  });
+
+  it("includes the mq-run-id label with the runId", () => {
+    expect(buildNamespaceManifest("mq-run-abc", "abc", 4)).toContain('mq-run-id: "abc"');
+  });
+
+  it("includes the ttl-hours label", () => {
+    expect(buildNamespaceManifest("mq-run-abc", "abc", 8)).toContain('ttl-hours: "8"');
+  });
+
+  it("includes a future delete-after annotation", () => {
+    const before = Date.now();
+    const yaml = buildNamespaceManifest("mq-run-abc", "abc", 4);
+    const match = yaml.match(/multiqlti\.io\/delete-after: "(.+)"/);
+    expect(match).not.toBeNull();
+    const deleteAfter = new Date(match![1]).getTime();
+    expect(deleteAfter).toBeGreaterThan(before);
+    expect(deleteAfter).toBeLessThanOrEqual(before + 4 * 60 * 60 * 1000 + 5_000);
+  });
+
+  it("sets the namespace name correctly", () => {
+    expect(buildNamespaceManifest("mq-run-xyz", "xyz", 2)).toContain("name: mq-run-xyz");
+  });
+
+  it("produces valid YAML kind: Namespace", () => {
+    expect(buildNamespaceManifest("mq-run-abc", "abc", 1)).toContain("kind: Namespace");
+  });
+});
+
+// ─── 4. buildResourceQuotaManifest ───────────────────────────────────────────
+
+describe("buildResourceQuotaManifest()", () => {
+  it("uses default CPU limit of 2", () => {
+    expect(buildResourceQuotaManifest("mq-run-ns", undefined)).toContain('limits.cpu: "2"');
+  });
+
+  it("uses default memory limit of 2Gi", () => {
+    expect(buildResourceQuotaManifest("mq-run-ns", undefined)).toContain('limits.memory: "2Gi"');
+  });
+
+  it("uses default pod count of 10", () => {
+    expect(buildResourceQuotaManifest("mq-run-ns", undefined)).toContain('pods: "10"');
+  });
+
+  it("respects custom CPU limit", () => {
+    expect(buildResourceQuotaManifest("mq-run-ns", { limitCpu: "500m" })).toContain('limits.cpu: "500m"');
+  });
+
+  it("respects custom memory limit", () => {
+    expect(buildResourceQuotaManifest("mq-run-ns", { limitMemory: "512Mi" })).toContain('limits.memory: "512Mi"');
+  });
+
+  it("respects custom max pod count", () => {
+    expect(buildResourceQuotaManifest("mq-run-ns", { maxPods: 5 })).toContain('pods: "5"');
+  });
+
+  it("scopes the quota to the given namespace", () => {
+    expect(buildResourceQuotaManifest("mq-run-xyz", undefined)).toContain("namespace: mq-run-xyz");
+  });
+
+  it("produces kind: ResourceQuota", () => {
+    expect(buildResourceQuotaManifest("mq-run-ns", undefined)).toContain("kind: ResourceQuota");
+  });
+});
+
+// ─── 5. buildNetworkPolicyManifest ───────────────────────────────────────────
+
+describe("buildNetworkPolicyManifest()", () => {
+  it("creates a default-deny Egress policyType with no egress stanza", () => {
+    const yaml = buildNetworkPolicyManifest("mq-run-ns");
+    expect(yaml).toContain("- Egress");
+    expect(yaml).not.toContain("  egress:");
+  });
+
+  it("includes an egress stanza when hosts are provided", () => {
+    const yaml = buildNetworkPolicyManifest("mq-run-ns", ["10.0.0.0/8"]);
+    expect(yaml).toContain("10.0.0.0/8");
+    expect(yaml).toContain("  egress:");
+  });
+
+  it("includes multiple CIDRs when multiple hosts are provided", () => {
+    const yaml = buildNetworkPolicyManifest("mq-run-ns", ["10.0.0.0/8", "172.16.0.0/12"]);
+    expect(yaml).toContain("10.0.0.0/8");
+    expect(yaml).toContain("172.16.0.0/12");
+  });
+
+  it("scopes the policy to the given namespace", () => {
+    expect(buildNetworkPolicyManifest("mq-run-abc")).toContain("namespace: mq-run-abc");
+  });
+
+  it("applies to all pods via empty podSelector", () => {
+    expect(buildNetworkPolicyManifest("mq-run-ns")).toContain("podSelector: {}");
+  });
+
+  it("produces kind: NetworkPolicy", () => {
+    expect(buildNetworkPolicyManifest("mq-run-ns")).toContain("kind: NetworkPolicy");
+  });
+});
+
+// ─── 6. runE2eKubernetesStage — validation ───────────────────────────────────
+
+describe("runE2eKubernetesStage() input validation", () => {
+  it("throws E2eKubernetesError when imageRef is missing", async () => {
+    await expect(
+      runE2eKubernetesStage("run-001", { ...makeStageCfg(), imageRef: "" }, undefined, okRunner()),
+    ).rejects.toThrow(E2eKubernetesError);
+  });
+
+  it("throws E2eKubernetesError when imageRef is whitespace", async () => {
+    await expect(
+      runE2eKubernetesStage("run-001", { ...makeStageCfg(), imageRef: "   " }, undefined, okRunner()),
+    ).rejects.toThrow(E2eKubernetesError);
+  });
+
+  it("throws E2eKubernetesError when testImage is missing", async () => {
+    await expect(
+      runE2eKubernetesStage("run-001", { ...makeStageCfg(), testImage: "" }, undefined, okRunner()),
+    ).rejects.toThrow(E2eKubernetesError);
+  });
+
+  it("throws E2eKubernetesError when testCommand is empty", async () => {
+    await expect(
+      runE2eKubernetesStage("run-001", { ...makeStageCfg(), testCommand: [] }, undefined, okRunner()),
+    ).rejects.toThrow(E2eKubernetesError);
+  });
+
+  it("throws E2eGuardrailError when privileged container is configured", async () => {
+    const cfg = makeStageCfg({
+      testPodSpec: { containers: [{ name: "evil", securityContext: { privileged: true } }] },
+    });
+    await expect(
+      runE2eKubernetesStage("run-001", cfg, undefined, okRunner()),
+    ).rejects.toThrow(E2eGuardrailError);
+  });
+
+  it("throws E2eGuardrailError when hostNetwork is true", async () => {
+    await expect(
+      runE2eKubernetesStage(
+        "run-001",
+        makeStageCfg({ testPodSpec: { hostNetwork: true } }),
+        undefined,
+        okRunner(),
+      ),
+    ).rejects.toThrow(E2eGuardrailError);
+  });
+
+  it("throws E2eGuardrailError when hostPath volume is configured", async () => {
+    const cfg = makeStageCfg({
+      testPodSpec: { volumes: [{ name: "host", hostPath: { path: "/" } }] },
+    });
+    await expect(
+      runE2eKubernetesStage("run-001", cfg, undefined, okRunner()),
+    ).rejects.toThrow(E2eGuardrailError);
+  });
+
+  it("guardrail errors are thrown before any command is run", async () => {
+    const runner = new FakeRunner([{ exitCode: 0, stdout: "", stderr: "" }]);
+    const cfg = makeStageCfg({ testPodSpec: { hostNetwork: true } });
+    await expect(
+      runE2eKubernetesStage("run-001", cfg, undefined, runner),
+    ).rejects.toThrow(E2eGuardrailError);
+    // No commands should have been issued
+    expect(runner.calls).toHaveLength(0);
+  });
+});
+
+// ─── 7. runE2eKubernetesStage — success lifecycle ────────────────────────────
+
+describe("runE2eKubernetesStage() success lifecycle", () => {
+  function makeSuccessRunner(): FakeRunner {
+    return new FakeRunner([
+      { exitCode: 0, stdout: "", stderr: "" },           // kubectl apply (bootstrap)
+      { exitCode: 0, stdout: "deployed", stderr: "" },   // helm upgrade --install
+      { exitCode: 0, stdout: "MANIFEST_YAML", stderr: "" }, // helm get manifest
+      { exitCode: 0, stdout: "test-passed\n", stderr: "" }, // kubectl run test pod
+      { exitCode: 0, stdout: "", stderr: "" },           // kubectl delete namespace
+    ]);
+  }
+
+  it("returns success=true when test command exits 0", async () => {
+    const result = await runE2eKubernetesStage("run-success", makeStageCfg(), undefined, makeSuccessRunner());
+    expect(result.success).toBe(true);
+  });
+
+  it("returns testExitCode=0 on success", async () => {
+    const result = await runE2eKubernetesStage("run-success", makeStageCfg(), undefined, makeSuccessRunner());
+    expect(result.testExitCode).toBe(0);
+  });
+
+  it("captures test stdout in testStdout", async () => {
+    const result = await runE2eKubernetesStage("run-success", makeStageCfg(), undefined, makeSuccessRunner());
+    expect(result.testStdout).toContain("test-passed");
+  });
+
+  it("namespace name is derived from runId with mq-run- prefix", async () => {
+    const result = await runE2eKubernetesStage("run-success", makeStageCfg(), undefined, makeSuccessRunner());
+    expect(result.namespace).toMatch(/^mq-run-/);
+    expect(result.namespace).toContain("run-success");
+  });
+
+  it("uses the configured ttlHours in the result", async () => {
+    const runner = new FakeRunner([
+      { exitCode: 0, stdout: "" },
+      { exitCode: 0, stdout: "" },
+      { exitCode: 0, stdout: "" },
+      { exitCode: 0, stdout: "" },
+      { exitCode: 0, stdout: "" },
+    ]);
+    const result = await runE2eKubernetesStage(
+      "run-ttl",
+      makeStageCfg({ ttlHours: 8 }),
+      undefined,
+      runner,
+    );
+    expect(result.ttlHours).toBe(8);
+  });
+
+  it("captures Helm manifest in artifacts.helmManifest", async () => {
+    const result = await runE2eKubernetesStage("run-success", makeStageCfg(), undefined, makeSuccessRunner());
+    expect(result.artifacts.helmManifest).toContain("MANIFEST_YAML");
+  });
+
+  it("does not include podEvents in artifacts on success", async () => {
+    const result = await runE2eKubernetesStage("run-success", makeStageCfg(), undefined, makeSuccessRunner());
+    expect(result.artifacts.podEvents).toBeUndefined();
+  });
+
+  it("calls bootstrap (kubectl apply) before helm", async () => {
+    const runner = makeSuccessRunner();
+    await runE2eKubernetesStage("run-order", makeStageCfg(), undefined, runner);
+    const [first, second] = runner.calls;
+    expect(first.cmd).toBe("kubectl");
+    expect(first.args).toContain("apply");
+    expect(second.cmd).toBe("helm");
+  });
+});
+
+// ─── 8. runE2eKubernetesStage — failure lifecycle ─────────────────────────────
+
+describe("runE2eKubernetesStage() failure lifecycle", () => {
+  function makeFailureRunner(): FakeRunner {
+    return new FakeRunner([
+      { exitCode: 0, stdout: "", stderr: "" },              // bootstrap
+      { exitCode: 0, stdout: "", stderr: "" },              // helm upgrade
+      { exitCode: 0, stdout: "", stderr: "" },              // helm get manifest
+      { exitCode: 1, stdout: "", stderr: "ASSERTION_FAIL" }, // test pod fails
+      { exitCode: 0, stdout: "EVENT_LIST", stderr: "" },    // kubectl get events
+      { exitCode: 0, stdout: "", stderr: "" },              // kubectl annotate TTL
+    ]);
+  }
+
+  it("returns success=false when test command exits non-zero", async () => {
+    const result = await runE2eKubernetesStage("run-fail", makeStageCfg(), undefined, makeFailureRunner());
+    expect(result.success).toBe(false);
+  });
+
+  it("returns the actual exit code from the test pod", async () => {
+    const result = await runE2eKubernetesStage("run-fail", makeStageCfg(), undefined, makeFailureRunner());
+    expect(result.testExitCode).toBe(1);
+  });
+
+  it("captures stderr from test pod in testStderr", async () => {
+    const result = await runE2eKubernetesStage("run-fail", makeStageCfg(), undefined, makeFailureRunner());
+    expect(result.testStderr).toContain("ASSERTION_FAIL");
+  });
+
+  it("includes podEvents in artifacts on failure", async () => {
+    const result = await runE2eKubernetesStage("run-fail", makeStageCfg(), undefined, makeFailureRunner());
+    expect(result.artifacts.podEvents).toContain("EVENT_LIST");
+  });
+
+  it("throws E2eKubernetesError when namespace bootstrap fails", async () => {
+    const runner = new FakeRunner([
+      { exitCode: 1, stdout: "", stderr: "forbidden: cannot create namespace" },
+    ]);
+    await expect(
+      runE2eKubernetesStage("run-bootstrap-fail", makeStageCfg(), undefined, runner),
+    ).rejects.toThrow(E2eKubernetesError);
+  });
+
+  it("throws E2eKubernetesError when Helm deploy fails", async () => {
+    const runner = new FakeRunner([
+      { exitCode: 0, stdout: "", stderr: "" },             // bootstrap ok
+      { exitCode: 1, stdout: "", stderr: "chart not found" }, // helm fails
+      { exitCode: 0, stdout: "", stderr: "" },             // annotate (teardown)
+    ]);
+    await expect(
+      runE2eKubernetesStage("run-helm-fail", makeStageCfg(), undefined, runner),
+    ).rejects.toThrow(E2eKubernetesError);
+  });
+});
+
+// ─── 9. Teardown behaviour ────────────────────────────────────────────────────
+
+describe("runE2eKubernetesStage() teardown", () => {
+  it("calls kubectl delete namespace on success (deleteOnSuccess=true by default)", async () => {
+    const runner = new FakeRunner([
+      { exitCode: 0, stdout: "" },  // bootstrap
+      { exitCode: 0, stdout: "" },  // helm upgrade
+      { exitCode: 0, stdout: "" },  // helm get manifest
+      { exitCode: 0, stdout: "" },  // test pod
+      { exitCode: 0, stdout: "" },  // delete namespace
+    ]);
+
+    await runE2eKubernetesStage("run-del", makeStageCfg(), undefined, runner);
+
+    expect(runner.wasCalledWith("kubectl", "delete", "namespace")).toBe(true);
+  });
+
+  it("calls kubectl annotate with TTL on success when deleteOnSuccess=false", async () => {
+    const runner = okRunner();
+
+    await runE2eKubernetesStage(
+      "run-keep",
+      makeStageCfg({ deleteOnSuccess: false }),
+      undefined,
+      runner,
+    );
+
+    expect(runner.wasCalledWith("kubectl", "annotate", "namespace")).toBe(true);
+    const annotateCall = runner.calls.find(
+      (c) => c.cmd === "kubectl" && c.args.includes("annotate") && c.args.some((a) => a.includes("delete-after")),
+    );
+    expect(annotateCall).toBeDefined();
+  });
+
+  it("annotates with TTL on failure instead of deleting", async () => {
+    const runner = new FakeRunner([
+      { exitCode: 0, stdout: "" },   // bootstrap
+      { exitCode: 0, stdout: "" },   // helm upgrade
+      { exitCode: 0, stdout: "" },   // helm get manifest
+      { exitCode: 2, stdout: "" },   // test pod fails
+      { exitCode: 0, stdout: "" },   // kubectl get events
+      { exitCode: 0, stdout: "" },   // annotate TTL
+    ]);
+
+    const result = await runE2eKubernetesStage("run-fail-ttl", makeStageCfg(), undefined, runner);
+    expect(result.success).toBe(false);
+
+    const annotateCall = runner.calls.find(
+      (c) => c.cmd === "kubectl" && c.args.includes("annotate") && c.args.some((a) => a.includes("delete-after")),
+    );
+    expect(annotateCall).toBeDefined();
+
+    // No hard delete should have occurred
+    expect(runner.wasCalledWith("kubectl", "delete", "namespace")).toBe(false);
+  });
+
+  it("passes kubeconfig path to all kubectl calls when provided", async () => {
+    const runner = okRunner();
+    await runE2eKubernetesStage("run-kc", makeStageCfg(), "/home/user/.kube/config", runner);
+
+    for (const call of runner.calls) {
+      if (call.cmd === "kubectl") {
+        expect(call.args).toContain("--kubeconfig");
+      }
+    }
+  });
+});
+
+// ─── 10. Artifact capture ─────────────────────────────────────────────────────
+
+describe("runE2eKubernetesStage() artifact capture", () => {
+  it("testLogs includes both stdout and stderr from the test pod", async () => {
+    const runner = new FakeRunner([
+      { exitCode: 0, stdout: "" },
+      { exitCode: 0, stdout: "" },
+      { exitCode: 0, stdout: "" },
+      { exitCode: 1, stdout: "TEST_OUT", stderr: "TEST_ERR" },
+      { exitCode: 0, stdout: "events" },
+      { exitCode: 0, stdout: "" },
+    ]);
+
+    const result = await runE2eKubernetesStage("run-logs", makeStageCfg(), undefined, runner);
+    expect(result.artifacts.testLogs).toContain("TEST_OUT");
+    expect(result.artifacts.testLogs).toContain("TEST_ERR");
+  });
+
+  it("helmManifest falls back gracefully when helm get manifest fails", async () => {
+    const runner = new FakeRunner([
+      { exitCode: 0, stdout: "" },
+      { exitCode: 0, stdout: "" },
+      { exitCode: 1, stdout: "", stderr: "no manifest" }, // helm get manifest fails
+      { exitCode: 0, stdout: "" },
+      { exitCode: 0, stdout: "" },
+    ]);
+
+    const result = await runE2eKubernetesStage("run-manifest-fail", makeStageCfg(), undefined, runner);
+    expect(result.success).toBe(true);
+    // Should have a non-empty fallback string
+    expect(result.artifacts.helmManifest.length).toBeGreaterThan(0);
+  });
+
+  it("testLogs combines stdout and stderr with a separator", async () => {
+    const runner = new FakeRunner([
+      { exitCode: 0, stdout: "" },
+      { exitCode: 0, stdout: "" },
+      { exitCode: 0, stdout: "" },
+      { exitCode: 0, stdout: "STDOUT_CONTENT", stderr: "STDERR_CONTENT" },
+      { exitCode: 0, stdout: "" },
+    ]);
+
+    const result = await runE2eKubernetesStage("run-combined", makeStageCfg(), undefined, runner);
+    expect(result.artifacts.testLogs).toContain("STDOUT_CONTENT");
+    expect(result.artifacts.testLogs).toContain("STDERR_CONTENT");
+    expect(result.artifacts.testLogs).toContain("--- stderr ---");
+  });
+});
+
+// ─── 11. runEphemeralJanitor — expired / non-expired ─────────────────────────
+
+describe("runEphemeralJanitor()", () => {
+  function makeListOutput(
+    entries: Array<{ name: string; deleteAfter: string; created?: string }>,
+  ): string {
+    return entries
+      .map((e) => `${e.name}|${e.deleteAfter}|${e.created ?? new Date().toISOString()}`)
+      .join("\n") + "\n";
+  }
+
+  it("deletes namespaces whose delete-after is in the past", async () => {
+    const past = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const runner = new FakeRunner([
+      { exitCode: 0, stdout: makeListOutput([{ name: "mq-run-expired", deleteAfter: past }]), stderr: "" },
+      { exitCode: 0, stdout: "deleted", stderr: "" }, // delete call
+    ]);
+
+    const result = await runEphemeralJanitor({ runner });
+    expect(result.deleted).toContain("mq-run-expired");
+    expect(result.errors).toHaveLength(0);
+    expect(result.scanned).toBe(1);
+  });
+
+  it("does not delete namespaces whose delete-after is in the future", async () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const runner = new FakeRunner([
+      { exitCode: 0, stdout: makeListOutput([{ name: "mq-run-alive", deleteAfter: future }]), stderr: "" },
+    ]);
+
+    const result = await runEphemeralJanitor({ runner });
+    expect(result.deleted).not.toContain("mq-run-alive");
+    expect(runner.calls).toHaveLength(1); // only the list call
+    const entry = result.namespacesByAge.find((n) => n.namespace === "mq-run-alive");
+    expect(entry?.expired).toBe(false);
+  });
+
+  it("handles a mix of expired and non-expired namespaces", async () => {
+    const past = new Date(Date.now() - 1000).toISOString();
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const runner = new FakeRunner([
+      {
+        exitCode: 0,
+        stdout: makeListOutput([
+          { name: "mq-run-old", deleteAfter: past },
+          { name: "mq-run-new", deleteAfter: future },
+        ]),
+        stderr: "",
+      },
+      { exitCode: 0, stdout: "deleted", stderr: "" }, // delete mq-run-old
+    ]);
+
+    const result = await runEphemeralJanitor({ runner });
+    expect(result.deleted).toContain("mq-run-old");
+    expect(result.deleted).not.toContain("mq-run-new");
+  });
+
+  it("populates namespacesByAge with correct age and expired flag", async () => {
+    const past = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    const created = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+    const runner = new FakeRunner([
+      { exitCode: 0, stdout: makeListOutput([{ name: "mq-run-old", deleteAfter: past, created }]), stderr: "" },
+      { exitCode: 0, stdout: "deleted", stderr: "" },
+    ]);
+
+    const result = await runEphemeralJanitor({ runner });
+    const entry = result.namespacesByAge.find((n) => n.namespace === "mq-run-old");
+    expect(entry).toBeDefined();
+    expect(entry!.expired).toBe(true);
+    expect(entry!.ageHours).toBeGreaterThan(2);
+  });
+
+  it("returns empty result when no ephemeral namespaces exist", async () => {
+    const runner = new FakeRunner([{ exitCode: 0, stdout: "", stderr: "" }]);
+    const result = await runEphemeralJanitor({ runner });
+    expect(result.scanned).toBe(0);
+    expect(result.deleted).toHaveLength(0);
+    expect(result.namespacesByAge).toHaveLength(0);
+  });
+
+  it("records ranAt timestamp close to now", async () => {
+    const runner = new FakeRunner([{ exitCode: 0, stdout: "", stderr: "" }]);
+    const before = new Date();
+    const result = await runEphemeralJanitor({ runner });
+    expect(result.ranAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+  });
+});
+
+// ─── 12. runEphemeralJanitor — dry-run mode ───────────────────────────────────
+
+describe("runEphemeralJanitor() dry-run mode", () => {
+  it("reports expired namespaces in deleted list without calling kubectl delete", async () => {
+    const past = new Date(Date.now() - 1000).toISOString();
+    const runner = new FakeRunner([
+      {
+        exitCode: 0,
+        stdout: `mq-run-expired|${past}|${new Date().toISOString()}\n`,
+        stderr: "",
+      },
+      // This would be the delete response — it should never be reached
+      { exitCode: 1, stdout: "", stderr: "should not have been called" },
+    ]);
+
+    const result = await runEphemeralJanitor({ dryRun: true, runner });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.deleted).toContain("mq-run-expired");
+    // Only the list call should have been made
+    expect(runner.calls).toHaveLength(1);
+  });
+
+  it("dryRun=false (default) actually performs deletion", async () => {
+    const past = new Date(Date.now() - 1000).toISOString();
+    const runner = new FakeRunner([
+      { exitCode: 0, stdout: `mq-run-stale|${past}|${new Date().toISOString()}\n`, stderr: "" },
+      { exitCode: 0, stdout: "deleted", stderr: "" },
+    ]);
+
+    const result = await runEphemeralJanitor({ runner });
+    expect(result.dryRun).toBe(false);
+    expect(runner.calls).toHaveLength(2); // list + delete
+  });
+});
+
+// ─── 13. runEphemeralJanitor — label selector safety ─────────────────────────
+
+describe("runEphemeralJanitor() label selector safety", () => {
+  it("passes the default label selector 'ephemeral=true' to kubectl", async () => {
+    const runner = new FakeRunner([{ exitCode: 0, stdout: "", stderr: "" }]);
+    await runEphemeralJanitor({ runner });
+
+    const listCall = runner.calls.find((c) => c.args.includes("get") && c.args.includes("namespaces"));
+    expect(listCall).toBeDefined();
+    const selectorIndex = listCall!.args.indexOf("--selector");
+    expect(selectorIndex).toBeGreaterThan(-1);
+    expect(listCall!.args[selectorIndex + 1]).toBe("ephemeral=true");
+  });
+
+  it("uses a custom label selector when provided", async () => {
+    const runner = new FakeRunner([{ exitCode: 0, stdout: "", stderr: "" }]);
+    await runEphemeralJanitor({ runner, labelSelector: "managed-by=my-tool" });
+
+    const listCall = runner.calls.find((c) => c.args.includes("get") && c.args.includes("namespaces"));
+    const selectorIndex = listCall!.args.indexOf("--selector");
+    expect(listCall!.args[selectorIndex + 1]).toBe("managed-by=my-tool");
+  });
+
+  it("passes kubeconfig to kubectl when provided", async () => {
+    const runner = new FakeRunner([{ exitCode: 0, stdout: "", stderr: "" }]);
+    await runEphemeralJanitor({ runner, kubeconfigPath: "/etc/kube/config" });
+
+    const listCall = runner.calls[0];
+    expect(listCall.args).toContain("--kubeconfig");
+    expect(listCall.args).toContain("/etc/kube/config");
+  });
+});
+
+// ─── 14. runEphemeralJanitor — error handling ─────────────────────────────────
+
+describe("runEphemeralJanitor() error handling", () => {
+  it("throws when listing namespaces fails", async () => {
+    const runner = new FakeRunner([
+      { exitCode: 1, stdout: "", stderr: "connection refused" },
+    ]);
+    await expect(runEphemeralJanitor({ runner })).rejects.toThrow(/Failed to list ephemeral namespaces/);
+  });
+
+  it("records failed deletions in errors without aborting remaining deletes", async () => {
+    const past = new Date(Date.now() - 1000).toISOString();
+    const listOutput = [
+      `mq-run-failme|${past}|${new Date().toISOString()}`,
+      `mq-run-ok|${past}|${new Date().toISOString()}`,
+    ].join("\n") + "\n";
+
+    const runner = new FakeRunner([
+      { exitCode: 0, stdout: listOutput, stderr: "" },  // list
+      { exitCode: 1, stdout: "", stderr: "forbidden" }, // first delete fails
+      { exitCode: 0, stdout: "ok", stderr: "" },        // second delete ok
+    ]);
+
+    const result = await runEphemeralJanitor({ runner });
+
+    expect(result.errors.length + result.deleted.length).toBe(2);
+    expect(result.errors).toHaveLength(1);
+    expect(result.deleted).toHaveLength(1);
+  });
+
+  it("error entry includes the namespace name and error message", async () => {
+    const past = new Date(Date.now() - 1000).toISOString();
+    const runner = new FakeRunner([
+      { exitCode: 0, stdout: `mq-run-forbidden|${past}|${new Date().toISOString()}\n`, stderr: "" },
+      { exitCode: 1, stdout: "", stderr: "permission denied" },
+    ]);
+
+    const result = await runEphemeralJanitor({ runner });
+    expect(result.errors[0].namespace).toBe("mq-run-forbidden");
+    expect(result.errors[0].error).toContain("permission denied");
+  });
+});
+
+// ─── 15. startScheduledJanitor ────────────────────────────────────────────────
+
+describe("startScheduledJanitor()", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns a handle with stop() and lastResult()", () => {
+    const runner = new FakeRunner([{ exitCode: 0, stdout: "", stderr: "" }]);
+    const handle = startScheduledJanitor({ intervalMs: 60_000, runner });
+    expect(typeof handle.stop).toBe("function");
+    expect(typeof handle.lastResult).toBe("function");
+    handle.stop();
+  });
+
+  it("lastResult() is null before the first async run completes", () => {
+    // Use a runner whose Promise never resolves during the synchronous test
+    const neverRunner: CommandRunner = {
+      run: () => new Promise(() => { /* never resolves */ }),
+    };
+    const handle = startScheduledJanitor({ intervalMs: 60_000, runner: neverRunner });
+    // Synchronously, the result is still null
+    expect(handle.lastResult()).toBeNull();
+    handle.stop();
+  });
+
+  it("does not issue new runs after stop() is called", async () => {
+    let runCount = 0;
+    const countingRunner: CommandRunner = {
+      run: () => {
+        runCount++;
+        return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+      },
+    };
+
+    const handle = startScheduledJanitor({ intervalMs: 1_000, runner: countingRunner });
+    handle.stop();
+    const countAfterStop = runCount;
+
+    vi.advanceTimersByTime(10_000);
+    // Allow any synchronously scheduled microtasks to run
+    await Promise.resolve();
+
+    expect(runCount).toBe(countAfterStop);
+  });
+
+  it("lastResult() reflects completed run data after first run finishes", async () => {
+    // Real timers: this test uses actual async resolution
+    vi.useRealTimers();
+    const past = new Date(Date.now() - 1000).toISOString();
+    const runner = new FakeRunner([
+      { exitCode: 0, stdout: `mq-run-x|${past}|${new Date().toISOString()}\n`, stderr: "" },
+      { exitCode: 0, stdout: "deleted", stderr: "" },
+    ]);
+
+    const handle = startScheduledJanitor({ intervalMs: 60_000, runner });
+
+    // Poll until lastResult() is populated (the initial run is async)
+    await new Promise<void>((resolve) => {
+      const check = () => {
+        if (handle.lastResult() !== null) { resolve(); return; }
+        setTimeout(check, 5);
+      };
+      check();
+    });
+
+    const result = handle.lastResult();
+    expect(result).not.toBeNull();
+    expect(result!.scanned).toBe(1);
+    handle.stop();
+  });
+});


### PR DESCRIPTION
## Summary

- New `e2e_kubernetes` pipeline stage type with full lifecycle management
- Ephemeral namespace creation (`mq-run-<runId>`) with `ephemeral=true` label and `multiqlti.io/delete-after` TTL annotation
- Namespace-scoped `ResourceQuota` (CPU/memory/pod limits) and default-deny egress `NetworkPolicy`
- Helm chart deployment with configurable readiness checks (rollout status, service endpoints, custom command)
- Test pod execution that captures stdout/stderr and exit code
- Artifact collection: test logs, rendered Helm manifest, pod events on failure
- Teardown: success deletes namespace immediately (configurable), failure preserves namespace until TTL expiry for debugging
- Security guardrails enforced before any cluster interaction: no privileged containers, no hostNetwork, no hostPath volumes, egress locked to default-deny
- `EphemeralJanitor` background job finds namespaces past TTL and deletes them; includes `namespacesByAge` metric for observability
- `startScheduledJanitor` for production use with stop/lastResult lifecycle handle
- Injectable `CommandRunner` interface for clean unit testing without spawning real kubectl/helm

## New files

- `server/pipeline/stages/e2e-kubernetes.ts` — stage implementation
- `server/maintenance/ephemeral-janitor.ts` — TTL janitor
- `tests/unit/e2e-kubernetes-stage.test.ts` — 85 tests

## Types added to `shared/types.ts`

`E2eKubernetesStageConfig`, `E2eKubernetesResult`, `E2eKubernetesArtifacts`, `ReadinessConfig`, `EphemeralNamespaceQuota`, `EphemeralPodSpec`

Closes #272

## Test plan

- [x] Stage input validation (missing imageRef, testImage, testCommand)
- [x] Security guardrail enforcement (privileged, hostNetwork, hostPath) — rejected before any cluster call
- [x] Namespace manifest builders (labels, TTL annotation, quota defaults/overrides, network policy)
- [x] Full success lifecycle (bootstrap → helm → readiness → test → delete)
- [x] Full failure lifecycle (test exits non-zero → events captured → TTL annotated, not deleted)
- [x] Bootstrap failure and Helm failure error propagation
- [x] Teardown logic: deleteOnSuccess=true deletes, deleteOnSuccess=false annotates with TTL
- [x] Artifact capture: testLogs, helmManifest, podEvents on failure only
- [x] Kubeconfig path threading through all kubectl/helm calls
- [x] Janitor: expired namespaces deleted, non-expired preserved
- [x] Janitor: dry-run mode reports without acting
- [x] Janitor: label selector safety (only ephemeral-labelled namespaces)
- [x] Janitor: partial delete failures recorded without aborting remaining
- [x] Scheduler: stop/lastResult lifecycle
- [x] `npx tsc --noEmit`: 0 errors
- [x] `npx vitest run`: 2989 tests pass (85 new)