### PR TITLE
docs: External Connections documentation + examples (#273)

### DIFF
--- a/docs/connections/README.md
+++ b/docs/connections/README.md
@@ -1,0 +1,248 @@
+# External Connections
+
+External Connections let a workspace communicate with third-party services through
+built-in MCP (Model Context Protocol) servers. Each connection holds non-secret
+configuration (URLs, project keys, region, etc.) plus an encrypted secrets blob.
+When a pipeline stage runs, the platform resolves the connection, decrypts its
+secrets, and hands them to the appropriate MCP server — the secrets never leave the
+server process and are never included in tool output, audit logs, or API responses.
+
+## Provider matrix
+
+| Type | Display name | Built-in MCP server | Status |
+|---|---|---|---|
+| `gitlab` | GitLab | Yes — `GitLabMcpServer` | GA |
+| `github` | GitHub | Yes — `GitHubMcpServer` | GA |
+| `kubernetes` | Kubernetes | Yes — `KubernetesMcpServer` | GA |
+| `generic_mcp` | Generic MCP / Docker-Run | Yes — `DockerRunMcpServer` | GA |
+| `aws` | AWS | No built-in server | Preview |
+| `jira` | Jira | No built-in server | GA (config only) |
+| `grafana` | Grafana | No built-in server | GA (config only) |
+
+Providers marked **GA (config only)** expose their credentials to pipeline tools via
+connection metadata but do not ship a built-in MCP server. Use a `generic_mcp`
+connection pointing at a self-hosted MCP server if you need active tooling for those
+providers.
+
+## Security model
+
+### Credential storage
+
+Secrets are stored as an AES-GCM encrypted JSON blob (`secrets_encrypted` column)
+in the `workspace_connections` table. Plaintext secrets are accepted by the API,
+encrypted immediately inside the storage layer, and the plaintext is discarded.
+Secrets are **never** returned by any API endpoint — responses include only a boolean
+`hasSecrets` flag.
+
+The `config` field (URLs, project keys, region, etc.) is stored in plaintext in the
+`config_json` JSONB column because it is non-sensitive and needed for connectivity
+probes.
+
+### Scopes
+
+Every tool exposed by a built-in MCP server is tagged with one of two scopes:
+
+| Scope | Meaning |
+|---|---|
+| `read` | Always allowed; does not mutate remote state (or mutations are non-destructive, e.g. posting a comment). |
+| `destructive` | Blocked unless `allowDestructive=true` is set on the connection. |
+
+Tools with scope `destructive` include:
+- `k8s_delete_namespace` (Kubernetes)
+- `docker_run_privileged` (Docker-Run / generic MCP)
+
+### Audit log
+
+Every MCP tool call is recorded in the `mcp_tool_calls` table (90-day default
+retention, overridable with `MCP_TOOL_CALL_RETENTION_DAYS`). Before persistence,
+args and results pass through a redaction layer (`server/tools/audit.ts`) that:
+
+- Strips values whose key name matches a sensitive-key list (`token`, `authorization`,
+  `password`, `api_key`, `secret`, `credentials`, etc.).
+- Replaces string values that match known secret patterns (Bearer tokens, AWS AKIA
+  keys, GitHub `ghp_` PATs, GitLab `glpat-` PATs, long base64 strings) with
+  `[REDACTED]`.
+
+OTel spans are emitted alongside every DB write so traces appear in your
+observability pipeline.
+
+### RBAC
+
+Connection operations require one of two global roles:
+
+| Operation | Minimum role |
+|---|---|
+| List connections, read metadata, view usage metrics | `maintainer` |
+| Create, update, delete, test connections | `admin` |
+| Sync from `connections.yaml` | `admin` |
+
+`user`-role accounts receive HTTP 403 on all connection endpoints.
+
+### Encryption at rest
+
+The secrets blob is encrypted with AES-GCM using a server-managed key. The key
+material must be provided to the server via an environment variable or secret
+manager — it is never stored in the database or committed to source control.
+
+## How to add a connection
+
+### Via the REST API
+
+```http
+POST /api/workspaces/{workspaceId}/connections
+Content-Type: application/json
+Authorization: Bearer <token>
+
+{
+  "type": "gitlab",
+  "name": "My GitLab instance",
+  "config": {
+    "host": "https://gitlab.example.com",
+    "projectId": "42"
+  },
+  "secrets": {
+    "token": "glpat-xxxxxxxxxxxx"
+  }
+}
+```
+
+The `config` object is validated against the per-type Zod schema before saving
+(see [Per-type config schemas](#per-type-config-schemas) below). The `secrets`
+object accepts any key/value pairs; the well-known keys consumed by each built-in
+server are documented in the per-type guides.
+
+### Via connections.yaml (declarative)
+
+Place a `.multiqlti/connections.yaml` file in your workspace root:
+
+```yaml
+version: 1
+connections:
+  - name: My GitLab instance
+    type: gitlab
+    config:
+      host: https://gitlab.example.com
+      projectId: "42"
+    secrets:
+      token: ${env:GITLAB_TOKEN}
+```
+
+Secret values **must** use reference expressions — plaintext is rejected:
+
+| Expression | Resolves from |
+|---|---|
+| `${env:VAR_NAME}` | Environment variable |
+| `${file:./path/to/file}` | File contents (trimmed) |
+| `${vault:secret/path}` | HashiCorp Vault (if configured) |
+
+Trigger a sync (dry-run):
+
+```http
+POST /api/workspaces/{workspaceId}/connections/sync
+Content-Type: application/json
+
+{ "autoApply": false }
+```
+
+Pass `"autoApply": true` to apply the plan. Pass `"includeDeletes": true` to allow
+the sync to remove connections that are present in the DB but absent from the YAML.
+
+### Test a connection
+
+After creating a connection, verify reachability (no authentication required for
+the probe — it only checks network connectivity):
+
+```http
+POST /api/workspaces/{workspaceId}/connections/{connectionId}/test
+```
+
+Response:
+```json
+{ "ok": true, "latencyMs": 42, "details": "HTTP 200 from https://gitlab.com/api/v4/version" }
+```
+
+## Per-type config schemas
+
+Each connection type is validated against a Zod schema defined in
+`shared/schema.ts`. The tables below list every field.
+
+### gitlab
+
+| Field | Type | Default | Required |
+|---|---|---|---|
+| `host` | URL string | `https://gitlab.com` | No |
+| `projectId` | string | — | No |
+| `groupPath` | string | — | No |
+| `apiVersion` | `"v4"` | `"v4"` | No |
+
+### github
+
+| Field | Type | Default | Required |
+|---|---|---|---|
+| `host` | URL string | `https://api.github.com` | No |
+| `owner` | string | — | Yes |
+| `repo` | string | — | No |
+| `appId` | string | — | No |
+
+### kubernetes
+
+| Field | Type | Default | Required |
+|---|---|---|---|
+| `server` | URL string | — | Yes |
+| `namespace` | string | `"default"` | No |
+| `insecureSkipTlsVerify` | boolean | `false` | No |
+
+### aws
+
+| Field | Type | Default | Required |
+|---|---|---|---|
+| `region` | string | — | Yes |
+| `accountId` | string | — | No |
+| `roleArn` | string | — | No |
+
+### jira
+
+| Field | Type | Default | Required |
+|---|---|---|---|
+| `host` | URL string | — | Yes |
+| `email` | email string | — | No |
+| `projectKey` | string | — | No |
+
+### grafana
+
+| Field | Type | Default | Required |
+|---|---|---|---|
+| `host` | URL string | — | Yes |
+| `orgId` | positive integer | `1` | No |
+
+### generic_mcp
+
+| Field | Type | Default | Required |
+|---|---|---|---|
+| `endpoint` | URL string | — | Yes |
+| `transport` | `"stdio"` \| `"sse"` \| `"streamable-http"` | `"sse"` | No |
+| `description` | string | — | No |
+
+## Usage metrics
+
+```http
+GET /api/workspaces/{workspaceId}/connections/{connectionId}/usage
+```
+
+Returns a `ConnectionUsageMetrics` object with:
+
+- `callsPerDay` — calls per calendar day for the last 30 days
+- `topTools` — top tools ranked by invocation count
+- `errorRate7d` — error rate (0–1) over the last 7 days
+- `p95LatencyMs` — P95 latency in milliseconds over the last 30 days
+- `isOrphan` — `true` when the connection had zero calls in the last 30 days
+
+## Per-type guides
+
+- [GitLab](./gitlab.md)
+- [GitHub](./github.md)
+- [Kubernetes](./kubernetes.md)
+- [AWS](./aws.md) _(preview)_
+- [Jira](./jira.md)
+- [Grafana](./grafana.md)
+- [Generic MCP / Docker-Run](./generic-mcp.md)

--- a/docs/connections/aws.md
+++ b/docs/connections/aws.md
@@ -1,0 +1,58 @@
+# AWS Connection
+
+> **Preview** — The AWS connection type stores credentials and configuration for
+> use by pipeline tools, but there is no built-in MCP server for AWS yet. Use a
+> `generic_mcp` connection pointing at a self-hosted AWS MCP server (e.g. the
+> [AWS Labs MCP server](https://github.com/awslabs/mcp)) if you need active AWS
+> tooling today.
+
+## Config fields
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `region` | string | — | **Required.** AWS region (e.g. `us-east-1`). |
+| `accountId` | string | — | AWS account ID. Used for display and cross-account role validation. |
+| `roleArn` | string | — | IAM role ARN to assume via STS (e.g. `arn:aws:iam::123456789012:role/MyRole`). |
+
+## Recommended credential approach
+
+Prefer short-lived credentials via IAM role assumption over long-lived access keys:
+
+1. Create an IAM role with the minimum required policies.
+2. Set `roleArn` on the connection config.
+3. Store the caller's `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` as
+   connection secrets (see below).
+
+| Secret key | Description |
+|---|---|
+| `accessKeyId` | AWS Access Key ID for the calling identity. |
+| `secretAccessKey` | AWS Secret Access Key for the calling identity. |
+| `sessionToken` | AWS Session Token (for temporary credentials). |
+
+## Connectivity probe
+
+The test endpoint has no suitable AWS probe URL and returns
+`{ "ok": false, "details": "No probe URL available for type \"aws\"" }`.
+This is expected behavior — the connection is valid even when the probe fails.
+
+## Troubleshooting
+
+### No tools available after creating an AWS connection
+
+There is no built-in MCP server for AWS. To use AWS tools in pipelines, create a
+`generic_mcp` connection pointing at a compatible AWS MCP server endpoint, and
+store your AWS credentials in that connection's secrets.
+
+### Rotating credentials
+
+```http
+PATCH /api/workspaces/{workspaceId}/connections/{connectionId}
+Content-Type: application/json
+
+{
+  "secrets": {
+    "accessKeyId": "AKIANEW...",
+    "secretAccessKey": "new-secret-here"
+  }
+}
+```

--- a/docs/connections/generic-mcp.md
+++ b/docs/connections/generic-mcp.md
@@ -1,0 +1,146 @@
+# Generic MCP Connection
+
+The `generic_mcp` connection type serves two purposes:
+
+1. **Connect to any external MCP server** via SSE, streamable-HTTP, or stdio
+   transport. Use this for self-hosted MCP servers (Jira, Grafana, AWS, custom
+   tools, etc.).
+
+2. **Docker-Run capability** — when the connection config sets the `memoryLimit`,
+   `cpuLimit`, or other Docker-related fields (and is registered with the
+   `DockerRunMcpServer` factory), the built-in `docker_run` and
+   `docker_run_privileged` tools become available.
+
+## Config fields
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `endpoint` | URL string | — | **Required.** URL of the MCP server endpoint (e.g. `https://mcp.example.com/sse`). |
+| `transport` | `"stdio"` \| `"sse"` \| `"streamable-http"` | `"sse"` | Transport protocol. |
+| `description` | string | — | Human-readable description of what this MCP server provides. |
+
+### Additional fields for Docker-Run
+
+These fields are consumed by the `DockerRunMcpServer` when the connection is
+registered as a Docker-Run provider:
+
+| Field | Type | Notes |
+|---|---|---|
+| `memoryLimit` | string | Memory cap for containers (e.g. `"512m"`, `"1g"`). Hard cap is `"2g"`. |
+| `cpuLimit` | number | CPU fraction cap (e.g. `0.5` = half a core). Hard cap is `2`. |
+| `networkEnabled` | boolean | Whether containers may access the network. Default `false`. |
+| `timeout` | number | Timeout in seconds. Hard cap is `300`. |
+
+## Required credentials
+
+Generic MCP connections accept any secret key/value pairs. Common patterns:
+
+| Secret key | Description |
+|---|---|
+| `apiKey` | Bearer token or API key sent as an `Authorization` header by the MCP server. |
+| `token` | Alternative to `apiKey`. |
+
+The built-in `DockerRunMcpServer` does not require any secrets.
+
+## Supported tools (Docker-Run)
+
+### `docker_run` — scope: `read`
+
+Run a Docker image in a sandboxed container with CPU/memory caps. Network is
+disabled by default.
+
+| Argument | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `image` | string | Yes | — | Docker image (e.g. `"python:3.12-slim"`). |
+| `command` | string | Yes | — | Shell command to execute inside the container. |
+| `memoryLimit` | string | No | connection default | Capped at connection limit and hard cap (`2g`). |
+| `cpuLimit` | number | No | connection default | Capped at connection limit and hard cap (`2`). |
+| `timeout` | number | No | connection default | Seconds; capped at connection limit and hard cap (`300`). |
+| `files` | array | No | — | Files to write into the workdir before running. Each item: `{ path: string, content: string }`. |
+| `env` | object | No | — | Environment variables to set inside the container. |
+| `installCommand` | string | No | — | Command to run before the main command (e.g. `"pip install -r requirements.txt"`). |
+| `workdir` | string | No | — | Working directory inside the container. |
+
+Returns exit code, duration, memory/CPU limits used, stdout, and stderr.
+
+### `docker_run_privileged` — scope: `destructive`
+
+Same as `docker_run` but with network access forced on. Requires
+`allowDestructive=true` on the connection.
+
+## Connectivity probe
+
+The test endpoint probes `{endpoint}` directly (HTTP GET). Any response with
+status < 500 is treated as a healthy connection.
+
+## Example pipeline snippets
+
+### External MCP server
+
+```yaml
+version: 1
+connections:
+  - name: my-jira-mcp
+    type: generic_mcp
+    config:
+      endpoint: https://mcp.example.com/jira/sse
+      transport: sse
+      description: Self-hosted Jira MCP server
+    secrets:
+      apiKey: ${env:JIRA_MCP_API_KEY}
+```
+
+### Docker-Run sandbox
+
+```yaml
+version: 1
+connections:
+  - name: docker-sandbox
+    type: generic_mcp
+    config:
+      endpoint: https://not-used-for-docker-run.example.com
+      memoryLimit: "512m"
+      cpuLimit: 0.5
+      networkEnabled: false
+      timeout: 60
+```
+
+The `endpoint` field is required by the Zod schema even for Docker-Run
+connections. Use a placeholder URL when there is no external MCP endpoint.
+
+## Troubleshooting
+
+### `docker: command not found` / `docker_run` fails
+
+The Docker daemon must be running and accessible to the server process. Confirm
+with `docker info` on the server host.
+
+### Container exits with non-zero code
+
+Check `stderr` in the tool output. Common causes:
+- Missing dependencies: add an `installCommand`.
+- Wrong `image` tag: use `docker pull <image>` on the server host to verify.
+- Timeout exceeded: increase `timeout` up to the connection cap.
+
+### Memory limit rejected
+
+Memory strings must use `m` (megabytes) or `g` (gigabytes) suffix (e.g. `512m`,
+`1g`). The hard cap is `2g`.
+
+### `docker_run_privileged` returns `DestructiveOperationDeniedError`
+
+Set `allowDestructive: true` when creating or updating the connection.
+
+### MCP server returns 401/403
+
+- Verify the `apiKey` or `token` secret is correct.
+- Check the MCP server's own authentication documentation.
+
+### Rotating credentials
+
+```http
+PATCH /api/workspaces/{workspaceId}/connections/{connectionId}
+Content-Type: application/json
+
+{ "secrets": { "apiKey": "new-key-here" } }
+```

--- a/docs/connections/github.md
+++ b/docs/connections/github.md
@@ -1,0 +1,141 @@
+# GitHub Connection
+
+Connects a workspace to GitHub (github.com or GitHub Enterprise). The built-in
+`GitHubMcpServer` uses the GitHub REST API v2022-11-28 with a Personal Access
+Token or a GitHub App installation token.
+
+## Required credentials
+
+| Secret key | Description |
+|---|---|
+| `token` | GitHub Personal Access Token (`ghp_...`) or GitHub App installation token. |
+| `githubToken` | Alternative key — looked up if `token` is absent. |
+
+## Minimum token scopes
+
+For GitHub PATs, use fine-grained tokens scoped to the target repositories.
+
+| Permission | Level | Required for |
+|---|---|---|
+| `Pull requests` | Read | `github_list_prs`, `github_get_pr_files`, `github_get_pr_diff` |
+| `Issues` | Read-write | `github_post_comment` (comments appear on both PRs and issues via the Issues API) |
+| `Actions` | Read | `github_list_workflows` |
+
+For classic PATs, the `repo` scope covers all of the above.
+
+## Config fields
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `host` | URL string | `https://api.github.com` | Override for GitHub Enterprise (e.g. `https://github.example.com/api/v3`). |
+| `owner` | string | — | **Required.** GitHub org or user name. Accepts `owner/repo` to also set the default repo. |
+| `repo` | string | — | Default repository name (without owner prefix). |
+| `appId` | string | — | GitHub App ID, for future App-based auth flows (not currently consumed by the built-in server). |
+
+## Supported tools
+
+All tools are scoped `read`.
+
+### `github_list_prs`
+
+List pull requests for a repository.
+
+| Argument | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `repo` | string | No | connection default | `"owner/repo"` or just `"repo"` when owner is set on the connection. |
+| `state` | string | No | `"open"` | One of `open`, `closed`, `all`. |
+| `perPage` | number | No | `30` | 1–100. |
+| `page` | number | No | `1` | Page number. |
+
+### `github_get_pr_files`
+
+List files changed in a pull request.
+
+| Argument | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `repo` | string | No | connection default | `"owner/repo"`. |
+| `prNumber` | number | Yes | — | Pull request number. |
+
+Returns filename, status (`added`, `removed`, `modified`, etc.), additions, and deletions.
+
+### `github_get_pr_diff`
+
+Get the raw unified diff for a pull request. Uses
+`Accept: application/vnd.github.diff`.
+
+| Argument | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `repo` | string | No | connection default | `"owner/repo"`. |
+| `prNumber` | number | Yes | — | Pull request number. |
+
+### `github_post_comment`
+
+Post a comment on a pull request or issue. Classified as `read` scope
+(non-destructive write).
+
+| Argument | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `repo` | string | No | connection default | `"owner/repo"`. |
+| `issueNumber` | number | Yes | — | PR or issue number. |
+| `body` | string | Yes | — | Comment body (Markdown supported). |
+
+Returns the created comment URL.
+
+### `github_list_workflows`
+
+List recent Actions workflow runs.
+
+| Argument | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `repo` | string | No | connection default | `"owner/repo"`. |
+| `branch` | string | No | — | Filter by branch. |
+| `status` | string | No | — | One of `queued`, `in_progress`, `completed`, `waiting`, `requested`, `pending`. |
+| `perPage` | number | No | `10` | 1–30. |
+
+## Example pipeline snippet
+
+```yaml
+version: 1
+connections:
+  - name: my-github
+    type: github
+    config:
+      host: https://api.github.com
+      owner: my-org
+      repo: my-repo
+    secrets:
+      token: ${env:GITHUB_TOKEN}
+```
+
+## Troubleshooting
+
+### HTTP 401 Bad credentials
+
+- Confirm `GITHUB_TOKEN` is set and has not been revoked.
+- Fine-grained PATs require the token to be approved if the org has a policy
+  requiring admin approval.
+
+### HTTP 403 Resource not accessible
+
+- Check the token's repository permission scope.
+- If `owner` is an organization, the token must be authorized for that org
+  (SSO-protected orgs require SAML SSO authorization).
+
+### HTTP 404 Not Found
+
+- Verify `owner` and `repo` are correct. Names are case-insensitive on github.com
+  but case-sensitive on some GitHub Enterprise instances.
+
+### Diff endpoint returns empty string
+
+- Confirm the PR is not empty (no commits, or commits with no diff).
+- Very large diffs may be truncated by GitHub.
+
+### Rotating credentials
+
+```http
+PATCH /api/workspaces/{workspaceId}/connections/{connectionId}
+Content-Type: application/json
+
+{ "secrets": { "token": "ghp_new-token-here" } }
+```

--- a/docs/connections/gitlab.md
+++ b/docs/connections/gitlab.md
@@ -1,0 +1,151 @@
+# GitLab Connection
+
+Connects a workspace to a GitLab instance (GitLab.com or self-hosted). The
+built-in `GitLabMcpServer` uses the GitLab REST API v4 with a Personal Access
+Token (PAT) or a project/group access token.
+
+## Required credentials
+
+| Secret key | Description |
+|---|---|
+| `token` | GitLab Personal Access Token or project access token. |
+| `gitlabToken` | Alternative key — looked up if `token` is absent. |
+
+At least one of these keys must be present in the `secrets` object. The token
+must have the minimum scopes listed below.
+
+## Minimum token scopes
+
+| Scope | Required for |
+|---|---|
+| `read_api` | All read tools (`gitlab_list_mrs`, `gitlab_get_mr_diff`, `gitlab_list_pipelines`, `gitlab_list_commits`) |
+| `api` | Write tool (`gitlab_post_note`) |
+
+A PAT with `read_api` is sufficient for read-only pipelines. Add `api` only when
+the `gitlab_post_note` tool is needed.
+
+## Config fields
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `host` | URL string | `https://gitlab.com` | Base URL of your GitLab instance. |
+| `projectId` | string | — | Default project path (`namespace/project`) or numeric ID. Overridable per tool call. |
+| `groupPath` | string | — | Group path for group-level operations (not currently used by built-in tools; stored for future use). |
+| `apiVersion` | `"v4"` | `"v4"` | Must be `"v4"`. |
+
+## Supported tools
+
+All tools are scoped `read` (always allowed; no `allowDestructive` needed).
+
+### `gitlab_list_mrs`
+
+List merge requests for a project.
+
+| Argument | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `project` | string | No | connection default | Project path (`namespace/project`) or numeric ID. |
+| `state` | string | No | `"opened"` | One of `opened`, `closed`, `merged`, `locked`, `all`. |
+| `perPage` | number | No | `20` | 1–100. |
+| `page` | number | No | `1` | Page number. |
+
+Returns an array of MR objects with IID, title, state, author, and web URL.
+
+### `gitlab_get_mr_diff`
+
+Get per-file diffs for a merge request.
+
+| Argument | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `project` | string | No | connection default | Project path or ID. |
+| `mrIid` | number | Yes | — | MR IID (project-scoped integer). |
+
+### `gitlab_list_pipelines`
+
+List CI/CD pipeline runs.
+
+| Argument | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `project` | string | No | connection default | Project path or ID. |
+| `ref` | string | No | — | Filter by branch or tag. |
+| `status` | string | No | — | One of `created`, `waiting_for_resource`, `preparing`, `pending`, `running`, `success`, `failed`, `canceled`, `skipped`, `manual`, `scheduled`. |
+| `perPage` | number | No | `10` | 1–100. |
+
+### `gitlab_post_note`
+
+Post a comment on an MR or issue. Classified as `read` scope (non-destructive
+write — does not modify code or settings).
+
+| Argument | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `project` | string | No | connection default | Project path or ID. |
+| `resourceType` | string | No | `"merge_requests"` | `"merge_requests"` or `"issues"`. |
+| `resourceIid` | number | Yes | — | MR or issue IID. |
+| `body` | string | Yes | — | Note body (Markdown supported). |
+
+### `gitlab_list_commits`
+
+List commits for a branch.
+
+| Argument | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `project` | string | No | connection default | Project path or ID. |
+| `ref` | string | No | — | Branch, tag, or commit SHA. |
+| `perPage` | number | No | `20` | 1–100. |
+| `page` | number | No | `1` | Page number. |
+
+## Example pipeline snippet
+
+```yaml
+version: 1
+connections:
+  - name: my-gitlab
+    type: gitlab
+    config:
+      host: https://gitlab.com
+      projectId: my-org/my-project
+    secrets:
+      token: ${env:GITLAB_TOKEN}
+```
+
+Reference the connection in a pipeline stage by its name. The tools become
+available to any stage that lists the connection in `allowedConnections`.
+
+## Troubleshooting
+
+### HTTP 401 Unauthorized
+
+- Verify `GITLAB_TOKEN` is set and non-empty.
+- Check that the token has not expired (GitLab PATs have an optional expiry).
+- Self-hosted GitLab: confirm the `host` URL does not have a trailing slash and
+  that the instance is reachable from the server.
+
+### HTTP 403 Forbidden
+
+- The token lacks the required scope. Add `read_api` (or `api` for
+  `gitlab_post_note`).
+- For group-owned projects, the token must belong to a member of the group.
+
+### HTTP 404 Not Found on tool calls
+
+- Confirm `projectId` is the correct namespace/project path or numeric ID.
+- URL encoding is applied automatically — do not pre-encode the path.
+
+### Connectivity probe fails
+
+The test endpoint probes `{host}/api/v4/version`. If this returns 404, the host
+URL or GitLab version is incorrect. A 401 or 200 both indicate a reachable
+instance.
+
+### Rotating credentials
+
+Patch the connection with new secrets:
+
+```http
+PATCH /api/workspaces/{workspaceId}/connections/{connectionId}
+Content-Type: application/json
+
+{ "secrets": { "token": "glpat-new-token-here" } }
+```
+
+Omitting `secrets` from the PATCH body leaves existing secrets unchanged. Setting
+`"secrets": null` removes all stored secrets.

--- a/docs/connections/grafana.md
+++ b/docs/connections/grafana.md
@@ -1,0 +1,78 @@
+# Grafana Connection
+
+Stores credentials and configuration for a Grafana instance. There is no
+built-in MCP server for Grafana — the connection provides metadata and
+credentials for a self-hosted Grafana MCP server or custom pipeline tool.
+
+## Required credentials
+
+| Secret key | Description |
+|---|---|
+| `serviceAccountToken` | Grafana service account token (recommended). |
+| `apiKey` | Legacy Grafana API key (deprecated in Grafana 9+; prefer service account tokens). |
+
+Generate a service account token at
+`{host}/org/serviceaccounts` or via the Grafana API.
+
+## Minimum permissions
+
+| Permission | Required for |
+|---|---|
+| `dashboards:read` | Listing and fetching dashboard definitions. |
+| `datasources:read` | Querying data sources. |
+| `annotations:read` | Reading annotations. |
+| `annotations:write` | Creating annotations. |
+
+Assign these permissions to the service account via a Grafana role.
+
+## Config fields
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `host` | URL string | — | **Required.** Grafana base URL (e.g. `https://grafana.example.com`). |
+| `orgId` | positive integer | `1` | Grafana organization ID. Defaults to the default org (`1`). |
+
+## Connectivity probe
+
+The test endpoint probes `{host}/api/health`. A successful response indicates the
+instance is reachable and healthy.
+
+## Example pipeline snippet
+
+```yaml
+version: 1
+connections:
+  - name: my-grafana
+    type: grafana
+    config:
+      host: https://grafana.example.com
+      orgId: 1
+    secrets:
+      serviceAccountToken: ${env:GRAFANA_TOKEN}
+```
+
+## Troubleshooting
+
+### HTTP 401 Unauthorized
+
+- Confirm the service account token is valid and has not been revoked.
+- Check the `orgId` — a token scoped to org 1 cannot access org 2 resources.
+
+### Probe fails with connection refused
+
+- Verify the `host` URL is reachable from the server host (not from your
+  browser or workstation behind a VPN).
+
+### `/api/health` returns non-200
+
+- Grafana may be starting up or in maintenance mode.
+- Check Grafana server logs.
+
+### Rotating credentials
+
+```http
+PATCH /api/workspaces/{workspaceId}/connections/{connectionId}
+Content-Type: application/json
+
+{ "secrets": { "serviceAccountToken": "glsa_new-token-here" } }
+```

--- a/docs/connections/jira.md
+++ b/docs/connections/jira.md
@@ -1,0 +1,89 @@
+# Jira Connection
+
+Stores credentials and configuration for a Jira Cloud or Jira Data Center
+instance. There is no built-in MCP server for Jira — the connection provides
+metadata and credentials that a self-hosted Jira MCP server or custom pipeline
+tool can consume.
+
+## Required credentials
+
+| Secret key | Description |
+|---|---|
+| `apiToken` | Jira API token (Jira Cloud) or Personal Access Token (Jira Data Center). |
+| `password` | Basic-auth password (not recommended; prefer `apiToken`). |
+
+For Jira Cloud, generate an API token at
+`https://id.atlassian.com/manage-profile/security/api-tokens`.
+
+## Minimum permissions
+
+| Permission | Required for |
+|---|---|
+| Browse Projects (`BROWSE`) | Listing issues, sprints, and project metadata. |
+| Create Issues (`CREATE_ISSUES`) | Creating new issues. |
+| Edit Issues (`EDIT_ISSUES`) | Updating issue fields. |
+| Transition Issues (`TRANSITION_ISSUES`) | Moving issues through workflow states. |
+
+Assign these permissions through a Jira project role or a global role, depending
+on your Jira configuration.
+
+## Config fields
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `host` | URL string | — | **Required.** Jira base URL (e.g. `https://mycompany.atlassian.net` or `https://jira.example.com`). |
+| `email` | email string | — | Atlassian account email used with the API token for Jira Cloud basic auth. |
+| `projectKey` | string | — | Default project key (e.g. `ENG`). Used as a default by tools that support it. |
+
+## Supported tools
+
+There is no built-in MCP server for Jira. Use a `generic_mcp` connection to
+connect to a self-hosted Jira MCP server.
+
+## Connectivity probe
+
+The test endpoint probes `{host}/status`. A successful response (HTTP < 500)
+indicates the instance is reachable.
+
+## Example pipeline snippet
+
+```yaml
+version: 1
+connections:
+  - name: my-jira
+    type: jira
+    config:
+      host: https://mycompany.atlassian.net
+      email: automation@example.com
+      projectKey: ENG
+    secrets:
+      apiToken: ${env:JIRA_API_TOKEN}
+```
+
+## Troubleshooting
+
+### HTTP 401 Unauthorized
+
+- Confirm `email` matches the Atlassian account that owns the token.
+- For Jira Cloud, use an API token (not your login password) as the `apiToken`
+  secret.
+- For Jira Data Center, use a Personal Access Token and omit `email`.
+
+### HTTP 403 Forbidden
+
+- The account lacks the required Jira project permissions.
+
+### Host URL format
+
+- Jira Cloud: `https://yourcompany.atlassian.net` (no trailing slash, no `/rest`
+  suffix).
+- Jira Data Center: `https://jira.example.com` (root URL of your server).
+
+### Rotating credentials
+
+```http
+PATCH /api/workspaces/{workspaceId}/connections/{connectionId}
+Content-Type: application/json
+
+{ "secrets": { "apiToken": "new-token-here" } }
+```

--- a/docs/connections/kubernetes.md
+++ b/docs/connections/kubernetes.md
@@ -1,0 +1,192 @@
+# Kubernetes Connection
+
+Connects a workspace to a Kubernetes cluster. The built-in `KubernetesMcpServer`
+runs `kubectl` and `helm` commands in-process using `child_process.spawn` — no
+shell interpolation is used, so arguments cannot escape into shell.
+
+The server is **namespace-scoped**: every tool operates within the `namespace`
+set on the connection config. Tools cannot address resources outside that
+namespace, providing a hard isolation boundary for ephemeral environments.
+
+## Required credentials
+
+The server looks for a kubeconfig file path in the `secrets` object.
+
+| Secret key | Description |
+|---|---|
+| `kubeconfigPath` | Absolute path to a kubeconfig file on the server's filesystem. If absent, the in-cluster service account or `~/.kube/config` is used. |
+
+Alternatives supported by `kubectl` itself (environment variables like
+`KUBECONFIG`, or an in-cluster service account mount) also work when
+`kubeconfigPath` is not supplied.
+
+## Minimum RBAC permissions
+
+Grant the service account or user in the kubeconfig the following Kubernetes RBAC
+permissions within the target namespace:
+
+| Resource | Verbs | Required for |
+|---|---|---|
+| `pods`, `deployments`, `services`, `configmaps` | `get`, `list`, `create`, `update`, `patch` | `k8s_deploy_manifest` |
+| `pods/log` | `get` | `k8s_get_logs` |
+| `pods/portforward` | `create` | `k8s_port_forward_check` |
+| Helm releases (secrets/configmaps named `sh.helm.*`) | `get`, `list`, `create`, `update` | `k8s_apply_helm_chart` |
+| `namespaces` | `delete` | `k8s_delete_namespace` (destructive) |
+
+For ephemeral smoke-test namespaces, a `ClusterRole` with `admin` bound to the
+namespace is the simplest setup.
+
+## Config fields
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `server` | URL string | — | **Required.** Kubernetes API server URL (e.g. `https://k8s.example.com:6443`). |
+| `namespace` | string | `"default"` | Namespace all tools are scoped to. Must match Kubernetes naming rules (`^[a-z0-9][a-z0-9-]{0,251}[a-z0-9]$`). |
+| `insecureSkipTlsVerify` | boolean | `false` | Set `true` only for local dev clusters with self-signed certificates. |
+
+## Supported tools
+
+### `k8s_deploy_manifest` — scope: `read`
+
+Apply a Kubernetes YAML manifest to the scoped namespace via `kubectl apply`.
+
+| Argument | Type | Required | Notes |
+|---|---|---|---|
+| `manifest` | string | Yes | YAML manifest content. Multi-document YAML (`---` separators) is supported. |
+
+Returns `kubectl apply` stdout/stderr. Exit code non-zero is surfaced as an error
+string prefixed with `Error (exit N):`.
+
+### `k8s_apply_helm_chart` — scope: `read`
+
+Install or upgrade a Helm release via `helm upgrade --install`.
+
+| Argument | Type | Required | Notes |
+|---|---|---|---|
+| `releaseName` | string | Yes | Helm release name. |
+| `chart` | string | Yes | Chart reference: `repo/chart` (e.g. `bitnami/nginx`) or local path. |
+| `valuesYaml` | string | No | Helm values as a YAML string, piped to `helm upgrade -f -`. |
+| `version` | string | No | Chart version (e.g. `"1.2.3"`). |
+
+`--create-namespace` is always passed so the namespace is created if absent.
+
+### `k8s_port_forward_check` — scope: `read`
+
+Start a `kubectl port-forward` for a pod, wait 1.5 s, perform an HTTP health
+check with `curl`, then kill the forward.
+
+| Argument | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `podName` | string | Yes | — | Pod name in the scoped namespace. |
+| `targetPort` | number | Yes | — | Container port to forward. |
+| `healthPath` | string | No | `"/health"` | HTTP path to check. |
+
+The local port is computed as `30000 + (targetPort % 10000)` to stay above the
+privileged port boundary.
+
+Returns `Status: HEALTHY` or `Status: UNHEALTHY` plus the response body.
+
+### `k8s_get_logs` — scope: `read`
+
+Fetch the last N lines of pod logs via `kubectl logs --tail=N`.
+
+| Argument | Type | Required | Default | Notes |
+|---|---|---|---|---|
+| `podName` | string | Yes | — | Pod name. |
+| `containerName` | string | No | — | Container name (needed for multi-container pods). |
+| `tail` | number | No | `100` | Lines to return (max 1000). |
+
+### `k8s_delete_namespace` — scope: `destructive`
+
+Delete the scoped namespace and all resources in it via
+`kubectl delete namespace`. Requires `allowDestructive=true` on the connection
+and `confirm: "DELETE"` in the tool call.
+
+| Argument | Type | Required | Notes |
+|---|---|---|---|
+| `confirm` | string | Yes | Must be exactly `"DELETE"`. |
+
+This tool is designed for tear-down of ephemeral smoke-test namespaces. Use a
+dedicated short-lived namespace (e.g. `smoke-test-<runId>`) — never point this
+at a shared or production namespace.
+
+## Example pipeline snippet
+
+```yaml
+version: 1
+connections:
+  - name: my-k8s-cluster
+    type: kubernetes
+    config:
+      server: https://k8s.example.com:6443
+      namespace: smoke-test
+    secrets:
+      kubeconfigPath: ${env:KUBECONFIG_PATH}
+```
+
+To enable the destructive tear-down tool, set `allowDestructive: true` on the
+connection via the API:
+
+```http
+POST /api/workspaces/{workspaceId}/connections
+Content-Type: application/json
+
+{
+  "type": "kubernetes",
+  "name": "my-k8s-cluster",
+  "config": { "server": "https://k8s.example.com:6443", "namespace": "smoke-test", "allowDestructive": true },
+  "secrets": { "kubeconfigPath": "/secrets/kube/config" }
+}
+```
+
+Note: `allowDestructive` is a top-level connection flag managed by the registry —
+not a config schema field — so it does not appear in the Zod config schema but
+must be passed at connection creation/update time.
+
+## Troubleshooting
+
+### `kubectl: command not found`
+
+The `kubectl` binary must be on the `PATH` of the server process. Install it on
+the server host and confirm with `which kubectl`.
+
+### `helm: command not found`
+
+Same as above for the Helm binary. Required only for `k8s_apply_helm_chart`.
+
+### `Error (exit 1): Unable to connect to the server`
+
+- Verify the `server` URL is reachable from the server host (not from your
+  workstation).
+- Check that the kubeconfig at `kubeconfigPath` has the correct `server` URL
+  and that the certificate authority is trusted.
+- For self-signed CAs, set `insecureSkipTlsVerify: true` (dev only).
+
+### `Error (exit 1): Forbidden`
+
+The service account lacks the required RBAC permissions. See
+[Minimum RBAC permissions](#minimum-rbac-permissions) above.
+
+### Port-forward health check always returns UNHEALTHY
+
+- Confirm the container is listening on `targetPort`.
+- Increase the wait time by using a readiness probe in your manifest before
+  calling the health check tool.
+- Confirm `curl` is installed on the server host.
+
+### Namespace validation error
+
+Kubernetes namespace names must match `^[a-z0-9][a-z0-9-]{0,251}[a-z0-9]$`.
+Single-character names (`[a-z0-9]`) are also valid.
+
+### Rotating credentials
+
+Replace the kubeconfig file at the path stored in `kubeconfigPath`, or patch the
+connection with a new path:
+
+```http
+PATCH /api/workspaces/{workspaceId}/connections/{connectionId}
+Content-Type: application/json
+
+{ "secrets": { "kubeconfigPath": "/new/path/kubeconfig" } }
+```

--- a/docs/examples/gitlab-mr-stats.yaml
+++ b/docs/examples/gitlab-mr-stats.yaml
@@ -1,0 +1,103 @@
+# GitLab MR Stats Pipeline
+#
+# Queries GitLab for merge requests over the last 30 days, aggregates statistics
+# (open/merged/closed counts, top authors, average time-to-merge), and produces
+# a Markdown summary report posted back as a GitLab note.
+#
+# ── Prerequisites ──────────────────────────────────────────────────────────────
+#
+#   1. A GitLab connection in your workspace (see docs/connections/gitlab.md).
+#      Minimum token scope: read_api (+ api if you want the note posted).
+#
+#   2. Environment variable GITLAB_TOKEN set on the server or referenced below.
+#
+# ── Step 1: Add the connection ─────────────────────────────────────────────────
+#
+# Place this in .multiqlti/connections.yaml at your workspace root, then call:
+#
+#   POST /api/workspaces/{workspaceId}/connections/sync
+#   { "autoApply": true }
+#
+# ──────────────────────────────────────────────────────────────────────────────
+
+version: 1
+connections:
+  - name: gitlab-mr-stats
+    type: gitlab
+    config:
+      host: https://gitlab.com
+      # Replace with your project path (namespace/project) or numeric project ID.
+      projectId: my-org/my-project
+      apiVersion: v4
+    secrets:
+      # Reference an environment variable — never store plaintext tokens here.
+      token: ${env:GITLAB_TOKEN}
+
+# ── Step 2: Create the pipeline ───────────────────────────────────────────────
+#
+# POST /api/pipelines
+# Content-Type: application/json
+#
+# {
+#   "name": "GitLab MR Stats (last 30 days)",
+#   "description": "Aggregate merge request statistics for the last 30 days and produce a Markdown report.",
+#   "stages": [
+#     {
+#       "teamId": "planning",
+#       "modelSlug": "claude-sonnet-4-5",
+#       "enabled": true,
+#       "systemPromptOverride": "You are a data analyst. Use the gitlab_list_mrs tool to fetch all merge requests for the last 30 days (state=all, perPage=100). Page through the results if needed. Aggregate the following statistics:\n- Total MRs opened\n- Total MRs merged\n- Total MRs still open\n- Total MRs closed (not merged)\n- Top 5 authors by MR count\n- Average time from opened_at to merged_at for merged MRs (in hours)\n\nReturn a Markdown report with a summary table and a section for each statistic. End with a one-sentence conclusion about team velocity.",
+#       "allowedConnections": ["<connectionId-of-gitlab-mr-stats>"]
+#     },
+#     {
+#       "teamId": "code_review",
+#       "modelSlug": "claude-sonnet-4-5",
+#       "enabled": true,
+#       "systemPromptOverride": "You receive a Markdown MR statistics report. Review it for accuracy and clarity. If anything looks anomalous (e.g. unusually high or low merge rate), add a 'Observations' section noting it. Return the final polished report.",
+#       "allowedConnections": []
+#     }
+#   ]
+# }
+#
+# Replace <connectionId-of-gitlab-mr-stats> with the ID returned when the
+# connection was created (visible in GET /api/workspaces/{id}/connections).
+#
+# ── Step 3: Run the pipeline ──────────────────────────────────────────────────
+#
+# POST /api/pipelines/{pipelineId}/run
+# Content-Type: application/json
+#
+# {
+#   "input": "Generate the GitLab MR statistics report for the last 30 days."
+# }
+#
+# ── Tool reference ─────────────────────────────────────────────────────────────
+#
+# Stage 1 uses:
+#   gitlab_list_mrs(project, state="all", perPage=100, page=N)
+#     → Returns MR objects with: iid, title, state, author, created_at,
+#       merged_at, closed_at, web_url
+#
+# To also post the report as a GitLab note on an issue, add to the final stage:
+#   gitlab_post_note(project, resourceType="issues", resourceIid=<issueIid>, body=<report>)
+#   (requires api scope on the token)
+#
+# ── Expected output ────────────────────────────────────────────────────────────
+#
+# ## MR Statistics — my-org/my-project (last 30 days)
+#
+# | Metric | Value |
+# |---|---|
+# | Total opened | 47 |
+# | Merged | 38 |
+# | Still open | 6 |
+# | Closed (not merged) | 3 |
+# | Avg time-to-merge | 18.4 h |
+#
+# ### Top authors
+# 1. alice (12 MRs)
+# 2. bob (9 MRs)
+# ...
+#
+# ### Observations
+# Merge rate of 80.9% is healthy. No anomalies detected.

--- a/docs/examples/k8s-smoke-test.yaml
+++ b/docs/examples/k8s-smoke-test.yaml
@@ -1,0 +1,138 @@
+# Kubernetes Smoke Test Pipeline
+#
+# Builds a Docker image, deploys it to an ephemeral Kubernetes namespace,
+# runs a smoke test (HTTP health check via port-forward), tears down the
+# namespace, and posts a pass/fail summary.
+#
+# ── Prerequisites ──────────────────────────────────────────────────────────────
+#
+#   1. A Kubernetes connection with allowDestructive=true (for tear-down).
+#      See docs/connections/kubernetes.md.
+#
+#   2. A generic_mcp (Docker-Run) connection for building the image.
+#      See docs/connections/generic-mcp.md.
+#
+#   3. kubectl and helm installed on the server host.
+#
+#   4. The target k8s namespace must be short-lived / dedicated to this test.
+#      NEVER use a shared or production namespace.
+#
+# ── Step 1: Add the connections ───────────────────────────────────────────────
+#
+# Place this in .multiqlti/connections.yaml at your workspace root, then call:
+#
+#   POST /api/workspaces/{workspaceId}/connections/sync
+#   { "autoApply": true }
+#
+# ──────────────────────────────────────────────────────────────────────────────
+
+version: 1
+connections:
+  - name: k8s-smoke-cluster
+    type: kubernetes
+    config:
+      # Kubernetes API server URL.
+      server: https://k8s.example.com:6443
+      # Dedicated ephemeral namespace — isolated from other workloads.
+      namespace: smoke-test
+      insecureSkipTlsVerify: false
+    secrets:
+      # Absolute path to a kubeconfig file on the server host.
+      kubeconfigPath: ${env:KUBECONFIG_PATH}
+
+  - name: docker-build-sandbox
+    type: generic_mcp
+    config:
+      # endpoint is required by the schema even for docker-run connections.
+      endpoint: https://placeholder.internal/not-used
+      # Resource caps for the build container.
+      memoryLimit: "1g"
+      cpuLimit: 1
+      networkEnabled: true
+      timeout: 120
+    secrets: {}
+
+# ── Step 2: Create the pipeline ───────────────────────────────────────────────
+#
+# POST /api/pipelines
+# Content-Type: application/json
+#
+# {
+#   "name": "K8s Smoke Test",
+#   "description": "Build Docker image, deploy to ephemeral k8s namespace, run smoke test, tear down.",
+#   "stages": [
+#     {
+#       "teamId": "planning",
+#       "modelSlug": "claude-sonnet-4-5",
+#       "enabled": true,
+#       "systemPromptOverride": "You are a DevOps engineer. Build a minimal Docker image using the docker_run tool:\n- image: docker:24-dind (or use the project's Dockerfile content passed as input)\n- Use the 'files' argument to write a simple Dockerfile if none is provided\n- Run: docker build -t smoke-test-image:latest .\nIf the build succeeds, return the image name 'smoke-test-image:latest'. If it fails, return the build errors.",
+#       "allowedConnections": ["<connectionId-of-docker-build-sandbox>"]
+#     },
+#     {
+#       "teamId": "development",
+#       "modelSlug": "claude-sonnet-4-5",
+#       "enabled": true,
+#       "systemPromptOverride": "You are a Kubernetes operator. The previous stage produced an image name. Deploy it to the smoke-test namespace:\n1. Use k8s_deploy_manifest to apply a Deployment + Service manifest for the image.\n   - Deployment: 1 replica, image from previous stage, port 8080.\n   - Service: ClusterIP, port 8080 → targetPort 8080.\n2. Wait for the pod to be ready by calling k8s_get_logs on the pod after ~10 seconds.\n3. Call k8s_port_forward_check(podName=<pod>, targetPort=8080, healthPath='/health') to verify the service responds.\n4. Return the pod name and health check result.",
+#       "allowedConnections": ["<connectionId-of-k8s-smoke-cluster>"]
+#     },
+#     {
+#       "teamId": "testing",
+#       "modelSlug": "claude-sonnet-4-5",
+#       "enabled": true,
+#       "systemPromptOverride": "You are a QA engineer. The previous stage returned a health check result. Evaluate it:\n- If Status: HEALTHY → smoke test PASSED.\n- If Status: UNHEALTHY or any error → smoke test FAILED (include error details).\nThen call k8s_delete_namespace(confirm='DELETE') to tear down the ephemeral namespace regardless of test outcome.\nReturn a final Markdown summary:\n## Smoke Test Result: PASSED/FAILED\n- Image: <image>\n- Pod: <pod>\n- Health check: <result>\n- Namespace deleted: yes/no",
+#       "allowedConnections": ["<connectionId-of-k8s-smoke-cluster>"]
+#     }
+#   ]
+# }
+#
+# Replace <connectionId-of-...> with the IDs from GET /api/workspaces/{id}/connections.
+#
+# IMPORTANT: The k8s-smoke-cluster connection must have allowDestructive=true.
+# Set this when creating the connection:
+#
+# POST /api/workspaces/{workspaceId}/connections
+# {
+#   "type": "kubernetes",
+#   "name": "k8s-smoke-cluster",
+#   "config": {
+#     "server": "https://k8s.example.com:6443",
+#     "namespace": "smoke-test",
+#     "allowDestructive": true
+#   },
+#   "secrets": { "kubeconfigPath": "/secrets/kube/config" }
+# }
+#
+# ── Step 3: Run the pipeline ──────────────────────────────────────────────────
+#
+# POST /api/pipelines/{pipelineId}/run
+# Content-Type: application/json
+#
+# {
+#   "input": "Run a smoke test for image myapp:v1.2.3. Dockerfile: FROM nginx:alpine\\nCOPY ./dist /usr/share/nginx/html\\nEXPOSE 8080"
+# }
+#
+# ── Tool reference ─────────────────────────────────────────────────────────────
+#
+# Stage 1 (build):
+#   docker_run(image, command, files, memoryLimit, cpuLimit, timeout, networkEnabled)
+#     → Returns exit code, stdout (build log), stderr
+#
+# Stage 2 (deploy):
+#   k8s_deploy_manifest(manifest)
+#     → Returns kubectl apply output
+#   k8s_get_logs(podName, tail=50)
+#     → Returns last N lines of pod logs
+#   k8s_port_forward_check(podName, targetPort=8080, healthPath="/health")
+#     → Returns "Status: HEALTHY" or "Status: UNHEALTHY" + response body
+#
+# Stage 3 (test + teardown):
+#   k8s_delete_namespace(confirm="DELETE")
+#     → Returns "Namespace smoke-test deleted." (DESTRUCTIVE — requires allowDestructive=true)
+#
+# ── Expected output ────────────────────────────────────────────────────────────
+#
+# ## Smoke Test Result: PASSED
+# - Image: smoke-test-image:latest
+# - Pod: myapp-deployment-7d4f8b9c6-xk2qp
+# - Health check: Status: HEALTHY / Response: {"status":"ok"}
+# - Namespace deleted: yes


### PR DESCRIPTION
## Summary

- Overview doc (`docs/connections/README.md`) with provider matrix, security model (credential storage, scopes, audit redaction, RBAC, encryption at rest), config schema tables, and YAML sync usage
- Per-type guides for all 7 connection types: GitLab, GitHub, Kubernetes, AWS (preview stub), Jira, Grafana, Generic MCP / Docker-Run
- Each guide covers: required credentials, minimum scopes/permissions, all config fields (matching actual Zod schemas in `shared/schema.ts`), all supported tools with full argument tables (matching built-in MCP server implementations), example `connections.yaml` snippet, and troubleshooting section
- 2 ready-to-import example pipelines under `docs/examples/`:
  - `gitlab-mr-stats.yaml` — connections.yaml + pipeline stage config to query GitLab MRs over 30 days, aggregate stats, and produce a Markdown report
  - `k8s-smoke-test.yaml` — build Docker image, deploy to ephemeral k8s namespace, port-forward health check, tear down, post summary
- All tool names, argument names, config field names, and secret key names are taken directly from the source (`server/mcp-servers/*/index.ts`, `shared/schema.ts`, `server/routes/connections.ts`, `server/tools/audit.ts`)

Closes #273

## Test plan

- [x] `npx tsc --noEmit` passes (docs-only change, 0 errors)
- [ ] Verify connection creation with each config example against the Zod schemas
- [ ] Verify tool argument tables match MCP server `inputSchema` definitions
- [ ] Review audit redaction key list against `SENSITIVE_KEY_NAMES` in `server/tools/audit.ts`