### PR TITLE
feat: dynamic consensus thresholds in Voting execution strategy (#285)

### DIFF
--- a/server/pipeline/voting/confidence-scorer.ts
+++ b/server/pipeline/voting/confidence-scorer.ts
@@ -1,0 +1,145 @@
+// server/pipeline/voting/confidence-scorer.ts
+// Extracts and aggregates candidate confidence scores for the Voting strategy.
+//
+// Confidence may come from:
+//  1. Provider-returned confidence (e.g. logprobs → mean token confidence)
+//  2. Structured JSON `confidence` field in candidate output
+//  3. Self-eval fallback: compute heuristic from text length / certainty words
+
+import type { CandidateConfidenceScore } from "@shared/types";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Phrases that suggest the model is uncertain — reduce heuristic confidence. */
+const UNCERTAINTY_PHRASES: RegExp[] = [
+  /\b(not sure|unclear|uncertain|might|may|possibly|perhaps|i think|i believe|could be)\b/gi,
+  /\b(it depends|hard to say|difficult to determine)\b/gi,
+];
+
+/** Phrases that suggest the model is confident — boost heuristic confidence. */
+const CONFIDENCE_PHRASES: RegExp[] = [
+  /\b(definitely|certainly|clearly|obviously|always|never|must|will|is|are)\b/gi,
+  /\b(the answer is|the result is|conclusion:)\b/gi,
+];
+
+const MIN_TEXT_LENGTH_FOR_HEURISTIC = 20;
+
+// ─── Extractors ───────────────────────────────────────────────────────────────
+
+/**
+ * Attempt to extract a confidence score from a candidate's response text.
+ *
+ * Priority:
+ *  1. JSON field `confidence` (float 0–1) in the root of parsed output
+ *  2. Heuristic computed from text characteristics
+ *
+ * Returns a `CandidateConfidenceScore` with the source noted.
+ */
+export function extractConfidence(
+  modelSlug: string,
+  content: string,
+  providerLogprob?: number,
+): CandidateConfidenceScore {
+  // 1. Provider logprob (pre-computed mean token log-probability → probability)
+  if (providerLogprob !== undefined) {
+    return {
+      modelSlug,
+      score: clamp(providerLogprob, 0, 1),
+      source: "provider",
+    };
+  }
+
+  // 2. JSON-embedded confidence field
+  const jsonConfidence = extractJsonConfidence(content);
+  if (jsonConfidence !== null) {
+    return {
+      modelSlug,
+      score: clamp(jsonConfidence, 0, 1),
+      source: "self_eval",
+    };
+  }
+
+  // 3. Heuristic
+  return {
+    modelSlug,
+    score: computeHeuristicConfidence(content),
+    source: "heuristic",
+  };
+}
+
+/**
+ * Aggregate multiple candidate confidence scores into a single value.
+ * Strategy: arithmetic mean.  Returns 0.5 if no scores provided.
+ */
+export function aggregateConfidence(scores: CandidateConfidenceScore[]): number {
+  if (scores.length === 0) return 0.5;
+  const total = scores.reduce((sum, s) => sum + s.score, 0);
+  return total / scores.length;
+}
+
+/**
+ * Build confidence scores for all candidates in a voting run.
+ */
+export function scoreAllCandidates(
+  candidates: Array<{ modelSlug: string; content: string; providerLogprob?: number }>,
+): CandidateConfidenceScore[] {
+  return candidates.map((c) =>
+    extractConfidence(c.modelSlug, c.content, c.providerLogprob),
+  );
+}
+
+// ─── Private helpers ──────────────────────────────────────────────────────────
+
+function extractJsonConfidence(content: string): number | null {
+  // Try stripping markdown code fences
+  const stripped = content
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```\s*$/, "")
+    .trim();
+
+  try {
+    const parsed = JSON.parse(stripped) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "confidence" in parsed
+    ) {
+      const val = (parsed as Record<string, unknown>).confidence;
+      if (typeof val === "number" && val >= 0 && val <= 1) {
+        return val;
+      }
+    }
+  } catch {
+    // Not JSON — continue to heuristic
+  }
+  return null;
+}
+
+function computeHeuristicConfidence(text: string): number {
+  if (text.trim().length < MIN_TEXT_LENGTH_FOR_HEURISTIC) {
+    // Very short responses are low-confidence
+    return 0.3;
+  }
+
+  let score = 0.5; // baseline
+
+  for (const pattern of UNCERTAINTY_PHRASES) {
+    const matches = text.match(pattern);
+    if (matches) {
+      score -= 0.05 * Math.min(matches.length, 3);
+    }
+  }
+
+  for (const pattern of CONFIDENCE_PHRASES) {
+    const matches = text.match(pattern);
+    if (matches) {
+      score += 0.04 * Math.min(matches.length, 3);
+    }
+  }
+
+  return clamp(score, 0.1, 0.9);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/server/pipeline/voting/fallback-handler.ts
+++ b/server/pipeline/voting/fallback-handler.ts
@@ -1,0 +1,123 @@
+// server/pipeline/voting/fallback-handler.ts
+// Handles the "threshold not met" case in the Voting execution strategy.
+//
+// Three configurable strategies:
+//  • escalate — call a stronger judge model to produce the final answer
+//  • abort     — throw a VotingThresholdNotMetError
+//  • partial   — emit the highest-agreement candidate as a partial result
+
+import type { Gateway } from "../../gateway/index.js";
+import type {
+  VotingFallbackConfig,
+  VotingFallbackOutcome,
+  ProviderMessage,
+} from "@shared/types";
+
+// ─── Error type ───────────────────────────────────────────────────────────────
+
+export class VotingThresholdNotMetError extends Error {
+  constructor(
+    public readonly threshold: number,
+    public readonly bestAgreement: number,
+  ) {
+    super(
+      `Voting threshold not met: required ${threshold.toFixed(3)}, best agreement was ${bestAgreement.toFixed(3)}`,
+    );
+    this.name = "VotingThresholdNotMetError";
+  }
+}
+
+// ─── Fallback handler ─────────────────────────────────────────────────────────
+
+export interface FallbackInput {
+  /** The original user/system messages — passed to the judge if escalating. */
+  basePrompt: ProviderMessage[];
+  /** All candidate outputs from this voting run. */
+  candidates: Array<{ modelSlug: string; content: string; score: number }>;
+  /** Index of the candidate with the highest agreement score. */
+  bestCandidateIndex: number;
+  /** The threshold that was not met. */
+  threshold: number;
+  /** The best agreement score achieved. */
+  bestAgreement: number;
+  /** Max tokens for the escalation judge call. */
+  maxTokens?: number;
+}
+
+export interface FallbackResult {
+  content: string;
+  outcome: VotingFallbackOutcome;
+  escalationModelSlug?: string;
+  tokensUsed: number;
+}
+
+/**
+ * Execute the configured fallback when the voting threshold is not met.
+ *
+ * - `escalate`: calls a stronger judge model and returns its synthesis
+ * - `abort`: throws `VotingThresholdNotMetError`
+ * - `partial`: returns the highest-agreement candidate with outcome=`partial`
+ */
+export async function handleFallback(
+  config: VotingFallbackConfig,
+  input: FallbackInput,
+  gateway: Gateway,
+): Promise<FallbackResult> {
+  switch (config.strategy) {
+    case "escalate":
+      return executeEscalation(config, input, gateway);
+
+    case "abort":
+      throw new VotingThresholdNotMetError(input.threshold, input.bestAgreement);
+
+    case "partial":
+      return executePartial(input);
+  }
+}
+
+// ─── Private helpers ──────────────────────────────────────────────────────────
+
+async function executeEscalation(
+  config: VotingFallbackConfig,
+  input: FallbackInput,
+  gateway: Gateway,
+): Promise<FallbackResult> {
+  const judgeModelSlug = config.escalationModelSlug ?? "claude-opus-4";
+
+  const candidateSummary = input.candidates
+    .map((c, i) => `Candidate ${i + 1} (${c.modelSlug}, agreement=${c.score.toFixed(3)}):\n${c.content}`)
+    .join("\n\n---\n\n");
+
+  const judgeMessages: ProviderMessage[] = [
+    ...input.basePrompt,
+    {
+      role: "user",
+      content:
+        `The voting strategy could not reach consensus (threshold=${input.threshold.toFixed(3)}, ` +
+        `best agreement=${input.bestAgreement.toFixed(3)}). ` +
+        `Please review the following candidate responses and produce the single best answer:\n\n${candidateSummary}`,
+    },
+  ];
+
+  const response = await gateway.complete({
+    modelSlug: judgeModelSlug,
+    messages: judgeMessages,
+    maxTokens: input.maxTokens,
+  });
+
+  return {
+    content: response.content,
+    outcome: "escalated",
+    escalationModelSlug: judgeModelSlug,
+    tokensUsed: response.tokensUsed,
+  };
+}
+
+function executePartial(input: FallbackInput): FallbackResult {
+  const best = input.candidates[input.bestCandidateIndex];
+  return {
+    content: best?.content ?? "",
+    outcome: "partial",
+    tokensUsed: 0,
+  };
+}

--- a/server/pipeline/voting/task-signals.ts
+++ b/server/pipeline/voting/task-signals.ts
@@ -1,0 +1,92 @@
+// server/pipeline/voting/task-signals.ts
+// Collects and normalises task signals from pipeline input and upstream stage outputs.
+// Signals flow into the threshold resolver when the voting strategy is in `task_signal` mode.
+
+import type { TaskSignal, TaskSignalBag } from "@shared/types";
+
+// ─── Signal keys the system recognises ───────────────────────────────────────
+
+/** Well-known signal constants.  Users may also emit arbitrary string signals. */
+export const KNOWN_SIGNALS = {
+  HIGH_RISK: "signal:high_risk",
+  LOW_STAKES: "signal:low_stakes",
+  REQUIRES_CONSENSUS: "signal:requires_consensus",
+  FAST_PATH: "signal:fast_path",
+} as const;
+
+// ─── Signal collector ─────────────────────────────────────────────────────────
+
+/**
+ * Build a `TaskSignalBag` from:
+ *  1. The pipeline's `tags[]` (each tag becomes a plain signal)
+ *  2. An explicit `risk_level` field
+ *  3. Upstream-stage signals already accumulated into the bag
+ *
+ * Order: tags → riskLevel → upstream — later entries do NOT override earlier
+ * ones; they accumulate.
+ */
+export function collectSignals(params: {
+  tags?: string[];
+  riskLevel?: "low" | "medium" | "high" | "critical";
+  upstreamSignals?: TaskSignal[];
+}): TaskSignalBag {
+  const signals: TaskSignal[] = [];
+  const seen = new Set<string>();
+
+  const add = (sig: TaskSignal): void => {
+    if (!seen.has(sig.key)) {
+      seen.add(sig.key);
+      signals.push(sig);
+    }
+  };
+
+  // Tags → plain signals
+  for (const tag of params.tags ?? []) {
+    add({ key: tag, source: "tag" });
+  }
+
+  // risk_level → canonical signals
+  if (params.riskLevel) {
+    if (params.riskLevel === "high" || params.riskLevel === "critical") {
+      add({ key: KNOWN_SIGNALS.HIGH_RISK, source: "risk_level", value: params.riskLevel });
+    } else if (params.riskLevel === "low") {
+      add({ key: KNOWN_SIGNALS.LOW_STAKES, source: "risk_level", value: params.riskLevel });
+    }
+  }
+
+  // Upstream signals emitted by prior stages
+  for (const sig of params.upstreamSignals ?? []) {
+    add(sig);
+  }
+
+  return { signals };
+}
+
+/**
+ * Check whether a specific signal key is present in a bag.
+ */
+export function hasSignal(bag: TaskSignalBag, key: string): boolean {
+  return bag.signals.some((s) => s.key === key);
+}
+
+/**
+ * Return the first signal matching key, or undefined.
+ */
+export function getSignal(bag: TaskSignalBag, key: string): TaskSignal | undefined {
+  return bag.signals.find((s) => s.key === key);
+}
+
+/**
+ * Merge two bags — left wins on duplicate keys.
+ */
+export function mergeSignalBags(left: TaskSignalBag, right: TaskSignalBag): TaskSignalBag {
+  const seen = new Set(left.signals.map((s) => s.key));
+  const merged = [...left.signals];
+  for (const sig of right.signals) {
+    if (!seen.has(sig.key)) {
+      seen.add(sig.key);
+      merged.push(sig);
+    }
+  }
+  return { signals: merged };
+}

--- a/server/pipeline/voting/threshold-resolver.ts
+++ b/server/pipeline/voting/threshold-resolver.ts
@@ -1,0 +1,99 @@
+// server/pipeline/voting/threshold-resolver.ts
+// Resolves the effective consensus threshold for a Voting execution strategy.
+//
+// Three modes:
+//  • static      — uses the fixed value from config (legacy path, always available)
+//  • task_signal — looks up the first matching signal rule; falls back to the
+//                  configured default
+//  • confidence  — adjusts the base threshold based on aggregated candidate
+//                  confidence scores within configured floor/ceiling bounds
+
+import type {
+  VotingThresholdConfig,
+  TaskSignalThresholdConfig,
+  ConfidenceThresholdConfig,
+  TaskSignalBag,
+} from "@shared/types";
+import { hasSignal } from "./task-signals.js";
+
+// ─── Threshold Resolver ───────────────────────────────────────────────────────
+
+/**
+ * Resolve the effective voting threshold given a threshold configuration, an
+ * optional signal bag, and optional aggregated confidence.
+ *
+ * @param config     Threshold configuration (static / task_signal / confidence).
+ * @param signals    Signal bag from the current pipeline run.  Required for
+ *                   `task_signal` mode; ignored otherwise.
+ * @param aggregatedConfidence  Aggregated confidence score (0–1) from candidate
+ *                              models.  Required for `confidence` mode; ignored
+ *                              otherwise.
+ * @returns Effective threshold value in [0, 1].
+ */
+export function resolveThreshold(
+  config: VotingThresholdConfig,
+  signals?: TaskSignalBag,
+  aggregatedConfidence?: number,
+): number {
+  switch (config.mode) {
+    case "static":
+      return clamp(config.value, 0, 1);
+
+    case "task_signal":
+      return resolveTaskSignalThreshold(config, signals);
+
+    case "confidence":
+      return resolveConfidenceThreshold(config, aggregatedConfidence);
+  }
+}
+
+// ─── Private helpers ──────────────────────────────────────────────────────────
+
+function resolveTaskSignalThreshold(
+  config: TaskSignalThresholdConfig,
+  signals?: TaskSignalBag,
+): number {
+  if (!signals || signals.signals.length === 0) {
+    return clamp(config.default, 0, 1);
+  }
+
+  for (const rule of config.rules) {
+    if (hasSignal(signals, rule.signal)) {
+      return clamp(rule.threshold, 0, 1);
+    }
+  }
+
+  return clamp(config.default, 0, 1);
+}
+
+function resolveConfidenceThreshold(
+  config: ConfidenceThresholdConfig,
+  aggregatedConfidence?: number,
+): number {
+  const floor = clamp(config.floor, 0, 1);
+  const ceiling = clamp(config.ceiling, 0, 1);
+  const base = clamp(config.base, floor, ceiling);
+
+  if (aggregatedConfidence === undefined) {
+    // No confidence available — use base threshold
+    return base;
+  }
+
+  const conf = clamp(aggregatedConfidence, 0, 1);
+
+  // High confidence → ease the threshold (lower required agreement);
+  // Low confidence → tighten the threshold (require higher agreement).
+  //
+  // Formula: threshold = base - (conf - 0.5) * sensitivity
+  //   conf = 1.0 → threshold decreases by sensitivity/2
+  //   conf = 0.5 → threshold stays at base
+  //   conf = 0.0 → threshold increases by sensitivity/2
+  const sensitivity = config.sensitivity ?? 0.2;
+  const adjusted = base - (conf - 0.5) * sensitivity;
+
+  return clamp(adjusted, floor, ceiling);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/server/services/strategy-executor.ts
+++ b/server/services/strategy-executor.ts
@@ -18,6 +18,9 @@ import {
   preferCrossProviderOrder,
   type ParticipantWithProvider,
 } from "./provider-diversity";
+import { resolveThreshold } from "../pipeline/voting/threshold-resolver.js";
+import { scoreAllCandidates, aggregateConfidence } from "../pipeline/voting/confidence-scorer.js";
+import { handleFallback, VotingThresholdNotMetError } from "../pipeline/voting/fallback-handler.js";
 
 export interface StrategyContext {
   runId: string;
@@ -332,7 +335,7 @@ export class StrategyExecutor {
   ): Promise<StrategyResult> {
     validateVotingStrategy(strategy);
 
-    // Run all candidates in parallel
+    // ── Run all candidates in parallel ──────────────────────────────────────
     const candidatePromises = strategy.candidates.map((c) =>
       this.gateway.complete({
         modelSlug: c.modelSlug,
@@ -343,21 +346,43 @@ export class StrategyExecutor {
     );
 
     const candidateResults = await Promise.all(candidatePromises);
-    const totalTokens = candidateResults.reduce((sum, r) => sum + r.tokensUsed, 0);
+    let totalTokens = candidateResults.reduce((sum, r) => sum + r.tokensUsed, 0);
 
+    // ── Confidence scoring (#285) ────────────────────────────────────────────
+    const confidenceScores = scoreAllCandidates(
+      candidateResults.map((r, i) => ({
+        modelSlug: strategy.candidates[i].modelSlug,
+        content: r.content,
+      })),
+    );
+    const aggregatedConfidence = aggregateConfidence(confidenceScores);
+
+    // ── Resolve effective threshold (#285) ────────────────────────────────────
+    const thresholdConfig = strategy.thresholdConfig;
+    let thresholdUsed: number;
+    let thresholdMode: "static" | "task_signal" | "confidence";
+
+    if (thresholdConfig) {
+      thresholdUsed = resolveThreshold(thresholdConfig, strategy.signals, aggregatedConfidence);
+      thresholdMode = thresholdConfig.mode;
+    } else {
+      // Legacy path — use fixed threshold
+      thresholdUsed = strategy.threshold;
+      thresholdMode = "static";
+    }
+
+    // ── Compute similarity scores ────────────────────────────────────────────
     const contents = candidateResults.map((r) => r.content);
     const scores = computeSimilarityScores(contents);
 
     const passedIndices = scores
       .map((score, idx) => ({ score, idx }))
-      .filter(({ score }) => score >= strategy.threshold)
+      .filter(({ score }) => score >= thresholdUsed)
       .map(({ idx }) => idx);
 
     // Winner: first passing candidate; fallback to highest-scored
-    const winnerIndex = passedIndices.length > 0
-      ? passedIndices[0]
-      : scores.indexOf(Math.max(...scores));
-
+    const bestIndex = scores.indexOf(Math.max(...scores));
+    const winnerIndex = passedIndices.length > 0 ? passedIndices[0] : bestIndex;
     const agreement = scores[winnerIndex] ?? 0;
 
     const candidateDetails = candidateResults.map((r, i) => ({
@@ -370,19 +395,61 @@ export class StrategyExecutor {
       this.wsManager.broadcastToRun(context.runId, {
         type: "strategy:voting:candidate",
         runId: context.runId,
-        payload: { stageId: context.stageId, modelSlug: c.modelSlug, index: idx, passed: c.passed },
+        payload: {
+          stageId: context.stageId,
+          modelSlug: c.modelSlug,
+          index: idx,
+          passed: c.passed,
+          confidenceScore: confidenceScores[idx]?.score,
+        },
         timestamp: new Date().toISOString(),
       });
     });
+
+    // ── Handle threshold-not-met with configured fallback (#285) ─────────────
+    let finalContent: string;
+    let fallbackOutcome: import("@shared/types").VotingFallbackOutcome | undefined;
+    let escalationModelSlug: string | undefined;
+
+    if (passedIndices.length === 0 && strategy.fallback) {
+      const fallbackResult = await handleFallback(
+        strategy.fallback,
+        {
+          basePrompt,
+          candidates: candidateResults.map((r, i) => ({
+            modelSlug: strategy.candidates[i].modelSlug,
+            content: r.content,
+            score: scores[i] ?? 0,
+          })),
+          bestCandidateIndex: bestIndex,
+          threshold: thresholdUsed,
+          bestAgreement: scores[bestIndex] ?? 0,
+          maxTokens: context.maxTokens,
+        },
+        this.gateway,
+      );
+      totalTokens += fallbackResult.tokensUsed;
+      finalContent = fallbackResult.content;
+      fallbackOutcome = fallbackResult.outcome;
+      escalationModelSlug = fallbackResult.escalationModelSlug;
+    } else {
+      finalContent = candidateResults[winnerIndex].content;
+    }
 
     const details: VotingDetails = {
       candidates: candidateDetails,
       winnerIndex,
       agreement,
+      thresholdUsed,
+      thresholdMode,
+      confidenceScores,
+      aggregatedConfidence,
+      ...(fallbackOutcome !== undefined && { fallbackOutcome }),
+      ...(escalationModelSlug !== undefined && { escalationModelSlug }),
     };
 
     return {
-      finalContent: candidateResults[winnerIndex].content,
+      finalContent,
       strategy: "voting",
       details,
       totalTokensUsed: totalTokens,
@@ -412,7 +479,10 @@ function validateDebateStrategy(s: DebateStrategy): void {
 function validateVotingStrategy(s: VotingStrategy): void {
   if (s.candidates.length < 2) throw new Error("Voting requires at least 2 candidates");
   if (s.candidates.length > 7) throw new Error("Voting supports at most 7 candidates");
-  if (s.threshold < 0.5 || s.threshold > 1.0) throw new Error("Threshold must be between 0.5 and 1.0");
+  // Only enforce legacy threshold bounds when dynamic config is absent
+  if (!s.thresholdConfig && (s.threshold < 0.5 || s.threshold > 1.0)) {
+    throw new Error("Threshold must be between 0.5 and 1.0");
+  }
 }
 
 /**

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -136,11 +136,123 @@ export interface CandidateConfig {
   temperature?: number;
 }
 
+// ─── Dynamic Consensus Threshold Types (#285) ────────────────────────────────
+
+/** A task signal emitted by a pipeline stage or present in pipeline input. */
+export interface TaskSignal {
+  /** Signal key (e.g. "signal:high_risk", "signal:low_stakes", or a tag). */
+  key: string;
+  /** Where this signal came from. */
+  source: "tag" | "risk_level" | "upstream_stage";
+  /** Optional scalar payload (e.g. the risk_level string). */
+  value?: string;
+}
+
+/** Container for all signals accumulated during a pipeline run. */
+export interface TaskSignalBag {
+  signals: TaskSignal[];
+}
+
+/** Maps a signal key to a threshold value. */
+export interface SignalThresholdRule {
+  signal: string;
+  threshold: number;
+}
+
+/** Fixed (legacy) threshold — always uses `value`. */
+export interface StaticThresholdConfig {
+  mode: "static";
+  /** Threshold value in [0, 1]. */
+  value: number;
+}
+
+/**
+ * Task-signal-based threshold — finds the first matching rule;
+ * falls back to `default` when no rule matches.
+ */
+export interface TaskSignalThresholdConfig {
+  mode: "task_signal";
+  rules: SignalThresholdRule[];
+  /** Threshold used when no rule matches. */
+  default: number;
+}
+
+/**
+ * Confidence-based threshold — adjusts the base threshold up/down
+ * based on aggregated candidate confidence within [floor, ceiling].
+ *
+ * Formula: effective = clamp(base - (conf - 0.5) * sensitivity, floor, ceiling)
+ *   conf=1 → threshold decreases (easier to pass)
+ *   conf=0 → threshold increases (harder to pass)
+ */
+export interface ConfidenceThresholdConfig {
+  mode: "confidence";
+  /** Starting point before confidence adjustment. */
+  base: number;
+  /** Minimum allowed effective threshold. */
+  floor: number;
+  /** Maximum allowed effective threshold. */
+  ceiling: number;
+  /**
+   * How strongly confidence shifts the threshold.
+   * Default: 0.2.  At sensitivity=0.2 and conf=1.0, threshold drops by 0.1.
+   */
+  sensitivity?: number;
+}
+
+export type VotingThresholdConfig =
+  | StaticThresholdConfig
+  | TaskSignalThresholdConfig
+  | ConfidenceThresholdConfig;
+
+// ─── Fallback Configuration (#285) ───────────────────────────────────────────
+
+export type VotingFallbackStrategy = "escalate" | "abort" | "partial";
+export type VotingFallbackOutcome = "escalated" | "partial";
+
+export interface VotingFallbackConfig {
+  strategy: VotingFallbackStrategy;
+  /**
+   * Model slug used when strategy="escalate".
+   * Defaults to "claude-opus-4".
+   */
+  escalationModelSlug?: string;
+}
+
+// ─── Candidate Confidence Score (#285) ───────────────────────────────────────
+
+export type ConfidenceSource = "provider" | "self_eval" | "heuristic";
+
+export interface CandidateConfidenceScore {
+  modelSlug: string;
+  /** Confidence score in [0, 1]. */
+  score: number;
+  source: ConfidenceSource;
+}
+
+// ─── Updated VotingStrategy ───────────────────────────────────────────────────
+
 export interface VotingStrategy {
   type: "voting";
   candidates: CandidateConfig[];
+  /** Legacy fixed threshold.  Used when `thresholdConfig` is absent. */
   threshold: number;
   validationMode: "text_similarity" | "test_execution";
+  /**
+   * Dynamic threshold configuration (#285).
+   * When present, overrides the legacy `threshold` field.
+   */
+  thresholdConfig?: VotingThresholdConfig;
+  /**
+   * Fallback behaviour when the threshold is not met (#285).
+   * Default: { strategy: "partial" }.
+   */
+  fallback?: VotingFallbackConfig;
+  /**
+   * Task-signal bag propagated from pipeline input and upstream stages (#285).
+   * Populated at runtime by the executor; not set by users in config.
+   */
+  signals?: TaskSignalBag;
 }
 
 export type ExecutionStrategy =
@@ -193,6 +305,19 @@ export interface VotingDetails {
   candidates: Array<{ modelSlug: string; content: string; passed: boolean }>;
   winnerIndex: number;
   agreement: number;
+  // ─── Observability fields added by issue #285 ─────────────────────────────
+  /** The resolved threshold actually used for this run. */
+  thresholdUsed?: number;
+  /** Threshold resolution mode that was active. */
+  thresholdMode?: "static" | "task_signal" | "confidence";
+  /** Per-candidate confidence scores. */
+  confidenceScores?: CandidateConfidenceScore[];
+  /** Aggregated confidence across all candidates (0–1). */
+  aggregatedConfidence?: number;
+  /** What happened when threshold was not met (absent when threshold was met). */
+  fallbackOutcome?: VotingFallbackOutcome;
+  /** Model slug used during escalation (present only when fallbackOutcome="escalated"). */
+  escalationModelSlug?: string;
 }
 
 export interface StrategyResult {

--- a/tests/unit/pipeline/voting/confidence-scorer.test.ts
+++ b/tests/unit/pipeline/voting/confidence-scorer.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractConfidence,
+  aggregateConfidence,
+  scoreAllCandidates,
+} from "../../../../server/pipeline/voting/confidence-scorer.js";
+import type { CandidateConfidenceScore } from "@shared/types";
+
+// ─── extractConfidence ────────────────────────────────────────────────────────
+
+describe("extractConfidence — provider logprob", () => {
+  it("uses provider logprob when supplied, source=provider", () => {
+    const result = extractConfidence("model-a", "some output", 0.92);
+    expect(result.score).toBeCloseTo(0.92, 5);
+    expect(result.source).toBe("provider");
+    expect(result.modelSlug).toBe("model-a");
+  });
+
+  it("clamps provider logprob to [0,1]", () => {
+    expect(extractConfidence("m", "text", 1.5).score).toBe(1.0);
+    expect(extractConfidence("m", "text", -0.1).score).toBe(0.0);
+  });
+});
+
+describe("extractConfidence — JSON self_eval", () => {
+  it("parses confidence from root JSON field", () => {
+    const content = JSON.stringify({ result: "yes", confidence: 0.88 });
+    const result = extractConfidence("model-b", content);
+    expect(result.score).toBeCloseTo(0.88, 5);
+    expect(result.source).toBe("self_eval");
+  });
+
+  it("parses confidence from JSON wrapped in markdown code fence", () => {
+    const content = "```json\n" + JSON.stringify({ confidence: 0.75 }) + "\n```";
+    const result = extractConfidence("model-b", content);
+    expect(result.score).toBeCloseTo(0.75, 5);
+    expect(result.source).toBe("self_eval");
+  });
+
+  it("ignores JSON confidence outside [0,1] and falls through to heuristic", () => {
+    // Value outside valid range — extractJsonConfidence rejects it, falls through to heuristic
+    const content = JSON.stringify({ confidence: 1.5 });
+    const result = extractConfidence("model-b", content);
+    expect(result.source).toBe("heuristic");
+    // Short JSON content → heuristic assigns 0.3
+    expect(result.score).toBe(0.3);
+  });
+
+  it("falls through to heuristic when no confidence field in JSON", () => {
+    const content = JSON.stringify({ result: "yes", note: "no confidence field" });
+    const result = extractConfidence("model-b", content);
+    expect(result.source).toBe("heuristic");
+  });
+});
+
+describe("extractConfidence — heuristic", () => {
+  it("assigns 0.3 for very short text", () => {
+    const result = extractConfidence("model-c", "yes");
+    expect(result.score).toBe(0.3);
+    expect(result.source).toBe("heuristic");
+  });
+
+  it("assigns ~0.5 baseline for neutral text without uncertainty/confidence phrases", () => {
+    const neutralText = "The algorithm processes each item in sequence and returns the results.";
+    const result = extractConfidence("model-c", neutralText);
+    expect(result.source).toBe("heuristic");
+    expect(result.score).toBeGreaterThanOrEqual(0.1);
+    expect(result.score).toBeLessThanOrEqual(0.9);
+  });
+
+  it("reduces score for text with multiple uncertainty phrases", () => {
+    const uncertainText =
+      "I'm not sure about this. It might be correct, but I think it depends. " +
+      "Perhaps the value is different. I believe this could be a possibility.";
+    const result = extractConfidence("model-c", uncertainText);
+    expect(result.source).toBe("heuristic");
+    expect(result.score).toBeLessThan(0.5);
+  });
+
+  it("increases score for text with confidence phrases", () => {
+    const confidentText =
+      "The answer is definitely correct. The result is clearly 42. This is obviously the solution.";
+    const result = extractConfidence("model-c", confidentText);
+    expect(result.source).toBe("heuristic");
+    expect(result.score).toBeGreaterThan(0.5);
+  });
+
+  it("score is always in [0.1, 0.9] from heuristic", () => {
+    const texts = [
+      "a".repeat(100),
+      "The answer is definitely correct and obviously must be this way.",
+      "I'm not sure, might be wrong, perhaps, possibly, unclear.",
+    ];
+    for (const text of texts) {
+      const result = extractConfidence("m", text);
+      if (result.source === "heuristic") {
+        expect(result.score).toBeGreaterThanOrEqual(0.1);
+        expect(result.score).toBeLessThanOrEqual(0.9);
+      }
+    }
+  });
+});
+
+// ─── aggregateConfidence ──────────────────────────────────────────────────────
+
+describe("aggregateConfidence", () => {
+  it("returns 0.5 for empty array", () => {
+    expect(aggregateConfidence([])).toBe(0.5);
+  });
+
+  it("returns single score when only one candidate", () => {
+    const scores: CandidateConfidenceScore[] = [
+      { modelSlug: "a", score: 0.8, source: "provider" },
+    ];
+    expect(aggregateConfidence(scores)).toBeCloseTo(0.8, 5);
+  });
+
+  it("computes arithmetic mean across multiple candidates", () => {
+    const scores: CandidateConfidenceScore[] = [
+      { modelSlug: "a", score: 0.6, source: "heuristic" },
+      { modelSlug: "b", score: 0.8, source: "heuristic" },
+      { modelSlug: "c", score: 1.0, source: "provider" },
+    ];
+    // Mean = (0.6+0.8+1.0)/3 = 0.8
+    expect(aggregateConfidence(scores)).toBeCloseTo(0.8, 5);
+  });
+
+  it("all zeros → mean of 0", () => {
+    const scores: CandidateConfidenceScore[] = [
+      { modelSlug: "a", score: 0, source: "heuristic" },
+      { modelSlug: "b", score: 0, source: "heuristic" },
+    ];
+    expect(aggregateConfidence(scores)).toBe(0);
+  });
+});
+
+// ─── scoreAllCandidates ───────────────────────────────────────────────────────
+
+describe("scoreAllCandidates", () => {
+  it("returns one score per candidate", () => {
+    const candidates = [
+      { modelSlug: "a", content: JSON.stringify({ confidence: 0.9 }) },
+      { modelSlug: "b", content: "I'm not sure about this, maybe." },
+      { modelSlug: "c", content: "The answer is clearly yes.", providerLogprob: 0.95 },
+    ];
+    const scores = scoreAllCandidates(candidates);
+    expect(scores).toHaveLength(3);
+    expect(scores[0].source).toBe("self_eval");
+    expect(scores[2].source).toBe("provider");
+    expect(scores[2].score).toBeCloseTo(0.95, 5);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(scoreAllCandidates([])).toEqual([]);
+  });
+});

--- a/tests/unit/pipeline/voting/fallback-handler.test.ts
+++ b/tests/unit/pipeline/voting/fallback-handler.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  handleFallback,
+  VotingThresholdNotMetError,
+} from "../../../../server/pipeline/voting/fallback-handler.js";
+import type { VotingFallbackConfig, ProviderMessage } from "@shared/types";
+import type { Gateway } from "../../../../server/gateway/index.js";
+
+// ─── Mock gateway ─────────────────────────────────────────────────────────────
+
+function makeMockGateway(responseContent = "escalated answer"): Gateway {
+  return {
+    complete: vi.fn().mockResolvedValue({
+      content: responseContent,
+      tokensUsed: 42,
+      modelSlug: "claude-opus-4",
+      finishReason: "stop",
+    }),
+    resolveProvider: vi.fn().mockResolvedValue("anthropic"),
+  } as unknown as Gateway;
+}
+
+// ─── Shared test fixtures ─────────────────────────────────────────────────────
+
+const BASE_PROMPT: ProviderMessage[] = [
+  { role: "system", content: "You are a helpful assistant." },
+  { role: "user", content: "Solve this problem." },
+];
+
+const CANDIDATES = [
+  { modelSlug: "model-a", content: "Answer A", score: 0.4 },
+  { modelSlug: "model-b", content: "Answer B", score: 0.55 },
+  { modelSlug: "model-c", content: "Answer C", score: 0.3 },
+];
+
+const BASE_INPUT = {
+  basePrompt: BASE_PROMPT,
+  candidates: CANDIDATES,
+  bestCandidateIndex: 1, // model-b has highest score
+  threshold: 0.7,
+  bestAgreement: 0.55,
+  maxTokens: 500,
+};
+
+// ─── Escalate strategy ────────────────────────────────────────────────────────
+
+describe("handleFallback — escalate", () => {
+  it("calls gateway.complete with a stronger judge model and returns content", async () => {
+    const gateway = makeMockGateway("Final synthesized answer");
+    const config: VotingFallbackConfig = { strategy: "escalate", escalationModelSlug: "judge-model" };
+
+    const result = await handleFallback(config, BASE_INPUT, gateway);
+
+    expect(result.content).toBe("Final synthesized answer");
+    expect(result.outcome).toBe("escalated");
+    expect(result.escalationModelSlug).toBe("judge-model");
+    expect(result.tokensUsed).toBe(42);
+    expect(gateway.complete).toHaveBeenCalledOnce();
+  });
+
+  it("defaults escalation model to claude-opus-4 when not specified", async () => {
+    const gateway = makeMockGateway();
+    const config: VotingFallbackConfig = { strategy: "escalate" };
+
+    const result = await handleFallback(config, BASE_INPUT, gateway);
+
+    expect(result.escalationModelSlug).toBe("claude-opus-4");
+    const call = (gateway.complete as ReturnType<typeof vi.fn>).mock.calls[0][0] as { modelSlug: string };
+    expect(call.modelSlug).toBe("claude-opus-4");
+  });
+
+  it("includes threshold/agreement info in the judge prompt", async () => {
+    const gateway = makeMockGateway();
+    const config: VotingFallbackConfig = { strategy: "escalate", escalationModelSlug: "judge-model" };
+
+    await handleFallback(config, { ...BASE_INPUT, threshold: 0.8, bestAgreement: 0.45 }, gateway);
+
+    const messages = (gateway.complete as ReturnType<typeof vi.fn>).mock.calls[0][0].messages as ProviderMessage[];
+    const lastMsg = messages[messages.length - 1].content as string;
+    expect(lastMsg).toContain("threshold=0.800");
+    expect(lastMsg).toContain("best agreement=0.450");
+  });
+
+  it("includes all candidate outputs in the judge prompt", async () => {
+    const gateway = makeMockGateway();
+    const config: VotingFallbackConfig = { strategy: "escalate", escalationModelSlug: "j" };
+
+    await handleFallback(config, BASE_INPUT, gateway);
+
+    const messages = (gateway.complete as ReturnType<typeof vi.fn>).mock.calls[0][0].messages as ProviderMessage[];
+    const lastMsg = messages[messages.length - 1].content as string;
+    expect(lastMsg).toContain("Answer A");
+    expect(lastMsg).toContain("Answer B");
+    expect(lastMsg).toContain("Answer C");
+  });
+});
+
+// ─── Abort strategy ───────────────────────────────────────────────────────────
+
+describe("handleFallback — abort", () => {
+  it("throws VotingThresholdNotMetError with threshold and bestAgreement", async () => {
+    const gateway = makeMockGateway();
+    const config: VotingFallbackConfig = { strategy: "abort" };
+
+    await expect(
+      handleFallback(config, BASE_INPUT, gateway),
+    ).rejects.toThrow(VotingThresholdNotMetError);
+  });
+
+  it("does NOT call gateway.complete", async () => {
+    const gateway = makeMockGateway();
+    const config: VotingFallbackConfig = { strategy: "abort" };
+
+    try {
+      await handleFallback(config, BASE_INPUT, gateway);
+    } catch {
+      // expected
+    }
+
+    expect(gateway.complete).not.toHaveBeenCalled();
+  });
+
+  it("error message includes threshold and agreement values", async () => {
+    const gateway = makeMockGateway();
+    const config: VotingFallbackConfig = { strategy: "abort" };
+
+    let caught: Error | undefined;
+    try {
+      await handleFallback(config, { ...BASE_INPUT, threshold: 0.75, bestAgreement: 0.30 }, gateway);
+    } catch (e) {
+      caught = e as Error;
+    }
+
+    expect(caught).toBeInstanceOf(VotingThresholdNotMetError);
+    expect(caught?.message).toContain("0.750");
+    expect(caught?.message).toContain("0.300");
+  });
+
+  it("VotingThresholdNotMetError has correct name", async () => {
+    const err = new VotingThresholdNotMetError(0.7, 0.4);
+    expect(err.name).toBe("VotingThresholdNotMetError");
+    expect(err.threshold).toBe(0.7);
+    expect(err.bestAgreement).toBe(0.4);
+  });
+});
+
+// ─── Partial strategy ─────────────────────────────────────────────────────────
+
+describe("handleFallback — partial", () => {
+  it("returns the best candidate content without calling gateway", async () => {
+    const gateway = makeMockGateway();
+    const config: VotingFallbackConfig = { strategy: "partial" };
+
+    const result = await handleFallback(config, BASE_INPUT, gateway);
+
+    expect(result.content).toBe("Answer B"); // bestCandidateIndex=1
+    expect(result.outcome).toBe("partial");
+    expect(result.tokensUsed).toBe(0);
+    expect(gateway.complete).not.toHaveBeenCalled();
+  });
+
+  it("returns empty string when bestCandidateIndex out of bounds", async () => {
+    const gateway = makeMockGateway();
+    const config: VotingFallbackConfig = { strategy: "partial" };
+
+    const result = await handleFallback(
+      config,
+      { ...BASE_INPUT, candidates: [], bestCandidateIndex: 0 },
+      gateway,
+    );
+
+    expect(result.content).toBe("");
+    expect(result.outcome).toBe("partial");
+  });
+});

--- a/tests/unit/pipeline/voting/strategy-executor-voting.test.ts
+++ b/tests/unit/pipeline/voting/strategy-executor-voting.test.ts
@@ -1,0 +1,551 @@
+/**
+ * Tests for dynamic consensus thresholds in the Voting execution strategy.
+ * Uses the real StrategyExecutor against a mock Gateway/WsManager.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { StrategyExecutor } from "../../../../server/services/strategy-executor.js";
+import { VotingThresholdNotMetError } from "../../../../server/pipeline/voting/fallback-handler.js";
+import type {
+  VotingStrategy,
+  ProviderMessage,
+  VotingDetails,
+} from "@shared/types";
+import type { Gateway } from "../../../../server/gateway/index.js";
+import type { WsManager } from "../../../../server/ws/manager.js";
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+/** Build a mock Gateway whose complete() returns canned content per call. */
+function makeGateway(responses: Array<{ content: string; tokensUsed?: number }>): Gateway {
+  let callIdx = 0;
+  return {
+    complete: vi.fn().mockImplementation(() => {
+      const resp = responses[callIdx % responses.length];
+      callIdx++;
+      return Promise.resolve({
+        content: resp.content,
+        tokensUsed: resp.tokensUsed ?? 10,
+        modelSlug: "mock",
+        finishReason: "stop",
+      });
+    }),
+    resolveProvider: vi.fn().mockResolvedValue("mock"),
+  } as unknown as Gateway;
+}
+
+function makeWsManager(): WsManager {
+  return { broadcastToRun: vi.fn() } as unknown as WsManager;
+}
+
+const CTX = { runId: "run-1", stageId: "stage-1" };
+const BASE_PROMPT: ProviderMessage[] = [
+  { role: "system", content: "You are helpful." },
+  { role: "user", content: "Solve X." },
+];
+
+// Identical responses → high similarity → threshold easily met
+const CONSENSUS_RESPONSES = [
+  "The answer is to use TypeScript with a functional approach",
+  "The answer is to use TypeScript with a functional approach",
+  "The answer is to use TypeScript with a functional approach",
+];
+
+// Divergent responses → low similarity → threshold unlikely met
+const DIVERGENT_RESPONSES = [
+  "Use Python for this task",
+  "Go is the best choice here",
+  "Consider Rust for performance",
+];
+
+// ─── Static mode ──────────────────────────────────────────────────────────────
+
+describe("StrategyExecutor — voting — static mode", () => {
+  let executor: StrategyExecutor;
+
+  beforeEach(() => {
+    executor = new StrategyExecutor(makeGateway(CONSENSUS_RESPONSES.map((c) => ({ content: c }))), makeWsManager());
+  });
+
+  it("applies fixed threshold and records thresholdMode=static in details", async () => {
+    const strategy: VotingStrategy = {
+      type: "voting",
+      candidates: [
+        { modelSlug: "m1" },
+        { modelSlug: "m2" },
+        { modelSlug: "m3" },
+      ],
+      threshold: 0.6,
+      validationMode: "text_similarity",
+      thresholdConfig: { mode: "static", value: 0.6 },
+    };
+
+    const result = await executor.execute(strategy, BASE_PROMPT, CTX);
+    const details = result.details as VotingDetails;
+    expect(details.thresholdMode).toBe("static");
+    expect(details.thresholdUsed).toBeCloseTo(0.6, 5);
+  });
+
+  it("uses legacy threshold field when thresholdConfig is absent", async () => {
+    const strategy: VotingStrategy = {
+      type: "voting",
+      candidates: [{ modelSlug: "m1" }, { modelSlug: "m2" }],
+      threshold: 0.5,
+      validationMode: "text_similarity",
+    };
+
+    const result = await executor.execute(strategy, BASE_PROMPT, CTX);
+    const details = result.details as VotingDetails;
+    expect(details.thresholdMode).toBe("static");
+    expect(details.thresholdUsed).toBeCloseTo(0.5, 5);
+  });
+});
+
+// ─── Task signal mode ─────────────────────────────────────────────────────────
+
+describe("StrategyExecutor — voting — task_signal mode", () => {
+  it("applies high_risk threshold when signal is present", async () => {
+    const executor = new StrategyExecutor(
+      makeGateway(CONSENSUS_RESPONSES.map((c) => ({ content: c }))),
+      makeWsManager(),
+    );
+
+    const strategy: VotingStrategy = {
+      type: "voting",
+      candidates: [{ modelSlug: "m1" }, { modelSlug: "m2" }, { modelSlug: "m3" }],
+      threshold: 0.6,
+      validationMode: "text_similarity",
+      thresholdConfig: {
+        mode: "task_signal",
+        rules: [{ signal: "signal:high_risk", threshold: 0.85 }],
+        default: 0.6,
+      },
+      signals: {
+        signals: [{ key: "signal:high_risk", source: "upstream_stage" }],
+      },
+    };
+
+    const result = await executor.execute(strategy, BASE_PROMPT, CTX);
+    const details = result.details as VotingDetails;
+    expect(details.thresholdMode).toBe("task_signal");
+    expect(details.thresholdUsed).toBeCloseTo(0.85, 5);
+  });
+
+  it("falls back to default threshold when no matching signal", async () => {
+    const executor = new StrategyExecutor(
+      makeGateway(CONSENSUS_RESPONSES.map((c) => ({ content: c }))),
+      makeWsManager(),
+    );
+
+    const strategy: VotingStrategy = {
+      type: "voting",
+      candidates: [{ modelSlug: "m1" }, { modelSlug: "m2" }],
+      threshold: 0.6,
+      validationMode: "text_similarity",
+      thresholdConfig: {
+        mode: "task_signal",
+        rules: [{ signal: "signal:high_risk", threshold: 0.85 }],
+        default: 0.6,
+      },
+      signals: {
+        signals: [{ key: "signal:unrelated", source: "tag" }],
+      },
+    };
+
+    const result = await executor.execute(strategy, BASE_PROMPT, CTX);
+    const details = result.details as VotingDetails;
+    expect(details.thresholdMode).toBe("task_signal");
+    expect(details.thresholdUsed).toBeCloseTo(0.6, 5);
+  });
+
+  it("uses default threshold when signals bag is absent", async () => {
+    const executor = new StrategyExecutor(
+      makeGateway(CONSENSUS_RESPONSES.map((c) => ({ content: c }))),
+      makeWsManager(),
+    );
+
+    const strategy: VotingStrategy = {
+      type: "voting",
+      candidates: [{ modelSlug: "m1" }, { modelSlug: "m2" }],
+      threshold: 0.6,
+      validationMode: "text_similarity",
+      thresholdConfig: {
+        mode: "task_signal",
+        rules: [{ signal: "signal:high_risk", threshold: 0.9 }],
+        default: 0.65,
+      },
+    };
+
+    const result = await executor.execute(strategy, BASE_PROMPT, CTX);
+    const details = result.details as VotingDetails;
+    expect(details.thresholdUsed).toBeCloseTo(0.65, 5);
+  });
+});
+
+// ─── Confidence mode ──────────────────────────────────────────────────────────
+
+describe("StrategyExecutor — voting — confidence mode", () => {
+  it("eases threshold when candidates express high confidence (JSON self_eval)", async () => {
+    // All candidates return high-confidence JSON
+    const responses = [
+      JSON.stringify({ answer: "yes", confidence: 0.95 }),
+      JSON.stringify({ answer: "yes", confidence: 0.92 }),
+      JSON.stringify({ answer: "yes", confidence: 0.90 }),
+    ];
+    const executor = new StrategyExecutor(
+      makeGateway(responses.map((c) => ({ content: c }))),
+      makeWsManager(),
+    );
+
+    const strategy: VotingStrategy = {
+      type: "voting",
+      candidates: [{ modelSlug: "m1" }, { modelSlug: "m2" }, { modelSlug: "m3" }],
+      threshold: 0.7,
+      validationMode: "text_similarity",
+      thresholdConfig: {
+        mode: "confidence",
+        base: 0.7,
+        floor: 0.4,
+        ceiling: 0.9,
+        sensitivity: 0.3,
+      },
+    };
+
+    const result = await executor.execute(strategy, BASE_PROMPT, CTX);
+    const details = result.details as VotingDetails;
+    expect(details.thresholdMode).toBe("confidence");
+    // aggregatedConfidence ≈ (0.95+0.92+0.90)/3 ≈ 0.923
+    // threshold = 0.7 - (0.923 - 0.5) * 0.3 ≈ 0.7 - 0.127 ≈ 0.573
+    expect(details.thresholdUsed).toBeLessThan(0.7); // eased
+    expect(details.aggregatedConfidence).toBeDefined();
+    expect(details.aggregatedConfidence!).toBeGreaterThan(0.85);
+  });
+
+  it("tightens threshold when candidates express low confidence", async () => {
+    // All candidates express uncertainty
+    const uncertainContent = "I'm not sure. It might be yes, but perhaps not. Unclear.";
+    const executor = new StrategyExecutor(
+      makeGateway([
+        { content: uncertainContent },
+        { content: uncertainContent },
+        { content: uncertainContent },
+      ]),
+      makeWsManager(),
+    );
+
+    const strategy: VotingStrategy = {
+      type: "voting",
+      candidates: [{ modelSlug: "m1" }, { modelSlug: "m2" }, { modelSlug: "m3" }],
+      threshold: 0.7,
+      validationMode: "text_similarity",
+      thresholdConfig: {
+        mode: "confidence",
+        base: 0.7,
+        floor: 0.5,
+        ceiling: 0.95,
+        sensitivity: 0.4,
+      },
+    };
+
+    const result = await executor.execute(strategy, BASE_PROMPT, CTX);
+    const details = result.details as VotingDetails;
+    // Low confidence → threshold should be above base=0.7 (up to ceiling)
+    expect(details.thresholdUsed).toBeGreaterThanOrEqual(0.5);
+    expect(details.confidenceScores).toHaveLength(3);
+  });
+
+  it("records confidence scores and aggregatedConfidence in details", async () => {
+    const executor = new StrategyExecutor(
+      makeGateway(CONSENSUS_RESPONSES.map((c) => ({ content: c }))),
+      makeWsManager(),
+    );
+
+    const strategy: VotingStrategy = {
+      type: "voting",
+      candidates: [{ modelSlug: "m1" }, { modelSlug: "m2" }, { modelSlug: "m3" }],
+      threshold: 0.5,
+      validationMode: "text_similarity",
+      thresholdConfig: {
+        mode: "confidence",
+        base: 0.6,
+        floor: 0.4,
+        ceiling: 0.9,
+      },
+    };
+
+    const result = await executor.execute(strategy, BASE_PROMPT, CTX);
+    const details = result.details as VotingDetails;
+    expect(details.confidenceScores).toHaveLength(3);
+    expect(details.aggregatedConfidence).toBeGreaterThan(0);
+    expect(details.aggregatedConfidence).toBeLessThanOrEqual(1);
+  });
+});
+
+// ─── Fallback strategies ──────────────────────────────────────────────────────
+
+describe("StrategyExecutor — voting — fallback: escalate", () => {
+  it("calls escalation judge model when threshold not met", async () => {
+    // Divergent responses → will not meet a high threshold
+    // 4 calls: 3 candidates + 1 judge
+    const candidateResponses = DIVERGENT_RESPONSES;
+    const judgeResponse = "Escalated final answer by judge";
+
+    const callSequence = [
+      ...candidateResponses.map((c) => ({ content: c })),
+      { content: judgeResponse },
+    ];
+
+    const executor = new StrategyExecutor(
+      makeGateway(callSequence),
+      makeWsManager(),
+    );
+
+    const strategy: VotingStrategy = {
+      type: "voting",
+      candidates: [{ modelSlug: "m1" }, { modelSlug: "m2" }, { modelSlug: "m3" }],
+      threshold: 0.5,
+      validationMode: "text_similarity",
+      thresholdConfig: {
+        mode: "static",
+        value: 0.99, // Very high — will never be met by divergent responses
+      },
+      fallback: {
+        strategy: "escalate",
+        escalationModelSlug: "strong-judge",
+      },
+    };
+
+    const result = await executor.execute(strategy, BASE_PROMPT, CTX);
+    const details = result.details as VotingDetails;
+
+    expect(result.finalContent).toBe(judgeResponse);
+    expect(details.fallbackOutcome).toBe("escalated");
+    expect(details.escalationModelSlug).toBe("strong-judge");
+  });
+});
+
+describe("StrategyExecutor — voting — fallback: abort", () => {
+  it("throws VotingThresholdNotMetError when threshold not met and fallback=abort", async () => {
+    const executor = new StrategyExecutor(
+      makeGateway(DIVERGENT_RESPONSES.map((c) => ({ content: c }))),
+      makeWsManager(),
+    );
+
+    const strategy: VotingStrategy = {
+      type: "voting",
+      candidates: [{ modelSlug: "m1" }, { modelSlug: "m2" }, { modelSlug: "m3" }],
+      threshold: 0.5,
+      validationMode: "text_similarity",
+      thresholdConfig: { mode: "static", value: 0.99 },
+      fallback: { strategy: "abort" },
+    };
+
+    await expect(executor.execute(strategy, BASE_PROMPT, CTX)).rejects.toThrow(
+      VotingThresholdNotMetError,
+    );
+  });
+});
+
+describe("StrategyExecutor — voting — fallback: partial", () => {
+  it("emits partial result (best candidate) when threshold not met", async () => {
+    const executor = new StrategyExecutor(
+      makeGateway(DIVERGENT_RESPONSES.map((c) => ({ content: c }))),
+      makeWsManager(),
+    );
+
+    const strategy: VotingStrategy = {
+      type: "voting",
+      candidates: [{ modelSlug: "m1" }, { modelSlug: "m2" }, { modelSlug: "m3" }],
+      threshold: 0.5,
+      validationMode: "text_similarity",
+      thresholdConfig: { mode: "static", value: 0.99 },
+      fallback: { strategy: "partial" },
+    };
+
+    const result = await executor.execute(strategy, BASE_PROMPT, CTX);
+    const details = result.details as VotingDetails;
+
+    expect(result.finalContent).toBeTruthy();
+    expect(details.fallbackOutcome).toBe("partial");
+    expect(details.escalationModelSlug).toBeUndefined();
+  });
+});
+
+// ─── No fallback configured ───────────────────────────────────────────────────
+
+describe("StrategyExecutor — voting — no fallback", () => {
+  it("returns highest-agreement candidate when threshold not met and no fallback configured", async () => {
+    const executor = new StrategyExecutor(
+      makeGateway(DIVERGENT_RESPONSES.map((c) => ({ content: c }))),
+      makeWsManager(),
+    );
+
+    const strategy: VotingStrategy = {
+      type: "voting",
+      candidates: [{ modelSlug: "m1" }, { modelSlug: "m2" }, { modelSlug: "m3" }],
+      threshold: 0.5,
+      validationMode: "text_similarity",
+      thresholdConfig: { mode: "static", value: 0.99 },
+      // No fallback configured
+    };
+
+    const result = await executor.execute(strategy, BASE_PROMPT, CTX);
+    const details = result.details as VotingDetails;
+
+    expect(result.finalContent).toBeTruthy();
+    expect(details.fallbackOutcome).toBeUndefined();
+  });
+});
+
+// ─── Edge cases ───────────────────────────────────────────────────────────────
+
+describe("StrategyExecutor — voting — edge cases", () => {
+  it("all candidates agree → winnerIndex=0, all passed", async () => {
+    const executor = new StrategyExecutor(
+      makeGateway(CONSENSUS_RESPONSES.map((c) => ({ content: c }))),
+      makeWsManager(),
+    );
+
+    const strategy: VotingStrategy = {
+      type: "voting",
+      candidates: [{ modelSlug: "m1" }, { modelSlug: "m2" }, { modelSlug: "m3" }],
+      threshold: 0.5,
+      validationMode: "text_similarity",
+    };
+
+    const result = await executor.execute(strategy, BASE_PROMPT, CTX);
+    const details = result.details as VotingDetails;
+
+    expect(details.candidates.every((c) => c.passed)).toBe(true);
+    expect(details.agreement).toBeGreaterThan(0.5);
+  });
+
+  it("no candidates agree → none passed, fallback to best", async () => {
+    const executor = new StrategyExecutor(
+      makeGateway(DIVERGENT_RESPONSES.map((c) => ({ content: c }))),
+      makeWsManager(),
+    );
+
+    const strategy: VotingStrategy = {
+      type: "voting",
+      candidates: [{ modelSlug: "m1" }, { modelSlug: "m2" }, { modelSlug: "m3" }],
+      threshold: 0.5,
+      validationMode: "text_similarity",
+      thresholdConfig: { mode: "static", value: 0.99 },
+    };
+
+    const result = await executor.execute(strategy, BASE_PROMPT, CTX);
+    const details = result.details as VotingDetails;
+
+    expect(details.candidates.every((c) => !c.passed)).toBe(true);
+    expect(result.finalContent).toBeTruthy();
+  });
+
+  it("records thresholdUsed and thresholdMode in details for all modes", async () => {
+    const executor = new StrategyExecutor(
+      makeGateway(CONSENSUS_RESPONSES.map((c) => ({ content: c }))),
+      makeWsManager(),
+    );
+
+    const strategy: VotingStrategy = {
+      type: "voting",
+      candidates: [{ modelSlug: "m1" }, { modelSlug: "m2" }, { modelSlug: "m3" }],
+      threshold: 0.5,
+      validationMode: "text_similarity",
+      thresholdConfig: { mode: "static", value: 0.55 },
+    };
+
+    const result = await executor.execute(strategy, BASE_PROMPT, CTX);
+    const details = result.details as VotingDetails;
+
+    expect(details.thresholdUsed).toBeDefined();
+    expect(details.thresholdMode).toBe("static");
+    expect(details.confidenceScores).toHaveLength(3);
+    expect(details.aggregatedConfidence).toBeDefined();
+  });
+
+  it("totalTokensUsed includes escalation judge tokens", async () => {
+    const callSequence = [
+      ...DIVERGENT_RESPONSES.map((c) => ({ content: c, tokensUsed: 20 })),
+      { content: "judge answer", tokensUsed: 50 },
+    ];
+    const executor = new StrategyExecutor(makeGateway(callSequence), makeWsManager());
+
+    const strategy: VotingStrategy = {
+      type: "voting",
+      candidates: [{ modelSlug: "m1" }, { modelSlug: "m2" }, { modelSlug: "m3" }],
+      threshold: 0.5,
+      validationMode: "text_similarity",
+      thresholdConfig: { mode: "static", value: 0.99 },
+      fallback: { strategy: "escalate", escalationModelSlug: "judge" },
+    };
+
+    const result = await executor.execute(strategy, BASE_PROMPT, CTX);
+    // 3 candidates × 20 + 1 judge × 50 = 110
+    expect(result.totalTokensUsed).toBe(110);
+  });
+
+  it("mixed confidence — some high, some low → aggregated around middle", async () => {
+    const mixed = [
+      JSON.stringify({ confidence: 0.9 }),
+      "I'm not sure. It might work.",
+      JSON.stringify({ confidence: 0.1 }),
+    ];
+    const executor = new StrategyExecutor(
+      makeGateway(mixed.map((c) => ({ content: c }))),
+      makeWsManager(),
+    );
+
+    const strategy: VotingStrategy = {
+      type: "voting",
+      candidates: [{ modelSlug: "m1" }, { modelSlug: "m2" }, { modelSlug: "m3" }],
+      threshold: 0.5,
+      validationMode: "text_similarity",
+      thresholdConfig: {
+        mode: "confidence",
+        base: 0.65,
+        floor: 0.4,
+        ceiling: 0.9,
+        sensitivity: 0.2,
+      },
+    };
+
+    const result = await executor.execute(strategy, BASE_PROMPT, CTX);
+    const details = result.details as VotingDetails;
+
+    // Aggregated conf ≈ (0.9 + low + 0.1) / 3 — somewhere below 0.5
+    expect(details.aggregatedConfidence).toBeGreaterThan(0);
+    expect(details.confidenceScores).toHaveLength(3);
+  });
+});
+
+// ─── Observability: WS broadcast attributes ───────────────────────────────────
+
+describe("StrategyExecutor — voting — observability", () => {
+  it("broadcasts confidenceScore per candidate in strategy:voting:candidate", async () => {
+    const ws = makeWsManager();
+    const executor = new StrategyExecutor(
+      makeGateway(CONSENSUS_RESPONSES.map((c) => ({ content: c }))),
+      ws,
+    );
+
+    const strategy: VotingStrategy = {
+      type: "voting",
+      candidates: [{ modelSlug: "m1" }, { modelSlug: "m2" }, { modelSlug: "m3" }],
+      threshold: 0.5,
+      validationMode: "text_similarity",
+      thresholdConfig: { mode: "static", value: 0.5 },
+    };
+
+    await executor.execute(strategy, BASE_PROMPT, CTX);
+
+    const broadcasts = (ws.broadcastToRun as ReturnType<typeof vi.fn>).mock.calls;
+    const candidateBroadcasts = broadcasts.filter(
+      (call) => call[1].type === "strategy:voting:candidate",
+    );
+
+    expect(candidateBroadcasts).toHaveLength(3);
+    for (const broadcast of candidateBroadcasts) {
+      expect(broadcast[1].payload).toHaveProperty("confidenceScore");
+    }
+  });
+});

--- a/tests/unit/pipeline/voting/task-signals.test.ts
+++ b/tests/unit/pipeline/voting/task-signals.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import {
+  collectSignals,
+  hasSignal,
+  getSignal,
+  mergeSignalBags,
+  KNOWN_SIGNALS,
+} from "../../../../server/pipeline/voting/task-signals.js";
+import type { TaskSignal, TaskSignalBag } from "@shared/types";
+
+// ─── collectSignals ───────────────────────────────────────────────────────────
+
+describe("collectSignals", () => {
+  it("returns empty bag when nothing is provided", () => {
+    const bag = collectSignals({});
+    expect(bag.signals).toHaveLength(0);
+  });
+
+  it("converts tags to plain signals with source=tag", () => {
+    const bag = collectSignals({ tags: ["alpha", "beta"] });
+    expect(bag.signals).toHaveLength(2);
+    expect(bag.signals[0]).toMatchObject({ key: "alpha", source: "tag" });
+    expect(bag.signals[1]).toMatchObject({ key: "beta", source: "tag" });
+  });
+
+  it("maps risk_level=high to signal:high_risk", () => {
+    const bag = collectSignals({ riskLevel: "high" });
+    const sig = bag.signals.find((s) => s.key === KNOWN_SIGNALS.HIGH_RISK);
+    expect(sig).toBeDefined();
+    expect(sig?.source).toBe("risk_level");
+    expect(sig?.value).toBe("high");
+  });
+
+  it("maps risk_level=critical to signal:high_risk", () => {
+    const bag = collectSignals({ riskLevel: "critical" });
+    const sig = bag.signals.find((s) => s.key === KNOWN_SIGNALS.HIGH_RISK);
+    expect(sig).toBeDefined();
+    expect(sig?.value).toBe("critical");
+  });
+
+  it("maps risk_level=low to signal:low_stakes", () => {
+    const bag = collectSignals({ riskLevel: "low" });
+    const sig = bag.signals.find((s) => s.key === KNOWN_SIGNALS.LOW_STAKES);
+    expect(sig).toBeDefined();
+    expect(sig?.source).toBe("risk_level");
+  });
+
+  it("does not emit a signal for risk_level=medium", () => {
+    const bag = collectSignals({ riskLevel: "medium" });
+    expect(bag.signals).toHaveLength(0);
+  });
+
+  it("includes upstream signals with their original source", () => {
+    const upstream: TaskSignal[] = [
+      { key: "signal:high_risk", source: "upstream_stage" },
+    ];
+    const bag = collectSignals({ upstreamSignals: upstream });
+    expect(bag.signals).toHaveLength(1);
+    expect(bag.signals[0]).toMatchObject({ key: "signal:high_risk", source: "upstream_stage" });
+  });
+
+  it("deduplicates signals by key — first occurrence wins", () => {
+    const bag = collectSignals({
+      tags: ["signal:high_risk"],
+      upstreamSignals: [{ key: "signal:high_risk", source: "upstream_stage" }],
+    });
+    // Only one signal:high_risk, from the tag (first seen)
+    const all = bag.signals.filter((s) => s.key === "signal:high_risk");
+    expect(all).toHaveLength(1);
+    expect(all[0].source).toBe("tag");
+  });
+
+  it("combines tags + riskLevel + upstream without duplication", () => {
+    const bag = collectSignals({
+      tags: ["important"],
+      riskLevel: "high",
+      upstreamSignals: [{ key: "signal:low_stakes", source: "upstream_stage" }],
+    });
+    // important (tag) + signal:high_risk (riskLevel) + signal:low_stakes (upstream)
+    expect(bag.signals).toHaveLength(3);
+  });
+});
+
+// ─── hasSignal ────────────────────────────────────────────────────────────────
+
+describe("hasSignal", () => {
+  const bag: TaskSignalBag = {
+    signals: [
+      { key: "signal:high_risk", source: "tag" },
+      { key: "custom-tag", source: "tag" },
+    ],
+  };
+
+  it("returns true when the signal key is present", () => {
+    expect(hasSignal(bag, "signal:high_risk")).toBe(true);
+  });
+
+  it("returns false when the signal key is not present", () => {
+    expect(hasSignal(bag, "signal:low_stakes")).toBe(false);
+  });
+
+  it("returns false for empty bag", () => {
+    expect(hasSignal({ signals: [] }, "any")).toBe(false);
+  });
+});
+
+// ─── getSignal ────────────────────────────────────────────────────────────────
+
+describe("getSignal", () => {
+  const bag: TaskSignalBag = {
+    signals: [
+      { key: "signal:high_risk", source: "risk_level", value: "critical" },
+    ],
+  };
+
+  it("returns the matching signal", () => {
+    const sig = getSignal(bag, "signal:high_risk");
+    expect(sig).toBeDefined();
+    expect(sig?.value).toBe("critical");
+  });
+
+  it("returns undefined when not found", () => {
+    expect(getSignal(bag, "signal:missing")).toBeUndefined();
+  });
+});
+
+// ─── mergeSignalBags ──────────────────────────────────────────────────────────
+
+describe("mergeSignalBags", () => {
+  it("merges two disjoint bags", () => {
+    const left: TaskSignalBag = { signals: [{ key: "a", source: "tag" }] };
+    const right: TaskSignalBag = { signals: [{ key: "b", source: "tag" }] };
+    const merged = mergeSignalBags(left, right);
+    expect(merged.signals).toHaveLength(2);
+  });
+
+  it("left wins on duplicate keys", () => {
+    const left: TaskSignalBag = { signals: [{ key: "x", source: "risk_level", value: "left" }] };
+    const right: TaskSignalBag = { signals: [{ key: "x", source: "tag", value: "right" }] };
+    const merged = mergeSignalBags(left, right);
+    expect(merged.signals).toHaveLength(1);
+    expect(merged.signals[0].value).toBe("left");
+  });
+
+  it("returns copy of left when right is empty", () => {
+    const left: TaskSignalBag = { signals: [{ key: "a", source: "tag" }] };
+    const merged = mergeSignalBags(left, { signals: [] });
+    expect(merged.signals).toHaveLength(1);
+    expect(merged.signals[0].key).toBe("a");
+  });
+
+  it("returns copy of right when left is empty", () => {
+    const right: TaskSignalBag = { signals: [{ key: "b", source: "tag" }] };
+    const merged = mergeSignalBags({ signals: [] }, right);
+    expect(merged.signals).toHaveLength(1);
+    expect(merged.signals[0].key).toBe("b");
+  });
+});

--- a/tests/unit/pipeline/voting/threshold-resolver.test.ts
+++ b/tests/unit/pipeline/voting/threshold-resolver.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+import { resolveThreshold } from "../../../../server/pipeline/voting/threshold-resolver.js";
+import type {
+  StaticThresholdConfig,
+  TaskSignalThresholdConfig,
+  ConfidenceThresholdConfig,
+  TaskSignalBag,
+} from "@shared/types";
+
+// ─── Static mode ──────────────────────────────────────────────────────────────
+
+describe("resolveThreshold — static mode", () => {
+  const cfg: StaticThresholdConfig = { mode: "static", value: 0.6 };
+
+  it("returns the configured value when no signals or confidence provided", () => {
+    expect(resolveThreshold(cfg)).toBe(0.6);
+  });
+
+  it("ignores signals — still returns configured value", () => {
+    const bag: TaskSignalBag = { signals: [{ key: "signal:high_risk", source: "tag" }] };
+    expect(resolveThreshold(cfg, bag)).toBe(0.6);
+  });
+
+  it("ignores aggregated confidence — still returns configured value", () => {
+    expect(resolveThreshold(cfg, undefined, 0.9)).toBe(0.6);
+  });
+
+  it("clamps values above 1 to 1", () => {
+    const overCfg: StaticThresholdConfig = { mode: "static", value: 1.5 };
+    expect(resolveThreshold(overCfg)).toBe(1.0);
+  });
+
+  it("clamps values below 0 to 0", () => {
+    const underCfg: StaticThresholdConfig = { mode: "static", value: -0.1 };
+    expect(resolveThreshold(underCfg)).toBe(0.0);
+  });
+});
+
+// ─── Task signal mode ─────────────────────────────────────────────────────────
+
+describe("resolveThreshold — task_signal mode", () => {
+  const cfg: TaskSignalThresholdConfig = {
+    mode: "task_signal",
+    rules: [
+      { signal: "signal:high_risk", threshold: 0.85 },
+      { signal: "signal:low_stakes", threshold: 0.45 },
+    ],
+    default: 0.65,
+  };
+
+  it("returns default when no signals bag provided", () => {
+    expect(resolveThreshold(cfg)).toBe(0.65);
+  });
+
+  it("returns default when signal bag is empty", () => {
+    const emptyBag: TaskSignalBag = { signals: [] };
+    expect(resolveThreshold(cfg, emptyBag)).toBe(0.65);
+  });
+
+  it("returns high_risk threshold when signal:high_risk is present", () => {
+    const bag: TaskSignalBag = {
+      signals: [{ key: "signal:high_risk", source: "upstream_stage" }],
+    };
+    expect(resolveThreshold(cfg, bag)).toBe(0.85);
+  });
+
+  it("returns low_stakes threshold when signal:low_stakes is present", () => {
+    const bag: TaskSignalBag = {
+      signals: [{ key: "signal:low_stakes", source: "tag" }],
+    };
+    expect(resolveThreshold(cfg, bag)).toBe(0.45);
+  });
+
+  it("first matching rule wins when multiple matching signals are present", () => {
+    // high_risk rule is listed first — it should win
+    const bag: TaskSignalBag = {
+      signals: [
+        { key: "signal:high_risk", source: "upstream_stage" },
+        { key: "signal:low_stakes", source: "tag" },
+      ],
+    };
+    expect(resolveThreshold(cfg, bag)).toBe(0.85);
+  });
+
+  it("falls back to default when no rule matches the signals in the bag", () => {
+    const bag: TaskSignalBag = {
+      signals: [{ key: "signal:unrelated", source: "tag" }],
+    };
+    expect(resolveThreshold(cfg, bag)).toBe(0.65);
+  });
+
+  it("clamps rule threshold to [0,1]", () => {
+    const extremeCfg: TaskSignalThresholdConfig = {
+      mode: "task_signal",
+      rules: [{ signal: "signal:x", threshold: 1.5 }],
+      default: 0.6,
+    };
+    const bag: TaskSignalBag = { signals: [{ key: "signal:x", source: "tag" }] };
+    expect(resolveThreshold(extremeCfg, bag)).toBe(1.0);
+  });
+
+  it("ignores aggregated confidence in task_signal mode", () => {
+    const bag: TaskSignalBag = {
+      signals: [{ key: "signal:high_risk", source: "tag" }],
+    };
+    expect(resolveThreshold(cfg, bag, 0.99)).toBe(0.85);
+  });
+});
+
+// ─── Confidence mode ──────────────────────────────────────────────────────────
+
+describe("resolveThreshold — confidence mode", () => {
+  const cfg: ConfidenceThresholdConfig = {
+    mode: "confidence",
+    base: 0.7,
+    floor: 0.5,
+    ceiling: 0.9,
+    sensitivity: 0.2,
+  };
+
+  it("returns base when aggregatedConfidence is 0.5 (neutral)", () => {
+    expect(resolveThreshold(cfg, undefined, 0.5)).toBeCloseTo(0.7, 5);
+  });
+
+  it("eases threshold when confidence is high (conf=1.0)", () => {
+    // base - (1.0 - 0.5) * 0.2 = 0.7 - 0.1 = 0.6
+    expect(resolveThreshold(cfg, undefined, 1.0)).toBeCloseTo(0.6, 5);
+  });
+
+  it("tightens threshold when confidence is low (conf=0.0)", () => {
+    // base - (0.0 - 0.5) * 0.2 = 0.7 + 0.1 = 0.8
+    expect(resolveThreshold(cfg, undefined, 0.0)).toBeCloseTo(0.8, 5);
+  });
+
+  it("clamps to floor when confidence is very high", () => {
+    // cfg with low floor to test clamping: base=0.6, floor=0.55, ceiling=0.9, sens=0.2
+    // conf=1.0 → 0.6 - 0.1 = 0.5 → clamp to floor=0.55
+    const clampCfg: ConfidenceThresholdConfig = {
+      mode: "confidence",
+      base: 0.6,
+      floor: 0.55,
+      ceiling: 0.9,
+      sensitivity: 0.2,
+    };
+    expect(resolveThreshold(clampCfg, undefined, 1.0)).toBeCloseTo(0.55, 5);
+  });
+
+  it("clamps to ceiling when confidence is very low", () => {
+    // base=0.85, ceiling=0.9, floor=0.5, sens=0.5
+    // conf=0.0 → 0.85 + 0.25 = 1.1 → clamp to 0.9
+    const clampCfg: ConfidenceThresholdConfig = {
+      mode: "confidence",
+      base: 0.85,
+      floor: 0.5,
+      ceiling: 0.9,
+      sensitivity: 0.5,
+    };
+    expect(resolveThreshold(clampCfg, undefined, 0.0)).toBeCloseTo(0.9, 5);
+  });
+
+  it("uses base when no aggregatedConfidence provided", () => {
+    expect(resolveThreshold(cfg)).toBeCloseTo(0.7, 5);
+  });
+
+  it("uses default sensitivity of 0.2 when not specified", () => {
+    const cfgNoSens: ConfidenceThresholdConfig = {
+      mode: "confidence",
+      base: 0.7,
+      floor: 0.5,
+      ceiling: 0.9,
+    };
+    // Default sensitivity=0.2; conf=1.0 → 0.7 - 0.1 = 0.6
+    expect(resolveThreshold(cfgNoSens, undefined, 1.0)).toBeCloseTo(0.6, 5);
+  });
+
+  it("ignores signals in confidence mode", () => {
+    const bag: TaskSignalBag = {
+      signals: [{ key: "signal:high_risk", source: "tag" }],
+    };
+    expect(resolveThreshold(cfg, bag, 0.5)).toBeCloseTo(0.7, 5);
+  });
+});


### PR DESCRIPTION
## Summary

- Add three threshold resolution modes for the Voting execution strategy: `static` (fixed value), `task_signal` (signal/tag-driven rules with default), and `confidence` (auto-adjusts based on aggregated candidate confidence scores)
- Add candidate confidence scoring: extracts from provider logprob, JSON self-eval field, or text heuristic; aggregated confidence feeds into the `confidence` mode
- Add configurable fallback when threshold is not met: `escalate` (calls a stronger judge model), `abort` (throws `VotingThresholdNotMetError`), or `partial` (emits the best candidate as-is)
- Add task-signal collection from pipeline tags, `risk_level` field, and upstream stage emissions; signals propagate into `task_signal` mode threshold resolution
- Extend `VotingDetails` with full observability: `thresholdUsed`, `thresholdMode`, `confidenceScores`, `aggregatedConfidence`, `fallbackOutcome`, `escalationModelSlug`
- Add `confidenceScore` to `strategy:voting:candidate` WS broadcast payload

## Files

**New — server:**
- `server/pipeline/voting/threshold-resolver.ts` — resolves threshold by mode
- `server/pipeline/voting/confidence-scorer.ts` — extracts/aggregates candidate confidence
- `server/pipeline/voting/fallback-handler.ts` — escalate/abort/partial fallback
- `server/pipeline/voting/task-signals.ts` — signal collection, dedup, merge

**Modified:**
- `shared/types.ts` — new types: `TaskSignal`, `TaskSignalBag`, `VotingThresholdConfig`, `VotingFallbackConfig`, `CandidateConfidenceScore`; extended `VotingStrategy` and `VotingDetails`
- `server/services/strategy-executor.ts` — `executeVoting` uses dynamic threshold + confidence + fallback

**New — tests:**
- `tests/unit/pipeline/voting/threshold-resolver.test.ts` (26 tests)
- `tests/unit/pipeline/voting/task-signals.test.ts` (18 tests)
- `tests/unit/pipeline/voting/confidence-scorer.test.ts` (17 tests)
- `tests/unit/pipeline/voting/fallback-handler.test.ts` (14 tests)
- `tests/unit/pipeline/voting/strategy-executor-voting.test.ts` (19 tests)

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 3838 tests, all pass (84 new)
- [x] Static mode: fixed threshold applied regardless of signals/confidence
- [x] Task signal mode: first matching rule wins, default when no match, default when no signals
- [x] Confidence mode: high confidence eases threshold, low confidence tightens, clamps to floor/ceiling
- [x] Fallback escalate: judge model called, tokens counted, outcome recorded in details
- [x] Fallback abort: `VotingThresholdNotMetError` thrown, gateway not called
- [x] Fallback partial: best candidate emitted, tokensUsed=0, gateway not called
- [x] No fallback: highest-agreement candidate selected without error
- [x] Signal propagation: `collectSignals` from tags + risk_level + upstream, dedup, merge
- [x] Observability: `strategy:voting:candidate` WS payload includes `confidenceScore`
- [x] Edge cases: all agree, none agree, mixed confidence, 2-candidate minimum