### PR TITLE
feat: hybrid RAG memory with pgvector retrieval (#282)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,6 +22,7 @@ import Settings from "@/pages/Settings";
 import Privacy from "@/pages/Privacy";
 import Statistics from "@/pages/Statistics";
 import Memory from "@/pages/Memory";
+import Knowledge from "@/pages/Knowledge";
 import WorkspaceList from "@/pages/WorkspaceList";
 import Workspace from "@/pages/Workspace";
 import Connections from "@/pages/Connections";
@@ -107,6 +108,9 @@ function ProtectedRouter() {
         )} />
         <Route path="/workspaces/:id/inventory" component={() => (
           <ErrorBoundary><Inventory /></ErrorBoundary>
+        )} />
+        <Route path="/workspaces/:id/knowledge" component={() => (
+          <ErrorBoundary><Knowledge /></ErrorBoundary>
         )} />
         <Route path="/workspaces/:id" component={() => (
           <ErrorBoundary><Workspace /></ErrorBoundary>

--- a/client/src/pages/Knowledge.tsx
+++ b/client/src/pages/Knowledge.tsx
@@ -1,0 +1,377 @@
+import { useState } from "react";
+import { useRoute, Link } from "wouter";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Brain, Search, Upload, Trash2, Settings, ChevronRight, FileText, Code2, Clock, Database, RefreshCw } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+import { apiRequest } from "@/lib/queryClient";
+import { cn } from "@/lib/utils";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface KnowledgeSource {
+  sourceType: "code" | "pipeline_run" | "document" | "memory_entry";
+  sourceId: string;
+  count: number;
+}
+
+interface SearchResult {
+  id: string;
+  sourceType: string;
+  sourceId: string;
+  chunkText: string;
+  score: number;
+  metadata: Record<string, unknown>;
+  ts: string;
+}
+
+interface EmbeddingConfig {
+  provider: string;
+  model: string;
+  dimensions: number;
+  config?: Record<string, string>;
+}
+
+const SOURCE_TYPE_ICONS: Record<string, React.ReactNode> = {
+  code: <Code2 className="h-3.5 w-3.5" />,
+  pipeline_run: <Clock className="h-3.5 w-3.5" />,
+  document: <FileText className="h-3.5 w-3.5" />,
+  memory_entry: <Brain className="h-3.5 w-3.5" />,
+};
+
+const SOURCE_TYPE_COLORS: Record<string, string> = {
+  code: "bg-blue-500/15 text-blue-600 border-blue-500/30",
+  pipeline_run: "bg-amber-500/15 text-amber-600 border-amber-500/30",
+  document: "bg-emerald-500/15 text-emerald-600 border-emerald-500/30",
+  memory_entry: "bg-purple-500/15 text-purple-600 border-purple-500/30",
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function Knowledge() {
+  const [, params] = useRoute("/workspaces/:id/knowledge");
+  const workspaceId = params?.id ?? "";
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+
+  const [ingestText, setIngestText] = useState("");
+  const [ingestSourceId, setIngestSourceId] = useState("");
+  const [ingestSourceType, setIngestSourceType] = useState<string>("document");
+
+  // ─── Queries ────────────────────────────────────────────────────────────────
+
+  const { data: sources = [], isLoading: sourcesLoading } = useQuery<KnowledgeSource[]>({
+    queryKey: ["/api/workspaces", workspaceId, "knowledge", "sources"],
+    queryFn: () => apiRequest("GET", `/api/workspaces/${workspaceId}/knowledge/sources`).then((r) => r.json()),
+    enabled: !!workspaceId,
+  });
+
+  const { data: embeddingConfig } = useQuery<EmbeddingConfig>({
+    queryKey: ["/api/workspaces", workspaceId, "knowledge", "config"],
+    queryFn: () => apiRequest("GET", `/api/workspaces/${workspaceId}/knowledge/config`).then((r) => r.json()),
+    enabled: !!workspaceId,
+  });
+
+  // ─── Mutations ───────────────────────────────────────────────────────────────
+
+  const ingestMutation = useMutation({
+    mutationFn: (data: { sourceType: string; sourceId: string; text: string; replace: boolean }) =>
+      apiRequest("POST", `/api/workspaces/${workspaceId}/knowledge/ingest`, data).then((r) => r.json()),
+    onSuccess: (result: { inserted: number }) => {
+      toast({ title: "Ingested", description: `${result.inserted} chunks indexed.` });
+      queryClient.invalidateQueries({ queryKey: ["/api/workspaces", workspaceId, "knowledge", "sources"] });
+      setIngestText("");
+      setIngestSourceId("");
+    },
+    onError: (err: Error) => {
+      toast({ title: "Ingest failed", description: err.message, variant: "destructive" });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: ({ sourceType, sourceId }: { sourceType: string; sourceId: string }) =>
+      apiRequest("DELETE", `/api/workspaces/${workspaceId}/knowledge/sources/${sourceType}/${encodeURIComponent(sourceId)}`).then((r) => r.json()),
+    onSuccess: () => {
+      toast({ title: "Deleted" });
+      queryClient.invalidateQueries({ queryKey: ["/api/workspaces", workspaceId, "knowledge", "sources"] });
+    },
+    onError: () => {
+      toast({ title: "Delete failed", variant: "destructive" });
+    },
+  });
+
+  const reEmbedMutation = useMutation({
+    mutationFn: () =>
+      apiRequest("POST", `/api/workspaces/${workspaceId}/knowledge/re-embed`, {}).then((r) => r.json()),
+    onSuccess: (result: { totalChunks: number }) => {
+      toast({ title: "Re-embed started", description: `Queued ${result.totalChunks} chunks for re-embedding.` });
+    },
+    onError: () => {
+      toast({ title: "Re-embed failed", variant: "destructive" });
+    },
+  });
+
+  // ─── Handlers ────────────────────────────────────────────────────────────────
+
+  async function handleSearch() {
+    if (!searchQuery.trim()) return;
+    setIsSearching(true);
+    try {
+      const res = await apiRequest("GET", `/api/workspaces/${workspaceId}/knowledge/search?q=${encodeURIComponent(searchQuery)}&topK=10`);
+      const results = await res.json();
+      setSearchResults(results);
+    } catch (err) {
+      toast({ title: "Search failed", description: (err as Error).message, variant: "destructive" });
+    } finally {
+      setIsSearching(false);
+    }
+  }
+
+  function handleIngest() {
+    if (!ingestText.trim() || !ingestSourceId.trim()) return;
+    ingestMutation.mutate({
+      sourceType: ingestSourceType,
+      sourceId: ingestSourceId,
+      text: ingestText,
+      replace: true,
+    });
+  }
+
+  const totalChunks = sources.reduce((sum, s) => sum + s.count, 0);
+
+  // ─── Render ───────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="border-b px-6 py-4 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Brain className="h-5 w-5 text-purple-500" />
+          <div>
+            <h1 className="font-semibold text-lg">Knowledge Base</h1>
+            <p className="text-sm text-muted-foreground">
+              {totalChunks.toLocaleString()} chunks indexed
+              {embeddingConfig && (
+                <span className="ml-2 text-xs">
+                  via <span className="font-mono">{embeddingConfig.model}</span> ({embeddingConfig.provider})
+                </span>
+              )}
+            </p>
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => reEmbedMutation.mutate()}
+          disabled={reEmbedMutation.isPending}
+        >
+          <RefreshCw className={cn("h-4 w-4 mr-2", reEmbedMutation.isPending && "animate-spin")} />
+          Re-embed All
+        </Button>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto p-6">
+        <Tabs defaultValue="sources">
+          <TabsList className="mb-6">
+            <TabsTrigger value="sources">
+              <Database className="h-4 w-4 mr-2" />
+              Sources
+            </TabsTrigger>
+            <TabsTrigger value="search">
+              <Search className="h-4 w-4 mr-2" />
+              Search
+            </TabsTrigger>
+            <TabsTrigger value="import">
+              <Upload className="h-4 w-4 mr-2" />
+              Import
+            </TabsTrigger>
+          </TabsList>
+
+          {/* ── Sources tab ── */}
+          <TabsContent value="sources">
+            {sourcesLoading ? (
+              <div className="text-sm text-muted-foreground">Loading sources…</div>
+            ) : sources.length === 0 ? (
+              <Card>
+                <CardContent className="py-12 text-center">
+                  <Database className="h-10 w-10 mx-auto mb-3 text-muted-foreground/40" />
+                  <p className="text-muted-foreground text-sm">No knowledge sources indexed yet.</p>
+                  <p className="text-muted-foreground text-xs mt-1">Use the Import tab to add documents or text.</p>
+                </CardContent>
+              </Card>
+            ) : (
+              <div className="space-y-2">
+                {sources.map((source) => (
+                  <Card key={`${source.sourceType}:${source.sourceId}`}>
+                    <CardContent className="py-3 px-4 flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <Badge
+                          variant="outline"
+                          className={cn("text-xs gap-1", SOURCE_TYPE_COLORS[source.sourceType])}
+                        >
+                          {SOURCE_TYPE_ICONS[source.sourceType]}
+                          {source.sourceType}
+                        </Badge>
+                        <span className="text-sm font-mono truncate max-w-xs">{source.sourceId}</span>
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <span className="text-xs text-muted-foreground">{source.count} chunks</span>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7 text-destructive hover:text-destructive"
+                          onClick={() => deleteMutation.mutate({ sourceType: source.sourceType, sourceId: source.sourceId })}
+                          disabled={deleteMutation.isPending}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </TabsContent>
+
+          {/* ── Search tab ── */}
+          <TabsContent value="search">
+            <Card className="mb-4">
+              <CardContent className="pt-4 pb-4">
+                <div className="flex gap-2">
+                  <Input
+                    placeholder="Search knowledge base semantically…"
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+                    className="flex-1"
+                  />
+                  <Button onClick={handleSearch} disabled={isSearching || !searchQuery.trim()}>
+                    <Search className={cn("h-4 w-4 mr-2", isSearching && "animate-spin")} />
+                    Search
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+
+            {searchResults.length > 0 ? (
+              <div className="space-y-3">
+                {searchResults.map((result) => (
+                  <Card key={result.id}>
+                    <CardContent className="py-3 px-4">
+                      <div className="flex items-start justify-between gap-2 mb-2">
+                        <div className="flex items-center gap-2">
+                          <Badge
+                            variant="outline"
+                            className={cn("text-xs gap-1", SOURCE_TYPE_COLORS[result.sourceType])}
+                          >
+                            {SOURCE_TYPE_ICONS[result.sourceType]}
+                            {result.sourceType}
+                          </Badge>
+                          <span className="text-xs font-mono text-muted-foreground truncate max-w-xs">
+                            {result.sourceId}
+                          </span>
+                        </div>
+                        <Badge variant="secondary" className="text-xs shrink-0">
+                          {(result.score * 100).toFixed(0)}% match
+                        </Badge>
+                      </div>
+                      <p className="text-sm text-muted-foreground leading-relaxed line-clamp-4">
+                        {result.chunkText}
+                      </p>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            ) : searchQuery && !isSearching ? (
+              <p className="text-sm text-muted-foreground text-center py-8">No results found.</p>
+            ) : null}
+          </TabsContent>
+
+          {/* ── Import tab ── */}
+          <TabsContent value="import">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Import Document</CardTitle>
+                <CardDescription>
+                  Paste text or code to chunk and embed it into the knowledge base.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Source Type</label>
+                    <Select value={ingestSourceType} onValueChange={setIngestSourceType}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="document">Document</SelectItem>
+                        <SelectItem value="code">Code</SelectItem>
+                        <SelectItem value="pipeline_run">Pipeline Run</SelectItem>
+                        <SelectItem value="memory_entry">Memory Entry</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Source ID</label>
+                    <Input
+                      placeholder="e.g. README.md, run-123"
+                      value={ingestSourceId}
+                      onChange={(e) => setIngestSourceId(e.target.value)}
+                    />
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Content</label>
+                  <Textarea
+                    placeholder="Paste your document or code here…"
+                    value={ingestText}
+                    onChange={(e) => setIngestText(e.target.value)}
+                    rows={10}
+                    className="font-mono text-sm"
+                  />
+                </div>
+
+                <Button
+                  onClick={handleIngest}
+                  disabled={ingestMutation.isPending || !ingestText.trim() || !ingestSourceId.trim()}
+                  className="w-full"
+                >
+                  {ingestMutation.isPending ? (
+                    <>
+                      <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+                      Indexing…
+                    </>
+                  ) : (
+                    <>
+                      <Upload className="h-4 w-4 mr-2" />
+                      Embed & Index
+                    </>
+                  )}
+                </Button>
+              </CardContent>
+            </Card>
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  );
+}

--- a/migrations/0018_memory_chunks.sql
+++ b/migrations/0018_memory_chunks.sql
@@ -1,0 +1,59 @@
+-- migration: 0018_memory_chunks
+-- Adds vector-backed memory chunks for hybrid RAG retrieval (issue #282).
+-- Requires: CREATE EXTENSION vector (pgvector) — applied here if absent.
+-- HNSW index gives sub-millisecond ANN search at O(log n) complexity.
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- ─── memory_chunks ────────────────────────────────────────────────────────────
+-- source_type: 'code' | 'pipeline_run' | 'document' | 'memory_entry'
+-- embedding dimensions are parametrized at insert time; 1536 is the OpenAI/
+-- Voyage default. Ollama nomic-embed-text uses 768. Both fit in vector(1536)
+-- because pgvector supports any inner dimension up to max_dimensions.
+-- We store the actual model dimension in metadata.dim so ANN comparisons are
+-- always within the same model family.
+
+CREATE TABLE IF NOT EXISTS memory_chunks (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id  VARCHAR NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  source_type   TEXT NOT NULL CHECK (source_type IN ('code','pipeline_run','document','memory_entry')),
+  source_id     TEXT NOT NULL,
+  chunk_text    TEXT NOT NULL,
+  embedding     vector(1536),
+  metadata      JSONB NOT NULL DEFAULT '{}',
+  ts            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- HNSW index for fast approximate nearest-neighbour search (cosine distance).
+-- m=16 / ef_construction=64 are sensible production defaults per pgvector docs.
+CREATE INDEX IF NOT EXISTS memory_chunks_embedding_hnsw_idx
+  ON memory_chunks
+  USING hnsw (embedding vector_cosine_ops)
+  WITH (m = 16, ef_construction = 64);
+
+-- Composite index for bulk deletes by workspace + source
+CREATE INDEX IF NOT EXISTS memory_chunks_workspace_source_idx
+  ON memory_chunks (workspace_id, source_type, source_id);
+
+-- Index for time-ordered scans
+CREATE INDEX IF NOT EXISTS memory_chunks_ts_idx
+  ON memory_chunks (workspace_id, ts DESC);
+
+-- ─── embedding_provider_config ────────────────────────────────────────────────
+-- Per-workspace embedding provider configuration.
+-- provider: 'ollama' | 'openai' | 'voyage' | 'jina'
+-- config: provider-specific JSON (model, dimensions, api_key ref, etc.)
+
+CREATE TABLE IF NOT EXISTS embedding_provider_config (
+  workspace_id  VARCHAR NOT NULL PRIMARY KEY REFERENCES workspaces(id) ON DELETE CASCADE,
+  provider      TEXT NOT NULL DEFAULT 'ollama',
+  model         TEXT NOT NULL DEFAULT 'nomic-embed-text',
+  dimensions    INTEGER NOT NULL DEFAULT 768,
+  config        JSONB NOT NULL DEFAULT '{}',
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Rollback:
+--   DROP TABLE IF EXISTS embedding_provider_config;
+--   DROP TABLE IF EXISTS memory_chunks;
+--   DROP EXTENSION IF EXISTS vector;

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
         "pg": "^8.16.3",
+        "pgvector": "^0.2.1",
         "prismjs": "^1.30.0",
         "react": "^19.2.0",
         "react-day-picker": "^9.11.1",
@@ -8517,6 +8518,15 @@
       "license": "MIT",
       "dependencies": {
         "split2": "^4.1.0"
+      }
+    },
+    "node_modules/pgvector": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/pgvector/-/pgvector-0.2.1.tgz",
+      "integrity": "sha512-nKaQY9wtuiidwLMdVIce1O3kL0d+FxrigCVzsShnoqzOSaWWWOvuctb/sYwlai5cTwwzRSNa+a/NtN2kVZGNJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
     "pg": "^8.16.3",
+    "pgvector": "^0.2.1",
     "prismjs": "^1.30.0",
     "react": "^19.2.0",
     "react-day-picker": "^9.11.1",

--- a/server/memory/chunker.ts
+++ b/server/memory/chunker.ts
@@ -1,0 +1,278 @@
+/**
+ * Text chunking for different source types.
+ *
+ * Strategy per source:
+ *   code         — split on function/class boundaries (regex), fall back to sliding window
+ *   pipeline_run — split on paragraph / blank-line boundaries
+ *   document     — sentence-aware sliding window
+ *   memory_entry — treat each entry as a single chunk (usually short)
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ChunkSourceType = "code" | "pipeline_run" | "document" | "memory_entry";
+
+export interface TextChunk {
+  text: string;
+  /** 0-based index of this chunk within the source. */
+  index: number;
+  /** Character offset where the chunk starts in the original text. */
+  startOffset: number;
+  /** Character offset where the chunk ends in the original text (exclusive). */
+  endOffset: number;
+  /** Extra context attached to the chunk. */
+  metadata: Record<string, unknown>;
+}
+
+export interface ChunkerOptions {
+  maxChunkTokens?: number;
+  overlapTokens?: number;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const CHARS_PER_TOKEN = 4;
+const DEFAULT_MAX_CHUNK_TOKENS = 512;
+const DEFAULT_OVERLAP_TOKENS = 64;
+
+// Regex patterns that identify function/class start boundaries in JS/TS/Python.
+const CODE_BOUNDARY_RE =
+  /(?:^|\n)(?:export\s+)?(?:async\s+)?(?:function\b|class\b|const\s+\w+\s*=\s*(?:async\s+)?\(|def\s+\w+\s*[(]|class\s+\w+(?:\s*:|\s*[(]))/g;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function tokenEstimate(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+function slidingWindowChunks(
+  text: string,
+  maxTokens: number,
+  overlapTokens: number,
+  baseOffset = 0,
+  baseIndex = 0,
+  meta: Record<string, unknown> = {},
+): TextChunk[] {
+  const maxChars = maxTokens * CHARS_PER_TOKEN;
+  const overlapChars = overlapTokens * CHARS_PER_TOKEN;
+  const chunks: TextChunk[] = [];
+  let pos = 0;
+  let index = baseIndex;
+
+  while (pos < text.length) {
+    const end = Math.min(pos + maxChars, text.length);
+    const slice = text.slice(pos, end);
+    chunks.push({
+      text: slice,
+      index,
+      startOffset: baseOffset + pos,
+      endOffset: baseOffset + end,
+      metadata: { ...meta },
+    });
+    index++;
+    // Advance by window minus overlap to maintain context continuity.
+    pos += maxChars - overlapChars;
+    if (pos >= text.length) break;
+  }
+
+  return chunks;
+}
+
+// ─── Source-specific chunkers ─────────────────────────────────────────────────
+
+function chunkCode(text: string, opts: Required<ChunkerOptions>): TextChunk[] {
+  const maxChars = opts.maxChunkTokens * CHARS_PER_TOKEN;
+  const chunks: TextChunk[] = [];
+
+  // Find all boundary positions (function/class starts).
+  const boundaries: number[] = [0];
+  let m: RegExpExecArray | null;
+  CODE_BOUNDARY_RE.lastIndex = 0;
+  while ((m = CODE_BOUNDARY_RE.exec(text)) !== null) {
+    const pos = m.index === 0 ? 0 : m.index + 1; // skip leading newline
+    if (pos > 0 && !boundaries.includes(pos)) {
+      boundaries.push(pos);
+    }
+  }
+  boundaries.push(text.length);
+
+  let chunkIndex = 0;
+  for (let i = 0; i < boundaries.length - 1; i++) {
+    const start = boundaries[i];
+    const end = boundaries[i + 1];
+    const segment = text.slice(start, end);
+
+    if (segment.length <= maxChars) {
+      chunks.push({
+        text: segment.trimStart(),
+        index: chunkIndex++,
+        startOffset: start,
+        endOffset: end,
+        metadata: { segmentIndex: i },
+      });
+    } else {
+      // Segment too large — apply sliding window within it.
+      const sub = slidingWindowChunks(segment, opts.maxChunkTokens, opts.overlapTokens, start, chunkIndex, { segmentIndex: i });
+      chunkIndex += sub.length;
+      chunks.push(...sub);
+    }
+  }
+
+  return chunks.filter((c) => c.text.trim().length > 0);
+}
+
+function chunkByParagraphs(text: string, opts: Required<ChunkerOptions>): TextChunk[] {
+  const paragraphs = text.split(/\n\s*\n/);
+  const maxChars = opts.maxChunkTokens * CHARS_PER_TOKEN;
+  const chunks: TextChunk[] = [];
+  let chunkIndex = 0;
+  let offset = 0;
+
+  let buffer = "";
+  let bufferStart = 0;
+
+  for (const para of paragraphs) {
+    const paraWithNewline = para + "\n\n";
+    if (buffer.length > 0 && buffer.length + para.length > maxChars) {
+      // Flush current buffer.
+      chunks.push({
+        text: buffer.trimEnd(),
+        index: chunkIndex++,
+        startOffset: bufferStart,
+        endOffset: offset,
+        metadata: {},
+      });
+      buffer = para + "\n\n";
+      bufferStart = offset;
+    } else {
+      buffer += paraWithNewline;
+    }
+    offset += paraWithNewline.length;
+  }
+
+  if (buffer.trim().length > 0) {
+    chunks.push({
+      text: buffer.trimEnd(),
+      index: chunkIndex++,
+      startOffset: bufferStart,
+      endOffset: offset,
+      metadata: {},
+    });
+  }
+
+  return chunks;
+}
+
+function chunkDocument(text: string, opts: Required<ChunkerOptions>): TextChunk[] {
+  // Sentence-aware: split at sentence boundaries, then build sliding window.
+  const sentenceRe = /(?<=[.!?])\s+/g;
+  const sentences = text.split(sentenceRe);
+  const maxChars = opts.maxChunkTokens * CHARS_PER_TOKEN;
+  const overlapChars = opts.overlapTokens * CHARS_PER_TOKEN;
+
+  const chunks: TextChunk[] = [];
+  let chunkIndex = 0;
+  let globalOffset = 0;
+
+  let windowSentences: string[] = [];
+  let windowStart = 0;
+  let windowLen = 0;
+
+  for (const sentence of sentences) {
+    const sLen = sentence.length + 1; // +1 for separator
+
+    if (windowLen + sLen > maxChars && windowSentences.length > 0) {
+      const chunkText = windowSentences.join(" ");
+      chunks.push({
+        text: chunkText,
+        index: chunkIndex++,
+        startOffset: windowStart,
+        endOffset: windowStart + chunkText.length,
+        metadata: {},
+      });
+
+      // Keep overlap sentences.
+      const overlapSentences: string[] = [];
+      let overlapLen = 0;
+      for (let i = windowSentences.length - 1; i >= 0; i--) {
+        const candidate = windowSentences[i].length + 1;
+        if (overlapLen + candidate <= overlapChars) {
+          overlapSentences.unshift(windowSentences[i]);
+          overlapLen += candidate;
+        } else {
+          break;
+        }
+      }
+
+      windowSentences = overlapSentences;
+      windowLen = overlapLen;
+      windowStart = globalOffset - overlapLen;
+    }
+
+    windowSentences.push(sentence);
+    windowLen += sLen;
+    globalOffset += sLen;
+  }
+
+  if (windowSentences.length > 0 && windowSentences.join(" ").trim().length > 0) {
+    const chunkText = windowSentences.join(" ");
+    chunks.push({
+      text: chunkText,
+      index: chunkIndex++,
+      startOffset: windowStart,
+      endOffset: windowStart + chunkText.length,
+      metadata: {},
+    });
+  }
+
+  return chunks.filter((c) => c.text.trim().length > 0);
+}
+
+function chunkMemoryEntry(text: string, meta: Record<string, unknown> = {}): TextChunk[] {
+  return [
+    {
+      text,
+      index: 0,
+      startOffset: 0,
+      endOffset: text.length,
+      metadata: meta,
+    },
+  ];
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export class TextChunker {
+  private readonly opts: Required<ChunkerOptions>;
+
+  constructor(options?: ChunkerOptions) {
+    this.opts = {
+      maxChunkTokens: options?.maxChunkTokens ?? DEFAULT_MAX_CHUNK_TOKENS,
+      overlapTokens: options?.overlapTokens ?? DEFAULT_OVERLAP_TOKENS,
+    };
+  }
+
+  chunk(text: string, sourceType: ChunkSourceType, meta: Record<string, unknown> = {}): TextChunk[] {
+    if (!text || text.trim().length === 0) return [];
+
+    switch (sourceType) {
+      case "code":
+        return chunkCode(text, this.opts).map((c) => ({ ...c, metadata: { ...meta, ...c.metadata } }));
+      case "pipeline_run":
+        return chunkByParagraphs(text, this.opts).map((c) => ({ ...c, metadata: { ...meta, ...c.metadata } }));
+      case "document":
+        return chunkDocument(text, this.opts).map((c) => ({ ...c, metadata: { ...meta, ...c.metadata } }));
+      case "memory_entry":
+        return chunkMemoryEntry(text, meta);
+      default: {
+        const _exhaustive: never = sourceType;
+        throw new Error(`Unknown source type: ${String(_exhaustive)}`);
+      }
+    }
+  }
+
+  /** Rough token estimate for a chunk. */
+  static estimateTokens(text: string): number {
+    return tokenEstimate(text);
+  }
+}

--- a/server/memory/embeddings.ts
+++ b/server/memory/embeddings.ts
@@ -1,0 +1,263 @@
+/**
+ * Pluggable embedding provider system.
+ *
+ * Default: Ollama (local, zero external calls).
+ * Supported: openai, voyage, jina, ollama.
+ *
+ * Each provider implements the EmbeddingProvider interface.
+ * Use EmbeddingProviderFactory.create() to instantiate per workspace config.
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type EmbeddingProviderName = "ollama" | "openai" | "voyage" | "jina";
+
+export interface EmbeddingProviderConfig {
+  provider: EmbeddingProviderName;
+  /** Model identifier for the provider. */
+  model: string;
+  /** Expected output dimensions. */
+  dimensions: number;
+  /** Provider-specific options (api key ref, base URL, etc.) */
+  options?: Record<string, string>;
+}
+
+export interface EmbeddingProvider {
+  readonly name: EmbeddingProviderName;
+  readonly model: string;
+  readonly dimensions: number;
+  /**
+   * Embed a batch of texts. Returns a 2D array: [textIndex][dimension].
+   * Must respect rate limits internally.
+   */
+  embedBatch(texts: string[]): Promise<number[][]>;
+  /** Convenience wrapper for a single text. */
+  embed(text: string): Promise<number[]>;
+}
+
+// ─── Ollama provider (local-first default) ────────────────────────────────────
+
+/** Ollama embedding API — runs on localhost:11434 by default. */
+export class OllamaEmbeddingProvider implements EmbeddingProvider {
+  readonly name = "ollama" as const;
+  readonly model: string;
+  readonly dimensions: number;
+  private readonly baseUrl: string;
+
+  constructor(model = "nomic-embed-text", dimensions = 768, baseUrl = "http://localhost:11434") {
+    this.model = model;
+    this.dimensions = dimensions;
+    this.baseUrl = baseUrl;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const [vec] = await this.embedBatch([text]);
+    return vec;
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    const results: number[][] = [];
+    // Ollama /api/embed accepts one prompt at a time; process sequentially.
+    for (const text of texts) {
+      const response = await fetch(`${this.baseUrl}/api/embed`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: this.model, input: text }),
+      });
+      if (!response.ok) {
+        throw new Error(`Ollama embed failed: ${response.status} ${response.statusText}`);
+      }
+      const data = (await response.json()) as { embeddings?: number[][] };
+      const vec = data.embeddings?.[0];
+      if (!vec || vec.length === 0) {
+        throw new Error(`Ollama returned empty embedding for model ${this.model}`);
+      }
+      results.push(vec);
+    }
+    return results;
+  }
+}
+
+// ─── OpenAI provider ─────────────────────────────────────────────────────────
+
+const OPENAI_BATCH_SIZE = 100;
+const OPENAI_BASE_URL = "https://api.openai.com/v1";
+
+export class OpenAIEmbeddingProvider implements EmbeddingProvider {
+  readonly name = "openai" as const;
+  readonly model: string;
+  readonly dimensions: number;
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+
+  constructor(apiKey: string, model = "text-embedding-3-small", dimensions = 1536, baseUrl = OPENAI_BASE_URL) {
+    this.apiKey = apiKey;
+    this.model = model;
+    this.dimensions = dimensions;
+    this.baseUrl = baseUrl;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const [vec] = await this.embedBatch([text]);
+    return vec;
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    const results: number[][] = [];
+    // Process in batches to stay within OpenAI's 2048 item limit.
+    for (let i = 0; i < texts.length; i += OPENAI_BATCH_SIZE) {
+      const batch = texts.slice(i, i + OPENAI_BATCH_SIZE);
+      const response = await fetch(`${this.baseUrl}/embeddings`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify({ model: this.model, input: batch }),
+      });
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`OpenAI embed failed: ${response.status} ${body}`);
+      }
+      const data = (await response.json()) as { data: Array<{ embedding: number[]; index: number }> };
+      const sorted = data.data.sort((a, b) => a.index - b.index);
+      results.push(...sorted.map((d) => d.embedding));
+    }
+    return results;
+  }
+}
+
+// ─── Voyage provider ─────────────────────────────────────────────────────────
+
+const VOYAGE_BASE_URL = "https://api.voyageai.com/v1";
+const VOYAGE_BATCH_SIZE = 128;
+
+export class VoyageEmbeddingProvider implements EmbeddingProvider {
+  readonly name = "voyage" as const;
+  readonly model: string;
+  readonly dimensions: number;
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+
+  constructor(apiKey: string, model = "voyage-2", dimensions = 1024, baseUrl = VOYAGE_BASE_URL) {
+    this.apiKey = apiKey;
+    this.model = model;
+    this.dimensions = dimensions;
+    this.baseUrl = baseUrl;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const [vec] = await this.embedBatch([text]);
+    return vec;
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    const results: number[][] = [];
+    for (let i = 0; i < texts.length; i += VOYAGE_BATCH_SIZE) {
+      const batch = texts.slice(i, i + VOYAGE_BATCH_SIZE);
+      const response = await fetch(`${this.baseUrl}/embeddings`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify({ model: this.model, input: batch }),
+      });
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`Voyage embed failed: ${response.status} ${body}`);
+      }
+      const data = (await response.json()) as { data: Array<{ embedding: number[]; index: number }> };
+      const sorted = data.data.sort((a, b) => a.index - b.index);
+      results.push(...sorted.map((d) => d.embedding));
+    }
+    return results;
+  }
+}
+
+// ─── Jina provider ───────────────────────────────────────────────────────────
+
+const JINA_BASE_URL = "https://api.jina.ai/v1";
+const JINA_BATCH_SIZE = 64;
+
+export class JinaEmbeddingProvider implements EmbeddingProvider {
+  readonly name = "jina" as const;
+  readonly model: string;
+  readonly dimensions: number;
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+
+  constructor(apiKey: string, model = "jina-embeddings-v2-base-en", dimensions = 768, baseUrl = JINA_BASE_URL) {
+    this.apiKey = apiKey;
+    this.model = model;
+    this.dimensions = dimensions;
+    this.baseUrl = baseUrl;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const [vec] = await this.embedBatch([text]);
+    return vec;
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    const results: number[][] = [];
+    for (let i = 0; i < texts.length; i += JINA_BATCH_SIZE) {
+      const batch = texts.slice(i, i + JINA_BATCH_SIZE);
+      const response = await fetch(`${this.baseUrl}/embeddings`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify({ model: this.model, input: batch.map((text) => ({ text })) }),
+      });
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`Jina embed failed: ${response.status} ${body}`);
+      }
+      const data = (await response.json()) as { data: Array<{ embedding: number[]; index: number }> };
+      const sorted = data.data.sort((a, b) => a.index - b.index);
+      results.push(...sorted.map((d) => d.embedding));
+    }
+    return results;
+  }
+}
+
+// ─── Factory ─────────────────────────────────────────────────────────────────
+
+/** Default config — local Ollama, zero external calls. */
+export const DEFAULT_EMBEDDING_CONFIG: EmbeddingProviderConfig = {
+  provider: "ollama",
+  model: "nomic-embed-text",
+  dimensions: 768,
+};
+
+export class EmbeddingProviderFactory {
+  static create(config: EmbeddingProviderConfig = DEFAULT_EMBEDDING_CONFIG): EmbeddingProvider {
+    switch (config.provider) {
+      case "ollama": {
+        const baseUrl = config.options?.baseUrl ?? "http://localhost:11434";
+        return new OllamaEmbeddingProvider(config.model, config.dimensions, baseUrl);
+      }
+      case "openai": {
+        const apiKey = config.options?.apiKey ?? "";
+        if (!apiKey) throw new Error("OpenAI embedding provider requires apiKey in options");
+        return new OpenAIEmbeddingProvider(apiKey, config.model, config.dimensions);
+      }
+      case "voyage": {
+        const apiKey = config.options?.apiKey ?? "";
+        if (!apiKey) throw new Error("Voyage embedding provider requires apiKey in options");
+        return new VoyageEmbeddingProvider(apiKey, config.model, config.dimensions);
+      }
+      case "jina": {
+        const apiKey = config.options?.apiKey ?? "";
+        if (!apiKey) throw new Error("Jina embedding provider requires apiKey in options");
+        return new JinaEmbeddingProvider(apiKey, config.model, config.dimensions);
+      }
+      default: {
+        const _exhaustive: never = config.provider;
+        throw new Error(`Unknown embedding provider: ${String(_exhaustive)}`);
+      }
+    }
+  }
+}

--- a/server/memory/retriever.ts
+++ b/server/memory/retriever.ts
@@ -1,0 +1,128 @@
+/**
+ * RAG retrieval helper.
+ *
+ * retrieveContext() embeds the query, searches the vector store, applies a
+ * token budget, and returns formatted context chunks ready for LLM injection.
+ */
+import type { EmbeddingProvider } from "./embeddings.js";
+import type { VectorStore, VectorSearchResult } from "./vector-store.js";
+import type { ChunkSourceType } from "./chunker.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface RetrievalOptions {
+  query: string;
+  workspaceId: string;
+  topK?: number;
+  /** Only return chunks from these source types. */
+  filter?: ChunkSourceType[];
+  /** Max tokens to include in the returned context. Enforced by truncating. */
+  maxTokens?: number;
+  /** Minimum similarity score (0–1). */
+  minScore?: number;
+}
+
+export interface RetrievedChunk {
+  id: string;
+  sourceType: ChunkSourceType;
+  sourceId: string;
+  chunkText: string;
+  score: number;
+  metadata: Record<string, unknown>;
+}
+
+export interface RetrievalResult {
+  chunks: RetrievedChunk[];
+  /** Formatted context string ready to prepend as system context. */
+  context: string;
+  /** Total approximate tokens in the returned context. */
+  tokensUsed: number;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const CHARS_PER_TOKEN = 4;
+const DEFAULT_TOP_K = 5;
+const DEFAULT_MAX_TOKENS = 2000;
+const DEFAULT_MIN_SCORE = 0.3;
+
+// ─── Retriever ────────────────────────────────────────────────────────────────
+
+export class Retriever {
+  constructor(
+    private readonly embeddingProvider: EmbeddingProvider,
+    private readonly vectorStore: VectorStore,
+  ) {}
+
+  async retrieveContext(options: RetrievalOptions): Promise<RetrievalResult> {
+    const topK = options.topK ?? DEFAULT_TOP_K;
+    const maxTokens = options.maxTokens ?? DEFAULT_MAX_TOKENS;
+    const minScore = options.minScore ?? DEFAULT_MIN_SCORE;
+    const maxChars = maxTokens * CHARS_PER_TOKEN;
+
+    // Embed the query.
+    const queryEmbedding = await this.embeddingProvider.embed(options.query);
+
+    // Search the vector store.
+    const searchResults = await this.vectorStore.search(options.workspaceId, queryEmbedding, {
+      topK,
+      sourceTypes: options.filter,
+      minScore,
+    });
+
+    // Apply token budget: include chunks in order of relevance until budget exhausted.
+    const selectedChunks: RetrievedChunk[] = [];
+    let usedChars = 0;
+
+    for (const result of searchResults) {
+      const chunkChars = result.chunkText.length;
+      if (usedChars + chunkChars > maxChars && selectedChunks.length > 0) {
+        // Partial inclusion: truncate the last chunk to fit within budget.
+        const remaining = maxChars - usedChars;
+        if (remaining > 40) {
+          selectedChunks.push({
+            id: result.id,
+            sourceType: result.sourceType,
+            sourceId: result.sourceId,
+            chunkText: result.chunkText.slice(0, remaining) + "…",
+            score: result.score,
+            metadata: result.metadata,
+          });
+          usedChars += remaining;
+        }
+        break;
+      }
+      selectedChunks.push({
+        id: result.id,
+        sourceType: result.sourceType,
+        sourceId: result.sourceId,
+        chunkText: result.chunkText,
+        score: result.score,
+        metadata: result.metadata,
+      });
+      usedChars += chunkChars;
+    }
+
+    const context = formatContext(selectedChunks);
+    const tokensUsed = Math.ceil(usedChars / CHARS_PER_TOKEN);
+
+    return { chunks: selectedChunks, context, tokensUsed };
+  }
+}
+
+// ─── Formatting ───────────────────────────────────────────────────────────────
+
+function formatContext(chunks: RetrievedChunk[]): string {
+  if (chunks.length === 0) return "";
+
+  const lines: string[] = ["## Relevant Context\n"];
+
+  for (const chunk of chunks) {
+    const header = `[${chunk.sourceType}:${chunk.sourceId}] (score: ${chunk.score.toFixed(2)})`;
+    lines.push(header);
+    lines.push(chunk.chunkText.trim());
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}

--- a/server/memory/vector-store.ts
+++ b/server/memory/vector-store.ts
@@ -1,0 +1,241 @@
+/**
+ * Vector store operations backed by pgvector.
+ *
+ * All queries use parameterized inputs — never string concatenation.
+ * Cosine similarity is used for ANN search (HNSW index).
+ */
+import { db } from "../db.js";
+import { sql as drizzleSql, eq, and } from "drizzle-orm";
+import { memoryChunks, embeddingProviderConfig } from "@shared/schema";
+import type { MemoryChunkRow, InsertMemoryChunk, EmbeddingProviderConfigRow } from "@shared/schema";
+import type { EmbeddingProviderConfig } from "./embeddings.js";
+import type { ChunkSourceType } from "./chunker.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface VectorSearchResult {
+  id: string;
+  workspaceId: string;
+  sourceType: ChunkSourceType;
+  sourceId: string;
+  chunkText: string;
+  metadata: Record<string, unknown>;
+  ts: Date;
+  /** Cosine similarity score (0–1, higher = more similar). */
+  score: number;
+}
+
+export interface VectorSearchOptions {
+  topK?: number;
+  /** Filter by one or more source types. */
+  sourceTypes?: ChunkSourceType[];
+  /** Filter by specific source ID. */
+  sourceId?: string;
+  /** Minimum similarity score threshold (0–1). */
+  minScore?: number;
+}
+
+// ─── Vector Store ─────────────────────────────────────────────────────────────
+
+export class VectorStore {
+  /**
+   * Insert a single chunk with its embedding vector.
+   */
+  async insertChunk(data: InsertMemoryChunk): Promise<MemoryChunkRow> {
+    const [row] = await db.insert(memoryChunks).values(data).returning();
+    return row;
+  }
+
+  /**
+   * Insert multiple chunks in a single statement.
+   */
+  async insertChunks(data: InsertMemoryChunk[]): Promise<MemoryChunkRow[]> {
+    if (data.length === 0) return [];
+    return db.insert(memoryChunks).values(data).returning();
+  }
+
+  /**
+   * ANN similarity search using pgvector cosine distance.
+   * Returns at most `topK` results ordered by similarity (descending).
+   *
+   * Uses raw SQL because drizzle-orm does not yet expose pgvector operator
+   * bindings for ORDER BY and WHERE expressions.
+   */
+  async search(
+    workspaceId: string,
+    queryEmbedding: number[],
+    options: VectorSearchOptions = {},
+  ): Promise<VectorSearchResult[]> {
+    const topK = options.topK ?? 10;
+    const minScore = options.minScore ?? 0;
+
+    // Encode the query vector as a pgvector literal: '[x,y,z]'
+    const vecLiteral = `[${queryEmbedding.join(",")}]`;
+
+    // Build parameterized conditions.
+    const conditions = [`mc.workspace_id = $1`];
+    const params: unknown[] = [workspaceId];
+    let paramIdx = 2;
+
+    if (options.sourceTypes && options.sourceTypes.length > 0) {
+      const placeholders = options.sourceTypes.map(() => `$${paramIdx++}`).join(", ");
+      conditions.push(`mc.source_type IN (${placeholders})`);
+      params.push(...options.sourceTypes);
+    }
+
+    if (options.sourceId) {
+      conditions.push(`mc.source_id = $${paramIdx++}`);
+      params.push(options.sourceId);
+    }
+
+    const whereClause = conditions.join(" AND ");
+    const vecParam = `$${paramIdx}`;
+    const minScoreParam = `$${paramIdx + 1}`;
+    const topKParam = `$${paramIdx + 2}`;
+    params.push(vecLiteral, minScore, topK);
+
+    // 1 - cosine_distance = cosine_similarity.
+    const query = `
+      SELECT
+        mc.id,
+        mc.workspace_id,
+        mc.source_type,
+        mc.source_id,
+        mc.chunk_text,
+        mc.metadata,
+        mc.ts,
+        1 - (mc.embedding <=> ${vecParam}::vector) AS score
+      FROM memory_chunks mc
+      WHERE ${whereClause}
+        AND mc.embedding IS NOT NULL
+        AND 1 - (mc.embedding <=> ${vecParam}::vector) >= ${minScoreParam}
+      ORDER BY mc.embedding <=> ${vecParam}::vector
+      LIMIT ${topKParam}
+    `;
+
+    // Access the underlying pg pool through drizzle's $client.
+    const pgDb = db as unknown as {
+      $client: {
+        query: (text: string, values: unknown[]) => Promise<{ rows: Record<string, unknown>[] }>;
+      };
+    };
+    const result = await pgDb.$client.query(query, params);
+
+    return result.rows.map((row) => ({
+      id: String(row.id),
+      workspaceId: String(row.workspace_id),
+      sourceType: row.source_type as ChunkSourceType,
+      sourceId: String(row.source_id),
+      chunkText: String(row.chunk_text),
+      metadata: (row.metadata as Record<string, unknown>) ?? {},
+      ts: new Date(row.ts as string),
+      score: Number(row.score),
+    }));
+  }
+
+  /**
+   * Delete all chunks for a specific source.
+   */
+  async deleteBySource(workspaceId: string, sourceType: ChunkSourceType, sourceId: string): Promise<number> {
+    const result = await db
+      .delete(memoryChunks)
+      .where(
+        and(
+          eq(memoryChunks.workspaceId, workspaceId),
+          eq(memoryChunks.sourceType, sourceType),
+          eq(memoryChunks.sourceId, sourceId),
+        ),
+      )
+      .returning({ id: memoryChunks.id });
+    return result.length;
+  }
+
+  /**
+   * Delete all chunks for a workspace.
+   */
+  async deleteByWorkspace(workspaceId: string): Promise<number> {
+    const result = await db
+      .delete(memoryChunks)
+      .where(eq(memoryChunks.workspaceId, workspaceId))
+      .returning({ id: memoryChunks.id });
+    return result.length;
+  }
+
+  /**
+   * Count chunks for a workspace, optionally filtered by source type.
+   */
+  async countChunks(workspaceId: string, sourceType?: ChunkSourceType): Promise<number> {
+    const conditions = [eq(memoryChunks.workspaceId, workspaceId)];
+    if (sourceType) {
+      conditions.push(eq(memoryChunks.sourceType, sourceType));
+    }
+    const [row] = await db
+      .select({ count: drizzleSql<number>`count(*)::int` })
+      .from(memoryChunks)
+      .where(and(...conditions));
+    return row?.count ?? 0;
+  }
+
+  /**
+   * List distinct sources for a workspace.
+   */
+  async listSources(
+    workspaceId: string,
+  ): Promise<Array<{ sourceType: ChunkSourceType; sourceId: string; count: number }>> {
+    const rows = await db
+      .select({
+        sourceType: memoryChunks.sourceType,
+        sourceId: memoryChunks.sourceId,
+        count: drizzleSql<number>`count(*)::int`,
+      })
+      .from(memoryChunks)
+      .where(eq(memoryChunks.workspaceId, workspaceId))
+      .groupBy(memoryChunks.sourceType, memoryChunks.sourceId)
+      .orderBy(memoryChunks.sourceType);
+
+    return rows.map((r) => ({
+      sourceType: r.sourceType as ChunkSourceType,
+      sourceId: r.sourceId,
+      count: r.count,
+    }));
+  }
+
+  // ─── Embedding provider config ──────────────────────────────────────────────
+
+  async getEmbeddingConfig(workspaceId: string): Promise<EmbeddingProviderConfigRow | null> {
+    const [row] = await db
+      .select()
+      .from(embeddingProviderConfig)
+      .where(eq(embeddingProviderConfig.workspaceId, workspaceId));
+    return row ?? null;
+  }
+
+  async upsertEmbeddingConfig(
+    workspaceId: string,
+    cfg: Partial<EmbeddingProviderConfig> & { provider: string; model: string; dimensions: number },
+  ): Promise<EmbeddingProviderConfigRow> {
+    const [row] = await db
+      .insert(embeddingProviderConfig)
+      .values({
+        workspaceId,
+        provider: cfg.provider,
+        model: cfg.model,
+        dimensions: cfg.dimensions,
+        config: cfg.options ?? {},
+      })
+      .onConflictDoUpdate({
+        target: embeddingProviderConfig.workspaceId,
+        set: {
+          provider: cfg.provider,
+          model: cfg.model,
+          dimensions: cfg.dimensions,
+          config: cfg.options ?? {},
+          updatedAt: drizzleSql`NOW()`,
+        },
+      })
+      .returning();
+    return row;
+  }
+}
+
+export const vectorStore = new VectorStore();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -67,6 +67,7 @@ import { registerWorkspaceTraceRoutes } from "./routes/workspace-traces";
 import { registerCostRoutes } from "./routes/costs";
 import { registerWorkspaceToolRoutes } from "./routes/workspace-tools";
 import { registerMcpRoutes } from "./routes/mcp";
+import { registerKnowledgeRoutes } from "./routes/knowledge";
 import { SessionSharingService } from "./federation/session-sharing";
 import { MemoryFederationService } from "./federation/memory-federation";
 import { PipelineSyncService } from "./federation/pipeline-sync";
@@ -123,6 +124,7 @@ export async function registerRoutes(
   app.use("/api/remote-agents", requireAuth);
   app.use("/api/skill-market", requireAuth);
   app.use("/api/federation", requireAuth);
+  app.use("/api/workspaces/:id/knowledge", requireAuth);
 
   // Register route implementations
   registerModelRoutes(app, storage);

--- a/server/routes/knowledge.ts
+++ b/server/routes/knowledge.ts
@@ -1,0 +1,275 @@
+/**
+ * Knowledge management API — RAG chunk ingestion, search, and source management.
+ *
+ * Routes:
+ *   GET    /api/workspaces/:id/knowledge/sources     — list indexed sources
+ *   GET    /api/workspaces/:id/knowledge/search      — semantic search preview
+ *   POST   /api/workspaces/:id/knowledge/ingest      — ingest text as chunks
+ *   DELETE /api/workspaces/:id/knowledge/sources/:type/:sourceId — remove source
+ *   GET    /api/workspaces/:id/knowledge/config      — get embedding config
+ *   PUT    /api/workspaces/:id/knowledge/config      — update embedding config
+ *   POST   /api/workspaces/:id/knowledge/re-embed    — re-embed all chunks (async job)
+ */
+import { Router } from "express";
+import { z } from "zod";
+import { VectorStore } from "../memory/vector-store";
+import { TextChunker } from "../memory/chunker";
+import { EmbeddingProviderFactory, DEFAULT_EMBEDDING_CONFIG } from "../memory/embeddings";
+import type { EmbeddingProviderConfig } from "../memory/embeddings";
+import { CHUNK_SOURCE_TYPES, EMBEDDING_PROVIDERS } from "@shared/schema";
+import type { ChunkSourceType } from "../memory/chunker";
+
+// ─── Validation schemas ───────────────────────────────────────────────────────
+
+const ingestBodySchema = z.object({
+  sourceType: z.enum(CHUNK_SOURCE_TYPES),
+  sourceId: z.string().min(1).max(255),
+  text: z.string().min(1),
+  metadata: z.record(z.unknown()).optional().default({}),
+  /** Replace existing chunks for this source before ingesting. */
+  replace: z.boolean().optional().default(false),
+});
+
+const searchQuerySchema = z.object({
+  q: z.string().min(1),
+  topK: z.coerce.number().int().min(1).max(50).optional().default(10),
+  sourceType: z.enum(CHUNK_SOURCE_TYPES).optional(),
+});
+
+const configBodySchema = z.object({
+  provider: z.enum(EMBEDDING_PROVIDERS),
+  model: z.string().min(1),
+  dimensions: z.number().int().min(64).max(4096),
+  options: z.record(z.string()).optional(),
+});
+
+// ─── Route registration ───────────────────────────────────────────────────────
+
+export function registerKnowledgeRoutes(app: Router): void {
+  // GET /api/workspaces/:id/knowledge/sources
+  app.get("/api/workspaces/:id/knowledge/sources", async (req, res) => {
+    const { id: workspaceId } = req.params;
+    try {
+      const store = new VectorStore();
+      const sources = await store.listSources(workspaceId);
+      return res.json(sources);
+    } catch {
+      return res.status(500).json({ error: "Failed to list knowledge sources" });
+    }
+  });
+
+  // GET /api/workspaces/:id/knowledge/search
+  app.get("/api/workspaces/:id/knowledge/search", async (req, res) => {
+    const { id: workspaceId } = req.params;
+    const parsed = searchQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      return res.status(400).json({ error: parsed.error.flatten() });
+    }
+
+    try {
+      const store = new VectorStore();
+      const configRow = await store.getEmbeddingConfig(workspaceId);
+      const embeddingConfig: EmbeddingProviderConfig = configRow
+        ? {
+            provider: configRow.provider as EmbeddingProviderConfig["provider"],
+            model: configRow.model,
+            dimensions: configRow.dimensions,
+            options: configRow.config as Record<string, string> | undefined,
+          }
+        : DEFAULT_EMBEDDING_CONFIG;
+
+      const provider = EmbeddingProviderFactory.create(embeddingConfig);
+      const queryEmbedding = await provider.embed(parsed.data.q);
+
+      const results = await store.search(workspaceId, queryEmbedding, {
+        topK: parsed.data.topK,
+        sourceTypes: parsed.data.sourceType ? [parsed.data.sourceType] : undefined,
+        minScore: 0.2,
+      });
+
+      return res.json(results);
+    } catch (err) {
+      return res.status(500).json({ error: `Search failed: ${(err as Error).message}` });
+    }
+  });
+
+  // POST /api/workspaces/:id/knowledge/ingest
+  app.post("/api/workspaces/:id/knowledge/ingest", async (req, res) => {
+    const { id: workspaceId } = req.params;
+    const parsed = ingestBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: parsed.error.flatten() });
+    }
+
+    const { sourceType, sourceId, text, metadata, replace } = parsed.data;
+
+    try {
+      const store = new VectorStore();
+      const configRow = await store.getEmbeddingConfig(workspaceId);
+      const embeddingConfig: EmbeddingProviderConfig = configRow
+        ? {
+            provider: configRow.provider as EmbeddingProviderConfig["provider"],
+            model: configRow.model,
+            dimensions: configRow.dimensions,
+            options: configRow.config as Record<string, string> | undefined,
+          }
+        : DEFAULT_EMBEDDING_CONFIG;
+
+      const provider = EmbeddingProviderFactory.create(embeddingConfig);
+      const chunker = new TextChunker({ maxChunkTokens: 512, overlapTokens: 64 });
+
+      if (replace) {
+        await store.deleteBySource(workspaceId, sourceType as ChunkSourceType, sourceId);
+      }
+
+      const chunks = chunker.chunk(text, sourceType as ChunkSourceType, metadata);
+      if (chunks.length === 0) {
+        return res.json({ inserted: 0, chunks: [] });
+      }
+
+      // Embed all chunks in batch.
+      const embeddings = await provider.embedBatch(chunks.map((c) => c.text));
+
+      const rows = chunks.map((chunk, i) => ({
+        workspaceId,
+        sourceType,
+        sourceId,
+        chunkText: chunk.text,
+        embedding: embeddings[i],
+        metadata: {
+          ...chunk.metadata,
+          dim: embeddingConfig.dimensions,
+          model: embeddingConfig.model,
+          provider: embeddingConfig.provider,
+        },
+      }));
+
+      const inserted = await store.insertChunks(rows);
+
+      return res.status(201).json({ inserted: inserted.length, chunks: inserted.map((r) => r.id) });
+    } catch (err) {
+      return res.status(500).json({ error: `Ingest failed: ${(err as Error).message}` });
+    }
+  });
+
+  // DELETE /api/workspaces/:id/knowledge/sources/:type/:sourceId
+  app.delete("/api/workspaces/:id/knowledge/sources/:type/:sourceId", async (req, res) => {
+    const { id: workspaceId, type, sourceId } = req.params;
+
+    if (!CHUNK_SOURCE_TYPES.includes(type as ChunkSourceType)) {
+      return res.status(400).json({ error: `Invalid source type: ${type}` });
+    }
+
+    try {
+      const store = new VectorStore();
+      const deleted = await store.deleteBySource(workspaceId, type as ChunkSourceType, sourceId);
+      return res.json({ deleted });
+    } catch {
+      return res.status(500).json({ error: "Failed to delete knowledge source" });
+    }
+  });
+
+  // GET /api/workspaces/:id/knowledge/config
+  app.get("/api/workspaces/:id/knowledge/config", async (req, res) => {
+    const { id: workspaceId } = req.params;
+    try {
+      const store = new VectorStore();
+      const config = await store.getEmbeddingConfig(workspaceId);
+      return res.json(config ?? { provider: "ollama", model: "nomic-embed-text", dimensions: 768 });
+    } catch {
+      return res.status(500).json({ error: "Failed to get embedding config" });
+    }
+  });
+
+  // PUT /api/workspaces/:id/knowledge/config
+  app.put("/api/workspaces/:id/knowledge/config", async (req, res) => {
+    const { id: workspaceId } = req.params;
+    const parsed = configBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: parsed.error.flatten() });
+    }
+
+    try {
+      const store = new VectorStore();
+      const row = await store.upsertEmbeddingConfig(workspaceId, {
+        ...parsed.data,
+        options: parsed.data.options,
+      });
+      return res.json(row);
+    } catch {
+      return res.status(500).json({ error: "Failed to update embedding config" });
+    }
+  });
+
+  // POST /api/workspaces/:id/knowledge/re-embed
+  // Triggers a background re-embedding job when provider/model changes.
+  app.post("/api/workspaces/:id/knowledge/re-embed", async (req, res) => {
+    const { id: workspaceId } = req.params;
+    try {
+      const store = new VectorStore();
+      const count = await store.countChunks(workspaceId);
+
+      // Fire-and-forget: re-embed in background. We acknowledge immediately.
+      reEmbedWorkspace(workspaceId).catch((err) => {
+        console.warn(`[knowledge] re-embed failed for workspace ${workspaceId}:`, err);
+      });
+
+      return res.json({ accepted: true, totalChunks: count });
+    } catch {
+      return res.status(500).json({ error: "Failed to start re-embed job" });
+    }
+  });
+}
+
+// ─── Re-embed job ─────────────────────────────────────────────────────────────
+
+/**
+ * Re-embed all chunks in a workspace using the current provider config.
+ * Processes in batches to avoid memory pressure.
+ */
+async function reEmbedWorkspace(workspaceId: string): Promise<void> {
+  const { db } = await import("../db.js");
+  const { memoryChunks } = await import("@shared/schema");
+  const { eq, isNotNull, sql: drizzleSql } = await import("drizzle-orm");
+
+  const store = new VectorStore();
+  const configRow = await store.getEmbeddingConfig(workspaceId);
+  const embeddingConfig: EmbeddingProviderConfig = configRow
+    ? {
+        provider: configRow.provider as EmbeddingProviderConfig["provider"],
+        model: configRow.model,
+        dimensions: configRow.dimensions,
+        options: configRow.config as Record<string, string> | undefined,
+      }
+    : DEFAULT_EMBEDDING_CONFIG;
+
+  const provider = EmbeddingProviderFactory.create(embeddingConfig);
+
+  const BATCH = 50;
+  let offset = 0;
+
+  while (true) {
+    const rows = await db
+      .select({ id: memoryChunks.id, chunkText: memoryChunks.chunkText })
+      .from(memoryChunks)
+      .where(eq(memoryChunks.workspaceId, workspaceId))
+      .limit(BATCH)
+      .offset(offset);
+
+    if (rows.length === 0) break;
+
+    const embeddings = await provider.embedBatch(rows.map((r) => r.chunkText));
+
+    for (let i = 0; i < rows.length; i++) {
+      await db
+        .update(memoryChunks)
+        .set({
+          embedding: embeddings[i],
+          metadata: drizzleSql`jsonb_set(metadata, '{model}', ${JSON.stringify(embeddingConfig.model)}::jsonb)`,
+        })
+        .where(eq(memoryChunks.id, rows[i].id));
+    }
+
+    offset += BATCH;
+  }
+}

--- a/server/tools/builtin/memory-search.ts
+++ b/server/tools/builtin/memory-search.ts
@@ -3,9 +3,16 @@ import { storage } from "../../storage";
 import { getFederationManager } from "../../federation/manager-state";
 import { MemoryFederationService } from "../../federation/memory-federation";
 import type { FederatedMemoryResult } from "../../federation/memory-federation";
+import { EmbeddingProviderFactory, DEFAULT_EMBEDDING_CONFIG } from "../../memory/embeddings";
+import type { EmbeddingProviderName } from "../../memory/embeddings";
+import { VectorStore } from "../../memory/vector-store";
+import type { ChunkSourceType } from "../../memory/chunker";
 
 /** Timeout for federated search fan-out (ms). */
 const FEDERATION_TIMEOUT_MS = 3000;
+
+/** Top-K results for vector search. */
+const DEFAULT_TOP_K = 5;
 
 /**
  * Build a MemoryFederationService on first use and cache it.
@@ -29,36 +36,65 @@ function formatFederatedResult(r: FederatedMemoryResult): string {
   return `[${r.sourceInstanceName}] ${r.content}${relevance}`;
 }
 
+function formatVectorResult(chunk: { chunkText: string; sourceType: string; sourceId: string; score: number }): string {
+  return `[vector:${chunk.sourceType}/${chunk.sourceId}] ${chunk.chunkText.slice(0, 200)} (score: ${chunk.score.toFixed(2)})`;
+}
+
 export const memorySearchHandler: ToolHandler = {
   definition: {
     name: "memory_search",
-    description: "Search project memories — decisions, patterns, known issues, preferences, and facts stored by previous pipeline runs. When federation is enabled, also searches peer instances.",
+    description:
+      "Search project memories — decisions, patterns, known issues, preferences, and facts stored by previous pipeline runs. " +
+      "When a workspace_id is provided, also performs semantic vector search over embedded knowledge chunks. " +
+      "When federation is enabled, also searches peer instances.",
     inputSchema: {
       type: "object",
       properties: {
         query: { type: "string", description: "Search query to find relevant memories" },
+        workspace_id: { type: "string", description: "Optional workspace ID to include vector search results" },
+        top_k: { type: "number", description: "Max vector search results to return (default 5)" },
       },
       required: ["query"],
     },
     source: "builtin",
-    tags: ["memory", "search", "context"],
+    tags: ["memory", "search", "context", "rag"],
   },
   async execute(args) {
     const query = String(args.query ?? "").trim();
     if (!query) return "Query cannot be empty.";
 
+    const workspaceId = args.workspace_id ? String(args.workspace_id) : undefined;
+    const topK = typeof args.top_k === "number" ? Math.max(1, Math.min(args.top_k, 20)) : DEFAULT_TOP_K;
+
     try {
-      const localMemories = await storage.searchMemories(query);
+      const [localMemories, vectorResults] = await Promise.all([
+        storage.searchMemories(query),
+        workspaceId ? performVectorSearch(workspaceId, query, topK) : Promise.resolve([]),
+      ]);
 
       const federation = getMemoryFederation();
-      if (!federation) {
-        if (localMemories.length === 0) {
-          return `No memories found matching "${query}".`;
-        }
-        return localMemories.map(formatLocalResult).join("\n");
+
+      // Build output parts.
+      const parts: string[] = [];
+
+      if (vectorResults.length > 0) {
+        parts.push("--- Semantic Memory ---");
+        parts.push(...vectorResults.map(formatVectorResult));
       }
 
-      // Build local results for federation merge (only published memories).
+      if (localMemories.length > 0) {
+        parts.push("--- Structured Memory ---");
+        parts.push(...localMemories.map(formatLocalResult));
+      }
+
+      if (!federation) {
+        if (parts.length === 0) {
+          return `No memories found matching "${query}".`;
+        }
+        return parts.join("\n");
+      }
+
+      // Federated search.
       const publishedLocal: FederatedMemoryResult[] = localMemories
         .filter((m) => m.published)
         .map((m) => ({
@@ -76,27 +112,20 @@ export const memorySearchHandler: ToolHandler = {
         FEDERATION_TIMEOUT_MS,
       );
 
-      // Combine local (all) + remote (federated) results.
-      const localLines = localMemories.map(formatLocalResult);
       const remoteResults = federatedResults.filter((r) => r.sourceInstance !== "local");
-      const remoteLines = remoteResults.map(formatFederatedResult);
+      if (remoteResults.length > 0) {
+        parts.push("--- Federated ---");
+        parts.push(...remoteResults.map(formatFederatedResult));
 
-      if (localLines.length === 0 && remoteLines.length === 0) {
+        const sourceInfo = Object.entries(sources)
+          .map(([src, count]) => `${src}: ${count}`)
+          .join(", ");
+        parts.push(`\n(Sources: ${sourceInfo})`);
+      }
+
+      if (parts.length === 0) {
         return `No memories found matching "${query}".`;
       }
-
-      const parts: string[] = [];
-      if (localLines.length > 0) {
-        parts.push("--- Local ---", ...localLines);
-      }
-      if (remoteLines.length > 0) {
-        parts.push("--- Federated ---", ...remoteLines);
-      }
-
-      const sourceInfo = Object.entries(sources)
-        .map(([src, count]) => `${src}: ${count}`)
-        .join(", ");
-      parts.push(`\n(Sources: ${sourceInfo})`);
 
       return parts.join("\n");
     } catch (err) {
@@ -105,3 +134,33 @@ export const memorySearchHandler: ToolHandler = {
     }
   },
 };
+
+// ─── Vector search helper ─────────────────────────────────────────────────────
+
+async function performVectorSearch(
+  workspaceId: string,
+  query: string,
+  topK: number,
+): Promise<Array<{ chunkText: string; sourceType: ChunkSourceType; sourceId: string; score: number }>> {
+  try {
+    const store = new VectorStore();
+    const configRow = await store.getEmbeddingConfig(workspaceId);
+
+    const embeddingConfig = configRow
+      ? {
+          provider: configRow.provider as EmbeddingProviderName,
+          model: configRow.model,
+          dimensions: configRow.dimensions,
+          options: configRow.config as Record<string, string> | undefined,
+        }
+      : DEFAULT_EMBEDDING_CONFIG;
+
+    const provider = EmbeddingProviderFactory.create(embeddingConfig);
+    const queryEmbedding = await provider.embed(query);
+    return store.search(workspaceId, queryEmbedding, { topK, minScore: 0.3 });
+  } catch {
+    // Vector search is best-effort — fail silently if Ollama is not running
+    // or no embeddings exist yet.
+    return [];
+  }
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -12,6 +12,7 @@ import {
   unique,
   index,
 } from "drizzle-orm/pg-core";
+import { vector } from "drizzle-orm/pg-core/columns/vector_extension/vector";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 import type { MaintenanceCategoryConfig, ScoutFinding, TriggerConfig, TriggerType, ManagerConfig, ManagerDecision, TraceSpan, SwarmCloneResult, SwarmMerger, SwarmSplitter, LogSourceConfig, SkillVersionConfig, TaskTraceSpan, TrackerProvider } from "./types.js";
@@ -1447,3 +1448,69 @@ export const workspaceSettings = pgTable(
 );
 
 export type WorkspaceSettingsRow = typeof workspaceSettings.$inferSelect;
+
+// ─── Memory Chunks (issue #282 — hybrid RAG / pgvector) ───────────────────────
+// Stores embedded text chunks for semantic search via pgvector ANN.
+// Dimensions default to 1536 (OpenAI/Voyage); Ollama nomic-embed-text uses 768.
+// The actual model dimension is stored in metadata.dim.
+
+export const CHUNK_SOURCE_TYPES = ["code", "pipeline_run", "document", "memory_entry"] as const;
+export type ChunkSourceType = typeof CHUNK_SOURCE_TYPES[number];
+
+export const memoryChunks = pgTable(
+  "memory_chunks",
+  {
+    id: varchar("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    workspaceId: varchar("workspace_id")
+      .notNull()
+      .references(() => workspaces.id, { onDelete: "cascade" }),
+    sourceType: text("source_type").notNull().$type<ChunkSourceType>(),
+    sourceId: text("source_id").notNull(),
+    chunkText: text("chunk_text").notNull(),
+    /** Vector embedding; nullable until embedding job completes. */
+    embedding: vector("embedding", { dimensions: 1536 }),
+    metadata: jsonb("metadata").notNull().default(sql`'{}'::jsonb`),
+    ts: timestamp("ts").notNull().defaultNow(),
+  },
+  (table) => [
+    index("memory_chunks_workspace_source_idx").on(table.workspaceId, table.sourceType, table.sourceId),
+    index("memory_chunks_ts_idx").on(table.workspaceId, table.ts),
+  ],
+);
+
+export const insertMemoryChunkSchema = createInsertSchema(memoryChunks).omit({
+  id: true,
+  ts: true,
+}).extend({
+  sourceType: z.enum(CHUNK_SOURCE_TYPES),
+  embedding: z.array(z.number()).nullable().optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export type InsertMemoryChunk = z.infer<typeof insertMemoryChunkSchema>;
+export type MemoryChunkRow = typeof memoryChunks.$inferSelect;
+
+// ─── Embedding Provider Config (issue #282) ───────────────────────────────────
+// Per-workspace embedding provider selection and configuration.
+
+export const EMBEDDING_PROVIDERS = ["ollama", "openai", "voyage", "jina"] as const;
+export type EmbeddingProviderName = typeof EMBEDDING_PROVIDERS[number];
+
+export const embeddingProviderConfig = pgTable(
+  "embedding_provider_config",
+  {
+    workspaceId: varchar("workspace_id")
+      .notNull()
+      .primaryKey()
+      .references(() => workspaces.id, { onDelete: "cascade" }),
+    provider: text("provider").notNull().default("ollama").$type<EmbeddingProviderName>(),
+    model: text("model").notNull().default("nomic-embed-text"),
+    dimensions: integer("dimensions").notNull().default(768),
+    config: jsonb("config").notNull().default(sql`'{}'::jsonb`),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+);
+
+export type EmbeddingProviderConfigRow = typeof embeddingProviderConfig.$inferSelect;

--- a/tests/unit/rag/chunker.test.ts
+++ b/tests/unit/rag/chunker.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for the TextChunker.
+ *
+ * Tests cover all four source types, overlap behavior, edge cases.
+ */
+import { describe, it, expect } from "vitest";
+import { TextChunker } from "../../../server/memory/chunker.js";
+
+describe("TextChunker", () => {
+  const chunker = new TextChunker({ maxChunkTokens: 100, overlapTokens: 20 });
+
+  // ─── memory_entry ──────────────────────────────────────────────────────────
+
+  describe("memory_entry source type", () => {
+    it("returns a single chunk for short text", () => {
+      const chunks = chunker.chunk("A brief memory.", "memory_entry");
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].text).toBe("A brief memory.");
+      expect(chunks[0].index).toBe(0);
+      expect(chunks[0].startOffset).toBe(0);
+      expect(chunks[0].endOffset).toBe("A brief memory.".length);
+    });
+
+    it("preserves metadata on the chunk", () => {
+      const chunks = chunker.chunk("content", "memory_entry", { key: "val" });
+      expect(chunks[0].metadata).toMatchObject({ key: "val" });
+    });
+
+    it("returns empty array for empty text", () => {
+      expect(chunker.chunk("", "memory_entry")).toHaveLength(0);
+      expect(chunker.chunk("   ", "memory_entry")).toHaveLength(0);
+    });
+  });
+
+  // ─── document source type ──────────────────────────────────────────────────
+
+  describe("document source type", () => {
+    it("returns at least one chunk for non-empty text", () => {
+      const text = "This is a sentence. And this is another. And yet another one here.";
+      const chunks = chunker.chunk(text, "document");
+      expect(chunks.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("each chunk is non-empty", () => {
+      const text = Array.from({ length: 20 }, (_, i) => `Sentence ${i + 1} about something important.`).join(" ");
+      const chunks = chunker.chunk(text, "document");
+      for (const chunk of chunks) {
+        expect(chunk.text.trim().length).toBeGreaterThan(0);
+      }
+    });
+
+    it("chunk indices are sequential and zero-based", () => {
+      const text = Array.from({ length: 30 }, (_, i) => `Word${i}.`).join(" ");
+      const chunks = chunker.chunk(text, "document");
+      chunks.forEach((chunk, i) => {
+        expect(chunk.index).toBe(i);
+      });
+    });
+
+    it("larger text produces multiple chunks", () => {
+      // Use a small chunker to force splits: 10 tokens = 40 chars
+      const smallChunker = new TextChunker({ maxChunkTokens: 10, overlapTokens: 2 });
+      // Create text of ~120 chars (3x the budget)
+      const text = "Alpha beta gamma delta. " .repeat(5);
+      const chunks = smallChunker.chunk(text, "document");
+      expect(chunks.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("applies metadata from options", () => {
+      const chunks = chunker.chunk("Hello world.", "document", { docId: "abc" });
+      for (const chunk of chunks) {
+        expect(chunk.metadata).toMatchObject({ docId: "abc" });
+      }
+    });
+  });
+
+  // ─── pipeline_run source type ──────────────────────────────────────────────
+
+  describe("pipeline_run source type", () => {
+    it("splits on blank lines", () => {
+      // Use a small chunker (10 tokens = 40 chars) so each paragraph forces a new chunk
+      const smallChunker = new TextChunker({ maxChunkTokens: 10, overlapTokens: 0 });
+      const text = "Paragraph one.\nStill in para one.\n\nParagraph two.\n\nParagraph three.";
+      const chunks = smallChunker.chunk(text, "pipeline_run");
+      expect(chunks.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("returns single chunk when text fits budget", () => {
+      const text = "Short decision: use TypeScript.";
+      const chunks = chunker.chunk(text, "pipeline_run");
+      expect(chunks).toHaveLength(1);
+    });
+
+    it("each chunk text is non-empty", () => {
+      const text = "Para A.\n\nPara B.\n\nPara C.\n\n";
+      const chunks = chunker.chunk(text, "pipeline_run");
+      for (const chunk of chunks) {
+        expect(chunk.text.trim().length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  // ─── code source type ─────────────────────────────────────────────────────
+
+  describe("code source type", () => {
+    it("splits at function boundaries", () => {
+      const code = `
+function alpha() {
+  return 1;
+}
+
+function beta() {
+  return 2;
+}
+
+function gamma() {
+  return 3;
+}
+`.trim();
+      const chunks = chunker.chunk(code, "code");
+      expect(chunks.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("splits at class boundaries", () => {
+      const code = `
+class Foo {
+  constructor() {}
+}
+
+class Bar {
+  constructor() {}
+}
+`.trim();
+      const chunks = chunker.chunk(code, "code");
+      expect(chunks.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("all chunk texts are non-empty", () => {
+      const code = `
+export async function doSomething(x: string): Promise<void> {
+  console.log(x);
+}
+
+export class Worker {
+  run() { return true; }
+}
+`.trim();
+      const chunks = chunker.chunk(code, "code");
+      for (const chunk of chunks) {
+        expect(chunk.text.trim().length).toBeGreaterThan(0);
+      }
+    });
+
+    it("applies sliding window when function body exceeds max tokens", () => {
+      // Create a function body that's much larger than the 100 token limit
+      const bigBody = Array.from({ length: 150 }, (_, i) => `  const x${i} = ${i};`).join("\n");
+      const code = `function bigFn() {\n${bigBody}\n}\n`;
+      const chunks = chunker.chunk(code, "code");
+      expect(chunks.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("chunk indices are zero-based and sequential", () => {
+      const code = `
+function a() { return 1; }
+function b() { return 2; }
+function c() { return 3; }
+`.trim();
+      const chunks = chunker.chunk(code, "code");
+      chunks.forEach((chunk, i) => {
+        expect(chunk.index).toBe(i);
+      });
+    });
+
+    it("returns empty array for empty code", () => {
+      expect(chunker.chunk("", "code")).toHaveLength(0);
+      expect(chunker.chunk("   \n  ", "code")).toHaveLength(0);
+    });
+  });
+
+  // ─── Token estimation ──────────────────────────────────────────────────────
+
+  describe("TextChunker.estimateTokens", () => {
+    it("estimates 4 chars per token", () => {
+      expect(TextChunker.estimateTokens("1234")).toBe(1);
+      expect(TextChunker.estimateTokens("12345678")).toBe(2);
+    });
+
+    it("rounds up", () => {
+      expect(TextChunker.estimateTokens("12345")).toBe(2);
+    });
+  });
+
+  // ─── Chunk offsets ────────────────────────────────────────────────────────
+
+  describe("chunk offset tracking", () => {
+    it("startOffset and endOffset reflect position in original text", () => {
+      const text = "Short text.";
+      const chunks = chunker.chunk(text, "memory_entry");
+      expect(chunks[0].startOffset).toBe(0);
+      expect(chunks[0].endOffset).toBe(text.length);
+    });
+  });
+});

--- a/tests/unit/rag/embeddings.test.ts
+++ b/tests/unit/rag/embeddings.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Unit tests for the pluggable embedding provider system.
+ *
+ * All network calls are mocked — zero external API calls in tests.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  OllamaEmbeddingProvider,
+  OpenAIEmbeddingProvider,
+  VoyageEmbeddingProvider,
+  JinaEmbeddingProvider,
+  EmbeddingProviderFactory,
+  DEFAULT_EMBEDDING_CONFIG,
+} from "../../../server/memory/embeddings.js";
+import type { EmbeddingProviderConfig } from "../../../server/memory/embeddings.js";
+
+// ─── Mock fetch ───────────────────────────────────────────────────────────────
+
+function makeFetchMock(responseBody: unknown, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: () => Promise.resolve(responseBody),
+    text: () => Promise.resolve(JSON.stringify(responseBody)),
+  });
+}
+
+function ollamaResponse(embedding: number[]) {
+  return { embeddings: [embedding] };
+}
+
+function openaiResponse(embeddings: number[][]) {
+  return {
+    data: embeddings.map((embedding, index) => ({ embedding, index })),
+  };
+}
+
+function voyageResponse(embeddings: number[][]) {
+  return {
+    data: embeddings.map((embedding, index) => ({ embedding, index })),
+  };
+}
+
+function jinaResponse(embeddings: number[][]) {
+  return {
+    data: embeddings.map((embedding, index) => ({ embedding, index })),
+  };
+}
+
+const SAMPLE_VEC_768 = Array.from({ length: 768 }, (_, i) => i * 0.001);
+const SAMPLE_VEC_1536 = Array.from({ length: 1536 }, (_, i) => i * 0.001);
+const SAMPLE_VEC_1024 = Array.from({ length: 1024 }, (_, i) => i * 0.001);
+
+// ─── Ollama ───────────────────────────────────────────────────────────────────
+
+describe("OllamaEmbeddingProvider", () => {
+  let provider: OllamaEmbeddingProvider;
+
+  beforeEach(() => {
+    provider = new OllamaEmbeddingProvider("nomic-embed-text", 768, "http://localhost:11434");
+  });
+
+  it("should have correct provider name and model", () => {
+    expect(provider.name).toBe("ollama");
+    expect(provider.model).toBe("nomic-embed-text");
+    expect(provider.dimensions).toBe(768);
+  });
+
+  it("embed() calls /api/embed and returns vector", async () => {
+    const mockFetch = makeFetchMock(ollamaResponse(SAMPLE_VEC_768));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await provider.embed("hello world");
+    expect(result).toEqual(SAMPLE_VEC_768);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:11434/api/embed",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("embedBatch() calls /api/embed once per text", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(ollamaResponse([1, 2, 3])) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(ollamaResponse([4, 5, 6])) });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const results = await provider.embedBatch(["text1", "text2"]);
+    expect(results).toEqual([[1, 2, 3], [4, 5, 6]]);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("embed() throws when API returns non-2xx", async () => {
+    vi.stubGlobal("fetch", makeFetchMock({}, 500));
+    await expect(provider.embed("test")).rejects.toThrow("Ollama embed failed: 500");
+  });
+
+  it("embed() throws when embedding is empty", async () => {
+    vi.stubGlobal("fetch", makeFetchMock({ embeddings: [[]] }));
+    await expect(provider.embed("test")).rejects.toThrow("empty embedding");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+});
+
+// ─── OpenAI ───────────────────────────────────────────────────────────────────
+
+describe("OpenAIEmbeddingProvider", () => {
+  let provider: OpenAIEmbeddingProvider;
+
+  beforeEach(() => {
+    provider = new OpenAIEmbeddingProvider("sk-test", "text-embedding-3-small", 1536);
+  });
+
+  it("should have correct metadata", () => {
+    expect(provider.name).toBe("openai");
+    expect(provider.model).toBe("text-embedding-3-small");
+    expect(provider.dimensions).toBe(1536);
+  });
+
+  it("embed() calls /v1/embeddings with Bearer auth", async () => {
+    const mockFetch = makeFetchMock(openaiResponse([SAMPLE_VEC_1536]));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await provider.embed("hello");
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/embeddings");
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe("Bearer sk-test");
+  });
+
+  it("embedBatch() returns vectors in correct order", async () => {
+    const vec1 = [1, 2, 3];
+    const vec2 = [4, 5, 6];
+    // API returns out-of-order
+    const mockFetch = makeFetchMock({
+      data: [
+        { embedding: vec2, index: 1 },
+        { embedding: vec1, index: 0 },
+      ],
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const results = await provider.embedBatch(["a", "b"]);
+    expect(results[0]).toEqual(vec1);
+    expect(results[1]).toEqual(vec2);
+  });
+
+  it("embedBatch() throws on non-2xx response", async () => {
+    vi.stubGlobal("fetch", makeFetchMock({ error: "quota exceeded" }, 429));
+    await expect(provider.embedBatch(["text"])).rejects.toThrow("OpenAI embed failed: 429");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+});
+
+// ─── Voyage ───────────────────────────────────────────────────────────────────
+
+describe("VoyageEmbeddingProvider", () => {
+  let provider: VoyageEmbeddingProvider;
+
+  beforeEach(() => {
+    provider = new VoyageEmbeddingProvider("voy-test", "voyage-2", 1024);
+  });
+
+  it("should have correct metadata", () => {
+    expect(provider.name).toBe("voyage");
+    expect(provider.model).toBe("voyage-2");
+    expect(provider.dimensions).toBe(1024);
+  });
+
+  it("embed() returns a vector", async () => {
+    vi.stubGlobal("fetch", makeFetchMock(voyageResponse([SAMPLE_VEC_1024])));
+    const result = await provider.embed("test");
+    expect(result).toEqual(SAMPLE_VEC_1024);
+  });
+
+  it("embedBatch() returns vectors in correct order", async () => {
+    const v1 = [1], v2 = [2], v3 = [3];
+    vi.stubGlobal("fetch", makeFetchMock({
+      data: [
+        { embedding: v3, index: 2 },
+        { embedding: v1, index: 0 },
+        { embedding: v2, index: 1 },
+      ],
+    }));
+    const results = await provider.embedBatch(["a", "b", "c"]);
+    expect(results).toEqual([v1, v2, v3]);
+  });
+
+  it("throws on error response", async () => {
+    vi.stubGlobal("fetch", makeFetchMock({}, 401));
+    await expect(provider.embed("test")).rejects.toThrow("Voyage embed failed: 401");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+});
+
+// ─── Jina ─────────────────────────────────────────────────────────────────────
+
+describe("JinaEmbeddingProvider", () => {
+  let provider: JinaEmbeddingProvider;
+
+  beforeEach(() => {
+    provider = new JinaEmbeddingProvider("jina-test", "jina-embeddings-v2-base-en", 768);
+  });
+
+  it("should have correct metadata", () => {
+    expect(provider.name).toBe("jina");
+    expect(provider.model).toBe("jina-embeddings-v2-base-en");
+    expect(provider.dimensions).toBe(768);
+  });
+
+  it("embed() sends input as array of objects with text field", async () => {
+    const mockFetch = makeFetchMock(jinaResponse([SAMPLE_VEC_768]));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await provider.embed("hello");
+    const body = JSON.parse((mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string);
+    expect(body.input[0]).toEqual({ text: "hello" });
+  });
+
+  it("throws on error response", async () => {
+    vi.stubGlobal("fetch", makeFetchMock({}, 500));
+    await expect(provider.embed("test")).rejects.toThrow("Jina embed failed: 500");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+});
+
+// ─── Factory ─────────────────────────────────────────────────────────────────
+
+describe("EmbeddingProviderFactory", () => {
+  it("creates OllamaEmbeddingProvider by default", () => {
+    const provider = EmbeddingProviderFactory.create();
+    expect(provider.name).toBe("ollama");
+    expect(provider.model).toBe(DEFAULT_EMBEDDING_CONFIG.model);
+  });
+
+  it("creates OllamaEmbeddingProvider for provider=ollama", () => {
+    const provider = EmbeddingProviderFactory.create({ provider: "ollama", model: "nomic-embed-text", dimensions: 768 });
+    expect(provider.name).toBe("ollama");
+  });
+
+  it("creates OpenAIEmbeddingProvider for provider=openai", () => {
+    const provider = EmbeddingProviderFactory.create({
+      provider: "openai",
+      model: "text-embedding-3-small",
+      dimensions: 1536,
+      options: { apiKey: "sk-test" },
+    });
+    expect(provider.name).toBe("openai");
+  });
+
+  it("throws when openai apiKey is missing", () => {
+    expect(() =>
+      EmbeddingProviderFactory.create({ provider: "openai", model: "text-embedding-3-small", dimensions: 1536 }),
+    ).toThrow("apiKey");
+  });
+
+  it("creates VoyageEmbeddingProvider for provider=voyage", () => {
+    const provider = EmbeddingProviderFactory.create({
+      provider: "voyage",
+      model: "voyage-2",
+      dimensions: 1024,
+      options: { apiKey: "voy-key" },
+    });
+    expect(provider.name).toBe("voyage");
+  });
+
+  it("throws when voyage apiKey is missing", () => {
+    expect(() =>
+      EmbeddingProviderFactory.create({ provider: "voyage", model: "voyage-2", dimensions: 1024 }),
+    ).toThrow("apiKey");
+  });
+
+  it("creates JinaEmbeddingProvider for provider=jina", () => {
+    const provider = EmbeddingProviderFactory.create({
+      provider: "jina",
+      model: "jina-embeddings-v2-base-en",
+      dimensions: 768,
+      options: { apiKey: "jina-key" },
+    });
+    expect(provider.name).toBe("jina");
+  });
+
+  it("throws when jina apiKey is missing", () => {
+    expect(() =>
+      EmbeddingProviderFactory.create({ provider: "jina", model: "jina-embeddings-v2-base-en", dimensions: 768 }),
+    ).toThrow("apiKey");
+  });
+
+  it("DEFAULT_EMBEDDING_CONFIG uses ollama with local defaults", () => {
+    expect(DEFAULT_EMBEDDING_CONFIG.provider).toBe("ollama");
+    expect(DEFAULT_EMBEDDING_CONFIG.model).toBe("nomic-embed-text");
+    expect(DEFAULT_EMBEDDING_CONFIG.dimensions).toBe(768);
+  });
+});

--- a/tests/unit/rag/memory-search-tool.test.ts
+++ b/tests/unit/rag/memory-search-tool.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for the memory_search MCP tool.
+ *
+ * Tests focus on the tool's contract: input validation, output formatting,
+ * structured memory integration, and graceful degradation.
+ * Vector search mocking is handled separately in retriever/vector-store tests.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const mockSearchMemories = vi.hoisted(() =>
+  vi.fn<[], Promise<unknown[]>>().mockResolvedValue([]),
+);
+
+vi.mock("../../../server/storage", () => ({
+  storage: {
+    searchMemories: mockSearchMemories,
+  },
+}));
+
+vi.mock("../../../server/federation/manager-state", () => ({
+  getFederationManager: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("../../../server/federation/memory-federation", () => ({
+  MemoryFederationService: vi.fn(),
+}));
+
+// Mock VectorStore and EmbeddingProviderFactory so performVectorSearch works in tests.
+// Use simple return values without complex mock chaining.
+vi.mock("../../../server/memory/vector-store", () => ({
+  VectorStore: class MockVectorStore {
+    async search() { return []; }
+    async getEmbeddingConfig() { return null; }
+    async insertChunk() { return {}; }
+    async insertChunks() { return []; }
+    async deleteBySource() { return 0; }
+    async deleteByWorkspace() { return 0; }
+    async countChunks() { return 0; }
+    async listSources() { return []; }
+    async upsertEmbeddingConfig() { return {}; }
+  },
+}));
+
+vi.mock("../../../server/memory/embeddings", () => ({
+  EmbeddingProviderFactory: {
+    create: vi.fn().mockReturnValue({
+      embed: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+    }),
+  },
+  DEFAULT_EMBEDDING_CONFIG: {
+    provider: "ollama",
+    model: "nomic-embed-text",
+    dimensions: 768,
+  },
+}));
+
+import { memorySearchHandler } from "../../../server/tools/builtin/memory-search";
+
+// ─── Sample data ──────────────────────────────────────────────────────────────
+
+function makeMemory(key: string, type = "fact") {
+  return {
+    id: Math.random(),
+    type,
+    key,
+    content: `Content for ${key}`,
+    confidence: 0.9,
+    published: true,
+    tags: [],
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("memorySearchHandler", () => {
+  beforeEach(() => {
+    mockSearchMemories.mockClear().mockResolvedValue([]);
+  });
+
+  // ─── Input validation ────────────────────────────────────────────────────────
+
+  it("returns error message for empty query", async () => {
+    const result = await memorySearchHandler.execute({ query: "" });
+    expect(result).toBe("Query cannot be empty.");
+  });
+
+  it("returns error message for whitespace-only query", async () => {
+    const result = await memorySearchHandler.execute({ query: "   " });
+    expect(result).toBe("Query cannot be empty.");
+  });
+
+  // ─── No results ───────────────────────────────────────────────────────────────
+
+  it('returns "no memories found" when nothing found', async () => {
+    const result = await memorySearchHandler.execute({ query: "unknown topic" });
+    expect(result).toContain(`No memories found matching "unknown topic"`);
+  });
+
+  it("handles query with no results gracefully", async () => {
+    mockSearchMemories.mockResolvedValue([]);
+    const result = await memorySearchHandler.execute({ query: "obscure topic" });
+    expect(typeof result).toBe("string");
+    expect(result).toContain("No memories found");
+  });
+
+  // ─── Local structured memory ───────────────────────────────────────────────
+
+  it("returns formatted local memories with type and confidence", async () => {
+    mockSearchMemories.mockResolvedValue([
+      makeMemory("arch-decision"),
+      makeMemory("perf-issue", "issue"),
+    ]);
+
+    const result = await memorySearchHandler.execute({ query: "architecture" });
+    expect(result).toContain("[fact] arch-decision:");
+    expect(result).toContain("[issue] perf-issue:");
+    expect(result).toContain("confidence: 0.90");
+  });
+
+  it("formats multiple memory types correctly", async () => {
+    mockSearchMemories.mockResolvedValue([
+      makeMemory("decision-1", "decision"),
+      makeMemory("pattern-1", "pattern"),
+      makeMemory("dep-1", "dependency"),
+    ]);
+
+    const result = await memorySearchHandler.execute({ query: "test" });
+    expect(result).toContain("[decision] decision-1:");
+    expect(result).toContain("[pattern] pattern-1:");
+    expect(result).toContain("[dependency] dep-1:");
+  });
+
+  it("shows Structured Memory section when local results exist", async () => {
+    mockSearchMemories.mockResolvedValue([makeMemory("local-key")]);
+
+    const result = await memorySearchHandler.execute({ query: "test" });
+    expect(result).toContain("Structured Memory");
+  });
+
+  // ─── workspace_id handling ────────────────────────────────────────────────
+
+  it("accepts workspace_id parameter without throwing", async () => {
+    const result = await memorySearchHandler.execute({
+      query: "test",
+      workspace_id: "ws-1",
+    });
+    expect(typeof result).toBe("string");
+  });
+
+  it("accepts top_k parameter without throwing", async () => {
+    const result = await memorySearchHandler.execute({
+      query: "test",
+      workspace_id: "ws-1",
+      top_k: 3,
+    });
+    expect(typeof result).toBe("string");
+  });
+
+  it("accepts large top_k value without throwing (clamped to 20)", async () => {
+    const result = await memorySearchHandler.execute({
+      query: "test",
+      workspace_id: "ws-1",
+      top_k: 9999,
+    });
+    expect(typeof result).toBe("string");
+  });
+
+  it("does not call vector search when workspace_id is absent", async () => {
+    mockSearchMemories.mockResolvedValue([makeMemory("key1")]);
+    const result = await memorySearchHandler.execute({ query: "test" });
+    // Should not include "Semantic Memory" section since no workspace_id
+    expect(result).not.toContain("Semantic Memory");
+  });
+
+  // ─── Error handling ────────────────────────────────────────────────────────
+
+  it("returns error message when storage throws", async () => {
+    mockSearchMemories.mockRejectedValueOnce(new Error("DB connection failed"));
+    const result = await memorySearchHandler.execute({ query: "test" });
+    expect(typeof result).toBe("string");
+    expect(result).toContain("unavailable");
+  });
+
+  // ─── Tool definition ───────────────────────────────────────────────────────
+
+  it("tool definition has correct name", () => {
+    expect(memorySearchHandler.definition.name).toBe("memory_search");
+  });
+
+  it("tool definition has 'builtin' source", () => {
+    expect(memorySearchHandler.definition.source).toBe("builtin");
+  });
+
+  it("tool definition includes 'memory' and 'rag' tags", () => {
+    expect(memorySearchHandler.definition.tags).toContain("memory");
+    expect(memorySearchHandler.definition.tags).toContain("rag");
+  });
+
+  it("tool definition requires 'query' field", () => {
+    expect(memorySearchHandler.definition.inputSchema.required).toContain("query");
+  });
+
+  it("tool definition describes workspace_id as optional", () => {
+    const props = memorySearchHandler.definition.inputSchema.properties as Record<string, unknown>;
+    expect(props["workspace_id"]).toBeDefined();
+    expect(memorySearchHandler.definition.inputSchema.required).not.toContain("workspace_id");
+  });
+});

--- a/tests/unit/rag/retriever.test.ts
+++ b/tests/unit/rag/retriever.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Unit tests for the Retriever.
+ *
+ * Mocks EmbeddingProvider and VectorStore to test retrieval logic in isolation.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Retriever } from "../../../server/memory/retriever.js";
+import type { EmbeddingProvider } from "../../../server/memory/embeddings.js";
+import type { VectorStore, VectorSearchResult } from "../../../server/memory/vector-store.js";
+import type { ChunkSourceType } from "../../../server/memory/chunker.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeVec(len = 768): number[] {
+  return Array.from({ length: len }, (_, i) => i / len);
+}
+
+function makeResult(id: string, score: number, chunkText: string, sourceType: ChunkSourceType = "document"): VectorSearchResult {
+  return {
+    id,
+    workspaceId: "ws-1",
+    sourceType,
+    sourceId: `src-${id}`,
+    chunkText,
+    score,
+    metadata: {},
+    ts: new Date(),
+  };
+}
+
+function makeEmbeddingProvider(): EmbeddingProvider {
+  return {
+    name: "ollama",
+    model: "nomic-embed-text",
+    dimensions: 768,
+    embed: vi.fn().mockResolvedValue(makeVec()),
+    embedBatch: vi.fn().mockResolvedValue([makeVec()]),
+  };
+}
+
+function makeVectorStore(results: VectorSearchResult[] = []): VectorStore {
+  return {
+    search: vi.fn().mockResolvedValue(results),
+    insertChunk: vi.fn(),
+    insertChunks: vi.fn(),
+    deleteBySource: vi.fn(),
+    deleteByWorkspace: vi.fn(),
+    countChunks: vi.fn().mockResolvedValue(0),
+    listSources: vi.fn().mockResolvedValue([]),
+    getEmbeddingConfig: vi.fn().mockResolvedValue(null),
+    upsertEmbeddingConfig: vi.fn(),
+  } as unknown as VectorStore;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("Retriever", () => {
+  let provider: EmbeddingProvider;
+  let store: VectorStore;
+
+  beforeEach(() => {
+    provider = makeEmbeddingProvider();
+    store = makeVectorStore();
+  });
+
+  // ─── Basic retrieval ───────────────────────────────────────────────────────
+
+  describe("retrieveContext", () => {
+    it("embeds the query using the embedding provider", async () => {
+      const retriever = new Retriever(provider, makeVectorStore());
+      await retriever.retrieveContext({ query: "how to handle errors", workspaceId: "ws-1" });
+      expect(provider.embed).toHaveBeenCalledWith("how to handle errors");
+    });
+
+    it("passes the query embedding to the vector store", async () => {
+      const queryVec = makeVec();
+      (provider.embed as ReturnType<typeof vi.fn>).mockResolvedValue(queryVec);
+      const retriever = new Retriever(provider, store);
+
+      await retriever.retrieveContext({ query: "test", workspaceId: "ws-1" });
+      expect(store.search).toHaveBeenCalledWith("ws-1", queryVec, expect.any(Object));
+    });
+
+    it("returns empty context when no results found", async () => {
+      const retriever = new Retriever(provider, makeVectorStore([]));
+      const result = await retriever.retrieveContext({ query: "test", workspaceId: "ws-1" });
+
+      expect(result.chunks).toHaveLength(0);
+      expect(result.context).toBe("");
+      expect(result.tokensUsed).toBe(0);
+    });
+
+    it("returns all chunks when under token budget", async () => {
+      const results = [
+        makeResult("1", 0.9, "Short text A"),
+        makeResult("2", 0.8, "Short text B"),
+      ];
+      const retriever = new Retriever(provider, makeVectorStore(results));
+      const result = await retriever.retrieveContext({
+        query: "test",
+        workspaceId: "ws-1",
+        maxTokens: 1000,
+      });
+
+      expect(result.chunks).toHaveLength(2);
+      expect(result.chunks[0].id).toBe("1");
+      expect(result.chunks[1].id).toBe("2");
+    });
+
+    it("respects topK option", async () => {
+      const retriever = new Retriever(provider, store);
+      await retriever.retrieveContext({ query: "test", workspaceId: "ws-1", topK: 3 });
+
+      expect(store.search).toHaveBeenCalledWith("ws-1", expect.any(Array), expect.objectContaining({ topK: 3 }));
+    });
+
+    it("passes filter (source types) to vector store", async () => {
+      const retriever = new Retriever(provider, store);
+      await retriever.retrieveContext({
+        query: "test",
+        workspaceId: "ws-1",
+        filter: ["code", "document"],
+      });
+
+      expect(store.search).toHaveBeenCalledWith("ws-1", expect.any(Array), expect.objectContaining({
+        sourceTypes: ["code", "document"],
+      }));
+    });
+  });
+
+  // ─── Token budget enforcement ──────────────────────────────────────────────
+
+  describe("token budget enforcement", () => {
+    it("stops including chunks when token budget is exceeded", async () => {
+      // 10 maxTokens × 4 chars/token = 40 chars budget
+      // Each chunk has 30 chars, so max 1 full chunk
+      const results = [
+        makeResult("1", 0.9, "A".repeat(30), "document"),
+        makeResult("2", 0.8, "B".repeat(30), "document"),
+        makeResult("3", 0.7, "C".repeat(30), "document"),
+      ];
+      const retriever = new Retriever(provider, makeVectorStore(results));
+      const result = await retriever.retrieveContext({
+        query: "test",
+        workspaceId: "ws-1",
+        maxTokens: 10, // 40 chars
+      });
+
+      // Only 1 full chunk fits (30 chars), maybe partial second
+      expect(result.chunks.length).toBeLessThanOrEqual(2);
+      expect(result.tokensUsed).toBeLessThanOrEqual(10 + 1); // slight rounding
+    });
+
+    it("truncates last chunk when it exceeds remaining budget", async () => {
+      // Budget: 20 tokens = 80 chars
+      // First chunk: 60 chars (fits)
+      // Second chunk: 60 chars (only 20 chars remain → truncated)
+      const results = [
+        makeResult("1", 0.9, "A".repeat(60), "document"),
+        makeResult("2", 0.8, "B".repeat(60), "document"),
+      ];
+      const retriever = new Retriever(provider, makeVectorStore(results));
+      const result = await retriever.retrieveContext({
+        query: "test",
+        workspaceId: "ws-1",
+        maxTokens: 20, // 80 chars
+      });
+
+      if (result.chunks.length === 2) {
+        // Second chunk should be truncated with ellipsis
+        expect(result.chunks[1].chunkText).toContain("…");
+      }
+      expect(result.tokensUsed).toBeLessThanOrEqual(21); // allow rounding
+    });
+
+    it("reports tokensUsed correctly", async () => {
+      const text = "Hello world here."; // 17 chars = ceil(17/4) = 5 tokens
+      const retriever = new Retriever(provider, makeVectorStore([makeResult("1", 0.9, text)]));
+      const result = await retriever.retrieveContext({ query: "test", workspaceId: "ws-1" });
+
+      expect(result.tokensUsed).toBe(Math.ceil(text.length / 4));
+    });
+  });
+
+  // ─── Context formatting ────────────────────────────────────────────────────
+
+  describe("context formatting", () => {
+    it("includes source metadata in context header", async () => {
+      const results = [makeResult("1", 0.87, "Some important code", "code")];
+      const retriever = new Retriever(provider, makeVectorStore(results));
+      const { context } = await retriever.retrieveContext({ query: "test", workspaceId: "ws-1" });
+
+      expect(context).toContain("## Relevant Context");
+      expect(context).toContain("code:");
+      expect(context).toContain("0.87");
+      expect(context).toContain("Some important code");
+    });
+
+    it("includes all chunks in context output", async () => {
+      const results = [
+        makeResult("1", 0.9, "First chunk"),
+        makeResult("2", 0.8, "Second chunk"),
+      ];
+      const retriever = new Retriever(provider, makeVectorStore(results));
+      const { context } = await retriever.retrieveContext({ query: "test", workspaceId: "ws-1" });
+
+      expect(context).toContain("First chunk");
+      expect(context).toContain("Second chunk");
+    });
+
+    it("returns empty string when no chunks", async () => {
+      const retriever = new Retriever(provider, makeVectorStore([]));
+      const { context } = await retriever.retrieveContext({ query: "test", workspaceId: "ws-1" });
+      expect(context).toBe("");
+    });
+  });
+
+  // ─── MinScore filtering ────────────────────────────────────────────────────
+
+  describe("minScore option", () => {
+    it("passes minScore to vector store search", async () => {
+      const retriever = new Retriever(provider, store);
+      await retriever.retrieveContext({ query: "test", workspaceId: "ws-1", minScore: 0.7 });
+
+      expect(store.search).toHaveBeenCalledWith("ws-1", expect.any(Array), expect.objectContaining({ minScore: 0.7 }));
+    });
+
+    it("uses default minScore of 0.3 when not specified", async () => {
+      const retriever = new Retriever(provider, store);
+      await retriever.retrieveContext({ query: "test", workspaceId: "ws-1" });
+
+      expect(store.search).toHaveBeenCalledWith("ws-1", expect.any(Array), expect.objectContaining({ minScore: 0.3 }));
+    });
+  });
+});

--- a/tests/unit/rag/vector-store.test.ts
+++ b/tests/unit/rag/vector-store.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Unit tests for VectorStore.
+ *
+ * All database calls are mocked — no real Postgres required.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Hoisted mocks (must be before all imports) ────────────────────────────────
+
+const mockReturning = vi.hoisted(() => vi.fn());
+const mockInsert = vi.hoisted(() => vi.fn());
+const mockDelete = vi.hoisted(() => vi.fn());
+const mockDbSelect = vi.hoisted(() => vi.fn());
+const mockQuery = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../server/db.js", () => ({
+  db: {
+    insert: mockInsert,
+    delete: mockDelete,
+    select: mockDbSelect,
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({ returning: mockReturning })),
+      })),
+    })),
+    $client: {
+      query: mockQuery,
+    },
+  },
+}));
+
+vi.mock("@shared/schema", () => ({
+  memoryChunks: {
+    workspaceId: "workspace_id",
+    sourceType: "source_type",
+    sourceId: "source_id",
+    id: "id",
+    embedding: "embedding",
+    chunkText: "chunk_text",
+    metadata: "metadata",
+    ts: "ts",
+  },
+  embeddingProviderConfig: {
+    workspaceId: "workspace_id",
+    provider: "provider",
+    model: "model",
+    dimensions: "dimensions",
+    config: "config",
+    updatedAt: "updated_at",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
+  and: vi.fn((...args: unknown[]) => args),
+  sql: vi.fn((parts: unknown) => parts),
+  inArray: vi.fn((col: unknown, vals: unknown) => ({ col, vals })),
+  isNotNull: vi.fn((col: unknown) => ({ col })),
+}));
+
+import { VectorStore } from "../../../server/memory/vector-store.js";
+
+// ─── Sample data ──────────────────────────────────────────────────────────────
+
+function makeVec(len = 768): number[] {
+  return Array.from({ length: len }, () => Math.random());
+}
+
+function makeSearchRow(id: string, score: number) {
+  return {
+    id,
+    workspace_id: "ws-1",
+    source_type: "document",
+    source_id: "doc-1",
+    chunk_text: "Some text",
+    metadata: {},
+    ts: new Date().toISOString(),
+    score,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("VectorStore", () => {
+  let store: VectorStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store = new VectorStore();
+
+    // Default mock implementations
+    mockInsert.mockReturnValue({
+      values: vi.fn(() => ({
+        returning: mockReturning,
+        onConflictDoUpdate: vi.fn(() => ({ returning: mockReturning })),
+      })),
+    });
+
+    mockDelete.mockReturnValue({
+      where: vi.fn(() => ({
+        returning: mockReturning,
+      })),
+    });
+
+    mockDbSelect.mockReturnValue({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          groupBy: vi.fn(() => ({
+            orderBy: vi.fn().mockResolvedValue([]),
+          })),
+        })),
+      })),
+    });
+  });
+
+  // ─── insertChunk ──────────────────────────────────────────────────────────
+
+  describe("insertChunk", () => {
+    it("calls db.insert and returns the row", async () => {
+      const fakeRow = {
+        id: "abc",
+        workspaceId: "ws-1",
+        sourceType: "document" as const,
+        sourceId: "doc-1",
+        chunkText: "hello",
+        metadata: {},
+        ts: new Date(),
+        embedding: makeVec(),
+      };
+      mockReturning.mockResolvedValueOnce([fakeRow]);
+
+      const result = await store.insertChunk({
+        workspaceId: "ws-1",
+        sourceType: "document",
+        sourceId: "doc-1",
+        chunkText: "hello",
+        embedding: makeVec(),
+        metadata: {},
+      });
+
+      expect(mockInsert).toHaveBeenCalled();
+      expect(result).toEqual(fakeRow);
+    });
+  });
+
+  // ─── insertChunks ─────────────────────────────────────────────────────────
+
+  describe("insertChunks", () => {
+    it("returns empty array for empty input without hitting DB", async () => {
+      const result = await store.insertChunks([]);
+      expect(result).toEqual([]);
+      expect(mockInsert).not.toHaveBeenCalled();
+    });
+
+    it("inserts multiple chunks in one call", async () => {
+      const rows = [
+        { id: "1", workspaceId: "ws-1", sourceType: "document" as const, sourceId: "s1", chunkText: "a", metadata: {}, ts: new Date(), embedding: makeVec() },
+        { id: "2", workspaceId: "ws-1", sourceType: "document" as const, sourceId: "s1", chunkText: "b", metadata: {}, ts: new Date(), embedding: makeVec() },
+      ];
+      mockReturning.mockResolvedValueOnce(rows);
+
+      const result = await store.insertChunks([
+        { workspaceId: "ws-1", sourceType: "document", sourceId: "s1", chunkText: "a", embedding: makeVec(), metadata: {} },
+        { workspaceId: "ws-1", sourceType: "document", sourceId: "s1", chunkText: "b", embedding: makeVec(), metadata: {} },
+      ]);
+
+      expect(mockInsert).toHaveBeenCalledOnce();
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  // ─── search ───────────────────────────────────────────────────────────────
+
+  describe("search", () => {
+    it("executes raw SQL query and returns formatted results", async () => {
+      const rows = [makeSearchRow("id-1", 0.9), makeSearchRow("id-2", 0.7)];
+      mockQuery.mockResolvedValueOnce({ rows });
+
+      const queryVec = makeVec();
+      const results = await store.search("ws-1", queryVec, { topK: 5 });
+
+      expect(mockQuery).toHaveBeenCalledOnce();
+      const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain("memory_chunks");
+      expect(sql).toContain("workspace_id = $1");
+      expect(params[0]).toBe("ws-1");
+      // Verify vector literal format
+      expect(params).toContain(`[${queryVec.join(",")}]`);
+    });
+
+    it("applies topK limit via query parameter", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      await store.search("ws-1", makeVec(), { topK: 3 });
+
+      const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+      expect(params).toContain(3);
+    });
+
+    it("returns results with correct score values", async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [makeSearchRow("a", 0.9), makeSearchRow("b", 0.7), makeSearchRow("c", 0.5)],
+      });
+
+      const results = await store.search("ws-1", makeVec());
+      expect(results[0].score).toBe(0.9);
+      expect(results[1].score).toBe(0.7);
+      expect(results[2].score).toBe(0.5);
+    });
+
+    it("maps result rows to VectorSearchResult shape", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [makeSearchRow("uuid-1", 0.85)] });
+      const results = await store.search("ws-1", makeVec());
+
+      expect(results[0]).toMatchObject({
+        id: "uuid-1",
+        workspaceId: "ws-1",
+        sourceType: "document",
+        sourceId: "doc-1",
+        chunkText: "Some text",
+        score: 0.85,
+      });
+      expect(results[0].ts).toBeInstanceOf(Date);
+    });
+
+    it("filters by sourceTypes by adding IN clause to SQL", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      await store.search("ws-1", makeVec(), { sourceTypes: ["code", "document"] });
+
+      const [sql] = mockQuery.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain("IN (");
+    });
+
+    it("filters by sourceId by adding equality to params", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      await store.search("ws-1", makeVec(), { sourceId: "specific-doc" });
+
+      const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+      expect(params).toContain("specific-doc");
+    });
+
+    it("returns empty array when no results", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      const results = await store.search("ws-1", makeVec());
+      expect(results).toEqual([]);
+    });
+
+    it("passes minScore as query parameter", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      await store.search("ws-1", makeVec(), { minScore: 0.6 });
+
+      const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+      expect(params).toContain(0.6);
+    });
+  });
+
+  // ─── deleteBySource ───────────────────────────────────────────────────────
+
+  describe("deleteBySource", () => {
+    it("calls db.delete and returns count of deleted rows", async () => {
+      mockReturning.mockResolvedValueOnce([{ id: "1" }, { id: "2" }]);
+
+      const count = await store.deleteBySource("ws-1", "document", "doc-1");
+      expect(mockDelete).toHaveBeenCalled();
+      expect(count).toBe(2);
+    });
+
+    it("returns 0 when nothing matched", async () => {
+      mockReturning.mockResolvedValueOnce([]);
+      const count = await store.deleteBySource("ws-1", "code", "nonexistent");
+      expect(count).toBe(0);
+    });
+  });
+
+  // ─── deleteByWorkspace ────────────────────────────────────────────────────
+
+  describe("deleteByWorkspace", () => {
+    it("deletes all chunks for workspace and returns count", async () => {
+      mockReturning.mockResolvedValueOnce([{ id: "1" }, { id: "2" }, { id: "3" }]);
+      const count = await store.deleteByWorkspace("ws-1");
+      expect(mockDelete).toHaveBeenCalled();
+      expect(count).toBe(3);
+    });
+  });
+
+  // ─── countChunks ─────────────────────────────────────────────────────────
+
+  describe("countChunks", () => {
+    it("returns 0 when no rows returned", async () => {
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn(() => ({
+          where: vi.fn().mockResolvedValue([]),
+        })),
+      });
+
+      const count = await store.countChunks("ws-1");
+      expect(count).toBe(0);
+    });
+
+    it("returns count from query result", async () => {
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn(() => ({
+          where: vi.fn().mockResolvedValue([{ count: 42 }]),
+        })),
+      });
+
+      const count = await store.countChunks("ws-1");
+      expect(count).toBe(42);
+    });
+  });
+
+  // ─── listSources ─────────────────────────────────────────────────────────
+
+  describe("listSources", () => {
+    it("returns grouped sources from query", async () => {
+      const mockSources = [
+        { sourceType: "document", sourceId: "doc-1", count: 10 },
+        { sourceType: "code", sourceId: "src/index.ts", count: 5 },
+      ];
+      mockDbSelect.mockReturnValueOnce({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            groupBy: vi.fn(() => ({
+              orderBy: vi.fn().mockResolvedValue(mockSources),
+            })),
+          })),
+        })),
+      });
+
+      const sources = await store.listSources("ws-1");
+      expect(sources).toHaveLength(2);
+      expect(sources[0]).toMatchObject({ sourceType: "document", sourceId: "doc-1", count: 10 });
+    });
+
+    it("returns empty array when no sources exist", async () => {
+      const sources = await store.listSources("ws-1");
+      expect(sources).toEqual([]);
+    });
+  });
+});

--- a/tests/unit/tools/tool-builtins.test.ts
+++ b/tests/unit/tools/tool-builtins.test.ts
@@ -5,6 +5,7 @@
  *   - storage module: vi.mock("../../server/storage") — no real DB
  *   - fetch: vi.spyOn(globalThis, "fetch") — no real HTTP calls
  *   - configLoader: vi.mock("../../server/config/loader") — no real config files
+ *   - db: vi.mock("../../server/db") — no real Postgres (required by vector-store)
  *
  * Tests verify:
  *   - Happy path: returns formatted results string
@@ -40,6 +41,65 @@ const { mockConfigGet } = vi.hoisted(() => ({
 vi.mock("../../../server/config/loader.js", () => ({
   configLoader: {
     get: mockConfigGet,
+  },
+}));
+
+// ─── Mock db to prevent Postgres initialization crash ────────────────────────
+// vector-store.ts imports db at module level; this mock prevents the crash.
+
+vi.mock("../../../server/db.js", () => ({
+  db: {
+    insert: vi.fn(),
+    delete: vi.fn(),
+    select: vi.fn(),
+    update: vi.fn(),
+    $client: { query: vi.fn() },
+  },
+  pool: {},
+}));
+
+// ─── Mock federation modules ──────────────────────────────────────────────────
+
+vi.mock("../../../server/federation/manager-state.js", () => ({
+  getFederationManager: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("../../../server/federation/memory-federation.js", () => ({
+  MemoryFederationService: vi.fn(),
+}));
+
+// ─── Mock vector-store (no pgvector in tests) ────────────────────────────────
+
+vi.mock("../../../server/memory/vector-store.js", () => ({
+  VectorStore: class MockVectorStore {
+    async search() { return []; }
+    async getEmbeddingConfig() { return null; }
+    async insertChunk() { return {}; }
+    async insertChunks() { return []; }
+    async deleteBySource() { return 0; }
+    async deleteByWorkspace() { return 0; }
+    async countChunks() { return 0; }
+    async listSources() { return []; }
+    async upsertEmbeddingConfig() { return {}; }
+  },
+  vectorStore: {
+    search: vi.fn().mockResolvedValue([]),
+    getEmbeddingConfig: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+// ─── Mock embeddings (no real embedding calls in tests) ──────────────────────
+
+vi.mock("../../../server/memory/embeddings.js", () => ({
+  EmbeddingProviderFactory: {
+    create: vi.fn().mockReturnValue({
+      embed: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+    }),
+  },
+  DEFAULT_EMBEDDING_CONFIG: {
+    provider: "ollama",
+    model: "nomic-embed-text",
+    dimensions: 768,
   },
 }));
 
@@ -288,8 +348,10 @@ describe("memory_search — execute()", () => {
 
     const result = await memorySearchHandler.execute({ query: "key" });
 
-    const lines = result.split("\n").filter((l) => l.trim().length > 0);
-    expect(lines).toHaveLength(2);
+    // Updated: memory-search now prepends a section header, so both memories
+    // plus the header appear in output. Verify both memories are present.
+    expect(result).toContain("key1");
+    expect(result).toContain("key2");
   });
 });
 

--- a/tests/unit/tools/tool-registry.test.ts
+++ b/tests/unit/tools/tool-registry.test.ts
@@ -20,6 +20,73 @@ import type { ToolDefinition, ToolCall } from "../../../shared/types.js";
 import { ToolRegistry } from "../../../server/tools/registry.js";
 import type { ToolHandler } from "../../../server/tools/registry.js";
 
+// ─── Top-level mocks for transitive DB/config dependencies ───────────────────
+// The toolRegistry singleton imports memory-search → vector-store → db.
+// These mocks prevent the config-loader crash on module initialization.
+
+vi.mock("../../../server/storage.js", () => ({
+  storage: {
+    getLlmRequests: vi.fn().mockResolvedValue({ rows: [], total: 0 }),
+    searchMemories: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock("../../../server/config/loader.js", () => ({
+  configLoader: {
+    get: vi.fn().mockReturnValue({ providers: { tavily: undefined } }),
+  },
+}));
+
+vi.mock("../../../server/db.js", () => ({
+  db: {
+    insert: vi.fn(),
+    delete: vi.fn(),
+    select: vi.fn(),
+    update: vi.fn(),
+    $client: { query: vi.fn() },
+  },
+  pool: {},
+}));
+
+vi.mock("../../../server/federation/manager-state.js", () => ({
+  getFederationManager: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("../../../server/federation/memory-federation.js", () => ({
+  MemoryFederationService: vi.fn(),
+}));
+
+vi.mock("../../../server/memory/vector-store.js", () => ({
+  VectorStore: class MockVectorStore {
+    async search() { return []; }
+    async getEmbeddingConfig() { return null; }
+    async insertChunk() { return {}; }
+    async insertChunks() { return []; }
+    async deleteBySource() { return 0; }
+    async deleteByWorkspace() { return 0; }
+    async countChunks() { return 0; }
+    async listSources() { return []; }
+    async upsertEmbeddingConfig() { return {}; }
+  },
+  vectorStore: {
+    search: vi.fn().mockResolvedValue([]),
+    getEmbeddingConfig: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+vi.mock("../../../server/memory/embeddings.js", () => ({
+  EmbeddingProviderFactory: {
+    create: vi.fn().mockReturnValue({
+      embed: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+    }),
+  },
+  DEFAULT_EMBEDDING_CONFIG: {
+    provider: "ollama",
+    model: "nomic-embed-text",
+    dimensions: 768,
+  },
+}));
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function makeHandler(
@@ -299,19 +366,6 @@ describe("ToolRegistry — tool definition shape", () => {
 
 describe("toolRegistry singleton — builtin tool registration", () => {
   it("getAvailableTools() returns a non-empty array", async () => {
-    // Mock storage and config to avoid import-side-effects from the builtins
-    vi.mock("../../../server/storage.js", () => ({
-      storage: {
-        getLlmRequests: vi.fn().mockResolvedValue({ rows: [], total: 0 }),
-        searchMemories: vi.fn().mockResolvedValue([]),
-      },
-    }));
-    vi.mock("../../../server/config/loader.js", () => ({
-      configLoader: {
-        get: vi.fn().mockReturnValue({ providers: { tavily: undefined } }),
-      },
-    }));
-
     const { toolRegistry } = await import("../../../server/tools/index.js");
 
     const tools = toolRegistry.getAvailableTools();


### PR DESCRIPTION
## Summary

- Adds pgvector-backed vector store with `memory_chunks` table and HNSW index for approximate nearest-neighbor search
- Implements pluggable embedding providers: Ollama (default/local-first), OpenAI, Voyage, Jina — per-workspace config stored in `embedding_provider_config`
- Adds `Retriever` class with token-budget enforcement and markdown context formatting
- Extends `memory_search` MCP tool with optional `workspace_id` + `top_k` params for combined semantic + structured memory search
- Adds Knowledge UI tab (Sources / Search / Import) for managing embedded knowledge
- Adds `/api/workspaces/:id/knowledge/*` routes for ingest, search, source management, and provider config
- Adds comprehensive unit tests: 94 RAG tests (embeddings, chunker, vector-store, retriever, tool) + fixes to 2 existing tool test files

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 3643 tests pass across 164 test files
- [x] `tests/unit/rag/` — 94 new tests all passing
- [ ] Manual: start Ollama locally with `nomic-embed-text`, ingest a document via Knowledge tab, verify semantic search returns relevant chunks
- [ ] Manual: switch workspace embedding provider to OpenAI, trigger re-embed job, verify chunks are re-embedded
- [ ] Integration: run `psql` migration `0018_memory_chunks.sql`, verify `memory_chunks` table and HNSW index exist

## Files changed

| File | Change |
|------|--------|
| `migrations/0018_memory_chunks.sql` | New: pgvector schema with HNSW index |
| `shared/schema.ts` | Added `memoryChunks` and `embeddingProviderConfig` tables |
| `server/memory/embeddings.ts` | New: pluggable embedding providers + factory |
| `server/memory/chunker.ts` | New: source-type-aware text chunker |
| `server/memory/vector-store.ts` | New: VectorStore with parameterized pgvector queries |
| `server/memory/retriever.ts` | New: Retriever with token-budget enforcement |
| `server/routes/knowledge.ts` | New: Knowledge API routes |
| `server/tools/builtin/memory-search.ts` | Extended with vector search capability |
| `server/routes.ts` | Registered knowledge routes |
| `client/src/pages/Knowledge.tsx` | New: Knowledge UI (Sources/Search/Import tabs) |
| `client/src/App.tsx` | Added Knowledge route |
| `tests/unit/rag/*.test.ts` | New: 5 test files, 94 tests |
| `tests/unit/tools/tool-builtins.test.ts` | Fixed: add mocks for new transitive DB deps |
| `tests/unit/tools/tool-registry.test.ts` | Fixed: promote mocks to top-level |