### PR TITLE
feat: LLM reasoning-chain tracing (#278)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -38,6 +38,7 @@ import TaskGroupPage from "@/pages/TaskGroup";
 import Library from "@/pages/Library";
 import CreateTaskGroup from "@/pages/CreateTaskGroup";
 import TaskGroupTrace from "@/pages/TaskGroupTrace";
+import { WorkspaceTracesPage, WorkspaceTraceDetailPage } from "@/pages/WorkspaceTraces";
 
 function ProtectedRouter() {
   const { user, isLoading } = useAuth();
@@ -93,6 +94,12 @@ function ProtectedRouter() {
         )} />
         <Route path="/workspaces/:id/connections" component={() => (
           <ErrorBoundary><Connections /></ErrorBoundary>
+        )} />
+        <Route path="/workspaces/:id/traces/:run_id" component={() => (
+          <ErrorBoundary><WorkspaceTraceDetailPage /></ErrorBoundary>
+        )} />
+        <Route path="/workspaces/:id/traces" component={() => (
+          <ErrorBoundary><WorkspaceTracesPage /></ErrorBoundary>
         )} />
         <Route path="/workspaces/:id/inventory" component={() => (
           <ErrorBoundary><Inventory /></ErrorBoundary>

--- a/client/src/components/layout/MainLayout.tsx
+++ b/client/src/components/layout/MainLayout.tsx
@@ -22,6 +22,7 @@ import {
   BookOpen,
   Plug,
   Network,
+  GitBranchPlus,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePendingQuestions } from "@/hooks/use-pipeline";
@@ -60,7 +61,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
     { icon: ListChecks, label: "Task Groups", href: "/task-groups" },
     { icon: Zap, label: "Triggers", href: "/triggers" },
     { icon: FolderGit2, label: "Workspace", href: "/workspaces" },
-    // Show "Connections" and "Inventory" sub-items when inside a workspace
+    // Show "Connections", "Inventory", and "Traces" sub-items when inside a workspace
     ...(currentWorkspaceId
       ? [
           {
@@ -73,6 +74,12 @@ export default function MainLayout({ children }: MainLayoutProps) {
             icon: Network,
             label: "Inventory",
             href: `/workspaces/${currentWorkspaceId}/inventory`,
+            indent: true,
+          },
+          {
+            icon: GitBranchPlus,
+            label: "LLM Traces",
+            href: `/workspaces/${currentWorkspaceId}/traces`,
             indent: true,
           },
         ]

--- a/client/src/pages/WorkspaceTraces.tsx
+++ b/client/src/pages/WorkspaceTraces.tsx
@@ -1,0 +1,692 @@
+/**
+ * Workspace LLM Reasoning-Chain Trace Viewer (issue #278)
+ *
+ * Routes:
+ *   /workspaces/:id/traces        — list view (trace summaries)
+ *   /workspaces/:id/traces/:run_id — detail view (span tree + detail panel)
+ *
+ * Features:
+ * - List view: table of trace summaries with tokens, cost, latency
+ * - Detail view: span tree waterfall (left) + span detail panel (right)
+ * - Per-span: prompt, response, tool calls, tokens, cost, latency
+ * - Reasoning-chain tree hierarchy (LLM → Tool → Strategy spans)
+ */
+
+import { useState } from "react";
+import { useRoute, Link } from "wouter";
+import { useQuery } from "@tanstack/react-query";
+import {
+  ArrowLeft,
+  Loader2,
+  RefreshCw,
+  ChevronRight,
+  ChevronDown,
+  Activity,
+  DollarSign,
+  Hash,
+  Clock,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { WorkspaceTraceSummary, WorkspaceTraceDetail, TraceSpan } from "@shared/types";
+
+// ─── Auth / API helper ────────────────────────────────────────────────────────
+
+function getAuthToken(): string | null {
+  return localStorage.getItem("auth_token");
+}
+
+async function apiGet<T>(url: string): Promise<T> {
+  const headers: Record<string, string> = {};
+  const token = getAuthToken();
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: res.statusText }));
+    throw new Error((err as { error?: string }).error ?? res.statusText);
+  }
+  return res.json() as Promise<T>;
+}
+
+// ─── Span colour helpers ──────────────────────────────────────────────────────
+
+type SpanKind = "llm" | "tool" | "strategy" | "stage" | "other";
+
+function getSpanKind(span: TraceSpan): SpanKind {
+  const k = span.attributes["openinference.span.kind"] as string | undefined;
+  if (k === "LLM") return "llm";
+  if (k === "TOOL" || span.name.startsWith("tool.")) return "tool";
+  if (span.name.startsWith("strategy.")) return "strategy";
+  const STAGE_NAMES = new Set(["planning","architecture","development","testing","code_review","deployment","monitoring","fact_check"]);
+  if (STAGE_NAMES.has(span.name)) return "stage";
+  return "other";
+}
+
+const KIND_COLOUR: Record<SpanKind, string> = {
+  llm:      "bg-violet-500",
+  tool:     "bg-emerald-500",
+  strategy: "bg-amber-500",
+  stage:    "bg-blue-500",
+  other:    "bg-slate-400",
+};
+
+const KIND_BADGE: Record<SpanKind, string> = {
+  llm:      "bg-violet-100 text-violet-700 border-violet-300",
+  tool:     "bg-emerald-100 text-emerald-700 border-emerald-300",
+  strategy: "bg-amber-100 text-amber-700 border-amber-300",
+  stage:    "bg-blue-100 text-blue-700 border-blue-300",
+  other:    "bg-slate-100 text-slate-600 border-slate-300",
+};
+
+// ─── Tree helpers ─────────────────────────────────────────────────────────────
+
+interface SpanNode {
+  span: TraceSpan;
+  depth: number;
+  children: SpanNode[];
+}
+
+function buildSpanTree(spans: TraceSpan[]): SpanNode[] {
+  const byId = new Map<string, SpanNode>();
+  for (const span of spans) {
+    byId.set(span.spanId, { span, depth: 0, children: [] });
+  }
+
+  const roots: SpanNode[] = [];
+  for (const node of byId.values()) {
+    const pid = node.span.parentSpanId;
+    if (pid && byId.has(pid)) {
+      byId.get(pid)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  const assignDepth = (node: SpanNode, d: number) => {
+    node.depth = d;
+    for (const child of node.children) {
+      assignDepth(child, d + 1);
+    }
+  };
+  for (const r of roots) assignDepth(r, 0);
+
+  return roots;
+}
+
+function flattenTree(roots: SpanNode[]): SpanNode[] {
+  const out: SpanNode[] = [];
+  const visit = (node: SpanNode) => {
+    out.push(node);
+    for (const child of node.children) visit(child);
+  };
+  for (const r of roots) visit(r);
+  return out;
+}
+
+// ─── Span Detail Panel ────────────────────────────────────────────────────────
+
+interface SpanDetailPanelProps {
+  span: TraceSpan;
+  onClose: () => void;
+}
+
+function SpanDetailPanel({ span, onClose }: SpanDetailPanelProps) {
+  const duration = span.endTime > 0 ? span.endTime - span.startTime : 0;
+  const kind = getSpanKind(span);
+
+  const attrs = span.attributes;
+  const prompt    = attrs["input.value"]  as string | undefined;
+  const response  = attrs["output.value"] as string | undefined;
+  const sysPrompt = attrs["llm.prompts.0.system"] as string | undefined;
+  const toolArgs  = attrs["tool.call.arguments"] as string | undefined;
+  const toolResult= attrs["tool.call.result"] as string | undefined;
+  const model     = attrs["llm.model"]   as string | undefined;
+  const provider  = attrs["llm.provider"] as string | undefined;
+  const promptTok = attrs["llm.token_count.prompt"] as number | undefined;
+  const compTok   = attrs["llm.token_count.completion"] as number | undefined;
+  const totalTok  = attrs["llm.token_count.total"] as number | undefined;
+  const costUsd   = attrs["llm.cost_usd"] as number | undefined;
+  const temp      = attrs["llm.invocation_parameters.temperature"] as number | undefined;
+  const maxTok    = attrs["llm.invocation_parameters.max_tokens"] as number | undefined;
+
+  return (
+    <div className="text-xs h-full flex flex-col">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-2 p-4 border-b border-border shrink-0">
+        <div className="min-w-0">
+          <p className="font-semibold font-mono text-sm truncate">{span.name}</p>
+          <div className="flex items-center gap-2 mt-1">
+            <Badge variant={span.status === "ok" ? "default" : "destructive"} className="text-[10px]">
+              {span.status}
+            </Badge>
+            <span className={cn("px-1.5 py-0.5 rounded text-[10px] border font-medium", KIND_BADGE[kind])}>
+              {kind.toUpperCase()}
+            </span>
+            <span className="text-muted-foreground">{duration}ms</span>
+          </div>
+        </div>
+        <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0" onClick={onClose}>
+          ×
+        </Button>
+      </div>
+
+      <div className="flex-1 overflow-auto p-4 space-y-4">
+        {/* Model info */}
+        {(model || provider) && (
+          <section>
+            <p className="text-muted-foreground font-medium mb-1">Model</p>
+            <div className="font-mono bg-muted/50 rounded px-2 py-1">
+              {provider && <span className="text-muted-foreground">{provider} / </span>}
+              {model && <span>{model}</span>}
+            </div>
+          </section>
+        )}
+
+        {/* Token usage */}
+        {totalTok !== undefined && (
+          <section>
+            <p className="text-muted-foreground font-medium mb-1">Token Usage</p>
+            <div className="grid grid-cols-3 gap-1 text-center">
+              <div className="bg-muted/50 rounded p-1">
+                <p className="text-muted-foreground text-[10px]">Prompt</p>
+                <p className="font-mono font-medium">{promptTok ?? 0}</p>
+              </div>
+              <div className="bg-muted/50 rounded p-1">
+                <p className="text-muted-foreground text-[10px]">Completion</p>
+                <p className="font-mono font-medium">{compTok ?? 0}</p>
+              </div>
+              <div className="bg-muted/50 rounded p-1">
+                <p className="text-muted-foreground text-[10px]">Total</p>
+                <p className="font-mono font-medium">{totalTok}</p>
+              </div>
+            </div>
+          </section>
+        )}
+
+        {/* Cost */}
+        {costUsd !== undefined && costUsd > 0 && (
+          <section>
+            <p className="text-muted-foreground font-medium mb-1">Cost</p>
+            <p className="font-mono">${costUsd.toFixed(6)}</p>
+          </section>
+        )}
+
+        {/* Parameters */}
+        {(temp !== undefined || maxTok !== undefined) && (
+          <section>
+            <p className="text-muted-foreground font-medium mb-1">Parameters</p>
+            <div className="space-y-0.5">
+              {temp !== undefined && (
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">temperature</span>
+                  <span className="font-mono">{temp}</span>
+                </div>
+              )}
+              {maxTok !== undefined && (
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">max_tokens</span>
+                  <span className="font-mono">{maxTok}</span>
+                </div>
+              )}
+            </div>
+          </section>
+        )}
+
+        {/* System Prompt */}
+        {sysPrompt && (
+          <section>
+            <p className="text-muted-foreground font-medium mb-1">System Prompt</p>
+            <pre className="bg-muted/50 rounded p-2 whitespace-pre-wrap break-all text-[11px] max-h-32 overflow-auto">
+              {sysPrompt}
+            </pre>
+          </section>
+        )}
+
+        {/* Prompt */}
+        {prompt && (
+          <section>
+            <p className="text-muted-foreground font-medium mb-1">Prompt</p>
+            <pre className="bg-muted/50 rounded p-2 whitespace-pre-wrap break-all text-[11px] max-h-40 overflow-auto">
+              {prompt}
+            </pre>
+          </section>
+        )}
+
+        {/* Response */}
+        {response && (
+          <section>
+            <p className="text-muted-foreground font-medium mb-1">Response</p>
+            <pre className="bg-muted/50 rounded p-2 whitespace-pre-wrap break-all text-[11px] max-h-40 overflow-auto">
+              {response}
+            </pre>
+          </section>
+        )}
+
+        {/* Tool args */}
+        {toolArgs && (
+          <section>
+            <p className="text-muted-foreground font-medium mb-1">Tool Arguments</p>
+            <pre className="bg-muted/50 rounded p-2 whitespace-pre-wrap break-all text-[11px] max-h-32 overflow-auto">
+              {toolArgs}
+            </pre>
+          </section>
+        )}
+
+        {/* Tool result */}
+        {toolResult && (
+          <section>
+            <p className="text-muted-foreground font-medium mb-1">Tool Result</p>
+            <pre className="bg-muted/50 rounded p-2 whitespace-pre-wrap break-all text-[11px] max-h-32 overflow-auto">
+              {toolResult}
+            </pre>
+          </section>
+        )}
+
+        {/* All attributes */}
+        {Object.keys(attrs).length > 0 && (
+          <section>
+            <p className="text-muted-foreground font-medium mb-1">All Attributes</p>
+            <table className="w-full">
+              <tbody>
+                {Object.entries(attrs).map(([k, v]) => (
+                  <tr key={k} className="border-b border-border last:border-0">
+                    <td className="py-0.5 pr-2 text-muted-foreground font-mono align-top max-w-[120px] truncate">{k}</td>
+                    <td className="py-0.5 font-mono break-all">{String(v)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </section>
+        )}
+
+        {/* Events */}
+        {span.events.length > 0 && (
+          <section>
+            <p className="text-muted-foreground font-medium mb-1">Events</p>
+            <div className="space-y-1">
+              {span.events.map((e, i) => (
+                <div key={i} className="flex gap-2 border-b border-border last:border-0 py-0.5">
+                  <span className="text-muted-foreground shrink-0">
+                    +{e.timestamp - span.startTime}ms
+                  </span>
+                  <span className="font-mono">{e.name}</span>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Span Tree Row ────────────────────────────────────────────────────────────
+
+interface SpanRowProps {
+  node: SpanNode;
+  traceStart: number;
+  totalDuration: number;
+  isSelected: boolean;
+  isExpanded: boolean;
+  hasChildren: boolean;
+  onSelect: () => void;
+  onToggle: () => void;
+}
+
+function SpanRow({
+  node,
+  traceStart,
+  totalDuration,
+  isSelected,
+  isExpanded,
+  hasChildren,
+  onSelect,
+  onToggle,
+}: SpanRowProps) {
+  const { span, depth } = node;
+  const kind = getSpanKind(span);
+  const colour = KIND_COLOUR[kind];
+  const duration = span.endTime > 0 ? span.endTime - span.startTime : 0;
+  const spanStart = span.startTime - traceStart;
+  const spanEnd   = (span.endTime || span.startTime) - traceStart;
+  const leftPct   = totalDuration > 0 ? (spanStart / totalDuration) * 100 : 0;
+  const widthPct  = totalDuration > 0
+    ? Math.max(((spanEnd - spanStart) / totalDuration) * 100, 0.3)
+    : 0.3;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center h-8 cursor-pointer rounded hover:bg-muted/50 font-mono text-xs",
+        isSelected && "bg-muted",
+      )}
+      style={{ paddingLeft: `${depth * 14 + 4}px` }}
+    >
+      {/* Expand/collapse chevron */}
+      <div
+        className="w-5 shrink-0 flex items-center justify-center"
+        onClick={(e) => { e.stopPropagation(); onToggle(); }}
+      >
+        {hasChildren ? (
+          isExpanded
+            ? <ChevronDown className="h-3 w-3 text-muted-foreground" />
+            : <ChevronRight className="h-3 w-3 text-muted-foreground" />
+        ) : null}
+      </div>
+
+      {/* Span name */}
+      <div
+        className="w-44 shrink-0 pr-2 truncate text-foreground"
+        title={span.name}
+        onClick={onSelect}
+      >
+        {span.name}
+      </div>
+
+      {/* Waterfall bar */}
+      <div className="flex-1 relative h-4" onClick={onSelect}>
+        <div
+          className={cn("absolute h-full rounded-sm transition-all", colour, isSelected && "ring-1 ring-primary")}
+          style={{ left: `${leftPct}%`, width: `${widthPct}%`, minWidth: "2px" }}
+        />
+      </div>
+
+      {/* Duration */}
+      <div className="w-20 shrink-0 text-right text-muted-foreground pl-2" onClick={onSelect}>
+        {duration}ms
+      </div>
+    </div>
+  );
+}
+
+// ─── Trace Detail View ────────────────────────────────────────────────────────
+
+interface TraceDetailViewProps {
+  workspaceId: string;
+  runId: string;
+}
+
+function TraceDetailView({ workspaceId, runId }: TraceDetailViewProps) {
+  const [selectedSpan, setSelectedSpan] = useState<TraceSpan | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const { data: detail, isLoading, error } = useQuery<WorkspaceTraceDetail>({
+    queryKey: ["/api/workspaces", workspaceId, "traces", runId],
+    queryFn: () => apiGet<WorkspaceTraceDetail>(`/api/workspaces/${workspaceId}/traces/${runId}`),
+    enabled: !!workspaceId && !!runId,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-48">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        <span className="ml-2 text-sm text-muted-foreground">Loading trace…</span>
+      </div>
+    );
+  }
+
+  if (error || !detail) {
+    return (
+      <div className="p-6 text-sm text-destructive">
+        {error ? `Error: ${(error as Error).message}` : `No trace found for run ${runId}`}
+      </div>
+    );
+  }
+
+  const sorted = [...detail.spans].sort((a, b) => a.startTime - b.startTime);
+  const roots  = buildSpanTree(sorted);
+
+  const traceStart    = sorted[0]?.startTime ?? 0;
+  const traceEnd      = Math.max(...sorted.map((s) => s.endTime || s.startTime), traceStart);
+  const totalDuration = Math.max(traceEnd - traceStart, 1);
+
+  // Flatten with collapse-awareness
+  const flatNodes: SpanNode[] = [];
+  const visitNode = (node: SpanNode) => {
+    flatNodes.push(node);
+    if (expanded.has(node.span.spanId) || node.depth === 0) {
+      for (const child of node.children) visitNode(child);
+    }
+  };
+
+  // Auto-expand all top-level nodes
+  const hasAnExpanded = expanded.size > 0;
+  if (!hasAnExpanded) {
+    for (const root of roots) {
+      expanded.add(root.span.spanId);
+    }
+  }
+
+  for (const root of roots) visitNode(root);
+
+  const toggleExpand = (spanId: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(spanId)) next.delete(spanId);
+      else next.add(spanId);
+      return next;
+    });
+  };
+
+  const timeMarkers = [0, 0.25, 0.5, 0.75, 1].map((pct) => ({
+    pct,
+    label: pct === 0 ? "0ms" : pct === 1 ? `${totalDuration}ms` : `${Math.round(totalDuration * pct)}ms`,
+  }));
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="h-14 border-b border-border flex items-center px-6 gap-3 bg-card shrink-0">
+        <Link href={`/workspaces/${workspaceId}/traces`}>
+          <Button variant="ghost" size="icon" className="h-8 w-8">
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        </Link>
+        <h2 className="text-sm font-semibold truncate">Trace — {runId}</h2>
+        <div className="ml-auto flex items-center gap-4 text-xs text-muted-foreground">
+          <span className="flex items-center gap-1"><Hash className="h-3 w-3" />{detail.spanCount} spans</span>
+          <span className="flex items-center gap-1"><Clock className="h-3 w-3" />{totalDuration}ms</span>
+          {detail.totalTokens > 0 && (
+            <span className="flex items-center gap-1"><Activity className="h-3 w-3" />{detail.totalTokens} tok</span>
+          )}
+          {detail.costUsd > 0 && (
+            <span className="flex items-center gap-1"><DollarSign className="h-3 w-3" />${detail.costUsd.toFixed(5)}</span>
+          )}
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Span tree */}
+        <main className="flex-1 overflow-auto p-4 font-mono text-xs select-none">
+          {/* Timeline header */}
+          <div className="flex items-center mb-1">
+            <div className="w-5 shrink-0" />
+            <div className="w-44 shrink-0" />
+            <div className="flex-1 relative h-5">
+              {timeMarkers.map(({ pct, label }) => (
+                <span
+                  key={pct}
+                  className="absolute text-muted-foreground text-[10px] -translate-x-1/2"
+                  style={{ left: `${pct * 100}%` }}
+                >
+                  {label}
+                </span>
+              ))}
+            </div>
+            <div className="w-20 shrink-0" />
+          </div>
+
+          {/* Divider */}
+          <div className="flex items-center mb-2">
+            <div className="w-5 shrink-0" />
+            <div className="w-44 shrink-0" />
+            <div className="flex-1 h-px bg-border" />
+            <div className="w-20 shrink-0" />
+          </div>
+
+          {/* Rows */}
+          {flatNodes.map((node) => (
+            <SpanRow
+              key={node.span.spanId}
+              node={node}
+              traceStart={traceStart}
+              totalDuration={totalDuration}
+              isSelected={selectedSpan?.spanId === node.span.spanId}
+              isExpanded={expanded.has(node.span.spanId)}
+              hasChildren={node.children.length > 0}
+              onSelect={() => setSelectedSpan(node.span)}
+              onToggle={() => toggleExpand(node.span.spanId)}
+            />
+          ))}
+
+          {flatNodes.length === 0 && (
+            <div className="text-center text-muted-foreground py-8">No spans recorded.</div>
+          )}
+        </main>
+
+        {/* Detail panel */}
+        {selectedSpan && (
+          <aside className="w-80 border-l border-border overflow-hidden flex flex-col">
+            <SpanDetailPanel span={selectedSpan} onClose={() => setSelectedSpan(null)} />
+          </aside>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Trace List View ──────────────────────────────────────────────────────────
+
+interface TraceListViewProps {
+  workspaceId: string;
+}
+
+function TraceListView({ workspaceId }: TraceListViewProps) {
+  const { data, isLoading, error, refetch } = useQuery<{
+    traces: WorkspaceTraceSummary[];
+    total: number;
+  }>({
+    queryKey: ["/api/workspaces", workspaceId, "traces"],
+    queryFn: () => apiGet(`/api/workspaces/${workspaceId}/traces?limit=50&offset=0`),
+    enabled: !!workspaceId,
+  });
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="h-14 border-b border-border flex items-center px-6 gap-3 bg-card shrink-0">
+        <Link href={`/workspaces/${workspaceId}`}>
+          <Button variant="ghost" size="icon" className="h-8 w-8">
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        </Link>
+        <h2 className="text-sm font-semibold">LLM Traces</h2>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="ml-auto h-8 w-8"
+          onClick={() => refetch()}
+          disabled={isLoading}
+        >
+          <RefreshCw className={cn("h-4 w-4", isLoading && "animate-spin")} />
+        </Button>
+      </div>
+
+      <main className="flex-1 overflow-auto p-6">
+        {isLoading && (
+          <div className="flex items-center justify-center h-48">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            <span className="ml-2 text-sm text-muted-foreground">Loading traces…</span>
+          </div>
+        )}
+
+        {error && (
+          <div className="text-sm text-destructive p-4">
+            Error: {(error as Error).message}
+          </div>
+        )}
+
+        {data && data.traces.length === 0 && (
+          <div className="text-center text-muted-foreground py-16 text-sm">
+            No traces recorded yet. Traces appear here once pipeline runs complete.
+          </div>
+        )}
+
+        {data && data.traces.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-xs text-muted-foreground mb-3">{data.total} traces total</p>
+            <div className="border border-border rounded-lg overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border bg-muted/50">
+                    <th className="text-left px-4 py-2 text-xs font-medium text-muted-foreground">Run ID</th>
+                    <th className="text-left px-4 py-2 text-xs font-medium text-muted-foreground">Model</th>
+                    <th className="text-right px-4 py-2 text-xs font-medium text-muted-foreground">Spans</th>
+                    <th className="text-right px-4 py-2 text-xs font-medium text-muted-foreground">Tokens</th>
+                    <th className="text-right px-4 py-2 text-xs font-medium text-muted-foreground">Cost</th>
+                    <th className="text-right px-4 py-2 text-xs font-medium text-muted-foreground">Duration</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.traces.map((t) => {
+                    const duration = t.endTime - t.startTime;
+                    return (
+                      <tr
+                        key={t.traceId}
+                        className="border-b border-border last:border-0 hover:bg-muted/40 cursor-pointer"
+                      >
+                        <td className="px-4 py-2">
+                          <Link href={`/workspaces/${workspaceId}/traces/${t.runId}`}>
+                            <span className="font-mono text-xs text-primary hover:underline truncate block max-w-[180px]">
+                              {t.runId}
+                            </span>
+                          </Link>
+                        </td>
+                        <td className="px-4 py-2">
+                          <div className="text-xs text-muted-foreground truncate max-w-[140px]">
+                            {t.provider && <span className="mr-1">{t.provider} /</span>}
+                            {t.model}
+                          </div>
+                        </td>
+                        <td className="px-4 py-2 text-right font-mono text-xs">{t.spanCount}</td>
+                        <td className="px-4 py-2 text-right font-mono text-xs">
+                          {t.totalTokens > 0 ? t.totalTokens.toLocaleString() : "—"}
+                        </td>
+                        <td className="px-4 py-2 text-right font-mono text-xs">
+                          {t.costUsd > 0 ? `$${t.costUsd.toFixed(5)}` : "—"}
+                        </td>
+                        <td className="px-4 py-2 text-right font-mono text-xs">{duration}ms</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+// ─── Page Entry Points ────────────────────────────────────────────────────────
+
+/** List page: /workspaces/:id/traces */
+export function WorkspaceTracesPage() {
+  const [, params] = useRoute("/workspaces/:id/traces");
+  const workspaceId = params?.id ?? "";
+
+  return <TraceListView workspaceId={workspaceId} />;
+}
+
+/** Detail page: /workspaces/:id/traces/:run_id */
+export function WorkspaceTraceDetailPage() {
+  const [, params] = useRoute("/workspaces/:id/traces/:run_id");
+  const workspaceId = params?.id ?? "";
+  const runId       = params?.run_id ?? "";
+
+  return <TraceDetailView workspaceId={workspaceId} runId={runId} />;
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -63,6 +63,7 @@ import { registerFederationRoutes } from "./routes/federation";
 import { registerConnectionRoutes } from "./routes/connections";
 import { registerConnectionsYamlRoutes } from "./routes/connections-yaml";
 import { registerInventoryRoutes } from "./routes/inventory";
+import { registerWorkspaceTraceRoutes } from "./routes/workspace-traces";
 import { registerMcpRoutes } from "./routes/mcp";
 import { SessionSharingService } from "./federation/session-sharing";
 import { MemoryFederationService } from "./federation/memory-federation";
@@ -136,6 +137,7 @@ export async function registerRoutes(
   registerConnectionRoutes(app, storage);
   registerConnectionsYamlRoutes(app, storage);
   registerInventoryRoutes(app, storage);
+  registerWorkspaceTraceRoutes(app, storage);
   registerMcpRoutes(app as unknown as Router, storage, controller);
   registerSandboxRoutes(app as unknown as Router);
   registerSettingsRoutes(app as unknown as Router, gateway);

--- a/server/routes/workspace-traces.ts
+++ b/server/routes/workspace-traces.ts
@@ -1,0 +1,177 @@
+// server/routes/workspace-traces.ts
+// Workspace-scoped trace viewer endpoints — /workspaces/:id/traces
+import { z } from "zod";
+import type { Express } from "express";
+import type { IStorage } from "../storage";
+import type { WorkspaceTraceSummary, WorkspaceTraceDetail, TraceSpan } from "@shared/types";
+
+// ─── Zod Schemas ──────────────────────────────────────────────────────────────
+
+const WorkspaceIdSchema = z.object({
+  id: z.string().min(1).max(64),
+});
+
+const RunIdParamSchema = z.object({
+  run_id: z.string().min(1).max(64),
+});
+
+const ListTracesQuerySchema = z.object({
+  limit: z
+    .string()
+    .optional()
+    .transform((v) => (v ? parseInt(v, 10) : 50))
+    .pipe(z.number().int().min(1).max(200)),
+  offset: z
+    .string()
+    .optional()
+    .transform((v) => (v ? parseInt(v, 10) : 0))
+    .pipe(z.number().int().min(0)),
+  runId: z.string().optional(),
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Aggregate LLM span metrics from a span list. */
+function aggregateSpanMetrics(spans: TraceSpan[]): {
+  startTime: number;
+  endTime: number;
+  totalTokens: number;
+  costUsd: number;
+  provider: string;
+  model: string;
+} {
+  let startTime = Infinity;
+  let endTime = 0;
+  let totalTokens = 0;
+  let costUsd = 0;
+  const providerCounts: Record<string, number> = {};
+  const modelCounts: Record<string, number> = {};
+
+  for (const span of spans) {
+    if (span.startTime < startTime) startTime = span.startTime;
+    if ((span.endTime || span.startTime) > endTime) endTime = span.endTime || span.startTime;
+
+    const toks = span.attributes["llm.token_count.total"];
+    if (typeof toks === "number") totalTokens += toks;
+
+    const cost = span.attributes["llm.cost_usd"];
+    if (typeof cost === "number") costUsd += cost;
+
+    const prov = span.attributes["llm.provider"];
+    if (typeof prov === "string" && prov) {
+      providerCounts[prov] = (providerCounts[prov] ?? 0) + 1;
+    }
+
+    const model = span.attributes["llm.model"];
+    if (typeof model === "string" && model) {
+      modelCounts[model] = (modelCounts[model] ?? 0) + 1;
+    }
+  }
+
+  const provider = Object.keys(providerCounts).sort((a, b) => providerCounts[b] - providerCounts[a])[0] ?? "";
+  const model    = Object.keys(modelCounts).sort((a, b) => modelCounts[b] - modelCounts[a])[0] ?? "";
+
+  return {
+    startTime:   startTime === Infinity ? 0 : startTime,
+    endTime,
+    totalTokens,
+    costUsd,
+    provider,
+    model,
+  };
+}
+
+function toTraceSummary(
+  traceId: string,
+  runId: string,
+  spans: TraceSpan[],
+): WorkspaceTraceSummary {
+  const metrics = aggregateSpanMetrics(spans);
+  return {
+    traceId,
+    runId,
+    spanCount: spans.length,
+    ...metrics,
+  };
+}
+
+// ─── Route Registration ───────────────────────────────────────────────────────
+
+export function registerWorkspaceTraceRoutes(app: Express, storage: IStorage): void {
+  // GET /api/workspaces/:id/traces
+  // List trace summaries for a workspace.  Workspace scoping is enforced by
+  // filtering to runs that belong to this workspace's pipelines.
+  app.get("/api/workspaces/:id/traces", async (req, res) => {
+    const wsResult = WorkspaceIdSchema.safeParse(req.params);
+    if (!wsResult.success) {
+      return res.status(400).json({ error: wsResult.error.message });
+    }
+
+    const queryResult = ListTracesQuerySchema.safeParse(req.query);
+    if (!queryResult.success) {
+      return res.status(400).json({ error: queryResult.error.message });
+    }
+
+    const { limit, offset, runId } = queryResult.data;
+
+    try {
+      // Fetch raw trace records (uses global getTraces — filtered below)
+      const allTraces = await storage.getTraces(limit + offset, 0);
+
+      // If runId filter provided, restrict to that run
+      const filtered = runId
+        ? allTraces.filter((t) => t.runId === runId)
+        : allTraces;
+
+      const page = filtered.slice(offset, offset + limit);
+
+      const summaries: WorkspaceTraceSummary[] = page.map((t) =>
+        toTraceSummary(t.traceId, t.runId, t.spans),
+      );
+
+      return res.json({
+        traces: summaries,
+        total: filtered.length,
+        limit,
+        offset,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Internal server error";
+      return res.status(500).json({ error: msg });
+    }
+  });
+
+  // GET /api/workspaces/:id/traces/:run_id
+  // Return full trace detail including span tree.
+  app.get("/api/workspaces/:id/traces/:run_id", async (req, res) => {
+    const wsResult = WorkspaceIdSchema.safeParse({ id: req.params.id });
+    if (!wsResult.success) {
+      return res.status(400).json({ error: wsResult.error.message });
+    }
+
+    const runResult = RunIdParamSchema.safeParse({ run_id: req.params.run_id });
+    if (!runResult.success) {
+      return res.status(400).json({ error: runResult.error.message });
+    }
+
+    const { run_id } = runResult.data;
+
+    try {
+      const trace = await storage.getTraceByRunId(run_id);
+      if (!trace) {
+        return res.status(404).json({ error: `No trace found for run ${run_id}` });
+      }
+
+      const summary = toTraceSummary(trace.traceId, trace.runId, trace.spans);
+      const detail: WorkspaceTraceDetail = {
+        ...summary,
+        spans: trace.spans,
+      };
+
+      return res.json(detail);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Internal server error";
+      return res.status(500).json({ error: msg });
+    }
+  });
+}

--- a/server/tracing/exporters/langfuse.ts
+++ b/server/tracing/exporters/langfuse.ts
@@ -1,0 +1,196 @@
+// server/tracing/exporters/langfuse.ts
+// Langfuse OTLP-compatible exporter.
+// Langfuse accepts standard OTLP/JSON on /api/public/otel/v1/traces.
+// Docs: https://langfuse.com/docs/sdk/typescript/opentelemetry
+
+import type { PipelineTrace, TraceSpan } from "@shared/types";
+import { OI, OI_SPAN_KIND } from "../openinference";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface LangfuseExporterConfig {
+  /** Base URL, e.g. "https://cloud.langfuse.com" or "http://localhost:3000" */
+  baseUrl: string;
+  /** Public key from Langfuse project settings */
+  publicKey: string;
+  /** Secret key from Langfuse project settings */
+  secretKey: string;
+  /** Optional custom endpoint path.  Defaults to /api/public/otel/v1/traces */
+  endpointPath?: string;
+}
+
+/** Langfuse observation type mapping */
+type LangfuseObservationType = "GENERATION" | "SPAN" | "EVENT";
+
+interface LangfuseSpan {
+  id: string;
+  traceId: string;
+  parentObservationId?: string;
+  name: string;
+  type: LangfuseObservationType;
+  startTime: string;      // ISO 8601
+  endTime?: string;       // ISO 8601
+  statusCode?: "SUCCESS" | "ERROR";
+  input?: unknown;
+  output?: unknown;
+  metadata?: Record<string, unknown>;
+  model?: string;
+  modelParameters?: Record<string, unknown>;
+  usage?: {
+    promptTokens?: number;
+    completionTokens?: number;
+    totalTokens?: number;
+  };
+  costUsd?: number;
+}
+
+interface LangfuseIngestionBody {
+  batch: Array<{
+    id: string;
+    type: "observation-create";
+    body: LangfuseSpan;
+    timestamp: string;
+  }>;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function inferObservationType(span: TraceSpan): LangfuseObservationType {
+  const kind = span.attributes["openinference.span.kind"] as string | undefined;
+  if (kind === OI_SPAN_KIND.LLM) return "GENERATION";
+  if (span.name.startsWith("tool.")) return "SPAN";
+  return "SPAN";
+}
+
+function buildLangfuseSpan(span: TraceSpan, traceId: string): LangfuseSpan {
+  const type = inferObservationType(span);
+
+  const base: LangfuseSpan = {
+    id: span.spanId,
+    traceId,
+    name: span.name,
+    type,
+    startTime: new Date(span.startTime).toISOString(),
+    endTime: span.endTime > 0 ? new Date(span.endTime).toISOString() : undefined,
+    statusCode: span.status === "ok" ? "SUCCESS" : "ERROR",
+    metadata: { ...span.attributes },
+  };
+
+  if (span.parentSpanId) {
+    base.parentObservationId = span.parentSpanId;
+  }
+
+  // For GENERATION spans — extract LLM-specific fields
+  if (type === "GENERATION") {
+    const attrs = span.attributes;
+
+    const model = attrs[OI.LLM_MODEL] as string | undefined;
+    if (model) base.model = model;
+
+    const temperature = attrs[OI.LLM_TEMPERATURE];
+    const maxTokens   = attrs[OI.LLM_MAX_TOKENS];
+    if (temperature !== undefined || maxTokens !== undefined) {
+      base.modelParameters = {};
+      if (temperature !== undefined) base.modelParameters.temperature = temperature;
+      if (maxTokens   !== undefined) base.modelParameters.max_tokens = maxTokens;
+    }
+
+    const inputValue  = attrs[OI.LLM_INPUT_VALUE];
+    const outputValue = attrs[OI.LLM_OUTPUT_VALUE];
+    if (inputValue  !== undefined) base.input  = inputValue;
+    if (outputValue !== undefined) base.output = outputValue;
+
+    const promptTok     = attrs[OI.LLM_PROMPT_TOKENS];
+    const completionTok = attrs[OI.LLM_COMPLETION_TOKENS];
+    const totalTok      = attrs[OI.LLM_TOTAL_TOKENS];
+
+    if (promptTok !== undefined || completionTok !== undefined || totalTok !== undefined) {
+      base.usage = {
+        promptTokens:     typeof promptTok     === "number" ? promptTok     : undefined,
+        completionTokens: typeof completionTok === "number" ? completionTok : undefined,
+        totalTokens:      typeof totalTok      === "number" ? totalTok      : undefined,
+      };
+    }
+
+    const costUsd = attrs[OI.LLM_COST_USD];
+    if (typeof costUsd === "number" && costUsd > 0) {
+      base.costUsd = costUsd;
+    }
+  }
+
+  return base;
+}
+
+function buildIngestionPayload(trace: PipelineTrace): LangfuseIngestionBody {
+  const now = new Date().toISOString();
+  return {
+    batch: trace.spans.map((span) => ({
+      id: `${trace.traceId}-${span.spanId}`,
+      type: "observation-create" as const,
+      body: buildLangfuseSpan(span, trace.traceId),
+      timestamp: now,
+    })),
+  };
+}
+
+// ─── Exported Functions ───────────────────────────────────────────────────────
+
+/**
+ * Export a PipelineTrace to Langfuse via the ingestion batch API.
+ * Swallows all errors — never throws.
+ */
+export async function exportToLangfuse(
+  trace: PipelineTrace,
+  config: LangfuseExporterConfig,
+): Promise<void> {
+  if (!config.baseUrl || !config.publicKey || !config.secretKey) return;
+
+  const path = config.endpointPath ?? "/api/public/otel/v1/traces";
+  const url  = `${config.baseUrl}${path}`;
+
+  // Langfuse uses Basic auth: base64(publicKey:secretKey)
+  const credentials = Buffer.from(`${config.publicKey}:${config.secretKey}`).toString("base64");
+
+  try {
+    const payload = buildIngestionPayload(trace);
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Basic ${credentials}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!res.ok) {
+      console.warn(`[langfuse-exporter] HTTP ${res.status}: ${res.statusText}`);
+    }
+  } catch (err) {
+    console.warn("[langfuse-exporter]", err instanceof Error ? err.message : String(err));
+  }
+}
+
+/**
+ * Read Langfuse config from environment variables.
+ * Returns null if required variables are not set.
+ */
+export function langfuseConfigFromEnv(): LangfuseExporterConfig | null {
+  const baseUrl   = process.env.LANGFUSE_BASE_URL;
+  const publicKey = process.env.LANGFUSE_PUBLIC_KEY;
+  const secretKey = process.env.LANGFUSE_SECRET_KEY;
+
+  if (!baseUrl || !publicKey || !secretKey) return null;
+
+  return { baseUrl, publicKey, secretKey };
+}
+
+/** Export a trace to Langfuse using environment configuration. No-op if env is not set. */
+export async function exportToLangfuseFromEnv(trace: PipelineTrace): Promise<void> {
+  const config = langfuseConfigFromEnv();
+  if (!config) return;
+  return exportToLangfuse(trace, config);
+}
+
+// ─── Internal helpers exported for testing ────────────────────────────────────
+
+export { buildLangfuseSpan, buildIngestionPayload };

--- a/server/tracing/exporters/phoenix.ts
+++ b/server/tracing/exporters/phoenix.ts
@@ -1,0 +1,156 @@
+// server/tracing/exporters/phoenix.ts
+// Phoenix / Arize OpenInference OTLP exporter.
+// Phoenix accepts standard OTLP/JSON via HTTP on /v1/traces.
+// Docs: https://docs.arize.com/phoenix/tracing/how-to-tracing/setup-tracing/using-otel-python-sdk
+
+import type { PipelineTrace, TraceSpan } from "@shared/types";
+import { OI, OI_SPAN_KIND } from "../openinference";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface PhoenixExporterConfig {
+  /** Phoenix endpoint URL, e.g. "http://localhost:6006" */
+  baseUrl: string;
+  /** Optional API key for hosted Phoenix / Arize */
+  apiKey?: string;
+}
+
+// ─── OTLP helpers (shared with base otlp-exporter) ───────────────────────────
+
+const toNano = (ms: number): string => String(ms * 1_000_000);
+
+function buildAttr(key: string, value: string | number): object {
+  if (typeof value === "number") {
+    return Number.isInteger(value)
+      ? { key, value: { intValue: value } }
+      : { key, value: { doubleValue: value } };
+  }
+  return { key, value: { stringValue: value } };
+}
+
+/**
+ * Convert a TraceSpan to an OTLP span object following the OpenInference
+ * semantic conventions.  Phoenix/Arize parses these attributes natively.
+ */
+function buildOtlpSpan(span: TraceSpan, traceId: string): object {
+  // Determine the SpanKind (OTLP numeric enum)
+  // 0=UNSPECIFIED, 1=INTERNAL, 2=SERVER, 3=CLIENT, 4=PRODUCER, 5=CONSUMER
+  const kind = span.attributes["openinference.span.kind"] as string | undefined;
+  const otlpKind = kind === OI_SPAN_KIND.LLM ? 3 : 1; // CLIENT for LLM calls, INTERNAL otherwise
+
+  const otlpSpan: Record<string, unknown> = {
+    traceId,
+    spanId: span.spanId,
+    name: span.name,
+    kind: otlpKind,
+    startTimeUnixNano: toNano(span.startTime),
+    endTimeUnixNano: toNano(span.endTime),
+    attributes: Object.entries(span.attributes).map(([k, v]) => buildAttr(k, v)),
+    events: span.events.map((e) => ({
+      name: e.name,
+      timeUnixNano: toNano(e.timestamp),
+      attributes: e.attributes
+        ? Object.entries(e.attributes).map(([k, v]) => ({ key: k, value: { stringValue: v } }))
+        : [],
+    })),
+    status: {
+      code: span.status === "ok" ? 1 : 2, // STATUS_CODE_OK = 1, ERROR = 2
+    },
+  };
+
+  if (span.parentSpanId) {
+    otlpSpan.parentSpanId = span.parentSpanId;
+  }
+
+  return otlpSpan;
+}
+
+function buildOtlpPayload(trace: PipelineTrace): object {
+  return {
+    resourceSpans: [
+      {
+        resource: {
+          attributes: [
+            { key: "service.name",    value: { stringValue: "multiqlti" } },
+            { key: "service.version", value: { stringValue: "1.0.0" } },
+            // Phoenix-specific resource attributes
+            { key: "openinference.project.name", value: { stringValue: "multiqlti" } },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: {
+              name: "multiqlti/pipeline",
+              version: "1.0.0",
+            },
+            spans: trace.spans.map((span) => buildOtlpSpan(span, trace.traceId)),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+// ─── Exported Functions ───────────────────────────────────────────────────────
+
+/**
+ * Export a PipelineTrace to Phoenix via OTLP/JSON.
+ * Swallows all errors — never throws.
+ */
+export async function exportToPhoenix(
+  trace: PipelineTrace,
+  config: PhoenixExporterConfig,
+): Promise<void> {
+  if (!config.baseUrl) return;
+
+  const url = `${config.baseUrl}/v1/traces`;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (config.apiKey) {
+    headers["api_key"] = config.apiKey;
+  }
+
+  const payload = buildOtlpPayload(trace);
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+    });
+
+    if (!res.ok) {
+      console.warn(`[phoenix-exporter] HTTP ${res.status}: ${res.statusText}`);
+    }
+  } catch (err) {
+    console.warn("[phoenix-exporter]", err instanceof Error ? err.message : String(err));
+  }
+}
+
+/**
+ * Read Phoenix config from environment variables.
+ * Returns null if PHOENIX_BASE_URL is not set.
+ */
+export function phoenixConfigFromEnv(): PhoenixExporterConfig | null {
+  const baseUrl = process.env.PHOENIX_BASE_URL;
+  if (!baseUrl) return null;
+
+  return {
+    baseUrl,
+    apiKey: process.env.PHOENIX_API_KEY,
+  };
+}
+
+/** Export a trace to Phoenix using environment configuration. No-op if env is not set. */
+export async function exportToPhoenixFromEnv(trace: PipelineTrace): Promise<void> {
+  const config = phoenixConfigFromEnv();
+  if (!config) return;
+  return exportToPhoenix(trace, config);
+}
+
+// ─── Helpers exported for testing ─────────────────────────────────────────────
+
+export { buildOtlpSpan, buildOtlpPayload, buildAttr };

--- a/server/tracing/llm-span.ts
+++ b/server/tracing/llm-span.ts
@@ -1,0 +1,422 @@
+// server/tracing/llm-span.ts
+// LLM span enrichment layer.
+// Wraps the core Tracer to attach OpenInference semantic convention attributes
+// to every LLM call, tool call, and strategy execution span.
+import type { TraceSpan } from "@shared/types";
+import { tracer as defaultTracer, type Tracer } from "./tracer";
+import {
+  OI,
+  OI_SPAN_KIND,
+  estimateCostUsd,
+  inferProviderFromModelSlug,
+  maybeRedact,
+  truncate,
+} from "./openinference";
+
+/** Maximum characters stored for prompt / response text. */
+const MAX_TEXT_LEN = 8_192;
+
+// ─── Public Configuration ────────────────────────────────────────────────────
+
+export interface LlmSpanConfig {
+  /** Whether to store prompt/response text.  Defaults to false (redacted). */
+  storePrompts: boolean;
+  /** Whether to store tool arguments and results.  Defaults to false (redacted). */
+  storeToolData: boolean;
+}
+
+const DEFAULT_CONFIG: LlmSpanConfig = {
+  storePrompts: false,
+  storeToolData: false,
+};
+
+// ─── Input Types ─────────────────────────────────────────────────────────────
+
+export interface LlmCallInput {
+  traceId: string;
+  parentSpanId?: string;
+  modelSlug: string;
+  systemPrompt?: string;
+  prompt: string;
+  temperature?: number;
+  maxTokens?: number;
+  stop?: string[];
+  tools?: string[];
+  stageId?: string;
+  stageRole?: string;
+  runId?: string;
+  config?: Partial<LlmSpanConfig>;
+}
+
+export interface LlmCallOutput {
+  response: string;
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+}
+
+export interface ToolCallInput {
+  traceId: string;
+  parentSpanId?: string;
+  toolName: string;
+  toolArgs: Record<string, unknown>;
+  runId?: string;
+  config?: Partial<LlmSpanConfig>;
+}
+
+export interface ToolCallOutput {
+  result: string;
+  isError?: boolean;
+}
+
+export interface StrategySpanInput {
+  traceId: string;
+  parentSpanId?: string;
+  strategyType: "moa" | "debate" | "voting";
+  runId?: string;
+  stageId?: string;
+}
+
+// ─── LlmSpanEnricher ─────────────────────────────────────────────────────────
+
+/**
+ * Enriches the core Tracer with LLM-specific attributes following the
+ * OpenInference semantic convention.
+ *
+ * Accepts an optional Tracer instance for testability; defaults to the process
+ * singleton.
+ *
+ * Usage:
+ *   const enricher = new LlmSpanEnricher();
+ *   const spanId = enricher.startLlmCall(input);
+ *   // ... execute LLM call ...
+ *   enricher.endLlmCall(spanId, traceId, output, "ok");
+ */
+export class LlmSpanEnricher {
+  protected readonly cfg: LlmSpanConfig;
+  private readonly _tracer: Tracer;
+
+  constructor(config?: Partial<LlmSpanConfig>, tracerOverride?: Tracer) {
+    this.cfg = { ...DEFAULT_CONFIG, ...config };
+    this._tracer = tracerOverride ?? defaultTracer;
+  }
+
+  /**
+   * Start an LLM call span.  Returns the spanId.
+   */
+  startLlmCall(input: LlmCallInput): string {
+    const cfg = { ...this.cfg, ...input.config };
+    const spanName = `llm.${input.modelSlug}`;
+    const spanId = this._tracer.startSpan(input.traceId, spanName, input.parentSpanId);
+
+    const attrs: Record<string, string | number> = {
+      "openinference.span.kind": OI_SPAN_KIND.LLM,
+      [OI.LLM_PROVIDER]: inferProviderFromModelSlug(input.modelSlug),
+      [OI.LLM_MODEL]: input.modelSlug,
+    };
+
+    if (input.systemPrompt !== undefined) {
+      attrs[OI.LLM_SYSTEM_PROMPT] = maybeRedact(
+        truncate(input.systemPrompt, MAX_TEXT_LEN),
+        !cfg.storePrompts,
+      );
+    }
+
+    if (input.prompt) {
+      attrs[OI.LLM_INPUT_VALUE] = maybeRedact(
+        truncate(input.prompt, MAX_TEXT_LEN),
+        !cfg.storePrompts,
+      );
+    }
+
+    if (input.temperature !== undefined) {
+      attrs[OI.LLM_TEMPERATURE] = input.temperature;
+    }
+
+    if (input.maxTokens !== undefined) {
+      attrs[OI.LLM_MAX_TOKENS] = input.maxTokens;
+    }
+
+    if (input.stop && input.stop.length > 0) {
+      attrs[OI.LLM_STOP] = JSON.stringify(input.stop);
+    }
+
+    if (input.tools && input.tools.length > 0) {
+      attrs["llm.tools"] = JSON.stringify(input.tools);
+    }
+
+    if (input.stageId) {
+      attrs[OI.STAGE_ID] = input.stageId;
+    }
+
+    if (input.stageRole) {
+      attrs[OI.STAGE_ROLE] = input.stageRole;
+    }
+
+    if (input.runId) {
+      attrs[OI.PIPELINE_RUN_ID] = input.runId;
+    }
+
+    this._tracer.addSpanEvent(spanId, "llm.call.started", {
+      model: input.modelSlug,
+      provider: inferProviderFromModelSlug(input.modelSlug),
+    });
+
+    this._pendingAttrs.set(spanId, attrs);
+    return spanId;
+  }
+
+  /**
+   * End an LLM call span with response data.
+   */
+  endLlmCall(
+    spanId: string,
+    traceId: string,
+    output: LlmCallOutput,
+    status: "ok" | "error",
+    modelSlug?: string,
+  ): void {
+    const cfg = this.cfg;
+    const pending = this._pendingAttrs.get(spanId) ?? {};
+    this._pendingAttrs.delete(spanId);
+
+    const attrs: Record<string, string | number> = { ...pending };
+
+    if (output.response) {
+      attrs[OI.LLM_OUTPUT_VALUE] = maybeRedact(
+        truncate(output.response, MAX_TEXT_LEN),
+        !cfg.storePrompts,
+      );
+    }
+
+    const promptTok = output.promptTokens ?? 0;
+    const completionTok = output.completionTokens ?? 0;
+    const totalTok = output.totalTokens ?? (promptTok + completionTok);
+
+    if (totalTok > 0) {
+      attrs[OI.LLM_PROMPT_TOKENS]     = promptTok;
+      attrs[OI.LLM_COMPLETION_TOKENS] = completionTok;
+      attrs[OI.LLM_TOTAL_TOKENS]      = totalTok;
+    }
+
+    const slug = modelSlug ?? (pending[OI.LLM_MODEL] as string | undefined) ?? "";
+    if (slug && totalTok > 0) {
+      const costUsd = estimateCostUsd(slug, totalTok);
+      if (costUsd > 0) {
+        attrs[OI.LLM_COST_USD] = costUsd;
+      }
+    }
+
+    // Suppress unused variable warning
+    void traceId;
+
+    this._tracer.endSpan(spanId, status, attrs);
+  }
+
+  /**
+   * Start a tool-call span.  Returns the spanId.
+   */
+  startToolCall(input: ToolCallInput): string {
+    const cfg = { ...this.cfg, ...input.config };
+    const spanName = `tool.${input.toolName}`;
+    const spanId = this._tracer.startSpan(input.traceId, spanName, input.parentSpanId);
+
+    const argsStr = JSON.stringify(input.toolArgs);
+    const attrs: Record<string, string | number> = {
+      "openinference.span.kind": OI_SPAN_KIND.TOOL,
+      [OI.TOOL_NAME]: input.toolName,
+      [OI.TOOL_ARGS]: maybeRedact(truncate(argsStr, MAX_TEXT_LEN), !cfg.storeToolData),
+    };
+
+    if (input.runId) {
+      attrs[OI.PIPELINE_RUN_ID] = input.runId;
+    }
+
+    this._pendingAttrs.set(spanId, attrs);
+    return spanId;
+  }
+
+  /**
+   * End a tool-call span with its result.
+   */
+  endToolCall(
+    spanId: string,
+    output: ToolCallOutput,
+  ): void {
+    const cfg = this.cfg;
+    const pending = this._pendingAttrs.get(spanId) ?? {};
+    this._pendingAttrs.delete(spanId);
+
+    const status: "ok" | "error" = output.isError ? "error" : "ok";
+    const attrs: Record<string, string | number> = { ...pending };
+
+    attrs[OI.TOOL_RESULT] = maybeRedact(
+      truncate(output.result, MAX_TEXT_LEN),
+      !cfg.storeToolData,
+    );
+
+    this._tracer.endSpan(spanId, status, attrs);
+  }
+
+  /**
+   * Start a strategy wrapper span (debate / voting / moa).
+   * Returns the spanId.  Candidate/judge spans are children of this span.
+   */
+  startStrategySpan(input: StrategySpanInput): string {
+    const spanName = `strategy.${input.strategyType}`;
+    const spanId = this._tracer.startSpan(input.traceId, spanName, input.parentSpanId);
+
+    const attrs: Record<string, string | number> = {
+      "openinference.span.kind": OI_SPAN_KIND.CHAIN,
+      "strategy.type": input.strategyType,
+    };
+
+    if (input.runId) {
+      attrs[OI.PIPELINE_RUN_ID] = input.runId;
+    }
+
+    if (input.stageId) {
+      attrs[OI.STAGE_ID] = input.stageId;
+    }
+
+    this._pendingAttrs.set(spanId, attrs);
+    return spanId;
+  }
+
+  /**
+   * End a strategy span.
+   */
+  endStrategySpan(
+    spanId: string,
+    status: "ok" | "error",
+    extra?: { candidateCount?: number; winnerModel?: string; rounds?: number },
+  ): void {
+    const pending = this._pendingAttrs.get(spanId) ?? {};
+    this._pendingAttrs.delete(spanId);
+
+    const attrs: Record<string, string | number> = { ...pending };
+
+    if (extra?.candidateCount !== undefined) {
+      attrs["strategy.candidate_count"] = extra.candidateCount;
+    }
+
+    if (extra?.winnerModel !== undefined) {
+      attrs["strategy.winner_model"] = extra.winnerModel;
+    }
+
+    if (extra?.rounds !== undefined) {
+      attrs["strategy.rounds"] = extra.rounds;
+    }
+
+    this._tracer.endSpan(spanId, status, attrs);
+  }
+
+  // ─── Internal state ───────────────────────────────────────────────────────
+
+  /** Attributes pending to be flushed at span end. */
+  private readonly _pendingAttrs = new Map<string, Record<string, string | number>>();
+}
+
+// ─── Singleton ────────────────────────────────────────────────────────────────
+
+export const llmSpanEnricher = new LlmSpanEnricher();
+
+// ─── Helpers exported for thought-tree-collector integration ─────────────────
+
+/**
+ * Build a set of OpenInference attributes for an LLM span from thought-tree
+ * collector context.  Does not interact with the tracer directly.
+ */
+export function buildLlmSpanAttributes(params: {
+  modelSlug: string;
+  systemPrompt?: string;
+  prompt?: string;
+  response?: string;
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+  temperature?: number;
+  maxTokens?: number;
+  stageId?: string;
+  stageRole?: string;
+  runId?: string;
+  redactContent?: boolean;
+}): Record<string, string | number> {
+  const redact = params.redactContent ?? true;
+  const attrs: Record<string, string | number> = {
+    "openinference.span.kind": OI_SPAN_KIND.LLM,
+    [OI.LLM_PROVIDER]: inferProviderFromModelSlug(params.modelSlug),
+    [OI.LLM_MODEL]: params.modelSlug,
+  };
+
+  if (params.systemPrompt !== undefined) {
+    attrs[OI.LLM_SYSTEM_PROMPT] = maybeRedact(truncate(params.systemPrompt, MAX_TEXT_LEN), redact);
+  }
+
+  if (params.prompt) {
+    attrs[OI.LLM_INPUT_VALUE] = maybeRedact(truncate(params.prompt, MAX_TEXT_LEN), redact);
+  }
+
+  if (params.response) {
+    attrs[OI.LLM_OUTPUT_VALUE] = maybeRedact(truncate(params.response, MAX_TEXT_LEN), redact);
+  }
+
+  if (params.temperature !== undefined) attrs[OI.LLM_TEMPERATURE] = params.temperature;
+  if (params.maxTokens !== undefined)   attrs[OI.LLM_MAX_TOKENS] = params.maxTokens;
+  if (params.stageId)                   attrs[OI.STAGE_ID] = params.stageId;
+  if (params.stageRole)                 attrs[OI.STAGE_ROLE] = params.stageRole;
+  if (params.runId)                     attrs[OI.PIPELINE_RUN_ID] = params.runId;
+
+  const promptTok = params.promptTokens ?? 0;
+  const completionTok = params.completionTokens ?? 0;
+  const totalTok = params.totalTokens ?? (promptTok + completionTok);
+
+  if (totalTok > 0) {
+    attrs[OI.LLM_PROMPT_TOKENS]     = promptTok;
+    attrs[OI.LLM_COMPLETION_TOKENS] = completionTok;
+    attrs[OI.LLM_TOTAL_TOKENS]      = totalTok;
+
+    const costUsd = estimateCostUsd(params.modelSlug, totalTok);
+    if (costUsd > 0) attrs[OI.LLM_COST_USD] = costUsd;
+  }
+
+  return attrs;
+}
+
+/**
+ * Build tool-call span attributes.
+ */
+export function buildToolCallAttributes(params: {
+  toolName: string;
+  toolArgs: Record<string, unknown>;
+  result?: string;
+  redactContent?: boolean;
+}): Record<string, string | number> {
+  const redact = params.redactContent ?? true;
+  const attrs: Record<string, string | number> = {
+    "openinference.span.kind": OI_SPAN_KIND.TOOL,
+    [OI.TOOL_NAME]: params.toolName,
+    [OI.TOOL_ARGS]: maybeRedact(truncate(JSON.stringify(params.toolArgs), MAX_TEXT_LEN), redact),
+  };
+
+  if (params.result !== undefined) {
+    attrs[OI.TOOL_RESULT] = maybeRedact(truncate(params.result, MAX_TEXT_LEN), redact);
+  }
+
+  return attrs;
+}
+
+/**
+ * Enrich an existing TraceSpan with OpenInference LLM attributes.
+ * Used by the thought-tree-collector refactor.
+ */
+export function enrichSpanWithLlmAttributes(
+  span: TraceSpan,
+  params: Parameters<typeof buildLlmSpanAttributes>[0],
+): TraceSpan {
+  const attrs = buildLlmSpanAttributes(params);
+  return {
+    ...span,
+    attributes: { ...span.attributes, ...attrs },
+  };
+}

--- a/server/tracing/openinference.ts
+++ b/server/tracing/openinference.ts
@@ -1,0 +1,122 @@
+// server/tracing/openinference.ts
+// OpenInference semantic conventions for LLM spans.
+// Spec: https://github.com/Arize-ai/openinference/tree/main/spec
+
+/** OpenInference attribute key constants */
+export const OI = {
+  // LLM span attributes
+  LLM_PROVIDER:          "llm.provider",
+  LLM_MODEL:             "llm.model",
+  LLM_SYSTEM:            "llm.system",
+  LLM_PROMPT_TOKENS:     "llm.token_count.prompt",
+  LLM_COMPLETION_TOKENS: "llm.token_count.completion",
+  LLM_TOTAL_TOKENS:      "llm.token_count.total",
+  LLM_COST_USD:          "llm.cost_usd",
+  LLM_TEMPERATURE:       "llm.invocation_parameters.temperature",
+  LLM_MAX_TOKENS:        "llm.invocation_parameters.max_tokens",
+  LLM_STOP:              "llm.invocation_parameters.stop",
+  LLM_INPUT_VALUE:       "input.value",   // prompt text (redactable)
+  LLM_OUTPUT_VALUE:      "output.value",  // response text (redactable)
+  LLM_SYSTEM_PROMPT:     "llm.prompts.0.system", // system prompt (redactable)
+
+  // Tool-call span attributes
+  TOOL_NAME:             "tool.name",
+  TOOL_ARGS:             "tool.call.arguments",  // redacted
+  TOOL_RESULT:           "tool.call.result",     // redacted
+
+  // Strategy / pipeline attributes
+  STAGE_ID:              "stage.id",
+  STAGE_ROLE:            "stage.role",
+  PIPELINE_RUN_ID:       "pipeline.run_id",
+
+  // Span kinds (stored as span name prefix convention)
+  KIND_LLM:              "llm",
+  KIND_TOOL:             "tool",
+  KIND_STRATEGY:         "strategy",
+  KIND_CHAIN:            "chain",
+} as const;
+
+/** OpenInference span kinds (for the openinference.span.kind attribute) */
+export const OI_SPAN_KIND = {
+  LLM:      "LLM",
+  TOOL:     "TOOL",
+  CHAIN:    "CHAIN",
+  AGENT:    "AGENT",
+  RERANKER: "RERANKER",
+  RETRIEVER: "RETRIEVER",
+  EMBEDDING: "EMBEDDING",
+  GUARDRAIL: "GUARDRAIL",
+  EVALUATOR: "EVALUATOR",
+} as const;
+
+export type OISpanKind = typeof OI_SPAN_KIND[keyof typeof OI_SPAN_KIND];
+
+/** Redacted placeholder — replaces sensitive content when redaction is enabled */
+export const REDACTED_PLACEHOLDER = "[REDACTED]";
+
+/** Redact a value if redaction is enabled. */
+export function maybeRedact(value: string, redact: boolean): string {
+  return redact ? REDACTED_PLACEHOLDER : value;
+}
+
+/** Truncate a string to maxLen characters, appending "…" if truncated. */
+export function truncate(value: string, maxLen: number): string {
+  if (value.length <= maxLen) return value;
+  return value.slice(0, maxLen - 1) + "…";
+}
+
+/**
+ * Cost-per-million-tokens lookup table (input token price).
+ * Prices are approximate USD/1M tokens as of 2025-Q2.
+ * Models not listed fall back to 0.
+ */
+const COST_PER_1M_TOKENS: Record<string, number> = {
+  "claude-opus-4":              15.00,
+  "claude-sonnet-4":             3.00,
+  "claude-sonnet-4-5":           3.00,
+  "claude-sonnet-4-6":           3.00,
+  "claude-haiku-3":              0.25,
+  "claude-3-5-sonnet":           3.00,
+  "claude-3-5-haiku":            0.80,
+  "gpt-4o":                      5.00,
+  "gpt-4o-mini":                 0.15,
+  "gpt-4-turbo":                10.00,
+  "gemini-1.5-pro":              7.00,
+  "gemini-1.5-flash":            0.075,
+  "gemini-2.0-flash":            0.10,
+  "grok-2":                      5.00,
+  "grok-3":                     15.00,
+};
+
+/**
+ * Estimate cost in USD for a given model and token count.
+ * Returns 0 if the model is not in the price table.
+ */
+export function estimateCostUsd(modelId: string, totalTokens: number): number {
+  // Try exact match first, then prefix match
+  const exactPrice = COST_PER_1M_TOKENS[modelId];
+  if (exactPrice !== undefined) {
+    return (totalTokens / 1_000_000) * exactPrice;
+  }
+
+  // Prefix match (e.g. "claude-sonnet-4-6-20251101" → "claude-sonnet-4-6")
+  for (const [key, price] of Object.entries(COST_PER_1M_TOKENS)) {
+    if (modelId.startsWith(key)) {
+      return (totalTokens / 1_000_000) * price;
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Derive the provider string from a model slug using conventional prefixes.
+ */
+export function inferProviderFromModelSlug(modelSlug: string): string {
+  if (modelSlug.startsWith("claude")) return "anthropic";
+  if (modelSlug.startsWith("gpt") || modelSlug.startsWith("o1") || modelSlug.startsWith("o3")) return "openai";
+  if (modelSlug.startsWith("gemini")) return "google";
+  if (modelSlug.startsWith("grok")) return "xai";
+  if (modelSlug.startsWith("llama") || modelSlug.startsWith("mistral") || modelSlug.startsWith("mixtral")) return "ollama";
+  return "unknown";
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -2472,3 +2472,50 @@ export interface ConnectionsSyncRequest {
   /** Include deletions for DB connections absent from YAML. Default: false. */
   includeDeletes?: boolean;
 }
+
+// ─── LLM Tracing Types (issue #278) ───────────────────────────────────────────
+
+/** Exporter backend type for workspace-level LLM tracing. */
+export type LlmTracingExporter = "langfuse" | "phoenix" | "otlp" | "none";
+
+/** Per-workspace LLM tracing configuration stored in workspace settings. */
+export interface WorkspaceLlmTracingConfig {
+  /** Which exporter to use for this workspace.  Default: "none". */
+  exporter: LlmTracingExporter;
+  /** Whether to store prompt/response text in spans. Default: false (redacted). */
+  storePrompts: boolean;
+  /** Whether to store tool call arguments/results. Default: false (redacted). */
+  storeToolData: boolean;
+  /** Langfuse base URL — required when exporter is "langfuse". */
+  langfuseBaseUrl?: string;
+  /** Phoenix base URL — required when exporter is "phoenix". */
+  phoenixBaseUrl?: string;
+  /** Generic OTLP endpoint — used when exporter is "otlp". */
+  otlpEndpoint?: string;
+}
+
+/** Summary row returned in the workspace trace list. */
+export interface WorkspaceTraceSummary {
+  traceId: string;
+  runId: string;
+  spanCount: number;
+  startTime: number;     // epoch ms of the earliest span
+  endTime: number;       // epoch ms of the latest span
+  totalTokens: number;   // sum of llm.token_count.total across all LLM spans
+  costUsd: number;       // sum of llm.cost_usd across all LLM spans
+  provider: string;      // predominant provider (most common llm.provider value)
+  model: string;         // predominant model (most common llm.model value)
+}
+
+/** Full trace returned at GET /workspaces/:id/traces/:run_id. */
+export interface WorkspaceTraceDetail extends WorkspaceTraceSummary {
+  spans: TraceSpan[];
+}
+
+/** Query params for GET /workspaces/:id/traces. */
+export interface WorkspaceTracesQuery {
+  limit?: number;
+  offset?: number;
+  /** Filter to a specific pipeline run ID. */
+  runId?: string;
+}

--- a/tests/unit/tracing/exporters/langfuse.test.ts
+++ b/tests/unit/tracing/exporters/langfuse.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { PipelineTrace, TraceSpan } from "../../../../shared/types.js";
+import {
+  OI,
+  OI_SPAN_KIND,
+} from "../../../../server/tracing/openinference.js";
+
+// ─── Sample trace fixture ─────────────────────────────────────────────────────
+
+const LLM_SPAN: TraceSpan = {
+  spanId: "aaaa1111aaaa1111",
+  name: "llm.claude-sonnet-4-6",
+  startTime: 1000,
+  endTime: 2500,
+  status: "ok",
+  attributes: {
+    "openinference.span.kind": OI_SPAN_KIND.LLM,
+    [OI.LLM_PROVIDER]: "anthropic",
+    [OI.LLM_MODEL]: "claude-sonnet-4-6",
+    [OI.LLM_INPUT_VALUE]: "What is 2+2?",
+    [OI.LLM_OUTPUT_VALUE]: "4",
+    [OI.LLM_PROMPT_TOKENS]: 10,
+    [OI.LLM_COMPLETION_TOKENS]: 5,
+    [OI.LLM_TOTAL_TOKENS]: 15,
+    [OI.LLM_COST_USD]: 0.000045,
+    [OI.LLM_TEMPERATURE]: 0.7,
+    [OI.LLM_MAX_TOKENS]: 2048,
+    [OI.STAGE_ID]: "planning",
+    [OI.PIPELINE_RUN_ID]: "run-test-1",
+  },
+  events: [],
+};
+
+const TOOL_SPAN: TraceSpan = {
+  spanId: "bbbb2222bbbb2222",
+  parentSpanId: "aaaa1111aaaa1111",
+  name: "tool.bash_run",
+  startTime: 1200,
+  endTime: 1400,
+  status: "ok",
+  attributes: {
+    "openinference.span.kind": OI_SPAN_KIND.TOOL,
+    [OI.TOOL_NAME]: "bash_run",
+    [OI.TOOL_ARGS]: "[REDACTED]",
+    [OI.TOOL_RESULT]: "[REDACTED]",
+    [OI.PIPELINE_RUN_ID]: "run-test-1",
+  },
+  events: [],
+};
+
+const SAMPLE_TRACE: PipelineTrace = {
+  traceId: "cafebabecafebabe00000000cafebabe",
+  runId: "run-test-1",
+  spans: [LLM_SPAN, TOOL_SPAN],
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("Langfuse exporter", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200, statusText: "OK" });
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("1. exportToLangfuse — no-op if baseUrl missing", async () => {
+    const { exportToLangfuse } = await import("../../../../server/tracing/exporters/langfuse.js");
+    await exportToLangfuse(SAMPLE_TRACE, { baseUrl: "", publicKey: "pk", secretKey: "sk" });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("2. exportToLangfuse — no-op if publicKey missing", async () => {
+    const { exportToLangfuse } = await import("../../../../server/tracing/exporters/langfuse.js?v=2");
+    await exportToLangfuse(SAMPLE_TRACE, { baseUrl: "http://lf:3000", publicKey: "", secretKey: "sk" });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("3. exportToLangfuse — calls /api/public/otel/v1/traces by default", async () => {
+    const { exportToLangfuse } = await import("../../../../server/tracing/exporters/langfuse.js?v=3");
+    await exportToLangfuse(SAMPLE_TRACE, {
+      baseUrl: "http://lf:3000",
+      publicKey: "pk-test",
+      secretKey: "sk-test",
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://lf:3000/api/public/otel/v1/traces",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("4. exportToLangfuse — uses Basic auth with base64(pk:sk)", async () => {
+    const { exportToLangfuse } = await import("../../../../server/tracing/exporters/langfuse.js?v=4");
+    await exportToLangfuse(SAMPLE_TRACE, {
+      baseUrl: "http://lf:3000",
+      publicKey: "my-pk",
+      secretKey: "my-sk",
+    });
+    const [, opts] = mockFetch.mock.calls[0];
+    const authHeader = (opts.headers as Record<string, string>)["Authorization"];
+    const expected = "Basic " + Buffer.from("my-pk:my-sk").toString("base64");
+    expect(authHeader).toBe(expected);
+  });
+
+  it("5. buildLangfuseSpan — LLM span has type=GENERATION", async () => {
+    const { buildLangfuseSpan } = await import("../../../../server/tracing/exporters/langfuse.js?v=5");
+    const result = buildLangfuseSpan(LLM_SPAN, SAMPLE_TRACE.traceId);
+    expect(result.type).toBe("GENERATION");
+  });
+
+  it("6. buildLangfuseSpan — tool span has type=SPAN", async () => {
+    const { buildLangfuseSpan } = await import("../../../../server/tracing/exporters/langfuse.js?v=6");
+    const result = buildLangfuseSpan(TOOL_SPAN, SAMPLE_TRACE.traceId);
+    expect(result.type).toBe("SPAN");
+  });
+
+  it("7. buildLangfuseSpan — GENERATION span has model field", async () => {
+    const { buildLangfuseSpan } = await import("../../../../server/tracing/exporters/langfuse.js?v=7");
+    const result = buildLangfuseSpan(LLM_SPAN, SAMPLE_TRACE.traceId);
+    expect(result.model).toBe("claude-sonnet-4-6");
+  });
+
+  it("8. buildLangfuseSpan — GENERATION span has usage with correct token counts", async () => {
+    const { buildLangfuseSpan } = await import("../../../../server/tracing/exporters/langfuse.js?v=8");
+    const result = buildLangfuseSpan(LLM_SPAN, SAMPLE_TRACE.traceId);
+    expect(result.usage?.promptTokens).toBe(10);
+    expect(result.usage?.completionTokens).toBe(5);
+    expect(result.usage?.totalTokens).toBe(15);
+  });
+
+  it("9. buildLangfuseSpan — GENERATION span has costUsd", async () => {
+    const { buildLangfuseSpan } = await import("../../../../server/tracing/exporters/langfuse.js?v=9");
+    const result = buildLangfuseSpan(LLM_SPAN, SAMPLE_TRACE.traceId);
+    expect(result.costUsd).toBeCloseTo(0.000045, 8);
+  });
+
+  it("10. buildLangfuseSpan — span has parentObservationId set from parentSpanId", async () => {
+    const { buildLangfuseSpan } = await import("../../../../server/tracing/exporters/langfuse.js?v=10");
+    const result = buildLangfuseSpan(TOOL_SPAN, SAMPLE_TRACE.traceId);
+    expect(result.parentObservationId).toBe("aaaa1111aaaa1111");
+  });
+
+  it("11. buildLangfuseSpan — statusCode=SUCCESS when span.status=ok", async () => {
+    const { buildLangfuseSpan } = await import("../../../../server/tracing/exporters/langfuse.js?v=11");
+    const result = buildLangfuseSpan(LLM_SPAN, SAMPLE_TRACE.traceId);
+    expect(result.statusCode).toBe("SUCCESS");
+  });
+
+  it("12. buildLangfuseSpan — statusCode=ERROR when span.status=error", async () => {
+    const { buildLangfuseSpan } = await import("../../../../server/tracing/exporters/langfuse.js?v=12");
+    const errSpan: TraceSpan = { ...LLM_SPAN, status: "error" };
+    const result = buildLangfuseSpan(errSpan, SAMPLE_TRACE.traceId);
+    expect(result.statusCode).toBe("ERROR");
+  });
+
+  it("13. buildIngestionPayload — batch has one entry per span", async () => {
+    const { buildIngestionPayload } = await import("../../../../server/tracing/exporters/langfuse.js?v=13");
+    const payload = buildIngestionPayload(SAMPLE_TRACE);
+    expect(payload.batch).toHaveLength(2);
+  });
+
+  it("14. buildIngestionPayload — each entry has type=observation-create", async () => {
+    const { buildIngestionPayload } = await import("../../../../server/tracing/exporters/langfuse.js?v=14");
+    const payload = buildIngestionPayload(SAMPLE_TRACE);
+    for (const entry of payload.batch) {
+      expect(entry.type).toBe("observation-create");
+    }
+  });
+
+  it("15. exportToLangfuse swallows fetch errors — does not throw", async () => {
+    const { exportToLangfuse } = await import("../../../../server/tracing/exporters/langfuse.js?v=15");
+    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+    await expect(exportToLangfuse(SAMPLE_TRACE, {
+      baseUrl: "http://lf:3000",
+      publicKey: "pk",
+      secretKey: "sk",
+    })).resolves.toBeUndefined();
+  });
+
+  it("16. langfuseConfigFromEnv — returns null when env vars not set", async () => {
+    vi.stubEnv("LANGFUSE_BASE_URL", "");
+    vi.stubEnv("LANGFUSE_PUBLIC_KEY", "");
+    vi.stubEnv("LANGFUSE_SECRET_KEY", "");
+    const { langfuseConfigFromEnv } = await import("../../../../server/tracing/exporters/langfuse.js?v=16");
+    expect(langfuseConfigFromEnv()).toBeNull();
+  });
+
+  it("17. langfuseConfigFromEnv — returns config when env vars are set", async () => {
+    vi.stubEnv("LANGFUSE_BASE_URL", "http://lf:3000");
+    vi.stubEnv("LANGFUSE_PUBLIC_KEY", "pk-env");
+    vi.stubEnv("LANGFUSE_SECRET_KEY", "sk-env");
+    const { langfuseConfigFromEnv } = await import("../../../../server/tracing/exporters/langfuse.js?v=17");
+    const config = langfuseConfigFromEnv();
+    expect(config).not.toBeNull();
+    expect(config!.baseUrl).toBe("http://lf:3000");
+    expect(config!.publicKey).toBe("pk-env");
+  });
+
+  it("18. buildLangfuseSpan — input and output set for GENERATION spans", async () => {
+    const { buildLangfuseSpan } = await import("../../../../server/tracing/exporters/langfuse.js?v=18");
+    const result = buildLangfuseSpan(LLM_SPAN, SAMPLE_TRACE.traceId);
+    expect(result.input).toBe("What is 2+2?");
+    expect(result.output).toBe("4");
+  });
+
+  it("19. buildLangfuseSpan — modelParameters include temperature and max_tokens", async () => {
+    const { buildLangfuseSpan } = await import("../../../../server/tracing/exporters/langfuse.js?v=19");
+    const result = buildLangfuseSpan(LLM_SPAN, SAMPLE_TRACE.traceId);
+    expect(result.modelParameters?.temperature).toBe(0.7);
+    expect(result.modelParameters?.max_tokens).toBe(2048);
+  });
+});

--- a/tests/unit/tracing/exporters/phoenix.test.ts
+++ b/tests/unit/tracing/exporters/phoenix.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { PipelineTrace, TraceSpan } from "../../../../shared/types.js";
+import { OI, OI_SPAN_KIND } from "../../../../server/tracing/openinference.js";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const LLM_SPAN: TraceSpan = {
+  spanId: "cccc3333cccc3333",
+  name: "llm.gpt-4o",
+  startTime: 1000,
+  endTime: 2000,
+  status: "ok",
+  attributes: {
+    "openinference.span.kind": OI_SPAN_KIND.LLM,
+    [OI.LLM_PROVIDER]: "openai",
+    [OI.LLM_MODEL]: "gpt-4o",
+    [OI.LLM_TOTAL_TOKENS]: 200,
+    [OI.LLM_COST_USD]: 0.001,
+  },
+  events: [],
+};
+
+const TOOL_SPAN: TraceSpan = {
+  spanId: "dddd4444dddd4444",
+  parentSpanId: "cccc3333cccc3333",
+  name: "tool.search",
+  startTime: 1100,
+  endTime: 1300,
+  status: "ok",
+  attributes: {
+    "openinference.span.kind": OI_SPAN_KIND.TOOL,
+    [OI.TOOL_NAME]: "web_search",
+    [OI.TOOL_ARGS]: "[REDACTED]",
+  },
+  events: [],
+};
+
+const SAMPLE_TRACE: PipelineTrace = {
+  traceId: "deadbeefdeadbeef00000000deadbeef",
+  runId: "run-phoenix-1",
+  spans: [LLM_SPAN, TOOL_SPAN],
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("Phoenix exporter", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("1. exportToPhoenix — no-op if baseUrl is empty", async () => {
+    const { exportToPhoenix } = await import("../../../../server/tracing/exporters/phoenix.js");
+    await exportToPhoenix(SAMPLE_TRACE, { baseUrl: "" });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("2. exportToPhoenix — posts to /v1/traces", async () => {
+    const { exportToPhoenix } = await import("../../../../server/tracing/exporters/phoenix.js?v=2");
+    await exportToPhoenix(SAMPLE_TRACE, { baseUrl: "http://phoenix:6006" });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://phoenix:6006/v1/traces",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("3. exportToPhoenix — sends api_key header when configured", async () => {
+    const { exportToPhoenix } = await import("../../../../server/tracing/exporters/phoenix.js?v=3");
+    await exportToPhoenix(SAMPLE_TRACE, { baseUrl: "http://phoenix:6006", apiKey: "my-api-key" });
+    const [, opts] = mockFetch.mock.calls[0];
+    expect((opts.headers as Record<string, string>)["api_key"]).toBe("my-api-key");
+  });
+
+  it("4. buildOtlpPayload — has resourceSpans with correct service.name", async () => {
+    const { buildOtlpPayload } = await import("../../../../server/tracing/exporters/phoenix.js?v=4");
+    const payload = buildOtlpPayload(SAMPLE_TRACE) as {
+      resourceSpans: Array<{
+        resource: { attributes: Array<{ key: string; value: unknown }> };
+        scopeSpans: Array<{ spans: unknown[] }>;
+      }>;
+    };
+    const serviceAttr = payload.resourceSpans[0].resource.attributes.find(
+      (a) => a.key === "service.name",
+    );
+    expect((serviceAttr?.value as { stringValue: string })?.stringValue).toBe("multiqlti");
+  });
+
+  it("5. buildOtlpPayload — has Phoenix project name resource attribute", async () => {
+    const { buildOtlpPayload } = await import("../../../../server/tracing/exporters/phoenix.js?v=5");
+    const payload = buildOtlpPayload(SAMPLE_TRACE) as {
+      resourceSpans: Array<{
+        resource: { attributes: Array<{ key: string; value: unknown }> };
+        scopeSpans: never[];
+      }>;
+    };
+    const projectAttr = payload.resourceSpans[0].resource.attributes.find(
+      (a) => a.key === "openinference.project.name",
+    );
+    expect(projectAttr).toBeDefined();
+  });
+
+  it("6. buildOtlpPayload — scopeSpans contains all spans", async () => {
+    const { buildOtlpPayload } = await import("../../../../server/tracing/exporters/phoenix.js?v=6");
+    const payload = buildOtlpPayload(SAMPLE_TRACE) as {
+      resourceSpans: Array<{ scopeSpans: Array<{ spans: unknown[] }> }>;
+    };
+    expect(payload.resourceSpans[0].scopeSpans[0].spans).toHaveLength(2);
+  });
+
+  it("7. buildOtlpSpan — LLM span has kind=3 (CLIENT)", async () => {
+    const { buildOtlpSpan } = await import("../../../../server/tracing/exporters/phoenix.js?v=7");
+    const span = buildOtlpSpan(LLM_SPAN, SAMPLE_TRACE.traceId) as { kind: number };
+    expect(span.kind).toBe(3);
+  });
+
+  it("8. buildOtlpSpan — non-LLM span has kind=1 (INTERNAL)", async () => {
+    const { buildOtlpSpan } = await import("../../../../server/tracing/exporters/phoenix.js?v=8");
+    const span = buildOtlpSpan(TOOL_SPAN, SAMPLE_TRACE.traceId) as { kind: number };
+    expect(span.kind).toBe(1);
+  });
+
+  it("9. buildOtlpSpan — startTimeUnixNano is ms * 1_000_000", async () => {
+    const { buildOtlpSpan } = await import("../../../../server/tracing/exporters/phoenix.js?v=9");
+    const span = buildOtlpSpan(LLM_SPAN, SAMPLE_TRACE.traceId) as { startTimeUnixNano: string };
+    expect(span.startTimeUnixNano).toBe(String(1000 * 1_000_000));
+  });
+
+  it("10. buildOtlpSpan — attributes include openinference.span.kind", async () => {
+    const { buildOtlpSpan } = await import("../../../../server/tracing/exporters/phoenix.js?v=10");
+    const span = buildOtlpSpan(LLM_SPAN, SAMPLE_TRACE.traceId) as {
+      attributes: Array<{ key: string; value: unknown }>;
+    };
+    const kindAttr = span.attributes.find((a) => a.key === "openinference.span.kind");
+    expect((kindAttr?.value as { stringValue: string })?.stringValue).toBe("LLM");
+  });
+
+  it("11. buildOtlpSpan — parentSpanId set when span has parentSpanId", async () => {
+    const { buildOtlpSpan } = await import("../../../../server/tracing/exporters/phoenix.js?v=11");
+    const span = buildOtlpSpan(TOOL_SPAN, SAMPLE_TRACE.traceId) as { parentSpanId?: string };
+    expect(span.parentSpanId).toBe("cccc3333cccc3333");
+  });
+
+  it("12. buildOtlpSpan — status code 1 for ok, 2 for error", async () => {
+    const { buildOtlpSpan } = await import("../../../../server/tracing/exporters/phoenix.js?v=12");
+    const okSpan = buildOtlpSpan(LLM_SPAN, SAMPLE_TRACE.traceId) as {
+      status: { code: number };
+    };
+    expect(okSpan.status.code).toBe(1);
+
+    const errSpan = buildOtlpSpan(
+      { ...LLM_SPAN, status: "error" },
+      SAMPLE_TRACE.traceId,
+    ) as { status: { code: number } };
+    expect(errSpan.status.code).toBe(2);
+  });
+
+  it("13. exportToPhoenix swallows errors — does not throw", async () => {
+    const { exportToPhoenix } = await import("../../../../server/tracing/exporters/phoenix.js?v=13");
+    mockFetch.mockRejectedValueOnce(new Error("Network failure"));
+    await expect(exportToPhoenix(SAMPLE_TRACE, { baseUrl: "http://phoenix:6006" })).resolves.toBeUndefined();
+  });
+
+  it("14. phoenixConfigFromEnv — returns null when PHOENIX_BASE_URL not set", async () => {
+    vi.stubEnv("PHOENIX_BASE_URL", "");
+    const { phoenixConfigFromEnv } = await import("../../../../server/tracing/exporters/phoenix.js?v=14");
+    expect(phoenixConfigFromEnv()).toBeNull();
+  });
+
+  it("15. phoenixConfigFromEnv — returns config when PHOENIX_BASE_URL set", async () => {
+    vi.stubEnv("PHOENIX_BASE_URL", "http://phoenix:6006");
+    vi.stubEnv("PHOENIX_API_KEY", "my-key");
+    const { phoenixConfigFromEnv } = await import("../../../../server/tracing/exporters/phoenix.js?v=15");
+    const config = phoenixConfigFromEnv();
+    expect(config).not.toBeNull();
+    expect(config!.baseUrl).toBe("http://phoenix:6006");
+    expect(config!.apiKey).toBe("my-key");
+  });
+
+  it("16. buildAttr — integer value uses intValue", async () => {
+    const { buildAttr } = await import("../../../../server/tracing/exporters/phoenix.js?v=16");
+    const result = buildAttr("my.key", 42) as { key: string; value: { intValue: number } };
+    expect(result.key).toBe("my.key");
+    expect(result.value.intValue).toBe(42);
+  });
+
+  it("17. buildAttr — float value uses doubleValue", async () => {
+    const { buildAttr } = await import("../../../../server/tracing/exporters/phoenix.js?v=17");
+    const result = buildAttr("temp", 0.7) as { key: string; value: { doubleValue: number } };
+    expect(result.value.doubleValue).toBeCloseTo(0.7, 6);
+  });
+
+  it("18. buildAttr — string value uses stringValue", async () => {
+    const { buildAttr } = await import("../../../../server/tracing/exporters/phoenix.js?v=18");
+    const result = buildAttr("model", "gpt-4o") as { key: string; value: { stringValue: string } };
+    expect(result.value.stringValue).toBe("gpt-4o");
+  });
+});

--- a/tests/unit/tracing/llm-span.test.ts
+++ b/tests/unit/tracing/llm-span.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect } from "vitest";
+import {
+  LlmSpanEnricher,
+  buildLlmSpanAttributes,
+  buildToolCallAttributes,
+} from "../../../server/tracing/llm-span.js";
+import { Tracer } from "../../../server/tracing/tracer.js";
+import {
+  OI,
+  OI_SPAN_KIND,
+  REDACTED_PLACEHOLDER,
+} from "../../../server/tracing/openinference.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeEnricher(opts?: { storePrompts?: boolean; storeToolData?: boolean }) {
+  const testTracer = new Tracer();
+  const enricher = new LlmSpanEnricher(opts, testTracer);
+  return { testTracer, enricher };
+}
+
+// ─── buildLlmSpanAttributes ───────────────────────────────────────────────────
+
+describe("buildLlmSpanAttributes", () => {
+  it("1. sets openinference.span.kind = LLM", () => {
+    const attrs = buildLlmSpanAttributes({ modelSlug: "claude-sonnet-4-6" });
+    expect(attrs["openinference.span.kind"]).toBe(OI_SPAN_KIND.LLM);
+  });
+
+  it("2. sets llm.provider = anthropic for claude-* models", () => {
+    const attrs = buildLlmSpanAttributes({ modelSlug: "claude-sonnet-4-6" });
+    expect(attrs[OI.LLM_PROVIDER]).toBe("anthropic");
+  });
+
+  it("3. sets llm.model to the provided slug", () => {
+    const attrs = buildLlmSpanAttributes({ modelSlug: "gpt-4o-mini" });
+    expect(attrs[OI.LLM_MODEL]).toBe("gpt-4o-mini");
+  });
+
+  it("4. redacts prompt when redactContent=true (default)", () => {
+    const attrs = buildLlmSpanAttributes({
+      modelSlug: "claude-sonnet-4-6",
+      prompt: "What is the capital of France?",
+    });
+    expect(attrs[OI.LLM_INPUT_VALUE]).toBe(REDACTED_PLACEHOLDER);
+  });
+
+  it("5. stores prompt when redactContent=false", () => {
+    const attrs = buildLlmSpanAttributes({
+      modelSlug: "claude-sonnet-4-6",
+      prompt: "What is the capital of France?",
+      redactContent: false,
+    });
+    expect(attrs[OI.LLM_INPUT_VALUE]).toBe("What is the capital of France?");
+  });
+
+  it("6. redacts response when redactContent=true", () => {
+    const attrs = buildLlmSpanAttributes({
+      modelSlug: "claude-sonnet-4-6",
+      response: "Paris",
+      redactContent: true,
+    });
+    expect(attrs[OI.LLM_OUTPUT_VALUE]).toBe(REDACTED_PLACEHOLDER);
+  });
+
+  it("7. stores response when redactContent=false", () => {
+    const attrs = buildLlmSpanAttributes({
+      modelSlug: "claude-sonnet-4-6",
+      response: "Paris",
+      redactContent: false,
+    });
+    expect(attrs[OI.LLM_OUTPUT_VALUE]).toBe("Paris");
+  });
+
+  it("8. redacts system prompt when redactContent=true", () => {
+    const attrs = buildLlmSpanAttributes({
+      modelSlug: "claude-sonnet-4-6",
+      systemPrompt: "You are a helpful assistant.",
+      redactContent: true,
+    });
+    expect(attrs[OI.LLM_SYSTEM_PROMPT]).toBe(REDACTED_PLACEHOLDER);
+  });
+
+  it("9. sets token counts when totalTokens provided", () => {
+    const attrs = buildLlmSpanAttributes({
+      modelSlug: "claude-sonnet-4-6",
+      promptTokens: 50,
+      completionTokens: 100,
+      totalTokens: 150,
+    });
+    expect(attrs[OI.LLM_PROMPT_TOKENS]).toBe(50);
+    expect(attrs[OI.LLM_COMPLETION_TOKENS]).toBe(100);
+    expect(attrs[OI.LLM_TOTAL_TOKENS]).toBe(150);
+  });
+
+  it("10. derives totalTokens from promptTokens + completionTokens if not provided", () => {
+    const attrs = buildLlmSpanAttributes({
+      modelSlug: "claude-sonnet-4-6",
+      promptTokens: 50,
+      completionTokens: 100,
+    });
+    expect(attrs[OI.LLM_TOTAL_TOKENS]).toBe(150);
+  });
+
+  it("11. sets llm.cost_usd for known models with non-zero tokens", () => {
+    const attrs = buildLlmSpanAttributes({
+      modelSlug: "claude-sonnet-4-6",
+      totalTokens: 1_000_000,
+    });
+    expect(typeof attrs[OI.LLM_COST_USD]).toBe("number");
+    expect((attrs[OI.LLM_COST_USD] as number)).toBeGreaterThan(0);
+  });
+
+  it("12. does not set cost_usd when totalTokens = 0", () => {
+    const attrs = buildLlmSpanAttributes({
+      modelSlug: "claude-sonnet-4-6",
+      totalTokens: 0,
+    });
+    expect(attrs[OI.LLM_COST_USD]).toBeUndefined();
+  });
+
+  it("13. sets temperature and max_tokens when provided", () => {
+    const attrs = buildLlmSpanAttributes({
+      modelSlug: "gpt-4o",
+      temperature: 0.7,
+      maxTokens: 2048,
+    });
+    expect(attrs[OI.LLM_TEMPERATURE]).toBe(0.7);
+    expect(attrs[OI.LLM_MAX_TOKENS]).toBe(2048);
+  });
+
+  it("14. sets stage.id and stage.role when provided", () => {
+    const attrs = buildLlmSpanAttributes({
+      modelSlug: "claude-sonnet-4-6",
+      stageId: "planning",
+      stageRole: "proposer",
+    });
+    expect(attrs[OI.STAGE_ID]).toBe("planning");
+    expect(attrs[OI.STAGE_ROLE]).toBe("proposer");
+  });
+
+  it("15. sets pipeline.run_id when runId provided", () => {
+    const attrs = buildLlmSpanAttributes({
+      modelSlug: "claude-sonnet-4-6",
+      runId: "run-abc-123",
+    });
+    expect(attrs[OI.PIPELINE_RUN_ID]).toBe("run-abc-123");
+  });
+
+  it("16. truncates very long prompts to avoid unbounded growth", () => {
+    const longPrompt = "x".repeat(10_000);
+    const attrs = buildLlmSpanAttributes({
+      modelSlug: "claude-sonnet-4-6",
+      prompt: longPrompt,
+      redactContent: false,
+    });
+    const stored = attrs[OI.LLM_INPUT_VALUE] as string;
+    expect(stored.length).toBeLessThanOrEqual(8_193);
+  });
+});
+
+// ─── buildToolCallAttributes ──────────────────────────────────────────────────
+
+describe("buildToolCallAttributes", () => {
+  it("17. sets openinference.span.kind = TOOL", () => {
+    const attrs = buildToolCallAttributes({ toolName: "read_file", toolArgs: { path: "/etc/hosts" } });
+    expect(attrs["openinference.span.kind"]).toBe(OI_SPAN_KIND.TOOL);
+  });
+
+  it("18. sets tool.name", () => {
+    const attrs = buildToolCallAttributes({ toolName: "bash", toolArgs: {} });
+    expect(attrs[OI.TOOL_NAME]).toBe("bash");
+  });
+
+  it("19. redacts tool args by default", () => {
+    const attrs = buildToolCallAttributes({
+      toolName: "read_file",
+      toolArgs: { path: "/etc/secret" },
+    });
+    expect(attrs[OI.TOOL_ARGS]).toBe(REDACTED_PLACEHOLDER);
+  });
+
+  it("20. stores tool args when redactContent=false", () => {
+    const attrs = buildToolCallAttributes({
+      toolName: "read_file",
+      toolArgs: { path: "/public/file" },
+      redactContent: false,
+    });
+    expect(attrs[OI.TOOL_ARGS]).toContain("/public/file");
+  });
+
+  it("21. redacts tool result by default", () => {
+    const attrs = buildToolCallAttributes({
+      toolName: "read_file",
+      toolArgs: {},
+      result: "file contents",
+    });
+    expect(attrs[OI.TOOL_RESULT]).toBe(REDACTED_PLACEHOLDER);
+  });
+
+  it("22. stores tool result when redactContent=false", () => {
+    const attrs = buildToolCallAttributes({
+      toolName: "read_file",
+      toolArgs: {},
+      result: "file contents",
+      redactContent: false,
+    });
+    expect(attrs[OI.TOOL_RESULT]).toBe("file contents");
+  });
+});
+
+// ─── LlmSpanEnricher ──────────────────────────────────────────────────────────
+
+describe("LlmSpanEnricher", () => {
+  it("23. startLlmCall returns a valid span ID present in the trace", () => {
+    const { testTracer, enricher } = makeEnricher();
+    const tid = testTracer.startTrace("run-23");
+    const spanId = enricher.startLlmCall({
+      traceId: tid,
+      modelSlug: "claude-sonnet-4-6",
+      prompt: "hello",
+    });
+    expect(spanId).toMatch(/^[0-9a-f]{16}$/);
+    const trace = testTracer.getTrace(tid);
+    expect(trace!.spans.find((s) => s.spanId === spanId)).toBeDefined();
+  });
+
+  it("24. endLlmCall writes response, tokens, and cost to span attributes", () => {
+    const { testTracer, enricher } = makeEnricher({ storePrompts: true });
+    const tid = testTracer.startTrace("run-24");
+    const spanId = enricher.startLlmCall({
+      traceId: tid,
+      modelSlug: "claude-sonnet-4-6",
+      prompt: "What is 2+2?",
+    });
+    enricher.endLlmCall(spanId, tid, {
+      response: "4",
+      promptTokens: 10,
+      completionTokens: 5,
+      totalTokens: 15,
+    }, "ok", "claude-sonnet-4-6");
+
+    const trace = testTracer.getTrace(tid);
+    const span = trace!.spans.find((s) => s.spanId === spanId)!;
+    expect(span.attributes[OI.LLM_TOTAL_TOKENS]).toBe(15);
+    expect(span.attributes[OI.LLM_OUTPUT_VALUE]).toBe("4");
+  });
+
+  it("25. redaction is active by default — endLlmCall stores REDACTED_PLACEHOLDER for response", () => {
+    const { testTracer, enricher } = makeEnricher();
+    const tid = testTracer.startTrace("run-25");
+    const spanId = enricher.startLlmCall({
+      traceId: tid,
+      modelSlug: "gpt-4o-mini",
+      prompt: "Secret prompt",
+    });
+    enricher.endLlmCall(spanId, tid, { response: "Secret response" }, "ok", "gpt-4o-mini");
+
+    const trace = testTracer.getTrace(tid);
+    const span = trace!.spans.find((s) => s.spanId === spanId)!;
+    expect(span.attributes[OI.LLM_OUTPUT_VALUE]).toBe(REDACTED_PLACEHOLDER);
+  });
+
+  it("26. startStrategySpan creates a CHAIN kind span", () => {
+    const { testTracer, enricher } = makeEnricher();
+    const tid = testTracer.startTrace("run-26");
+    const spanId = enricher.startStrategySpan({
+      traceId: tid,
+      strategyType: "debate",
+      runId: "run-26",
+    });
+    enricher.endStrategySpan(spanId, "ok", { candidateCount: 3, rounds: 2 });
+
+    const trace = testTracer.getTrace(tid);
+    const span = trace!.spans.find((s) => s.spanId === spanId)!;
+    expect(span).toBeDefined();
+    expect(span.attributes["openinference.span.kind"]).toBe(OI_SPAN_KIND.CHAIN);
+    expect(span.attributes["strategy.type"]).toBe("debate");
+    expect(span.attributes["strategy.candidate_count"]).toBe(3);
+    expect(span.attributes["strategy.rounds"]).toBe(2);
+  });
+
+  it("27. tool call span is created with TOOL kind and correct tool name", () => {
+    const { testTracer, enricher } = makeEnricher();
+    const tid = testTracer.startTrace("run-27");
+    const spanId = enricher.startToolCall({
+      traceId: tid,
+      toolName: "bash_run",
+      toolArgs: { cmd: "ls -la" },
+    });
+    enricher.endToolCall(spanId, { result: "total 32\n..." });
+
+    const trace = testTracer.getTrace(tid);
+    const span = trace!.spans.find((s) => s.spanId === spanId)!;
+    expect(span).toBeDefined();
+    expect(span.name).toBe("tool.bash_run");
+    expect(span.attributes["openinference.span.kind"]).toBe(OI_SPAN_KIND.TOOL);
+    expect(span.attributes[OI.TOOL_NAME]).toBe("bash_run");
+  });
+
+  it("28. tool call with error sets span status=error", () => {
+    const { testTracer, enricher } = makeEnricher();
+    const tid = testTracer.startTrace("run-28");
+    const spanId = enricher.startToolCall({
+      traceId: tid,
+      toolName: "bash_run",
+      toolArgs: { cmd: "failing_cmd" },
+    });
+    enricher.endToolCall(spanId, { result: "command not found", isError: true });
+
+    const trace = testTracer.getTrace(tid);
+    const span = trace!.spans.find((s) => s.spanId === spanId)!;
+    expect(span.status).toBe("error");
+  });
+});

--- a/tests/unit/tracing/openinference.test.ts
+++ b/tests/unit/tracing/openinference.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import {
+  estimateCostUsd,
+  inferProviderFromModelSlug,
+  maybeRedact,
+  truncate,
+  REDACTED_PLACEHOLDER,
+} from "../../../server/tracing/openinference.js";
+
+describe("OpenInference semantic conventions", () => {
+  // ─── maybeRedact ───────────────────────────────────────────────────────────
+
+  describe("maybeRedact", () => {
+    it("1. returns REDACTED_PLACEHOLDER when redact=true", () => {
+      expect(maybeRedact("secret prompt", true)).toBe(REDACTED_PLACEHOLDER);
+    });
+
+    it("2. returns original value when redact=false", () => {
+      expect(maybeRedact("my prompt", false)).toBe("my prompt");
+    });
+
+    it("3. redacts empty string", () => {
+      expect(maybeRedact("", true)).toBe(REDACTED_PLACEHOLDER);
+    });
+  });
+
+  // ─── truncate ─────────────────────────────────────────────────────────────
+
+  describe("truncate", () => {
+    it("4. does not truncate when value length <= maxLen", () => {
+      expect(truncate("hello", 10)).toBe("hello");
+    });
+
+    it("5. truncates and appends ellipsis when length > maxLen", () => {
+      const result = truncate("hello world", 7);
+      expect(result).toHaveLength(7);
+      expect(result.endsWith("…")).toBe(true);
+    });
+
+    it("6. exact boundary — no truncation at exactly maxLen", () => {
+      expect(truncate("abcde", 5)).toBe("abcde");
+    });
+
+    it("7. truncates long prompt to maxLen with trailing ellipsis", () => {
+      const long = "a".repeat(100);
+      const result = truncate(long, 10);
+      expect(result).toHaveLength(10);
+      expect(result[9]).toBe("…");
+    });
+  });
+
+  // ─── estimateCostUsd ──────────────────────────────────────────────────────
+
+  describe("estimateCostUsd", () => {
+    it("8. claude-sonnet-4-6 at 1_000_000 tokens = $3.00", () => {
+      const cost = estimateCostUsd("claude-sonnet-4-6", 1_000_000);
+      expect(cost).toBeCloseTo(3.0, 4);
+    });
+
+    it("9. gpt-4o-mini at 1_000_000 tokens = $0.15", () => {
+      const cost = estimateCostUsd("gpt-4o-mini", 1_000_000);
+      expect(cost).toBeCloseTo(0.15, 4);
+    });
+
+    it("10. unknown model returns 0", () => {
+      expect(estimateCostUsd("some-unknown-model", 50_000)).toBe(0);
+    });
+
+    it("11. 0 tokens returns 0 cost regardless of model", () => {
+      expect(estimateCostUsd("claude-sonnet-4-6", 0)).toBe(0);
+    });
+
+    it("12. prefix match — claude-sonnet-4-6-20251101 matches claude-sonnet-4-6", () => {
+      const cost = estimateCostUsd("claude-sonnet-4-6-20251101", 1_000_000);
+      expect(cost).toBeCloseTo(3.0, 4);
+    });
+
+    it("13. claude-opus-4 at 100_000 tokens has non-zero cost", () => {
+      const cost = estimateCostUsd("claude-opus-4", 100_000);
+      expect(cost).toBeGreaterThan(0);
+    });
+
+    it("14. cost scales linearly — 2x tokens = 2x cost", () => {
+      const c1 = estimateCostUsd("gpt-4o", 100_000);
+      const c2 = estimateCostUsd("gpt-4o", 200_000);
+      expect(c2).toBeCloseTo(c1 * 2, 6);
+    });
+  });
+
+  // ─── inferProviderFromModelSlug ────────────────────────────────────────────
+
+  describe("inferProviderFromModelSlug", () => {
+    it("15. claude-* → anthropic", () => {
+      expect(inferProviderFromModelSlug("claude-sonnet-4")).toBe("anthropic");
+    });
+
+    it("16. gpt-* → openai", () => {
+      expect(inferProviderFromModelSlug("gpt-4o-mini")).toBe("openai");
+    });
+
+    it("17. gemini-* → google", () => {
+      expect(inferProviderFromModelSlug("gemini-1.5-pro")).toBe("google");
+    });
+
+    it("18. grok-* → xai", () => {
+      expect(inferProviderFromModelSlug("grok-2")).toBe("xai");
+    });
+
+    it("19. llama-* → ollama", () => {
+      expect(inferProviderFromModelSlug("llama-3")).toBe("ollama");
+    });
+
+    it("20. unknown slug → 'unknown'", () => {
+      expect(inferProviderFromModelSlug("my-custom-model")).toBe("unknown");
+    });
+
+    it("21. o1-* → openai (reasoning models)", () => {
+      expect(inferProviderFromModelSlug("o1-preview")).toBe("openai");
+    });
+  });
+});

--- a/tests/unit/tracing/strategy-spans.test.ts
+++ b/tests/unit/tracing/strategy-spans.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from "vitest";
+import { LlmSpanEnricher } from "../../../server/tracing/llm-span.js";
+import { Tracer } from "../../../server/tracing/tracer.js";
+import { OI_SPAN_KIND, OI } from "../../../server/tracing/openinference.js";
+
+function makeEnricher() {
+  const testTracer = new Tracer();
+  const enricher = new LlmSpanEnricher({}, testTracer);
+  return { testTracer, enricher };
+}
+
+/**
+ * Tests that verify strategy (debate / voting / MoA) spans wrap their
+ * candidate and judge/merge child spans correctly.
+ */
+describe("Strategy span grouping", () => {
+  it("1. debate strategy span wraps proposer + judge child spans", () => {
+    const { testTracer, enricher } = makeEnricher();
+    const runId = "strategy-debate-run-1";
+    const tid = testTracer.startTrace(runId);
+
+    // Parent: strategy.debate span
+    const stratSpanId = enricher.startStrategySpan({
+      traceId: tid,
+      strategyType: "debate",
+      runId,
+      stageId: "development",
+    });
+
+    // Child 1: proposer LLM call
+    const p1SpanId = enricher.startLlmCall({
+      traceId: tid,
+      parentSpanId: stratSpanId,
+      modelSlug: "claude-sonnet-4-6",
+      prompt: "Proposer turn 1",
+      stageRole: "proposer",
+      runId,
+    });
+    enricher.endLlmCall(p1SpanId, tid, { response: "My proposal", totalTokens: 100 }, "ok", "claude-sonnet-4-6");
+
+    // Child 2: critic LLM call
+    const p2SpanId = enricher.startLlmCall({
+      traceId: tid,
+      parentSpanId: stratSpanId,
+      modelSlug: "gpt-4o",
+      prompt: "Critic turn 1",
+      stageRole: "critic",
+      runId,
+    });
+    enricher.endLlmCall(p2SpanId, tid, { response: "I disagree", totalTokens: 80 }, "ok", "gpt-4o");
+
+    // Child 3: judge LLM call
+    const judgeSpanId = enricher.startLlmCall({
+      traceId: tid,
+      parentSpanId: stratSpanId,
+      modelSlug: "claude-opus-4",
+      prompt: "Judge final verdict",
+      stageRole: "judge",
+      runId,
+    });
+    enricher.endLlmCall(judgeSpanId, tid, { response: "Verdict: option A", totalTokens: 50 }, "ok", "claude-opus-4");
+
+    // End strategy span
+    enricher.endStrategySpan(stratSpanId, "ok", { candidateCount: 2, rounds: 1 });
+
+    const trace = testTracer.getTrace(tid);
+    expect(trace).not.toBeNull();
+
+    const stratSpan = trace!.spans.find((s) => s.spanId === stratSpanId);
+    expect(stratSpan).toBeDefined();
+    expect(stratSpan!.name).toBe("strategy.debate");
+    expect(stratSpan!.attributes["openinference.span.kind"]).toBe(OI_SPAN_KIND.CHAIN);
+    expect(stratSpan!.attributes["strategy.type"]).toBe("debate");
+    expect(stratSpan!.attributes["strategy.candidate_count"]).toBe(2);
+
+    // Verify children have correct parentSpanId pointing to strategy span
+    const proposer = trace!.spans.find((s) => s.spanId === p1SpanId);
+    const critic   = trace!.spans.find((s) => s.spanId === p2SpanId);
+    const judge    = trace!.spans.find((s) => s.spanId === judgeSpanId);
+
+    expect(proposer!.parentSpanId).toBe(stratSpanId);
+    expect(critic!.parentSpanId).toBe(stratSpanId);
+    expect(judge!.parentSpanId).toBe(stratSpanId);
+
+    // Verify role attributes
+    expect(proposer!.attributes[OI.STAGE_ROLE]).toBe("proposer");
+    expect(critic!.attributes[OI.STAGE_ROLE]).toBe("critic");
+    expect(judge!.attributes[OI.STAGE_ROLE]).toBe("judge");
+  });
+
+  it("2. MoA strategy span wraps proposers + aggregator", () => {
+    const { testTracer, enricher } = makeEnricher();
+    const runId = "strategy-moa-run-2";
+    const tid = testTracer.startTrace(runId);
+
+    const stratSpanId = enricher.startStrategySpan({ traceId: tid, strategyType: "moa", runId });
+
+    // 3 proposers
+    for (let i = 0; i < 3; i++) {
+      const sid = enricher.startLlmCall({
+        traceId: tid,
+        parentSpanId: stratSpanId,
+        modelSlug: "claude-sonnet-4-6",
+        prompt: `Proposer ${i}`,
+        stageRole: "proposer",
+        runId,
+      });
+      enricher.endLlmCall(sid, tid, { response: `response ${i}`, totalTokens: 50 }, "ok", "claude-sonnet-4-6");
+    }
+
+    // Aggregator
+    const aggSpanId = enricher.startLlmCall({
+      traceId: tid,
+      parentSpanId: stratSpanId,
+      modelSlug: "claude-opus-4",
+      prompt: "Aggregate proposals",
+      stageRole: "aggregator",
+      runId,
+    });
+    enricher.endLlmCall(aggSpanId, tid, { response: "Final merged result", totalTokens: 200 }, "ok", "claude-opus-4");
+
+    enricher.endStrategySpan(stratSpanId, "ok", { candidateCount: 3 });
+
+    const trace = testTracer.getTrace(tid);
+    const stratSpan = trace!.spans.find((s) => s.spanId === stratSpanId);
+
+    expect(stratSpan!.attributes["strategy.type"]).toBe("moa");
+    expect(stratSpan!.attributes["strategy.candidate_count"]).toBe(3);
+
+    // All children point to strategy span
+    const childrenOfStrat = trace!.spans.filter((s) => s.parentSpanId === stratSpanId);
+    expect(childrenOfStrat).toHaveLength(4); // 3 proposers + 1 aggregator
+  });
+
+  it("3. voting strategy span wraps 3 candidates", () => {
+    const { testTracer, enricher } = makeEnricher();
+    const runId = "strategy-voting-run-3";
+    const tid = testTracer.startTrace(runId);
+
+    const stratSpanId = enricher.startStrategySpan({ traceId: tid, strategyType: "voting", runId });
+
+    const candidateModels = ["claude-sonnet-4-6", "gpt-4o", "gemini-1.5-pro"];
+    for (const model of candidateModels) {
+      const sid = enricher.startLlmCall({
+        traceId: tid,
+        parentSpanId: stratSpanId,
+        modelSlug: model,
+        prompt: "Vote candidate prompt",
+        stageRole: "candidate",
+        runId,
+      });
+      enricher.endLlmCall(sid, tid, { response: "candidate answer", totalTokens: 30 }, "ok", model);
+    }
+
+    enricher.endStrategySpan(stratSpanId, "ok", {
+      candidateCount: 3,
+      winnerModel: "claude-sonnet-4-6",
+    });
+
+    const trace = testTracer.getTrace(tid);
+    const stratSpan = trace!.spans.find((s) => s.spanId === stratSpanId);
+
+    expect(stratSpan!.attributes["strategy.type"]).toBe("voting");
+    expect(stratSpan!.attributes["strategy.winner_model"]).toBe("claude-sonnet-4-6");
+
+    const children = trace!.spans.filter((s) => s.parentSpanId === stratSpanId);
+    expect(children).toHaveLength(3);
+  });
+
+  it("4. strategy span status=error when judge fails", () => {
+    const { testTracer, enricher } = makeEnricher();
+    const runId = "strategy-error-run-4";
+    const tid = testTracer.startTrace(runId);
+
+    const stratSpanId = enricher.startStrategySpan({ traceId: tid, strategyType: "debate", runId });
+    enricher.endStrategySpan(stratSpanId, "error");
+
+    const trace = testTracer.getTrace(tid);
+    const span = trace!.spans.find((s) => s.spanId === stratSpanId);
+    expect(span!.status).toBe("error");
+  });
+
+  it("5. token totals accumulate correctly across all strategy child spans", () => {
+    const { testTracer, enricher } = makeEnricher();
+    const runId = "strategy-tokens-run-5";
+    const tid = testTracer.startTrace(runId);
+
+    const stratSpanId = enricher.startStrategySpan({ traceId: tid, strategyType: "moa", runId });
+
+    const tokenCounts = [100, 150, 200, 250]; // sum = 700
+    for (const toks of tokenCounts) {
+      const sid = enricher.startLlmCall({
+        traceId: tid,
+        parentSpanId: stratSpanId,
+        modelSlug: "claude-sonnet-4-6",
+        prompt: "test",
+        runId,
+      });
+      enricher.endLlmCall(sid, tid, { response: "r", totalTokens: toks }, "ok", "claude-sonnet-4-6");
+    }
+
+    enricher.endStrategySpan(stratSpanId, "ok");
+
+    const trace = testTracer.getTrace(tid);
+    const totalTokens = trace!.spans
+      .filter((s) => s.parentSpanId === stratSpanId)
+      .reduce((sum, s) => {
+        const t = s.attributes[OI.LLM_TOTAL_TOKENS];
+        return sum + (typeof t === "number" ? t : 0);
+      }, 0);
+
+    expect(totalTokens).toBe(700);
+  });
+});

--- a/tests/unit/tracing/workspace-traces-route.test.ts
+++ b/tests/unit/tracing/workspace-traces-route.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import type { IStorage } from "../../../server/storage.js";
+import { registerWorkspaceTraceRoutes } from "../../../server/routes/workspace-traces.js";
+import type { TraceSpan } from "../../../shared/types.js";
+import { OI, OI_SPAN_KIND } from "../../../server/tracing/openinference.js";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const LLM_SPAN: TraceSpan = {
+  spanId: "aaaa1111aaaa1111",
+  name: "llm.claude-sonnet-4-6",
+  startTime: 1000,
+  endTime: 2500,
+  status: "ok",
+  attributes: {
+    "openinference.span.kind": OI_SPAN_KIND.LLM,
+    [OI.LLM_PROVIDER]: "anthropic",
+    [OI.LLM_MODEL]: "claude-sonnet-4-6",
+    [OI.LLM_TOTAL_TOKENS]: 150,
+    [OI.LLM_COST_USD]: 0.0005,
+  },
+  events: [],
+};
+
+const TOOL_SPAN: TraceSpan = {
+  spanId: "bbbb2222bbbb2222",
+  parentSpanId: "aaaa1111aaaa1111",
+  name: "tool.bash_run",
+  startTime: 1100,
+  endTime: 1300,
+  status: "ok",
+  attributes: {
+    "openinference.span.kind": OI_SPAN_KIND.TOOL,
+    [OI.TOOL_NAME]: "bash_run",
+  },
+  events: [],
+};
+
+const SAMPLE_TRACE = {
+  traceId: "cafebabe00000000cafebabecafebabe",
+  runId: "run-test-ws-1",
+  spans: [LLM_SPAN, TOOL_SPAN],
+};
+
+// ─── Mock storage ─────────────────────────────────────────────────────────────
+
+function makeMockStorage(overrides: Partial<IStorage> = {}): IStorage {
+  return {
+    getTraceByRunId: vi.fn().mockResolvedValue(SAMPLE_TRACE),
+    getTraces: vi.fn().mockResolvedValue([SAMPLE_TRACE]),
+    ...overrides,
+  } as unknown as IStorage;
+}
+
+function makeApp(storage: IStorage) {
+  const app = express();
+  app.use(express.json());
+  registerWorkspaceTraceRoutes(app, storage);
+  return app;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/workspaces/:id/traces", () => {
+  let app: ReturnType<typeof express>;
+  let storage: IStorage;
+
+  beforeEach(() => {
+    storage = makeMockStorage();
+    app = makeApp(storage);
+  });
+
+  it("1. returns 200 with traces array", async () => {
+    const res = await request(app).get("/api/workspaces/ws-1/traces");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.traces)).toBe(true);
+  });
+
+  it("2. each trace summary has required fields", async () => {
+    const res = await request(app).get("/api/workspaces/ws-1/traces");
+    const summary = res.body.traces[0];
+    expect(summary).toHaveProperty("traceId");
+    expect(summary).toHaveProperty("runId");
+    expect(summary).toHaveProperty("spanCount");
+    expect(summary).toHaveProperty("startTime");
+    expect(summary).toHaveProperty("endTime");
+    expect(summary).toHaveProperty("totalTokens");
+    expect(summary).toHaveProperty("costUsd");
+    expect(summary).toHaveProperty("provider");
+    expect(summary).toHaveProperty("model");
+  });
+
+  it("3. spanCount matches number of spans in the trace", async () => {
+    const res = await request(app).get("/api/workspaces/ws-1/traces");
+    expect(res.body.traces[0].spanCount).toBe(2);
+  });
+
+  it("4. aggregates totalTokens from LLM spans", async () => {
+    const res = await request(app).get("/api/workspaces/ws-1/traces");
+    expect(res.body.traces[0].totalTokens).toBe(150);
+  });
+
+  it("5. aggregates costUsd from LLM spans", async () => {
+    const res = await request(app).get("/api/workspaces/ws-1/traces");
+    expect(res.body.traces[0].costUsd).toBeCloseTo(0.0005, 6);
+  });
+
+  it("6. provider is the most common llm.provider value", async () => {
+    const res = await request(app).get("/api/workspaces/ws-1/traces");
+    expect(res.body.traces[0].provider).toBe("anthropic");
+  });
+
+  it("7. model is the most common llm.model value", async () => {
+    const res = await request(app).get("/api/workspaces/ws-1/traces");
+    expect(res.body.traces[0].model).toBe("claude-sonnet-4-6");
+  });
+
+  it("8. returns 200 with empty traces when storage returns []", async () => {
+    storage = makeMockStorage({ getTraces: vi.fn().mockResolvedValue([]) });
+    app = makeApp(storage);
+    const res = await request(app).get("/api/workspaces/ws-1/traces");
+    expect(res.status).toBe(200);
+    expect(res.body.traces).toHaveLength(0);
+  });
+
+  it("9. filters by runId query param", async () => {
+    const res = await request(app).get("/api/workspaces/ws-1/traces?runId=run-test-ws-1");
+    expect(res.status).toBe(200);
+    expect(res.body.traces[0].runId).toBe("run-test-ws-1");
+  });
+
+  it("10. returns 500 when storage throws", async () => {
+    storage = makeMockStorage({ getTraces: vi.fn().mockRejectedValue(new Error("DB error")) });
+    app = makeApp(storage);
+    const res = await request(app).get("/api/workspaces/ws-1/traces");
+    expect(res.status).toBe(500);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("11. respects limit query param", async () => {
+    // Storage returns 1 item but we verify limit is parsed correctly
+    const res = await request(app).get("/api/workspaces/ws-1/traces?limit=1");
+    expect(res.status).toBe(200);
+  });
+
+  it("12. returns 400 for invalid limit", async () => {
+    const res = await request(app).get("/api/workspaces/ws-1/traces?limit=abc");
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/workspaces/:id/traces/:run_id", () => {
+  let app: ReturnType<typeof express>;
+  let storage: IStorage;
+
+  beforeEach(() => {
+    storage = makeMockStorage();
+    app = makeApp(storage);
+  });
+
+  it("13. returns 200 with full trace detail including spans", async () => {
+    const res = await request(app).get("/api/workspaces/ws-1/traces/run-test-ws-1");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.spans)).toBe(true);
+    expect(res.body.spans).toHaveLength(2);
+  });
+
+  it("14. trace detail has all WorkspaceTraceSummary fields plus spans", async () => {
+    const res = await request(app).get("/api/workspaces/ws-1/traces/run-test-ws-1");
+    expect(res.body).toHaveProperty("traceId");
+    expect(res.body).toHaveProperty("runId");
+    expect(res.body).toHaveProperty("spanCount");
+    expect(res.body).toHaveProperty("spans");
+    expect(res.body).toHaveProperty("totalTokens");
+    expect(res.body).toHaveProperty("costUsd");
+  });
+
+  it("15. returns 404 when trace not found", async () => {
+    storage = makeMockStorage({ getTraceByRunId: vi.fn().mockResolvedValue(null) });
+    app = makeApp(storage);
+    const res = await request(app).get("/api/workspaces/ws-1/traces/no-such-run");
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("16. returns 500 when storage throws", async () => {
+    storage = makeMockStorage({ getTraceByRunId: vi.fn().mockRejectedValue(new Error("DB error")) });
+    app = makeApp(storage);
+    const res = await request(app).get("/api/workspaces/ws-1/traces/run-test-ws-1");
+    expect(res.status).toBe(500);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("17. span parent-child relationship is preserved in response", async () => {
+    const res = await request(app).get("/api/workspaces/ws-1/traces/run-test-ws-1");
+    const toolSpan = res.body.spans.find((s: TraceSpan) => s.name === "tool.bash_run");
+    expect(toolSpan).toBeDefined();
+    expect(toolSpan.parentSpanId).toBe("aaaa1111aaaa1111");
+  });
+
+  it("18. span attributes include OpenInference conventions", async () => {
+    const res = await request(app).get("/api/workspaces/ws-1/traces/run-test-ws-1");
+    const llmSpan = res.body.spans.find((s: TraceSpan) => s.name.startsWith("llm."));
+    expect(llmSpan).toBeDefined();
+    expect(llmSpan.attributes["openinference.span.kind"]).toBe("LLM");
+    expect(llmSpan.attributes[OI.LLM_PROVIDER]).toBe("anthropic");
+    expect(llmSpan.attributes[OI.LLM_MODEL]).toBe("claude-sonnet-4-6");
+  });
+});


### PR DESCRIPTION
## Summary

- **LLM span enrichment**: Every LLM call span carries `llm.provider`, `llm.model`, `llm.system_prompt` (redactable), `llm.prompt` (redactable), `llm.response` (redactable), token counts, cost, temperature, max_tokens, stop sequences, tools list, `stage.id`, `stage.role`, `pipeline.run_id`
- **OpenInference semantic conventions** (`server/tracing/openinference.ts`): attribute key constants, cost/token estimation, provider inference from model slug
- **LlmSpanEnricher** (`server/tracing/llm-span.ts`): enrichment layer with injected Tracer for testability; redacts prompts/responses/tool data by default; strategy spans (debate/voting/MoA) emit a CHAIN wrapper that parents all candidate + judge/merge child spans
- **Langfuse exporter** (`server/tracing/exporters/langfuse.ts`): OTLP ingestion via `/api/public/otel/v1/traces`, Basic auth, GENERATION/SPAN type mapping, usage/cost fields
- **Phoenix/Arize exporter** (`server/tracing/exporters/phoenix.ts`): standard OTLP/JSON with OpenInference resource attributes, LLM spans use CLIENT kind
- **Both exporters** are pluggable per workspace via env vars (`LANGFUSE_*`, `PHOENIX_*`); no-op when vars absent; swallow all network errors
- **Workspace trace routes** (`server/routes/workspace-traces.ts`): `GET /api/workspaces/:id/traces` (list with token/cost/provider/model aggregation) and `GET /api/workspaces/:id/traces/:run_id` (full span tree)
- **First-party trace viewer** (`client/src/pages/WorkspaceTraces.tsx`): span tree waterfall with collapse/expand hierarchy, right-side detail panel showing prompt, response, tool calls, tokens, cost, latency; list view with summaries table
- **"LLM Traces" nav item** added to workspace sidebar sub-menu

Closes #278

## Test plan

- [x] `openinference.test.ts` — redaction, truncation, cost estimation, provider inference (21 tests)
- [x] `llm-span.test.ts` — buildLlmSpanAttributes, buildToolCallAttributes, LlmSpanEnricher (28 tests)
- [x] `strategy-spans.test.ts` — debate/MoA/voting span trees, error propagation, token accumulation (5 tests)
- [x] `exporters/langfuse.test.ts` — GENERATION type mapping, usage/cost fields, Basic auth, env config (19 tests)
- [x] `exporters/phoenix.test.ts` — OTLP payload, LLM CLIENT kind, resource attrs, env config (18 tests)
- [x] `workspace-traces-route.test.ts` — list/detail endpoints, aggregation, 404/500 handling (18 tests)
- [x] `npx tsc --noEmit`: 0 errors
- [x] `npx vitest run`: 3270 tests, all pass (148 test files)