### PR TITLE
feat: conflict resolution for shared sessions (#229)

### DIFF
--- a/migrations/0019_conflict_resolution.sql
+++ b/migrations/0019_conflict_resolution.sql
@@ -1,0 +1,43 @@
+-- Subjective Conflict Resolution (issue #229)
+-- session_conflicts: mutable lifecycle table for active disputes
+-- decision_log: append-only history of all resolved conflicts
+
+CREATE TABLE IF NOT EXISTS "session_conflicts" (
+  "id"                   varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+  "session_id"           varchar NOT NULL,
+  "raised_by"            text NOT NULL,
+  "raised_by_instance"   text NOT NULL,
+  "question"             text NOT NULL,
+  "context"              text,
+  "strategy"             text NOT NULL,
+  "status"               text NOT NULL DEFAULT 'open',
+  "proposals"            jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "votes"                jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "quorum_threshold"     real NOT NULL DEFAULT 0.67,
+  "timeout_ms"           integer NOT NULL DEFAULT 300000,
+  "judgement"            jsonb,
+  "experiment_results"   jsonb,
+  "outcome"              jsonb,
+  "created_at"           timestamp NOT NULL DEFAULT now(),
+  "updated_at"           timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "session_conflicts_session_idx" ON "session_conflicts" ("session_id");
+CREATE INDEX IF NOT EXISTS "session_conflicts_status_idx"  ON "session_conflicts" ("status");
+
+CREATE TABLE IF NOT EXISTS "decision_log" (
+  "id"                varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+  "session_id"        varchar NOT NULL,
+  "conflict_id"       varchar NOT NULL,
+  "question"          text NOT NULL,
+  "strategy"          text NOT NULL,
+  "outcome"           jsonb NOT NULL,
+  "participant_count" integer NOT NULL DEFAULT 0,
+  "proposal_count"    integer NOT NULL DEFAULT 0,
+  "duration_ms"       integer NOT NULL DEFAULT 0,
+  "recorded_at"       timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "decision_log_session_idx"     ON "decision_log" ("session_id");
+CREATE INDEX IF NOT EXISTS "decision_log_conflict_idx"    ON "decision_log" ("conflict_id");
+CREATE INDEX IF NOT EXISTS "decision_log_recorded_at_idx" ON "decision_log" ("recorded_at");

--- a/server/federation/conflict-resolution.ts
+++ b/server/federation/conflict-resolution.ts
@@ -1,0 +1,677 @@
+/**
+ * Subjective Conflict Resolution Service (issue #229)
+ *
+ * Handles disputes in shared sessions where correctness is subjective and
+ * cannot be determined by simple approve/reject arbitration.
+ *
+ * Supported resolution strategies:
+ *   structured_debate    -- participants argue positions; optional LLM judge evaluates
+ *   quorum_vote          -- N participants vote; configurable threshold decides winner
+ *   parallel_experiment  -- both approaches run as pipeline branches; best result wins
+ *   defer_to_owner       -- session owner's choice is final (used as fallback)
+ *
+ * All resolved conflicts are appended to the decision log for organisational learning.
+ */
+import crypto from "crypto";
+import type { Gateway } from "../gateway/index.js";
+import type {
+  SessionConflict,
+  ConflictProposal,
+  ConflictVote,
+  DebateJudgement,
+  ExperimentBranchResult,
+  ResolutionOutcome,
+  SubjectiveResolutionStrategy,
+  ConflictStatus,
+  RaiseConflictInput,
+  CastConflictVoteInput,
+  DecisionLogEntry,
+} from "@shared/types";
+
+// ─── Constants ─────────────────────────────────────────────────────────────────
+
+const DEFAULT_QUORUM_THRESHOLD = 0.67;
+const DEFAULT_TIMEOUT_MS = 300_000; // 5 minutes
+const MAX_PROPOSALS_PER_CONFLICT = 10;
+const MAX_CONFLICTS_IN_MEMORY = 500;
+const JUDGE_MODEL_SLUG = "default";
+
+// ─── Pending resolution promise handle ─────────────────────────────────────────
+
+interface PendingResolution {
+  conflict: SessionConflict;
+  createdAt: number;
+  resolve: (outcome: ResolutionOutcome) => void;
+  reject: (err: Error) => void;
+}
+
+// ─── Service ───────────────────────────────────────────────────────────────────
+
+/**
+ * ConflictResolutionService manages the full lifecycle of subjective disputes
+ * in shared federation sessions.
+ */
+export class ConflictResolutionService {
+  /** Active conflicts keyed by conflict ID. */
+  private conflicts = new Map<string, SessionConflict>();
+
+  /** Pending resolution promises keyed by conflict ID. */
+  private pending = new Map<string, PendingResolution>();
+
+  /** Timeout handles keyed by conflict ID. */
+  private timeouts = new Map<string, ReturnType<typeof setTimeout>>();
+
+  /** Decision log (in-memory; PgStorage persists to DB). */
+  private log: DecisionLogEntry[] = [];
+
+  /** Optional storage sink injected for persistence. */
+  private storageSink?: ConflictStorageSink;
+
+  constructor(
+    private readonly gateway: Gateway | null,
+    storageSink?: ConflictStorageSink,
+  ) {
+    this.storageSink = storageSink;
+  }
+
+  // ── Public API ────────────────────────────────────────────────────────────────
+
+  /**
+   * Raise a new conflict in a shared session.
+   * Returns the conflict ID and a promise that resolves with the outcome.
+   */
+  async raiseConflict(
+    input: RaiseConflictInput,
+  ): Promise<{ conflictId: string; resolution: Promise<ResolutionOutcome> }> {
+    const conflictId = crypto.randomBytes(16).toString("hex");
+    const now = Date.now();
+
+    const conflict: SessionConflict = {
+      id: conflictId,
+      sessionId: input.sessionId,
+      raisedBy: input.raisedBy,
+      raisedByInstance: input.raisedByInstance,
+      question: input.question,
+      context: input.context,
+      strategy: input.strategy,
+      status: "open",
+      proposals: [],
+      votes: [],
+      quorumThreshold: input.quorumThreshold ?? DEFAULT_QUORUM_THRESHOLD,
+      timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.enforceCapacityLimit();
+    this.conflicts.set(conflictId, conflict);
+
+    if (this.storageSink) {
+      await this.storageSink.saveConflict(conflict);
+    }
+
+    const resolution = new Promise<ResolutionOutcome>((resolve, reject) => {
+      this.pending.set(conflictId, {
+        conflict,
+        createdAt: now,
+        resolve,
+        reject,
+      });
+    });
+
+    const handle = setTimeout(
+      () => this.handleTimeout(conflictId),
+      conflict.timeoutMs,
+    );
+    this.timeouts.set(conflictId, handle);
+
+    // For defer_to_owner, resolve immediately with the raiser as owner
+    if (input.strategy === "defer_to_owner") {
+      await this.resolveWithOutcome(conflictId, {
+        strategy: "defer_to_owner",
+        reasoning: `Deferred to session owner (${input.raisedBy}) by design.`,
+        decidedBy: "owner",
+        decidedAt: now,
+      });
+    }
+
+    return { conflictId, resolution };
+  }
+
+  /**
+   * Add a proposal to an open conflict.
+   * Returns the updated conflict.
+   */
+  async addProposal(
+    conflictId: string,
+    proposal: Omit<ConflictProposal, "id" | "submittedAt">,
+  ): Promise<SessionConflict> {
+    const conflict = this.requireOpenConflict(conflictId);
+
+    if (conflict.proposals.length >= MAX_PROPOSALS_PER_CONFLICT) {
+      throw new Error(
+        `Conflict ${conflictId} already has the maximum of ${MAX_PROPOSALS_PER_CONFLICT} proposals.`,
+      );
+    }
+
+    const newProposal: ConflictProposal = {
+      ...proposal,
+      id: crypto.randomBytes(8).toString("hex"),
+      submittedAt: Date.now(),
+    };
+
+    conflict.proposals = [...conflict.proposals, newProposal];
+    conflict.updatedAt = Date.now();
+
+    if (conflict.strategy === "structured_debate") {
+      conflict.status = "debate_in_progress";
+    } else if (conflict.strategy === "quorum_vote") {
+      conflict.status = "voting_in_progress";
+    } else if (conflict.strategy === "parallel_experiment") {
+      conflict.status = "experiment_in_progress";
+      // Initialise branch result stubs for each proposal
+      conflict.experimentResults = conflict.proposals.map((p) => ({
+        proposalId: p.id,
+        runId: "",
+        status: "pending",
+      }));
+    }
+
+    await this.persistConflict(conflict);
+    return conflict;
+  }
+
+  /**
+   * Cast a vote for a proposal in a quorum-vote conflict.
+   * When the quorum threshold is reached, the conflict resolves automatically.
+   */
+  async castVote(
+    conflictId: string,
+    voteInput: CastConflictVoteInput,
+  ): Promise<SessionConflict> {
+    const conflict = this.requireConflictForVoting(conflictId);
+
+    // Prevent duplicate votes from the same participant
+    const alreadyVoted = conflict.votes.some(
+      (v) => v.participantId === voteInput.participantId &&
+             v.instanceId === voteInput.instanceId,
+    );
+    if (alreadyVoted) {
+      throw new Error(
+        `Participant ${voteInput.participantId} has already voted on conflict ${conflictId}.`,
+      );
+    }
+
+    // Validate proposal exists
+    const proposalExists = conflict.proposals.some((p) => p.id === voteInput.proposalId);
+    if (!proposalExists) {
+      throw new Error(`Proposal ${voteInput.proposalId} not found in conflict ${conflictId}.`);
+    }
+
+    const vote: ConflictVote = {
+      participantId: voteInput.participantId,
+      instanceId: voteInput.instanceId,
+      proposalId: voteInput.proposalId,
+      anonymous: voteInput.anonymous ?? false,
+      submittedAt: Date.now(),
+    };
+
+    conflict.votes = [...conflict.votes, vote];
+    conflict.updatedAt = Date.now();
+
+    await this.persistConflict(conflict);
+
+    // Check if quorum is met
+    await this.checkQuorum(conflict);
+
+    return conflict;
+  }
+
+  /**
+   * Submit the LLM judge's verdict for a structured debate.
+   * Triggers automatic resolution.
+   */
+  async submitDebateJudgement(
+    conflictId: string,
+    judgement: DebateJudgement,
+  ): Promise<SessionConflict> {
+    const conflict = this.requireConflictWithStrategy(conflictId, "structured_debate");
+
+    conflict.judgement = judgement;
+    conflict.updatedAt = Date.now();
+
+    await this.persistConflict(conflict);
+
+    // Resolve using judge's verdict
+    const winnerProposal = judgement.winner
+      ? conflict.proposals.find((p) => p.id === judgement.winner)
+      : undefined;
+
+    await this.resolveWithOutcome(conflictId, {
+      strategy: "structured_debate",
+      winningProposalId: winnerProposal?.id,
+      reasoning: judgement.reasoning,
+      decidedBy: "judge",
+      decidedAt: Date.now(),
+    });
+
+    return this.conflicts.get(conflictId)!;
+  }
+
+  /**
+   * Update an experiment branch result and check if all branches have completed.
+   */
+  async updateExperimentBranch(
+    conflictId: string,
+    result: ExperimentBranchResult,
+  ): Promise<SessionConflict> {
+    const conflict = this.requireConflictWithStrategy(conflictId, "parallel_experiment");
+
+    const branches = conflict.experimentResults ?? [];
+    const idx = branches.findIndex((b) => b.proposalId === result.proposalId);
+    if (idx === -1) {
+      throw new Error(`Branch for proposal ${result.proposalId} not found.`);
+    }
+
+    const updated = [...branches];
+    updated[idx] = { ...updated[idx], ...result };
+    conflict.experimentResults = updated;
+    conflict.updatedAt = Date.now();
+
+    await this.persistConflict(conflict);
+
+    // If all branches are done, resolve with the completed one(s)
+    const allDone = updated.every((b) => b.status !== "pending");
+    if (allDone) {
+      const winner = updated.find((b) => b.status === "completed") ?? updated[0];
+      await this.resolveWithOutcome(conflictId, {
+        strategy: "parallel_experiment",
+        winningProposalId: winner?.proposalId,
+        reasoning: "Parallel experiment completed; first successful branch adopted.",
+        decidedBy: "owner",
+        decidedAt: Date.now(),
+      });
+    }
+
+    return this.conflicts.get(conflictId)!;
+  }
+
+  /**
+   * Manually resolve a conflict (e.g., owner override).
+   */
+  async forceResolve(
+    conflictId: string,
+    winningProposalId: string | undefined,
+    reasoning: string,
+    decidedBy: ResolutionOutcome["decidedBy"] = "owner",
+  ): Promise<SessionConflict> {
+    const conflict = this.requireOpenConflict(conflictId);
+
+    await this.resolveWithOutcome(conflictId, {
+      strategy: conflict.strategy,
+      winningProposalId,
+      reasoning,
+      decidedBy,
+      decidedAt: Date.now(),
+    });
+
+    return this.conflicts.get(conflictId)!;
+  }
+
+  /**
+   * Run the LLM judge on a structured debate, if a gateway is available.
+   * This is a convenience method called explicitly (not automatically triggered).
+   */
+  async runDebateJudge(conflictId: string): Promise<DebateJudgement> {
+    const conflict = this.requireConflictWithStrategy(conflictId, "structured_debate");
+
+    if (!this.gateway) {
+      throw new Error("No LLM gateway available for debate judgement.");
+    }
+
+    if (conflict.proposals.length < 2) {
+      throw new Error("Structured debate requires at least 2 proposals before judging.");
+    }
+
+    const prompt = buildDebateJudgePrompt(conflict);
+
+    let responseContent: string;
+    try {
+      const response = await this.gateway.complete({
+        modelSlug: JUDGE_MODEL_SLUG,
+        messages: [{ role: "user", content: prompt }],
+      });
+      responseContent = response.content;
+    } catch (err) {
+      throw new Error(`LLM judge call failed: ${(err as Error).message}`);
+    }
+
+    const judgement = parseJudgeResponse(responseContent, conflictId);
+    await this.submitDebateJudgement(conflictId, judgement);
+
+    return judgement;
+  }
+
+  // ── Query API ─────────────────────────────────────────────────────────────────
+
+  /** Get a conflict by ID. */
+  getConflict(conflictId: string): SessionConflict | null {
+    return this.conflicts.get(conflictId) ?? null;
+  }
+
+  /** List all conflicts for a session. */
+  getSessionConflicts(sessionId: string): SessionConflict[] {
+    return Array.from(this.conflicts.values()).filter(
+      (c) => c.sessionId === sessionId,
+    );
+  }
+
+  /** Get all decision log entries (in-memory). */
+  getDecisionLog(): DecisionLogEntry[] {
+    return [...this.log];
+  }
+
+  /** Get decision log entries for a specific session. */
+  getSessionDecisionLog(sessionId: string): DecisionLogEntry[] {
+    return this.log.filter((e) => e.sessionId === sessionId);
+  }
+
+  // ── Internal resolution machinery ─────────────────────────────────────────────
+
+  private async resolveWithOutcome(
+    conflictId: string,
+    outcome: ResolutionOutcome,
+  ): Promise<void> {
+    const conflict = this.conflicts.get(conflictId);
+    if (!conflict) return;
+    if (conflict.status === "resolved") return;
+
+    conflict.outcome = outcome;
+    conflict.status = "resolved";
+    conflict.updatedAt = Date.now();
+
+    this.clearTimeout(conflictId);
+    await this.persistConflict(conflict);
+    await this.appendDecisionLog(conflict, outcome);
+
+    const pending = this.pending.get(conflictId);
+    if (pending) {
+      this.pending.delete(conflictId);
+      pending.resolve(outcome);
+    }
+  }
+
+  private async checkQuorum(conflict: SessionConflict): Promise<void> {
+    if (conflict.proposals.length === 0) return;
+
+    const totalVotes = conflict.votes.length;
+    // Require at least 2 votes so a single participant cannot unilaterally form a quorum.
+    if (totalVotes < 2) return;
+
+    // Count votes per proposal
+    const voteCounts = new Map<string, number>();
+    for (const v of conflict.votes) {
+      voteCounts.set(v.proposalId, (voteCounts.get(v.proposalId) ?? 0) + 1);
+    }
+
+    // Find proposal with the highest vote share
+    let winnerProposalId: string | undefined;
+    let maxShare = 0;
+
+    for (const [proposalId, count] of voteCounts) {
+      const share = count / totalVotes;
+      if (share > maxShare) {
+        maxShare = share;
+        winnerProposalId = proposalId;
+      }
+    }
+
+    if (winnerProposalId && maxShare >= conflict.quorumThreshold) {
+      const winnerProposal = conflict.proposals.find((p) => p.id === winnerProposalId);
+      await this.resolveWithOutcome(conflict.id, {
+        strategy: "quorum_vote",
+        winningProposalId: winnerProposalId,
+        reasoning: `Quorum reached: proposal "${winnerProposal?.title ?? winnerProposalId}" received ${(maxShare * 100).toFixed(0)}% of votes (threshold: ${(conflict.quorumThreshold * 100).toFixed(0)}%).`,
+        decidedBy: "quorum",
+        decidedAt: Date.now(),
+      });
+    }
+  }
+
+  private async handleTimeout(conflictId: string): Promise<void> {
+    const conflict = this.conflicts.get(conflictId);
+    if (!conflict || conflict.status === "resolved") return;
+
+    // On timeout: try to salvage with current votes (partial quorum) or escalate to owner
+    if (
+      conflict.strategy === "quorum_vote" &&
+      conflict.votes.length > 0
+    ) {
+      // Resolve with the leading proposal even if threshold not reached
+      const voteCounts = new Map<string, number>();
+      for (const v of conflict.votes) {
+        voteCounts.set(v.proposalId, (voteCounts.get(v.proposalId) ?? 0) + 1);
+      }
+
+      let bestId: string | undefined;
+      let bestCount = 0;
+      for (const [id, count] of voteCounts) {
+        if (count > bestCount) {
+          bestCount = count;
+          bestId = id;
+        }
+      }
+
+      await this.resolveWithOutcome(conflictId, {
+        strategy: conflict.strategy,
+        winningProposalId: bestId,
+        reasoning: `Timeout reached with ${conflict.votes.length} votes cast. Plurality winner adopted.`,
+        decidedBy: "timeout",
+        decidedAt: Date.now(),
+      });
+      return;
+    }
+
+    conflict.status = "expired";
+    conflict.updatedAt = Date.now();
+    await this.persistConflict(conflict);
+
+    // Append a no-decision log entry
+    await this.appendDecisionLog(conflict, {
+      strategy: conflict.strategy,
+      reasoning: "Conflict expired without resolution.",
+      decidedBy: "timeout",
+      decidedAt: Date.now(),
+    });
+
+    const pending = this.pending.get(conflictId);
+    if (pending) {
+      this.pending.delete(conflictId);
+      pending.reject(new Error(`Conflict ${conflictId} expired without resolution.`));
+    }
+  }
+
+  private clearTimeout(conflictId: string): void {
+    const handle = this.timeouts.get(conflictId);
+    if (handle !== undefined) {
+      clearTimeout(handle);
+      this.timeouts.delete(conflictId);
+    }
+  }
+
+  private async persistConflict(conflict: SessionConflict): Promise<void> {
+    this.conflicts.set(conflict.id, conflict);
+    if (this.storageSink) {
+      await this.storageSink.saveConflict(conflict);
+    }
+  }
+
+  private async appendDecisionLog(
+    conflict: SessionConflict,
+    outcome: ResolutionOutcome,
+  ): Promise<void> {
+    const entry: DecisionLogEntry = {
+      id: crypto.randomBytes(16).toString("hex"),
+      sessionId: conflict.sessionId,
+      conflictId: conflict.id,
+      question: conflict.question,
+      strategy: conflict.strategy,
+      outcome,
+      participantCount: new Set([
+        ...conflict.votes.map((v) => v.participantId),
+        ...conflict.proposals.map((p) => p.authorId),
+      ]).size,
+      proposalCount: conflict.proposals.length,
+      durationMs: Date.now() - conflict.createdAt,
+      recordedAt: Date.now(),
+    };
+
+    this.log.push(entry);
+
+    if (this.storageSink) {
+      await this.storageSink.appendDecisionLog(entry);
+    }
+  }
+
+  private requireOpenConflict(conflictId: string): SessionConflict {
+    const conflict = this.conflicts.get(conflictId);
+    if (!conflict) throw new Error(`Conflict ${conflictId} not found.`);
+    if (conflict.status === "resolved" || conflict.status === "expired") {
+      throw new Error(`Conflict ${conflictId} is already ${conflict.status}.`);
+    }
+    return conflict;
+  }
+
+  private requireConflictForVoting(conflictId: string): SessionConflict {
+    const conflict = this.requireOpenConflict(conflictId);
+    if (conflict.strategy !== "quorum_vote") {
+      throw new Error(
+        `Conflict ${conflictId} uses strategy "${conflict.strategy}", not "quorum_vote".`,
+      );
+    }
+    return conflict;
+  }
+
+  private requireConflictWithStrategy(
+    conflictId: string,
+    strategy: SubjectiveResolutionStrategy,
+  ): SessionConflict {
+    const conflict = this.requireOpenConflict(conflictId);
+    if (conflict.strategy !== strategy) {
+      throw new Error(
+        `Conflict ${conflictId} uses strategy "${conflict.strategy}", expected "${strategy}".`,
+      );
+    }
+    return conflict;
+  }
+
+  private enforceCapacityLimit(): void {
+    if (this.conflicts.size >= MAX_CONFLICTS_IN_MEMORY) {
+      // Remove the oldest resolved/expired conflict to make space
+      for (const [id, c] of this.conflicts) {
+        if (c.status === "resolved" || c.status === "expired") {
+          this.conflicts.delete(id);
+          return;
+        }
+      }
+      // If no resolved conflicts, evict the oldest one
+      const oldest = this.conflicts.keys().next().value;
+      if (oldest !== undefined) {
+        this.conflicts.delete(oldest);
+        this.pending.delete(oldest);
+        this.clearTimeout(oldest);
+      }
+    }
+  }
+
+  // ── Internal helpers exposed for testing ─────────────────────────────────────
+
+  /** Visible for testing — trigger a timeout immediately. */
+  _triggerTimeout(conflictId: string): Promise<void> {
+    return this.handleTimeout(conflictId);
+  }
+
+  /** Visible for testing — return the pending map size. */
+  _getPendingCount(): number {
+    return this.pending.size;
+  }
+}
+
+// ─── Storage sink interface ───────────────────────────────────────────────────
+
+/**
+ * Minimal persistence interface the service uses.
+ * Implemented by IStorage in storage.ts; a no-op stub is used in tests.
+ */
+export interface ConflictStorageSink {
+  saveConflict(conflict: SessionConflict): Promise<void>;
+  appendDecisionLog(entry: DecisionLogEntry): Promise<void>;
+}
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+function buildDebateJudgePrompt(conflict: SessionConflict): string {
+  const proposalText = conflict.proposals
+    .map(
+      (p, i) =>
+        `### Proposal ${i + 1} (ID: ${p.id})\n` +
+        `Author: ${p.authorId}\n` +
+        `Title: ${p.title}\n` +
+        `Description: ${p.description}\n` +
+        (p.arguments ? `Arguments: ${p.arguments}` : ""),
+    )
+    .join("\n\n---\n\n");
+
+  return `You are an impartial judge evaluating proposals for a subjective architectural/design dispute.
+
+Question:
+${conflict.question}
+
+${conflict.context ? `Context:\n${conflict.context}\n\n` : ""}Proposals:
+${proposalText}
+
+Evaluate each proposal and select the winner.
+Respond with a valid JSON object only (no markdown, no prose outside JSON):
+{
+  "winner": "<proposal_id>",
+  "reasoning": "<explanation of your decision>",
+  "confidence": 0.85
+}`;
+}
+
+function parseJudgeResponse(
+  content: string,
+  conflictId: string,
+): DebateJudgement {
+  const jsonStr = content
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```\s*$/, "")
+    .trim();
+
+  try {
+    const parsed = JSON.parse(jsonStr) as {
+      winner?: string;
+      reasoning?: string;
+      confidence?: number;
+    };
+
+    return {
+      judgeModelSlug: JUDGE_MODEL_SLUG,
+      winner: typeof parsed.winner === "string" ? parsed.winner : undefined,
+      reasoning: typeof parsed.reasoning === "string"
+        ? parsed.reasoning
+        : "No reasoning provided.",
+      confidence: typeof parsed.confidence === "number"
+        ? Math.max(0, Math.min(1, parsed.confidence))
+        : 0.5,
+      evaluatedAt: Date.now(),
+    };
+  } catch {
+    return {
+      judgeModelSlug: JUDGE_MODEL_SLUG,
+      reasoning: `Failed to parse judge response for conflict ${conflictId}.`,
+      confidence: 0,
+      evaluatedAt: Date.now(),
+    };
+  }
+}

--- a/server/routes/federation.ts
+++ b/server/routes/federation.ts
@@ -45,6 +45,7 @@ import type { PipelineSyncService } from "../federation/pipeline-sync";
 import type { FederationManager } from "../federation/index";
 import type { CrossInstanceDelegationService } from "../federation/delegation";
 import type { IStorage } from "../storage";
+import type { ConflictResolutionService } from "../federation/conflict-resolution";
 
 // ─── Validation schemas ───────────────────────────────────────────────────────
 
@@ -101,6 +102,49 @@ const DelegationRequestSchema = z.object({
   timeoutMs: z.number().int().positive().optional(),
 });
 
+const VALID_STRATEGIES = [
+  "structured_debate",
+  "quorum_vote",
+  "parallel_experiment",
+  "defer_to_owner",
+] as const;
+
+const RaiseConflictSchema = z.object({
+  question: z.string().min(1).max(2000),
+  context: z.string().max(5000).optional(),
+  strategy: z.enum(VALID_STRATEGIES),
+  quorumThreshold: z.number().min(0.5).max(1.0).optional(),
+  timeoutMs: z.number().int().min(5000).max(3_600_000).optional(),
+});
+
+const AddProposalSchema = z.object({
+  authorId: z.string().min(1),
+  instanceId: z.string().min(1),
+  title: z.string().min(1).max(255),
+  description: z.string().min(1).max(5000),
+  arguments: z.string().max(5000).optional(),
+});
+
+const CastConflictVoteSchema = z.object({
+  participantId: z.string().min(1),
+  instanceId: z.string().min(1),
+  proposalId: z.string().min(1),
+  anonymous: z.boolean().optional(),
+});
+
+const ForceResolveSchema = z.object({
+  winningProposalId: z.string().optional(),
+  reasoning: z.string().min(1).max(2000),
+  decidedBy: z.enum(["quorum", "judge", "owner", "timeout"]).optional(),
+});
+
+const UpdateExperimentBranchSchema = z.object({
+  proposalId: z.string().min(1),
+  runId: z.string().min(1),
+  status: z.enum(["pending", "completed", "failed"]),
+  outcome: z.string().max(5000).optional(),
+});
+
 
 // ─── Route registration ───────────────────────────────────────────────────────
 
@@ -112,6 +156,7 @@ export function registerFederationRoutes(
   pipelineSync?: PipelineSyncService | null,
   storage?: IStorage | null,
   crossDelegation?: CrossInstanceDelegationService | null,
+  conflictResolution?: ConflictResolutionService | null,
 ): void {
   const federationDisabledResponse = (res: Response) =>
     res.status(503).json({
@@ -486,5 +531,209 @@ export function registerFederationRoutes(
       return res.status(404).json({ error: "Delegation not found or already completed" });
     }
     return res.status(200).json({ cancelled: true, delegationId });
+  });
+
+  // ─── Conflict Resolution (issue #229) ────────────────────────────────────────
+
+  // POST /api/sessions/:id/conflicts -- raise a conflict
+  app.post("/api/sessions/:id/conflicts", async (req: Request, res: Response) => {
+    if (!conflictResolution) {
+      return res.status(503).json({ error: "Conflict resolution service not available" });
+    }
+
+    const parsed = RaiseConflictSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid request", issues: parsed.error.flatten() });
+    }
+
+    const user = (req as unknown as { user?: { id?: string } }).user;
+    if (!user?.id) {
+      return res.status(401).json({ error: "Authenticated user required" });
+    }
+
+    try {
+      const { conflictId } = await conflictResolution.raiseConflict({
+        sessionId: String(req.params.id),
+        raisedBy: user.id,
+        raisedByInstance: "local",
+        question: parsed.data.question,
+        context: parsed.data.context,
+        strategy: parsed.data.strategy,
+        quorumThreshold: parsed.data.quorumThreshold,
+        timeoutMs: parsed.data.timeoutMs,
+      });
+
+      const conflict = conflictResolution.getConflict(conflictId);
+      return res.status(201).json(conflict);
+    } catch (err) {
+      return res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  // GET /api/sessions/:id/conflicts -- list conflicts for a session
+  app.get("/api/sessions/:id/conflicts", (_req: Request, res: Response) => {
+    if (!conflictResolution) {
+      return res.status(503).json({ error: "Conflict resolution service not available" });
+    }
+
+    const conflicts = conflictResolution.getSessionConflicts(String(_req.params.id));
+    return res.json(conflicts);
+  });
+
+  // POST /api/sessions/:id/conflicts/:cid/proposals -- add a proposal
+  app.post("/api/sessions/:id/conflicts/:cid/proposals", async (req: Request, res: Response) => {
+    if (!conflictResolution) {
+      return res.status(503).json({ error: "Conflict resolution service not available" });
+    }
+
+    const parsed = AddProposalSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid request", issues: parsed.error.flatten() });
+    }
+
+    try {
+      const conflict = await conflictResolution.addProposal(
+        String(req.params.cid),
+        {
+          authorId: parsed.data.authorId,
+          instanceId: parsed.data.instanceId,
+          title: parsed.data.title,
+          description: parsed.data.description,
+          arguments: parsed.data.arguments,
+        },
+      );
+      return res.status(201).json(conflict);
+    } catch (err) {
+      const msg = (err as Error).message;
+      if (msg.includes("not found") || msg.includes("already resolved") || msg.includes("already expired")) {
+        return res.status(404).json({ error: msg });
+      }
+      return res.status(400).json({ error: msg });
+    }
+  });
+
+  // POST /api/sessions/:id/conflicts/:cid/vote -- cast a vote
+  app.post("/api/sessions/:id/conflicts/:cid/vote", async (req: Request, res: Response) => {
+    if (!conflictResolution) {
+      return res.status(503).json({ error: "Conflict resolution service not available" });
+    }
+
+    const parsed = CastConflictVoteSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid request", issues: parsed.error.flatten() });
+    }
+
+    try {
+      const conflict = await conflictResolution.castVote(
+        String(req.params.cid),
+        {
+          participantId: parsed.data.participantId,
+          instanceId: parsed.data.instanceId,
+          proposalId: parsed.data.proposalId,
+          anonymous: parsed.data.anonymous,
+        },
+      );
+      return res.json(conflict);
+    } catch (err) {
+      const msg = (err as Error).message;
+      if (msg.includes("already voted")) {
+        return res.status(409).json({ error: msg });
+      }
+      if (msg.includes("not found")) {
+        return res.status(404).json({ error: msg });
+      }
+      return res.status(400).json({ error: msg });
+    }
+  });
+
+  // POST /api/sessions/:id/conflicts/:cid/resolve -- force-resolve a conflict
+  app.post("/api/sessions/:id/conflicts/:cid/resolve", async (req: Request, res: Response) => {
+    if (!conflictResolution) {
+      return res.status(503).json({ error: "Conflict resolution service not available" });
+    }
+
+    const parsed = ForceResolveSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid request", issues: parsed.error.flatten() });
+    }
+
+    try {
+      const conflict = await conflictResolution.forceResolve(
+        String(req.params.cid),
+        parsed.data.winningProposalId,
+        parsed.data.reasoning,
+        parsed.data.decidedBy,
+      );
+      return res.json(conflict);
+    } catch (err) {
+      const msg = (err as Error).message;
+      if (msg.includes("not found") || msg.includes("already")) {
+        return res.status(404).json({ error: msg });
+      }
+      return res.status(400).json({ error: msg });
+    }
+  });
+
+  // POST /api/sessions/:id/conflicts/:cid/judge -- run LLM debate judge
+  app.post("/api/sessions/:id/conflicts/:cid/judge", async (req: Request, res: Response) => {
+    if (!conflictResolution) {
+      return res.status(503).json({ error: "Conflict resolution service not available" });
+    }
+
+    try {
+      const judgement = await conflictResolution.runDebateJudge(String(req.params.cid));
+      return res.json(judgement);
+    } catch (err) {
+      const msg = (err as Error).message;
+      if (msg.includes("not found") || msg.includes("already")) {
+        return res.status(404).json({ error: msg });
+      }
+      if (msg.includes("No LLM gateway")) {
+        return res.status(503).json({ error: msg });
+      }
+      return res.status(400).json({ error: msg });
+    }
+  });
+
+  // POST /api/sessions/:id/conflicts/:cid/experiment -- update an experiment branch
+  app.post("/api/sessions/:id/conflicts/:cid/experiment", async (req: Request, res: Response) => {
+    if (!conflictResolution) {
+      return res.status(503).json({ error: "Conflict resolution service not available" });
+    }
+
+    const parsed = UpdateExperimentBranchSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid request", issues: parsed.error.flatten() });
+    }
+
+    try {
+      const conflict = await conflictResolution.updateExperimentBranch(
+        String(req.params.cid),
+        {
+          proposalId: parsed.data.proposalId,
+          runId: parsed.data.runId,
+          status: parsed.data.status,
+          outcome: parsed.data.outcome,
+          completedAt: parsed.data.status !== "pending" ? Date.now() : undefined,
+        },
+      );
+      return res.json(conflict);
+    } catch (err) {
+      const msg = (err as Error).message;
+      if (msg.includes("not found") || msg.includes("already")) {
+        return res.status(404).json({ error: msg });
+      }
+      return res.status(400).json({ error: msg });
+    }
+  });
+
+  // GET /api/sessions/:id/decision-log -- get decision log for a session
+  app.get("/api/sessions/:id/decision-log", (_req: Request, res: Response) => {
+    if (!conflictResolution) {
+      return res.status(503).json({ error: "Conflict resolution service not available" });
+    }
+
+    const log = conflictResolution.getSessionDecisionLog(String(_req.params.id));
+    return res.json(log);
   });
 }

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -68,8 +68,12 @@ import {
   type InsertBudget,
   type UpdateBudget,
   workspaceSettings,
+  sessionConflicts,
+  decisionLog,
+  type SessionConflictRow,
+  type DecisionLogRow,
 } from "@shared/schema";
-import type { TraceSpan, SkillVersionRecord, MarketplaceSkill, MarketplaceFilters, InsertSkillVersion, SharedSession, CreateSharedSessionInput, ShareRole, WorkspaceConnection, CreateWorkspaceConnectionInput, UpdateWorkspaceConnectionInput, McpToolCall, ConnectionUsageMetrics, RecordMcpToolCallInput } from "@shared/types";
+import type { TraceSpan, SkillVersionRecord, MarketplaceSkill, MarketplaceFilters, InsertSkillVersion, SharedSession, CreateSharedSessionInput, ShareRole, WorkspaceConnection, CreateWorkspaceConnectionInput, UpdateWorkspaceConnectionInput, McpToolCall, ConnectionUsageMetrics, RecordMcpToolCallInput, SessionConflict, DecisionLogEntry, RaiseConflictInput, CastConflictVoteInput, DebateJudgement, ExperimentBranchResult, ResolutionOutcome } from "@shared/types";
 
 import { encrypt, decrypt } from "./crypto";
 
@@ -1729,6 +1733,126 @@ export class PgStorage implements IStorage {
           set: { value: value as Record<string, unknown>, updatedAt: new Date() },
         });
     }
+  }
+
+  // ── Conflict Resolution (issue #229) ──────────────────────────────────────
+
+  private rowToSessionConflict(row: SessionConflictRow): SessionConflict {
+    return {
+      id: row.id,
+      sessionId: row.sessionId,
+      raisedBy: row.raisedBy,
+      raisedByInstance: row.raisedByInstance,
+      question: row.question,
+      context: row.context ?? undefined,
+      strategy: row.strategy as SessionConflict["strategy"],
+      status: row.status as SessionConflict["status"],
+      proposals: (row.proposals as SessionConflict["proposals"]) ?? [],
+      votes: (row.votes as SessionConflict["votes"]) ?? [],
+      quorumThreshold: row.quorumThreshold,
+      timeoutMs: row.timeoutMs,
+      judgement: row.judgement as SessionConflict["judgement"] ?? undefined,
+      experimentResults: row.experimentResults as SessionConflict["experimentResults"] ?? undefined,
+      outcome: row.outcome as SessionConflict["outcome"] ?? undefined,
+      createdAt: row.createdAt.getTime(),
+      updatedAt: row.updatedAt.getTime(),
+    };
+  }
+
+  private rowToDecisionLogEntry(row: DecisionLogRow): DecisionLogEntry {
+    return {
+      id: row.id,
+      sessionId: row.sessionId,
+      conflictId: row.conflictId,
+      question: row.question,
+      strategy: row.strategy as DecisionLogEntry["strategy"],
+      outcome: row.outcome as DecisionLogEntry["outcome"],
+      participantCount: row.participantCount,
+      proposalCount: row.proposalCount,
+      durationMs: row.durationMs,
+      recordedAt: row.recordedAt.getTime(),
+    };
+  }
+
+  async saveConflict(conflict: SessionConflict): Promise<void> {
+    await db
+      .insert(sessionConflicts)
+      .values({
+        id: conflict.id,
+        sessionId: conflict.sessionId,
+        raisedBy: conflict.raisedBy,
+        raisedByInstance: conflict.raisedByInstance,
+        question: conflict.question,
+        context: conflict.context ?? null,
+        strategy: conflict.strategy,
+        status: conflict.status,
+        proposals: conflict.proposals as unknown as typeof sessionConflicts.$inferInsert["proposals"],
+        votes: conflict.votes as unknown as typeof sessionConflicts.$inferInsert["votes"],
+        quorumThreshold: conflict.quorumThreshold,
+        timeoutMs: conflict.timeoutMs,
+        judgement: conflict.judgement as unknown as typeof sessionConflicts.$inferInsert["judgement"] ?? null,
+        experimentResults: conflict.experimentResults as unknown as typeof sessionConflicts.$inferInsert["experimentResults"] ?? null,
+        outcome: conflict.outcome as unknown as typeof sessionConflicts.$inferInsert["outcome"] ?? null,
+        createdAt: new Date(conflict.createdAt),
+        updatedAt: new Date(conflict.updatedAt),
+      } as typeof sessionConflicts.$inferInsert)
+      .onConflictDoUpdate({
+        target: sessionConflicts.id,
+        set: {
+          status: conflict.status,
+          proposals: conflict.proposals as unknown as typeof sessionConflicts.$inferInsert["proposals"],
+          votes: conflict.votes as unknown as typeof sessionConflicts.$inferInsert["votes"],
+          judgement: conflict.judgement as unknown as typeof sessionConflicts.$inferInsert["judgement"] ?? null,
+          experimentResults: conflict.experimentResults as unknown as typeof sessionConflicts.$inferInsert["experimentResults"] ?? null,
+          outcome: conflict.outcome as unknown as typeof sessionConflicts.$inferInsert["outcome"] ?? null,
+          updatedAt: new Date(conflict.updatedAt),
+        },
+      });
+  }
+
+  async getConflict(conflictId: string): Promise<SessionConflict | null> {
+    const [row] = await db
+      .select()
+      .from(sessionConflicts)
+      .where(eq(sessionConflicts.id, conflictId));
+    return row ? this.rowToSessionConflict(row) : null;
+  }
+
+  async getSessionConflicts(sessionId: string): Promise<SessionConflict[]> {
+    const rows = await db
+      .select()
+      .from(sessionConflicts)
+      .where(eq(sessionConflicts.sessionId, sessionId))
+      .orderBy(desc(sessionConflicts.createdAt));
+    return rows.map((r) => this.rowToSessionConflict(r));
+  }
+
+  async appendDecisionLog(entry: DecisionLogEntry): Promise<void> {
+    await db.insert(decisionLog).values({
+      id: entry.id,
+      sessionId: entry.sessionId,
+      conflictId: entry.conflictId,
+      question: entry.question,
+      strategy: entry.strategy,
+      outcome: entry.outcome as unknown as typeof decisionLog.$inferInsert["outcome"],
+      participantCount: entry.participantCount,
+      proposalCount: entry.proposalCount,
+      durationMs: entry.durationMs,
+      recordedAt: new Date(entry.recordedAt),
+    } as typeof decisionLog.$inferInsert);
+  }
+
+  async getDecisionLog(sessionId?: string): Promise<DecisionLogEntry[]> {
+    const query = db
+      .select()
+      .from(decisionLog)
+      .orderBy(desc(decisionLog.recordedAt));
+
+    const rows = sessionId
+      ? await query.where(eq(decisionLog.sessionId, sessionId))
+      : await query;
+
+    return rows.map((r) => this.rowToDecisionLogEntry(r));
   }
 
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -56,7 +56,7 @@ import {
   type UpdateBudget,
   type WorkspaceSettingsRow,
 } from "@shared/schema";
-import type { Memory, InsertMemory, MemoryScope, MemoryType, McpServerConfig, TraceSpan, TaskTraceSpan, SkillVersionRecord, MarketplaceSkill, MarketplaceFilters, InsertSkillVersion as InsertSkillVersionType, SharedSession, CreateSharedSessionInput, SharePermissions, ShareRole, WorkspaceConnection, CreateWorkspaceConnectionInput, UpdateWorkspaceConnectionInput, McpToolCall, ConnectionUsageMetrics, RecordMcpToolCallInput } from "@shared/types";
+import type { Memory, InsertMemory, MemoryScope, MemoryType, McpServerConfig, TraceSpan, TaskTraceSpan, SkillVersionRecord, MarketplaceSkill, MarketplaceFilters, InsertSkillVersion as InsertSkillVersionType, SharedSession, CreateSharedSessionInput, SharePermissions, ShareRole, WorkspaceConnection, CreateWorkspaceConnectionInput, UpdateWorkspaceConnectionInput, McpToolCall, ConnectionUsageMetrics, RecordMcpToolCallInput, SessionConflict, DecisionLogEntry, RaiseConflictInput, CastConflictVoteInput, DebateJudgement, ExperimentBranchResult, ResolutionOutcome } from "@shared/types";
 import { randomUUID } from "crypto";
 import { PgStorage } from "./storage-pg";
 import { configLoader } from "./config/loader";
@@ -343,6 +343,13 @@ export interface IStorage {
   // Workspace Settings (issue #280)
   getWorkspaceSettings(workspaceId: string): Promise<Record<string, unknown> | null>;
   upsertWorkspaceSettings(workspaceId: string, patch: Record<string, unknown>): Promise<void>;
+
+  // Conflict Resolution (issue #229)
+  saveConflict(conflict: SessionConflict): Promise<void>;
+  getConflict(conflictId: string): Promise<SessionConflict | null>;
+  getSessionConflicts(sessionId: string): Promise<SessionConflict[]>;
+  appendDecisionLog(entry: DecisionLogEntry): Promise<void>;
+  getDecisionLog(sessionId?: string): Promise<DecisionLogEntry[]>;
 }
 
 export class MemStorage implements IStorage {
@@ -2083,6 +2090,36 @@ export class MemStorage implements IStorage {
   async upsertWorkspaceSettings(workspaceId: string, patch: Record<string, unknown>): Promise<void> {
     const existing = this.workspaceSettingsMap.get(workspaceId) ?? {};
     this.workspaceSettingsMap.set(workspaceId, { ...existing, ...patch });
+  }
+
+  // ── Conflict Resolution (issue #229) ────────────────────────────────────────
+
+  private conflictsMap: Map<string, SessionConflict> = new Map();
+  private decisionLogEntries: DecisionLogEntry[] = [];
+
+  async saveConflict(conflict: SessionConflict): Promise<void> {
+    this.conflictsMap.set(conflict.id, { ...conflict });
+  }
+
+  async getConflict(conflictId: string): Promise<SessionConflict | null> {
+    return this.conflictsMap.get(conflictId) ?? null;
+  }
+
+  async getSessionConflicts(sessionId: string): Promise<SessionConflict[]> {
+    return Array.from(this.conflictsMap.values()).filter(
+      (c) => c.sessionId === sessionId,
+    );
+  }
+
+  async appendDecisionLog(entry: DecisionLogEntry): Promise<void> {
+    this.decisionLogEntries.push({ ...entry });
+  }
+
+  async getDecisionLog(sessionId?: string): Promise<DecisionLogEntry[]> {
+    if (sessionId) {
+      return this.decisionLogEntries.filter((e) => e.sessionId === sessionId);
+    }
+    return [...this.decisionLogEntries];
   }
 
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1514,3 +1514,81 @@ export const embeddingProviderConfig = pgTable(
 );
 
 export type EmbeddingProviderConfigRow = typeof embeddingProviderConfig.$inferSelect;
+
+// ── Federation: Subjective Conflict Resolution (issue #229) ──────────────────
+
+export const CONFLICT_STRATEGIES = [
+  "structured_debate",
+  "quorum_vote",
+  "parallel_experiment",
+  "defer_to_owner",
+] as const;
+
+export const CONFLICT_STATUSES = [
+  "open",
+  "debate_in_progress",
+  "voting_in_progress",
+  "experiment_in_progress",
+  "resolved",
+  "expired",
+] as const;
+
+/**
+ * Active/open conflict records (mutable during dispute lifecycle).
+ * Proposals, votes, and ephemeral state are stored as JSONB for flexibility.
+ */
+export const sessionConflicts = pgTable(
+  "session_conflicts",
+  {
+    id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+    sessionId: varchar("session_id").notNull(),
+    raisedBy: text("raised_by").notNull(),
+    raisedByInstance: text("raised_by_instance").notNull(),
+    question: text("question").notNull(),
+    context: text("context"),
+    strategy: text("strategy").notNull().$type<typeof CONFLICT_STRATEGIES[number]>(),
+    status: text("status").notNull().default("open").$type<typeof CONFLICT_STATUSES[number]>(),
+    proposals: jsonb("proposals").notNull().default(sql`'[]'::jsonb`),
+    votes: jsonb("votes").notNull().default(sql`'[]'::jsonb`),
+    quorumThreshold: real("quorum_threshold").notNull().default(0.67),
+    timeoutMs: integer("timeout_ms").notNull().default(300_000),
+    judgement: jsonb("judgement"),
+    experimentResults: jsonb("experiment_results"),
+    outcome: jsonb("outcome"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [
+    index("session_conflicts_session_idx").on(table.sessionId),
+    index("session_conflicts_status_idx").on(table.status),
+  ],
+);
+
+export type SessionConflictRow = typeof sessionConflicts.$inferSelect;
+
+/**
+ * Decision log (append-only).
+ * Written once when a conflict resolves; never updated.
+ */
+export const decisionLog = pgTable(
+  "decision_log",
+  {
+    id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+    sessionId: varchar("session_id").notNull(),
+    conflictId: varchar("conflict_id").notNull(),
+    question: text("question").notNull(),
+    strategy: text("strategy").notNull().$type<typeof CONFLICT_STRATEGIES[number]>(),
+    outcome: jsonb("outcome").notNull(),
+    participantCount: integer("participant_count").notNull().default(0),
+    proposalCount: integer("proposal_count").notNull().default(0),
+    durationMs: integer("duration_ms").notNull().default(0),
+    recordedAt: timestamp("recorded_at").notNull().defaultNow(),
+  },
+  (table) => [
+    index("decision_log_session_idx").on(table.sessionId),
+    index("decision_log_conflict_idx").on(table.conflictId),
+    index("decision_log_recorded_at_idx").on(table.recordedAt),
+  ],
+);
+
+export type DecisionLogRow = typeof decisionLog.$inferSelect;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -2698,3 +2698,123 @@ export interface WorkspaceTracesQuery {
   /** Filter to a specific pipeline run ID. */
   runId?: string;
 }
+
+// ── Federation: Subjective Conflict Resolution (issue #229) ──────────────────
+
+/** Strategy used to resolve a subjective dispute in a shared session. */
+export type SubjectiveResolutionStrategy =
+  | "structured_debate"
+  | "quorum_vote"
+  | "parallel_experiment"
+  | "defer_to_owner";
+
+/** Current lifecycle state of a conflict. */
+export type ConflictStatus =
+  | "open"
+  | "debate_in_progress"
+  | "voting_in_progress"
+  | "experiment_in_progress"
+  | "resolved"
+  | "expired";
+
+/** A single option submitted to a quorum vote or debate. */
+export interface ConflictProposal {
+  id: string;
+  authorId: string;
+  instanceId: string;
+  title: string;
+  description: string;
+  arguments?: string;
+  submittedAt: number;
+}
+
+/** A participant's vote on a specific proposal. */
+export interface ConflictVote {
+  participantId: string;
+  instanceId: string;
+  proposalId: string;
+  anonymous: boolean;
+  submittedAt: number;
+}
+
+/** Result of a debate round: the LLM judge's evaluation. */
+export interface DebateJudgement {
+  judgeModelSlug: string;
+  winner?: string;
+  reasoning: string;
+  confidence: number;
+  evaluatedAt: number;
+}
+
+/** Outcome of a parallel experiment branch. */
+export interface ExperimentBranchResult {
+  proposalId: string;
+  runId: string;
+  status: "pending" | "completed" | "failed";
+  outcome?: string;
+  completedAt?: number;
+}
+
+/** Final outcome of a conflict resolution process. */
+export interface ResolutionOutcome {
+  strategy: SubjectiveResolutionStrategy;
+  winningProposalId?: string;
+  reasoning: string;
+  decidedBy: "quorum" | "judge" | "owner" | "timeout";
+  decidedAt: number;
+}
+
+/** A subjective conflict in a shared session. */
+export interface SessionConflict {
+  id: string;
+  sessionId: string;
+  raisedBy: string;
+  raisedByInstance: string;
+  question: string;
+  context?: string;
+  strategy: SubjectiveResolutionStrategy;
+  status: ConflictStatus;
+  proposals: ConflictProposal[];
+  votes: ConflictVote[];
+  quorumThreshold: number;
+  timeoutMs: number;
+  judgement?: DebateJudgement;
+  experimentResults?: ExperimentBranchResult[];
+  outcome?: ResolutionOutcome;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** Input for raising a new conflict. */
+export interface RaiseConflictInput {
+  sessionId: string;
+  raisedBy: string;
+  raisedByInstance: string;
+  question: string;
+  context?: string;
+  strategy: SubjectiveResolutionStrategy;
+  quorumThreshold?: number;
+  timeoutMs?: number;
+}
+
+/** Input for casting a vote on a conflict. */
+export interface CastConflictVoteInput {
+  participantId: string;
+  instanceId: string;
+  proposalId: string;
+  anonymous?: boolean;
+}
+
+/** A decision log entry (append-only). */
+export interface DecisionLogEntry {
+  id: string;
+  sessionId: string;
+  conflictId: string;
+  question: string;
+  strategy: SubjectiveResolutionStrategy;
+  outcome: ResolutionOutcome;
+  participantCount: number;
+  proposalCount: number;
+  durationMs: number;
+  recordedAt: number;
+}

--- a/tests/unit/conflict-resolution-routes.test.ts
+++ b/tests/unit/conflict-resolution-routes.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Tests for Conflict Resolution API routes (issue #229)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import { registerFederationRoutes } from "../../server/routes/federation";
+import type { ConflictResolutionService } from "../../server/federation/conflict-resolution";
+import type { SessionConflict } from "../../shared/types";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeConflict(overrides: Partial<SessionConflict> = {}): SessionConflict {
+  const now = Date.now();
+  return {
+    id: "conflict-1",
+    sessionId: "session-1",
+    raisedBy: "user-1",
+    raisedByInstance: "instance-1",
+    question: "REST vs GraphQL?",
+    strategy: "quorum_vote",
+    status: "open",
+    proposals: [],
+    votes: [],
+    quorumThreshold: 0.67,
+    timeoutMs: 300_000,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function createMockConflictService(): ConflictResolutionService {
+  const conflict = makeConflict();
+
+  return {
+    raiseConflict: vi.fn(async () => ({
+      conflictId: "conflict-1",
+      resolution: Promise.resolve({
+        strategy: "quorum_vote" as const,
+        reasoning: "Quorum reached.",
+        decidedBy: "quorum" as const,
+        decidedAt: Date.now(),
+      }),
+    })),
+    getConflict: vi.fn(() => conflict),
+    getSessionConflicts: vi.fn(() => [conflict]),
+    addProposal: vi.fn(async () => ({ ...conflict, proposals: [] })),
+    castVote: vi.fn(async () => conflict),
+    forceResolve: vi.fn(async () => ({ ...conflict, status: "resolved" as const })),
+    runDebateJudge: vi.fn(async () => ({
+      judgeModelSlug: "default",
+      reasoning: "Proposal 1 wins.",
+      confidence: 0.9,
+      evaluatedAt: Date.now(),
+    })),
+    updateExperimentBranch: vi.fn(async () => conflict),
+    getSessionDecisionLog: vi.fn(() => []),
+    getDecisionLog: vi.fn(() => []),
+    submitDebateJudgement: vi.fn(async () => conflict),
+    _triggerTimeout: vi.fn(async () => {}),
+    _getPendingCount: vi.fn(() => 0),
+  } as unknown as ConflictResolutionService;
+}
+
+function buildApp(conflictService: ConflictResolutionService | null = null) {
+  const app = express();
+  app.use(express.json());
+
+  // Inject a mock user
+  app.use((req, _res, next) => {
+    (req as unknown as { user: { id: string; role: string } }).user = {
+      id: "user-1",
+      role: "user",
+    };
+    next();
+  });
+
+  registerFederationRoutes(
+    app,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    conflictService,
+  );
+
+  return app;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("Conflict Resolution Routes", () => {
+  let mockService: ConflictResolutionService;
+  let app: express.Application;
+
+  beforeEach(() => {
+    mockService = createMockConflictService();
+    app = buildApp(mockService);
+  });
+
+  // ── POST /api/sessions/:id/conflicts ─────────────────────────────────────────
+
+  describe("POST /api/sessions/:id/conflicts", () => {
+    it("returns 201 with the new conflict", async () => {
+      const res = await request(app)
+        .post("/api/sessions/session-1/conflicts")
+        .send({
+          question: "REST vs GraphQL?",
+          strategy: "quorum_vote",
+        });
+
+      expect(res.status).toBe(201);
+      expect(res.body.id).toBe("conflict-1");
+      expect(mockService.raiseConflict).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: "session-1",
+          raisedBy: "user-1",
+          question: "REST vs GraphQL?",
+          strategy: "quorum_vote",
+        }),
+      );
+    });
+
+    it("returns 400 for missing question", async () => {
+      const res = await request(app)
+        .post("/api/sessions/session-1/conflicts")
+        .send({ strategy: "quorum_vote" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBeTruthy();
+    });
+
+    it("returns 400 for invalid strategy", async () => {
+      const res = await request(app)
+        .post("/api/sessions/session-1/conflicts")
+        .send({ question: "Q", strategy: "invalid_strategy" });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 503 when service is not available", async () => {
+      const res = await request(buildApp(null))
+        .post("/api/sessions/session-1/conflicts")
+        .send({ question: "Q", strategy: "quorum_vote" });
+
+      expect(res.status).toBe(503);
+    });
+  });
+
+  // ── GET /api/sessions/:id/conflicts ──────────────────────────────────────────
+
+  describe("GET /api/sessions/:id/conflicts", () => {
+    it("returns 200 with conflict list", async () => {
+      const res = await request(app).get("/api/sessions/session-1/conflicts");
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body[0].id).toBe("conflict-1");
+    });
+
+    it("returns 503 when service is not available", async () => {
+      const res = await request(buildApp(null)).get(
+        "/api/sessions/session-1/conflicts",
+      );
+      expect(res.status).toBe(503);
+    });
+  });
+
+  // ── POST /api/sessions/:id/conflicts/:cid/proposals ──────────────────────────
+
+  describe("POST /api/sessions/:id/conflicts/:cid/proposals", () => {
+    it("returns 201 with updated conflict", async () => {
+      const res = await request(app)
+        .post("/api/sessions/session-1/conflicts/conflict-1/proposals")
+        .send({
+          authorId: "user-1",
+          instanceId: "instance-1",
+          title: "Use REST",
+          description: "Simple and well-understood",
+        });
+
+      expect(res.status).toBe(201);
+      expect(mockService.addProposal).toHaveBeenCalledWith(
+        "conflict-1",
+        expect.objectContaining({ title: "Use REST" }),
+      );
+    });
+
+    it("returns 400 for missing required fields", async () => {
+      const res = await request(app)
+        .post("/api/sessions/session-1/conflicts/conflict-1/proposals")
+        .send({ title: "Incomplete" });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 404 when service throws 'not found'", async () => {
+      (mockService.addProposal as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error("Conflict xyz not found."),
+      );
+
+      const res = await request(app)
+        .post("/api/sessions/session-1/conflicts/xyz/proposals")
+        .send({
+          authorId: "u1",
+          instanceId: "i1",
+          title: "T",
+          description: "D",
+        });
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ── POST /api/sessions/:id/conflicts/:cid/vote ────────────────────────────────
+
+  describe("POST /api/sessions/:id/conflicts/:cid/vote", () => {
+    it("returns 200 with updated conflict", async () => {
+      const res = await request(app)
+        .post("/api/sessions/session-1/conflicts/conflict-1/vote")
+        .send({
+          participantId: "user-1",
+          instanceId: "instance-1",
+          proposalId: "proposal-1",
+        });
+
+      expect(res.status).toBe(200);
+      expect(mockService.castVote).toHaveBeenCalledWith(
+        "conflict-1",
+        expect.objectContaining({ proposalId: "proposal-1" }),
+      );
+    });
+
+    it("returns 409 when duplicate vote detected", async () => {
+      (mockService.castVote as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error("Participant user-1 has already voted on conflict conflict-1."),
+      );
+
+      const res = await request(app)
+        .post("/api/sessions/session-1/conflicts/conflict-1/vote")
+        .send({
+          participantId: "user-1",
+          instanceId: "instance-1",
+          proposalId: "proposal-1",
+        });
+
+      expect(res.status).toBe(409);
+    });
+
+    it("returns 400 for missing fields", async () => {
+      const res = await request(app)
+        .post("/api/sessions/session-1/conflicts/conflict-1/vote")
+        .send({ participantId: "user-1" });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ── POST /api/sessions/:id/conflicts/:cid/resolve ─────────────────────────────
+
+  describe("POST /api/sessions/:id/conflicts/:cid/resolve", () => {
+    it("returns 200 with resolved conflict", async () => {
+      const res = await request(app)
+        .post("/api/sessions/session-1/conflicts/conflict-1/resolve")
+        .send({ reasoning: "Owner decided." });
+
+      expect(res.status).toBe(200);
+      expect(mockService.forceResolve).toHaveBeenCalledWith(
+        "conflict-1",
+        undefined,
+        "Owner decided.",
+        undefined,
+      );
+    });
+
+    it("returns 404 when already resolved", async () => {
+      (mockService.forceResolve as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error("Conflict conflict-1 is already resolved."),
+      );
+
+      const res = await request(app)
+        .post("/api/sessions/session-1/conflicts/conflict-1/resolve")
+        .send({ reasoning: "Again?" });
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 for missing reasoning", async () => {
+      const res = await request(app)
+        .post("/api/sessions/session-1/conflicts/conflict-1/resolve")
+        .send({});
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ── POST /api/sessions/:id/conflicts/:cid/judge ──────────────────────────────
+
+  describe("POST /api/sessions/:id/conflicts/:cid/judge", () => {
+    it("returns 200 with judgement", async () => {
+      const res = await request(app).post(
+        "/api/sessions/session-1/conflicts/conflict-1/judge",
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.reasoning).toBe("Proposal 1 wins.");
+    });
+
+    it("returns 503 when no gateway available", async () => {
+      (mockService.runDebateJudge as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error("No LLM gateway available for debate judgement."),
+      );
+
+      const res = await request(app).post(
+        "/api/sessions/session-1/conflicts/conflict-1/judge",
+      );
+
+      expect(res.status).toBe(503);
+    });
+  });
+
+  // ── POST /api/sessions/:id/conflicts/:cid/experiment ─────────────────────────
+
+  describe("POST /api/sessions/:id/conflicts/:cid/experiment", () => {
+    it("returns 200 with updated conflict", async () => {
+      const res = await request(app)
+        .post("/api/sessions/session-1/conflicts/conflict-1/experiment")
+        .send({
+          proposalId: "proposal-1",
+          runId: "run-abc",
+          status: "completed",
+          outcome: "10ms avg",
+        });
+
+      expect(res.status).toBe(200);
+      expect(mockService.updateExperimentBranch).toHaveBeenCalledWith(
+        "conflict-1",
+        expect.objectContaining({ proposalId: "proposal-1", status: "completed" }),
+      );
+    });
+
+    it("returns 400 for invalid status", async () => {
+      const res = await request(app)
+        .post("/api/sessions/session-1/conflicts/conflict-1/experiment")
+        .send({ proposalId: "p1", runId: "r1", status: "unknown_status" });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ── GET /api/sessions/:id/decision-log ───────────────────────────────────────
+
+  describe("GET /api/sessions/:id/decision-log", () => {
+    it("returns 200 with empty array", async () => {
+      const res = await request(app).get(
+        "/api/sessions/session-1/decision-log",
+      );
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+    });
+
+    it("calls getSessionDecisionLog with the session ID", async () => {
+      await request(app).get("/api/sessions/session-42/decision-log");
+      expect(mockService.getSessionDecisionLog).toHaveBeenCalledWith("session-42");
+    });
+
+    it("returns 503 when service is not available", async () => {
+      const res = await request(buildApp(null)).get(
+        "/api/sessions/session-1/decision-log",
+      );
+      expect(res.status).toBe(503);
+    });
+  });
+});

--- a/tests/unit/conflict-resolution.test.ts
+++ b/tests/unit/conflict-resolution.test.ts
@@ -1,0 +1,939 @@
+/**
+ * Tests for ConflictResolutionService (issue #229)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  ConflictResolutionService,
+  type ConflictStorageSink,
+} from "../../server/federation/conflict-resolution";
+import type { Gateway } from "../../server/gateway/index";
+import type {
+  SessionConflict,
+  DecisionLogEntry,
+  ResolutionOutcome,
+} from "../../shared/types";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function createMockGateway(
+  response: string = '{"winner":"p1","reasoning":"Proposal 1 is superior.","confidence":0.9}',
+): Gateway {
+  return {
+    complete: vi.fn(async () => ({
+      content: response,
+      tokensUsed: 50,
+      modelSlug: "default",
+      finishReason: "stop",
+    })),
+  } as unknown as Gateway;
+}
+
+function createMockSink(): ConflictStorageSink & {
+  _conflicts: Map<string, SessionConflict>;
+  _log: DecisionLogEntry[];
+} {
+  const _conflicts = new Map<string, SessionConflict>();
+  const _log: DecisionLogEntry[] = [];
+
+  return {
+    _conflicts,
+    _log,
+    async saveConflict(c: SessionConflict) {
+      _conflicts.set(c.id, { ...c });
+    },
+    async appendDecisionLog(e: DecisionLogEntry) {
+      _log.push({ ...e });
+    },
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("ConflictResolutionService", () => {
+  let gateway: Gateway;
+  let sink: ReturnType<typeof createMockSink>;
+  let service: ConflictResolutionService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    gateway = createMockGateway();
+    sink = createMockSink();
+    service = new ConflictResolutionService(gateway, sink);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ── raiseConflict ─────────────────────────────────────────────────────────────
+
+  describe("raiseConflict", () => {
+    it("creates a conflict with correct initial state", async () => {
+      const { conflictId } = await service.raiseConflict({
+        sessionId: "session-1",
+        raisedBy: "user-1",
+        raisedByInstance: "instance-1",
+        question: "Should we use REST or GraphQL?",
+        strategy: "quorum_vote",
+      });
+
+      const conflict = service.getConflict(conflictId);
+      expect(conflict).not.toBeNull();
+      expect(conflict!.sessionId).toBe("session-1");
+      expect(conflict!.question).toBe("Should we use REST or GraphQL?");
+      expect(conflict!.status).toBe("open");
+      expect(conflict!.strategy).toBe("quorum_vote");
+      expect(conflict!.proposals).toHaveLength(0);
+      expect(conflict!.votes).toHaveLength(0);
+    });
+
+    it("persists the conflict to the sink", async () => {
+      const { conflictId } = await service.raiseConflict({
+        sessionId: "session-1",
+        raisedBy: "user-1",
+        raisedByInstance: "instance-1",
+        question: "Microservices vs monolith?",
+        strategy: "structured_debate",
+      });
+
+      expect(sink._conflicts.has(conflictId)).toBe(true);
+    });
+
+    it("uses default quorum threshold when not provided", async () => {
+      const { conflictId } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "quorum_vote",
+      });
+
+      expect(service.getConflict(conflictId)!.quorumThreshold).toBe(0.67);
+    });
+
+    it("applies custom quorum threshold", async () => {
+      const { conflictId } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "quorum_vote",
+        quorumThreshold: 0.75,
+      });
+
+      expect(service.getConflict(conflictId)!.quorumThreshold).toBe(0.75);
+    });
+
+    it("defer_to_owner resolves immediately", async () => {
+      const { resolution } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "defer_to_owner",
+      });
+
+      const outcome = await resolution;
+      expect(outcome.strategy).toBe("defer_to_owner");
+      expect(outcome.decidedBy).toBe("owner");
+    });
+
+    it("returns a resolution promise that resolves after quorum", async () => {
+      // Threshold=0.8, minimum 2 votes required.
+      // Strategy: 1 vote for B (minority), then 4 votes for A.
+      // After 5 total votes, A has 4/5=80% → quorum met.
+      const { conflictId, resolution } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "quorum_vote",
+        quorumThreshold: 0.8,
+      });
+
+      // Add two competing proposals
+      await service.addProposal(conflictId, {
+        authorId: "u1",
+        instanceId: "i1",
+        title: "Option A",
+        description: "Use REST",
+      });
+      await service.addProposal(conflictId, {
+        authorId: "u2",
+        instanceId: "i2",
+        title: "Option B",
+        description: "Use GraphQL",
+      });
+
+      const proposals = service.getConflict(conflictId)!.proposals;
+
+      // Cast first vote for B (minority), then three for A
+      await service.castVote(conflictId, { participantId: "user-4", instanceId: "i4", proposalId: proposals[1].id });
+      await service.castVote(conflictId, { participantId: "user-1", instanceId: "i1", proposalId: proposals[0].id });
+      await service.castVote(conflictId, { participantId: "user-2", instanceId: "i2", proposalId: proposals[0].id });
+      await service.castVote(conflictId, { participantId: "user-3", instanceId: "i3", proposalId: proposals[0].id });
+
+      // 4 total: A=3/4=75% < 80% — not resolved yet
+      expect(service.getConflict(conflictId)!.status).not.toBe("resolved");
+
+      // 5th vote pushes A to 4/5=80% → quorum met
+      await service.castVote(conflictId, { participantId: "user-5", instanceId: "i5", proposalId: proposals[0].id });
+
+      const outcome = await resolution;
+      expect(outcome.strategy).toBe("quorum_vote");
+      expect(outcome.winningProposalId).toBe(proposals[0].id);
+      expect(outcome.decidedBy).toBe("quorum");
+    });
+  });
+
+  // ── addProposal ──────────────────────────────────────────────────────────────
+
+  describe("addProposal", () => {
+    it("adds a proposal to the conflict", async () => {
+      const { conflictId } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "structured_debate",
+      });
+
+      const updated = await service.addProposal(conflictId, {
+        authorId: "u1",
+        instanceId: "i1",
+        title: "Use DDD",
+        description: "Domain-driven design approach",
+        arguments: "Better separation of concerns",
+      });
+
+      expect(updated.proposals).toHaveLength(1);
+      expect(updated.proposals[0].title).toBe("Use DDD");
+      expect(updated.proposals[0].id).toBeTruthy();
+    });
+
+    it("transitions debate conflict to debate_in_progress", async () => {
+      const { conflictId } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "structured_debate",
+      });
+
+      const updated = await service.addProposal(conflictId, {
+        authorId: "u1",
+        instanceId: "i1",
+        title: "Proposal 1",
+        description: "First proposal",
+      });
+
+      expect(updated.status).toBe("debate_in_progress");
+    });
+
+    it("transitions quorum conflict to voting_in_progress", async () => {
+      const { conflictId } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "quorum_vote",
+      });
+
+      const updated = await service.addProposal(conflictId, {
+        authorId: "u1",
+        instanceId: "i1",
+        title: "Vote target",
+        description: "Option to vote on",
+      });
+
+      expect(updated.status).toBe("voting_in_progress");
+    });
+
+    it("transitions parallel_experiment conflict and creates branch stubs", async () => {
+      const { conflictId } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "parallel_experiment",
+      });
+
+      const updated = await service.addProposal(conflictId, {
+        authorId: "u1",
+        instanceId: "i1",
+        title: "Branch A",
+        description: "First branch",
+      });
+
+      expect(updated.status).toBe("experiment_in_progress");
+      expect(updated.experimentResults).toHaveLength(1);
+      expect(updated.experimentResults![0].status).toBe("pending");
+    });
+
+    it("throws when conflict is resolved", async () => {
+      const { conflictId } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "defer_to_owner",
+      });
+
+      // defer_to_owner resolves immediately
+      await expect(
+        service.addProposal(conflictId, {
+          authorId: "u1",
+          instanceId: "i1",
+          title: "Too late",
+          description: "Already resolved",
+        }),
+      ).rejects.toThrow("already resolved");
+    });
+
+    it("enforces max proposals limit", async () => {
+      const { conflictId } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "structured_debate",
+      });
+
+      for (let i = 0; i < 10; i++) {
+        await service.addProposal(conflictId, {
+          authorId: "u1",
+          instanceId: "i1",
+          title: `Proposal ${i}`,
+          description: "desc",
+        });
+      }
+
+      await expect(
+        service.addProposal(conflictId, {
+          authorId: "u1",
+          instanceId: "i1",
+          title: "Too many",
+          description: "Over limit",
+        }),
+      ).rejects.toThrow("maximum");
+    });
+  });
+
+  // ── castVote ─────────────────────────────────────────────────────────────────
+
+  describe("castVote", () => {
+    // Use threshold=1.0 (100% unanimous) so individual votes during setup
+    // don't accidentally trigger quorum resolution.
+    async function setupVotingConflict(threshold = 1.0) {
+      const { conflictId, resolution } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "quorum_vote",
+        quorumThreshold: threshold,
+      });
+
+      await service.addProposal(conflictId, {
+        authorId: "u1",
+        instanceId: "i1",
+        title: "Option A",
+        description: "A",
+      });
+
+      await service.addProposal(conflictId, {
+        authorId: "u2",
+        instanceId: "i2",
+        title: "Option B",
+        description: "B",
+      });
+
+      const proposals = service.getConflict(conflictId)!.proposals;
+      return { conflictId, resolution, proposals };
+    }
+
+    it("records a vote without auto-resolving", async () => {
+      const { conflictId, proposals } = await setupVotingConflict(1.0);
+
+      const updated = await service.castVote(conflictId, {
+        participantId: "user-1",
+        instanceId: "i1",
+        proposalId: proposals[0].id,
+      });
+
+      expect(updated.votes).toHaveLength(1);
+      expect(updated.votes[0].proposalId).toBe(proposals[0].id);
+      // Not resolved yet — unanimity (1.0) requires all votes
+      expect(updated.status).not.toBe("resolved");
+    });
+
+    it("prevents duplicate votes from the same participant", async () => {
+      const { conflictId, proposals } = await setupVotingConflict(1.0);
+
+      await service.castVote(conflictId, {
+        participantId: "user-1",
+        instanceId: "i1",
+        proposalId: proposals[0].id,
+      });
+
+      await expect(
+        service.castVote(conflictId, {
+          participantId: "user-1",
+          instanceId: "i1",
+          proposalId: proposals[1].id,
+        }),
+      ).rejects.toThrow("already voted");
+    });
+
+    it("rejects vote for unknown proposal", async () => {
+      const { conflictId } = await setupVotingConflict(1.0);
+
+      await expect(
+        service.castVote(conflictId, {
+          participantId: "user-1",
+          instanceId: "i1",
+          proposalId: "nonexistent-proposal",
+        }),
+      ).rejects.toThrow("not found");
+    });
+
+    it("rejects vote on non-quorum_vote conflict", async () => {
+      const { conflictId } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "structured_debate",
+      });
+
+      await service.addProposal(conflictId, {
+        authorId: "u1",
+        instanceId: "i1",
+        title: "P",
+        description: "D",
+      });
+
+      const proposalId = service.getConflict(conflictId)!.proposals[0].id;
+
+      await expect(
+        service.castVote(conflictId, {
+          participantId: "user-1",
+          instanceId: "i1",
+          proposalId,
+        }),
+      ).rejects.toThrow('strategy "structured_debate"');
+    });
+
+    it("resolves when quorum threshold is met", async () => {
+      // Use threshold=0.6: need 3 of 4 votes (75%) on one proposal to cross it
+      const { conflictId, resolution, proposals } = await setupVotingConflict(0.6);
+
+      // First 2 votes split evenly: 50% each — no resolution
+      await service.castVote(conflictId, { participantId: "u1", instanceId: "i1", proposalId: proposals[0].id });
+      await service.castVote(conflictId, { participantId: "u2", instanceId: "i2", proposalId: proposals[1].id });
+
+      expect(service.getConflict(conflictId)!.status).not.toBe("resolved");
+
+      // 3rd vote pushes proposals[0] to 2/3 ≈ 67% > 60% → quorum
+      await service.castVote(conflictId, { participantId: "u3", instanceId: "i3", proposalId: proposals[0].id });
+
+      const outcome = await resolution;
+      expect(outcome.decidedBy).toBe("quorum");
+      expect(outcome.winningProposalId).toBe(proposals[0].id);
+    });
+
+    it("does not resolve when quorum threshold is not reached", async () => {
+      // Use threshold=0.75: need 3 of 4 votes to resolve
+      const { conflictId, proposals } = await setupVotingConflict(0.75);
+
+      // 2 votes split 50/50 — no proposal reaches 75%
+      await service.castVote(conflictId, { participantId: "u1", instanceId: "i1", proposalId: proposals[0].id });
+      await service.castVote(conflictId, { participantId: "u2", instanceId: "i2", proposalId: proposals[1].id });
+
+      const conflict = service.getConflict(conflictId);
+      expect(conflict!.status).not.toBe("resolved");
+    });
+  });
+
+  // ── structured debate ─────────────────────────────────────────────────────────
+
+  describe("structured_debate", () => {
+    async function setupDebateConflict() {
+      const { conflictId, resolution } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "REST vs GraphQL?",
+        strategy: "structured_debate",
+      });
+
+      await service.addProposal(conflictId, {
+        authorId: "u1",
+        instanceId: "i1",
+        title: "REST",
+        description: "Use REST API",
+        arguments: "Simpler, more cacheable",
+      });
+
+      await service.addProposal(conflictId, {
+        authorId: "u2",
+        instanceId: "i2",
+        title: "GraphQL",
+        description: "Use GraphQL API",
+        arguments: "Flexible, fewer round-trips",
+      });
+
+      const proposals = service.getConflict(conflictId)!.proposals;
+      return { conflictId, resolution, proposals };
+    }
+
+    it("runDebateJudge calls gateway and resolves conflict", async () => {
+      const { conflictId, resolution, proposals } = await setupDebateConflict();
+
+      // Mock gateway to return winner as first proposal
+      (gateway.complete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        content: `{"winner":"${proposals[0].id}","reasoning":"REST is better here.","confidence":0.85}`,
+        tokensUsed: 60,
+        modelSlug: "default",
+        finishReason: "stop",
+      });
+
+      const judgement = await service.runDebateJudge(conflictId);
+
+      expect(judgement.winner).toBe(proposals[0].id);
+      expect(judgement.reasoning).toContain("REST");
+      expect(judgement.confidence).toBe(0.85);
+
+      const outcome = await resolution;
+      expect(outcome.strategy).toBe("structured_debate");
+      expect(outcome.winningProposalId).toBe(proposals[0].id);
+      expect(outcome.decidedBy).toBe("judge");
+    });
+
+    it("runDebateJudge fails gracefully when gateway throws", async () => {
+      const { conflictId } = await setupDebateConflict();
+
+      (gateway.complete as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error("LLM unavailable"),
+      );
+
+      await expect(service.runDebateJudge(conflictId)).rejects.toThrow(
+        "LLM judge call failed",
+      );
+    });
+
+    it("runDebateJudge requires at least 2 proposals", async () => {
+      const { conflictId } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "structured_debate",
+      });
+
+      await service.addProposal(conflictId, {
+        authorId: "u1",
+        instanceId: "i1",
+        title: "Solo proposal",
+        description: "Only one",
+      });
+
+      await expect(service.runDebateJudge(conflictId)).rejects.toThrow(
+        "at least 2 proposals",
+      );
+    });
+
+    it("runDebateJudge throws when no gateway is available", async () => {
+      const noGatewayService = new ConflictResolutionService(null);
+      const { conflictId } = await noGatewayService.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "structured_debate",
+      });
+
+      await noGatewayService.addProposal(conflictId, {
+        authorId: "u1",
+        instanceId: "i1",
+        title: "P1",
+        description: "D1",
+      });
+      await noGatewayService.addProposal(conflictId, {
+        authorId: "u2",
+        instanceId: "i2",
+        title: "P2",
+        description: "D2",
+      });
+
+      await expect(noGatewayService.runDebateJudge(conflictId)).rejects.toThrow(
+        "No LLM gateway",
+      );
+    });
+
+    it("handles malformed judge JSON response gracefully", async () => {
+      const { conflictId, resolution, proposals } = await setupDebateConflict();
+
+      (gateway.complete as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        content: "This is not JSON at all",
+        tokensUsed: 30,
+        modelSlug: "default",
+        finishReason: "stop",
+      });
+
+      const judgement = await service.runDebateJudge(conflictId);
+      expect(judgement.confidence).toBe(0);
+      expect(judgement.winner).toBeUndefined();
+
+      const outcome = await resolution;
+      expect(outcome.decidedBy).toBe("judge");
+      expect(outcome.winningProposalId).toBeUndefined();
+    });
+
+    it("submitDebateJudgement directly resolves with judge winner", async () => {
+      const { conflictId, resolution, proposals } = await setupDebateConflict();
+
+      const conflict = await service.submitDebateJudgement(conflictId, {
+        judgeModelSlug: "custom-model",
+        winner: proposals[1].id,
+        reasoning: "GraphQL wins for this use case.",
+        confidence: 0.92,
+        evaluatedAt: Date.now(),
+      });
+
+      expect(conflict.status).toBe("resolved");
+      expect(conflict.judgement?.winner).toBe(proposals[1].id);
+
+      const outcome = await resolution;
+      expect(outcome.winningProposalId).toBe(proposals[1].id);
+    });
+  });
+
+  // ── parallel_experiment ───────────────────────────────────────────────────────
+
+  describe("parallel_experiment", () => {
+    it("resolves when all branches complete", async () => {
+      const { conflictId, resolution } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Which DB schema is better?",
+        strategy: "parallel_experiment",
+      });
+
+      await service.addProposal(conflictId, {
+        authorId: "u1",
+        instanceId: "i1",
+        title: "Schema A",
+        description: "Normalised",
+      });
+      await service.addProposal(conflictId, {
+        authorId: "u2",
+        instanceId: "i2",
+        title: "Schema B",
+        description: "Denormalised",
+      });
+
+      const proposals = service.getConflict(conflictId)!.proposals;
+
+      // Complete first branch
+      await service.updateExperimentBranch(conflictId, {
+        proposalId: proposals[0].id,
+        runId: "run-a",
+        status: "completed",
+        outcome: "3.2ms avg query",
+        completedAt: Date.now(),
+      });
+
+      // Still pending (1 of 2 done)
+      expect(service.getConflict(conflictId)!.status).toBe("experiment_in_progress");
+
+      // Complete second branch
+      await service.updateExperimentBranch(conflictId, {
+        proposalId: proposals[1].id,
+        runId: "run-b",
+        status: "failed",
+      });
+
+      const outcome = await resolution;
+      expect(outcome.strategy).toBe("parallel_experiment");
+      expect(outcome.winningProposalId).toBe(proposals[0].id); // first completed
+    });
+
+    it("throws when updating branch on wrong strategy conflict", async () => {
+      const { conflictId } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "quorum_vote",
+      });
+
+      await service.addProposal(conflictId, {
+        authorId: "u1",
+        instanceId: "i1",
+        title: "P",
+        description: "D",
+      });
+
+      const proposalId = service.getConflict(conflictId)!.proposals[0].id;
+
+      await expect(
+        service.updateExperimentBranch(conflictId, {
+          proposalId,
+          runId: "run-x",
+          status: "completed",
+        }),
+      ).rejects.toThrow('expected "parallel_experiment"');
+    });
+  });
+
+  // ── forceResolve ─────────────────────────────────────────────────────────────
+
+  describe("forceResolve", () => {
+    it("resolves an open conflict immediately", async () => {
+      const { conflictId, resolution } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "quorum_vote",
+      });
+
+      await service.addProposal(conflictId, {
+        authorId: "u1",
+        instanceId: "i1",
+        title: "P",
+        description: "D",
+      });
+
+      const proposals = service.getConflict(conflictId)!.proposals;
+
+      await service.forceResolve(
+        conflictId,
+        proposals[0].id,
+        "Owner decided.",
+        "owner",
+      );
+
+      const outcome = await resolution;
+      expect(outcome.decidedBy).toBe("owner");
+      expect(outcome.winningProposalId).toBe(proposals[0].id);
+      expect(service.getConflict(conflictId)!.status).toBe("resolved");
+    });
+
+    it("throws when conflict is already resolved", async () => {
+      const { conflictId } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "defer_to_owner",
+      });
+
+      await expect(
+        service.forceResolve(conflictId, undefined, "Again?"),
+      ).rejects.toThrow("already resolved");
+    });
+  });
+
+  // ── timeout ───────────────────────────────────────────────────────────────────
+
+  describe("timeout handling", () => {
+    it("resolves quorum_vote with plurality winner on timeout", async () => {
+      const { conflictId, resolution } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "quorum_vote",
+        quorumThreshold: 0.9,
+        timeoutMs: 10_000,
+      });
+
+      await service.addProposal(conflictId, {
+        authorId: "u1",
+        instanceId: "i1",
+        title: "A",
+        description: "D",
+      });
+      await service.addProposal(conflictId, {
+        authorId: "u2",
+        instanceId: "i2",
+        title: "B",
+        description: "D",
+      });
+
+      const proposals = service.getConflict(conflictId)!.proposals;
+
+      // Cast minority vote for proposals[1] first, then 2 for proposals[0].
+      // With min-2-vote quorum and threshold=0.9:
+      // After 3 votes: proposals[0]=2/3=67% < 90% → no auto-resolve.
+      await service.castVote(conflictId, { participantId: "u1", instanceId: "i1", proposalId: proposals[1].id });
+      await service.castVote(conflictId, { participantId: "u2", instanceId: "i2", proposalId: proposals[0].id });
+      await service.castVote(conflictId, { participantId: "u3", instanceId: "i3", proposalId: proposals[0].id });
+
+      // Manually trigger timeout — plurality winner is proposals[0] (2/3 votes)
+      await service._triggerTimeout(conflictId);
+
+      const outcome = await resolution;
+      expect(outcome.decidedBy).toBe("timeout");
+      expect(outcome.winningProposalId).toBe(proposals[0].id); // plurality
+    });
+
+    it("expires without resolution when no votes were cast", async () => {
+      const { conflictId, resolution } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "quorum_vote",
+        timeoutMs: 10_000,
+      });
+
+      await service._triggerTimeout(conflictId);
+
+      await expect(resolution).rejects.toThrow("expired without resolution");
+
+      const conflict = service.getConflict(conflictId);
+      expect(conflict!.status).toBe("expired");
+    });
+
+    it("timer fires automatically after timeoutMs", async () => {
+      const { conflictId, resolution } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "structured_debate",
+        timeoutMs: 30_000,
+      });
+
+      vi.advanceTimersByTime(30_001);
+
+      await expect(resolution).rejects.toThrow("expired");
+      expect(service.getConflict(conflictId)!.status).toBe("expired");
+    });
+  });
+
+  // ── decision log ─────────────────────────────────────────────────────────────
+
+  describe("decision log", () => {
+    it("appends log entry on resolution", async () => {
+      const { conflictId } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Should we cache?",
+        strategy: "defer_to_owner",
+      });
+
+      const log = service.getDecisionLog();
+      expect(log).toHaveLength(1);
+      expect(log[0].question).toBe("Should we cache?");
+      expect(log[0].strategy).toBe("defer_to_owner");
+      expect(log[0].conflictId).toBe(conflictId);
+    });
+
+    it("filters decision log by session ID", async () => {
+      await service.raiseConflict({
+        sessionId: "session-A",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q1",
+        strategy: "defer_to_owner",
+      });
+
+      await service.raiseConflict({
+        sessionId: "session-B",
+        raisedBy: "u2",
+        raisedByInstance: "i2",
+        question: "Q2",
+        strategy: "defer_to_owner",
+      });
+
+      expect(service.getSessionDecisionLog("session-A")).toHaveLength(1);
+      expect(service.getSessionDecisionLog("session-B")).toHaveLength(1);
+      expect(service.getDecisionLog()).toHaveLength(2);
+    });
+
+    it("persists log entries to the sink", async () => {
+      await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "To cache or not?",
+        strategy: "defer_to_owner",
+      });
+
+      expect(sink._log).toHaveLength(1);
+      expect(sink._log[0].question).toBe("To cache or not?");
+    });
+
+    it("records participant and proposal counts in log entry", async () => {
+      const { conflictId, resolution } = await service.raiseConflict({
+        sessionId: "s1",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q",
+        strategy: "quorum_vote",
+        quorumThreshold: 0.5,
+      });
+
+      await service.addProposal(conflictId, {
+        authorId: "u1",
+        instanceId: "i1",
+        title: "P",
+        description: "D",
+      });
+
+      const proposal = service.getConflict(conflictId)!.proposals[0];
+
+      await service.castVote(conflictId, { participantId: "u1", instanceId: "i1", proposalId: proposal.id });
+      await service.castVote(conflictId, { participantId: "u2", instanceId: "i2", proposalId: proposal.id });
+
+      await resolution;
+
+      const log = service.getDecisionLog();
+      expect(log[0].proposalCount).toBe(1);
+      expect(log[0].participantCount).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  // ── getSessionConflicts ───────────────────────────────────────────────────────
+
+  describe("getSessionConflicts", () => {
+    it("returns all conflicts for a session", async () => {
+      await service.raiseConflict({
+        sessionId: "sess-X",
+        raisedBy: "u1",
+        raisedByInstance: "i1",
+        question: "Q1",
+        strategy: "quorum_vote",
+      });
+
+      await service.raiseConflict({
+        sessionId: "sess-X",
+        raisedBy: "u2",
+        raisedByInstance: "i2",
+        question: "Q2",
+        strategy: "quorum_vote",
+      });
+
+      await service.raiseConflict({
+        sessionId: "sess-Y",
+        raisedBy: "u3",
+        raisedByInstance: "i3",
+        question: "Q3",
+        strategy: "quorum_vote",
+      });
+
+      expect(service.getSessionConflicts("sess-X")).toHaveLength(2);
+      expect(service.getSessionConflicts("sess-Y")).toHaveLength(1);
+    });
+
+    it("returns empty array for unknown session", () => {
+      expect(service.getSessionConflicts("no-such-session")).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements subjective dispute resolution for shared federation sessions (issue #229)
- Four resolution strategies: `structured_debate`, `quorum_vote`, `parallel_experiment`, `defer_to_owner`
- All resolved conflicts recorded in an append-only `decision_log` for organisational learning
- Minimum-2-vote guard on quorum so a single participant cannot unilaterally resolve a dispute

## Key files

- `server/federation/conflict-resolution.ts` — `ConflictResolutionService` with full lifecycle management including LLM judge, quorum voting, parallel experiment branch tracking, decision log
- `shared/types.ts` — 12 new types: `SessionConflict`, `ConflictProposal`, `ConflictVote`, `ResolutionOutcome`, `DecisionLogEntry`, etc.
- `shared/schema.ts` — Drizzle tables: `sessionConflicts`, `decisionLog`
- `migrations/0019_conflict_resolution.sql` — DB migration
- `server/storage.ts` + `server/storage-pg.ts` — `IStorage` interface + both implementations
- `server/routes/federation.ts` — 7 new routes under `/api/sessions/:id/conflicts`
- `tests/unit/conflict-resolution.test.ts` — 37 service tests
- `tests/unit/conflict-resolution-routes.test.ts` — 22 route tests

## API routes added

| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/api/sessions/:id/conflicts` | Raise a new conflict |
| `GET` | `/api/sessions/:id/conflicts` | List conflicts for a session |
| `POST` | `/api/sessions/:id/conflicts/:cid/proposals` | Add a proposal |
| `POST` | `/api/sessions/:id/conflicts/:cid/vote` | Cast a vote |
| `POST` | `/api/sessions/:id/conflicts/:cid/resolve` | Force-resolve (owner override) |
| `POST` | `/api/sessions/:id/conflicts/:cid/judge` | Run LLM debate judge |
| `POST` | `/api/sessions/:id/conflicts/:cid/experiment` | Update experiment branch |
| `GET` | `/api/sessions/:id/decision-log` | Get decision log for a session |

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 3968 tests, 180 files, all pass (59 new tests)
- [x] All 4 resolution strategies tested end-to-end
- [x] Edge cases: duplicate votes, max proposals, expired conflicts, LLM failures, malformed JSON responses, minimum quorum guard
- [x] Both MemStorage and route layer tested; PgStorage follows same pattern as existing implementations