### PR TITLE
feat: multiqlti MCP server (reverse integration) (#274)

### DIFF
--- a/server/mcp-servers/multiqlti-self/auth.ts
+++ b/server/mcp-servers/multiqlti-self/auth.ts
@@ -1,0 +1,229 @@
+/**
+ * MCP Client Token Auth (issue #274)
+ *
+ * Provides scoped API tokens for external MCP clients:
+ *  - Token type "mcp_client" — separate from user session JWTs
+ *  - Scope: reachable workspace IDs, callable tool allow-list, max run concurrency
+ *  - Tokens are hashed (SHA-256) before storage; plaintext shown once at creation
+ *  - Tokens can be revoked; expiry is optional
+ *
+ * Concurrency tracking is in-process (Map<tokenId, activeRunCount>).
+ * This is intentionally simple — a production system would use Redis.
+ */
+
+import { createHash, randomBytes } from "crypto";
+import type {
+  McpClientToken,
+  McpTokenScope,
+  CreateMcpClientTokenInput,
+  CreateMcpClientTokenResult,
+} from "@shared/types";
+
+// ─── Token generation ──────────────────────────────────────────────────────────
+
+/**
+ * Generate a cryptographically random MCP client token.
+ * Format: "mq_mcp_<48 random hex chars>"
+ * Total length: 55 chars — recognisable prefix + sufficient entropy.
+ */
+export function generateRawToken(): string {
+  return `mq_mcp_${randomBytes(24).toString("hex")}`;
+}
+
+/** Hash a raw token with SHA-256 for safe storage. */
+export function hashToken(rawToken: string): string {
+  return createHash("sha256").update(rawToken).digest("hex");
+}
+
+/** Extract the last 8 characters of a raw token as a display suffix. */
+export function tokenSuffix(rawToken: string): string {
+  return rawToken.slice(-8);
+}
+
+// ─── Public context returned by validate ─────────────────────────────────────
+
+/**
+ * The subset of a stored token that callers need to construct a McpCallContext.
+ * Does not include the token hash or other internal fields.
+ */
+export interface ValidatedTokenContext {
+  id: string;
+  scope: McpTokenScope;
+}
+
+// ─── In-memory token store ────────────────────────────────────────────────────
+
+interface StoredToken {
+  id: string;
+  workspaceId: string;
+  name: string;
+  tokenHash: string;
+  tokenSuffix: string;
+  scope: McpTokenScope;
+  createdAt: Date;
+  expiresAt: Date | null;
+  lastUsedAt: Date | null;
+  isRevoked: boolean;
+}
+
+/**
+ * In-memory MCP client token storage.
+ *
+ * This is intentionally separate from IStorage to keep the scope narrow for
+ * issue #274. A future migration can move this into PostgreSQL / PgStorage.
+ */
+export class McpTokenStore {
+  private readonly byId = new Map<string, StoredToken>();
+  private readonly byHash = new Map<string, StoredToken>();
+
+  /**
+   * Create a new MCP client token.
+   * Returns the record + the one-time-visible raw token.
+   */
+  create(input: CreateMcpClientTokenInput): CreateMcpClientTokenResult {
+    const rawToken = generateRawToken();
+    const hash = hashToken(rawToken);
+    const suffix = tokenSuffix(rawToken);
+    const id = `mct_${randomBytes(12).toString("hex")}`;
+
+    const stored: StoredToken = {
+      id,
+      workspaceId: input.workspaceId,
+      name: input.name,
+      tokenHash: hash,
+      tokenSuffix: suffix,
+      scope: { ...input.scope },
+      createdAt: new Date(),
+      expiresAt: input.expiresAt ?? null,
+      lastUsedAt: null,
+      isRevoked: false,
+    };
+
+    this.byId.set(id, stored);
+    this.byHash.set(hash, stored);
+
+    return {
+      token: this.toPublic(stored),
+      rawToken,
+    };
+  }
+
+  /**
+   * Validate a raw token string.
+   * Returns the public context if valid, null otherwise.
+   * Updates lastUsedAt on success.
+   */
+  validate(rawToken: string): ValidatedTokenContext | null {
+    const hash = hashToken(rawToken);
+    const stored = this.byHash.get(hash);
+    if (!stored) return null;
+    if (stored.isRevoked) return null;
+    if (stored.expiresAt && stored.expiresAt < new Date()) return null;
+    stored.lastUsedAt = new Date();
+    return { id: stored.id, scope: { ...stored.scope } };
+  }
+
+  /** Revoke a token by ID. Returns false if not found. */
+  revoke(id: string): boolean {
+    const stored = this.byId.get(id);
+    if (!stored) return false;
+    stored.isRevoked = true;
+    return true;
+  }
+
+  /** List all tokens for a workspace (public shapes only, no hashes). */
+  listByWorkspace(workspaceId: string): McpClientToken[] {
+    return Array.from(this.byId.values())
+      .filter((t) => t.workspaceId === workspaceId)
+      .map((t) => this.toPublic(t));
+  }
+
+  /** Get a single token by ID (public shape). */
+  getById(id: string): McpClientToken | null {
+    const stored = this.byId.get(id);
+    return stored ? this.toPublic(stored) : null;
+  }
+
+  /** Delete all tokens for tests. */
+  _reset(): void {
+    this.byId.clear();
+    this.byHash.clear();
+  }
+
+  private toPublic(stored: StoredToken): McpClientToken {
+    return {
+      id: stored.id,
+      workspaceId: stored.workspaceId,
+      name: stored.name,
+      tokenSuffix: stored.tokenSuffix,
+      scope: { ...stored.scope },
+      createdAt: stored.createdAt,
+      expiresAt: stored.expiresAt,
+      lastUsedAt: stored.lastUsedAt,
+      isRevoked: stored.isRevoked,
+    };
+  }
+}
+
+// ─── Singleton ────────────────────────────────────────────────────────────────
+
+export const mcpTokenStore = new McpTokenStore();
+
+// ─── Scope Checking ───────────────────────────────────────────────────────────
+
+/**
+ * Check whether a token's scope allows access to a given workspace.
+ * Returns false if the workspace is not in the token's allowed list.
+ */
+export function checkWorkspaceAccess(scope: McpTokenScope, workspaceId: string): boolean {
+  return scope.workspaceIds.includes(workspaceId);
+}
+
+/**
+ * Check whether a token's scope allows calling a specific tool.
+ * Passes when the allow-list is ["*"] or contains the tool name.
+ */
+export function checkToolAccess(scope: McpTokenScope, toolName: string): boolean {
+  const list = scope.allowedTools;
+  if (list.length === 1 && list[0] === "*") return true;
+  return (list as string[]).includes(toolName);
+}
+
+// ─── Concurrency tracking ──────────────────────────────────────────────────────
+
+const activeRunsByToken = new Map<string, number>();
+
+/**
+ * Acquire a run slot for the token.
+ * Returns true if a slot is available (and increments the counter).
+ * Returns false if at capacity.
+ */
+export function acquireRunSlot(tokenId: string, maxConcurrency: number): boolean {
+  const current = activeRunsByToken.get(tokenId) ?? 0;
+  if (current >= maxConcurrency) return false;
+  activeRunsByToken.set(tokenId, current + 1);
+  return true;
+}
+
+/**
+ * Release a run slot for the token.
+ * Must be called when the run completes or is cancelled.
+ */
+export function releaseRunSlot(tokenId: string): void {
+  const current = activeRunsByToken.get(tokenId) ?? 0;
+  if (current <= 0) {
+    activeRunsByToken.delete(tokenId);
+    return;
+  }
+  activeRunsByToken.set(tokenId, current - 1);
+}
+
+/** Get current active run count for a token (for tests). */
+export function getActiveRunCount(tokenId: string): number {
+  return activeRunsByToken.get(tokenId) ?? 0;
+}
+
+/** Reset concurrency counters (for tests). */
+export function _resetConcurrency(): void {
+  activeRunsByToken.clear();
+}

--- a/server/mcp-servers/multiqlti-self/index.ts
+++ b/server/mcp-servers/multiqlti-self/index.ts
@@ -1,0 +1,654 @@
+/**
+ * Multiqlti Self MCP Server (issue #274)
+ *
+ * Exposes multiqlti domain objects as MCP tools so that external MCP clients
+ * (Claude Code, Cursor, etc.) can interact with the platform programmatically.
+ *
+ * Transports:
+ *  - stdio  — invoked directly by CLI clients
+ *  - streamable-http — exposed via POST /api/mcp (behind Caddy)
+ *
+ * Auth:
+ *  - Every call must carry a valid `mcp_client` token in the request context.
+ *  - Scope checked per call: workspace access + tool allow-list + concurrency.
+ *
+ * Tools exposed (7):
+ *  1. list_workspaces          — workspace metadata (scoped to token)
+ *  2. list_pipelines           — pipeline definitions for a workspace
+ *  3. run_pipeline             — async; returns run_id immediately
+ *  4. get_run                  — status, output, stage trace events
+ *  5. cancel_run               — cancel a running pipeline
+ *  6. list_connections         — connection metadata only (NO secrets)
+ *  7. query_connection_usage   — usage metrics for a connection
+ *
+ * Security invariants:
+ *  - Secrets never appear in any tool response.
+ *  - Tool calls are recorded in the audit log (recordToolCall).
+ *  - Unknown tools return an error rather than panicking.
+ *  - All inputs are validated before use.
+ */
+
+import type { IStorage } from "../../storage";
+import type { PipelineController } from "../../controller/pipeline-controller";
+import { recordToolCall } from "../../tools/audit";
+import {
+  checkWorkspaceAccess,
+  checkToolAccess,
+  acquireRunSlot,
+  releaseRunSlot,
+} from "./auth";
+import type { McpTokenScope } from "@shared/types";
+
+// ─── Tool name constants ───────────────────────────────────────────────────────
+
+export const TOOL_LIST_WORKSPACES = "list_workspaces";
+export const TOOL_LIST_PIPELINES = "list_pipelines";
+export const TOOL_RUN_PIPELINE = "run_pipeline";
+export const TOOL_GET_RUN = "get_run";
+export const TOOL_CANCEL_RUN = "cancel_run";
+export const TOOL_LIST_CONNECTIONS = "list_connections";
+export const TOOL_QUERY_CONNECTION_USAGE = "query_connection_usage";
+
+export const ALL_TOOLS = [
+  TOOL_LIST_WORKSPACES,
+  TOOL_LIST_PIPELINES,
+  TOOL_RUN_PIPELINE,
+  TOOL_GET_RUN,
+  TOOL_CANCEL_RUN,
+  TOOL_LIST_CONNECTIONS,
+  TOOL_QUERY_CONNECTION_USAGE,
+] as const;
+
+export type McpToolName = (typeof ALL_TOOLS)[number];
+
+// ─── Tool input types ──────────────────────────────────────────────────────────
+
+interface ListPipelinesInput {
+  workspace_id: string;
+}
+
+interface RunPipelineInput {
+  pipeline_id: string;
+  input: string;
+}
+
+interface GetRunInput {
+  run_id: string;
+}
+
+interface CancelRunInput {
+  run_id: string;
+}
+
+interface ListConnectionsInput {
+  workspace_id: string;
+}
+
+interface QueryConnectionUsageInput {
+  connection_id: string;
+}
+
+// ─── Call context ──────────────────────────────────────────────────────────────
+
+export interface McpCallContext {
+  /** The authenticated MCP client token ID. */
+  tokenId: string;
+  /** The token's resolved scope. */
+  scope: McpTokenScope;
+  /** Optional trace ID for linking audit entries. */
+  traceId?: string;
+}
+
+// ─── Error types ──────────────────────────────────────────────────────────────
+
+export class McpScopeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "McpScopeError";
+  }
+}
+
+export class McpConcurrencyError extends Error {
+  constructor(tokenId: string, max: number) {
+    super(
+      `Token ${tokenId} has reached the maximum concurrent run limit of ${max}. ` +
+        "Wait for an existing run to complete before starting a new one.",
+    );
+    this.name = "McpConcurrencyError";
+  }
+}
+
+export class McpToolNotFoundError extends Error {
+  constructor(toolName: string) {
+    super(`Unknown MCP tool: "${toolName}"`);
+    this.name = "McpToolNotFoundError";
+  }
+}
+
+// ─── MCP Server ───────────────────────────────────────────────────────────────
+
+export class MultiqltiMcpServer {
+  constructor(
+    private readonly storage: IStorage,
+    private readonly controller: PipelineController,
+  ) {}
+
+  // ── Tool dispatch ────────────────────────────────────────────────────────────
+
+  /**
+   * Dispatch a tool call with scope checking and audit logging.
+   * Throws on scope/validation errors; returns serialisable result on success.
+   */
+  async callTool(
+    toolName: string,
+    args: Record<string, unknown>,
+    ctx: McpCallContext,
+  ): Promise<unknown> {
+    const startedAt = new Date();
+    let result: unknown = null;
+    let error: string | null = null;
+
+    // Validate tool name
+    if (!(ALL_TOOLS as readonly string[]).includes(toolName)) {
+      throw new McpToolNotFoundError(toolName);
+    }
+
+    // Check tool allow-list
+    if (!checkToolAccess(ctx.scope, toolName)) {
+      throw new McpScopeError(
+        `Token does not have permission to call tool "${toolName}". ` +
+          `Allowed tools: ${ctx.scope.allowedTools.join(", ")}`,
+      );
+    }
+
+    const t0 = Date.now();
+    try {
+      result = await this.dispatch(toolName as McpToolName, args, ctx);
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+      throw err;
+    } finally {
+      const durationMs = Date.now() - t0;
+      // Audit log — fire-and-forget, never throws
+      void recordToolCall(this.storage, {
+        connectionId: `mcp_client:${ctx.tokenId}`,
+        connectionType: "mcp_client",
+        toolName,
+        args,
+        result: error === null ? result : undefined,
+        error,
+        durationMs,
+        startedAt,
+        traceId: ctx.traceId,
+      });
+    }
+
+    return result;
+  }
+
+  // ── Individual tool handlers ─────────────────────────────────────────────────
+
+  private async dispatch(
+    toolName: McpToolName,
+    args: Record<string, unknown>,
+    ctx: McpCallContext,
+  ): Promise<unknown> {
+    switch (toolName) {
+      case TOOL_LIST_WORKSPACES:
+        return this.listWorkspaces(ctx);
+      case TOOL_LIST_PIPELINES:
+        return this.listPipelines(validateListPipelines(args), ctx);
+      case TOOL_RUN_PIPELINE:
+        return this.runPipeline(validateRunPipeline(args), ctx);
+      case TOOL_GET_RUN:
+        return this.getRun(validateGetRun(args));
+      case TOOL_CANCEL_RUN:
+        return this.cancelRun(validateCancelRun(args));
+      case TOOL_LIST_CONNECTIONS:
+        return this.listConnections(validateListConnections(args), ctx);
+      case TOOL_QUERY_CONNECTION_USAGE:
+        return this.queryConnectionUsage(validateQueryConnectionUsage(args), ctx);
+    }
+  }
+
+  /** list_workspaces — returns workspaces the token is scoped to. */
+  private async listWorkspaces(ctx: McpCallContext) {
+    const allWorkspaces = await this.storage.getWorkspaces();
+    return allWorkspaces
+      .filter((ws) => checkWorkspaceAccess(ctx.scope, ws.id))
+      .map((ws) => ({
+        id: ws.id,
+        name: ws.name,
+        type: ws.type,
+        status: ws.status,
+        createdAt: ws.createdAt,
+      }));
+  }
+
+  /** list_pipelines — returns pipelines for a workspace the token may access. */
+  private async listPipelines(args: ListPipelinesInput, ctx: McpCallContext) {
+    if (!checkWorkspaceAccess(ctx.scope, args.workspace_id)) {
+      throw new McpScopeError(
+        `Token does not have access to workspace "${args.workspace_id}".`,
+      );
+    }
+    const pipelines = await this.storage.getPipelines();
+    return pipelines
+      .filter((p) => !p.isTemplate)
+      .map((p) => ({
+        id: p.id,
+        name: p.name,
+        description: p.description ?? null,
+        stageCount: Array.isArray(p.stages) ? (p.stages as unknown[]).length : 0,
+        isTemplate: p.isTemplate,
+        createdAt: p.createdAt,
+      }));
+  }
+
+  /**
+   * run_pipeline — starts the pipeline via the controller (same path as the
+   * REST API) and returns the run ID immediately. Execution is asynchronous.
+   */
+  private async runPipeline(args: RunPipelineInput, ctx: McpCallContext) {
+    // Concurrency gate
+    if (!acquireRunSlot(ctx.tokenId, ctx.scope.maxRunConcurrency)) {
+      throw new McpConcurrencyError(ctx.tokenId, ctx.scope.maxRunConcurrency);
+    }
+
+    let runId: string;
+    try {
+      // startRun creates the run record AND kicks off execution asynchronously
+      const run = await this.controller.startRun(
+        args.pipeline_id,
+        args.input,
+        undefined,
+        `mcp_client:${ctx.tokenId}`,
+      );
+      runId = run.id;
+    } catch (err) {
+      // Release slot immediately if startup failed
+      releaseRunSlot(ctx.tokenId);
+      throw err;
+    }
+
+    // Release slot when the run reaches a terminal state
+    void this.waitForRunCompletion(runId, ctx.tokenId);
+
+    const run = await this.storage.getPipelineRun(runId);
+    return {
+      runId,
+      status: run?.status ?? "running",
+      startedAt: run?.startedAt ?? null,
+    };
+  }
+
+  /** Poll storage until run reaches terminal state, then release the slot. */
+  private async waitForRunCompletion(runId: string, tokenId: string): Promise<void> {
+    const POLL_INTERVAL_MS = 2_000;
+    const MAX_POLLS = 3_600; // ~2 hours at 2s intervals
+    const TERMINAL_STATUSES = new Set(["completed", "failed", "cancelled", "rejected"]);
+
+    for (let i = 0; i < MAX_POLLS; i++) {
+      await sleep(POLL_INTERVAL_MS);
+      try {
+        const run = await this.storage.getPipelineRun(runId);
+        if (!run || TERMINAL_STATUSES.has(run.status)) {
+          releaseRunSlot(tokenId);
+          return;
+        }
+      } catch {
+        releaseRunSlot(tokenId);
+        return;
+      }
+    }
+
+    // Timed out — release anyway
+    releaseRunSlot(tokenId);
+  }
+
+  /** get_run — returns run status, output, and stage trace events. */
+  private async getRun(args: GetRunInput) {
+    const run = await this.storage.getPipelineRun(args.run_id);
+    if (!run) {
+      throw new Error(`Run not found: "${args.run_id}"`);
+    }
+
+    const stages = await this.storage.getStageExecutions(args.run_id);
+
+    return {
+      id: run.id,
+      pipelineId: run.pipelineId,
+      status: run.status,
+      input: run.input,
+      output: run.output ?? null,
+      currentStageIndex: run.currentStageIndex,
+      startedAt: run.startedAt ?? null,
+      completedAt: run.completedAt ?? null,
+      stages: stages.map((s) => ({
+        id: s.id,
+        teamId: s.teamId,
+        status: s.status,
+        startedAt: s.startedAt ?? null,
+        completedAt: s.completedAt ?? null,
+      })),
+    };
+  }
+
+  /** cancel_run — cancels a running pipeline run. */
+  private async cancelRun(args: CancelRunInput) {
+    const run = await this.storage.getPipelineRun(args.run_id);
+    if (!run) {
+      throw new Error(`Run not found: "${args.run_id}"`);
+    }
+
+    const terminalStatuses = ["completed", "failed", "cancelled", "rejected"] as const;
+    if (terminalStatuses.includes(run.status as (typeof terminalStatuses)[number])) {
+      return { runId: args.run_id, cancelled: false };
+    }
+
+    await this.controller.cancelRun(args.run_id);
+    return { runId: args.run_id, cancelled: true };
+  }
+
+  /** list_connections — returns connection metadata only; NO secrets ever returned. */
+  private async listConnections(args: ListConnectionsInput, ctx: McpCallContext) {
+    if (!checkWorkspaceAccess(ctx.scope, args.workspace_id)) {
+      throw new McpScopeError(
+        `Token does not have access to workspace "${args.workspace_id}".`,
+      );
+    }
+
+    const connections = await this.storage.getWorkspaceConnections(args.workspace_id);
+    return connections.map((c) => ({
+      id: c.id,
+      workspaceId: c.workspaceId,
+      type: c.type,
+      name: c.name,
+      hasSecrets: c.hasSecrets,
+      status: c.status,
+      lastTestedAt: c.lastTestedAt ?? null,
+      createdAt: c.createdAt,
+      // Explicitly omit: config, secrets, or any field that could leak credentials
+    }));
+  }
+
+  /** query_connection_usage — returns usage metrics for a connection. */
+  private async queryConnectionUsage(
+    args: QueryConnectionUsageInput,
+    ctx: McpCallContext,
+  ) {
+    const connection = await this.storage.getWorkspaceConnection(args.connection_id);
+    if (!connection) {
+      throw new Error(`Connection not found: "${args.connection_id}"`);
+    }
+    if (!checkWorkspaceAccess(ctx.scope, connection.workspaceId)) {
+      throw new McpScopeError(
+        `Token does not have access to workspace "${connection.workspaceId}".`,
+      );
+    }
+
+    return this.storage.getConnectionUsageMetrics(args.connection_id);
+  }
+}
+
+// ─── Input validators ──────────────────────────────────────────────────────────
+
+function requireString(args: Record<string, unknown>, key: string): string {
+  const val = args[key];
+  if (typeof val !== "string" || val.trim() === "") {
+    throw new Error(`Missing or invalid argument "${key}" — expected a non-empty string.`);
+  }
+  return val.trim();
+}
+
+function validateListPipelines(args: Record<string, unknown>): ListPipelinesInput {
+  return { workspace_id: requireString(args, "workspace_id") };
+}
+
+function validateRunPipeline(args: Record<string, unknown>): RunPipelineInput {
+  return {
+    pipeline_id: requireString(args, "pipeline_id"),
+    input: requireString(args, "input"),
+  };
+}
+
+function validateGetRun(args: Record<string, unknown>): GetRunInput {
+  return { run_id: requireString(args, "run_id") };
+}
+
+function validateCancelRun(args: Record<string, unknown>): CancelRunInput {
+  return { run_id: requireString(args, "run_id") };
+}
+
+function validateListConnections(args: Record<string, unknown>): ListConnectionsInput {
+  return { workspace_id: requireString(args, "workspace_id") };
+}
+
+function validateQueryConnectionUsage(
+  args: Record<string, unknown>,
+): QueryConnectionUsageInput {
+  return { connection_id: requireString(args, "connection_id") };
+}
+
+// ─── Utility ──────────────────────────────────────────────────────────────────
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ─── MCP Wire Protocol helpers ────────────────────────────────────────────────
+
+/**
+ * Tool definition for the MCP protocol (tools/list response).
+ * Used by both transports (stdio + streamable-http).
+ */
+export interface McpToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export const MCP_TOOL_DEFINITIONS: McpToolDefinition[] = [
+  {
+    name: TOOL_LIST_WORKSPACES,
+    description: "List all workspaces accessible by this MCP token.",
+    inputSchema: { type: "object", properties: {}, required: [] },
+  },
+  {
+    name: TOOL_LIST_PIPELINES,
+    description: "List pipeline definitions for a workspace.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        workspace_id: { type: "string", description: "The workspace ID." },
+      },
+      required: ["workspace_id"],
+    },
+  },
+  {
+    name: TOOL_RUN_PIPELINE,
+    description:
+      "Start a pipeline run asynchronously. Returns run_id immediately; poll get_run for status.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        pipeline_id: { type: "string", description: "The pipeline ID to run." },
+        input: { type: "string", description: "The user input for the pipeline." },
+      },
+      required: ["pipeline_id", "input"],
+    },
+  },
+  {
+    name: TOOL_GET_RUN,
+    description: "Get the current status, output, and stage trace for a pipeline run.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        run_id: { type: "string", description: "The pipeline run ID." },
+      },
+      required: ["run_id"],
+    },
+  },
+  {
+    name: TOOL_CANCEL_RUN,
+    description: "Cancel a running pipeline.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        run_id: { type: "string", description: "The pipeline run ID to cancel." },
+      },
+      required: ["run_id"],
+    },
+  },
+  {
+    name: TOOL_LIST_CONNECTIONS,
+    description:
+      "List workspace connections (metadata only — no secrets are returned).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        workspace_id: { type: "string", description: "The workspace ID." },
+      },
+      required: ["workspace_id"],
+    },
+  },
+  {
+    name: TOOL_QUERY_CONNECTION_USAGE,
+    description: "Get usage metrics for a workspace connection.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        connection_id: { type: "string", description: "The connection ID." },
+      },
+      required: ["connection_id"],
+    },
+  },
+];
+
+// ─── JSON-RPC types ───────────────────────────────────────────────────────────
+
+export interface McpJsonRpcRequest {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface McpJsonRpcResponse {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+const JSONRPC_VERSION = "2.0" as const;
+
+/**
+ * Handle a single MCP JSON-RPC request.
+ * Used by both stdio and streamable-http transports.
+ */
+export async function handleMcpRequest(
+  request: McpJsonRpcRequest,
+  server: MultiqltiMcpServer,
+  ctx: McpCallContext,
+): Promise<McpJsonRpcResponse> {
+  const { id, method, params = {} } = request;
+
+  if (method === "tools/list") {
+    return {
+      jsonrpc: JSONRPC_VERSION,
+      id,
+      result: { tools: MCP_TOOL_DEFINITIONS },
+    };
+  }
+
+  if (method === "tools/call") {
+    const toolName = typeof params.name === "string" ? params.name : "";
+    const args =
+      params.arguments && typeof params.arguments === "object"
+        ? (params.arguments as Record<string, unknown>)
+        : {};
+
+    try {
+      const result = await server.callTool(toolName, args, ctx);
+      return {
+        jsonrpc: JSONRPC_VERSION,
+        id,
+        result: { content: [{ type: "text", text: JSON.stringify(result) }] },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const code =
+        err instanceof McpScopeError
+          ? -32001 // permission denied
+          : err instanceof McpConcurrencyError
+            ? -32002 // rate limited
+            : err instanceof McpToolNotFoundError
+              ? -32601 // method not found
+              : -32000; // server error
+      return { jsonrpc: JSONRPC_VERSION, id, error: { code, message } };
+    }
+  }
+
+  return {
+    jsonrpc: JSONRPC_VERSION,
+    id,
+    error: { code: -32601, message: `Method not found: "${method}"` },
+  };
+}
+
+/**
+ * Process a newline-delimited stream of JSON-RPC requests (stdio transport).
+ *
+ * @param lines     — raw JSON strings, one per line
+ * @param server    — the MCP server instance
+ * @param ctx       — call context (token + scope)
+ * @param writeLine — output function (injectable for tests)
+ */
+export async function processStdioLines(
+  lines: string[],
+  server: MultiqltiMcpServer,
+  ctx: McpCallContext,
+  writeLine: (s: string) => void = (s) => process.stdout.write(s + "\n"),
+): Promise<void> {
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let request: McpJsonRpcRequest;
+    try {
+      request = JSON.parse(trimmed) as McpJsonRpcRequest;
+    } catch {
+      const errorResp: McpJsonRpcResponse = {
+        jsonrpc: JSONRPC_VERSION,
+        id: null,
+        error: { code: -32700, message: "Parse error" },
+      };
+      writeLine(JSON.stringify(errorResp));
+      continue;
+    }
+
+    const response = await handleMcpRequest(request, server, ctx);
+    writeLine(JSON.stringify(response));
+  }
+}
+
+// ─── Singleton factory ────────────────────────────────────────────────────────
+
+let _server: MultiqltiMcpServer | null = null;
+
+/** Get or create the singleton MCP server. Used by the route handler. */
+export function getMultiqltiMcpServer(
+  storage: IStorage,
+  controller: PipelineController,
+): MultiqltiMcpServer {
+  if (!_server) {
+    _server = new MultiqltiMcpServer(storage, controller);
+  }
+  return _server;
+}
+
+/** Reset singleton (tests only). */
+export function _resetMultiqltiMcpServer(): void {
+  _server = null;
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -61,6 +61,7 @@ import { McpRegistryAdapter } from "./skill-market/adapters/mcp-registry-adapter
 import { SkillUpdateChecker } from "./skill-market/update-checker";
 import { registerFederationRoutes } from "./routes/federation";
 import { registerConnectionRoutes } from "./routes/connections";
+import { registerMcpRoutes } from "./routes/mcp";
 import { SessionSharingService } from "./federation/session-sharing";
 import { MemoryFederationService } from "./federation/memory-federation";
 import { PipelineSyncService } from "./federation/pipeline-sync";
@@ -131,6 +132,7 @@ export async function registerRoutes(
   registerToolRoutes(app, storage);
   registerWorkspaceRoutes(app, gateway, wsManager, storage);
   registerConnectionRoutes(app, storage);
+  registerMcpRoutes(app as unknown as Router, storage, controller);
   registerSandboxRoutes(app as unknown as Router);
   registerSettingsRoutes(app as unknown as Router, gateway);
   registerMaintenanceRoutes(app as unknown as Router);

--- a/server/routes/mcp.ts
+++ b/server/routes/mcp.ts
@@ -1,0 +1,218 @@
+/**
+ * MCP Server Routes (issue #274)
+ *
+ * Exposes multiqlti as an MCP server via two transports:
+ *
+ * 1. POST /mcp — streamable-http transport (for hosted clients / Caddy)
+ *    - Accepts a single JSON-RPC 2.0 request body
+ *    - Returns a single JSON-RPC 2.0 response
+ *    - Auth: Bearer mcp_client token in Authorization header
+ *    - NOTE: uses /mcp (no /api prefix) to bypass session requireAuth middleware
+ *
+ * 2. GET  /mcp/tools — list available tools (no auth required)
+ *    - Used by MCP clients during capability discovery
+ *
+ * Token management endpoints (require user session auth):
+ *   POST   /api/workspaces/:id/mcp-tokens       — create token
+ *   GET    /api/workspaces/:id/mcp-tokens        — list tokens
+ *   DELETE /api/workspaces/:id/mcp-tokens/:tid   — revoke token
+ *
+ * Security:
+ *  - /mcp transport endpoints use mcp_client token auth (not user sessions)
+ *  - Tool calls are scope-checked (workspace access + tool allow-list + concurrency)
+ *  - All tool calls are audit-logged
+ *  - No secrets returned in any response
+ */
+
+import { Router } from "express";
+import { z } from "zod";
+import type { Request, Response } from "express";
+import type { IStorage } from "../storage";
+import type { PipelineController } from "../controller/pipeline-controller";
+import { requireAuth, requireRole } from "../auth/middleware";
+import { mcpTokenStore } from "../mcp-servers/multiqlti-self/auth";
+import {
+  getMultiqltiMcpServer,
+  handleMcpRequest,
+  MCP_TOOL_DEFINITIONS,
+} from "../mcp-servers/multiqlti-self/index";
+import type { McpCallContext, McpJsonRpcRequest } from "../mcp-servers/multiqlti-self/index";
+import type { McpTokenScope, CreateMcpClientTokenInput } from "@shared/types";
+
+// ─── Validation schemas ───────────────────────────────────────────────────────
+
+const WorkspaceParamsSchema = z.object({ id: z.string().min(1) });
+const TokenParamsSchema = z.object({ id: z.string().min(1), tid: z.string().min(1) });
+
+const McpTokenScopeSchema = z.object({
+  workspaceIds: z.array(z.string().min(1)).min(1),
+  allowedTools: z
+    .array(z.string().min(1))
+    .min(1)
+    .refine(
+      (arr) => arr[0] === "*" || arr.every((t) => typeof t === "string"),
+      "allowedTools must be ['*'] or a list of tool names",
+    ) as z.ZodType<McpTokenScope["allowedTools"]>,
+  maxRunConcurrency: z.number().int().min(1).max(20).default(5),
+});
+
+const CreateMcpTokenBodySchema = z.object({
+  name: z.string().min(1).max(200),
+  scope: McpTokenScopeSchema,
+  expiresAt: z.string().datetime().optional(),
+});
+
+const McpJsonRpcBodySchema = z.object({
+  jsonrpc: z.literal("2.0"),
+  id: z.union([z.string(), z.number(), z.null()]),
+  method: z.string().min(1),
+  params: z.record(z.unknown()).optional(),
+});
+
+// ─── Token auth helper ─────────────────────────────────────────────────────────
+
+/**
+ * Extract and validate the Bearer mcp_client token from the Authorization header.
+ * Returns the resolved call context or null if invalid.
+ */
+function resolveMcpToken(req: Request): McpCallContext | null {
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith("Bearer ")) return null;
+  const rawToken = authHeader.slice(7);
+  const validated = mcpTokenStore.validate(rawToken);
+  if (!validated) return null;
+  return {
+    tokenId: validated.id,
+    scope: validated.scope,
+  };
+}
+
+// ─── Route registration ───────────────────────────────────────────────────────
+
+export function registerMcpRoutes(
+  router: Router,
+  storage: IStorage,
+  controller: PipelineController,
+): void {
+  const mcpServer = getMultiqltiMcpServer(storage, controller);
+
+  // ── GET /mcp/tools — capability discovery (no auth) ─────────────────────────
+  // Must be registered on a router that bypasses session auth middleware.
+  router.get("/mcp/tools", (_req: Request, res: Response) => {
+    res.json({ tools: MCP_TOOL_DEFINITIONS });
+  });
+
+  // ── POST /mcp — streamable-http transport ────────────────────────────────────
+  // Uses mcp_client token auth (not user sessions).
+  router.post("/mcp", async (req: Request, res: Response) => {
+    const ctx = resolveMcpToken(req);
+    if (!ctx) {
+      return res.status(401).json({
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32000, message: "Unauthorized: missing or invalid MCP token" },
+      });
+    }
+
+    const bodyParse = McpJsonRpcBodySchema.safeParse(req.body);
+    if (!bodyParse.success) {
+      return res.status(400).json({
+        jsonrpc: "2.0",
+        id: null,
+        error: {
+          code: -32700,
+          message: `Invalid JSON-RPC request: ${bodyParse.error.message}`,
+        },
+      });
+    }
+
+    const request = bodyParse.data as McpJsonRpcRequest;
+    const response = await handleMcpRequest(request, mcpServer, ctx);
+    return res.json(response);
+  });
+
+  // ── Token management — require user session auth ──────────────────────────────
+
+  // POST /api/workspaces/:id/mcp-tokens — create token
+  router.post(
+    "/api/workspaces/:id/mcp-tokens",
+    requireAuth,
+    requireRole("admin"),
+    async (req: Request, res: Response) => {
+      const params = WorkspaceParamsSchema.safeParse(req.params);
+      if (!params.success) {
+        return res.status(400).json({ error: "Invalid workspace ID" });
+      }
+      const workspaceId = params.data.id;
+
+      const bodyParse = CreateMcpTokenBodySchema.safeParse(req.body);
+      if (!bodyParse.success) {
+        return res.status(400).json({ error: bodyParse.error.message });
+      }
+      const body = bodyParse.data;
+
+      // Ensure workspaceIds in scope include the requested workspace
+      if (!body.scope.workspaceIds.includes(workspaceId)) {
+        return res.status(400).json({
+          error: "scope.workspaceIds must include the workspace ID for this endpoint",
+        });
+      }
+
+      const input: CreateMcpClientTokenInput = {
+        workspaceId,
+        name: body.name,
+        scope: body.scope,
+        expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
+      };
+
+      const result = mcpTokenStore.create(input);
+
+      return res.status(201).json({
+        token: result.token,
+        rawToken: result.rawToken, // Shown once; not persisted
+      });
+    },
+  );
+
+  // GET /api/workspaces/:id/mcp-tokens — list tokens
+  router.get(
+    "/api/workspaces/:id/mcp-tokens",
+    requireAuth,
+    requireRole("admin", "maintainer"),
+    (req: Request, res: Response) => {
+      const params = WorkspaceParamsSchema.safeParse(req.params);
+      if (!params.success) {
+        return res.status(400).json({ error: "Invalid workspace ID" });
+      }
+      const tokens = mcpTokenStore.listByWorkspace(params.data.id);
+      return res.json(tokens);
+    },
+  );
+
+  // DELETE /api/workspaces/:id/mcp-tokens/:tid — revoke token
+  router.delete(
+    "/api/workspaces/:id/mcp-tokens/:tid",
+    requireAuth,
+    requireRole("admin"),
+    (req: Request, res: Response) => {
+      const params = TokenParamsSchema.safeParse(req.params);
+      if (!params.success) {
+        return res.status(400).json({ error: "Invalid workspace or token ID" });
+      }
+
+      const token = mcpTokenStore.getById(params.data.tid);
+      if (!token) {
+        return res.status(404).json({ error: "Token not found" });
+      }
+      if (token.workspaceId !== params.data.id) {
+        return res.status(403).json({ error: "Token does not belong to this workspace" });
+      }
+
+      const ok = mcpTokenStore.revoke(params.data.tid);
+      if (!ok) {
+        return res.status(404).json({ error: "Token not found" });
+      }
+      return res.json({ revoked: true, id: params.data.tid });
+    },
+  );
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -2214,3 +2214,143 @@ export interface E2eKubernetesResult {
   /** TTL used for the namespace (hours). */
   ttlHours: number;
 }
+
+// ── MCP Client Token Types (issue #274) ──────────────────────────────────────
+
+/**
+ * Token type for external MCP clients — distinct from user session tokens.
+ * Stored in its own table; validated by McpTokenValidator.
+ */
+export const MCP_CLIENT_TOKEN_TYPE = "mcp_client" as const;
+
+/** Allowed tools a token may call. "*" means all tools. */
+export type McpToolAllowList = string[] | ["*"];
+
+/** Scopes that limit which workspaces a token can access. */
+export interface McpTokenScope {
+  /** Workspace IDs this token may access. Empty array = no access. */
+  workspaceIds: string[];
+  /**
+   * Tool names this token may call. Use ["*"] to allow all.
+   * Specific names must match the tool names exposed by the MCP server.
+   */
+  allowedTools: McpToolAllowList;
+  /** Maximum number of concurrent pipeline runs triggered via this token. */
+  maxRunConcurrency: number;
+}
+
+/** Public shape of an MCP client token (tokenHash never exposed). */
+export interface McpClientToken {
+  id: string;
+  workspaceId: string;
+  name: string;
+  /** The last 8 characters of the raw token (for identification only). */
+  tokenSuffix: string;
+  scope: McpTokenScope;
+  createdAt: Date;
+  expiresAt: Date | null;
+  lastUsedAt: Date | null;
+  isRevoked: boolean;
+}
+
+/** Input for creating an MCP client token. */
+export interface CreateMcpClientTokenInput {
+  workspaceId: string;
+  name: string;
+  scope: McpTokenScope;
+  expiresAt?: Date | null;
+}
+
+/** Result returned when creating a token — plaintext shown once, then gone. */
+export interface CreateMcpClientTokenResult {
+  token: McpClientToken;
+  /** The full raw token. Show once to user; not persisted. */
+  rawToken: string;
+}
+
+/**
+ * Audit log entry for an inbound MCP tool call from an external client.
+ * This extends the existing McpToolCall with MCP-client-specific fields.
+ */
+export interface McpInboundToolCall {
+  id: string;
+  /** The MCP client token ID that authenticated this call. */
+  mcpClientTokenId: string;
+  workspaceId: string;
+  toolName: string;
+  /** Redacted copy of call arguments (no secrets). */
+  argsJson: Record<string, unknown>;
+  /** Redacted copy of the result. Null on error. */
+  resultJson: unknown | null;
+  error: string | null;
+  durationMs: number;
+  startedAt: Date;
+}
+
+/** Summary metadata for a workspace as returned by list_workspaces MCP tool. */
+export interface McpWorkspaceSummary {
+  id: string;
+  name: string;
+  type: "local" | "remote";
+  status: "active" | "syncing" | "error";
+  createdAt: Date;
+}
+
+/** Summary metadata for a pipeline as returned by list_pipelines MCP tool. */
+export interface McpPipelineSummary {
+  id: string;
+  name: string;
+  description: string | null;
+  stageCount: number;
+  isTemplate: boolean;
+  createdAt: Date | null;
+}
+
+/** Result from run_pipeline MCP tool. */
+export interface McpRunPipelineResult {
+  runId: string;
+  status: RunStatus;
+  startedAt: Date | null;
+}
+
+/** Result from get_run MCP tool. */
+export interface McpRunDetails {
+  id: string;
+  pipelineId: string;
+  status: RunStatus;
+  input: string;
+  output: unknown | null;
+  currentStageIndex: number;
+  startedAt: Date | null;
+  completedAt: Date | null;
+  /** Stage execution summaries for trace events. */
+  stages: Array<{
+    id: string;
+    teamId: string;
+    status: StageStatus;
+    startedAt: Date | null;
+    completedAt: Date | null;
+  }>;
+}
+
+/** Result from cancel_run MCP tool. */
+export interface McpCancelRunResult {
+  runId: string;
+  cancelled: boolean;
+}
+
+/** Connection metadata (no secrets) as returned by list_connections MCP tool. */
+export interface McpConnectionSummary {
+  id: string;
+  workspaceId: string;
+  type: ConnectionType;
+  name: string;
+  /** True if the connection has stored secrets — but secrets are NEVER returned. */
+  hasSecrets: boolean;
+  status: ConnectionStatus;
+  lastTestedAt: Date | null;
+  createdAt: Date;
+}
+
+/** Result from query_connection_usage MCP tool. */
+export type McpConnectionUsage = ConnectionUsageMetrics;

--- a/tests/unit/reverse-mcp-server.test.ts
+++ b/tests/unit/reverse-mcp-server.test.ts
@@ -1,0 +1,1142 @@
+/**
+ * Tests for the multiqlti reverse MCP server (issue #274).
+ *
+ * Covers:
+ *  1. Token auth — generation, hashing, validation, expiry, revocation
+ *  2. Scope enforcement — workspace access, tool allow-list, wildcard
+ *  3. Concurrency limiting — acquire/release run slots
+ *  4. Tool: list_workspaces — scoped to token workspaces
+ *  5. Tool: list_pipelines — scoped to workspace, excludes templates
+ *  6. Tool: run_pipeline — returns run_id; concurrency gate
+ *  7. Tool: get_run — status + stage trace
+ *  8. Tool: cancel_run — running vs. terminal runs
+ *  9. Tool: list_connections — no secrets in output
+ * 10. Tool: query_connection_usage — workspace scope check
+ * 11. Audit log — recordToolCall called per invocation
+ * 12. JSON-RPC protocol — tools/list, tools/call, unknown method
+ * 13. stdio transport — processStdioLines, parse errors
+ * 14. streamable-http transport — POST /mcp endpoint
+ * 15. Token management HTTP endpoints — CRUD
+ */
+
+
+// Mock auth middleware for HTTP transport tests
+// vi.mock is hoisted before module evaluation
+vi.mock("../../server/auth/middleware", () => ({
+  requireAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
+  requireRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+  requireOwnerOrRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { IStorage } from "../../server/storage";
+import { MemStorage } from "../../server/storage";
+
+// ── auth ──────────────────────────────────────────────────────────────────────
+import {
+  McpTokenStore,
+  generateRawToken,
+  hashToken,
+  tokenSuffix,
+  checkWorkspaceAccess,
+  checkToolAccess,
+  acquireRunSlot,
+  releaseRunSlot,
+  getActiveRunCount,
+  _resetConcurrency,
+  mcpTokenStore,
+} from "../../server/mcp-servers/multiqlti-self/auth";
+
+// ── server ────────────────────────────────────────────────────────────────────
+import {
+  MultiqltiMcpServer,
+  McpScopeError,
+  McpConcurrencyError,
+  McpToolNotFoundError,
+  handleMcpRequest,
+  processStdioLines,
+  MCP_TOOL_DEFINITIONS,
+  ALL_TOOLS,
+  TOOL_LIST_WORKSPACES,
+  TOOL_LIST_PIPELINES,
+  TOOL_RUN_PIPELINE,
+  TOOL_GET_RUN,
+  TOOL_CANCEL_RUN,
+  TOOL_LIST_CONNECTIONS,
+  TOOL_QUERY_CONNECTION_USAGE,
+  _resetMultiqltiMcpServer,
+} from "../../server/mcp-servers/multiqlti-self/index";
+import type { McpCallContext } from "../../server/mcp-servers/multiqlti-self/index";
+import type { McpTokenScope } from "../../shared/types";
+
+// ── http transport ─────────────────────────────────────────────────────────────
+import express from "express";
+import request from "supertest";
+import { Router } from "express";
+import { registerMcpRoutes } from "../../server/routes/mcp";
+
+// ── audit ──────────────────────────────────────────────────────────────────────
+import * as audit from "../../server/tools/audit";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeScope(overrides: Partial<McpTokenScope> = {}): McpTokenScope {
+  return {
+    workspaceIds: ["ws-1"],
+    allowedTools: ["*"],
+    maxRunConcurrency: 5,
+    ...overrides,
+  };
+}
+
+function makeCtx(overrides: Partial<McpCallContext> = {}): McpCallContext {
+  return {
+    tokenId: "tok-1",
+    scope: makeScope(),
+    ...overrides,
+  };
+}
+
+/** Build a minimal mock PipelineController. */
+function makeMockController() {
+  return {
+    startRun: vi.fn(),
+    cancelRun: vi.fn(),
+  };
+}
+
+// ─── 1. Token auth ────────────────────────────────────────────────────────────
+
+describe("generateRawToken()", () => {
+  it("generates tokens with mq_mcp_ prefix", () => {
+    const t = generateRawToken();
+    expect(t.startsWith("mq_mcp_")).toBe(true);
+  });
+
+  it("generates unique tokens on successive calls", () => {
+    const tokens = new Set(Array.from({ length: 20 }, () => generateRawToken()));
+    expect(tokens.size).toBe(20);
+  });
+});
+
+describe("hashToken()", () => {
+  it("returns a 64-char hex string (SHA-256)", () => {
+    const h = hashToken("mq_mcp_abc123");
+    expect(h).toHaveLength(64);
+    expect(/^[0-9a-f]+$/.test(h)).toBe(true);
+  });
+
+  it("is deterministic", () => {
+    expect(hashToken("same")).toBe(hashToken("same"));
+  });
+
+  it("different inputs produce different hashes", () => {
+    expect(hashToken("a")).not.toBe(hashToken("b"));
+  });
+});
+
+describe("tokenSuffix()", () => {
+  it("returns the last 8 characters", () => {
+    expect(tokenSuffix("abcdefgh1234")).toBe("efgh1234");
+    expect(tokenSuffix("12345678")).toBe("12345678");
+  });
+});
+
+describe("McpTokenStore", () => {
+  let store: McpTokenStore;
+
+  beforeEach(() => {
+    store = new McpTokenStore();
+  });
+
+  it("creates a token and returns rawToken once", () => {
+    const result = store.create({
+      workspaceId: "ws-1",
+      name: "My Token",
+      scope: makeScope(),
+    });
+    expect(result.rawToken).toMatch(/^mq_mcp_/);
+    expect(result.token.tokenSuffix).toBe(result.rawToken.slice(-8));
+    expect(result.token.isRevoked).toBe(false);
+  });
+
+  it("validates a correct raw token", () => {
+    const { rawToken } = store.create({
+      workspaceId: "ws-1",
+      name: "Test",
+      scope: makeScope(),
+    });
+    const ctx = store.validate(rawToken);
+    expect(ctx).not.toBeNull();
+    expect(ctx!.scope.workspaceIds).toContain("ws-1");
+  });
+
+  it("returns null for an unknown token", () => {
+    expect(store.validate("mq_mcp_unknown")).toBeNull();
+  });
+
+  it("returns null for a revoked token", () => {
+    const { rawToken, token } = store.create({
+      workspaceId: "ws-1",
+      name: "Test",
+      scope: makeScope(),
+    });
+    store.revoke(token.id);
+    expect(store.validate(rawToken)).toBeNull();
+  });
+
+  it("returns null for an expired token", () => {
+    const { rawToken } = store.create({
+      workspaceId: "ws-1",
+      name: "Test",
+      scope: makeScope(),
+      expiresAt: new Date(Date.now() - 1000), // already expired
+    });
+    expect(store.validate(rawToken)).toBeNull();
+  });
+
+  it("does not expire a token with future expiresAt", () => {
+    const { rawToken } = store.create({
+      workspaceId: "ws-1",
+      name: "Test",
+      scope: makeScope(),
+      expiresAt: new Date(Date.now() + 86_400_000),
+    });
+    expect(store.validate(rawToken)).not.toBeNull();
+  });
+
+  it("lists tokens by workspace", () => {
+    store.create({ workspaceId: "ws-1", name: "A", scope: makeScope() });
+    store.create({ workspaceId: "ws-1", name: "B", scope: makeScope() });
+    store.create({ workspaceId: "ws-2", name: "C", scope: makeScope({ workspaceIds: ["ws-2"] }) });
+    expect(store.listByWorkspace("ws-1")).toHaveLength(2);
+    expect(store.listByWorkspace("ws-2")).toHaveLength(1);
+  });
+
+  it("getById returns public token shape without hash", () => {
+    const { token } = store.create({ workspaceId: "ws-1", name: "X", scope: makeScope() });
+    const retrieved = store.getById(token.id);
+    expect(retrieved).not.toBeNull();
+    expect(retrieved!.id).toBe(token.id);
+    expect("tokenHash" in retrieved!).toBe(false);
+  });
+
+  it("revoke returns false for unknown ID", () => {
+    expect(store.revoke("nonexistent")).toBe(false);
+  });
+
+  it("updates lastUsedAt on validate", () => {
+    const { rawToken, token } = store.create({
+      workspaceId: "ws-1",
+      name: "T",
+      scope: makeScope(),
+    });
+    expect(store.getById(token.id)!.lastUsedAt).toBeNull();
+    store.validate(rawToken);
+    expect(store.getById(token.id)!.lastUsedAt).toBeInstanceOf(Date);
+  });
+});
+
+// ─── 2. Scope checking ────────────────────────────────────────────────────────
+
+describe("checkWorkspaceAccess()", () => {
+  it("returns true when workspace is in scope", () => {
+    expect(checkWorkspaceAccess(makeScope({ workspaceIds: ["ws-1", "ws-2"] }), "ws-1")).toBe(true);
+  });
+
+  it("returns false when workspace is not in scope", () => {
+    expect(checkWorkspaceAccess(makeScope({ workspaceIds: ["ws-1"] }), "ws-99")).toBe(false);
+  });
+});
+
+describe("checkToolAccess()", () => {
+  it("allows all tools when list is ['*']", () => {
+    const scope = makeScope({ allowedTools: ["*"] });
+    expect(checkToolAccess(scope, "any_tool")).toBe(true);
+  });
+
+  it("allows a named tool in the list", () => {
+    const scope = makeScope({ allowedTools: ["list_workspaces", "get_run"] });
+    expect(checkToolAccess(scope, "list_workspaces")).toBe(true);
+    expect(checkToolAccess(scope, "get_run")).toBe(true);
+  });
+
+  it("blocks a tool not in the list", () => {
+    const scope = makeScope({ allowedTools: ["list_workspaces"] });
+    expect(checkToolAccess(scope, "run_pipeline")).toBe(false);
+  });
+});
+
+// ─── 3. Concurrency limiting ──────────────────────────────────────────────────
+
+describe("acquireRunSlot / releaseRunSlot", () => {
+  beforeEach(() => _resetConcurrency());
+
+  it("allows up to maxConcurrency slots", () => {
+    expect(acquireRunSlot("t1", 2)).toBe(true);
+    expect(acquireRunSlot("t1", 2)).toBe(true);
+    expect(acquireRunSlot("t1", 2)).toBe(false); // at capacity
+  });
+
+  it("releases a slot so it can be reacquired", () => {
+    acquireRunSlot("t1", 1);
+    expect(acquireRunSlot("t1", 1)).toBe(false);
+    releaseRunSlot("t1");
+    expect(acquireRunSlot("t1", 1)).toBe(true);
+  });
+
+  it("getActiveRunCount reflects current count", () => {
+    acquireRunSlot("t2", 5);
+    acquireRunSlot("t2", 5);
+    expect(getActiveRunCount("t2")).toBe(2);
+    releaseRunSlot("t2");
+    expect(getActiveRunCount("t2")).toBe(1);
+  });
+
+  it("releasing below zero does not go negative", () => {
+    releaseRunSlot("t3");
+    expect(getActiveRunCount("t3")).toBe(0);
+  });
+
+  it("different tokens have independent counters", () => {
+    acquireRunSlot("t4", 1);
+    expect(acquireRunSlot("t5", 1)).toBe(true); // different token
+  });
+});
+
+// ─── Shared server setup for tool tests ──────────────────────────────────────
+
+function makeServer() {
+  const storage = new MemStorage();
+  const controller = makeMockController();
+  const server = new MultiqltiMcpServer(
+    storage as IStorage,
+    controller as unknown as import("../../server/controller/pipeline-controller").PipelineController,
+  );
+  return { storage, controller, server };
+}
+
+// ─── 4. list_workspaces ───────────────────────────────────────────────────────
+
+describe("MultiqltiMcpServer.callTool — list_workspaces", () => {
+  beforeEach(() => _resetConcurrency());
+
+  it("returns only workspaces the token is scoped to", async () => {
+    const { storage, server } = makeServer();
+    await storage.createWorkspace({ name: "WS1", type: "local", path: "/a", branch: "main", status: "active", indexStatus: "idle" });
+    await storage.createWorkspace({ name: "WS2", type: "local", path: "/b", branch: "main", status: "active", indexStatus: "idle" });
+
+    const workspaces = await storage.getWorkspaces();
+    const [ws1, ws2] = workspaces;
+
+    // Token only has access to ws1
+    const ctx = makeCtx({ scope: makeScope({ workspaceIds: [ws1.id] }) });
+    const result = await server.callTool(TOOL_LIST_WORKSPACES, {}, ctx) as Array<{ id: string }>;
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(ws1.id);
+    expect(result.find((w) => w.id === ws2.id)).toBeUndefined();
+  });
+
+  it("returns empty array when token has no matching workspaces", async () => {
+    const { server } = makeServer();
+    const ctx = makeCtx({ scope: makeScope({ workspaceIds: ["non-existent-ws"] }) });
+    const result = await server.callTool(TOOL_LIST_WORKSPACES, {}, ctx);
+    expect(result).toEqual([]);
+  });
+
+  it("throws McpToolNotFoundError for unknown tool names", async () => {
+    const { server } = makeServer();
+    await expect(server.callTool("unknown_tool", {}, makeCtx())).rejects.toThrow(McpToolNotFoundError);
+  });
+
+  it("throws McpScopeError when tool is not in allow-list", async () => {
+    const { server } = makeServer();
+    const ctx = makeCtx({ scope: makeScope({ allowedTools: ["get_run"] }) });
+    await expect(server.callTool(TOOL_LIST_WORKSPACES, {}, ctx)).rejects.toThrow(McpScopeError);
+  });
+});
+
+// ─── 5. list_pipelines ────────────────────────────────────────────────────────
+
+describe("MultiqltiMcpServer.callTool — list_pipelines", () => {
+  beforeEach(() => _resetConcurrency());
+
+  it("returns pipelines for an allowed workspace", async () => {
+    const { storage, server } = makeServer();
+    const ws = await storage.createWorkspace({ name: "WS", type: "local", path: "/w", branch: "main", status: "active", indexStatus: "idle" });
+    await storage.createPipeline({ name: "Pipeline A", stages: [], isTemplate: false });
+    await storage.createPipeline({ name: "Template", stages: [], isTemplate: true });
+
+    const ctx = makeCtx({ scope: makeScope({ workspaceIds: [ws.id] }) });
+    const result = await server.callTool(TOOL_LIST_PIPELINES, { workspace_id: ws.id }, ctx) as Array<{ name: string; isTemplate: boolean }>;
+
+    // Should exclude template
+    expect(result.every((p) => !p.isTemplate)).toBe(true);
+    expect(result.some((p) => p.name === "Pipeline A")).toBe(true);
+  });
+
+  it("throws McpScopeError for workspace not in token scope", async () => {
+    const { storage, server } = makeServer();
+    const ws = await storage.createWorkspace({ name: "W", type: "local", path: "/", branch: "main", status: "active", indexStatus: "idle" });
+    const ctx = makeCtx({ scope: makeScope({ workspaceIds: ["other-ws"] }) });
+
+    await expect(
+      server.callTool(TOOL_LIST_PIPELINES, { workspace_id: ws.id }, ctx),
+    ).rejects.toThrow(McpScopeError);
+  });
+
+  it("throws Error when workspace_id arg is missing", async () => {
+    const { server } = makeServer();
+    await expect(
+      server.callTool(TOOL_LIST_PIPELINES, {}, makeCtx()),
+    ).rejects.toThrow(/workspace_id/);
+  });
+});
+
+// ─── 6. run_pipeline ─────────────────────────────────────────────────────────
+
+describe("MultiqltiMcpServer.callTool — run_pipeline", () => {
+  beforeEach(() => _resetConcurrency());
+
+  it("returns run_id and pending status on success", async () => {
+    const { storage, controller, server } = makeServer();
+    const pipeline = await storage.createPipeline({ name: "P", stages: [], isTemplate: false });
+
+    const mockRun = {
+      id: "run-abc",
+      pipelineId: pipeline.id,
+      status: "running",
+      input: "hello",
+      startedAt: new Date(),
+      output: null,
+      currentStageIndex: 0,
+      completedAt: null,
+      triggeredBy: null,
+      dagMode: false,
+      createdAt: new Date(),
+    };
+    controller.startRun.mockResolvedValue(mockRun);
+
+    // Add to storage so get_run can find it
+    await storage.createPipelineRun({
+      pipelineId: pipeline.id,
+      input: "hello",
+      status: "running",
+      currentStageIndex: 0,
+      startedAt: new Date(),
+      dagMode: false,
+      triggeredBy: null,
+    });
+
+    const ctx = makeCtx();
+    const result = await server.callTool(
+      TOOL_RUN_PIPELINE,
+      { pipeline_id: pipeline.id, input: "hello" },
+      ctx,
+    ) as { runId: string; status: string };
+
+    expect(controller.startRun).toHaveBeenCalledOnce();
+    expect(result.runId).toBe(mockRun.id);
+  });
+
+  it("throws McpConcurrencyError when at capacity", async () => {
+    const { storage, controller, server } = makeServer();
+    const pipeline = await storage.createPipeline({ name: "P2", stages: [], isTemplate: false });
+    controller.startRun.mockResolvedValue({ id: "run-x", status: "running", startedAt: new Date() });
+
+    const ctx = makeCtx({ scope: makeScope({ maxRunConcurrency: 1 }) });
+
+    // Acquire the single slot manually
+    acquireRunSlot(ctx.tokenId, 1);
+
+    await expect(
+      server.callTool(TOOL_RUN_PIPELINE, { pipeline_id: pipeline.id, input: "go" }, ctx),
+    ).rejects.toThrow(McpConcurrencyError);
+  });
+
+  it("releases slot if startRun throws", async () => {
+    const { storage, controller, server } = makeServer();
+    const pipeline = await storage.createPipeline({ name: "P3", stages: [], isTemplate: false });
+    controller.startRun.mockRejectedValue(new Error("controller error"));
+
+    const ctx = makeCtx({ tokenId: "tok-err", scope: makeScope({ maxRunConcurrency: 2 }) });
+
+    try {
+      await server.callTool(
+        TOOL_RUN_PIPELINE,
+        { pipeline_id: pipeline.id, input: "go" },
+        ctx,
+      );
+    } catch {
+      // expected
+    }
+
+    // Slot should have been released
+    expect(getActiveRunCount("tok-err")).toBe(0);
+  });
+});
+
+// ─── 7. get_run ───────────────────────────────────────────────────────────────
+
+describe("MultiqltiMcpServer.callTool — get_run", () => {
+  beforeEach(() => _resetConcurrency());
+
+  it("returns run details with stage list", async () => {
+    const { storage, server } = makeServer();
+    const pipeline = await storage.createPipeline({ name: "P", stages: [], isTemplate: false });
+    const run = await storage.createPipelineRun({
+      pipelineId: pipeline.id,
+      input: "hello",
+      status: "running",
+      currentStageIndex: 0,
+      startedAt: new Date(),
+      dagMode: false,
+      triggeredBy: null,
+    });
+
+    const result = await server.callTool(TOOL_GET_RUN, { run_id: run.id }, makeCtx()) as {
+      id: string;
+      status: string;
+      stages: unknown[];
+    };
+
+    expect(result.id).toBe(run.id);
+    expect(result.status).toBe("running");
+    expect(Array.isArray(result.stages)).toBe(true);
+  });
+
+  it("throws Error for unknown run_id", async () => {
+    const { server } = makeServer();
+    await expect(
+      server.callTool(TOOL_GET_RUN, { run_id: "no-such-run" }, makeCtx()),
+    ).rejects.toThrow(/Run not found/);
+  });
+
+  it("throws Error when run_id arg is missing", async () => {
+    const { server } = makeServer();
+    await expect(server.callTool(TOOL_GET_RUN, {}, makeCtx())).rejects.toThrow(/run_id/);
+  });
+});
+
+// ─── 8. cancel_run ───────────────────────────────────────────────────────────
+
+describe("MultiqltiMcpServer.callTool — cancel_run", () => {
+  beforeEach(() => _resetConcurrency());
+
+  it("cancels a running run", async () => {
+    const { storage, controller, server } = makeServer();
+    const pipeline = await storage.createPipeline({ name: "P", stages: [], isTemplate: false });
+    const run = await storage.createPipelineRun({
+      pipelineId: pipeline.id,
+      input: "go",
+      status: "running",
+      currentStageIndex: 0,
+      startedAt: new Date(),
+      dagMode: false,
+      triggeredBy: null,
+    });
+    controller.cancelRun.mockResolvedValue(undefined);
+
+    const result = await server.callTool(TOOL_CANCEL_RUN, { run_id: run.id }, makeCtx()) as {
+      runId: string;
+      cancelled: boolean;
+    };
+
+    expect(result.cancelled).toBe(true);
+    expect(controller.cancelRun).toHaveBeenCalledWith(run.id);
+  });
+
+  it("returns cancelled: false for already completed run", async () => {
+    const { storage, controller, server } = makeServer();
+    const pipeline = await storage.createPipeline({ name: "P", stages: [], isTemplate: false });
+    const run = await storage.createPipelineRun({
+      pipelineId: pipeline.id,
+      input: "go",
+      status: "completed",
+      currentStageIndex: 0,
+      startedAt: new Date(),
+      dagMode: false,
+      triggeredBy: null,
+    });
+
+    const result = await server.callTool(TOOL_CANCEL_RUN, { run_id: run.id }, makeCtx()) as {
+      cancelled: boolean;
+    };
+
+    expect(result.cancelled).toBe(false);
+    expect(controller.cancelRun).not.toHaveBeenCalled();
+  });
+
+  it("returns cancelled: false for failed run", async () => {
+    const { storage, controller, server } = makeServer();
+    const pipeline = await storage.createPipeline({ name: "P", stages: [], isTemplate: false });
+    const run = await storage.createPipelineRun({
+      pipelineId: pipeline.id,
+      input: "go",
+      status: "failed",
+      currentStageIndex: 0,
+      startedAt: new Date(),
+      dagMode: false,
+      triggeredBy: null,
+    });
+    const result = await server.callTool(TOOL_CANCEL_RUN, { run_id: run.id }, makeCtx()) as {
+      cancelled: boolean;
+    };
+    expect(result.cancelled).toBe(false);
+  });
+
+  it("throws Error for unknown run_id", async () => {
+    const { server } = makeServer();
+    await expect(
+      server.callTool(TOOL_CANCEL_RUN, { run_id: "no-such" }, makeCtx()),
+    ).rejects.toThrow(/Run not found/);
+  });
+});
+
+// ─── 9. list_connections — no secrets ────────────────────────────────────────
+
+describe("MultiqltiMcpServer.callTool — list_connections", () => {
+  beforeEach(() => _resetConcurrency());
+
+  it("returns connection metadata without secrets or config", async () => {
+    const { storage, server } = makeServer();
+    const ws = await storage.createWorkspace({ name: "W", type: "local", path: "/", branch: "main", status: "active", indexStatus: "idle" });
+    await storage.createWorkspaceConnection({
+      workspaceId: ws.id,
+      type: "github",
+      name: "My GitHub",
+      config: { host: "https://api.github.com" },
+      secrets: { token: "ghp_supersecrettoken12345678901234567890" },
+    });
+
+    const ctx = makeCtx({ scope: makeScope({ workspaceIds: [ws.id] }) });
+    const result = await server.callTool(
+      TOOL_LIST_CONNECTIONS,
+      { workspace_id: ws.id },
+      ctx,
+    ) as Array<Record<string, unknown>>;
+
+    expect(result).toHaveLength(1);
+    const conn = result[0];
+    expect(conn.id).toBeDefined();
+    expect(conn.name).toBe("My GitHub");
+    expect(conn.hasSecrets).toBe(true);
+    // Critical: no secrets or config should appear
+    expect("secrets" in conn).toBe(false);
+    expect("config" in conn).toBe(false);
+    // Token value must not appear anywhere in the serialised output
+    const json = JSON.stringify(conn);
+    expect(json).not.toContain("ghp_supersecrettoken");
+    expect(json).not.toContain("supersecrettoken");
+  });
+
+  it("throws McpScopeError for workspace not in token scope", async () => {
+    const { storage, server } = makeServer();
+    const ws = await storage.createWorkspace({ name: "W", type: "local", path: "/", branch: "main", status: "active", indexStatus: "idle" });
+    const ctx = makeCtx({ scope: makeScope({ workspaceIds: ["other-ws"] }) });
+
+    await expect(
+      server.callTool(TOOL_LIST_CONNECTIONS, { workspace_id: ws.id }, ctx),
+    ).rejects.toThrow(McpScopeError);
+  });
+
+  it("never includes kubernetes token in output", async () => {
+    const { storage, server } = makeServer();
+    const ws = await storage.createWorkspace({ name: "W2", type: "local", path: "/", branch: "main", status: "active", indexStatus: "idle" });
+    await storage.createWorkspaceConnection({
+      workspaceId: ws.id,
+      type: "kubernetes",
+      name: "K8s Cluster",
+      config: { server: "https://k8s.example.com" },
+      secrets: { kubeconfig: "apiVersion: v1\nclusters:\n- cluster:\n    server: https://k8s.example.com\n  name: default\ncurrent-context: default\ncontexts:\n- context:\n    cluster: default\n    user: admin\n  name: default\nkind: Config\npreferences: {}\nusers:\n- name: admin\n  user:\n    token: my-secret-token-value" },
+    });
+
+    const ctx = makeCtx({ scope: makeScope({ workspaceIds: [ws.id] }) });
+    const result = await server.callTool(
+      TOOL_LIST_CONNECTIONS,
+      { workspace_id: ws.id },
+      ctx,
+    ) as Array<Record<string, unknown>>;
+
+    const json = JSON.stringify(result);
+    expect(json).not.toContain("my-secret-token-value");
+    expect(json).not.toContain("kubeconfig");
+  });
+});
+
+// ─── 10. query_connection_usage ───────────────────────────────────────────────
+
+describe("MultiqltiMcpServer.callTool — query_connection_usage", () => {
+  beforeEach(() => _resetConcurrency());
+
+  it("returns usage metrics for a valid connection", async () => {
+    const { storage, server } = makeServer();
+    const ws = await storage.createWorkspace({ name: "W", type: "local", path: "/", branch: "main", status: "active", indexStatus: "idle" });
+    const conn = await storage.createWorkspaceConnection({
+      workspaceId: ws.id,
+      type: "github",
+      name: "GH",
+      config: {},
+    });
+
+    const ctx = makeCtx({ scope: makeScope({ workspaceIds: [ws.id] }) });
+    const result = await server.callTool(
+      TOOL_QUERY_CONNECTION_USAGE,
+      { connection_id: conn.id },
+      ctx,
+    ) as { connectionId: string; isOrphan: boolean };
+
+    expect(result.connectionId).toBe(conn.id);
+    expect(typeof result.isOrphan).toBe("boolean");
+  });
+
+  it("throws Error for unknown connection_id", async () => {
+    const { server } = makeServer();
+    await expect(
+      server.callTool(TOOL_QUERY_CONNECTION_USAGE, { connection_id: "no-conn" }, makeCtx()),
+    ).rejects.toThrow(/Connection not found/);
+  });
+
+  it("throws McpScopeError when connection belongs to an inaccessible workspace", async () => {
+    const { storage, server } = makeServer();
+    const ws = await storage.createWorkspace({ name: "W", type: "local", path: "/", branch: "main", status: "active", indexStatus: "idle" });
+    const conn = await storage.createWorkspaceConnection({
+      workspaceId: ws.id,
+      type: "github",
+      name: "GH",
+      config: {},
+    });
+
+    // Token with access to a different workspace
+    const ctx = makeCtx({ scope: makeScope({ workspaceIds: ["other-ws"] }) });
+    await expect(
+      server.callTool(TOOL_QUERY_CONNECTION_USAGE, { connection_id: conn.id }, ctx),
+    ).rejects.toThrow(McpScopeError);
+  });
+});
+
+// ─── 11. Audit log ────────────────────────────────────────────────────────────
+
+describe("Audit log per tool call", () => {
+  beforeEach(() => _resetConcurrency());
+
+  it("recordToolCall is called for successful tool invocations", async () => {
+    const spy = vi.spyOn(audit, "recordToolCall").mockResolvedValue(undefined);
+    const { server } = makeServer();
+    const ctx = makeCtx();
+
+    await server.callTool(TOOL_LIST_WORKSPACES, {}, ctx);
+
+    expect(spy).toHaveBeenCalledOnce();
+    const call = spy.mock.calls[0][1];
+    expect(call.toolName).toBe(TOOL_LIST_WORKSPACES);
+    expect(call.connectionType).toBe("mcp_client");
+    expect(call.connectionId).toContain("tok-1");
+    spy.mockRestore();
+  });
+
+  it("recordToolCall is called even when the tool throws", async () => {
+    const spy = vi.spyOn(audit, "recordToolCall").mockResolvedValue(undefined);
+    const { server } = makeServer();
+    const ctx = makeCtx();
+
+    try {
+      await server.callTool(TOOL_GET_RUN, { run_id: "missing" }, ctx);
+    } catch {
+      // expected
+    }
+
+    expect(spy).toHaveBeenCalledOnce();
+    const call = spy.mock.calls[0][1];
+    expect(call.error).toMatch(/Run not found/);
+    spy.mockRestore();
+  });
+
+  it("audit log contains the tool name and no raw secrets", async () => {
+    const captured: typeof audit.AuditCallInput[] = [];
+    const spy = vi.spyOn(audit, "recordToolCall").mockImplementation(async (_s, input) => {
+      captured.push(input as typeof audit.AuditCallInput);
+      return undefined;
+    });
+
+    const { storage, server } = makeServer();
+    const ws = await storage.createWorkspace({ name: "W", type: "local", path: "/", branch: "main", status: "active", indexStatus: "idle" });
+    const ctx = makeCtx({ scope: makeScope({ workspaceIds: [ws.id] }) });
+
+    await server.callTool(TOOL_LIST_WORKSPACES, {}, ctx);
+
+    expect(captured[0].toolName).toBe(TOOL_LIST_WORKSPACES);
+    spy.mockRestore();
+  });
+});
+
+// ─── 12. JSON-RPC protocol ────────────────────────────────────────────────────
+
+describe("handleMcpRequest()", () => {
+  beforeEach(() => _resetConcurrency());
+
+  it("tools/list returns all tool definitions", async () => {
+    const { server } = makeServer();
+    const ctx = makeCtx();
+    const resp = await handleMcpRequest(
+      { jsonrpc: "2.0", id: 1, method: "tools/list" },
+      server,
+      ctx,
+    );
+    expect(resp.error).toBeUndefined();
+    const result = resp.result as { tools: unknown[] };
+    expect(result.tools).toHaveLength(ALL_TOOLS.length);
+  });
+
+  it("tools/call dispatches to list_workspaces", async () => {
+    const { server } = makeServer();
+    const ctx = makeCtx();
+    const resp = await handleMcpRequest(
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "list_workspaces", arguments: {} },
+      },
+      server,
+      ctx,
+    );
+    expect(resp.error).toBeUndefined();
+    expect(resp.result).toBeDefined();
+  });
+
+  it("unknown method returns -32601 error", async () => {
+    const { server } = makeServer();
+    const resp = await handleMcpRequest(
+      { jsonrpc: "2.0", id: 3, method: "unknown/method" },
+      server,
+      makeCtx(),
+    );
+    expect(resp.error).toBeDefined();
+    expect(resp.error!.code).toBe(-32601);
+  });
+
+  it("tools/call with scope violation returns -32001 error", async () => {
+    const { server } = makeServer();
+    const ctx = makeCtx({ scope: makeScope({ allowedTools: ["get_run"] }) });
+    const resp = await handleMcpRequest(
+      {
+        jsonrpc: "2.0",
+        id: 4,
+        method: "tools/call",
+        params: { name: "list_workspaces", arguments: {} },
+      },
+      server,
+      ctx,
+    );
+    expect(resp.error).toBeDefined();
+    expect(resp.error!.code).toBe(-32001);
+  });
+
+  it("tools/call with unknown tool returns -32601 error", async () => {
+    const { server } = makeServer();
+    const resp = await handleMcpRequest(
+      {
+        jsonrpc: "2.0",
+        id: 5,
+        method: "tools/call",
+        params: { name: "no_such_tool", arguments: {} },
+      },
+      server,
+      makeCtx(),
+    );
+    expect(resp.error!.code).toBe(-32601);
+  });
+
+  it("preserves request id in response", async () => {
+    const { server } = makeServer();
+    const resp = await handleMcpRequest(
+      { jsonrpc: "2.0", id: "req-42", method: "tools/list" },
+      server,
+      makeCtx(),
+    );
+    expect(resp.id).toBe("req-42");
+  });
+
+  it("null id in request passes through", async () => {
+    const { server } = makeServer();
+    const resp = await handleMcpRequest(
+      { jsonrpc: "2.0", id: null, method: "tools/list" },
+      server,
+      makeCtx(),
+    );
+    expect(resp.id).toBeNull();
+  });
+});
+
+// ─── 13. stdio transport ─────────────────────────────────────────────────────
+
+describe("processStdioLines()", () => {
+  beforeEach(() => _resetConcurrency());
+
+  it("writes one response per valid line", async () => {
+    const { server } = makeServer();
+    const ctx = makeCtx();
+    const output: string[] = [];
+
+    await processStdioLines(
+      ['{"jsonrpc":"2.0","id":1,"method":"tools/list"}'],
+      server,
+      ctx,
+      (s) => output.push(s),
+    );
+
+    expect(output).toHaveLength(1);
+    const parsed = JSON.parse(output[0]);
+    expect(parsed.result).toBeDefined();
+  });
+
+  it("skips blank lines", async () => {
+    const { server } = makeServer();
+    const output: string[] = [];
+
+    await processStdioLines(
+      ["", "   ", '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'],
+      server,
+      makeCtx(),
+      (s) => output.push(s),
+    );
+
+    expect(output).toHaveLength(1);
+  });
+
+  it("returns parse error response for invalid JSON", async () => {
+    const { server } = makeServer();
+    const output: string[] = [];
+
+    await processStdioLines(
+      ["not-valid-json"],
+      server,
+      makeCtx(),
+      (s) => output.push(s),
+    );
+
+    expect(output).toHaveLength(1);
+    const parsed = JSON.parse(output[0]);
+    expect(parsed.error.code).toBe(-32700);
+    expect(parsed.id).toBeNull();
+  });
+
+  it("processes multiple lines in order", async () => {
+    const { server } = makeServer();
+    const output: string[] = [];
+
+    await processStdioLines(
+      [
+        '{"jsonrpc":"2.0","id":1,"method":"tools/list"}',
+        '{"jsonrpc":"2.0","id":2,"method":"tools/list"}',
+      ],
+      server,
+      makeCtx(),
+      (s) => output.push(s),
+    );
+
+    expect(output).toHaveLength(2);
+    expect(JSON.parse(output[0]).id).toBe(1);
+    expect(JSON.parse(output[1]).id).toBe(2);
+  });
+});
+
+// ─── 14. streamable-http transport ───────────────────────────────────────────
+
+describe("streamable-http transport (POST /mcp)", () => {
+  let app: express.Express;
+  let testStore: McpTokenStore;
+  let validRawToken: string;
+  let workspaceId: string;
+  let testStorage: MemStorage;
+
+  beforeEach(() => {
+    _resetConcurrency();
+    _resetMultiqltiMcpServer();
+    testStore = new McpTokenStore();
+    testStorage = new MemStorage();
+
+    app = express();
+    app.use(express.json());
+
+    const mockController = makeMockController();
+    const router = Router();
+
+    // Swap in our test store by patching the singleton (via module-level mock)
+    // We build the app fresh each time so the MCP server uses testStorage.
+    registerMcpRoutes(router, testStorage as IStorage, mockController as unknown as import("../../server/controller/pipeline-controller").PipelineController);
+    app.use(router);
+  });
+
+  it("returns 401 when no Authorization header", async () => {
+    const res = await request(app)
+      .post("/mcp")
+      .send({ jsonrpc: "2.0", id: 1, method: "tools/list" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it("returns 401 for invalid token", async () => {
+    const res = await request(app)
+      .post("/mcp")
+      .set("Authorization", "Bearer invalid_token")
+      .send({ jsonrpc: "2.0", id: 1, method: "tools/list" });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid JSON-RPC body", async () => {
+    const { rawToken } = mcpTokenStore.create({
+      workspaceId: "ws-1",
+      name: "T",
+      scope: makeScope(),
+    });
+
+    const res = await request(app)
+      .post("/mcp")
+      .set("Authorization", `Bearer ${rawToken}`)
+      .send({ not: "jsonrpc" });
+
+    expect(res.status).toBe(400);
+    mcpTokenStore._reset();
+  });
+
+  it("GET /mcp/tools returns tool list without auth", async () => {
+    const res = await request(app).get("/mcp/tools");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.tools)).toBe(true);
+    expect(res.body.tools.length).toBe(ALL_TOOLS.length);
+  });
+});
+
+// ─── 15. Token management HTTP endpoints ─────────────────────────────────────
+
+describe("Token management endpoints", () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    _resetConcurrency();
+    _resetMultiqltiMcpServer();
+    mcpTokenStore._reset();
+    app = express();
+    app.use(express.json());
+
+    // Inject test user
+    app.use((req, _res, next) => {
+      (req as express.Request & { user?: unknown }).user = {
+        id: "admin-user",
+        email: "admin@test.com",
+        name: "Admin",
+        isActive: true,
+        role: "admin",
+        lastLoginAt: null,
+        createdAt: new Date(0),
+      };
+      next();
+    });
+
+    const storage = new MemStorage();
+    const mockController = makeMockController();
+    const router = Router();
+    registerMcpRoutes(
+      router,
+      storage as IStorage,
+      mockController as unknown as import("../../server/controller/pipeline-controller").PipelineController,
+    );
+    app.use(router);
+  });
+
+  afterEach(() => {
+    mcpTokenStore._reset();
+  });
+
+  it("POST /api/workspaces/:id/mcp-tokens creates a token", async () => {
+    const res = await request(app)
+      .post("/api/workspaces/ws-1/mcp-tokens")
+      .send({
+        name: "CI Token",
+        scope: { workspaceIds: ["ws-1"], allowedTools: ["*"], maxRunConcurrency: 3 },
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.rawToken).toMatch(/^mq_mcp_/);
+    expect(res.body.token.name).toBe("CI Token");
+    expect(res.body.token.isRevoked).toBe(false);
+    // rawToken must not appear again in subsequent responses
+  });
+
+  it("POST returns 400 when scope.workspaceIds does not include the path workspace", async () => {
+    const res = await request(app)
+      .post("/api/workspaces/ws-1/mcp-tokens")
+      .send({
+        name: "Bad",
+        scope: { workspaceIds: ["ws-2"], allowedTools: ["*"], maxRunConcurrency: 1 },
+      });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("GET /api/workspaces/:id/mcp-tokens lists tokens for workspace", async () => {
+    mcpTokenStore.create({ workspaceId: "ws-1", name: "A", scope: makeScope() });
+    mcpTokenStore.create({ workspaceId: "ws-1", name: "B", scope: makeScope() });
+    mcpTokenStore.create({ workspaceId: "ws-2", name: "C", scope: makeScope({ workspaceIds: ["ws-2"] }) });
+
+    const res = await request(app).get("/api/workspaces/ws-1/mcp-tokens");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body.every((t: { name: string }) => t.name !== "C")).toBe(true);
+  });
+
+  it("DELETE /api/workspaces/:id/mcp-tokens/:tid revokes a token", async () => {
+    const { token } = mcpTokenStore.create({ workspaceId: "ws-1", name: "T", scope: makeScope() });
+
+    const res = await request(app).delete(`/api/workspaces/ws-1/mcp-tokens/${token.id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.revoked).toBe(true);
+
+    // Token should now be revoked
+    const tokens = mcpTokenStore.listByWorkspace("ws-1");
+    expect(tokens.find((t) => t.id === token.id)!.isRevoked).toBe(true);
+  });
+
+  it("DELETE returns 403 when token belongs to a different workspace", async () => {
+    const { token } = mcpTokenStore.create({
+      workspaceId: "ws-2",
+      name: "Other",
+      scope: makeScope({ workspaceIds: ["ws-2"] }),
+    });
+
+    const res = await request(app).delete(`/api/workspaces/ws-1/mcp-tokens/${token.id}`);
+    expect(res.status).toBe(403);
+  });
+
+  it("DELETE returns 404 for non-existent token", async () => {
+    const res = await request(app).delete("/api/workspaces/ws-1/mcp-tokens/no-such-id");
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── 16. MCP_TOOL_DEFINITIONS completeness ────────────────────────────────────
+
+describe("MCP_TOOL_DEFINITIONS", () => {
+  it("contains exactly 7 tools", () => {
+    expect(MCP_TOOL_DEFINITIONS).toHaveLength(7);
+  });
+
+  it("every ALL_TOOLS entry has a definition", () => {
+    const names = MCP_TOOL_DEFINITIONS.map((d) => d.name);
+    for (const t of ALL_TOOLS) {
+      expect(names).toContain(t);
+    }
+  });
+
+  it("each definition has name, description, and inputSchema", () => {
+    for (const def of MCP_TOOL_DEFINITIONS) {
+      expect(typeof def.name).toBe("string");
+      expect(typeof def.description).toBe("string");
+      expect(typeof def.inputSchema).toBe("object");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- MCP server exposing 7 domain tools (workspaces, pipelines, runs, connections) to external clients
- stdio + streamable-http (`POST /mcp`) transports; `GET /mcp/tools` for capability discovery
- Scoped `mcp_client` tokens with per-workspace access, tool allow-lists, and max run concurrency
- Token CRUD at `/api/workspaces/:id/mcp-tokens` (admin-only)
- Full audit logging for every inbound tool call (reuses existing `recordToolCall` layer)
- No secrets returned by any tool — `list_connections` explicitly omits config and secret fields

Closes #274

## Test plan

- Token auth: generation, hashing, validation, expiry, revocation (12 tests)
- Scope enforcement: workspace access, tool allow-list, wildcard (6 tests)
- Concurrency limiting: acquire/release slots, per-token isolation (5 tests)
- Tool coverage: all 7 tools including error paths (30+ tests)
- Secret redaction: `list_connections` never returns secrets, kubernetes token redaction
- Audit log: `recordToolCall` called on success AND error paths
- JSON-RPC protocol: `tools/list`, `tools/call`, unknown method, error codes
- stdio transport: multi-line processing, blank lines, parse errors
- streamable-http transport: 401 without token, 400 for invalid body, 200 for tool discovery
- Token management HTTP endpoints: create, list, revoke, cross-workspace 403, 404