### PR TITLE
feat: declarative YAML config for connections (#276)

### DIFF
--- a/script/connections-validate.ts
+++ b/script/connections-validate.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env tsx
+/**
+ * connections-validate — CLI linter for .multiqlti/connections.yaml
+ *
+ * Usage:
+ *   npx tsx script/connections-validate.ts [path/to/connections.yaml]
+ *   npx tsx script/connections-validate.ts  # uses .multiqlti/connections.yaml
+ *
+ * Exit codes:
+ *   0 — valid
+ *   1 — validation errors (schema violations, plaintext secrets, parse errors)
+ *   2 — file not found
+ *   3 — unexpected error
+ */
+
+import fs from "fs/promises";
+import path from "path";
+import { validateConnectionsYaml } from "../server/workspace/connections-yaml";
+
+const DEFAULT_PATH = ".multiqlti/connections.yaml";
+
+async function main(): Promise<void> {
+  const filePath = process.argv[2] ?? DEFAULT_PATH;
+  const resolvedPath = path.resolve(filePath);
+
+  console.log(`Validating: ${resolvedPath}\n`);
+
+  let raw: string;
+  try {
+    raw = await fs.readFile(resolvedPath, "utf-8");
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      console.error(`Error: File not found: ${resolvedPath}`);
+      process.exit(2);
+    }
+    console.error(`Error reading file: ${(err as Error).message}`);
+    process.exit(3);
+  }
+
+  const result = validateConnectionsYaml(raw);
+
+  if (result.errors.length > 0) {
+    console.error("Validation errors:");
+    for (const error of result.errors) {
+      console.error(`  ✗ ${error}`);
+    }
+    console.error("");
+  }
+
+  if (result.warnings.length > 0) {
+    console.warn("Warnings:");
+    for (const warning of result.warnings) {
+      console.warn(`  ⚠ ${warning}`);
+    }
+    console.warn("");
+  }
+
+  if (result.valid) {
+    console.log(`✓ Valid — ${result.connectionCount} connection(s) defined`);
+    if (result.warnings.length > 0) {
+      console.log(`  ${result.warnings.length} warning(s) — see above`);
+    }
+    process.exit(0);
+  } else {
+    console.error(`✗ Invalid — ${result.errors.length} error(s)`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(`Unexpected error: ${(err as Error).message}`);
+  process.exit(3);
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -61,6 +61,7 @@ import { McpRegistryAdapter } from "./skill-market/adapters/mcp-registry-adapter
 import { SkillUpdateChecker } from "./skill-market/update-checker";
 import { registerFederationRoutes } from "./routes/federation";
 import { registerConnectionRoutes } from "./routes/connections";
+import { registerConnectionsYamlRoutes } from "./routes/connections-yaml";
 import { registerInventoryRoutes } from "./routes/inventory";
 import { registerMcpRoutes } from "./routes/mcp";
 import { SessionSharingService } from "./federation/session-sharing";
@@ -133,6 +134,7 @@ export async function registerRoutes(
   registerToolRoutes(app, storage);
   registerWorkspaceRoutes(app, gateway, wsManager, storage);
   registerConnectionRoutes(app, storage);
+  registerConnectionsYamlRoutes(app, storage);
   registerInventoryRoutes(app, storage);
   registerMcpRoutes(app as unknown as Router, storage, controller);
   registerSandboxRoutes(app as unknown as Router);

--- a/server/routes/connections-yaml.ts
+++ b/server/routes/connections-yaml.ts
@@ -1,0 +1,139 @@
+/**
+ * Connections YAML Sync API (issue #276)
+ *
+ * POST /api/workspaces/:id/connections/sync
+ *
+ * Reads .multiqlti/connections.yaml from the workspace root, diffs against
+ * DB state, optionally applies, and returns the plan + drift report.
+ *
+ * RBAC: admin only (same as connection mutations).
+ *
+ * Security invariants:
+ *   - Resolved secrets are NEVER included in the response.
+ *   - Secret resolution errors are reported at the key level, not value level.
+ *   - Workspace root is resolved via the WorkspaceManager path helpers.
+ */
+
+import type { Express, Request, Response } from "express";
+import path from "path";
+import { z } from "zod";
+import type { IStorage } from "../storage";
+import { requireRole } from "../auth/middleware";
+import { log } from "../index";
+import { syncConnectionsFromYaml } from "../workspace/connections-yaml";
+
+// ─── Zod request schemas ──────────────────────────────────────────────────────
+
+const WorkspaceParamsSchema = z.object({
+  id: z.string().min(1),
+});
+
+const SyncBodySchema = z.object({
+  autoApply: z.boolean().optional().default(false),
+  includeDeletes: z.boolean().optional().default(false),
+});
+
+// ─── Workspace root resolver ─────────────────────────────────────────────────
+
+const WORKSPACE_DATA_DIR = path.resolve("data/workspaces");
+
+function resolveWorkspaceRoot(workspace: { type: string; id: string; path: string }): string {
+  if (workspace.type === "local") return workspace.path;
+  return path.join(WORKSPACE_DATA_DIR, workspace.id);
+}
+
+// ─── Route registration ───────────────────────────────────────────────────────
+
+export function registerConnectionsYamlRoutes(app: Express, storage: IStorage): void {
+  /**
+   * POST /api/workspaces/:id/connections/sync
+   *
+   * Read .multiqlti/connections.yaml, build reconciliation plan, optionally apply.
+   *
+   * Response shape:
+   * {
+   *   yamlMissing: boolean,
+   *   plan: { actions, hasChanges },
+   *   applied: boolean,
+   *   applyResult?: { created, updated, deleted, errors },
+   *   drift: [{ connectionId, connectionName, connectionType, driftedConfigKeys }]
+   * }
+   */
+  app.post(
+    "/api/workspaces/:id/connections/sync",
+    requireRole("admin"),
+    async (req: Request, res: Response) => {
+      const params = WorkspaceParamsSchema.safeParse(req.params);
+      if (!params.success) {
+        return res.status(400).json({ error: params.error.message });
+      }
+
+      const body = SyncBodySchema.safeParse(req.body ?? {});
+      if (!body.success) {
+        return res.status(400).json({
+          error: "Invalid request body",
+          issues: body.error.issues.map((i) => ({ path: i.path, message: i.message })),
+        });
+      }
+
+      try {
+        const workspace = await storage.getWorkspace(params.data.id);
+        if (!workspace) {
+          return res.status(404).json({ error: "Workspace not found" });
+        }
+
+        const workspaceRoot = resolveWorkspaceRoot(workspace);
+
+        const result = await syncConnectionsFromYaml(
+          params.data.id,
+          workspaceRoot,
+          storage,
+          {
+            autoApply: body.data.autoApply,
+            includeDeletes: body.data.includeDeletes,
+            createdBy: req.user?.id ?? null,
+          },
+        );
+
+        log(
+          `[connections-yaml] sync workspaceId=${params.data.id} ` +
+          `actions=${result.plan.actions.length} applied=${result.applied} ` +
+          `drift=${result.drift.length}`,
+          "connections-yaml",
+        );
+
+        // Strip internal yamlEntry details from actions (no need to expose full YAML data)
+        const sanitizedActions = result.plan.actions.map((a) => ({
+          type: a.type,
+          connectionName: a.connectionName,
+          reason: a.reason,
+        }));
+
+        return res.json({
+          yamlMissing: result.yamlMissing,
+          plan: {
+            actions: sanitizedActions,
+            hasChanges: result.plan.hasChanges,
+          },
+          applied: result.applied,
+          ...(result.applyResult ? { applyResult: result.applyResult } : {}),
+          drift: result.drift,
+        });
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        log(`[connections-yaml] sync error: ${message}`, "connections-yaml");
+
+        // YAML schema violations are user errors (400), not server errors (500)
+        if (
+          message.includes("connections.yaml validation failed") ||
+          message.includes("Plaintext secrets") ||
+          message.includes("YAML parse error")
+        ) {
+          return res.status(400).json({ error: message });
+        }
+
+        return res.status(500).json({ error: "Connections sync failed" });
+      }
+    },
+  );
+}

--- a/server/workspace/connections-yaml.ts
+++ b/server/workspace/connections-yaml.ts
@@ -1,0 +1,719 @@
+/**
+ * Declarative YAML config for workspace connections (issue #276)
+ *
+ * Reads `.multiqlti/connections.yaml` from the workspace root, resolves
+ * secret references (env/file), diffs against the current DB state, and
+ * produces a reconciliation plan.
+ *
+ * Security invariants:
+ *   - Inline plaintext secrets in YAML are rejected with a hard error.
+ *   - Resolved secret values are NEVER logged.
+ *   - The ${vault:…} reference is a typed stub for future implementation.
+ */
+
+import fs from "fs/promises";
+import path from "path";
+import yaml from "js-yaml";
+import { z } from "zod";
+import { CONNECTION_TYPES } from "@shared/schema";
+import type { WorkspaceConnection, CreateWorkspaceConnectionInput, UpdateWorkspaceConnectionInput, ConnectionType } from "@shared/types";
+import type { IStorage } from "../storage";
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+export const CONNECTIONS_YAML_PATH = ".multiqlti/connections.yaml";
+
+/** Supported secret reference prefixes. */
+const SECRET_REF_PATTERN = /^\$\{(env|file|vault):([^}]+)\}$/;
+
+/** Characters that suggest a value is a plaintext secret (not a reference). */
+const PLAINTEXT_SECRET_INDICATORS = /^[A-Za-z0-9+/]{20,}={0,2}$|glpat-|ghp_|xoxb-|sk-/;
+
+// ─── Zod schemas ─────────────────────────────────────────────────────────────
+
+/**
+ * A secret value in YAML must be a ${env:…}, ${file:…} or ${vault:…} reference.
+ * Any other string is rejected as a potential plaintext secret.
+ */
+const SecretRefSchema = z
+  .string()
+  .refine(
+    (v) => SECRET_REF_PATTERN.test(v),
+    (v) => ({
+      message: `Plaintext secrets are not allowed. Use \${env:VAR}, \${file:path}, or \${vault:path} references. Got: ${v.slice(0, 20)}…`,
+    }),
+  );
+
+const YamlConnectionSchema = z.object({
+  name: z.string().min(1).max(200),
+  type: z.enum(CONNECTION_TYPES),
+  config: z.record(z.unknown()).default({}),
+  /**
+   * secrets is a record of secret name → reference string.
+   * All values must be reference expressions — never plaintext.
+   */
+  secrets: z.record(SecretRefSchema).optional(),
+});
+
+export const ConnectionsFileSchema = z.object({
+  version: z.literal(1),
+  connections: z.array(YamlConnectionSchema).default([]),
+});
+
+export type YamlConnection = z.infer<typeof YamlConnectionSchema>;
+export type ConnectionsFile = z.infer<typeof ConnectionsFileSchema>;
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface SecretResolutionError {
+  connectionName: string;
+  secretKey: string;
+  ref: string;
+  message: string;
+}
+
+export interface ResolvedSecrets {
+  secrets: Record<string, string>;
+  errors: SecretResolutionError[];
+}
+
+/** A single action in the reconciliation plan. */
+export type ReconcileActionType = "create" | "update" | "delete" | "unchanged";
+
+export interface ReconcileAction {
+  type: ReconcileActionType;
+  connectionName: string;
+  /** Only set for update/create actions. */
+  yamlEntry?: YamlConnection;
+  /** Only set for update/delete actions — existing DB record. */
+  existing?: WorkspaceConnection;
+  /** Human-readable reason for the action. */
+  reason: string;
+}
+
+export interface ReconcilePlan {
+  actions: ReconcileAction[];
+  hasChanges: boolean;
+}
+
+export interface ApplyResult {
+  created: string[];
+  updated: string[];
+  deleted: string[];
+  errors: Array<{ connectionName: string; message: string }>;
+}
+
+/** Drift item: a connection modified in UI after YAML was applied. */
+export interface DriftItem {
+  connectionId: string;
+  connectionName: string;
+  connectionType: ConnectionType;
+  /** Keys whose values differ between YAML config and DB config. */
+  driftedConfigKeys: string[];
+}
+
+// ─── YAML Parsing ────────────────────────────────────────────────────────────
+
+/**
+ * Load and parse the connections YAML from a workspace root directory.
+ * Returns null when the file does not exist (graceful absence).
+ * Throws on parse error or schema violation.
+ */
+export async function loadConnectionsYaml(workspaceRoot: string): Promise<ConnectionsFile | null> {
+  const fullPath = path.join(workspaceRoot, CONNECTIONS_YAML_PATH);
+
+  let raw: string;
+  try {
+    raw = await fs.readFile(fullPath, "utf-8");
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return null;
+    throw err;
+  }
+
+  const parsed = yaml.load(raw);
+
+  const result = ConnectionsFileSchema.safeParse(parsed);
+  if (!result.success) {
+    const firstIssue = result.error.issues[0];
+    const path_ = firstIssue.path.join(".");
+    throw new Error(
+      `connections.yaml validation failed at "${path_}": ${firstIssue.message}`,
+    );
+  }
+
+  return result.data;
+}
+
+// ─── Secret Reference Resolution ─────────────────────────────────────────────
+
+/**
+ * Resolve a single secret reference string into its plaintext value.
+ *
+ * Supports:
+ *   ${env:VAR_NAME}    → process.env[VAR_NAME]
+ *   ${file:./path}     → fs.readFile(path, "utf-8").trim()
+ *   ${vault:path}      → throws NotImplemented (future extension stub)
+ *
+ * NEVER logs the resolved value.
+ */
+export async function resolveSecretRef(
+  ref: string,
+  workspaceRoot: string,
+): Promise<string> {
+  const match = SECRET_REF_PATTERN.exec(ref);
+  if (!match) {
+    throw new Error(`Invalid secret reference format: "${ref}"`);
+  }
+
+  const refType = match[1] as "env" | "file" | "vault";
+  const refValue = match[2];
+
+  switch (refType) {
+    case "env": {
+      const value = process.env[refValue];
+      if (value === undefined) {
+        throw new Error(`Environment variable "${refValue}" is not set`);
+      }
+      return value;
+    }
+
+    case "file": {
+      const resolvedPath = path.resolve(workspaceRoot, refValue);
+      // Guard against path traversal outside workspace root
+      if (!resolvedPath.startsWith(path.resolve(workspaceRoot))) {
+        throw new Error(`File reference "${refValue}" would escape the workspace root`);
+      }
+      try {
+        const content = await fs.readFile(resolvedPath, "utf-8");
+        return content.trim();
+      } catch (err: unknown) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "ENOENT") {
+          throw new Error(`Secret file not found: "${refValue}"`);
+        }
+        throw err;
+      }
+    }
+
+    case "vault": {
+      // Stub: vault integration is a future extension
+      throw new Error(
+        `Vault secret references are not yet implemented. Ref: "${ref}". ` +
+        `Please use \${env:VAR} or \${file:path} instead.`,
+      );
+    }
+
+    default: {
+      const _exhaustive: never = refType;
+      throw new Error(`Unknown secret reference type: ${_exhaustive}`);
+    }
+  }
+}
+
+/**
+ * Resolve all secret references for a single connection.
+ * Returns resolved secrets map + any resolution errors.
+ * Errors are collected (not thrown) so callers can decide to fail-open or fail-closed.
+ */
+export async function resolveConnectionSecrets(
+  connectionName: string,
+  secretRefs: Record<string, string>,
+  workspaceRoot: string,
+): Promise<ResolvedSecrets> {
+  const secrets: Record<string, string> = {};
+  const errors: SecretResolutionError[] = [];
+
+  for (const [key, ref] of Object.entries(secretRefs)) {
+    try {
+      secrets[key] = await resolveSecretRef(ref, workspaceRoot);
+    } catch (err: unknown) {
+      errors.push({
+        connectionName,
+        secretKey: key,
+        ref,
+        message: (err as Error).message,
+      });
+    }
+  }
+
+  return { secrets, errors };
+}
+
+// ─── Plaintext Secret Detection ───────────────────────────────────────────────
+
+/**
+ * Scans a raw YAML string for patterns that look like plaintext secrets in the
+ * secrets block. This is a defence-in-depth check on top of SecretRefSchema.
+ *
+ * Returns the first suspicious value found, or null if clean.
+ *
+ * NOTE: This operates on the raw YAML text before parsing to catch values that
+ * bypass Zod parsing (e.g. anchors, multi-line strings).
+ */
+export function detectPlaintextSecret(rawYaml: string): string | null {
+  // Find all values under `secrets:` blocks via a simple pattern scan
+  const secretsBlockPattern = /^\s+secrets:\s*\n((?:\s{4,}[^:]+:.*\n)*)/gm;
+  let match: RegExpExecArray | null;
+
+  while ((match = secretsBlockPattern.exec(rawYaml)) !== null) {
+    const block = match[1];
+    const valuePattern = /:\s*["']?([^"'\n#]+?)["']?\s*(?:#.*)?$/gm;
+    let valueMatch: RegExpExecArray | null;
+
+    while ((valueMatch = valuePattern.exec(block)) !== null) {
+      const value = valueMatch[1].trim();
+      // Skip reference expressions
+      if (SECRET_REF_PATTERN.test(value)) continue;
+      // Skip empty values
+      if (!value) continue;
+      // Flag if it looks like a token/key
+      if (PLAINTEXT_SECRET_INDICATORS.test(value)) {
+        return value.slice(0, 10) + "…";
+      }
+    }
+  }
+
+  return null;
+}
+
+// ─── Reconciliation ───────────────────────────────────────────────────────────
+
+/**
+ * Diff YAML entries against DB state and produce a plan.
+ *
+ * Rules:
+ *   - YAML has connection, DB does not → create
+ *   - YAML has connection, DB has it (by name+workspaceId) → compare config → update or unchanged
+ *   - DB has connection, YAML does not → delete (only for YAML-managed connections)
+ *
+ * "YAML-managed" is tracked by checking whether a connection's name matches
+ * any YAML entry. In a future extension a `yamlManaged: true` flag can be
+ * persisted, but for now we treat connections whose names match as managed.
+ */
+export function buildReconcilePlan(
+  yamlConnections: YamlConnection[],
+  dbConnections: WorkspaceConnection[],
+): ReconcilePlan {
+  const actions: ReconcileAction[] = [];
+
+  const dbByName = new Map<string, WorkspaceConnection>(
+    dbConnections.map((c) => [c.name, c]),
+  );
+
+  const yamlNames = new Set(yamlConnections.map((c) => c.name));
+
+  // Compute creates and updates
+  for (const yamlConn of yamlConnections) {
+    const existing = dbByName.get(yamlConn.name);
+
+    if (!existing) {
+      actions.push({
+        type: "create",
+        connectionName: yamlConn.name,
+        yamlEntry: yamlConn,
+        reason: "Connection defined in YAML but not in DB",
+      });
+      continue;
+    }
+
+    // Check for config drift
+    if (configDiffers(yamlConn.config, existing.config) || existing.type !== yamlConn.type) {
+      actions.push({
+        type: "update",
+        connectionName: yamlConn.name,
+        yamlEntry: yamlConn,
+        existing,
+        reason: configDiffReason(yamlConn, existing),
+      });
+    } else {
+      actions.push({
+        type: "unchanged",
+        connectionName: yamlConn.name,
+        yamlEntry: yamlConn,
+        existing,
+        reason: "No changes detected",
+      });
+    }
+  }
+
+  // Compute deletes: DB connections whose names were previously managed by YAML
+  // (i.e., names NOT in current YAML set)
+  for (const dbConn of dbConnections) {
+    if (!yamlNames.has(dbConn.name)) {
+      // Only delete connections that were known to be YAML-managed via a marker.
+      // Without a persistent marker we skip deletes to be safe (non-destructive default).
+      // Callers can pass includeDeletes=true to enable this.
+    }
+  }
+
+  return {
+    actions,
+    hasChanges: actions.some((a) => a.type !== "unchanged"),
+  };
+}
+
+/**
+ * Extended plan that includes deletions of DB connections not present in YAML.
+ * Useful when auto-apply mode with full reconciliation is desired.
+ */
+export function buildReconcilePlanWithDeletes(
+  yamlConnections: YamlConnection[],
+  dbConnections: WorkspaceConnection[],
+): ReconcilePlan {
+  const plan = buildReconcilePlan(yamlConnections, dbConnections);
+  const yamlNames = new Set(yamlConnections.map((c) => c.name));
+
+  for (const dbConn of dbConnections) {
+    if (!yamlNames.has(dbConn.name)) {
+      plan.actions.push({
+        type: "delete",
+        connectionName: dbConn.name,
+        existing: dbConn,
+        reason: "Connection exists in DB but is absent from YAML",
+      });
+    }
+  }
+
+  plan.hasChanges = plan.actions.some((a) => a.type !== "unchanged");
+  return plan;
+}
+
+/** Deep-compare config objects for reconciliation purposes. */
+function configDiffers(
+  yamlConfig: Record<string, unknown>,
+  dbConfig: Record<string, unknown>,
+): boolean {
+  return JSON.stringify(sortKeys(yamlConfig)) !== JSON.stringify(sortKeys(dbConfig));
+}
+
+function configDiffReason(yamlConn: YamlConnection, existing: WorkspaceConnection): string {
+  if (existing.type !== yamlConn.type) {
+    return `Type changed from "${existing.type}" to "${yamlConn.type}"`;
+  }
+  const yamlKeys = Object.keys(yamlConn.config);
+  const dbKeys = Object.keys(existing.config);
+  const changed = [
+    ...yamlKeys.filter((k) => JSON.stringify(yamlConn.config[k]) !== JSON.stringify(existing.config[k])),
+    ...dbKeys.filter((k) => !(k in yamlConn.config)),
+  ];
+  return `Config keys changed: ${changed.slice(0, 5).join(", ")}`;
+}
+
+function sortKeys(obj: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(obj).sort(([a], [b]) => a.localeCompare(b)),
+  );
+}
+
+// ─── Plan Application ─────────────────────────────────────────────────────────
+
+/**
+ * Apply a reconciliation plan against the database.
+ *
+ * @param plan        The plan produced by buildReconcilePlan.
+ * @param workspaceId The workspace to apply changes in.
+ * @param workspaceRoot  Filesystem root for resolving file-based secret refs.
+ * @param storage     Storage implementation.
+ * @param createdBy   User ID initiating the sync (optional).
+ */
+export async function applyReconcilePlan(
+  plan: ReconcilePlan,
+  workspaceId: string,
+  workspaceRoot: string,
+  storage: IStorage,
+  createdBy?: string | null,
+): Promise<ApplyResult> {
+  const result: ApplyResult = {
+    created: [],
+    updated: [],
+    deleted: [],
+    errors: [],
+  };
+
+  for (const action of plan.actions) {
+    if (action.type === "unchanged") continue;
+
+    try {
+      switch (action.type) {
+        case "create": {
+          const yamlEntry = action.yamlEntry!;
+          let resolvedSecrets: Record<string, string> | undefined;
+
+          if (yamlEntry.secrets && Object.keys(yamlEntry.secrets).length > 0) {
+            const resolution = await resolveConnectionSecrets(
+              yamlEntry.name,
+              yamlEntry.secrets,
+              workspaceRoot,
+            );
+            if (resolution.errors.length > 0) {
+              result.errors.push({
+                connectionName: yamlEntry.name,
+                message: resolution.errors.map((e) => `${e.secretKey}: ${e.message}`).join("; "),
+              });
+              continue;
+            }
+            resolvedSecrets = resolution.secrets;
+          }
+
+          const input: CreateWorkspaceConnectionInput = {
+            workspaceId,
+            type: yamlEntry.type,
+            name: yamlEntry.name,
+            config: yamlEntry.config,
+            ...(resolvedSecrets ? { secrets: resolvedSecrets } : {}),
+            createdBy: createdBy ?? null,
+          };
+
+          await storage.createWorkspaceConnection(input);
+          result.created.push(yamlEntry.name);
+          break;
+        }
+
+        case "update": {
+          const yamlEntry = action.yamlEntry!;
+          const existing = action.existing!;
+
+          let resolvedSecrets: Record<string, string> | null | undefined;
+
+          if (yamlEntry.secrets !== undefined) {
+            if (Object.keys(yamlEntry.secrets).length === 0) {
+              resolvedSecrets = null; // explicitly remove secrets
+            } else {
+              const resolution = await resolveConnectionSecrets(
+                yamlEntry.name,
+                yamlEntry.secrets,
+                workspaceRoot,
+              );
+              if (resolution.errors.length > 0) {
+                result.errors.push({
+                  connectionName: yamlEntry.name,
+                  message: resolution.errors.map((e) => `${e.secretKey}: ${e.message}`).join("; "),
+                });
+                continue;
+              }
+              resolvedSecrets = resolution.secrets;
+            }
+          }
+
+          const updates: UpdateWorkspaceConnectionInput = {
+            config: yamlEntry.config,
+            ...(resolvedSecrets !== undefined ? { secrets: resolvedSecrets } : {}),
+          };
+
+          await storage.updateWorkspaceConnection(existing.id, updates);
+          result.updated.push(yamlEntry.name);
+          break;
+        }
+
+        case "delete": {
+          const existing = action.existing!;
+          await storage.deleteWorkspaceConnection(existing.id);
+          result.deleted.push(action.connectionName);
+          break;
+        }
+      }
+    } catch (err: unknown) {
+      result.errors.push({
+        connectionName: action.connectionName,
+        message: (err as Error).message,
+      });
+    }
+  }
+
+  return result;
+}
+
+// ─── Drift Detection ─────────────────────────────────────────────────────────
+
+/**
+ * Detect connections whose DB config has drifted from the YAML definition.
+ *
+ * A drift occurs when a connection defined in YAML has been modified through
+ * the UI after the last YAML sync, causing the DB state to diverge.
+ *
+ * Only config (non-secret) fields are compared — secrets are never compared
+ * directly as they are stored encrypted.
+ */
+export function detectDrift(
+  yamlConnections: YamlConnection[],
+  dbConnections: WorkspaceConnection[],
+): DriftItem[] {
+  const dbByName = new Map<string, WorkspaceConnection>(
+    dbConnections.map((c) => [c.name, c]),
+  );
+
+  const driftItems: DriftItem[] = [];
+
+  for (const yamlConn of yamlConnections) {
+    const dbConn = dbByName.get(yamlConn.name);
+    if (!dbConn) continue; // not yet created — not drift
+
+    if (dbConn.type !== yamlConn.type) {
+      driftItems.push({
+        connectionId: dbConn.id,
+        connectionName: dbConn.name,
+        connectionType: dbConn.type,
+        driftedConfigKeys: ["type"],
+      });
+      continue;
+    }
+
+    const driftedKeys = findDriftedKeys(yamlConn.config, dbConn.config);
+    if (driftedKeys.length > 0) {
+      driftItems.push({
+        connectionId: dbConn.id,
+        connectionName: dbConn.name,
+        connectionType: dbConn.type,
+        driftedConfigKeys: driftedKeys,
+      });
+    }
+  }
+
+  return driftItems;
+}
+
+/** Return config keys that differ between YAML and DB config. */
+function findDriftedKeys(
+  yamlConfig: Record<string, unknown>,
+  dbConfig: Record<string, unknown>,
+): string[] {
+  const allKeys = new Set([...Object.keys(yamlConfig), ...Object.keys(dbConfig)]);
+  return [...allKeys].filter(
+    (k) => JSON.stringify(yamlConfig[k]) !== JSON.stringify(dbConfig[k]),
+  );
+}
+
+// ─── High-level workspace sync entrypoint ─────────────────────────────────────
+
+export interface ConnectionsSyncOptions {
+  /** When true, connections absent from YAML are deleted from DB. Default: false. */
+  includeDeletes?: boolean;
+  /** When true, apply the plan without user confirmation. Default: false. */
+  autoApply?: boolean;
+  /** User initiating the sync. */
+  createdBy?: string | null;
+}
+
+export interface ConnectionsSyncResult {
+  plan: ReconcilePlan;
+  applied: boolean;
+  applyResult?: ApplyResult;
+  drift: DriftItem[];
+  yamlMissing: boolean;
+}
+
+/**
+ * Full connections sync flow:
+ *  1. Load YAML
+ *  2. Load DB connections for workspace
+ *  3. Build plan
+ *  4. Detect drift
+ *  5. Apply if autoApply=true
+ *
+ * Returns a full result descriptor. The caller decides whether to apply
+ * (e.g. after showing the plan to the user in the API response).
+ */
+export async function syncConnectionsFromYaml(
+  workspaceId: string,
+  workspaceRoot: string,
+  storage: IStorage,
+  options: ConnectionsSyncOptions = {},
+): Promise<ConnectionsSyncResult> {
+  const { includeDeletes = false, autoApply = false, createdBy } = options;
+
+  const connectionsFile = await loadConnectionsYaml(workspaceRoot);
+
+  if (!connectionsFile) {
+    return {
+      plan: { actions: [], hasChanges: false },
+      applied: false,
+      drift: [],
+      yamlMissing: true,
+    };
+  }
+
+  const dbConnections = await storage.getWorkspaceConnections(workspaceId);
+
+  const plan = includeDeletes
+    ? buildReconcilePlanWithDeletes(connectionsFile.connections, dbConnections)
+    : buildReconcilePlan(connectionsFile.connections, dbConnections);
+
+  const drift = detectDrift(connectionsFile.connections, dbConnections);
+
+  if (!autoApply || !plan.hasChanges) {
+    return { plan, applied: false, drift, yamlMissing: false };
+  }
+
+  const applyResult = await applyReconcilePlan(
+    plan,
+    workspaceId,
+    workspaceRoot,
+    storage,
+    createdBy,
+  );
+
+  return { plan, applied: true, applyResult, drift, yamlMissing: false };
+}
+
+// ─── YAML Schema Validation (for CLI linter) ─────────────────────────────────
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+  connectionCount: number;
+}
+
+/**
+ * Validate a YAML string against the connections schema.
+ * Returns a structured result suitable for CLI output — never throws.
+ */
+export function validateConnectionsYaml(rawYaml: string): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // Pre-parse plaintext secret check
+  const plaintextSecret = detectPlaintextSecret(rawYaml);
+  if (plaintextSecret) {
+    errors.push(
+      `Potential plaintext secret detected in secrets block: "${plaintextSecret}". ` +
+      `Use \${env:VAR_NAME}, \${file:./path}, or \${vault:path} instead.`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(rawYaml);
+  } catch (err: unknown) {
+    errors.push(`YAML parse error: ${(err as Error).message}`);
+    return { valid: false, errors, warnings, connectionCount: 0 };
+  }
+
+  const result = ConnectionsFileSchema.safeParse(parsed);
+  if (!result.success) {
+    for (const issue of result.error.issues) {
+      const path_ = issue.path.join(".");
+      errors.push(`${path_ ? path_ + ": " : ""}${issue.message}`);
+    }
+    return { valid: errors.length === 0, errors, warnings, connectionCount: 0 };
+  }
+
+  // Warn on vault refs (not yet implemented)
+  for (const conn of result.data.connections) {
+    for (const [key, ref] of Object.entries(conn.secrets ?? {})) {
+      if (ref.startsWith("${vault:")) {
+        warnings.push(
+          `Connection "${conn.name}" secret "${key}": vault references are not yet implemented.`,
+        );
+      }
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+    connectionCount: result.data.connections.length,
+  };
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1312,3 +1312,42 @@ export const insertMcpToolCallSchema = createInsertSchema(mcpToolCalls).omit({
 
 export type InsertMcpToolCall = z.infer<typeof insertMcpToolCallSchema>;
 export type McpToolCallRow = typeof mcpToolCalls.$inferSelect;
+
+// ── Connections YAML Schema (issue #276) ─────────────────────────────────────
+//
+// Zod schemas for the .multiqlti/connections.yaml declarative config file.
+// These are re-exported from shared/schema so both the server and the CLI
+// validation script can import them without a circular dependency.
+
+const SECRET_REF_REGEX = /^\$\{(env|file|vault):([^}]+)\}$/;
+
+/**
+ * A secret value must be a reference expression — never plaintext.
+ * Accepted forms: ${env:NAME}, ${file:./path}, ${vault:secret/path}
+ */
+export const ConnectionSecretRefSchema = z
+  .string()
+  .refine(
+    (v) => SECRET_REF_REGEX.test(v),
+    (v) => ({
+      message:
+        `Plaintext secrets are not allowed in connections.yaml. ` +
+        `Use \${env:VAR}, \${file:path}, or \${vault:path}. ` +
+        `Received value starts with: "${v.slice(0, 12)}"`,
+    }),
+  );
+
+export const YamlConnectionEntrySchema = z.object({
+  name: z.string().min(1).max(200),
+  type: z.enum(CONNECTION_TYPES),
+  config: z.record(z.unknown()).default({}),
+  secrets: z.record(ConnectionSecretRefSchema).optional(),
+});
+
+export const ConnectionsYamlFileSchema = z.object({
+  version: z.literal(1),
+  connections: z.array(YamlConnectionEntrySchema).default([]),
+});
+
+export type YamlConnectionEntry = z.infer<typeof YamlConnectionEntrySchema>;
+export type ConnectionsYamlFile = z.infer<typeof ConnectionsYamlFileSchema>;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -2420,3 +2420,55 @@ export interface DeleteConnectionWithOverrideBody {
   /** Must be true to force-delete a connection that has dependents. */
   force?: boolean;
 }
+
+// ─── Connections YAML Sync Types (issue #276) ─────────────────────────────────
+
+/** Action type in a connections reconciliation plan. */
+export type ReconcileActionType = "create" | "update" | "delete" | "unchanged";
+
+/** A single planned change in the reconciliation plan. */
+export interface ReconcileAction {
+  type: ReconcileActionType;
+  connectionName: string;
+  reason: string;
+}
+
+/** Full reconciliation plan from diffing YAML against DB state. */
+export interface ConnectionsReconcilePlan {
+  actions: ReconcileAction[];
+  hasChanges: boolean;
+}
+
+/** Result of applying a reconciliation plan. */
+export interface ConnectionsApplyResult {
+  created: string[];
+  updated: string[];
+  deleted: string[];
+  errors: Array<{ connectionName: string; message: string }>;
+}
+
+/** A connection that has drifted from its YAML definition. */
+export interface ConnectionDriftItem {
+  connectionId: string;
+  connectionName: string;
+  connectionType: ConnectionType;
+  driftedConfigKeys: string[];
+}
+
+/** Full result of a connections YAML sync operation. */
+export interface ConnectionsSyncResult {
+  /** Whether the .multiqlti/connections.yaml file was absent. */
+  yamlMissing: boolean;
+  plan: ConnectionsReconcilePlan;
+  applied: boolean;
+  applyResult?: ConnectionsApplyResult;
+  drift: ConnectionDriftItem[];
+}
+
+/** Request body for POST /api/workspaces/:id/connections/sync. */
+export interface ConnectionsSyncRequest {
+  /** Auto-apply the plan without requiring a second call. Default: false. */
+  autoApply?: boolean;
+  /** Include deletions for DB connections absent from YAML. Default: false. */
+  includeDeletes?: boolean;
+}

--- a/tests/unit/connections-yaml.test.ts
+++ b/tests/unit/connections-yaml.test.ts
@@ -1,0 +1,1021 @@
+/**
+ * Tests for declarative YAML connections config (issue #276)
+ *
+ * Coverage:
+ *   - YAML parsing: valid, invalid, missing file
+ *   - Schema: version enforcement, unknown types, empty connections
+ *   - Secret reference resolution: ${env:…}, ${file:…}, ${vault:…} stub
+ *   - Plaintext secret rejection (hard error)
+ *   - Reconciliation diff: create, update, delete, unchanged
+ *   - Drift detection: UI-modified connections flagged
+ *   - Plan application: creates/updates/deletes in storage
+ *   - High-level sync: autoApply flag, missing YAML
+ *   - CLI validation helper: valid YAML, schema errors, plaintext secrets
+ *   - Edge cases: empty YAML, missing env var, path traversal in file ref
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { MemStorage } from "../../server/storage";
+import {
+  loadConnectionsYaml,
+  resolveSecretRef,
+  resolveConnectionSecrets,
+  detectPlaintextSecret,
+  buildReconcilePlan,
+  buildReconcilePlanWithDeletes,
+  detectDrift,
+  applyReconcilePlan,
+  syncConnectionsFromYaml,
+  validateConnectionsYaml,
+  CONNECTIONS_YAML_PATH,
+} from "../../server/workspace/connections-yaml";
+import type {
+  YamlConnection,
+  ReconcilePlan,
+} from "../../server/workspace/connections-yaml";
+import type { CreateWorkspaceConnectionInput } from "../../shared/types";
+import { ConnectionsYamlFileSchema, YamlConnectionEntrySchema, ConnectionSecretRefSchema } from "../../shared/schema";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeStorage(): InstanceType<typeof MemStorage> {
+  return new MemStorage();
+}
+
+function makeConnInput(
+  overrides: Partial<CreateWorkspaceConnectionInput> = {},
+): CreateWorkspaceConnectionInput {
+  return {
+    workspaceId: "ws-1",
+    type: "gitlab",
+    name: "main-gitlab",
+    config: { host: "https://gitlab.example.com", apiVersion: "v4" },
+    ...overrides,
+  };
+}
+
+function makeYamlConn(overrides: Partial<YamlConnection> = {}): YamlConnection {
+  return {
+    name: "main-gitlab",
+    type: "gitlab",
+    config: { host: "https://gitlab.example.com" },
+    ...overrides,
+  };
+}
+
+/** Write a temporary YAML file. Returns the temp dir path. */
+async function writeTempYaml(content: string, subPath = CONNECTIONS_YAML_PATH): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "multiqlti-test-"));
+  const fullPath = path.join(dir, subPath);
+  await fs.mkdir(path.dirname(fullPath), { recursive: true });
+  await fs.writeFile(fullPath, content, "utf-8");
+  return dir;
+}
+
+// ─── shared/schema Zod export tests ──────────────────────────────────────────
+
+describe("ConnectionSecretRefSchema", () => {
+  it("accepts ${env:VAR_NAME}", () => {
+    expect(() => ConnectionSecretRefSchema.parse("${env:GITLAB_TOKEN}")).not.toThrow();
+  });
+
+  it("accepts ${file:./path}", () => {
+    expect(() => ConnectionSecretRefSchema.parse("${file:./kubeconfig.yaml}")).not.toThrow();
+  });
+
+  it("accepts ${vault:secret/path}", () => {
+    expect(() => ConnectionSecretRefSchema.parse("${vault:secret/data/token}")).not.toThrow();
+  });
+
+  it("rejects a plain string", () => {
+    expect(() => ConnectionSecretRefSchema.parse("glpat-abc123")).toThrow();
+  });
+
+  it("rejects empty string", () => {
+    expect(() => ConnectionSecretRefSchema.parse("")).toThrow();
+  });
+
+  it("rejects a token-looking value", () => {
+    expect(() => ConnectionSecretRefSchema.parse("ghp_AAAAAAAAAAAAAAAA")).toThrow();
+  });
+});
+
+describe("YamlConnectionEntrySchema", () => {
+  it("accepts valid connection entry", () => {
+    const result = YamlConnectionEntrySchema.safeParse({
+      name: "my-gitlab",
+      type: "gitlab",
+      config: { host: "https://gitlab.com" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown connection type", () => {
+    const result = YamlConnectionEntrySchema.safeParse({
+      name: "test",
+      type: "unknown_type",
+      config: {},
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects plaintext secret in secrets block", () => {
+    const result = YamlConnectionEntrySchema.safeParse({
+      name: "test",
+      type: "gitlab",
+      config: {},
+      secrets: { token: "glpat-supersecrettoken" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts secret reference in secrets block", () => {
+    const result = YamlConnectionEntrySchema.safeParse({
+      name: "test",
+      type: "gitlab",
+      config: {},
+      secrets: { token: "${env:GITLAB_TOKEN}" },
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("ConnectionsYamlFileSchema", () => {
+  it("requires version: 1", () => {
+    const result = ConnectionsYamlFileSchema.safeParse({
+      version: 2,
+      connections: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("defaults connections to empty array", () => {
+    const result = ConnectionsYamlFileSchema.safeParse({ version: 1 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.connections).toEqual([]);
+    }
+  });
+});
+
+// ─── loadConnectionsYaml ─────────────────────────────────────────────────────
+
+describe("loadConnectionsYaml", () => {
+  it("returns null when file does not exist", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "multiqlti-test-"));
+    const result = await loadConnectionsYaml(dir);
+    await fs.rm(dir, { recursive: true });
+    expect(result).toBeNull();
+  });
+
+  it("parses a valid YAML file", async () => {
+    const yaml = `
+version: 1
+connections:
+  - name: main-gitlab
+    type: gitlab
+    config:
+      host: https://gitlab.example.com
+    secrets:
+      token: \${env:GITLAB_TOKEN}
+`;
+    const dir = await writeTempYaml(yaml);
+    const result = await loadConnectionsYaml(dir);
+    await fs.rm(dir, { recursive: true });
+
+    expect(result).not.toBeNull();
+    expect(result!.version).toBe(1);
+    expect(result!.connections).toHaveLength(1);
+    expect(result!.connections[0].name).toBe("main-gitlab");
+    expect(result!.connections[0].secrets?.token).toBe("${env:GITLAB_TOKEN}");
+  });
+
+  it("throws on invalid YAML syntax", async () => {
+    const dir = await writeTempYaml("version: 1\nconnections:\n  - name: [invalid");
+    await expect(loadConnectionsYaml(dir)).rejects.toThrow();
+    await fs.rm(dir, { recursive: true });
+  });
+
+  it("throws on wrong schema version", async () => {
+    const dir = await writeTempYaml("version: 2\nconnections: []");
+    await expect(loadConnectionsYaml(dir)).rejects.toThrow(/validation failed/);
+    await fs.rm(dir, { recursive: true });
+  });
+
+  it("throws when a connection has a plaintext secret", async () => {
+    const yaml = `
+version: 1
+connections:
+  - name: bad-conn
+    type: gitlab
+    config: {}
+    secrets:
+      token: glpat-supersecrettoken123456
+`;
+    const dir = await writeTempYaml(yaml);
+    await expect(loadConnectionsYaml(dir)).rejects.toThrow(/Plaintext secrets are not allowed/);
+    await fs.rm(dir, { recursive: true });
+  });
+
+  it("parses empty connections list", async () => {
+    const dir = await writeTempYaml("version: 1\nconnections: []");
+    const result = await loadConnectionsYaml(dir);
+    await fs.rm(dir, { recursive: true });
+    expect(result!.connections).toHaveLength(0);
+  });
+
+  it("throws on unknown connection type", async () => {
+    const yaml = `
+version: 1
+connections:
+  - name: bad
+    type: ftp
+    config: {}
+`;
+    const dir = await writeTempYaml(yaml);
+    await expect(loadConnectionsYaml(dir)).rejects.toThrow(/validation failed/);
+    await fs.rm(dir, { recursive: true });
+  });
+});
+
+// ─── resolveSecretRef ─────────────────────────────────────────────────────────
+
+describe("resolveSecretRef", () => {
+  it("resolves ${env:VAR} from process.env", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "test-"));
+    vi.stubEnv("TEST_SECRET_VAR_276", "my-secret-value");
+    const result = await resolveSecretRef("${env:TEST_SECRET_VAR_276}", tmpDir);
+    vi.unstubAllEnvs();
+    await fs.rm(tmpDir, { recursive: true });
+    expect(result).toBe("my-secret-value");
+  });
+
+  it("throws when env var is not set", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "test-"));
+    vi.stubEnv("UNSET_VAR_276", undefined as unknown as string);
+    // delete from env to ensure it's unset
+    delete process.env["UNSET_VAR_276"];
+    await expect(resolveSecretRef("${env:UNSET_VAR_276}", tmpDir)).rejects.toThrow(
+      /Environment variable "UNSET_VAR_276" is not set/,
+    );
+    await fs.rm(tmpDir, { recursive: true });
+  });
+
+  it("resolves ${file:./path} from workspace file", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "test-"));
+    await fs.writeFile(path.join(tmpDir, "kubeconfig.yaml"), "apiVersion: v1\n", "utf-8");
+    const result = await resolveSecretRef("${file:./kubeconfig.yaml}", tmpDir);
+    await fs.rm(tmpDir, { recursive: true });
+    expect(result).toBe("apiVersion: v1");
+  });
+
+  it("throws when file does not exist", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "test-"));
+    await expect(
+      resolveSecretRef("${file:./missing-file.yaml}", tmpDir),
+    ).rejects.toThrow(/Secret file not found/);
+    await fs.rm(tmpDir, { recursive: true });
+  });
+
+  it("throws on path traversal in file ref", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "test-"));
+    await expect(
+      resolveSecretRef("${file:../../etc/passwd}", tmpDir),
+    ).rejects.toThrow(/escape the workspace root/);
+    await fs.rm(tmpDir, { recursive: true });
+  });
+
+  it("throws a stub error for ${vault:…}", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "test-"));
+    await expect(
+      resolveSecretRef("${vault:secret/data/token}", tmpDir),
+    ).rejects.toThrow(/not yet implemented/);
+    await fs.rm(tmpDir, { recursive: true });
+  });
+
+  it("throws on an invalid reference format", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "test-"));
+    await expect(
+      resolveSecretRef("plain-string", tmpDir),
+    ).rejects.toThrow(/Invalid secret reference format/);
+    await fs.rm(tmpDir, { recursive: true });
+  });
+});
+
+// ─── resolveConnectionSecrets ─────────────────────────────────────────────────
+
+describe("resolveConnectionSecrets", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("resolves all valid refs successfully", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "test-"));
+    vi.stubEnv("MY_TOKEN_276", "token-value");
+    const result = await resolveConnectionSecrets(
+      "test-conn",
+      { token: "${env:MY_TOKEN_276}" },
+      tmpDir,
+    );
+    await fs.rm(tmpDir, { recursive: true });
+    expect(result.errors).toHaveLength(0);
+    expect(result.secrets.token).toBe("token-value");
+  });
+
+  it("collects errors for missing env vars without throwing", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "test-"));
+    delete process.env["MISSING_VAR_276"];
+    const result = await resolveConnectionSecrets(
+      "test-conn",
+      { token: "${env:MISSING_VAR_276}", apiKey: "${env:MISSING_VAR_276}" },
+      tmpDir,
+    );
+    await fs.rm(tmpDir, { recursive: true });
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0].secretKey).toBe("token");
+  });
+
+  it("returns empty secrets and no errors for empty refs", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "test-"));
+    const result = await resolveConnectionSecrets("conn", {}, tmpDir);
+    await fs.rm(tmpDir, { recursive: true });
+    expect(result.secrets).toEqual({});
+    expect(result.errors).toHaveLength(0);
+  });
+});
+
+// ─── detectPlaintextSecret ────────────────────────────────────────────────────
+
+describe("detectPlaintextSecret", () => {
+  it("returns null for YAML with no secrets block", () => {
+    const yaml = `version: 1\nconnections:\n  - name: a\n    type: gitlab\n    config: {}`;
+    expect(detectPlaintextSecret(yaml)).toBeNull();
+  });
+
+  it("returns null for YAML with reference secrets", () => {
+    const yaml = `
+version: 1
+connections:
+  - name: main-gitlab
+    type: gitlab
+    config: {}
+    secrets:
+      token: \${env:GITLAB_TOKEN}
+`;
+    expect(detectPlaintextSecret(yaml)).toBeNull();
+  });
+
+  it("detects a GitLab PAT-looking plaintext secret", () => {
+    const yaml = `
+version: 1
+connections:
+  - name: main-gitlab
+    type: gitlab
+    config: {}
+    secrets:
+      token: glpat-supersecretaccesstoken
+`;
+    const result = detectPlaintextSecret(yaml);
+    expect(result).not.toBeNull();
+    expect(result).toContain("glpat-");
+  });
+
+  it("detects a GitHub PAT-looking plaintext secret", () => {
+    const yaml = `
+version: 1
+connections:
+  - name: github-conn
+    type: github
+    config: {}
+    secrets:
+      token: ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAA
+`;
+    const result = detectPlaintextSecret(yaml);
+    expect(result).not.toBeNull();
+  });
+});
+
+// ─── buildReconcilePlan ───────────────────────────────────────────────────────
+
+describe("buildReconcilePlan", () => {
+  it("plans create for connection in YAML but not in DB", async () => {
+    const storage = makeStorage();
+    const yamlConns: YamlConnection[] = [makeYamlConn()];
+    const plan = buildReconcilePlan(yamlConns, []);
+
+    expect(plan.hasChanges).toBe(true);
+    expect(plan.actions).toHaveLength(1);
+    expect(plan.actions[0].type).toBe("create");
+    expect(plan.actions[0].connectionName).toBe("main-gitlab");
+  });
+
+  it("plans update when config differs", async () => {
+    const storage = makeStorage();
+    const conn = await storage.createWorkspaceConnection(
+      makeConnInput({ config: { host: "https://old.example.com", apiVersion: "v4" } }),
+    );
+
+    const yamlConns: YamlConnection[] = [
+      makeYamlConn({ config: { host: "https://new.example.com" } }),
+    ];
+
+    const plan = buildReconcilePlan(yamlConns, [conn]);
+    expect(plan.actions[0].type).toBe("update");
+    expect(plan.hasChanges).toBe(true);
+  });
+
+  it("plans unchanged when config is identical", async () => {
+    const storage = makeStorage();
+    const conn = await storage.createWorkspaceConnection(
+      makeConnInput({ config: { host: "https://gitlab.example.com", apiVersion: "v4" } }),
+    );
+
+    const yamlConns: YamlConnection[] = [
+      makeYamlConn({ config: { host: "https://gitlab.example.com", apiVersion: "v4" } }),
+    ];
+
+    const plan = buildReconcilePlan(yamlConns, [conn]);
+    expect(plan.actions[0].type).toBe("unchanged");
+    expect(plan.hasChanges).toBe(false);
+  });
+
+  it("does not add delete actions by default", async () => {
+    const storage = makeStorage();
+    const conn = await storage.createWorkspaceConnection(makeConnInput({ name: "old-conn" }));
+
+    const plan = buildReconcilePlan([], [conn]);
+    // Default plan does not delete — caller must use buildReconcilePlanWithDeletes
+    expect(plan.actions.filter((a) => a.type === "delete")).toHaveLength(0);
+  });
+
+  it("handles empty YAML and empty DB", () => {
+    const plan = buildReconcilePlan([], []);
+    expect(plan.hasChanges).toBe(false);
+    expect(plan.actions).toHaveLength(0);
+  });
+
+  it("handles multiple connections mixed create/update/unchanged", async () => {
+    const storage = makeStorage();
+    // existing: gitlab (unchanged) + github (needs update)
+    const existing1 = await storage.createWorkspaceConnection(
+      makeConnInput({ name: "gitlab-conn", config: { host: "https://gitlab.com", apiVersion: "v4" } }),
+    );
+    const existing2 = await storage.createWorkspaceConnection(
+      makeConnInput({ name: "github-conn", type: "github", config: { host: "https://api.github.com", owner: "old-org" } }),
+    );
+
+    const yamlConns: YamlConnection[] = [
+      { name: "gitlab-conn", type: "gitlab", config: { host: "https://gitlab.com", apiVersion: "v4" } },
+      { name: "github-conn", type: "github", config: { host: "https://api.github.com", owner: "new-org" } },
+      { name: "k8s-conn", type: "kubernetes", config: { server: "https://k8s.example.com" } },
+    ];
+
+    const plan = buildReconcilePlan(yamlConns, [existing1, existing2]);
+    expect(plan.actions).toHaveLength(3);
+
+    const types = new Map(plan.actions.map((a) => [a.connectionName, a.type]));
+    expect(types.get("gitlab-conn")).toBe("unchanged");
+    expect(types.get("github-conn")).toBe("update");
+    expect(types.get("k8s-conn")).toBe("create");
+  });
+});
+
+// ─── buildReconcilePlanWithDeletes ────────────────────────────────────────────
+
+describe("buildReconcilePlanWithDeletes", () => {
+  it("plans delete for connection in DB but not in YAML", async () => {
+    const storage = makeStorage();
+    const conn = await storage.createWorkspaceConnection(makeConnInput({ name: "old-conn" }));
+
+    const plan = buildReconcilePlanWithDeletes([], [conn]);
+    expect(plan.hasChanges).toBe(true);
+    const deleteAction = plan.actions.find((a) => a.type === "delete");
+    expect(deleteAction).toBeDefined();
+    expect(deleteAction!.connectionName).toBe("old-conn");
+  });
+});
+
+// ─── detectDrift ─────────────────────────────────────────────────────────────
+
+describe("detectDrift", () => {
+  it("returns empty array when no connections", () => {
+    expect(detectDrift([], [])).toHaveLength(0);
+  });
+
+  it("returns empty array when YAML and DB match", async () => {
+    const storage = makeStorage();
+    const conn = await storage.createWorkspaceConnection(
+      makeConnInput({ config: { host: "https://gitlab.example.com", apiVersion: "v4" } }),
+    );
+
+    const yamlConns: YamlConnection[] = [
+      makeYamlConn({ config: { host: "https://gitlab.example.com", apiVersion: "v4" } }),
+    ];
+
+    const drift = detectDrift(yamlConns, [conn]);
+    expect(drift).toHaveLength(0);
+  });
+
+  it("detects config key drift", async () => {
+    const storage = makeStorage();
+    const conn = await storage.createWorkspaceConnection(
+      makeConnInput({ config: { host: "https://gitlab.example.com", apiVersion: "v4", modified: "ui-value" } }),
+    );
+
+    const yamlConns: YamlConnection[] = [
+      makeYamlConn({ config: { host: "https://gitlab.example.com" } }),
+    ];
+
+    const drift = detectDrift(yamlConns, [conn]);
+    expect(drift).toHaveLength(1);
+    expect(drift[0].connectionName).toBe("main-gitlab");
+    expect(drift[0].driftedConfigKeys).toContain("modified");
+  });
+
+  it("detects type change as drift", async () => {
+    const storage = makeStorage();
+    const conn = await storage.createWorkspaceConnection(makeConnInput({ type: "github" }));
+
+    const yamlConns: YamlConnection[] = [
+      makeYamlConn({ type: "gitlab" }),
+    ];
+
+    const drift = detectDrift(yamlConns, [conn]);
+    expect(drift).toHaveLength(1);
+    expect(drift[0].driftedConfigKeys).toContain("type");
+  });
+
+  it("does not flag connections absent from YAML as drift", async () => {
+    const storage = makeStorage();
+    const conn = await storage.createWorkspaceConnection(makeConnInput({ name: "other-conn" }));
+
+    const drift = detectDrift([], [conn]);
+    expect(drift).toHaveLength(0);
+  });
+});
+
+// ─── applyReconcilePlan ───────────────────────────────────────────────────────
+
+describe("applyReconcilePlan", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("creates new connections from plan", async () => {
+    const storage = makeStorage();
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "test-"));
+
+    const plan: ReconcilePlan = {
+      hasChanges: true,
+      actions: [
+        {
+          type: "create",
+          connectionName: "new-conn",
+          yamlEntry: {
+            name: "new-conn",
+            type: "gitlab",
+            config: { host: "https://gitlab.com", apiVersion: "v4" },
+          },
+          reason: "New connection",
+        },
+      ],
+    };
+
+    const result = await applyReconcilePlan(plan, "ws-1", tmpDir, storage);
+    await fs.rm(tmpDir, { recursive: true });
+
+    expect(result.created).toContain("new-conn");
+    expect(result.errors).toHaveLength(0);
+
+    const connections = await storage.getWorkspaceConnections("ws-1");
+    expect(connections.some((c) => c.name === "new-conn")).toBe(true);
+  });
+
+  it("creates connection with resolved env secret", async () => {
+    const storage = makeStorage();
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "test-"));
+    vi.stubEnv("GITLAB_TOKEN_TEST_276", "my-actual-token");
+
+    const plan: ReconcilePlan = {
+      hasChanges: true,
+      actions: [
+        {
+          type: "create",
+          connectionName: "gitlab-conn",
+          yamlEntry: {
+            name: "gitlab-conn",
+            type: "gitlab",
+            config: { host: "https://gitlab.com", apiVersion: "v4" },
+            secrets: { token: "${env:GITLAB_TOKEN_TEST_276}" },
+          },
+          reason: "Create",
+        },
+      ],
+    };
+
+    const result = await applyReconcilePlan(plan, "ws-1", tmpDir, storage);
+    await fs.rm(tmpDir, { recursive: true });
+
+    expect(result.created).toContain("gitlab-conn");
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("collects errors when secret resolution fails", async () => {
+    const storage = makeStorage();
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "test-"));
+    delete process.env["MISSING_SECRET_276"];
+
+    const plan: ReconcilePlan = {
+      hasChanges: true,
+      actions: [
+        {
+          type: "create",
+          connectionName: "failing-conn",
+          yamlEntry: {
+            name: "failing-conn",
+            type: "gitlab",
+            config: { host: "https://gitlab.com", apiVersion: "v4" },
+            secrets: { token: "${env:MISSING_SECRET_276}" },
+          },
+          reason: "Create",
+        },
+      ],
+    };
+
+    const result = await applyReconcilePlan(plan, "ws-1", tmpDir, storage);
+    await fs.rm(tmpDir, { recursive: true });
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].connectionName).toBe("failing-conn");
+    expect(result.created).not.toContain("failing-conn");
+  });
+
+  it("updates existing connections from plan", async () => {
+    const storage = makeStorage();
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "test-"));
+    const conn = await storage.createWorkspaceConnection(
+      makeConnInput({ config: { host: "https://old.gitlab.com", apiVersion: "v4" } }),
+    );
+
+    const plan: ReconcilePlan = {
+      hasChanges: true,
+      actions: [
+        {
+          type: "update",
+          connectionName: "main-gitlab",
+          yamlEntry: makeYamlConn({ config: { host: "https://new.gitlab.com", apiVersion: "v4" } }),
+          existing: conn,
+          reason: "Config changed",
+        },
+      ],
+    };
+
+    const result = await applyReconcilePlan(plan, "ws-1", tmpDir, storage);
+    await fs.rm(tmpDir, { recursive: true });
+
+    expect(result.updated).toContain("main-gitlab");
+    const updated = await storage.getWorkspaceConnection(conn.id);
+    expect((updated!.config as Record<string, unknown>).host).toBe("https://new.gitlab.com");
+  });
+
+  it("deletes connections from plan", async () => {
+    const storage = makeStorage();
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "test-"));
+    const conn = await storage.createWorkspaceConnection(makeConnInput());
+
+    const plan: ReconcilePlan = {
+      hasChanges: true,
+      actions: [
+        {
+          type: "delete",
+          connectionName: "main-gitlab",
+          existing: conn,
+          reason: "Removed from YAML",
+        },
+      ],
+    };
+
+    const result = await applyReconcilePlan(plan, "ws-1", tmpDir, storage);
+    await fs.rm(tmpDir, { recursive: true });
+
+    expect(result.deleted).toContain("main-gitlab");
+    const remaining = await storage.getWorkspaceConnections("ws-1");
+    expect(remaining.find((c) => c.id === conn.id)).toBeUndefined();
+  });
+
+  it("skips unchanged actions", async () => {
+    const storage = makeStorage();
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "test-"));
+    const conn = await storage.createWorkspaceConnection(makeConnInput());
+
+    const plan: ReconcilePlan = {
+      hasChanges: false,
+      actions: [
+        {
+          type: "unchanged",
+          connectionName: "main-gitlab",
+          yamlEntry: makeYamlConn(),
+          existing: conn,
+          reason: "No changes",
+        },
+      ],
+    };
+
+    const result = await applyReconcilePlan(plan, "ws-1", tmpDir, storage);
+    await fs.rm(tmpDir, { recursive: true });
+
+    expect(result.created).toHaveLength(0);
+    expect(result.updated).toHaveLength(0);
+    expect(result.deleted).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+});
+
+// ─── syncConnectionsFromYaml ─────────────────────────────────────────────────
+
+describe("syncConnectionsFromYaml", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns yamlMissing=true when file is absent", async () => {
+    const storage = makeStorage();
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "test-"));
+    const result = await syncConnectionsFromYaml("ws-1", tmpDir, storage);
+    await fs.rm(tmpDir, { recursive: true });
+
+    expect(result.yamlMissing).toBe(true);
+    expect(result.applied).toBe(false);
+  });
+
+  it("returns plan without applying when autoApply=false", async () => {
+    const storage = makeStorage();
+    const yaml = `
+version: 1
+connections:
+  - name: main-gitlab
+    type: gitlab
+    config:
+      host: https://gitlab.example.com
+      apiVersion: v4
+`;
+    const tmpDir = await writeTempYaml(yaml);
+
+    const result = await syncConnectionsFromYaml("ws-1", tmpDir, storage, { autoApply: false });
+    await fs.rm(tmpDir, { recursive: true });
+
+    expect(result.yamlMissing).toBe(false);
+    expect(result.applied).toBe(false);
+    expect(result.plan.hasChanges).toBe(true);
+    expect(result.plan.actions[0].type).toBe("create");
+  });
+
+  it("applies plan when autoApply=true", async () => {
+    const storage = makeStorage();
+    const yaml = `
+version: 1
+connections:
+  - name: main-gitlab
+    type: gitlab
+    config:
+      host: https://gitlab.example.com
+      apiVersion: v4
+`;
+    const tmpDir = await writeTempYaml(yaml);
+
+    const result = await syncConnectionsFromYaml("ws-1", tmpDir, storage, { autoApply: true });
+    await fs.rm(tmpDir, { recursive: true });
+
+    expect(result.applied).toBe(true);
+    expect(result.applyResult?.created).toContain("main-gitlab");
+    const connections = await storage.getWorkspaceConnections("ws-1");
+    expect(connections.some((c) => c.name === "main-gitlab")).toBe(true);
+  });
+
+  it("reports drift for UI-modified connections", async () => {
+    const storage = makeStorage();
+    // Create connection via storage (simulating a past YAML apply)
+    await storage.createWorkspaceConnection(
+      makeConnInput({ config: { host: "https://gitlab.example.com", apiVersion: "v4", uiExtra: "ui-added" } }),
+    );
+
+    const yaml = `
+version: 1
+connections:
+  - name: main-gitlab
+    type: gitlab
+    config:
+      host: https://gitlab.example.com
+      apiVersion: v4
+`;
+    const tmpDir = await writeTempYaml(yaml);
+
+    const result = await syncConnectionsFromYaml("ws-1", tmpDir, storage);
+    await fs.rm(tmpDir, { recursive: true });
+
+    expect(result.drift).toHaveLength(1);
+    expect(result.drift[0].connectionName).toBe("main-gitlab");
+    expect(result.drift[0].driftedConfigKeys).toContain("uiExtra");
+  });
+
+  it("does not include deletes by default", async () => {
+    const storage = makeStorage();
+    await storage.createWorkspaceConnection(makeConnInput({ name: "legacy-conn" }));
+
+    const yaml = `version: 1\nconnections: []`;
+    const tmpDir = await writeTempYaml(yaml);
+
+    const result = await syncConnectionsFromYaml("ws-1", tmpDir, storage, { autoApply: true });
+    await fs.rm(tmpDir, { recursive: true });
+
+    // No plan changes means autoApply skips apply — applyResult is absent
+    expect(result.applyResult).toBeUndefined();
+    const remaining = await storage.getWorkspaceConnections("ws-1");
+    expect(remaining.some((c) => c.name === "legacy-conn")).toBe(true);
+  });
+
+  it("includes deletes when includeDeletes=true", async () => {
+    const storage = makeStorage();
+    await storage.createWorkspaceConnection(makeConnInput({ name: "legacy-conn" }));
+
+    const yaml = `version: 1\nconnections: []`;
+    const tmpDir = await writeTempYaml(yaml);
+
+    const result = await syncConnectionsFromYaml("ws-1", tmpDir, storage, {
+      autoApply: true,
+      includeDeletes: true,
+    });
+    await fs.rm(tmpDir, { recursive: true });
+
+    expect(result.applyResult?.deleted).toContain("legacy-conn");
+    const remaining = await storage.getWorkspaceConnections("ws-1");
+    expect(remaining.find((c) => c.name === "legacy-conn")).toBeUndefined();
+  });
+});
+
+// ─── validateConnectionsYaml (CLI linter) ────────────────────────────────────
+
+describe("validateConnectionsYaml", () => {
+  it("returns valid=true for correct YAML", () => {
+    const yaml = `
+version: 1
+connections:
+  - name: main-gitlab
+    type: gitlab
+    config:
+      host: https://gitlab.example.com
+    secrets:
+      token: \${env:GITLAB_TOKEN}
+`;
+    const result = validateConnectionsYaml(yaml);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.connectionCount).toBe(1);
+  });
+
+  it("returns valid=true for empty connections", () => {
+    const result = validateConnectionsYaml("version: 1\nconnections: []");
+    expect(result.valid).toBe(true);
+    expect(result.connectionCount).toBe(0);
+  });
+
+  it("returns valid=false for invalid YAML syntax", () => {
+    const result = validateConnectionsYaml("version: 1\nconnections:\n  - name: [unterminated");
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("YAML parse error"))).toBe(true);
+  });
+
+  it("returns valid=false for wrong version", () => {
+    const result = validateConnectionsYaml("version: 2\nconnections: []");
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it("returns valid=false for unknown connection type", () => {
+    const yaml = `
+version: 1
+connections:
+  - name: ftp-conn
+    type: ftp
+    config: {}
+`;
+    const result = validateConnectionsYaml(yaml);
+    expect(result.valid).toBe(false);
+  });
+
+  it("returns valid=false for plaintext secret", () => {
+    const yaml = `
+version: 1
+connections:
+  - name: main-gitlab
+    type: gitlab
+    config: {}
+    secrets:
+      token: glpat-supersecrettoken
+`;
+    const result = validateConnectionsYaml(yaml);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("Potential plaintext secret"))).toBe(true);
+  });
+
+  it("returns warning for vault refs (not yet implemented)", () => {
+    const yaml = `
+version: 1
+connections:
+  - name: main-gitlab
+    type: gitlab
+    config: {}
+    secrets:
+      token: \${vault:secret/data/gitlab-token}
+`;
+    const result = validateConnectionsYaml(yaml);
+    expect(result.valid).toBe(true);
+    expect(result.warnings.some((w) => w.includes("vault references are not yet implemented"))).toBe(true);
+  });
+
+  it("handles multiple connections", () => {
+    const yaml = `
+version: 1
+connections:
+  - name: gitlab-conn
+    type: gitlab
+    config:
+      host: https://gitlab.com
+  - name: k8s-conn
+    type: kubernetes
+    config:
+      server: https://k8s.example.com
+  - name: github-conn
+    type: github
+    config:
+      host: https://api.github.com
+      owner: myorg
+`;
+    const result = validateConnectionsYaml(yaml);
+    expect(result.valid).toBe(true);
+    expect(result.connectionCount).toBe(3);
+  });
+
+  it("reports multiple errors at once", () => {
+    const yaml = `
+version: 1
+connections:
+  - name: ""
+    type: ftp
+    config: {}
+`;
+    const result = validateConnectionsYaml(yaml);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});
+
+// ─── Edge cases ───────────────────────────────────────────────────────────────
+
+describe("Edge cases", () => {
+  it("handles YAML with no top-level keys gracefully", async () => {
+    const dir = await writeTempYaml("{}");
+    await expect(loadConnectionsYaml(dir)).rejects.toThrow(/validation failed/);
+    await fs.rm(dir, { recursive: true });
+  });
+
+  it("handles YAML null document", async () => {
+    const dir = await writeTempYaml("~\n");
+    await expect(loadConnectionsYaml(dir)).rejects.toThrow(/validation failed/);
+    await fs.rm(dir, { recursive: true });
+  });
+
+  it("resolveSecretRef trims file content", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "test-"));
+    await fs.writeFile(path.join(tmpDir, "token.txt"), "  my-token-value  \n", "utf-8");
+    const result = await resolveSecretRef("${file:./token.txt}", tmpDir);
+    await fs.rm(tmpDir, { recursive: true });
+    expect(result).toBe("my-token-value");
+  });
+
+  it("plan with all unchanged actions has hasChanges=false", async () => {
+    const storage = makeStorage();
+    const conn = await storage.createWorkspaceConnection(
+      makeConnInput({ config: { host: "https://gitlab.example.com", apiVersion: "v4" } }),
+    );
+    const yamlConns: YamlConnection[] = [
+      makeYamlConn({ config: { host: "https://gitlab.example.com", apiVersion: "v4" } }),
+    ];
+    const plan = buildReconcilePlan(yamlConns, [conn]);
+    expect(plan.hasChanges).toBe(false);
+  });
+
+  it("applyReconcilePlan handles empty plan gracefully", async () => {
+    const storage = makeStorage();
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "test-"));
+    const result = await applyReconcilePlan({ actions: [], hasChanges: false }, "ws-1", tmpDir, storage);
+    await fs.rm(tmpDir, { recursive: true });
+    expect(result.created).toHaveLength(0);
+    expect(result.updated).toHaveLength(0);
+    expect(result.deleted).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- `.multiqlti/connections.yaml` declarative config for workspace connections (GitOps-friendly)
- Secret references: `${env:VAR}`, `${file:./path}`, `${vault:path}` stub — **inline plaintext secrets rejected with hard error**
- Reconciliation engine: diff YAML vs DB → create/update/delete/unchanged plan → apply after confirmation or with `autoApply` flag
- Drift detection: connections modified in UI after YAML apply are flagged with diffed config keys
- `POST /api/workspaces/:id/connections/sync` API endpoint (admin only)
- `script/connections-validate.ts` CLI linter for local validation before commit

## Architecture

**`server/workspace/connections-yaml.ts`** — Core logic:
- `loadConnectionsYaml(workspaceRoot)` — parse + validate YAML
- `resolveSecretRef(ref, workspaceRoot)` — resolves `${env:}`, `${file:}`, throws stub for `${vault:}`
- `buildReconcilePlan(yaml, db)` — non-destructive diff
- `buildReconcilePlanWithDeletes(yaml, db)` — includes deletions
- `detectDrift(yaml, db)` — detects UI-modified connections
- `applyReconcilePlan(plan, ...)` — executes plan against storage
- `syncConnectionsFromYaml(workspaceId, root, storage, opts)` — high-level entrypoint
- `validateConnectionsYaml(rawYaml)` — CLI linter (never throws)

**`shared/schema.ts`** additions:
- `ConnectionSecretRefSchema` — Zod schema enforcing reference-only values
- `YamlConnectionEntrySchema`, `ConnectionsYamlFileSchema` — full YAML file schema

**`shared/types.ts`** additions:
- `ReconcileAction`, `ConnectionsReconcilePlan`, `ConnectionsApplyResult`, `ConnectionDriftItem`, `ConnectionsSyncResult`

## Test plan

- YAML parsing: valid, invalid syntax, wrong version, unknown types, empty file ✓
- Secret reference resolution: env var, file, path traversal guard, vault stub, missing ref ✓
- Plaintext secret rejection: Zod schema + pre-parse scan ✓
- Reconciliation diff: create, update, delete, unchanged ✓
- Mixed create/update/unchanged in single plan ✓
- Plan application: creates/updates/deletes in MemStorage ✓
- Secret resolution failure collected without throwing ✓
- Drift detection: key drift, type change, absent connections ✓
- CLI validation: valid YAML, parse errors, schema errors, plaintext secrets, vault warnings ✓
- Edge cases: empty YAML, null document, trimmed file content, empty plan ✓

71 new tests · 142 total test files · 3161 total tests — all pass
`npx tsc --noEmit` — 0 errors

Closes #276