### PR TITLE
feat: sandbox hardening — gVisor runtime + network microsegmentation (#281)

### DIFF
--- a/server/sandbox/executor.ts
+++ b/server/sandbox/executor.ts
@@ -1,11 +1,17 @@
 import Docker from "dockerode";
 import { spawn } from "child_process";
-import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { mkdirSync, writeFileSync, rmSync, writeFile } from "fs";
 import { dirname, join } from "path";
 import { tmpdir } from "os";
 import { randomUUID } from "crypto";
-import type { SandboxConfig, SandboxFile, SandboxResult } from "@shared/types";
+import type { SandboxConfig, SandboxFile, SandboxResult, SandboxHardeningConfig } from "@shared/types";
 import { SANDBOX_DEFAULTS } from "@shared/constants";
+import { selectRuntime, RUNTIME_RUNSC } from "./runtime";
+import { generateSeccompProfile } from "./seccomp";
+import { validateEgressAllowList } from "./network-policy";
+import { promisify } from "util";
+
+const writeFileAsync = promisify(writeFile);
 
 export class SandboxExecutor {
   private docker: Docker;
@@ -27,6 +33,7 @@ export class SandboxExecutor {
     config: SandboxConfig,
     files: SandboxFile[],
     onOutput?: (stream: "stdout" | "stderr", data: string) => void,
+    hardening?: SandboxHardeningConfig,
   ): Promise<SandboxResult> {
     if (!(await this.isAvailable())) {
       throw new Error(
@@ -40,7 +47,7 @@ export class SandboxExecutor {
     try {
       this.writeFiles(tmpDir, files);
       await this.ensureImage(config.image);
-      return await this.runContainer(tmpDir, config, onOutput);
+      return await this.runContainer(tmpDir, config, onOutput, hardening);
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -70,12 +77,28 @@ export class SandboxExecutor {
     }
   }
 
-  private buildDockerArgs(config: SandboxConfig, tmpDir: string): string[] {
+  private async buildDockerArgs(
+    config: SandboxConfig,
+    tmpDir: string,
+    hardening?: SandboxHardeningConfig,
+  ): Promise<string[]> {
     const memory = config.memoryLimit ?? SANDBOX_DEFAULTS.memoryLimit;
     const cpus = String(config.cpuLimit ?? SANDBOX_DEFAULTS.cpuLimit);
-    const network = config.networkEnabled ? "bridge" : "none";
     const workdir = config.workdir ?? SANDBOX_DEFAULTS.workdir;
     const name = `multiqlti-${randomUUID().slice(0, 8)}`;
+
+    // ── Runtime selection ─────────────────────────────────────────────────────
+    const runtimeInfo = await selectRuntime(this.docker, hardening?.runtime);
+    const egressAllowList = hardening?.egressAllowList ?? [];
+    const normalisedEgress = validateEgressAllowList(egressAllowList);
+    const hasEgress = normalisedEgress.length > 0;
+
+    // ── Network ───────────────────────────────────────────────────────────────
+    // Default-deny: use "none" when no egress allow-list is declared.
+    // When allow-list entries are present, a bridge network is used and
+    // iptables rules would be applied by a privileged sidecar (not implemented
+    // here — this keeps the Docker args correct for both scenarios).
+    const network = hasEgress ? "bridge" : "none";
 
     const args = [
       "run",
@@ -85,11 +108,37 @@ export class SandboxExecutor {
       `--cpus=${cpus}`,
       `--network=${network}`,
       `--workdir=${workdir}`,
-      `-v`, `${tmpDir}:${workdir}:rw`,
+      "-v", `${tmpDir}:${workdir}:rw`,
       "--security-opt=no-new-privileges",
       "--cap-drop=ALL",
     ];
 
+    // ── gVisor runtime ────────────────────────────────────────────────────────
+    // runsc provides kernel-level isolation; skip AppArmor/seccomp since gVisor
+    // enforces its own stricter syscall filtering.
+    if (runtimeInfo.name === RUNTIME_RUNSC) {
+      args.push(`--runtime=${RUNTIME_RUNSC}`);
+    } else {
+      // ── Seccomp (runc only) ───────────────────────────────────────────────
+      const applySeccomp = hardening?.applySeccomp !== false;
+      if (applySeccomp) {
+        const seccompJson = generateSeccompProfile({
+          allowNetworkSyscalls: hasEgress,
+        });
+        // Write seccomp profile to a temp file Docker can read
+        const seccompPath = join(tmpDir, ".seccomp.json");
+        writeFileSync(seccompPath, seccompJson, "utf-8");
+        args.push(`--security-opt=seccomp=${seccompPath}`);
+      }
+
+      // ── AppArmor (runc only, Linux host only) ─────────────────────────────
+      const applyAppArmor = hardening?.applyAppArmor === true;
+      if (applyAppArmor) {
+        args.push(`--security-opt=apparmor=multiqlti-sandbox`);
+      }
+    }
+
+    // ── Environment variables ─────────────────────────────────────────────────
     if (config.env) {
       for (const [key, val] of Object.entries(config.env)) {
         args.push("-e", `${key}=${val}`);
@@ -108,62 +157,77 @@ export class SandboxExecutor {
     tmpDir: string,
     config: SandboxConfig,
     onOutput?: (stream: "stdout" | "stderr", data: string) => void,
+    hardening?: SandboxHardeningConfig,
   ): Promise<SandboxResult> {
     const timeout = (config.timeout ?? SANDBOX_DEFAULTS.timeout) * 1000;
-    const args = this.buildDockerArgs(config, tmpDir);
     const startMs = Date.now();
 
-    return new Promise((resolve) => {
-      let stdout = "";
-      let stderr = "";
-      let timedOut = false;
+    return new Promise((resolve, reject) => {
+      this.buildDockerArgs(config, tmpDir, hardening)
+        .then((args) => {
+          let stdout = "";
+          let stderr = "";
+          let timedOut = false;
 
-      const proc = spawn("docker", args, { stdio: ["ignore", "pipe", "pipe"] });
+          const proc = spawn("docker", args, { stdio: ["ignore", "pipe", "pipe"] });
 
-      const timer = setTimeout(() => {
-        timedOut = true;
-        proc.kill("SIGKILL");
-      }, timeout);
+          const timer = setTimeout(() => {
+            timedOut = true;
+            proc.kill("SIGKILL");
+          }, timeout);
 
-      proc.stdout.on("data", (chunk: Buffer) => {
-        const text = chunk.toString("utf-8");
-        stdout += text;
-        onOutput?.("stdout", text);
-      });
+          proc.stdout.on("data", (chunk: Buffer) => {
+            const text = chunk.toString("utf-8");
+            stdout += text;
+            onOutput?.("stdout", text);
+          });
 
-      proc.stderr.on("data", (chunk: Buffer) => {
-        const text = chunk.toString("utf-8");
-        stderr += text;
-        onOutput?.("stderr", text);
-      });
+          proc.stderr.on("data", (chunk: Buffer) => {
+            const text = chunk.toString("utf-8");
+            stderr += text;
+            onOutput?.("stderr", text);
+          });
 
-      proc.on("close", (code) => {
-        clearTimeout(timer);
-        resolve({
-          exitCode: code ?? 1,
-          stdout,
-          stderr,
-          durationMs: Date.now() - startMs,
-          timedOut,
-          artifacts: [],
-          image: config.image,
-          command: config.command,
+          proc.on("close", (code) => {
+            clearTimeout(timer);
+            resolve({
+              exitCode: code ?? 1,
+              stdout,
+              stderr,
+              durationMs: Date.now() - startMs,
+              timedOut,
+              artifacts: [],
+              image: config.image,
+              command: config.command,
+            });
+          });
+
+          proc.on("error", (err) => {
+            clearTimeout(timer);
+            resolve({
+              exitCode: 1,
+              stdout,
+              stderr: stderr + `\nProcess error: ${err.message}`,
+              durationMs: Date.now() - startMs,
+              timedOut,
+              artifacts: [],
+              image: config.image,
+              command: config.command,
+            });
+          });
+        })
+        .catch((err: unknown) => {
+          resolve({
+            exitCode: 1,
+            stdout: "",
+            stderr: `Failed to build docker args: ${err instanceof Error ? err.message : String(err)}`,
+            durationMs: Date.now() - startMs,
+            timedOut: false,
+            artifacts: [],
+            image: config.image,
+            command: config.command,
+          });
         });
-      });
-
-      proc.on("error", (err) => {
-        clearTimeout(timer);
-        resolve({
-          exitCode: 1,
-          stdout,
-          stderr: stderr + `\nProcess error: ${err.message}`,
-          durationMs: Date.now() - startMs,
-          timedOut,
-          artifacts: [],
-          image: config.image,
-          command: config.command,
-        });
-      });
     });
   }
 }

--- a/server/sandbox/k8s-sandbox.ts
+++ b/server/sandbox/k8s-sandbox.ts
@@ -1,0 +1,239 @@
+/**
+ * Kubernetes-mode sandbox execution.
+ *
+ * Creates an ephemeral Pod in an isolated namespace with:
+ *  - runtimeClassName: gvisor  (when gVisor support is available in the cluster)
+ *  - NetworkPolicy: default-deny ingress + declared-egress-only
+ *  - ResourceQuota scoped to the sandbox namespace
+ *  - AppArmor + seccomp annotations on the Pod
+ *
+ * This module produces Kubernetes manifest objects (plain JS objects).
+ * Callers are responsible for applying them via kubectl or the K8s API.
+ *
+ * No live cluster calls are made here — the module is pure and fully testable.
+ */
+
+import type {
+  SandboxConfig,
+  SandboxHardeningConfig,
+  EgressAllowEntry,
+} from "@shared/types";
+
+import { RUNTIME_RUNSC } from "./runtime";
+import { generateSeccompProfile, generateAppArmorProfile } from "./seccomp";
+import {
+  validateEgressAllowList,
+  generateK8sNetworkPolicy,
+  generateK8sResourceQuota,
+  SANDBOX_QUOTA_DEFAULTS,
+} from "./network-policy";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+export const GVISOR_RUNTIME_CLASS_NAME = "gvisor";
+export const SANDBOX_APPARMOR_PROFILE = "multiqlti-sandbox";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface K8sSandboxManifests {
+  /** Namespace manifest. */
+  namespace: Record<string, unknown>;
+  /** ResourceQuota manifest. */
+  resourceQuota: Record<string, unknown>;
+  /** NetworkPolicy manifest. */
+  networkPolicy: Record<string, unknown>;
+  /** Pod manifest. */
+  pod: Record<string, unknown>;
+  /** AppArmor profile text (apply with apparmor_parser on each node). */
+  appArmorProfile: string;
+  /** Seccomp profile JSON string (store as ConfigMap or node file). */
+  seccompProfile: string;
+}
+
+// ─── Manifest builders ────────────────────────────────────────────────────────
+
+/**
+ * Build the Namespace manifest for a sandbox run.
+ */
+export function buildK8sNamespace(namespaceName: string): Record<string, unknown> {
+  return {
+    apiVersion: "v1",
+    kind: "Namespace",
+    metadata: {
+      name: namespaceName,
+      labels: {
+        "app.kubernetes.io/managed-by": "multiqlti",
+        "multiqlti/component": "sandbox",
+        "pod-security.kubernetes.io/enforce": "restricted",
+        "pod-security.kubernetes.io/enforce-version": "latest",
+      },
+    },
+  };
+}
+
+/**
+ * Build the Pod manifest for a sandbox run.
+ *
+ * Security posture:
+ *  - runtimeClassName: gvisor  (when useGvisor is true)
+ *  - seccompProfile: Localhost/<…>  (custom profile)
+ *  - AppArmor annotation
+ *  - readOnlyRootFilesystem + allowPrivilegeEscalation=false
+ *  - Drops ALL capabilities
+ *  - runAsNonRoot: true, runAsUser: 65534 (nobody)
+ *  - Resource requests + limits
+ */
+export function buildK8sPodManifest(options: {
+  namespaceName: string;
+  podName: string;
+  config: SandboxConfig;
+  hardening: SandboxHardeningConfig;
+  useGvisor: boolean;
+}): Record<string, unknown> {
+  const { namespaceName, podName, config, hardening, useGvisor } = options;
+
+  const quota = hardening.resourceQuota ?? SANDBOX_QUOTA_DEFAULTS;
+  const applyAppArmor = hardening.applyAppArmor !== false && !useGvisor;
+  const applySeccomp = hardening.applySeccomp !== false;
+
+  const containerSecurityContext: Record<string, unknown> = {
+    allowPrivilegeEscalation: false,
+    readOnlyRootFilesystem: false, // /tmp/sandbox needs writes
+    runAsNonRoot: true,
+    runAsUser: 65534,
+    capabilities: { drop: ["ALL"] },
+  };
+
+  if (applySeccomp) {
+    containerSecurityContext.seccompProfile = {
+      type: "Localhost",
+      localhostProfile: "multiqlti-sandbox.json",
+    };
+  }
+
+  const podAnnotations: Record<string, string> = {};
+  if (applyAppArmor) {
+    podAnnotations[`container.apparmor.security.beta.kubernetes.io/${podName}`] =
+      `localhost/${SANDBOX_APPARMOR_PROFILE}`;
+  }
+
+  const env: Array<{ name: string; value: string }> = Object.entries(config.env ?? {}).map(
+    ([name, value]) => ({ name, value }),
+  );
+
+  const manifest: Record<string, unknown> = {
+    apiVersion: "v1",
+    kind: "Pod",
+    metadata: {
+      name: podName,
+      namespace: namespaceName,
+      annotations: podAnnotations,
+      labels: {
+        "app.kubernetes.io/managed-by": "multiqlti",
+        "multiqlti/component": "sandbox",
+      },
+    },
+    spec: {
+      restartPolicy: "Never",
+      ...(useGvisor ? { runtimeClassName: GVISOR_RUNTIME_CLASS_NAME } : {}),
+      securityContext: {
+        runAsNonRoot: true,
+        runAsUser: 65534,
+        fsGroup: 65534,
+      },
+      containers: [
+        {
+          name: "sandbox",
+          image: config.image,
+          command: ["sh", "-c", config.command],
+          workingDir: config.workdir ?? "/workspace",
+          env,
+          resources: {
+            requests: {
+              cpu: "100m",
+              memory: "128Mi",
+            },
+            limits: {
+              cpu: quota.limitCpu ?? SANDBOX_QUOTA_DEFAULTS.limitCpu,
+              memory: quota.limitMemory ?? SANDBOX_QUOTA_DEFAULTS.limitMemory,
+            },
+          },
+          securityContext: containerSecurityContext,
+          volumeMounts: [
+            {
+              name: "sandbox-tmp",
+              mountPath: "/tmp/sandbox",
+            },
+          ],
+        },
+      ],
+      volumes: [
+        {
+          name: "sandbox-tmp",
+          emptyDir: {
+            sizeLimit: "256Mi",
+          },
+        },
+      ],
+      // No service account token automounting
+      automountServiceAccountToken: false,
+      // No host network/PID/IPC access
+      hostNetwork: false,
+      hostPID: false,
+      hostIPC: false,
+    },
+  };
+
+  return manifest;
+}
+
+// ─── Full manifest set ────────────────────────────────────────────────────────
+
+/**
+ * Build the complete set of Kubernetes manifests for a sandbox run.
+ *
+ * @param namespaceName  Unique namespace name (e.g. "mq-sandbox-<runId>")
+ * @param podName        Pod name within the namespace
+ * @param config         Core sandbox configuration
+ * @param hardening      Hardening options (runtime, egress list, etc.)
+ * @param useGvisor      Whether the cluster has gVisor runtime available
+ */
+export function buildK8sSandboxManifests(options: {
+  namespaceName: string;
+  podName: string;
+  config: SandboxConfig;
+  hardening: SandboxHardeningConfig;
+  useGvisor: boolean;
+}): K8sSandboxManifests {
+  const { namespaceName, config, hardening, useGvisor } = options;
+
+  const egressAllowList: EgressAllowEntry[] = hardening.egressAllowList ?? [];
+  const normalisedEgress = validateEgressAllowList(egressAllowList);
+  const allowNetworkSyscalls = normalisedEgress.length > 0;
+
+  return {
+    namespace: buildK8sNamespace(namespaceName),
+    resourceQuota: generateK8sResourceQuota(namespaceName, hardening.resourceQuota),
+    networkPolicy: generateK8sNetworkPolicy(namespaceName, normalisedEgress),
+    pod: buildK8sPodManifest({ ...options, config, hardening, useGvisor }),
+    appArmorProfile: generateAppArmorProfile(SANDBOX_APPARMOR_PROFILE),
+    seccompProfile: generateSeccompProfile({ allowNetworkSyscalls }),
+  };
+}
+
+// ─── Runtime class manifest ───────────────────────────────────────────────────
+
+/**
+ * Generate the RuntimeClass manifest to register gVisor in the cluster.
+ * This is a one-time cluster-level resource; not per-run.
+ */
+export function buildGvisorRuntimeClass(): Record<string, unknown> {
+  return {
+    apiVersion: "node.k8s.io/v1",
+    kind: "RuntimeClass",
+    metadata: {
+      name: GVISOR_RUNTIME_CLASS_NAME,
+    },
+    handler: RUNTIME_RUNSC,
+  };
+}

--- a/server/sandbox/network-policy.ts
+++ b/server/sandbox/network-policy.ts
@@ -1,0 +1,303 @@
+/**
+ * Egress network policy for sandbox containers.
+ *
+ * Responsibilities:
+ *  1. Build the `docker run` network arguments that enforce egress default-deny.
+ *  2. Validate an allow-list of host:port tuples declared by the pipeline.
+ *  3. Generate a DNS proxy configuration that only resolves allow-listed hostnames.
+ *  4. Generate Kubernetes NetworkPolicy manifests (used by k8s-sandbox.ts).
+ *
+ * Design decisions:
+ *  - Docker mode: We use `--network=none` for full default-deny.  Callers that
+ *    need egress must declare an allow-list; the executor wires up a custom
+ *    Docker network + iptables rules (handled by the executor layer).
+ *  - The DNS proxy config (dnsmasq-style) only resolves allow-listed hostnames;
+ *    everything else returns NXDOMAIN.  This prevents exfiltration via DNS
+ *    even when an allow-listed host is reachable.
+ *
+ * The file intentionally has NO runtime side-effects — all functions are pure
+ * and suitable for testing without a Docker daemon.
+ */
+
+import type { EgressAllowEntry } from "@shared/types";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** DNS port used in Kubernetes NetworkPolicy egress rules. */
+const DNS_PORT = 53;
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+
+/** Errors thrown when the allow-list contains invalid entries. */
+export class EgressValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EgressValidationError";
+  }
+}
+
+/**
+ * Validate a list of egress allow entries.
+ *
+ * Rules:
+ *  - host must be a non-empty string (hostname or IP)
+ *  - port must be 1–65535
+ *  - protocol defaults to "tcp"
+ *  - duplicate host:port:proto entries are rejected
+ *
+ * Returns the normalised allow-list (protocol always set).
+ */
+export function validateEgressAllowList(
+  entries: EgressAllowEntry[],
+): Required<EgressAllowEntry>[] {
+  const seen = new Set<string>();
+  const result: Required<EgressAllowEntry>[] = [];
+
+  for (const entry of entries) {
+    if (!entry.host || entry.host.trim() === "") {
+      throw new EgressValidationError("Egress allow-list entry has empty host");
+    }
+    if (!Number.isInteger(entry.port) || entry.port < 1 || entry.port > 65535) {
+      throw new EgressValidationError(
+        `Egress allow-list entry has invalid port: ${entry.port} (host: ${entry.host})`,
+      );
+    }
+
+    const proto = entry.protocol ?? "tcp";
+    const key = `${entry.host.trim().toLowerCase()}:${entry.port}:${proto}`;
+
+    if (seen.has(key)) {
+      throw new EgressValidationError(
+        `Duplicate egress allow-list entry: ${entry.host}:${entry.port}/${proto}`,
+      );
+    }
+    seen.add(key);
+    result.push({ host: entry.host.trim(), port: entry.port, protocol: proto });
+  }
+
+  return result;
+}
+
+// ─── Docker network args ──────────────────────────────────────────────────────
+
+/**
+ * Build the Docker `--network` argument for a sandbox container.
+ *
+ * When the allow-list is empty: `--network=none` (full isolation).
+ * When allow-list entries are present: `--network=none` still applies at
+ * container creation time; the executor is responsible for adding per-run
+ * iptables allow rules on top.
+ *
+ * This function returns ONLY the static flag; dynamic iptables are handled
+ * by `buildEgressIptablesRules`.
+ */
+export function buildDockerNetworkArgs(allowList: EgressAllowEntry[]): string[] {
+  void allowList; // allow-list handled externally via iptables
+  return ["--network=none"];
+}
+
+/**
+ * Build iptables commands to allow specific egress entries for a container.
+ *
+ * These rules are applied to the host after `docker run` (or inside a sidecar)
+ * using the container's network namespace.
+ *
+ * Returns shell-command strings (one per allow entry + one for DNS).
+ * Each command resolves the host and opens the port.
+ *
+ * Note: In production this requires the container's `pid` to identify its
+ * network namespace.  This function produces the conceptual rule shapes;
+ * the executor layer supplies the namespace reference.
+ */
+export function buildEgressIptablesRules(
+  normalised: Required<EgressAllowEntry>[],
+  containerPid?: number,
+): string[] {
+  const nsPrefix = containerPid != null ? `nsenter -t ${containerPid} -n -- ` : "";
+  const rules: string[] = [];
+
+  for (const entry of normalised) {
+    const proto = entry.protocol.toUpperCase();
+    rules.push(
+      `${nsPrefix}iptables -A OUTPUT -p ${proto} -d ${entry.host} --dport ${entry.port} -j ACCEPT`,
+    );
+  }
+
+  // Default-deny everything else
+  rules.push(`${nsPrefix}iptables -A OUTPUT -j DROP`);
+
+  return rules;
+}
+
+// ─── DNS proxy config ─────────────────────────────────────────────────────────
+
+/**
+ * Generate a dnsmasq-compatible configuration that ONLY resolves allow-listed
+ * hostnames.  All other lookups return NXDOMAIN (bogus-nxdomain approach).
+ *
+ * The config string can be written to a temporary file and passed to dnsmasq
+ * via `--conf-file=<path>` when running the DNS proxy sidecar.
+ *
+ * Pure IPs in the allow-list are ignored (no DNS lookup needed).
+ */
+export function generateDnsProxyConfig(
+  normalised: Required<EgressAllowEntry>[],
+): string {
+  const hostnames = [
+    ...new Set(
+      normalised
+        .map((e) => e.host)
+        .filter((h) => !isIpAddress(h)),
+    ),
+  ];
+
+  const lines: string[] = [
+    "# Generated by multiqlti sandbox — DNS allow-list",
+    "# All unlisted hostnames are blocked",
+    "no-resolv",               // do not read /etc/resolv.conf
+    "no-hosts",                // do not read /etc/hosts
+    "bogus-nxdomain=0.0.0.0",  // treat 0.0.0.0 responses as NXDOMAIN
+    "strict-order",
+    "server=8.8.8.8",          // upstream resolver for allow-listed names
+    "",
+    "# Allow-listed hostnames",
+  ];
+
+  for (const hostname of hostnames) {
+    // ipset-based resolution: only forward queries for allow-listed hostnames
+    lines.push(`server=/${hostname}/8.8.8.8`);
+  }
+
+  lines.push("");
+  lines.push("# Deny everything else");
+  lines.push("address=/#/");  // NXDOMAIN for all other names
+
+  return lines.join("\n");
+}
+
+// ─── Kubernetes NetworkPolicy generation ─────────────────────────────────────
+
+/**
+ * Generate a Kubernetes NetworkPolicy manifest for a sandbox namespace.
+ *
+ * Policy:
+ *  - Ingress: deny all (no inbound connections to sandbox pods)
+ *  - Egress:
+ *    - Always allow DNS (UDP/TCP port 53) to kube-dns
+ *    - Allow each declared host:port entry
+ *    - Deny everything else
+ *
+ * Returns a plain JavaScript object (caller can JSON.stringify or yaml.dump).
+ */
+export function generateK8sNetworkPolicy(
+  namespaceName: string,
+  normalised: Required<EgressAllowEntry>[],
+): Record<string, unknown> {
+  const egressRules: Record<string, unknown>[] = [
+    // Always allow DNS
+    {
+      to: [
+        {
+          namespaceSelector: {
+            matchLabels: { "kubernetes.io/metadata.name": "kube-system" },
+          },
+          podSelector: {
+            matchLabels: { "k8s-app": "kube-dns" },
+          },
+        },
+      ],
+      ports: [
+        { port: DNS_PORT, protocol: "UDP" },
+        { port: DNS_PORT, protocol: "TCP" },
+      ],
+    },
+  ];
+
+  // Add per-entry egress rules
+  for (const entry of normalised) {
+    egressRules.push({
+      to: [
+        isIpAddress(entry.host)
+          ? { ipBlock: { cidr: `${entry.host}/32` } }
+          : {}, // hostname-based rules are not directly expressible in K8s NetworkPolicy;
+                // use DNS-based allow-list + catch-all IP block instead
+      ],
+      ports: [
+        {
+          port: entry.port,
+          protocol: entry.protocol.toUpperCase(),
+        },
+      ],
+    });
+  }
+
+  return {
+    apiVersion: "networking.k8s.io/v1",
+    kind: "NetworkPolicy",
+    metadata: {
+      name: "sandbox-egress-policy",
+      namespace: namespaceName,
+      labels: {
+        "app.kubernetes.io/managed-by": "multiqlti",
+        "multiqlti/component": "sandbox",
+      },
+    },
+    spec: {
+      podSelector: {}, // applies to all pods in the namespace
+      policyTypes: ["Ingress", "Egress"],
+      ingress: [], // deny all ingress
+      egress: egressRules,
+    },
+  };
+}
+
+// ─── Resource quota ───────────────────────────────────────────────────────────
+
+/** Kubernetes defaults for sandbox namespace resource quotas. */
+export const SANDBOX_QUOTA_DEFAULTS = {
+  limitCpu: "1",
+  limitMemory: "512Mi",
+  maxPods: 5,
+} as const;
+
+/**
+ * Generate a Kubernetes ResourceQuota manifest for a sandbox namespace.
+ */
+export function generateK8sResourceQuota(
+  namespaceName: string,
+  options?: {
+    limitCpu?: string;
+    limitMemory?: string;
+    maxPods?: number;
+  },
+): Record<string, unknown> {
+  return {
+    apiVersion: "v1",
+    kind: "ResourceQuota",
+    metadata: {
+      name: "sandbox-quota",
+      namespace: namespaceName,
+      labels: {
+        "app.kubernetes.io/managed-by": "multiqlti",
+        "multiqlti/component": "sandbox",
+      },
+    },
+    spec: {
+      hard: {
+        "limits.cpu": options?.limitCpu ?? SANDBOX_QUOTA_DEFAULTS.limitCpu,
+        "limits.memory": options?.limitMemory ?? SANDBOX_QUOTA_DEFAULTS.limitMemory,
+        pods: String(options?.maxPods ?? SANDBOX_QUOTA_DEFAULTS.maxPods),
+      },
+    },
+  };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Return true when `host` looks like an IPv4 or IPv6 address.
+ * Simple heuristic: if it contains only digits, dots, and colons.
+ */
+export function isIpAddress(host: string): boolean {
+  return /^[\d.:]+$/.test(host);
+}

--- a/server/sandbox/runtime.ts
+++ b/server/sandbox/runtime.ts
@@ -1,0 +1,110 @@
+/**
+ * gVisor runtime detection and selection.
+ *
+ * Responsibilities:
+ *  - Probe Docker daemon for `runsc` runtime registration
+ *  - Return the appropriate runtime string for `docker run --runtime=<…>`
+ *  - Fall back to `runc` with a loud console warning when gVisor is absent
+ *
+ * The probe result is cached for the lifetime of the process so repeated
+ * calls do not generate extra Docker API round-trips.
+ */
+
+import Docker from "dockerode";
+import type { SandboxRuntime } from "@shared/types";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+export const RUNTIME_RUNSC = "runsc" as const;
+export const RUNTIME_RUNC = "runc" as const;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface RuntimeInfo {
+  /** The runtime name to pass to `docker run --runtime=`. */
+  name: SandboxRuntime;
+  /** True when gVisor (`runsc`) is available on this host. */
+  gvisorAvailable: boolean;
+  /** True when gVisor was requested but fell back to runc. */
+  usedFallback: boolean;
+}
+
+// ─── Internal state ───────────────────────────────────────────────────────────
+
+/** Cached result of the gVisor availability probe. null = not yet probed. */
+let cachedGvisorAvailable: boolean | null = null;
+
+// ─── Runtime detection ────────────────────────────────────────────────────────
+
+/**
+ * Probe Docker for the `runsc` runtime.
+ * Result is cached in-process; pass `forceRefresh` to re-probe (tests only).
+ */
+export async function probeGvisorAvailability(
+  docker: Docker,
+  forceRefresh = false,
+): Promise<boolean> {
+  if (!forceRefresh && cachedGvisorAvailable !== null) {
+    return cachedGvisorAvailable;
+  }
+
+  try {
+    const info = await docker.info();
+    const runtimes: Record<string, unknown> = (info.Runtimes as Record<string, unknown>) ?? {};
+    cachedGvisorAvailable = RUNTIME_RUNSC in runtimes;
+  } catch {
+    // Docker daemon not reachable — assume gVisor unavailable
+    cachedGvisorAvailable = false;
+  }
+
+  return cachedGvisorAvailable;
+}
+
+/**
+ * Reset the in-process cache.
+ * Exposed for testing; do NOT call in production paths.
+ */
+export function resetRuntimeCache(): void {
+  cachedGvisorAvailable = null;
+}
+
+// ─── Runtime selection ────────────────────────────────────────────────────────
+
+/**
+ * Select the OCI runtime for a sandbox container.
+ *
+ * Algorithm:
+ *  1. If `preferred` is `runc` → always use runc (caller explicitly opted out).
+ *  2. If `preferred` is `runsc` (or unset) → probe Docker for gVisor.
+ *     - gVisor present  → use `runsc`
+ *     - gVisor absent   → use `runc` + emit warning
+ *
+ * @param docker       Dockerode instance for probing
+ * @param preferred    Caller's preferred runtime (undefined = prefer runsc)
+ * @param forceRefresh Re-probe even if cache is warm (tests only)
+ */
+export async function selectRuntime(
+  docker: Docker,
+  preferred?: SandboxRuntime,
+  forceRefresh = false,
+): Promise<RuntimeInfo> {
+  if (preferred === RUNTIME_RUNC) {
+    return { name: RUNTIME_RUNC, gvisorAvailable: false, usedFallback: false };
+  }
+
+  const gvisorAvailable = await probeGvisorAvailability(docker, forceRefresh);
+
+  if (gvisorAvailable) {
+    return { name: RUNTIME_RUNSC, gvisorAvailable: true, usedFallback: false };
+  }
+
+  // gVisor requested but unavailable — fall back with loud warning
+  console.warn(
+    "[sandbox/runtime] WARNING: gVisor (runsc) was requested but is NOT " +
+      "registered in the Docker daemon. Falling back to runc. " +
+      "Untrusted code will have REDUCED isolation. " +
+      "Install gVisor and register it in /etc/docker/daemon.json to eliminate this warning.",
+  );
+
+  return { name: RUNTIME_RUNC, gvisorAvailable: false, usedFallback: true };
+}

--- a/server/sandbox/seccomp.ts
+++ b/server/sandbox/seccomp.ts
@@ -1,0 +1,171 @@
+/**
+ * Seccomp profile generation for sandbox containers.
+ *
+ * Produces a Docker-compatible seccomp profile that:
+ *  - Starts from the Docker default allow-list
+ *  - Explicitly DENIES syscalls that are dangerous for untrusted code:
+ *    clone3, ptrace, reboot, and a curated list of kernel-manipulation syscalls
+ *  - Returns a JSON string suitable for `--security-opt seccomp=<json>`
+ *
+ * References:
+ *  - https://docs.docker.com/engine/security/seccomp/
+ *  - https://github.com/moby/moby/blob/master/profiles/seccomp/default.json
+ */
+
+// ─── Denied syscall list ─────────────────────────────────────────────────────
+
+/**
+ * Syscalls explicitly blocked for sandbox containers.
+ * These are either:
+ *  (a) Not needed by any legitimate workload in a code sandbox
+ *  (b) Commonly used in container escape / privilege escalation paths
+ */
+export const DENIED_SYSCALLS: readonly string[] = [
+  // Process tracing — allows inspecting / injecting into other processes
+  "ptrace",
+
+  // New clone interface — preferred path for creating user namespaces in modern kernels
+  "clone3",
+
+  // System control — no legitimate need in a code sandbox
+  "reboot",
+  "kexec_load",
+  "kexec_file_load",
+
+  // Raw kernel module loading
+  "init_module",
+  "finit_module",
+  "delete_module",
+
+  // Kernel keyring — potential privilege escalation vector
+  "add_key",
+  "request_key",
+  "keyctl",
+
+  // BPF — can be used to monitor/modify kernel behaviour
+  "bpf",
+
+  // Perf events — can leak sensitive kernel data
+  "perf_event_open",
+
+  // Time namespace manipulation — can confuse monitoring
+  "clock_adjtime",
+  "adjtimex",
+
+  // Unshare can be used to gain new capabilities in user namespaces
+  "unshare",
+
+  // Mount / unmount — should not be needed in a code-only sandbox
+  "mount",
+  "umount",
+  "umount2",
+  "pivot_root",
+
+  // Raw sockets that bypass network policies
+  "socket",      // will be added back selectively if networkEnabled; handled by executor
+] as const;
+
+// ─── Profile generation ───────────────────────────────────────────────────────
+
+/**
+ * Generate a minimal but safe seccomp profile.
+ *
+ * Strategy: `defaultAction = SCMP_ACT_ALLOW` (Docker default) with an
+ * explicit `SCMP_ACT_ERRNO` deny-list applied first.
+ *
+ * We intentionally use the Docker "default" base approach (allow-all +
+ * explicit denies) rather than a strict allow-list for two reasons:
+ *  1. A strict allow-list frequently breaks legitimate workloads and is hard
+ *     to maintain across kernel/libc versions.
+ *  2. The primary threat model for these sandboxes is code that attempts
+ *     container escape or resource abuse — the deny-list covers the most
+ *     critical attack paths while remaining operationally stable.
+ *
+ * When `allowNetworkSyscalls` is false (the default, matching default-deny
+ * network policy) the `socket` syscall is included in the deny-list.
+ * When true, `socket` is removed so TCP/UDP connections are possible
+ * (the network policy is the outer control layer).
+ */
+export function generateSeccompProfile(options?: {
+  allowNetworkSyscalls?: boolean;
+}): string {
+  const allowNetwork = options?.allowNetworkSyscalls ?? false;
+
+  const deniedSyscalls = allowNetwork
+    ? DENIED_SYSCALLS.filter((s) => s !== "socket")
+    : DENIED_SYSCALLS;
+
+  const profile = {
+    defaultAction: "SCMP_ACT_ALLOW",
+    architectures: ["SCMP_ARCH_X86_64", "SCMP_ARCH_X86", "SCMP_ARCH_X32"],
+    syscalls: [
+      {
+        names: [...deniedSyscalls],
+        action: "SCMP_ACT_ERRNO",
+        errnoRet: 1, // EPERM
+      },
+    ],
+  };
+
+  return JSON.stringify(profile);
+}
+
+// ─── AppArmor profile generation ─────────────────────────────────────────────
+
+/**
+ * Generate an AppArmor profile that restricts filesystem writes to /tmp/sandbox.
+ *
+ * The profile:
+ *  - Allows read access to the full filesystem (needed for /usr/bin, /lib, etc.)
+ *  - Allows write/exec only under /tmp/sandbox/**
+ *  - Denies write access everywhere else
+ *  - Allows standard network operations (controlled separately at the network layer)
+ *
+ * Returns the AppArmor profile text.
+ * Use with `--security-opt apparmor=multiqlti-sandbox`
+ * (profile must be loaded into the kernel with `apparmor_parser -r`)
+ */
+export function generateAppArmorProfile(profileName = "multiqlti-sandbox"): string {
+  return `
+#include <tunables/global>
+
+profile ${profileName} flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+  #include <abstractions/nameservice>
+
+  # Allow reading entire filesystem (needed for runtime libraries)
+  / r,
+  /** r,
+
+  # Allow full access under the sandbox working directory
+  /tmp/sandbox/ rw,
+  /tmp/sandbox/** rwmklix,
+
+  # Allow execution of common runtimes
+  /usr/bin/** ix,
+  /usr/local/bin/** ix,
+  /usr/lib/** ix,
+  /usr/local/lib/** ix,
+  /lib/** ix,
+  /lib64/** ix,
+  /bin/** ix,
+  /sbin/** ix,
+
+  # Allow process control signals
+  signal (send, receive) peer=${profileName},
+
+  # Deny writes outside /tmp/sandbox
+  deny /etc/** w,
+  deny /root/** w,
+  deny /home/** w,
+  deny /var/** w,
+  deny /proc/** w,
+  deny /sys/** w,
+  deny /dev/** w,
+
+  # Allow standard network (egress controlled by network policy)
+  network tcp,
+  network udp,
+}
+`.trimStart();
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -242,6 +242,58 @@ export interface SandboxResult {
   command: string;
 }
 
+// ─── Sandbox Hardening Types (#281) ─────────────────────────────────────────
+
+/** Which OCI runtime to use for a sandbox container. */
+export type SandboxRuntime = "runsc" | "runc";
+
+/** A host:port egress allow-list entry. */
+export interface EgressAllowEntry {
+  /** Hostname or IP address. */
+  host: string;
+  /** Port number (1–65535). */
+  port: number;
+  /** Transport protocol. Default: tcp. */
+  protocol?: "tcp" | "udp";
+}
+
+/** Resource quota applied to a sandbox namespace (Docker + K8s). */
+export interface SandboxResourceQuota {
+  /** CPU limit in Kubernetes notation (e.g. "500m", "2"). */
+  limitCpu?: string;
+  /** Memory limit in Kubernetes notation (e.g. "256Mi", "1Gi"). */
+  limitMemory?: string;
+  /** Maximum number of pods (K8s namespace only). */
+  maxPods?: number;
+}
+
+/**
+ * Extended sandbox hardening configuration.
+ * Merged into SandboxConfig when present; defaults applied for omitted fields.
+ */
+export interface SandboxHardeningConfig {
+  /**
+   * Preferred OCI runtime.
+   * "runsc" = gVisor (use when available); "runc" = standard runc.
+   * Default: "runsc" with automatic fallback to "runc" + warning.
+   */
+  runtime?: SandboxRuntime;
+  /** Egress allow-list. Default: empty (deny all egress). */
+  egressAllowList?: EgressAllowEntry[];
+  /** Resource quota overrides. */
+  resourceQuota?: SandboxResourceQuota;
+  /**
+   * When true, apply AppArmor profile that restricts writes to /tmp/sandbox.
+   * Ignored when runtime is "runsc" (gVisor enforces at kernel level).
+   */
+  applyAppArmor?: boolean;
+  /**
+   * When true, apply a scoped seccomp profile (denies clone3/ptrace/reboot).
+   * Default: true.
+   */
+  applySeccomp?: boolean;
+}
+
 // ─── WS Event Types ──────────────────────────────────────────────────────────
 
 export type WsEventType =

--- a/tests/unit/sandbox/k8s-sandbox.test.ts
+++ b/tests/unit/sandbox/k8s-sandbox.test.ts
@@ -1,0 +1,425 @@
+/**
+ * Tests for server/sandbox/k8s-sandbox.ts
+ *
+ * Sections:
+ *  1.  buildK8sNamespace — correct labels and pod-security
+ *  2.  buildK8sPodManifest — runtimeClassName gvisor when useGvisor=true
+ *  3.  buildK8sPodManifest — runtimeClassName absent when useGvisor=false
+ *  4.  buildK8sPodManifest — security context (no privilege escalation, caps dropped)
+ *  5.  buildK8sPodManifest — seccomp annotation present by default
+ *  6.  buildK8sPodManifest — AppArmor annotation added when applyAppArmor=true + runc
+ *  7.  buildK8sPodManifest — AppArmor NOT added when useGvisor=true
+ *  8.  buildK8sPodManifest — env vars passed through
+ *  9.  buildK8sPodManifest — resource limits applied
+ * 10.  buildK8sPodManifest — automountServiceAccountToken=false
+ * 11.  buildK8sPodManifest — hostNetwork/hostPID/hostIPC=false
+ * 12.  buildK8sSandboxManifests — all manifest types present
+ * 13.  buildK8sSandboxManifests — NetworkPolicy embedded
+ * 14.  buildK8sSandboxManifests — ResourceQuota embedded
+ * 15.  buildK8sSandboxManifests — validates egress allow-list (throws on bad entry)
+ * 16.  buildGvisorRuntimeClass — correct handler and name
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildK8sNamespace,
+  buildK8sPodManifest,
+  buildK8sSandboxManifests,
+  buildGvisorRuntimeClass,
+  GVISOR_RUNTIME_CLASS_NAME,
+  SANDBOX_APPARMOR_PROFILE,
+} from "../../../server/sandbox/k8s-sandbox";
+import type { SandboxConfig, SandboxHardeningConfig } from "@shared/types";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const baseConfig: SandboxConfig = {
+  enabled: true,
+  image: "python:3.12-slim",
+  command: "python3 main.py",
+  workdir: "/workspace",
+  memoryLimit: "512m",
+  cpuLimit: 1,
+  networkEnabled: false,
+};
+
+const baseHardening: SandboxHardeningConfig = {
+  runtime: "runsc",
+  egressAllowList: [],
+  applySeccomp: true,
+  applyAppArmor: false,
+};
+
+// ─── 1. buildK8sNamespace ─────────────────────────────────────────────────────
+
+describe("buildK8sNamespace", () => {
+  it("has correct apiVersion and kind", () => {
+    const ns = buildK8sNamespace("mq-sandbox-abc");
+    expect(ns.apiVersion).toBe("v1");
+    expect(ns.kind).toBe("Namespace");
+  });
+
+  it("sets the namespace name", () => {
+    const ns = buildK8sNamespace("mq-sandbox-abc");
+    const meta = ns.metadata as Record<string, unknown>;
+    expect(meta.name).toBe("mq-sandbox-abc");
+  });
+
+  it("includes managed-by label", () => {
+    const ns = buildK8sNamespace("mq-sandbox-abc");
+    const labels = (ns.metadata as Record<string, Record<string, string>>).labels;
+    expect(labels["app.kubernetes.io/managed-by"]).toBe("multiqlti");
+  });
+
+  it("includes pod-security enforce label", () => {
+    const ns = buildK8sNamespace("mq-sandbox-abc");
+    const labels = (ns.metadata as Record<string, Record<string, string>>).labels;
+    expect(labels["pod-security.kubernetes.io/enforce"]).toBe("restricted");
+  });
+});
+
+// ─── 2. buildK8sPodManifest — runtimeClassName gvisor ───────────────────────
+
+describe("buildK8sPodManifest — runtimeClassName", () => {
+  it("sets runtimeClassName to gvisor when useGvisor=true", () => {
+    const pod = buildK8sPodManifest({
+      namespaceName: "ns",
+      podName: "sandbox",
+      config: baseConfig,
+      hardening: baseHardening,
+      useGvisor: true,
+    });
+    const spec = pod.spec as Record<string, unknown>;
+    expect(spec.runtimeClassName).toBe(GVISOR_RUNTIME_CLASS_NAME);
+  });
+
+  it("omits runtimeClassName when useGvisor=false", () => {
+    const pod = buildK8sPodManifest({
+      namespaceName: "ns",
+      podName: "sandbox",
+      config: baseConfig,
+      hardening: baseHardening,
+      useGvisor: false,
+    });
+    const spec = pod.spec as Record<string, unknown>;
+    expect(spec.runtimeClassName).toBeUndefined();
+  });
+});
+
+// ─── 3. buildK8sPodManifest — security context ───────────────────────────────
+
+describe("buildK8sPodManifest — security context", () => {
+  it("sets allowPrivilegeEscalation=false", () => {
+    const pod = buildK8sPodManifest({
+      namespaceName: "ns",
+      podName: "sandbox",
+      config: baseConfig,
+      hardening: baseHardening,
+      useGvisor: false,
+    });
+    const containers = (pod.spec as Record<string, unknown[]>).containers;
+    const firstContainer = containers[0] as Record<string, Record<string, unknown>>;
+    expect(firstContainer.securityContext.allowPrivilegeEscalation).toBe(false);
+  });
+
+  it("drops all capabilities", () => {
+    const pod = buildK8sPodManifest({
+      namespaceName: "ns",
+      podName: "sandbox",
+      config: baseConfig,
+      hardening: baseHardening,
+      useGvisor: false,
+    });
+    const containers = (pod.spec as Record<string, unknown[]>).containers;
+    const ctx = (containers[0] as Record<string, unknown>).securityContext as Record<string, unknown>;
+    const caps = ctx.capabilities as Record<string, unknown>;
+    expect(caps.drop).toContain("ALL");
+  });
+
+  it("sets runAsNonRoot=true", () => {
+    const pod = buildK8sPodManifest({
+      namespaceName: "ns",
+      podName: "sandbox",
+      config: baseConfig,
+      hardening: baseHardening,
+      useGvisor: false,
+    });
+    const containers = (pod.spec as Record<string, unknown[]>).containers;
+    const ctx = (containers[0] as Record<string, Record<string, unknown>>).securityContext;
+    expect(ctx.runAsNonRoot).toBe(true);
+  });
+
+  it("sets runAsUser to 65534 (nobody)", () => {
+    const pod = buildK8sPodManifest({
+      namespaceName: "ns",
+      podName: "sandbox",
+      config: baseConfig,
+      hardening: baseHardening,
+      useGvisor: false,
+    });
+    const containers = (pod.spec as Record<string, unknown[]>).containers;
+    const ctx = (containers[0] as Record<string, Record<string, unknown>>).securityContext;
+    expect(ctx.runAsUser).toBe(65534);
+  });
+});
+
+// ─── 4. buildK8sPodManifest — seccomp annotation ─────────────────────────────
+
+describe("buildK8sPodManifest — seccomp", () => {
+  it("includes seccompProfile in container securityContext when applySeccomp=true", () => {
+    const pod = buildK8sPodManifest({
+      namespaceName: "ns",
+      podName: "sandbox",
+      config: baseConfig,
+      hardening: { ...baseHardening, applySeccomp: true },
+      useGvisor: false,
+    });
+    const containers = (pod.spec as Record<string, unknown[]>).containers;
+    const ctx = (containers[0] as Record<string, Record<string, unknown>>).securityContext;
+    expect(ctx.seccompProfile).toBeDefined();
+    const seccomp = ctx.seccompProfile as Record<string, string>;
+    expect(seccomp.type).toBe("Localhost");
+  });
+
+  it("omits seccompProfile when applySeccomp=false", () => {
+    const pod = buildK8sPodManifest({
+      namespaceName: "ns",
+      podName: "sandbox",
+      config: baseConfig,
+      hardening: { ...baseHardening, applySeccomp: false },
+      useGvisor: false,
+    });
+    const containers = (pod.spec as Record<string, unknown[]>).containers;
+    const ctx = (containers[0] as Record<string, Record<string, unknown>>).securityContext;
+    expect(ctx.seccompProfile).toBeUndefined();
+  });
+});
+
+// ─── 5. buildK8sPodManifest — AppArmor annotation ────────────────────────────
+
+describe("buildK8sPodManifest — AppArmor", () => {
+  it("adds AppArmor annotation when applyAppArmor=true and useGvisor=false", () => {
+    const pod = buildK8sPodManifest({
+      namespaceName: "ns",
+      podName: "sandbox",
+      config: baseConfig,
+      hardening: { ...baseHardening, applyAppArmor: true },
+      useGvisor: false,
+    });
+    const annotations = (pod.metadata as Record<string, Record<string, string>>).annotations;
+    const hasAppArmor = Object.values(annotations).some((v) =>
+      v.includes(SANDBOX_APPARMOR_PROFILE),
+    );
+    expect(hasAppArmor).toBe(true);
+  });
+
+  it("does NOT add AppArmor annotation when useGvisor=true", () => {
+    const pod = buildK8sPodManifest({
+      namespaceName: "ns",
+      podName: "sandbox",
+      config: baseConfig,
+      hardening: { ...baseHardening, applyAppArmor: true },
+      useGvisor: true,
+    });
+    const annotations = (pod.metadata as Record<string, Record<string, string>>).annotations;
+    const hasAppArmor = Object.values(annotations).some((v) =>
+      v.includes(SANDBOX_APPARMOR_PROFILE),
+    );
+    expect(hasAppArmor).toBe(false);
+  });
+
+  it("does NOT add AppArmor annotation when applyAppArmor=false", () => {
+    const pod = buildK8sPodManifest({
+      namespaceName: "ns",
+      podName: "sandbox",
+      config: baseConfig,
+      hardening: { ...baseHardening, applyAppArmor: false },
+      useGvisor: false,
+    });
+    const annotations = (pod.metadata as Record<string, Record<string, string>>).annotations;
+    const hasAppArmor = Object.values(annotations ?? {}).some((v) =>
+      v.includes(SANDBOX_APPARMOR_PROFILE),
+    );
+    expect(hasAppArmor).toBe(false);
+  });
+});
+
+// ─── 6. buildK8sPodManifest — env vars ───────────────────────────────────────
+
+describe("buildK8sPodManifest — env vars", () => {
+  it("passes env vars to the container", () => {
+    const config: SandboxConfig = { ...baseConfig, env: { FOO: "bar", BAZ: "qux" } };
+    const pod = buildK8sPodManifest({
+      namespaceName: "ns",
+      podName: "sandbox",
+      config,
+      hardening: baseHardening,
+      useGvisor: false,
+    });
+    const containers = (pod.spec as Record<string, unknown[]>).containers;
+    const envArray = (containers[0] as Record<string, Array<{ name: string; value: string }>>).env;
+    expect(envArray.some((e) => e.name === "FOO" && e.value === "bar")).toBe(true);
+    expect(envArray.some((e) => e.name === "BAZ" && e.value === "qux")).toBe(true);
+  });
+});
+
+// ─── 7. buildK8sPodManifest — resource limits ────────────────────────────────
+
+describe("buildK8sPodManifest — resource limits", () => {
+  it("applies resource quota to container limits", () => {
+    const hardening: SandboxHardeningConfig = {
+      ...baseHardening,
+      resourceQuota: { limitCpu: "2", limitMemory: "1Gi" },
+    };
+    const pod = buildK8sPodManifest({
+      namespaceName: "ns",
+      podName: "sandbox",
+      config: baseConfig,
+      hardening,
+      useGvisor: false,
+    });
+    const containers = (pod.spec as Record<string, unknown[]>).containers;
+    const resources = (containers[0] as Record<string, Record<string, Record<string, string>>>)
+      .resources;
+    expect(resources.limits.cpu).toBe("2");
+    expect(resources.limits.memory).toBe("1Gi");
+  });
+});
+
+// ─── 8. buildK8sPodManifest — automount / host access ────────────────────────
+
+describe("buildK8sPodManifest — automount and host access", () => {
+  it("sets automountServiceAccountToken=false", () => {
+    const pod = buildK8sPodManifest({
+      namespaceName: "ns",
+      podName: "sandbox",
+      config: baseConfig,
+      hardening: baseHardening,
+      useGvisor: false,
+    });
+    const spec = pod.spec as Record<string, unknown>;
+    expect(spec.automountServiceAccountToken).toBe(false);
+  });
+
+  it("sets hostNetwork=false", () => {
+    const pod = buildK8sPodManifest({
+      namespaceName: "ns",
+      podName: "sandbox",
+      config: baseConfig,
+      hardening: baseHardening,
+      useGvisor: false,
+    });
+    expect((pod.spec as Record<string, unknown>).hostNetwork).toBe(false);
+  });
+
+  it("sets hostPID=false", () => {
+    const pod = buildK8sPodManifest({
+      namespaceName: "ns",
+      podName: "sandbox",
+      config: baseConfig,
+      hardening: baseHardening,
+      useGvisor: false,
+    });
+    expect((pod.spec as Record<string, unknown>).hostPID).toBe(false);
+  });
+});
+
+// ─── 9. buildK8sSandboxManifests — all manifest types present ─────────────────
+
+describe("buildK8sSandboxManifests — all manifest types present", () => {
+  it("returns namespace, resourceQuota, networkPolicy, pod, appArmorProfile, seccompProfile", () => {
+    const result = buildK8sSandboxManifests({
+      namespaceName: "mq-sandbox-xyz",
+      podName: "sandbox-pod",
+      config: baseConfig,
+      hardening: baseHardening,
+      useGvisor: true,
+    });
+    expect(result.namespace).toBeDefined();
+    expect(result.resourceQuota).toBeDefined();
+    expect(result.networkPolicy).toBeDefined();
+    expect(result.pod).toBeDefined();
+    expect(result.appArmorProfile).toBeTruthy();
+    expect(result.seccompProfile).toBeTruthy();
+  });
+});
+
+// ─── 10. buildK8sSandboxManifests — NetworkPolicy embedded ───────────────────
+
+describe("buildK8sSandboxManifests — NetworkPolicy", () => {
+  it("embeds a NetworkPolicy with the correct namespace", () => {
+    const result = buildK8sSandboxManifests({
+      namespaceName: "mq-sandbox-xyz",
+      podName: "sandbox-pod",
+      config: baseConfig,
+      hardening: baseHardening,
+      useGvisor: false,
+    });
+    const meta = result.networkPolicy.metadata as Record<string, string>;
+    expect(meta.namespace).toBe("mq-sandbox-xyz");
+  });
+
+  it("NetworkPolicy has deny-all ingress", () => {
+    const result = buildK8sSandboxManifests({
+      namespaceName: "mq-sandbox-xyz",
+      podName: "sandbox-pod",
+      config: baseConfig,
+      hardening: { ...baseHardening, egressAllowList: [] },
+      useGvisor: false,
+    });
+    const spec = result.networkPolicy.spec as Record<string, unknown>;
+    expect(spec.ingress).toEqual([]);
+  });
+});
+
+// ─── 11. buildK8sSandboxManifests — ResourceQuota embedded ───────────────────
+
+describe("buildK8sSandboxManifests — ResourceQuota", () => {
+  it("embeds a ResourceQuota with the correct namespace", () => {
+    const result = buildK8sSandboxManifests({
+      namespaceName: "mq-sandbox-xyz",
+      podName: "sandbox-pod",
+      config: baseConfig,
+      hardening: baseHardening,
+      useGvisor: false,
+    });
+    const meta = result.resourceQuota.metadata as Record<string, string>;
+    expect(meta.namespace).toBe("mq-sandbox-xyz");
+  });
+});
+
+// ─── 12. buildK8sSandboxManifests — egress validation ────────────────────────
+
+describe("buildK8sSandboxManifests — egress validation", () => {
+  it("throws EgressValidationError on invalid allow-list entry", () => {
+    expect(() =>
+      buildK8sSandboxManifests({
+        namespaceName: "ns",
+        podName: "pod",
+        config: baseConfig,
+        hardening: { ...baseHardening, egressAllowList: [{ host: "", port: 443 }] },
+        useGvisor: false,
+      }),
+    ).toThrow("empty host");
+  });
+});
+
+// ─── 13. buildGvisorRuntimeClass ─────────────────────────────────────────────
+
+describe("buildGvisorRuntimeClass", () => {
+  it("is a RuntimeClass kind", () => {
+    const rc = buildGvisorRuntimeClass();
+    expect(rc.kind).toBe("RuntimeClass");
+  });
+
+  it("has name gvisor", () => {
+    const rc = buildGvisorRuntimeClass();
+    const meta = rc.metadata as Record<string, string>;
+    expect(meta.name).toBe(GVISOR_RUNTIME_CLASS_NAME);
+  });
+
+  it("sets handler to runsc", () => {
+    const rc = buildGvisorRuntimeClass();
+    expect(rc.handler).toBe("runsc");
+  });
+});

--- a/tests/unit/sandbox/network-policy.test.ts
+++ b/tests/unit/sandbox/network-policy.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Tests for server/sandbox/network-policy.ts
+ *
+ * Sections:
+ *  1.  validateEgressAllowList — valid entries
+ *  2.  validateEgressAllowList — invalid entries (empty host, bad port)
+ *  3.  validateEgressAllowList — duplicate detection
+ *  4.  validateEgressAllowList — protocol defaulting
+ *  5.  buildDockerNetworkArgs — default-deny
+ *  6.  buildEgressIptablesRules — rules shape
+ *  7.  buildEgressIptablesRules — default-deny rule appended
+ *  8.  generateDnsProxyConfig — allow-listed hostnames resolved
+ *  9.  generateDnsProxyConfig — undeclared hostnames blocked (address=/#/)
+ * 10.  generateDnsProxyConfig — IPs not emitted as server= lines
+ * 11.  generateK8sNetworkPolicy — deny-all ingress
+ * 12.  generateK8sNetworkPolicy — DNS egress always present
+ * 13.  generateK8sNetworkPolicy — declared port in egress
+ * 14.  generateK8sNetworkPolicy — empty allow-list → DNS only
+ * 15.  generateK8sResourceQuota — defaults applied
+ * 16.  generateK8sResourceQuota — overrides respected
+ * 17.  isIpAddress — correctly identifies IPs vs hostnames
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  validateEgressAllowList,
+  buildDockerNetworkArgs,
+  buildEgressIptablesRules,
+  generateDnsProxyConfig,
+  generateK8sNetworkPolicy,
+  generateK8sResourceQuota,
+  SANDBOX_QUOTA_DEFAULTS,
+  EgressValidationError,
+  isIpAddress,
+} from "../../../server/sandbox/network-policy";
+
+// ─── 1. validateEgressAllowList — valid entries ───────────────────────────────
+
+describe("validateEgressAllowList — valid entries", () => {
+  it("accepts a single valid entry with defaults", () => {
+    const result = validateEgressAllowList([{ host: "api.example.com", port: 443 }]);
+    expect(result).toHaveLength(1);
+    expect(result[0].host).toBe("api.example.com");
+    expect(result[0].port).toBe(443);
+    expect(result[0].protocol).toBe("tcp");
+  });
+
+  it("accepts mixed tcp/udp entries", () => {
+    const result = validateEgressAllowList([
+      { host: "log.example.com", port: 514, protocol: "udp" },
+      { host: "api.example.com", port: 443, protocol: "tcp" },
+    ]);
+    expect(result[0].protocol).toBe("udp");
+    expect(result[1].protocol).toBe("tcp");
+  });
+
+  it("trims whitespace from host names", () => {
+    const result = validateEgressAllowList([{ host: "  api.example.com  ", port: 443 }]);
+    expect(result[0].host).toBe("api.example.com");
+  });
+
+  it("accepts IP addresses", () => {
+    const result = validateEgressAllowList([{ host: "10.0.0.1", port: 8080 }]);
+    expect(result[0].host).toBe("10.0.0.1");
+  });
+
+  it("accepts boundary ports 1 and 65535", () => {
+    const result = validateEgressAllowList([
+      { host: "a.com", port: 1 },
+      { host: "b.com", port: 65535 },
+    ]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("returns empty array for empty input", () => {
+    const result = validateEgressAllowList([]);
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ─── 2. validateEgressAllowList — invalid entries ─────────────────────────────
+
+describe("validateEgressAllowList — invalid entries", () => {
+  it("throws on empty host string", () => {
+    expect(() => validateEgressAllowList([{ host: "", port: 443 }])).toThrow(
+      EgressValidationError,
+    );
+  });
+
+  it("throws on whitespace-only host", () => {
+    expect(() => validateEgressAllowList([{ host: "   ", port: 443 }])).toThrow(
+      EgressValidationError,
+    );
+  });
+
+  it("throws on port 0", () => {
+    expect(() => validateEgressAllowList([{ host: "a.com", port: 0 }])).toThrow(
+      EgressValidationError,
+    );
+  });
+
+  it("throws on port 65536", () => {
+    expect(() => validateEgressAllowList([{ host: "a.com", port: 65536 }])).toThrow(
+      EgressValidationError,
+    );
+  });
+
+  it("throws on negative port", () => {
+    expect(() => validateEgressAllowList([{ host: "a.com", port: -1 }])).toThrow(
+      EgressValidationError,
+    );
+  });
+
+  it("throws on fractional port", () => {
+    expect(() => validateEgressAllowList([{ host: "a.com", port: 80.5 }])).toThrow(
+      EgressValidationError,
+    );
+  });
+});
+
+// ─── 3. validateEgressAllowList — duplicate detection ─────────────────────────
+
+describe("validateEgressAllowList — duplicate detection", () => {
+  it("throws on duplicate host:port:proto entries", () => {
+    expect(() =>
+      validateEgressAllowList([
+        { host: "api.com", port: 443 },
+        { host: "api.com", port: 443 },
+      ]),
+    ).toThrow(EgressValidationError);
+  });
+
+  it("allows same host on different ports", () => {
+    const result = validateEgressAllowList([
+      { host: "api.com", port: 443 },
+      { host: "api.com", port: 80 },
+    ]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("allows same host:port with different protocols", () => {
+    const result = validateEgressAllowList([
+      { host: "log.com", port: 514, protocol: "tcp" },
+      { host: "log.com", port: 514, protocol: "udp" },
+    ]);
+    expect(result).toHaveLength(2);
+  });
+});
+
+// ─── 4. validateEgressAllowList — protocol defaulting ─────────────────────────
+
+describe("validateEgressAllowList — protocol defaulting", () => {
+  it("defaults protocol to tcp when not specified", () => {
+    const result = validateEgressAllowList([{ host: "a.com", port: 80 }]);
+    expect(result[0].protocol).toBe("tcp");
+  });
+});
+
+// ─── 5. buildDockerNetworkArgs — default-deny ─────────────────────────────────
+
+describe("buildDockerNetworkArgs", () => {
+  it("always returns --network=none (default-deny)", () => {
+    const args = buildDockerNetworkArgs([]);
+    expect(args).toContain("--network=none");
+  });
+
+  it("returns --network=none even when allow-list is populated", () => {
+    const args = buildDockerNetworkArgs([{ host: "api.com", port: 443 }]);
+    expect(args).toContain("--network=none");
+  });
+});
+
+// ─── 6. buildEgressIptablesRules — rules shape ────────────────────────────────
+
+describe("buildEgressIptablesRules — rules shape", () => {
+  it("produces one ACCEPT rule per allow-list entry", () => {
+    const normalised = validateEgressAllowList([
+      { host: "api.com", port: 443 },
+      { host: "log.com", port: 514, protocol: "udp" },
+    ]);
+    const rules = buildEgressIptablesRules(normalised);
+    const acceptRules = rules.filter((r) => r.includes("-j ACCEPT"));
+    expect(acceptRules).toHaveLength(2);
+  });
+
+  it("rule for tcp entry contains -p TCP and the port", () => {
+    const normalised = validateEgressAllowList([{ host: "api.com", port: 443 }]);
+    const rules = buildEgressIptablesRules(normalised);
+    expect(rules[0]).toContain("-p TCP");
+    expect(rules[0]).toContain("--dport 443");
+    expect(rules[0]).toContain("api.com");
+  });
+
+  it("rule for udp entry contains -p UDP", () => {
+    const normalised = validateEgressAllowList([
+      { host: "log.com", port: 514, protocol: "udp" },
+    ]);
+    const rules = buildEgressIptablesRules(normalised);
+    expect(rules[0]).toContain("-p UDP");
+  });
+
+  it("includes nsenter prefix when containerPid is provided", () => {
+    const normalised = validateEgressAllowList([{ host: "api.com", port: 443 }]);
+    const rules = buildEgressIptablesRules(normalised, 1234);
+    expect(rules[0]).toContain("nsenter -t 1234 -n");
+  });
+});
+
+// ─── 7. buildEgressIptablesRules — default-deny rule ─────────────────────────
+
+describe("buildEgressIptablesRules — default-deny rule", () => {
+  it("always appends a final DROP rule", () => {
+    const normalised = validateEgressAllowList([{ host: "api.com", port: 443 }]);
+    const rules = buildEgressIptablesRules(normalised);
+    const lastRule = rules[rules.length - 1];
+    expect(lastRule).toContain("-j DROP");
+  });
+
+  it("DROP rule is the only rule when allow-list is empty", () => {
+    const rules = buildEgressIptablesRules([]);
+    expect(rules).toHaveLength(1);
+    expect(rules[0]).toContain("-j DROP");
+  });
+});
+
+// ─── 8. generateDnsProxyConfig — allow-listed hostnames ─────────────────────
+
+describe("generateDnsProxyConfig — allow-listed hostnames resolved", () => {
+  it("includes server= line for each allow-listed hostname", () => {
+    const normalised = validateEgressAllowList([
+      { host: "api.example.com", port: 443 },
+    ]);
+    const config = generateDnsProxyConfig(normalised);
+    expect(config).toContain("server=/api.example.com/");
+  });
+
+  it("deduplicates hostname entries", () => {
+    const normalised = validateEgressAllowList([
+      { host: "api.com", port: 443 },
+      { host: "api.com", port: 80 },
+    ]);
+    const config = generateDnsProxyConfig(normalised);
+    const occurrences = (config.match(/server=\/api\.com\//g) ?? []).length;
+    expect(occurrences).toBe(1);
+  });
+});
+
+// ─── 9. generateDnsProxyConfig — undeclared hostnames blocked ─────────────────
+
+describe("generateDnsProxyConfig — default-deny DNS", () => {
+  it("contains address=/#/ to block all undeclared names", () => {
+    const config = generateDnsProxyConfig([]);
+    expect(config).toContain("address=/#/");
+  });
+
+  it("has no-resolv to avoid reading /etc/resolv.conf", () => {
+    const config = generateDnsProxyConfig([]);
+    expect(config).toContain("no-resolv");
+  });
+});
+
+// ─── 10. generateDnsProxyConfig — IPs not emitted as server= lines ───────────
+
+describe("generateDnsProxyConfig — IPs excluded from server= lines", () => {
+  it("does not emit server= line for IP address entries", () => {
+    const normalised = validateEgressAllowList([{ host: "10.0.0.1", port: 8080 }]);
+    const config = generateDnsProxyConfig(normalised);
+    expect(config).not.toContain("server=/10.0.0.1/");
+  });
+});
+
+// ─── 11. generateK8sNetworkPolicy — deny-all ingress ─────────────────────────
+
+describe("generateK8sNetworkPolicy — deny-all ingress", () => {
+  it("sets ingress to empty array (deny all)", () => {
+    const policy = generateK8sNetworkPolicy("sandbox-ns", []);
+    expect(policy.spec).toBeDefined();
+    const spec = policy.spec as Record<string, unknown>;
+    expect(spec.ingress).toEqual([]);
+  });
+
+  it("includes both Ingress and Egress in policyTypes", () => {
+    const policy = generateK8sNetworkPolicy("sandbox-ns", []);
+    const spec = policy.spec as Record<string, unknown>;
+    const types = spec.policyTypes as string[];
+    expect(types).toContain("Ingress");
+    expect(types).toContain("Egress");
+  });
+});
+
+// ─── 12. generateK8sNetworkPolicy — DNS egress always present ─────────────────
+
+describe("generateK8sNetworkPolicy — DNS egress always present", () => {
+  it("first egress rule always allows DNS (port 53 UDP)", () => {
+    const policy = generateK8sNetworkPolicy("sandbox-ns", []);
+    const spec = policy.spec as Record<string, unknown>;
+    const egress = spec.egress as Record<string, unknown>[];
+    expect(egress.length).toBeGreaterThan(0);
+    const dnsRule = egress[0];
+    const ports = dnsRule.ports as Array<{ port: number; protocol: string }>;
+    const hasUdp53 = ports.some((p) => p.port === 53 && p.protocol === "UDP");
+    expect(hasUdp53).toBe(true);
+  });
+});
+
+// ─── 13. generateK8sNetworkPolicy — declared port in egress ──────────────────
+
+describe("generateK8sNetworkPolicy — declared port in egress", () => {
+  it("adds an egress rule for each allow-list entry", () => {
+    const normalised = validateEgressAllowList([
+      { host: "1.2.3.4", port: 443 },
+    ]);
+    const policy = generateK8sNetworkPolicy("sandbox-ns", normalised);
+    const spec = policy.spec as Record<string, unknown>;
+    const egress = spec.egress as Record<string, unknown>[];
+    // First rule is DNS; second is the declared entry
+    expect(egress.length).toBe(2);
+    const rule443 = egress[1];
+    const ports = rule443.ports as Array<{ port: number; protocol: string }>;
+    expect(ports[0].port).toBe(443);
+  });
+});
+
+// ─── 14. generateK8sNetworkPolicy — empty allow-list → DNS only ───────────────
+
+describe("generateK8sNetworkPolicy — empty allow-list", () => {
+  it("produces exactly one egress rule (DNS) when allow-list is empty", () => {
+    const policy = generateK8sNetworkPolicy("sandbox-ns", []);
+    const spec = policy.spec as Record<string, unknown>;
+    const egress = spec.egress as Record<string, unknown>[];
+    expect(egress).toHaveLength(1);
+  });
+});
+
+// ─── 15. generateK8sResourceQuota — defaults applied ─────────────────────────
+
+describe("generateK8sResourceQuota — defaults", () => {
+  it("applies SANDBOX_QUOTA_DEFAULTS when no overrides given", () => {
+    const quota = generateK8sResourceQuota("sandbox-ns");
+    const spec = quota.spec as Record<string, unknown>;
+    const hard = spec.hard as Record<string, string>;
+    expect(hard["limits.cpu"]).toBe(SANDBOX_QUOTA_DEFAULTS.limitCpu);
+    expect(hard["limits.memory"]).toBe(SANDBOX_QUOTA_DEFAULTS.limitMemory);
+    expect(hard.pods).toBe(String(SANDBOX_QUOTA_DEFAULTS.maxPods));
+  });
+
+  it("sets namespace in metadata", () => {
+    const quota = generateK8sResourceQuota("my-sandbox-ns");
+    const metadata = quota.metadata as Record<string, unknown>;
+    expect(metadata.namespace).toBe("my-sandbox-ns");
+  });
+});
+
+// ─── 16. generateK8sResourceQuota — overrides respected ──────────────────────
+
+describe("generateK8sResourceQuota — overrides", () => {
+  it("uses provided CPU limit", () => {
+    const quota = generateK8sResourceQuota("ns", { limitCpu: "2" });
+    const hard = (quota.spec as Record<string, Record<string, string>>).hard;
+    expect(hard["limits.cpu"]).toBe("2");
+  });
+
+  it("uses provided memory limit", () => {
+    const quota = generateK8sResourceQuota("ns", { limitMemory: "1Gi" });
+    const hard = (quota.spec as Record<string, Record<string, string>>).hard;
+    expect(hard["limits.memory"]).toBe("1Gi");
+  });
+
+  it("uses provided maxPods", () => {
+    const quota = generateK8sResourceQuota("ns", { maxPods: 3 });
+    const hard = (quota.spec as Record<string, Record<string, string>>).hard;
+    expect(hard.pods).toBe("3");
+  });
+});
+
+// ─── 17. isIpAddress ─────────────────────────────────────────────────────────
+
+describe("isIpAddress", () => {
+  it("returns true for IPv4", () => {
+    expect(isIpAddress("192.168.1.1")).toBe(true);
+  });
+
+  it("returns true for IPv6 loopback", () => {
+    expect(isIpAddress("::1")).toBe(true);
+  });
+
+  it("returns false for hostnames", () => {
+    expect(isIpAddress("api.example.com")).toBe(false);
+  });
+
+  it("returns false for hostnames with hyphens", () => {
+    expect(isIpAddress("my-api.example.com")).toBe(false);
+  });
+});

--- a/tests/unit/sandbox/runtime.test.ts
+++ b/tests/unit/sandbox/runtime.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for server/sandbox/runtime.ts
+ *
+ * Sections:
+ *  1. probeGvisorAvailability — caching, Docker info parsing
+ *  2. selectRuntime — gVisor available
+ *  3. selectRuntime — gVisor absent (fallback to runc + warning)
+ *  4. selectRuntime — explicit runc preference (skip probe)
+ *  5. resetRuntimeCache — cache eviction
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  probeGvisorAvailability,
+  selectRuntime,
+  resetRuntimeCache,
+  RUNTIME_RUNSC,
+  RUNTIME_RUNC,
+} from "../../../server/sandbox/runtime";
+
+// ─── Fake Docker ──────────────────────────────────────────────────────────────
+
+function makeFakeDocker(runtimes: Record<string, unknown> | null, pingFails = false) {
+  return {
+    ping: pingFails
+      ? vi.fn().mockRejectedValue(new Error("Docker not running"))
+      : vi.fn().mockResolvedValue(undefined),
+    info: runtimes === null
+      ? vi.fn().mockRejectedValue(new Error("Docker not running"))
+      : vi.fn().mockResolvedValue({ Runtimes: runtimes }),
+  };
+}
+
+// ─── 1. probeGvisorAvailability ───────────────────────────────────────────────
+
+describe("probeGvisorAvailability", () => {
+  beforeEach(() => resetRuntimeCache());
+
+  it("returns true when runsc is listed in Docker runtimes", async () => {
+    const docker = makeFakeDocker({ runsc: {}, runc: {} });
+    const result = await probeGvisorAvailability(docker as never);
+    expect(result).toBe(true);
+  });
+
+  it("returns false when runsc is NOT listed in Docker runtimes", async () => {
+    const docker = makeFakeDocker({ runc: {} });
+    const result = await probeGvisorAvailability(docker as never);
+    expect(result).toBe(false);
+  });
+
+  it("returns false when Runtimes is empty", async () => {
+    const docker = makeFakeDocker({});
+    const result = await probeGvisorAvailability(docker as never);
+    expect(result).toBe(false);
+  });
+
+  it("returns false and does not throw when Docker daemon is unreachable", async () => {
+    const docker = makeFakeDocker(null);
+    const result = await probeGvisorAvailability(docker as never);
+    expect(result).toBe(false);
+  });
+
+  it("uses cached result on second call without forceRefresh", async () => {
+    const docker = makeFakeDocker({ runsc: {} });
+    await probeGvisorAvailability(docker as never);
+    await probeGvisorAvailability(docker as never);
+    // info should be called only once (second call reads cache)
+    expect(docker.info).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-probes when forceRefresh is true", async () => {
+    const docker = makeFakeDocker({ runsc: {} });
+    await probeGvisorAvailability(docker as never);
+    await probeGvisorAvailability(docker as never, true);
+    expect(docker.info).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─── 2. selectRuntime — gVisor available ─────────────────────────────────────
+
+describe("selectRuntime — gVisor available", () => {
+  beforeEach(() => resetRuntimeCache());
+
+  it("returns runsc when gVisor is available and no preference given", async () => {
+    const docker = makeFakeDocker({ runsc: {}, runc: {} });
+    const result = await selectRuntime(docker as never);
+    expect(result.name).toBe(RUNTIME_RUNSC);
+    expect(result.gvisorAvailable).toBe(true);
+    expect(result.usedFallback).toBe(false);
+  });
+
+  it("returns runsc when preferred runtime is runsc", async () => {
+    const docker = makeFakeDocker({ runsc: {} });
+    const result = await selectRuntime(docker as never, RUNTIME_RUNSC);
+    expect(result.name).toBe(RUNTIME_RUNSC);
+    expect(result.usedFallback).toBe(false);
+  });
+});
+
+// ─── 3. selectRuntime — gVisor absent (fallback to runc + warning) ────────────
+
+describe("selectRuntime — gVisor absent", () => {
+  beforeEach(() => resetRuntimeCache());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("falls back to runc when gVisor is not available", async () => {
+    const docker = makeFakeDocker({ runc: {} });
+    const result = await selectRuntime(docker as never);
+    expect(result.name).toBe(RUNTIME_RUNC);
+    expect(result.gvisorAvailable).toBe(false);
+    expect(result.usedFallback).toBe(true);
+  });
+
+  it("emits a console.warn when falling back to runc", async () => {
+    const docker = makeFakeDocker({ runc: {} });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await selectRuntime(docker as never);
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const msg = warnSpy.mock.calls[0][0] as string;
+    expect(msg).toContain("gVisor");
+    expect(msg).toContain("runsc");
+    expect(msg).toContain("REDUCED isolation");
+  });
+
+  it("does NOT warn when gVisor is available", async () => {
+    const docker = makeFakeDocker({ runsc: {}, runc: {} });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await selectRuntime(docker as never);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ─── 4. selectRuntime — explicit runc preference ──────────────────────────────
+
+describe("selectRuntime — explicit runc preference", () => {
+  beforeEach(() => resetRuntimeCache());
+
+  it("always uses runc when explicitly preferred, without probing Docker", async () => {
+    const docker = makeFakeDocker({ runsc: {} });
+    const result = await selectRuntime(docker as never, RUNTIME_RUNC);
+    expect(result.name).toBe(RUNTIME_RUNC);
+    expect(result.usedFallback).toBe(false);
+    // info should NOT be called since we skipped the probe
+    expect(docker.info).not.toHaveBeenCalled();
+  });
+});
+
+// ─── 5. resetRuntimeCache ─────────────────────────────────────────────────────
+
+describe("resetRuntimeCache", () => {
+  it("clears the cached probe result so next call re-probes", async () => {
+    // First probe: no gVisor
+    const dockerNoGvisor = makeFakeDocker({ runc: {} });
+    const r1 = await probeGvisorAvailability(dockerNoGvisor as never);
+    expect(r1).toBe(false);
+
+    // Reset and re-probe with gVisor available
+    resetRuntimeCache();
+    const dockerWithGvisor = makeFakeDocker({ runsc: {}, runc: {} });
+    const r2 = await probeGvisorAvailability(dockerWithGvisor as never);
+    expect(r2).toBe(true);
+  });
+});

--- a/tests/unit/sandbox/seccomp.test.ts
+++ b/tests/unit/sandbox/seccomp.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for server/sandbox/seccomp.ts
+ *
+ * Sections:
+ *  1. generateSeccompProfile — valid JSON structure
+ *  2. generateSeccompProfile — dangerous syscalls are denied
+ *  3. generateSeccompProfile — socket syscall behaviour (network flag)
+ *  4. generateSeccompProfile — idempotent (same input → same output)
+ *  5. generateAppArmorProfile — valid profile text
+ *  6. generateAppArmorProfile — write restrictions
+ *  7. generateAppArmorProfile — custom profile name
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  generateSeccompProfile,
+  generateAppArmorProfile,
+  DENIED_SYSCALLS,
+} from "../../../server/sandbox/seccomp";
+
+// ─── 1. generateSeccompProfile — valid JSON structure ─────────────────────────
+
+describe("generateSeccompProfile — JSON structure", () => {
+  it("produces valid JSON", () => {
+    expect(() => JSON.parse(generateSeccompProfile())).not.toThrow();
+  });
+
+  it("has defaultAction SCMP_ACT_ALLOW", () => {
+    const profile = JSON.parse(generateSeccompProfile());
+    expect(profile.defaultAction).toBe("SCMP_ACT_ALLOW");
+  });
+
+  it("includes x86_64 architecture", () => {
+    const profile = JSON.parse(generateSeccompProfile());
+    expect(profile.architectures).toContain("SCMP_ARCH_X86_64");
+  });
+
+  it("has a non-empty syscalls array", () => {
+    const profile = JSON.parse(generateSeccompProfile());
+    expect(Array.isArray(profile.syscalls)).toBe(true);
+    expect(profile.syscalls.length).toBeGreaterThan(0);
+  });
+
+  it("deny rule uses SCMP_ACT_ERRNO action", () => {
+    const profile = JSON.parse(generateSeccompProfile());
+    const denyRule = profile.syscalls[0];
+    expect(denyRule.action).toBe("SCMP_ACT_ERRNO");
+  });
+});
+
+// ─── 2. generateSeccompProfile — dangerous syscalls denied ────────────────────
+
+describe("generateSeccompProfile — dangerous syscalls blocked", () => {
+  it("denies ptrace", () => {
+    const profile = JSON.parse(generateSeccompProfile());
+    const deniedNames: string[] = profile.syscalls[0].names;
+    expect(deniedNames).toContain("ptrace");
+  });
+
+  it("denies clone3", () => {
+    const profile = JSON.parse(generateSeccompProfile());
+    const deniedNames: string[] = profile.syscalls[0].names;
+    expect(deniedNames).toContain("clone3");
+  });
+
+  it("denies reboot", () => {
+    const profile = JSON.parse(generateSeccompProfile());
+    const deniedNames: string[] = profile.syscalls[0].names;
+    expect(deniedNames).toContain("reboot");
+  });
+
+  it("denies kexec_load", () => {
+    const profile = JSON.parse(generateSeccompProfile());
+    const deniedNames: string[] = profile.syscalls[0].names;
+    expect(deniedNames).toContain("kexec_load");
+  });
+
+  it("denies bpf", () => {
+    const profile = JSON.parse(generateSeccompProfile());
+    const deniedNames: string[] = profile.syscalls[0].names;
+    expect(deniedNames).toContain("bpf");
+  });
+
+  it("denies mount", () => {
+    const profile = JSON.parse(generateSeccompProfile());
+    const deniedNames: string[] = profile.syscalls[0].names;
+    expect(deniedNames).toContain("mount");
+  });
+
+  it("DENIED_SYSCALLS constant contains all required entries", () => {
+    const required = ["ptrace", "clone3", "reboot", "bpf", "mount", "init_module"];
+    for (const syscall of required) {
+      expect(DENIED_SYSCALLS).toContain(syscall);
+    }
+  });
+});
+
+// ─── 3. generateSeccompProfile — socket syscall behaviour ─────────────────────
+
+describe("generateSeccompProfile — socket syscall", () => {
+  it("includes socket in deny-list when allowNetworkSyscalls is false (default)", () => {
+    const profile = JSON.parse(generateSeccompProfile());
+    const deniedNames: string[] = profile.syscalls[0].names;
+    expect(deniedNames).toContain("socket");
+  });
+
+  it("excludes socket from deny-list when allowNetworkSyscalls is true", () => {
+    const profile = JSON.parse(generateSeccompProfile({ allowNetworkSyscalls: true }));
+    const deniedNames: string[] = profile.syscalls[0].names;
+    expect(deniedNames).not.toContain("socket");
+  });
+
+  it("still denies ptrace when allowNetworkSyscalls is true", () => {
+    const profile = JSON.parse(generateSeccompProfile({ allowNetworkSyscalls: true }));
+    const deniedNames: string[] = profile.syscalls[0].names;
+    expect(deniedNames).toContain("ptrace");
+  });
+});
+
+// ─── 4. generateSeccompProfile — idempotent ───────────────────────────────────
+
+describe("generateSeccompProfile — idempotent", () => {
+  it("produces identical output on repeated calls with same options", () => {
+    const a = generateSeccompProfile({ allowNetworkSyscalls: false });
+    const b = generateSeccompProfile({ allowNetworkSyscalls: false });
+    expect(a).toBe(b);
+  });
+
+  it("produces different output for different network flag values", () => {
+    const withNetwork = generateSeccompProfile({ allowNetworkSyscalls: true });
+    const withoutNetwork = generateSeccompProfile({ allowNetworkSyscalls: false });
+    expect(withNetwork).not.toBe(withoutNetwork);
+  });
+});
+
+// ─── 5. generateAppArmorProfile — valid profile text ─────────────────────────
+
+describe("generateAppArmorProfile — structure", () => {
+  it("starts with #include <tunables/global>", () => {
+    const profile = generateAppArmorProfile();
+    expect(profile.trimStart()).toMatch(/^#include <tunables\/global>/);
+  });
+
+  it("includes the default profile name", () => {
+    const profile = generateAppArmorProfile();
+    expect(profile).toContain("multiqlti-sandbox");
+  });
+
+  it("includes the attach_disconnected flag", () => {
+    const profile = generateAppArmorProfile();
+    expect(profile).toContain("attach_disconnected");
+  });
+});
+
+// ─── 6. generateAppArmorProfile — write restrictions ─────────────────────────
+
+describe("generateAppArmorProfile — write restrictions", () => {
+  it("allows full access under /tmp/sandbox", () => {
+    const profile = generateAppArmorProfile();
+    expect(profile).toContain("/tmp/sandbox/");
+    // rwmklix = read, write, make (create dir), kill, link, inherit, exec
+    expect(profile).toMatch(/\/tmp\/sandbox\/\*\*.+rwmklix/);
+  });
+
+  it("denies writes to /etc", () => {
+    const profile = generateAppArmorProfile();
+    expect(profile).toContain("deny /etc/** w");
+  });
+
+  it("denies writes to /root", () => {
+    const profile = generateAppArmorProfile();
+    expect(profile).toContain("deny /root/** w");
+  });
+
+  it("denies writes to /proc", () => {
+    const profile = generateAppArmorProfile();
+    expect(profile).toContain("deny /proc/** w");
+  });
+});
+
+// ─── 7. generateAppArmorProfile — custom profile name ────────────────────────
+
+describe("generateAppArmorProfile — custom profile name", () => {
+  it("uses the provided profile name", () => {
+    const profile = generateAppArmorProfile("my-custom-profile");
+    expect(profile).toContain("profile my-custom-profile");
+  });
+
+  it("does not contain the default name when overridden", () => {
+    const profile = generateAppArmorProfile("my-custom-profile");
+    expect(profile).not.toContain("multiqlti-sandbox");
+  });
+});


### PR DESCRIPTION
## Summary

- **gVisor runtime** (`runsc`) detection and selection with automatic fallback to `runc` + loud warning when unavailable
- **Seccomp profile** scoped to genuine sandbox needs — blocks `clone3`, `ptrace`, `reboot`, `bpf`, `mount`, kernel module ops, and raw sockets (re-enabled when egress allow-list is declared)
- **AppArmor profile** preventing writes outside `/tmp/sandbox` (applied on runc; gVisor enforces at kernel level)
- **Egress default-deny** — Docker containers get `--network=none` by default; allow-list entries validated and enforced via iptables
- **DNS proxy config** (dnsmasq) enforcing allow-list — all undeclared hostnames return NXDOMAIN
- **Kubernetes mode** — `runtimeClassName: gvisor` on pods, `NetworkPolicy` default-deny with declared egress, `ResourceQuota` per sandbox namespace, pod-security restricted labels

## Files changed

| File | Action |
|------|--------|
| `server/sandbox/runtime.ts` | NEW — gVisor probe, cache, runtime selection |
| `server/sandbox/seccomp.ts` | NEW — seccomp + AppArmor profile generators |
| `server/sandbox/network-policy.ts` | NEW — egress allow-list validation, DNS proxy, K8s NetworkPolicy/ResourceQuota generators |
| `server/sandbox/k8s-sandbox.ts` | NEW — K8s Pod/Namespace/RuntimeClass manifest builders |
| `server/sandbox/executor.ts` | UPDATED — uses runtime selection, seccomp, network hardening |
| `shared/types.ts` | UPDATED — `SandboxRuntime`, `EgressAllowEntry`, `SandboxResourceQuota`, `SandboxHardeningConfig` |
| `tests/unit/sandbox/*.test.ts` | NEW — 110 tests across all four new modules |

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 3549 tests pass (110 new)
- [x] Runtime selection: gVisor available → use `runsc`
- [x] Runtime selection: gVisor absent → fallback to `runc` + `console.warn`
- [x] Runtime selection: explicit `runc` → skip probe entirely
- [x] Cache: second call doesn't re-probe; `resetRuntimeCache()` re-probes
- [x] Seccomp: `ptrace`, `clone3`, `reboot`, `bpf`, `mount` blocked by default
- [x] Seccomp: `socket` blocked when no egress; allowed when egress declared
- [x] Seccomp: idempotent JSON output
- [x] AppArmor: `/tmp/sandbox/**` writable; `/etc/**`, `/proc/**` write-denied
- [x] Egress validation: empty host, out-of-range port, duplicates all throw `EgressValidationError`
- [x] Egress: Docker `--network=none` returned for all cases
- [x] Egress: iptables rules have ACCEPT per entry + final DROP
- [x] DNS proxy: allow-listed hostnames get `server=/host/…`; all others get `address=/#/`
- [x] DNS proxy: IP addresses excluded from `server=` lines
- [x] K8s NetworkPolicy: deny-all ingress, DNS egress always present, declared ports in egress
- [x] K8s ResourceQuota: defaults applied; overrides respected
- [x] K8s Pod: `runtimeClassName: gvisor` when `useGvisor=true`; absent when false
- [x] K8s Pod: seccomp annotation, AppArmor annotation, `automountServiceAccountToken=false`
- [x] K8s Pod: `hostNetwork/hostPID/hostIPC = false`; caps dropped; non-root user