### PR TITLE
feat: add CRDT-based P2P collaboration for federation (#230)

### DIFF
--- a/server/federation/crdt/document.ts
+++ b/server/federation/crdt/document.ts
@@ -1,0 +1,133 @@
+/**
+ * CRDT Document — compound CRDT representing a shared session's collaborative state.
+ *
+ * Composes the individual CRDT types into a single unit that can be
+ * serialised, sent over the wire, and merged atomically.
+ *
+ * Fields:
+ *   participants   ORSet<string>              — who's in the session
+ *   stageOutputs   LWWMap<string, string>     — stageId → output text
+ *   stageStatuses  LWWMap<string, string>     — stageId → status string
+ *   votes          GCounter                   — total votes cast
+ *   tags           ORSet<string>              — session tags
+ *   metadata       LWWRegister<object>        — arbitrary session metadata
+ *   vectorClock    VectorClock                — causal ordering
+ */
+
+import { GCounter, type GCounterState } from "./g-counter.js";
+import { LWWRegister, type LWWRegisterState } from "./lww-register.js";
+import { LWWMap, type LWWMapState } from "./lww-map.js";
+import { ORSet, type ORSetState } from "./or-set.js";
+import { VectorClock, type VectorClockState } from "./vector-clock.js";
+
+export interface CRDTDocumentState {
+  sessionId: string;
+  nodeId: string;
+  participants: ORSetState<string>;
+  stageOutputs: LWWMapState<string>;
+  stageStatuses: LWWMapState<string>;
+  votes: GCounterState;
+  tags: ORSetState<string>;
+  metadata: LWWRegisterState<Record<string, unknown>>;
+  vectorClock: VectorClockState;
+}
+
+export class CRDTDocument {
+  readonly participants: ORSet<string>;
+  readonly stageOutputs: LWWMap<string, string>;
+  readonly stageStatuses: LWWMap<string, string>;
+  readonly votes: GCounter;
+  readonly tags: ORSet<string>;
+  readonly metadata: LWWRegister<Record<string, unknown>>;
+  readonly vectorClock: VectorClock;
+
+  constructor(
+    readonly sessionId: string,
+    readonly nodeId: string,
+  ) {
+    this.participants = new ORSet<string>(nodeId);
+    this.stageOutputs = new LWWMap<string, string>(nodeId);
+    this.stageStatuses = new LWWMap<string, string>(nodeId);
+    this.votes = new GCounter(nodeId);
+    this.tags = new ORSet<string>(nodeId);
+    this.metadata = new LWWRegister<Record<string, unknown>>(nodeId);
+    this.vectorClock = new VectorClock(nodeId);
+  }
+
+  /**
+   * Merge a remote CRDT document state into this document.
+   * All component CRDTs are merged independently; the vector clock
+   * is updated to reflect the incoming causal information.
+   */
+  merge(remote: CRDTDocumentState): void {
+    if (remote.sessionId !== this.sessionId) {
+      throw new Error(
+        `Cannot merge documents for different sessions: ${remote.sessionId} vs ${this.sessionId}`,
+      );
+    }
+    this.participants.merge(remote.participants);
+    this.stageOutputs.merge(remote.stageOutputs);
+    this.stageStatuses.merge(remote.stageStatuses);
+    this.votes.merge(remote.votes);
+    this.tags.merge(remote.tags);
+    this.metadata.merge(remote.metadata);
+    this.vectorClock.merge(remote.vectorClock);
+  }
+
+  /** Tick the vector clock after performing a local mutation. */
+  tick(): void {
+    this.vectorClock.tick();
+  }
+
+  /** Serialize the entire document to a transportable JSON state. */
+  toState(): CRDTDocumentState {
+    return {
+      sessionId: this.sessionId,
+      nodeId: this.nodeId,
+      participants: this.participants.toState(),
+      stageOutputs: this.stageOutputs.toState(),
+      stageStatuses: this.stageStatuses.toState(),
+      votes: this.votes.toState(),
+      tags: this.tags.toState(),
+      metadata: this.metadata.toState(),
+      vectorClock: this.vectorClock.toState(),
+    };
+  }
+
+  /** Deserialize a document from JSON state. */
+  static fromState(state: CRDTDocumentState): CRDTDocument {
+    const doc = new CRDTDocument(state.sessionId, state.nodeId);
+
+    // Merge each component — this correctly handles the fromState bootstrapping
+    doc.participants.merge(state.participants);
+    doc.stageOutputs.merge(state.stageOutputs);
+    doc.stageStatuses.merge(state.stageStatuses);
+    doc.votes.merge(state.votes);
+    doc.tags.merge(state.tags);
+    doc.metadata.merge(state.metadata);
+    doc.vectorClock.merge(state.vectorClock);
+
+    return doc;
+  }
+
+  /** Convenience: get a human-readable snapshot of resolved values. */
+  snapshot(): {
+    participants: string[];
+    stageOutputs: Record<string, string | null>;
+    stageStatuses: Record<string, string | null>;
+    votes: number;
+    tags: string[];
+    metadata: Record<string, unknown> | null;
+    vectorClock: VectorClockState;
+  } {
+    return {
+      participants: this.participants.value(),
+      stageOutputs: this.stageOutputs.value(),
+      stageStatuses: this.stageStatuses.value(),
+      votes: this.votes.value(),
+      tags: this.tags.value(),
+      metadata: this.metadata.value(),
+      vectorClock: this.vectorClock.toState(),
+    };
+  }
+}

--- a/server/federation/crdt/g-counter.ts
+++ b/server/federation/crdt/g-counter.ts
@@ -1,0 +1,74 @@
+/**
+ * G-Counter (Grow-only Counter) CRDT
+ *
+ * A G-Counter is a counter that can only be incremented. Each node in the
+ * distributed system maintains its own counter slot. The merged value is the
+ * sum of the maximum observed value for each node.
+ *
+ * Properties:
+ *   - Commutative: merge(A, B) == merge(B, A)
+ *   - Associative: merge(merge(A, B), C) == merge(A, merge(B, C))
+ *   - Idempotent: merge(A, A) == A
+ */
+
+export interface GCounterState {
+  type: "g-counter";
+  counters: Record<string, number>;
+}
+
+export class GCounter {
+  private counters: Map<string, number>;
+
+  constructor(nodeId: string, counters?: Record<string, number>) {
+    this.counters = new Map(Object.entries(counters ?? {}));
+    // Ensure this node exists in the map even if at zero
+    if (!this.counters.has(nodeId)) {
+      this.counters.set(nodeId, 0);
+    }
+    this._nodeId = nodeId;
+  }
+
+  private _nodeId: string;
+
+  /** Increment this node's counter by delta (default 1). */
+  increment(delta = 1): void {
+    if (delta <= 0) throw new RangeError("GCounter delta must be positive");
+    const current = this.counters.get(this._nodeId) ?? 0;
+    this.counters.set(this._nodeId, current + delta);
+  }
+
+  /** Current total value across all nodes. */
+  value(): number {
+    let total = 0;
+    for (const v of this.counters.values()) {
+      total += v;
+    }
+    return total;
+  }
+
+  /**
+   * Merge a remote G-Counter state into this one.
+   * Takes the per-node maximum, making the operation idempotent.
+   */
+  merge(remote: GCounterState): void {
+    for (const [nodeId, remoteCount] of Object.entries(remote.counters)) {
+      const local = this.counters.get(nodeId) ?? 0;
+      if (remoteCount > local) {
+        this.counters.set(nodeId, remoteCount);
+      }
+    }
+  }
+
+  /** Serialize to transportable JSON state. */
+  toState(): GCounterState {
+    return {
+      type: "g-counter",
+      counters: Object.fromEntries(this.counters),
+    };
+  }
+
+  /** Deserialize from JSON state. */
+  static fromState(nodeId: string, state: GCounterState): GCounter {
+    return new GCounter(nodeId, state.counters);
+  }
+}

--- a/server/federation/crdt/index.ts
+++ b/server/federation/crdt/index.ts
@@ -1,0 +1,26 @@
+export { GCounter } from "./g-counter.js";
+export type { GCounterState } from "./g-counter.js";
+
+export { PNCounter } from "./pn-counter.js";
+export type { PNCounterState } from "./pn-counter.js";
+
+export { LWWRegister } from "./lww-register.js";
+export type { LWWRegisterState } from "./lww-register.js";
+
+export { ORSet } from "./or-set.js";
+export type { ORSetState } from "./or-set.js";
+
+export { LWWMap } from "./lww-map.js";
+export type { LWWMapState } from "./lww-map.js";
+
+export { VectorClock } from "./vector-clock.js";
+export type { VectorClockState, CausalRelation } from "./vector-clock.js";
+
+export { CRDTDocument } from "./document.js";
+export type { CRDTDocumentState } from "./document.js";
+
+export { CRDTSyncManager } from "./sync.js";
+export type { CRDTDelta, SendFn, SyncOptions } from "./sync.js";
+
+export { CRDTPeerSyncService } from "./peer-sync.js";
+export type { CollabSyncMode, PeerSyncOptions } from "./peer-sync.js";

--- a/server/federation/crdt/lww-map.ts
+++ b/server/federation/crdt/lww-map.ts
@@ -1,0 +1,91 @@
+/**
+ * LWW-Map (Last-Writer-Wins Map) CRDT
+ *
+ * A key-value map where each entry is an LWW-Register. Concurrent writes
+ * to the same key are resolved by taking the entry with the higher timestamp
+ * (ties broken by nodeId lexicographic order).
+ *
+ * Properties:
+ *   - Commutative, associative, idempotent (each register satisfies these)
+ *
+ * Key must be a string. Value V must be JSON-serializable.
+ */
+
+import { LWWRegister, type LWWRegisterState } from "./lww-register.js";
+
+export interface LWWMapState<V> {
+  type: "lww-map";
+  entries: Record<string, LWWRegisterState<V>>;
+}
+
+export class LWWMap<K extends string, V> {
+  private entries = new Map<K, LWWRegister<V>>();
+
+  constructor(private nodeId: string) {}
+
+  /** Set a key to value with an optional explicit timestamp. */
+  set(key: K, value: V, timestamp?: number): void {
+    let reg = this.entries.get(key);
+    if (!reg) {
+      reg = new LWWRegister<V>(this.nodeId);
+      this.entries.set(key, reg);
+    }
+    reg.set(value, timestamp);
+  }
+
+  /** Get the current value for a key (undefined if not set). */
+  get(key: K): V | null | undefined {
+    return this.entries.get(key)?.value();
+  }
+
+  /** Check if a key exists (has been set at least once). */
+  has(key: K): boolean {
+    return this.entries.has(key) && this.entries.get(key)!.value() !== null;
+  }
+
+  /** Get all key-value pairs as a plain object. */
+  value(): Record<K, V | null> {
+    const result = {} as Record<K, V | null>;
+    for (const [k, reg] of this.entries) {
+      result[k] = reg.value();
+    }
+    return result;
+  }
+
+  /**
+   * Merge a remote LWW-Map state into this one.
+   * Each register is merged independently.
+   */
+  merge(remote: LWWMapState<V>): void {
+    for (const [k, remoteState] of Object.entries(remote.entries) as [K, LWWRegisterState<V>][]) {
+      let reg = this.entries.get(k);
+      if (!reg) {
+        reg = new LWWRegister<V>(this.nodeId);
+        this.entries.set(k, reg);
+      }
+      reg.merge(remoteState);
+    }
+  }
+
+  /** Serialize to transportable JSON state. */
+  toState(): LWWMapState<V> {
+    const entries: Record<string, LWWRegisterState<V>> = {};
+    for (const [k, reg] of this.entries) {
+      entries[k] = reg.toState();
+    }
+    return {
+      type: "lww-map",
+      entries,
+    };
+  }
+
+  /** Deserialize from JSON state. */
+  static fromState<K extends string, V>(nodeId: string, state: LWWMapState<V>): LWWMap<K, V> {
+    const map = new LWWMap<K, V>(nodeId);
+    for (const [k, regState] of Object.entries(state.entries) as [K, LWWRegisterState<V>][]) {
+      const reg = LWWRegister.fromState<V>(nodeId, regState);
+      map.entries.set(k, reg);
+    }
+    return map;
+  }
+}

--- a/server/federation/crdt/lww-register.ts
+++ b/server/federation/crdt/lww-register.ts
@@ -1,0 +1,82 @@
+/**
+ * LWW-Register (Last-Writer-Wins Register) CRDT
+ *
+ * Stores a single value tagged with a logical timestamp. On merge, the
+ * value with the highest timestamp wins. Ties are broken deterministically
+ * by node ID to ensure all replicas converge to the same value.
+ *
+ * Properties:
+ *   - Commutative, associative, idempotent
+ *
+ * Type parameter T must be JSON-serializable.
+ */
+
+export interface LWWRegisterState<T> {
+  type: "lww-register";
+  value: T | null;
+  timestamp: number;
+  nodeId: string;
+}
+
+export class LWWRegister<T> {
+  private _value: T | null;
+  private _timestamp: number;
+  private _nodeId: string;
+
+  constructor(nodeId: string, value: T | null = null, timestamp = 0) {
+    this._nodeId = nodeId;
+    this._value = value;
+    this._timestamp = timestamp;
+  }
+
+  /** Set the value at the current logical time. */
+  set(value: T, timestamp?: number): void {
+    const ts = timestamp ?? Date.now();
+    // Only update if the new timestamp is strictly greater, or if equal and
+    // nodeId comparison breaks the tie.
+    if (ts > this._timestamp || (ts === this._timestamp && this._nodeId >= this._nodeId)) {
+      this._value = value;
+      this._timestamp = ts;
+    }
+  }
+
+  /** Current resolved value (null if never set). */
+  value(): T | null {
+    return this._value;
+  }
+
+  /** Current logical timestamp of the stored value. */
+  timestamp(): number {
+    return this._timestamp;
+  }
+
+  /**
+   * Merge a remote LWW-Register state into this one.
+   * The entry with the highest timestamp wins; ties broken by nodeId lexicographic order.
+   */
+  merge(remote: LWWRegisterState<T>): void {
+    if (
+      remote.timestamp > this._timestamp ||
+      (remote.timestamp === this._timestamp && remote.nodeId > this._nodeId)
+    ) {
+      this._value = remote.value;
+      this._timestamp = remote.timestamp;
+      this._nodeId = remote.nodeId;
+    }
+  }
+
+  /** Serialize to transportable JSON state. */
+  toState(): LWWRegisterState<T> {
+    return {
+      type: "lww-register",
+      value: this._value,
+      timestamp: this._timestamp,
+      nodeId: this._nodeId,
+    };
+  }
+
+  /** Deserialize from JSON state. */
+  static fromState<T>(nodeId: string, state: LWWRegisterState<T>): LWWRegister<T> {
+    return new LWWRegister<T>(nodeId, state.value, state.timestamp);
+  }
+}

--- a/server/federation/crdt/or-set.ts
+++ b/server/federation/crdt/or-set.ts
@@ -1,0 +1,151 @@
+/**
+ * OR-Set (Observed-Remove Set) CRDT
+ *
+ * An OR-Set allows elements to be added and removed without conflicts. Each
+ * add operation attaches a unique tag to the element. A remove operation
+ * removes all tags currently observed for that element. An element is in
+ * the set if and only if it has at least one tag that has not been removed.
+ *
+ * This resolves the classic add-remove conflict: if node A adds element X
+ * while node B removes X concurrently, the merged result contains X (add wins
+ * over concurrent remove).
+ *
+ * Properties:
+ *   - Commutative, associative, idempotent
+ *
+ * Type parameter T must be JSON-serializable and equality-comparable via
+ * JSON.stringify (i.e., primitives or stable-key objects work best).
+ */
+
+import crypto from "crypto";
+
+/** Each unique add operation is represented by a tag (UUID). */
+export interface ORSetState<T> {
+  type: "or-set";
+  /** Map from serialized element → set of unique add-tags. */
+  entries: Record<string, string[]>;
+  /** Set of tags that have been tombstoned (removed). */
+  tombstones: string[];
+}
+
+export class ORSet<T> {
+  /** key(element) → Set<tag> */
+  private entries = new Map<string, Set<string>>();
+  /** Tags that have been explicitly removed. */
+  private tombstones = new Set<string>();
+
+  constructor(private nodeId: string) {}
+
+  /** Serialize element to a stable string key. */
+  private key(element: T): string {
+    return JSON.stringify(element);
+  }
+
+  /** Add an element to the set with a fresh unique tag. */
+  add(element: T): void {
+    const k = this.key(element);
+    const tag = `${this.nodeId}:${crypto.randomUUID()}`;
+    let tags = this.entries.get(k);
+    if (!tags) {
+      tags = new Set();
+      this.entries.set(k, tags);
+    }
+    tags.add(tag);
+  }
+
+  /**
+   * Remove an element from the set by tombstoning all currently observed tags.
+   * Concurrent adds that arrive later (with new tags) will still be visible.
+   */
+  remove(element: T): void {
+    const k = this.key(element);
+    const tags = this.entries.get(k);
+    if (!tags) return;
+    for (const tag of tags) {
+      this.tombstones.add(tag);
+    }
+    this.entries.delete(k);
+  }
+
+  /** Check membership: element is present if it has at least one live tag. */
+  has(element: T): boolean {
+    const k = this.key(element);
+    const tags = this.entries.get(k);
+    if (!tags || tags.size === 0) return false;
+    for (const tag of tags) {
+      if (!this.tombstones.has(tag)) return true;
+    }
+    return false;
+  }
+
+  /** Current set of live elements. */
+  value(): T[] {
+    const result: T[] = [];
+    for (const [k, tags] of this.entries) {
+      const hasLive = Array.from(tags).some((t) => !this.tombstones.has(t));
+      if (hasLive) {
+        result.push(JSON.parse(k) as T);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Merge a remote OR-Set state into this one.
+   * Union the add-tags and tombstones, then apply tombstones to entries.
+   */
+  merge(remote: ORSetState<T>): void {
+    // Import tombstones first
+    for (const tag of remote.tombstones) {
+      this.tombstones.add(tag);
+    }
+
+    // Merge entries
+    for (const [k, remoteTags] of Object.entries(remote.entries)) {
+      let localTags = this.entries.get(k);
+      if (!localTags) {
+        localTags = new Set();
+        this.entries.set(k, localTags);
+      }
+      for (const tag of remoteTags) {
+        localTags.add(tag);
+      }
+    }
+
+    // Clean up fully-tombstoned entries for memory efficiency
+    for (const [k, tags] of this.entries) {
+      const allTombstoned = Array.from(tags).every((t) => this.tombstones.has(t));
+      if (allTombstoned) {
+        this.entries.delete(k);
+      }
+    }
+  }
+
+  /** Serialize to transportable JSON state. */
+  toState(): ORSetState<T> {
+    const entries: Record<string, string[]> = {};
+    for (const [k, tags] of this.entries) {
+      const liveTags = Array.from(tags).filter((t) => !this.tombstones.has(t));
+      if (liveTags.length > 0) {
+        entries[k] = liveTags;
+      }
+    }
+    return {
+      type: "or-set",
+      entries,
+      tombstones: Array.from(this.tombstones),
+    };
+  }
+
+  /** Deserialize from JSON state. */
+  static fromState<T>(nodeId: string, state: ORSetState<T>): ORSet<T> {
+    const set = new ORSet<T>(nodeId);
+    for (const tag of state.tombstones) {
+      set.tombstones.add(tag);
+    }
+    for (const [k, tags] of Object.entries(state.entries)) {
+      set.entries.set(k, new Set(tags));
+    }
+    return set;
+  }
+}

--- a/server/federation/crdt/peer-sync.ts
+++ b/server/federation/crdt/peer-sync.ts
@@ -1,0 +1,179 @@
+/**
+ * CRDT Peer Sync Service
+ *
+ * Bridges the CRDT sync protocol with the existing FederationManager transport.
+ * Hooks into federation message events to exchange CRDT state between instances.
+ *
+ * Federation messages used:
+ *   crdt:push   — full state-based push from one peer to another
+ *   crdt:ack    — acknowledgement with the receiver's current vector clock
+ *
+ * Sync mode is configurable per-session or globally:
+ *   single_writer  — current default; CRDT sync is disabled
+ *   crdt_p2p       — full P2P CRDT-based sync
+ */
+
+import type { FederationManager } from "../index.js";
+import type { FederationMessage, PeerInfo } from "../types.js";
+import { CRDTDocument } from "./document.js";
+import { CRDTSyncManager, type CRDTDelta } from "./sync.js";
+import type { VectorClockState } from "./vector-clock.js";
+
+export type CollabSyncMode = "single_writer" | "crdt_p2p";
+
+export interface PeerSyncOptions {
+  /** Default sync mode for new sessions. */
+  defaultMode?: CollabSyncMode;
+  /** Anti-entropy interval in ms (0 = disabled). */
+  antiEntropyIntervalMs?: number;
+}
+
+interface CrdtAckPayload {
+  sessionId: string;
+  receiverClock: VectorClockState;
+}
+
+export class CRDTPeerSyncService {
+  private syncManager: CRDTSyncManager;
+  /** sessionId → sync mode */
+  private sessionModes = new Map<string, CollabSyncMode>();
+  private defaultMode: CollabSyncMode;
+
+  constructor(
+    private readonly federation: FederationManager,
+    private readonly nodeId: string,
+    options: PeerSyncOptions = {},
+  ) {
+    this.defaultMode = options.defaultMode ?? "single_writer";
+
+    this.syncManager = new CRDTSyncManager(
+      nodeId,
+      (peerId, delta) => this.sendDelta(peerId, delta),
+      {
+        antiEntropyIntervalMs: options.antiEntropyIntervalMs ?? 0,
+        mode: "state",
+      },
+    );
+
+    // Register federation message handlers
+    this.federation.on("crdt:push", this.handlePush.bind(this));
+    this.federation.on("crdt:ack", this.handleAck.bind(this));
+  }
+
+  // ── Public API ──────────────────────────────────────────────────────────
+
+  /**
+   * Get or create a CRDT document for a session.
+   * If the session is in single_writer mode this returns undefined.
+   */
+  getOrCreateDocument(sessionId: string): CRDTDocument | undefined {
+    const mode = this.sessionModes.get(sessionId) ?? this.defaultMode;
+    if (mode !== "crdt_p2p") return undefined;
+
+    let doc = this.syncManager.getDocument(sessionId);
+    if (!doc) {
+      doc = new CRDTDocument(sessionId, this.nodeId);
+      this.syncManager.registerDocument(doc);
+    }
+    return doc;
+  }
+
+  /** Retrieve a managed document without creating it. */
+  getDocument(sessionId: string): CRDTDocument | undefined {
+    return this.syncManager.getDocument(sessionId);
+  }
+
+  /**
+   * Set the sync mode for a session.
+   * Switching to crdt_p2p automatically bootstraps a document and triggers
+   * an immediate push to all connected peers.
+   */
+  setSyncMode(sessionId: string, mode: CollabSyncMode): void {
+    this.sessionModes.set(sessionId, mode);
+
+    if (mode === "crdt_p2p") {
+      this.getOrCreateDocument(sessionId);
+      this.pushToAllPeers(sessionId);
+    }
+  }
+
+  /** Get the current sync mode for a session. */
+  getSyncMode(sessionId: string): CollabSyncMode {
+    return this.sessionModes.get(sessionId) ?? this.defaultMode;
+  }
+
+  /**
+   * Push current CRDT state for a session to all connected peers.
+   * Silently does nothing if the session is in single_writer mode.
+   */
+  pushToAllPeers(sessionId: string): void {
+    const mode = this.sessionModes.get(sessionId) ?? this.defaultMode;
+    if (mode !== "crdt_p2p") return;
+
+    const doc = this.syncManager.getDocument(sessionId);
+    if (!doc) return;
+
+    const peerIds = this.federation.getPeers().map((p) => p.instanceId);
+    this.syncManager.broadcast(sessionId, peerIds);
+  }
+
+  /**
+   * Push current CRDT state to a specific peer.
+   */
+  pushToPeer(sessionId: string, peerId: string): void {
+    const mode = this.sessionModes.get(sessionId) ?? this.defaultMode;
+    if (mode !== "crdt_p2p") return;
+    this.syncManager.push(sessionId, peerId);
+  }
+
+  /**
+   * Retrieve the list of peers and their last-known vector clock versions.
+   */
+  getPeerVersions(sessionId: string): Array<{
+    peerId: string;
+    clock: VectorClockState | undefined;
+  }> {
+    const doc = this.syncManager.getDocument(sessionId);
+    if (!doc) return [];
+
+    return this.federation.getPeers().map((p) => ({
+      peerId: p.instanceId,
+      clock: this.syncManager.getPeerClock(p.instanceId),
+    }));
+  }
+
+  /** Stop the sync service and the underlying anti-entropy loop. */
+  stop(): void {
+    this.syncManager.stop();
+  }
+
+  // ── Federation message handlers ─────────────────────────────────────────
+
+  private handlePush(msg: FederationMessage, _peer: PeerInfo): void {
+    const delta = msg.payload as CRDTDelta;
+    const changed = this.syncManager.receive(delta);
+
+    if (changed) {
+      // Send an ack with our updated vector clock
+      const doc = this.syncManager.getDocument(delta.sessionId);
+      if (doc) {
+        const ack: CrdtAckPayload = {
+          sessionId: delta.sessionId,
+          receiverClock: doc.vectorClock.toState(),
+        };
+        this.federation.send("crdt:ack", ack, msg.from);
+      }
+    }
+  }
+
+  private handleAck(msg: FederationMessage, _peer: PeerInfo): void {
+    const payload = msg.payload as CrdtAckPayload;
+    this.syncManager.updatePeerClock(msg.from, payload.receiverClock);
+  }
+
+  // ── Internal helpers ──────────────────────────────────────────────────────
+
+  private sendDelta(peerId: string, delta: CRDTDelta): void {
+    this.federation.send("crdt:push", delta, peerId);
+  }
+}

--- a/server/federation/crdt/pn-counter.ts
+++ b/server/federation/crdt/pn-counter.ts
@@ -1,0 +1,71 @@
+/**
+ * PN-Counter (Positive-Negative Counter) CRDT
+ *
+ * A PN-Counter supports both increment and decrement by composing two
+ * G-Counters: one for increments (P) and one for decrements (N).
+ * The resolved value is P.value() - N.value().
+ *
+ * Properties:
+ *   - Commutative, associative, idempotent (inherited from G-Counter)
+ */
+
+import { GCounter, type GCounterState } from "./g-counter.js";
+
+export interface PNCounterState {
+  type: "pn-counter";
+  positive: GCounterState;
+  negative: GCounterState;
+}
+
+export class PNCounter {
+  private positive: GCounter;
+  private negative: GCounter;
+
+  constructor(private nodeId: string, state?: { positive?: Record<string, number>; negative?: Record<string, number> }) {
+    this.positive = new GCounter(nodeId, state?.positive ?? {});
+    this.negative = new GCounter(nodeId, state?.negative ?? {});
+  }
+
+  /** Increment the counter by delta (default 1). */
+  increment(delta = 1): void {
+    if (delta <= 0) throw new RangeError("PNCounter increment delta must be positive");
+    this.positive.increment(delta);
+  }
+
+  /** Decrement the counter by delta (default 1). */
+  decrement(delta = 1): void {
+    if (delta <= 0) throw new RangeError("PNCounter decrement delta must be positive");
+    this.negative.increment(delta);
+  }
+
+  /** Current resolved value (may be negative). */
+  value(): number {
+    return this.positive.value() - this.negative.value();
+  }
+
+  /**
+   * Merge a remote PN-Counter state into this one.
+   * Merges each component G-Counter independently.
+   */
+  merge(remote: PNCounterState): void {
+    this.positive.merge(remote.positive);
+    this.negative.merge(remote.negative);
+  }
+
+  /** Serialize to transportable JSON state. */
+  toState(): PNCounterState {
+    return {
+      type: "pn-counter",
+      positive: this.positive.toState(),
+      negative: this.negative.toState(),
+    };
+  }
+
+  /** Deserialize from JSON state. */
+  static fromState(nodeId: string, state: PNCounterState): PNCounter {
+    return new PNCounter(nodeId, {
+      positive: state.positive.counters,
+      negative: state.negative.counters,
+    });
+  }
+}

--- a/server/federation/crdt/sync.ts
+++ b/server/federation/crdt/sync.ts
@@ -1,0 +1,216 @@
+/**
+ * CRDT Sync Protocol
+ *
+ * Two sync modes:
+ *
+ * 1. State-based sync: peers exchange full CRDT document state and merge locally.
+ *    Simple and correct; bandwidth scales with document size.
+ *
+ * 2. Delta-based sync: only send changes since last sync (tracked by vector clock).
+ *    Reduces bandwidth; falls back to full-state if delta is unavailable.
+ *
+ * Anti-entropy: periodic full-state exchange catches any missed deltas and
+ * guarantees eventual convergence even with unreliable transports.
+ */
+
+import { CRDTDocument, type CRDTDocumentState } from "./document.js";
+import { VectorClock, type VectorClockState } from "./vector-clock.js";
+
+// ─── Delta Types ─────────────────────────────────────────────────────────────
+
+/**
+ * A delta represents the changes to a CRDT document since a known vector-clock
+ * snapshot. Because we use state-based CRDTs, the "delta" is simply the full
+ * state — the recipient's merge operation is idempotent, so resending already-
+ * known state is safe (only wastes bandwidth, not correctness).
+ *
+ * Future optimization: track per-field dirty flags and only include changed
+ * sub-documents in the delta.
+ */
+export interface CRDTDelta {
+  sessionId: string;
+  fromNodeId: string;
+  /** The sender's vector clock at the time this delta was created. */
+  senderClock: VectorClockState;
+  /** The recipient's last-known clock (so the recipient can detect gaps). */
+  sinceRecipientClock: VectorClockState | null;
+  /** Full document state (used as the delta payload in this implementation). */
+  state: CRDTDocumentState;
+}
+
+// ─── Sync Manager ────────────────────────────────────────────────────────────
+
+export type SendFn = (peerId: string, delta: CRDTDelta) => void | Promise<void>;
+
+export interface SyncOptions {
+  /** Interval in ms for anti-entropy full-state broadcasts. 0 = disabled. */
+  antiEntropyIntervalMs?: number;
+  /** Sync mode. Defaults to "state". */
+  mode?: "state" | "delta";
+}
+
+export class CRDTSyncManager {
+  /** sessionId → document */
+  private documents = new Map<string, CRDTDocument>();
+
+  /**
+   * nodeId → last-known vector clock for that peer
+   * Used to construct deltas that only include new information.
+   */
+  private peerClocks = new Map<string, VectorClockState>();
+
+  private antiEntropyHandle: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private nodeId: string,
+    private sendFn: SendFn,
+    private options: SyncOptions = {},
+  ) {
+    if ((options.antiEntropyIntervalMs ?? 0) > 0) {
+      this.antiEntropyHandle = setInterval(
+        () => this.runAntiEntropy(),
+        options.antiEntropyIntervalMs,
+      );
+    }
+  }
+
+  // ── Document lifecycle ────────────────────────────────────────────────────
+
+  /** Register a document for sync management. */
+  registerDocument(doc: CRDTDocument): void {
+    this.documents.set(doc.sessionId, doc);
+  }
+
+  /** Retrieve a managed document by session ID. */
+  getDocument(sessionId: string): CRDTDocument | undefined {
+    return this.documents.get(sessionId);
+  }
+
+  /** Remove a document from sync management (e.g., session ended). */
+  unregisterDocument(sessionId: string): void {
+    this.documents.delete(sessionId);
+  }
+
+  // ── Outbound sync ─────────────────────────────────────────────────────────
+
+  /**
+   * Push current document state to all known peers (full-state mode)
+   * or a delta since the last known peer clock (delta mode).
+   */
+  push(sessionId: string, peerId: string): void {
+    const doc = this.documents.get(sessionId);
+    if (!doc) return;
+
+    const sinceRecipientClock =
+      this.options.mode === "delta"
+        ? (this.peerClocks.get(peerId) ?? null)
+        : null;
+
+    const delta: CRDTDelta = {
+      sessionId,
+      fromNodeId: this.nodeId,
+      senderClock: doc.vectorClock.toState(),
+      sinceRecipientClock,
+      state: doc.toState(),
+    };
+
+    void this.sendFn(peerId, delta);
+  }
+
+  /**
+   * Broadcast document state to all given peer IDs.
+   */
+  broadcast(sessionId: string, peerIds: string[]): void {
+    for (const peerId of peerIds) {
+      this.push(sessionId, peerId);
+    }
+  }
+
+  // ── Inbound sync ──────────────────────────────────────────────────────────
+
+  /**
+   * Receive and apply an incoming delta from a remote peer.
+   * Merges the state into the local document and updates the peer clock record.
+   *
+   * Returns true if the merge changed the local document, false if it was a no-op.
+   */
+  receive(delta: CRDTDelta): boolean {
+    const { sessionId, fromNodeId, senderClock, state } = delta;
+
+    let doc = this.documents.get(sessionId);
+    if (!doc) {
+      // Bootstrap a new document from the incoming state
+      doc = CRDTDocument.fromState(state);
+      this.documents.set(sessionId, doc);
+      this.peerClocks.set(fromNodeId, senderClock);
+      return true;
+    }
+
+    const localClock = doc.vectorClock.toState();
+    const vc = VectorClock.fromState(this.nodeId, localClock);
+    const relation = vc.compare(senderClock);
+
+    // Only skip if we are strictly after the sender — meaning our state is
+    // a superset of theirs. In all other cases (concurrent, equal, before)
+    // we perform the merge because:
+    //   - "before": sender has info we lack
+    //   - "concurrent": each side has independent info
+    //   - "equal": vector clocks match but state-based mutations may have
+    //     happened without ticking the clock (e.g., ORSet add uses UUIDs,
+    //     not the vector clock counter). Merging is always safe (idempotent).
+    if (relation === "after") {
+      // Our state strictly dominates — skip for bandwidth optimisation.
+      this.peerClocks.set(fromNodeId, senderClock);
+      return false;
+    }
+
+    // Merge the incoming state (idempotent)
+    doc.merge(state);
+
+    // Record the sender's clock so we can compute deltas for them later
+    this.peerClocks.set(fromNodeId, senderClock);
+    return true;
+  }
+
+  // ── Anti-entropy ──────────────────────────────────────────────────────────
+
+  /**
+   * Run an anti-entropy pass: broadcast full state of all managed documents
+   * to all known peers. This converges any missed deltas.
+   */
+  private runAntiEntropy(): void {
+    const peerIds = Array.from(this.peerClocks.keys());
+    if (peerIds.length === 0) return;
+
+    for (const [sessionId] of this.documents) {
+      this.broadcast(sessionId, peerIds);
+    }
+  }
+
+  // ── Peer clock management ─────────────────────────────────────────────────
+
+  /** Record or update a peer's last-known vector clock. */
+  updatePeerClock(peerId: string, clock: VectorClockState): void {
+    this.peerClocks.set(peerId, clock);
+  }
+
+  /** Retrieve a peer's last-known vector clock. */
+  getPeerClock(peerId: string): VectorClockState | undefined {
+    return this.peerClocks.get(peerId);
+  }
+
+  /** Get all peer IDs currently tracked. */
+  getTrackedPeerIds(): string[] {
+    return Array.from(this.peerClocks.keys());
+  }
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+  /** Stop the anti-entropy interval (for graceful shutdown). */
+  stop(): void {
+    if (this.antiEntropyHandle) {
+      clearInterval(this.antiEntropyHandle);
+      this.antiEntropyHandle = null;
+    }
+  }
+}

--- a/server/federation/crdt/vector-clock.ts
+++ b/server/federation/crdt/vector-clock.ts
@@ -1,0 +1,108 @@
+/**
+ * Vector Clock for causal ordering of events across distributed nodes.
+ *
+ * Each node maintains a counter. When a node sends a message it increments its
+ * own counter. When it receives a message it takes the component-wise maximum
+ * and then increments its own counter.
+ *
+ * Causality relations:
+ *   A < B (A happened-before B): A[i] <= B[i] for all i, and A[j] < B[j] for some j
+ *   A == B (concurrent): neither A < B nor B < A
+ */
+
+export interface VectorClockState {
+  clocks: Record<string, number>;
+}
+
+export type CausalRelation = "before" | "after" | "concurrent" | "equal";
+
+export class VectorClock {
+  private clocks: Map<string, number>;
+
+  constructor(private nodeId: string, clocks?: Record<string, number>) {
+    this.clocks = new Map(Object.entries(clocks ?? {}));
+    if (!this.clocks.has(nodeId)) {
+      this.clocks.set(nodeId, 0);
+    }
+  }
+
+  /** Increment this node's clock (called before sending a message). */
+  tick(): void {
+    const current = this.clocks.get(this.nodeId) ?? 0;
+    this.clocks.set(this.nodeId, current + 1);
+  }
+
+  /** Merge a remote clock and then tick (called on receiving a message). */
+  receive(remote: VectorClockState): void {
+    this.merge(remote);
+    this.tick();
+  }
+
+  /**
+   * Merge (component-wise maximum) without ticking.
+   * Used for read-only state synchronisation.
+   */
+  merge(remote: VectorClockState): void {
+    for (const [nodeId, remoteCount] of Object.entries(remote.clocks)) {
+      const local = this.clocks.get(nodeId) ?? 0;
+      if (remoteCount > local) {
+        this.clocks.set(nodeId, remoteCount);
+      }
+    }
+  }
+
+  /** Get the current counter for a node (0 if unseen). */
+  get(nodeId: string): number {
+    return this.clocks.get(nodeId) ?? 0;
+  }
+
+  /** This clock's current counter. */
+  currentTick(): number {
+    return this.clocks.get(this.nodeId) ?? 0;
+  }
+
+  /**
+   * Determine the causal relationship between this clock and another.
+   */
+  compare(other: VectorClockState): CausalRelation {
+    const allKeys = new Set([
+      ...this.clocks.keys(),
+      ...Object.keys(other.clocks),
+    ]);
+
+    let thisLessOnSome = false;
+    let otherLessOnSome = false;
+
+    for (const k of allKeys) {
+      const a = this.clocks.get(k) ?? 0;
+      const b = other.clocks[k] ?? 0;
+      if (a < b) thisLessOnSome = true;
+      if (a > b) otherLessOnSome = true;
+    }
+
+    if (!thisLessOnSome && !otherLessOnSome) return "equal";
+    if (!otherLessOnSome) return "before"; // this <= other on all dims
+    if (!thisLessOnSome) return "after";   // this >= other on all dims
+    return "concurrent";
+  }
+
+  /** True if this clock is strictly before (causally precedes) other. */
+  isBefore(other: VectorClockState): boolean {
+    return this.compare(other) === "before";
+  }
+
+  /** True if this clock is concurrent with other (no causal order). */
+  isConcurrent(other: VectorClockState): boolean {
+    return this.compare(other) === "concurrent";
+  }
+
+  /** Serialize to transportable JSON state. */
+  toState(): VectorClockState {
+    return { clocks: Object.fromEntries(this.clocks) };
+  }
+
+  /** Deserialize from JSON state. */
+  static fromState(nodeId: string, state: VectorClockState): VectorClock {
+    return new VectorClock(nodeId, state.clocks);
+  }
+}

--- a/server/routes/federation.ts
+++ b/server/routes/federation.ts
@@ -1,5 +1,5 @@
 /**
- * Federation Routes -- issues #224 + #225 + #226 + #233
+ * Federation Routes -- issues #224 + #225 + #226 + #233 + #230
  *
  * Session Sharing (issue #224):
  *   POST   /api/federation/sessions/share      -- share a run
@@ -34,6 +34,13 @@
  *   DELETE /api/federation/delegation/:id          -- cancel delegation
  *   GET    /api/federation/delegation/policy       -- get delegation policy
  *
+
+ * CRDT P2P Collaboration (issue #230):
+ *   GET    /api/sessions/:id/crdt-state       -- current CRDT document state
+ *   POST   /api/sessions/:id/crdt-merge       -- receive remote CRDT state and merge
+ *   GET    /api/sessions/:id/crdt-peers       -- list peers and their vector clock versions
+ *   POST   /api/sessions/:id/crdt-mode        -- set sync mode (single_writer | crdt_p2p)
+ *
  * All routes require authentication (covered by upstream requireAuth middleware).
  * Returns 503 when federation is not enabled.
  */
@@ -46,6 +53,7 @@ import type { FederationManager } from "../federation/index";
 import type { CrossInstanceDelegationService } from "../federation/delegation";
 import type { IStorage } from "../storage";
 import type { ConflictResolutionService } from "../federation/conflict-resolution";
+import type { CRDTPeerSyncService } from "../federation/crdt/peer-sync";
 
 // ─── Validation schemas ───────────────────────────────────────────────────────
 
@@ -157,6 +165,7 @@ export function registerFederationRoutes(
   storage?: IStorage | null,
   crossDelegation?: CrossInstanceDelegationService | null,
   conflictResolution?: ConflictResolutionService | null,
+  crdtPeerSync?: CRDTPeerSyncService | null,
 ): void {
   const federationDisabledResponse = (res: Response) =>
     res.status(503).json({
@@ -735,5 +744,146 @@ export function registerFederationRoutes(
 
     const log = conflictResolution.getSessionDecisionLog(String(_req.params.id));
     return res.json(log);
+  });
+}
+
+// ─── CRDT P2P Collaboration Routes (issue #230) ───────────────────────────────
+
+// Validation schema for mode changes
+const SetCRDTModeSchema = z.object({
+  mode: z.enum(["single_writer", "crdt_p2p"]),
+});
+
+// Validation schema for merging incoming CRDT state
+const CRDTMergeSchema = z.object({
+  state: z.object({
+    sessionId: z.string().min(1),
+    nodeId: z.string().min(1),
+    participants: z.object({
+      type: z.literal("or-set"),
+      entries: z.record(z.array(z.string())),
+      tombstones: z.array(z.string()),
+    }),
+    stageOutputs: z.object({
+      type: z.literal("lww-map"),
+      entries: z.record(z.unknown()),
+    }),
+    stageStatuses: z.object({
+      type: z.literal("lww-map"),
+      entries: z.record(z.unknown()),
+    }),
+    votes: z.object({
+      type: z.literal("g-counter"),
+      counters: z.record(z.number()),
+    }),
+    tags: z.object({
+      type: z.literal("or-set"),
+      entries: z.record(z.array(z.string())),
+      tombstones: z.array(z.string()),
+    }),
+    metadata: z.object({
+      type: z.literal("lww-register"),
+      value: z.unknown(),
+      timestamp: z.number(),
+      nodeId: z.string(),
+    }),
+    vectorClock: z.object({
+      clocks: z.record(z.number()),
+    }),
+  }),
+});
+
+export function registerCRDTRoutes(
+  app: Router,
+  crdtPeerSync: CRDTPeerSyncService | null,
+): void {
+  const notAvailable = (res: Response) =>
+    res.status(503).json({ error: "CRDT peer sync service not available" });
+
+  // GET /api/sessions/:id/crdt-state — current CRDT document state
+  app.get("/api/sessions/:id/crdt-state", (req: Request, res: Response) => {
+    if (!crdtPeerSync) return notAvailable(res);
+
+    const sessionId = String(req.params.id);
+    const mode = crdtPeerSync.getSyncMode(sessionId);
+
+    if (mode !== "crdt_p2p") {
+      return res.json({
+        sessionId,
+        syncMode: mode,
+        state: null,
+        value: null,
+      });
+    }
+
+    const doc = crdtPeerSync.getOrCreateDocument(sessionId);
+    if (!doc) return notAvailable(res);
+
+    return res.json({
+      sessionId,
+      syncMode: mode,
+      state: doc.toState(),
+      value: doc.snapshot(),
+    });
+  });
+
+  // POST /api/sessions/:id/crdt-merge — receive remote CRDT state and merge
+  app.post("/api/sessions/:id/crdt-merge", (req: Request, res: Response) => {
+    if (!crdtPeerSync) return notAvailable(res);
+
+    const sessionId = String(req.params.id);
+    const parsed = CRDTMergeSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid CRDT state", issues: parsed.error.flatten() });
+    }
+
+    const mode = crdtPeerSync.getSyncMode(sessionId);
+    if (mode !== "crdt_p2p") {
+      return res.status(409).json({
+        error: "Session is in single_writer mode; CRDT merge not applicable",
+        syncMode: mode,
+      });
+    }
+
+    const doc = crdtPeerSync.getOrCreateDocument(sessionId);
+    if (!doc) return notAvailable(res);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    doc.merge(parsed.data.state as any);
+
+    return res.json({
+      merged: true,
+      state: doc.toState(),
+      value: doc.snapshot(),
+    });
+  });
+
+  // GET /api/sessions/:id/crdt-peers — list peers and their vector clock versions
+  app.get("/api/sessions/:id/crdt-peers", (req: Request, res: Response) => {
+    if (!crdtPeerSync) return notAvailable(res);
+
+    const sessionId = String(req.params.id);
+    const peers = crdtPeerSync.getPeerVersions(sessionId);
+    return res.json(peers);
+  });
+
+  // POST /api/sessions/:id/crdt-mode — set sync mode
+  app.post("/api/sessions/:id/crdt-mode", (req: Request, res: Response) => {
+    if (!crdtPeerSync) return notAvailable(res);
+
+    const sessionId = String(req.params.id);
+    const parsed = SetCRDTModeSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "Invalid mode", issues: parsed.error.flatten() });
+    }
+
+    crdtPeerSync.setSyncMode(sessionId, parsed.data.mode);
+    const doc = crdtPeerSync.getDocument(sessionId);
+
+    return res.json({
+      sessionId,
+      syncMode: parsed.data.mode,
+      state: doc ? doc.toState() : null,
+    });
   });
 }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -2818,3 +2818,110 @@ export interface DecisionLogEntry {
   durationMs: number;
   recordedAt: number;
 }
+
+// ─── CRDT Types (issue #230) ──────────────────────────────────────────────────
+
+/** Sync mode for a shared session's collaborative state. */
+export type CollabSyncMode = "single_writer" | "crdt_p2p";
+
+/** Vector clock snapshot — maps nodeId to its logical counter. */
+export interface VectorClockSnapshot {
+  clocks: Record<string, number>;
+}
+
+/** Serialized G-Counter state. */
+export interface GCounterSnapshot {
+  type: "g-counter";
+  counters: Record<string, number>;
+}
+
+/** Serialized PN-Counter state. */
+export interface PNCounterSnapshot {
+  type: "pn-counter";
+  positive: GCounterSnapshot;
+  negative: GCounterSnapshot;
+}
+
+/** Serialized LWW-Register state. */
+export interface LWWRegisterSnapshot<T> {
+  type: "lww-register";
+  value: T | null;
+  timestamp: number;
+  nodeId: string;
+}
+
+/** Serialized OR-Set state. */
+export interface ORSetSnapshot<T> {
+  type: "or-set";
+  /** Serialized element → list of live add-tags. */
+  entries: Record<string, string[]>;
+  tombstones: string[];
+}
+
+/** Serialized LWW-Map state. */
+export interface LWWMapSnapshot<V> {
+  type: "lww-map";
+  entries: Record<string, LWWRegisterSnapshot<V>>;
+}
+
+/** Full serialized CRDT document for a shared session. */
+export interface CRDTDocumentSnapshot {
+  sessionId: string;
+  nodeId: string;
+  participants: ORSetSnapshot<string>;
+  stageOutputs: LWWMapSnapshot<string>;
+  stageStatuses: LWWMapSnapshot<string>;
+  votes: GCounterSnapshot;
+  tags: ORSetSnapshot<string>;
+  metadata: LWWRegisterSnapshot<Record<string, unknown>>;
+  vectorClock: VectorClockSnapshot;
+}
+
+/** Human-readable snapshot of resolved CRDT document values. */
+export interface CRDTDocumentValue {
+  participants: string[];
+  stageOutputs: Record<string, string | null>;
+  stageStatuses: Record<string, string | null>;
+  votes: number;
+  tags: string[];
+  metadata: Record<string, unknown> | null;
+  vectorClock: VectorClockSnapshot;
+}
+
+/** A CRDT delta sent from one peer to another. */
+export interface CRDTDeltaMessage {
+  sessionId: string;
+  fromNodeId: string;
+  senderClock: VectorClockSnapshot;
+  sinceRecipientClock: VectorClockSnapshot | null;
+  state: CRDTDocumentSnapshot;
+}
+
+/** Response from GET /api/sessions/:id/crdt-state */
+export interface CRDTStateResponse {
+  sessionId: string;
+  syncMode: CollabSyncMode;
+  state: CRDTDocumentSnapshot;
+  value: CRDTDocumentValue;
+}
+
+/** Request body for POST /api/sessions/:id/crdt-merge */
+export interface CRDTMergeRequest {
+  state: CRDTDocumentSnapshot;
+}
+
+/** Response from POST /api/sessions/:id/crdt-merge */
+export interface CRDTMergeResponse {
+  merged: boolean;
+  state: CRDTDocumentSnapshot;
+  value: CRDTDocumentValue;
+}
+
+/** Entry in GET /api/sessions/:id/crdt-peers response */
+export interface CRDTPeerEntry {
+  peerId: string;
+  clock: VectorClockSnapshot | undefined;
+}
+
+/** Response from GET /api/sessions/:id/crdt-peers */
+export type CRDTPeersResponse = CRDTPeerEntry[];

--- a/tests/unit/crdt.test.ts
+++ b/tests/unit/crdt.test.ts
@@ -1,0 +1,1121 @@
+/**
+ * Tests for CRDT-based P2P collaboration (issue #230)
+ *
+ * Covers:
+ *   - G-Counter: merge commutativity, associativity, idempotency, serialisation
+ *   - PN-Counter: same properties + decrement
+ *   - LWW-Register: LWW semantics, tie-breaking, serialisation
+ *   - OR-Set: add/remove without conflict, concurrent adds, serialisation
+ *   - LWW-Map: per-key LWW, merge, serialisation
+ *   - VectorClock: tick, merge, compare (before/after/concurrent/equal)
+ *   - CRDTDocument: compound merge, session mismatch guard, snapshot
+ *   - CRDTSyncManager: state-based sync, delta mode, anti-entropy, peer clocks
+ *   - CRDTPeerSyncService: mode switching, push/receive, peer versions
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GCounter } from "../../server/federation/crdt/g-counter";
+import { PNCounter } from "../../server/federation/crdt/pn-counter";
+import { LWWRegister } from "../../server/federation/crdt/lww-register";
+import { ORSet } from "../../server/federation/crdt/or-set";
+import { LWWMap } from "../../server/federation/crdt/lww-map";
+import { VectorClock } from "../../server/federation/crdt/vector-clock";
+import { CRDTDocument } from "../../server/federation/crdt/document";
+import { CRDTSyncManager } from "../../server/federation/crdt/sync";
+import { CRDTPeerSyncService } from "../../server/federation/crdt/peer-sync";
+import type { FederationManager } from "../../server/federation/index";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeFederationManager(peers: string[] = []): FederationManager {
+  return {
+    on: vi.fn(),
+    send: vi.fn(),
+    getPeers: vi.fn(() => peers.map((p) => ({ instanceId: p }))),
+    isEnabled: vi.fn(() => true),
+  } as unknown as FederationManager;
+}
+
+// ─── G-Counter ───────────────────────────────────────────────────────────────
+
+describe("GCounter", () => {
+  it("increments correctly", () => {
+    const c = new GCounter("A");
+    c.increment();
+    c.increment(3);
+    expect(c.value()).toBe(4);
+  });
+
+  it("rejects non-positive delta", () => {
+    const c = new GCounter("A");
+    expect(() => c.increment(0)).toThrow(RangeError);
+    expect(() => c.increment(-1)).toThrow(RangeError);
+  });
+
+  it("merge is commutative", () => {
+    const a = new GCounter("A");
+    const b = new GCounter("B");
+    a.increment(2);
+    b.increment(3);
+
+    const aState = a.toState();
+    const bState = b.toState();
+
+    const left = new GCounter("C");
+    left.merge(aState);
+    left.merge(bState);
+
+    const right = new GCounter("C");
+    right.merge(bState);
+    right.merge(aState);
+
+    expect(left.value()).toBe(right.value());
+    expect(left.value()).toBe(5);
+  });
+
+  it("merge is associative", () => {
+    const a = new GCounter("A");
+    const b = new GCounter("B");
+    const c = new GCounter("C");
+    a.increment(1);
+    b.increment(2);
+    c.increment(3);
+
+    // (A ∪ B) ∪ C
+    const left = GCounter.fromState("X", a.toState());
+    left.merge(b.toState());
+    left.merge(c.toState());
+
+    // A ∪ (B ∪ C)
+    const bc = GCounter.fromState("Y", b.toState());
+    bc.merge(c.toState());
+    const right = GCounter.fromState("Z", a.toState());
+    right.merge(bc.toState());
+
+    expect(left.value()).toBe(right.value());
+    expect(left.value()).toBe(6);
+  });
+
+  it("merge is idempotent", () => {
+    const a = new GCounter("A");
+    a.increment(5);
+    const state = a.toState();
+
+    const b = GCounter.fromState("B", state);
+    b.merge(state);
+    b.merge(state);
+
+    expect(b.value()).toBe(5);
+  });
+
+  it("serialisation round-trips", () => {
+    const a = new GCounter("A");
+    a.increment(7);
+    const state = a.toState();
+    const b = GCounter.fromState("A", state);
+    expect(b.value()).toBe(7);
+  });
+
+  it("multi-node merge sums maxima", () => {
+    const a = new GCounter("A");
+    a.increment(10);
+
+    const b = new GCounter("B");
+    b.increment(5);
+
+    const merged = GCounter.fromState("M", a.toState());
+    merged.merge(b.toState());
+
+    expect(merged.value()).toBe(15);
+  });
+});
+
+// ─── PN-Counter ──────────────────────────────────────────────────────────────
+
+describe("PNCounter", () => {
+  it("increment and decrement", () => {
+    const c = new PNCounter("A");
+    c.increment(5);
+    c.decrement(2);
+    expect(c.value()).toBe(3);
+  });
+
+  it("can go negative", () => {
+    const c = new PNCounter("A");
+    c.decrement(3);
+    expect(c.value()).toBe(-3);
+  });
+
+  it("rejects non-positive deltas", () => {
+    const c = new PNCounter("A");
+    expect(() => c.increment(0)).toThrow(RangeError);
+    expect(() => c.decrement(-1)).toThrow(RangeError);
+  });
+
+  it("merge is commutative", () => {
+    const a = new PNCounter("A");
+    const b = new PNCounter("B");
+    a.increment(10);
+    b.decrement(3);
+
+    const aS = a.toState();
+    const bS = b.toState();
+
+    const left = new PNCounter("C");
+    left.merge(aS);
+    left.merge(bS);
+
+    const right = new PNCounter("D");
+    right.merge(bS);
+    right.merge(aS);
+
+    expect(left.value()).toBe(right.value());
+    expect(left.value()).toBe(7);
+  });
+
+  it("merge is idempotent", () => {
+    const a = new PNCounter("A");
+    a.increment(4);
+    a.decrement(1);
+    const s = a.toState();
+
+    const b = PNCounter.fromState("B", s);
+    b.merge(s);
+    b.merge(s);
+
+    expect(b.value()).toBe(3);
+  });
+
+  it("serialisation round-trips", () => {
+    const a = new PNCounter("A");
+    a.increment(6);
+    a.decrement(2);
+    const b = PNCounter.fromState("A", a.toState());
+    expect(b.value()).toBe(4);
+  });
+});
+
+// ─── LWW-Register ─────────────────────────────────────────────────────────────
+
+describe("LWWRegister", () => {
+  it("stores a value", () => {
+    const r = new LWWRegister<string>("A");
+    r.set("hello", 100);
+    expect(r.value()).toBe("hello");
+  });
+
+  it("higher timestamp wins", () => {
+    const r = new LWWRegister<string>("A");
+    r.set("first", 100);
+    r.set("second", 200);
+    expect(r.value()).toBe("second");
+  });
+
+  it("lower timestamp does not overwrite", () => {
+    const r = new LWWRegister<string>("A");
+    r.set("newer", 200);
+    r.set("older", 100);
+    expect(r.value()).toBe("newer");
+  });
+
+  it("merge: remote timestamp higher wins", () => {
+    const a = new LWWRegister<string>("A");
+    a.set("local", 100);
+
+    const b = new LWWRegister<string>("B");
+    b.set("remote", 200);
+
+    a.merge(b.toState());
+    expect(a.value()).toBe("remote");
+  });
+
+  it("merge: local timestamp higher survives", () => {
+    const a = new LWWRegister<string>("A");
+    a.set("local", 300);
+
+    const b = new LWWRegister<string>("B");
+    b.set("remote", 100);
+
+    a.merge(b.toState());
+    expect(a.value()).toBe("local");
+  });
+
+  it("merge tie-breaking by nodeId", () => {
+    const a = new LWWRegister<string>("A");
+    a.set("from-A", 100);
+
+    const b = new LWWRegister<string>("B");
+    b.set("from-B", 100);
+
+    // "B" > "A" lexicographically
+    const merged = new LWWRegister<string>("A");
+    merged.merge(a.toState());
+    merged.merge(b.toState());
+    expect(merged.value()).toBe("from-B");
+  });
+
+  it("merge is commutative", () => {
+    const a = new LWWRegister<number>("A");
+    a.set(1, 50);
+    const b = new LWWRegister<number>("B");
+    b.set(2, 100);
+
+    const left = new LWWRegister<number>("C");
+    left.merge(a.toState());
+    left.merge(b.toState());
+
+    const right = new LWWRegister<number>("D");
+    right.merge(b.toState());
+    right.merge(a.toState());
+
+    expect(left.value()).toBe(right.value());
+  });
+
+  it("merge is idempotent", () => {
+    const a = new LWWRegister<string>("A");
+    a.set("x", 100);
+    const s = a.toState();
+
+    const b = LWWRegister.fromState("B", s);
+    b.merge(s);
+    b.merge(s);
+
+    expect(b.value()).toBe("x");
+  });
+
+  it("serialisation round-trips", () => {
+    const a = new LWWRegister<Record<string, number>>("A");
+    a.set({ count: 42 }, 999);
+    const b = LWWRegister.fromState<Record<string, number>>("A", a.toState());
+    expect(b.value()).toEqual({ count: 42 });
+    expect(b.timestamp()).toBe(999);
+  });
+});
+
+// ─── OR-Set ───────────────────────────────────────────────────────────────────
+
+describe("ORSet", () => {
+  it("add and has", () => {
+    const s = new ORSet<string>("A");
+    s.add("alice");
+    expect(s.has("alice")).toBe(true);
+    expect(s.has("bob")).toBe(false);
+  });
+
+  it("remove after add", () => {
+    const s = new ORSet<string>("A");
+    s.add("alice");
+    s.remove("alice");
+    expect(s.has("alice")).toBe(false);
+    expect(s.value()).not.toContain("alice");
+  });
+
+  it("remove on non-existent element is a no-op", () => {
+    const s = new ORSet<string>("A");
+    s.remove("ghost");
+    expect(s.value()).toHaveLength(0);
+  });
+
+  it("add after remove wins over the remove (concurrent add wins)", () => {
+    const a = new ORSet<string>("A");
+    const b = new ORSet<string>("B");
+
+    a.add("x");
+
+    // B removes the element it knew about
+    const beforeRemove = a.toState();
+    b.merge(beforeRemove);
+    b.remove("x");
+
+    // A concurrently adds "x" again with a new tag
+    a.remove("x");
+    a.add("x");
+
+    // Merge B's state into A
+    a.merge(b.toState());
+
+    // A's new add was concurrent with B's remove — new tag survives
+    expect(a.has("x")).toBe(true);
+  });
+
+  it("merge is commutative", () => {
+    const a = new ORSet<string>("A");
+    const b = new ORSet<string>("B");
+    a.add("foo");
+    b.add("bar");
+
+    const left = new ORSet<string>("C");
+    left.merge(a.toState());
+    left.merge(b.toState());
+
+    const right = new ORSet<string>("D");
+    right.merge(b.toState());
+    right.merge(a.toState());
+
+    expect(left.value().sort()).toEqual(right.value().sort());
+  });
+
+  it("merge is associative", () => {
+    const a = new ORSet<string>("A");
+    const b = new ORSet<string>("B");
+    const c = new ORSet<string>("C");
+    a.add("1");
+    b.add("2");
+    c.add("3");
+
+    const left = new ORSet<string>("X");
+    left.merge(a.toState());
+    left.merge(b.toState());
+    left.merge(c.toState());
+
+    const bc = new ORSet<string>("BC");
+    bc.merge(b.toState());
+    bc.merge(c.toState());
+
+    const right = new ORSet<string>("Y");
+    right.merge(a.toState());
+    right.merge(bc.toState());
+
+    expect(left.value().sort()).toEqual(right.value().sort());
+  });
+
+  it("merge is idempotent", () => {
+    const a = new ORSet<string>("A");
+    a.add("item");
+    const s = a.toState();
+
+    const b = ORSet.fromState<string>("B", s);
+    b.merge(s);
+    b.merge(s);
+
+    expect(b.value()).toHaveLength(1);
+    expect(b.value()).toContain("item");
+  });
+
+  it("serialisation round-trips", () => {
+    const a = new ORSet<string>("A");
+    a.add("alice");
+    a.add("bob");
+    a.remove("alice");
+
+    const b = ORSet.fromState<string>("B", a.toState());
+    expect(b.has("alice")).toBe(false);
+    expect(b.has("bob")).toBe(true);
+  });
+
+  it("works with non-string types", () => {
+    const s = new ORSet<number>("A");
+    s.add(1);
+    s.add(2);
+    s.remove(1);
+    expect(s.value()).toEqual([2]);
+  });
+});
+
+// ─── LWW-Map ──────────────────────────────────────────────────────────────────
+
+describe("LWWMap", () => {
+  it("set and get", () => {
+    const m = new LWWMap<string, string>("A");
+    m.set("k1", "v1", 100);
+    expect(m.get("k1")).toBe("v1");
+  });
+
+  it("higher timestamp wins per key", () => {
+    const m = new LWWMap<string, string>("A");
+    m.set("k", "old", 100);
+    m.set("k", "new", 200);
+    expect(m.get("k")).toBe("new");
+  });
+
+  it("merge: picks maximum per key", () => {
+    const a = new LWWMap<string, string>("A");
+    const b = new LWWMap<string, string>("B");
+    a.set("k1", "a-value", 100);
+    b.set("k1", "b-value", 200);
+    b.set("k2", "only-b", 50);
+
+    a.merge(b.toState());
+
+    expect(a.get("k1")).toBe("b-value");
+    expect(a.get("k2")).toBe("only-b");
+  });
+
+  it("merge is commutative", () => {
+    const a = new LWWMap<string, number>("A");
+    const b = new LWWMap<string, number>("B");
+    a.set("x", 1, 100);
+    b.set("x", 2, 200);
+
+    const left = new LWWMap<string, number>("C");
+    left.merge(a.toState());
+    left.merge(b.toState());
+
+    const right = new LWWMap<string, number>("D");
+    right.merge(b.toState());
+    right.merge(a.toState());
+
+    expect(left.get("x")).toBe(right.get("x"));
+  });
+
+  it("merge is idempotent", () => {
+    const a = new LWWMap<string, string>("A");
+    a.set("k", "val", 100);
+    const s = a.toState();
+
+    const b = LWWMap.fromState<string, string>("B", s);
+    b.merge(s);
+    b.merge(s);
+
+    expect(b.get("k")).toBe("val");
+  });
+
+  it("serialisation round-trips", () => {
+    const a = new LWWMap<string, string>("A");
+    a.set("foo", "bar", 42);
+    const b = LWWMap.fromState<string, string>("A", a.toState());
+    expect(b.get("foo")).toBe("bar");
+  });
+
+  it("value() returns all keys", () => {
+    const m = new LWWMap<string, string>("A");
+    m.set("a", "1", 1);
+    m.set("b", "2", 2);
+    const v = m.value();
+    expect(v["a"]).toBe("1");
+    expect(v["b"]).toBe("2");
+  });
+});
+
+// ─── VectorClock ─────────────────────────────────────────────────────────────
+
+describe("VectorClock", () => {
+  it("tick increments this node", () => {
+    const vc = new VectorClock("A");
+    vc.tick();
+    vc.tick();
+    expect(vc.currentTick()).toBe(2);
+  });
+
+  it("merge takes component-wise maximum", () => {
+    const a = new VectorClock("A");
+    a.tick();
+    a.tick();
+
+    const b = new VectorClock("B");
+    b.tick();
+
+    a.merge(b.toState());
+    expect(a.get("A")).toBe(2);
+    expect(a.get("B")).toBe(1);
+  });
+
+  it("receive merges and ticks", () => {
+    const a = new VectorClock("A");
+    a.tick();
+
+    const b = new VectorClock("B");
+    b.tick();
+
+    a.receive(b.toState());
+    expect(a.get("A")).toBe(2); // incremented from 1 after merge
+    expect(a.get("B")).toBe(1); // from remote
+  });
+
+  it("compare: equal", () => {
+    const a = new VectorClock("A");
+    const b = new VectorClock("A");
+    expect(a.compare(b.toState())).toBe("equal");
+  });
+
+  it("compare: before", () => {
+    const a = new VectorClock("A");
+    a.tick();
+
+    const b = new VectorClock("A");
+    b.tick();
+    b.tick();
+
+    expect(a.compare(b.toState())).toBe("before");
+    expect(a.isBefore(b.toState())).toBe(true);
+  });
+
+  it("compare: after", () => {
+    const a = new VectorClock("A");
+    a.tick();
+    a.tick();
+
+    const b = new VectorClock("A");
+    b.tick();
+
+    expect(a.compare(b.toState())).toBe("after");
+  });
+
+  it("compare: concurrent", () => {
+    const a = new VectorClock("A");
+    a.tick();
+
+    const b = new VectorClock("B");
+    b.tick();
+
+    expect(a.compare(b.toState())).toBe("concurrent");
+    expect(a.isConcurrent(b.toState())).toBe(true);
+  });
+
+  it("serialisation round-trips", () => {
+    const a = new VectorClock("A");
+    a.tick();
+    a.tick();
+    const b = VectorClock.fromState("A", a.toState());
+    expect(b.currentTick()).toBe(2);
+  });
+});
+
+// ─── CRDTDocument ─────────────────────────────────────────────────────────────
+
+describe("CRDTDocument", () => {
+  it("merges participants from two nodes", () => {
+    const docA = new CRDTDocument("session-1", "A");
+    const docB = new CRDTDocument("session-1", "B");
+
+    docA.participants.add("alice");
+    docB.participants.add("bob");
+
+    docA.merge(docB.toState());
+
+    expect(docA.participants.has("alice")).toBe(true);
+    expect(docA.participants.has("bob")).toBe(true);
+  });
+
+  it("merges stageOutputs with LWW semantics", () => {
+    const docA = new CRDTDocument("session-1", "A");
+    const docB = new CRDTDocument("session-1", "B");
+
+    docA.stageOutputs.set("stage-1", "output-A", 100);
+    docB.stageOutputs.set("stage-1", "output-B", 200);
+
+    docA.merge(docB.toState());
+    expect(docA.stageOutputs.get("stage-1")).toBe("output-B");
+  });
+
+  it("merges votes (G-Counter)", () => {
+    const docA = new CRDTDocument("session-1", "A");
+    const docB = new CRDTDocument("session-1", "B");
+
+    docA.votes.increment(3);
+    docB.votes.increment(2);
+
+    docA.merge(docB.toState());
+    expect(docA.votes.value()).toBe(5);
+  });
+
+  it("merges tags (OR-Set)", () => {
+    const docA = new CRDTDocument("session-1", "A");
+    const docB = new CRDTDocument("session-1", "B");
+
+    docA.tags.add("urgent");
+    docB.tags.add("beta");
+
+    docA.merge(docB.toState());
+    expect(docA.tags.value()).toContain("urgent");
+    expect(docA.tags.value()).toContain("beta");
+  });
+
+  it("merge updates vectorClock", () => {
+    const docA = new CRDTDocument("session-1", "A");
+    const docB = new CRDTDocument("session-1", "B");
+
+    docA.vectorClock.tick();
+    docB.vectorClock.tick();
+    docB.vectorClock.tick();
+
+    docA.merge(docB.toState());
+    expect(docA.vectorClock.get("B")).toBe(2);
+  });
+
+  it("rejects merge from a different session", () => {
+    const docA = new CRDTDocument("session-1", "A");
+    const docB = new CRDTDocument("session-2", "B");
+
+    expect(() => docA.merge(docB.toState())).toThrow(/Cannot merge.*session/);
+  });
+
+  it("serialisation round-trips via fromState", () => {
+    const doc = new CRDTDocument("session-1", "A");
+    doc.participants.add("alice");
+    doc.stageOutputs.set("s1", "out", 100);
+    doc.votes.increment(5);
+    doc.tags.add("review");
+
+    const restored = CRDTDocument.fromState(doc.toState());
+    expect(restored.participants.has("alice")).toBe(true);
+    expect(restored.stageOutputs.get("s1")).toBe("out");
+    expect(restored.votes.value()).toBe(5);
+    expect(restored.tags.has("review")).toBe(true);
+  });
+
+  it("snapshot returns resolved values", () => {
+    const doc = new CRDTDocument("session-1", "A");
+    doc.participants.add("alice");
+    doc.votes.increment(7);
+
+    const snap = doc.snapshot();
+    expect(snap.participants).toContain("alice");
+    expect(snap.votes).toBe(7);
+  });
+
+  it("concurrent modifications from 3 peers converge", () => {
+    const a = new CRDTDocument("session-1", "A");
+    const b = new CRDTDocument("session-1", "B");
+    const c = new CRDTDocument("session-1", "C");
+
+    // All three peers independently modify the document
+    a.participants.add("alice");
+    b.participants.add("bob");
+    c.participants.add("charlie");
+    a.votes.increment(1);
+    b.votes.increment(2);
+    c.votes.increment(3);
+
+    // Simulate full gossip
+    a.merge(b.toState());
+    a.merge(c.toState());
+    b.merge(a.toState());
+    b.merge(c.toState());
+    c.merge(a.toState());
+    c.merge(b.toState());
+
+    // All replicas should converge
+    expect(a.participants.value().sort()).toEqual(["alice", "bob", "charlie"]);
+    expect(b.participants.value().sort()).toEqual(["alice", "bob", "charlie"]);
+    expect(c.participants.value().sort()).toEqual(["alice", "bob", "charlie"]);
+    expect(a.votes.value()).toBe(6);
+    expect(b.votes.value()).toBe(6);
+    expect(c.votes.value()).toBe(6);
+  });
+});
+
+// ─── CRDTSyncManager ─────────────────────────────────────────────────────────
+
+describe("CRDTSyncManager", () => {
+  it("push calls sendFn with correct delta", () => {
+    const sent: Array<{ peerId: string; payload: unknown }> = [];
+    const sendFn = vi.fn((peerId: string, delta: unknown) => {
+      sent.push({ peerId, payload: delta });
+    });
+
+    const mgr = new CRDTSyncManager("A", sendFn);
+    const doc = new CRDTDocument("s1", "A");
+    doc.participants.add("alice");
+    mgr.registerDocument(doc);
+
+    mgr.push("s1", "peer-B");
+
+    expect(sendFn).toHaveBeenCalledOnce();
+    const delta = sent[0].payload as { sessionId: string; fromNodeId: string };
+    expect(delta.sessionId).toBe("s1");
+    expect(delta.fromNodeId).toBe("A");
+    expect(sent[0].peerId).toBe("peer-B");
+  });
+
+  it("receive merges and returns true when document changes", () => {
+    const sendFn = vi.fn();
+    const mgrA = new CRDTSyncManager("A", sendFn);
+    const mgrB = new CRDTSyncManager("B", vi.fn());
+
+    const docA = new CRDTDocument("s1", "A");
+    docA.participants.add("alice");
+    mgrA.registerDocument(docA);
+
+    const docB = new CRDTDocument("s1", "B");
+    mgrB.registerDocument(docB);
+
+    const delta = {
+      sessionId: "s1",
+      fromNodeId: "A",
+      senderClock: docA.vectorClock.toState(),
+      sinceRecipientClock: null,
+      state: docA.toState(),
+    };
+
+    const changed = mgrB.receive(delta);
+    expect(changed).toBe(true);
+    expect(mgrB.getDocument("s1")!.participants.has("alice")).toBe(true);
+  });
+
+  it("receive returns false when already up-to-date", () => {
+    const sendFn = vi.fn();
+    const mgrA = new CRDTSyncManager("A", sendFn);
+    const mgrB = new CRDTSyncManager("B", vi.fn());
+
+    const docA = new CRDTDocument("s1", "A");
+    docA.vectorClock.tick();
+    mgrA.registerDocument(docA);
+
+    const docB = new CRDTDocument("s1", "B");
+    docB.vectorClock.tick();
+    docB.vectorClock.tick();
+    mgrB.registerDocument(docB);
+
+    const delta = {
+      sessionId: "s1",
+      fromNodeId: "A",
+      senderClock: docA.vectorClock.toState(),
+      sinceRecipientClock: null,
+      state: docA.toState(),
+    };
+
+    // Simulate B having already merged A's tick
+    docB.vectorClock.merge(docA.vectorClock.toState());
+
+    // Now B's clock dominates A's — should skip merge
+    const changed = mgrB.receive(delta);
+    expect(changed).toBe(false);
+  });
+
+  it("receive bootstraps a new document from incoming state", () => {
+    const mgrB = new CRDTSyncManager("B", vi.fn());
+
+    const docA = new CRDTDocument("s1", "A");
+    docA.participants.add("alice");
+
+    const delta = {
+      sessionId: "s1",
+      fromNodeId: "A",
+      senderClock: docA.vectorClock.toState(),
+      sinceRecipientClock: null,
+      state: docA.toState(),
+    };
+
+    mgrB.receive(delta);
+    const doc = mgrB.getDocument("s1");
+    expect(doc).toBeDefined();
+    expect(doc!.participants.has("alice")).toBe(true);
+  });
+
+  it("broadcast calls push for each peer", () => {
+    const sendFn = vi.fn();
+    const mgr = new CRDTSyncManager("A", sendFn);
+    const doc = new CRDTDocument("s1", "A");
+    mgr.registerDocument(doc);
+
+    mgr.broadcast("s1", ["B", "C", "D"]);
+    expect(sendFn).toHaveBeenCalledTimes(3);
+  });
+
+  it("anti-entropy periodically pushes state to all peers", async () => {
+    vi.useFakeTimers();
+
+    const sendFn = vi.fn();
+    const mgr = new CRDTSyncManager("A", sendFn, {
+      antiEntropyIntervalMs: 1000,
+    });
+    mgr.updatePeerClock("B", { clocks: {} });
+    mgr.updatePeerClock("C", { clocks: {} });
+
+    const doc = new CRDTDocument("s1", "A");
+    mgr.registerDocument(doc);
+
+    vi.advanceTimersByTime(1100);
+
+    expect(sendFn).toHaveBeenCalledTimes(2); // once per peer
+
+    mgr.stop();
+    vi.useRealTimers();
+  });
+
+  it("stop prevents further anti-entropy sends", async () => {
+    vi.useFakeTimers();
+
+    const sendFn = vi.fn();
+    const mgr = new CRDTSyncManager("A", sendFn, {
+      antiEntropyIntervalMs: 500,
+    });
+    mgr.updatePeerClock("B", { clocks: {} });
+    const doc = new CRDTDocument("s1", "A");
+    mgr.registerDocument(doc);
+
+    mgr.stop();
+    vi.advanceTimersByTime(2000);
+
+    expect(sendFn).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("peer clock is updated after receive", () => {
+    const mgr = new CRDTSyncManager("A", vi.fn());
+    const doc = new CRDTDocument("s1", "B");
+    doc.vectorClock.tick();
+
+    const delta = {
+      sessionId: "s1",
+      fromNodeId: "B",
+      senderClock: doc.vectorClock.toState(),
+      sinceRecipientClock: null,
+      state: doc.toState(),
+    };
+
+    mgr.receive(delta);
+    const peerClock = mgr.getPeerClock("B");
+    expect(peerClock).toBeDefined();
+    expect(peerClock!.clocks["B"]).toBe(1);
+  });
+});
+
+// ─── CRDTPeerSyncService ──────────────────────────────────────────────────────
+
+describe("CRDTPeerSyncService", () => {
+  let federation: FederationManager;
+  let service: CRDTPeerSyncService;
+
+  beforeEach(() => {
+    federation = makeFederationManager(["peer-B", "peer-C"]);
+    service = new CRDTPeerSyncService(federation, "A", {
+      defaultMode: "single_writer",
+    });
+  });
+
+  it("getOrCreateDocument returns undefined in single_writer mode", () => {
+    const doc = service.getOrCreateDocument("s1");
+    expect(doc).toBeUndefined();
+  });
+
+  it("setSyncMode to crdt_p2p creates a document", () => {
+    service.setSyncMode("s1", "crdt_p2p");
+    const doc = service.getDocument("s1");
+    expect(doc).toBeDefined();
+    expect(doc!.sessionId).toBe("s1");
+  });
+
+  it("setSyncMode to crdt_p2p triggers push to all peers", () => {
+    service.setSyncMode("s1", "crdt_p2p");
+    expect(federation.send).toHaveBeenCalledWith(
+      "crdt:push",
+      expect.objectContaining({ sessionId: "s1" }),
+      "peer-B",
+    );
+    expect(federation.send).toHaveBeenCalledWith(
+      "crdt:push",
+      expect.objectContaining({ sessionId: "s1" }),
+      "peer-C",
+    );
+  });
+
+  it("getSyncMode returns correct mode", () => {
+    expect(service.getSyncMode("s1")).toBe("single_writer");
+    service.setSyncMode("s1", "crdt_p2p");
+    expect(service.getSyncMode("s1")).toBe("crdt_p2p");
+  });
+
+  it("pushToAllPeers does nothing in single_writer mode", () => {
+    vi.clearAllMocks();
+    service.pushToAllPeers("s1");
+    expect(federation.send).not.toHaveBeenCalled();
+  });
+
+  it("pushToAllPeers sends to all peers in crdt_p2p mode", () => {
+    service.setSyncMode("s1", "crdt_p2p");
+    vi.clearAllMocks();
+    service.pushToAllPeers("s1");
+    expect(federation.send).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles crdt:push federation message by merging state", () => {
+    service.setSyncMode("s1", "crdt_p2p");
+
+    const remoteDoc = new CRDTDocument("s1", "B");
+    remoteDoc.participants.add("bob");
+
+    // Retrieve the handler registered for "crdt:push"
+    const calls = (federation.on as ReturnType<typeof vi.fn>).mock.calls;
+    const pushHandler = calls.find(([type]: [string]) => type === "crdt:push")?.[1] as
+      | ((msg: { payload: unknown; from: string }, peer: unknown) => void)
+      | undefined;
+
+    expect(pushHandler).toBeDefined();
+    pushHandler!(
+      {
+        payload: {
+          sessionId: "s1",
+          fromNodeId: "B",
+          senderClock: remoteDoc.vectorClock.toState(),
+          sinceRecipientClock: null,
+          state: remoteDoc.toState(),
+        },
+        from: "B",
+      },
+      {},
+    );
+
+    const doc = service.getDocument("s1");
+    expect(doc!.participants.has("bob")).toBe(true);
+  });
+
+  it("getPeerVersions returns peers with clock info", () => {
+    service.setSyncMode("s1", "crdt_p2p");
+
+    const versions = service.getPeerVersions("s1");
+    expect(versions).toHaveLength(2);
+    expect(versions.map((v) => v.peerId)).toContain("peer-B");
+    expect(versions.map((v) => v.peerId)).toContain("peer-C");
+  });
+
+  it("stop does not throw", () => {
+    expect(() => service.stop()).not.toThrow();
+  });
+});
+
+// ─── CRDT API Route tests ─────────────────────────────────────────────────────
+
+import express from "express";
+import type { Express } from "express";
+import request from "supertest";
+import { registerCRDTRoutes } from "../../server/routes/federation";
+
+function buildApp(crdtService: CRDTPeerSyncService | null): Express {
+  const app = express();
+  app.use(express.json());
+  registerCRDTRoutes(app, crdtService);
+  return app;
+}
+
+describe("CRDT API Routes", () => {
+  let federation: FederationManager;
+  let service: CRDTPeerSyncService;
+  let app: Express;
+
+  beforeEach(() => {
+    federation = makeFederationManager(["peer-B"]);
+    service = new CRDTPeerSyncService(federation, "A");
+    app = buildApp(service);
+  });
+
+  afterEach(() => {
+    service.stop();
+  });
+
+  describe("GET /api/sessions/:id/crdt-state", () => {
+    it("returns null state for single_writer session", async () => {
+      const res = await request(app).get("/api/sessions/s1/crdt-state");
+      expect(res.status).toBe(200);
+      expect(res.body.syncMode).toBe("single_writer");
+      expect(res.body.state).toBeNull();
+    });
+
+    it("returns CRDT document state for crdt_p2p session", async () => {
+      service.setSyncMode("s1", "crdt_p2p");
+      const res = await request(app).get("/api/sessions/s1/crdt-state");
+      expect(res.status).toBe(200);
+      expect(res.body.syncMode).toBe("crdt_p2p");
+      expect(res.body.state).toBeDefined();
+      expect(res.body.value).toBeDefined();
+    });
+
+    it("returns 503 when service is unavailable", async () => {
+      const nullApp = buildApp(null);
+      const res = await request(nullApp).get("/api/sessions/s1/crdt-state");
+      expect(res.status).toBe(503);
+    });
+  });
+
+  describe("POST /api/sessions/:id/crdt-merge", () => {
+    it("returns 409 for single_writer session", async () => {
+      const remoteDoc = new CRDTDocument("s1", "B");
+      const res = await request(app)
+        .post("/api/sessions/s1/crdt-merge")
+        .send({ state: remoteDoc.toState() });
+      expect(res.status).toBe(409);
+    });
+
+    it("merges state and returns updated document", async () => {
+      service.setSyncMode("s1", "crdt_p2p");
+
+      const remoteDoc = new CRDTDocument("s1", "B");
+      remoteDoc.participants.add("bob");
+      remoteDoc.votes.increment(3);
+
+      const res = await request(app)
+        .post("/api/sessions/s1/crdt-merge")
+        .send({ state: remoteDoc.toState() });
+
+      expect(res.status).toBe(200);
+      expect(res.body.merged).toBe(true);
+      expect(res.body.value.participants).toContain("bob");
+      expect(res.body.value.votes).toBe(3);
+    });
+
+    it("returns 400 for invalid state", async () => {
+      service.setSyncMode("s1", "crdt_p2p");
+      const res = await request(app)
+        .post("/api/sessions/s1/crdt-merge")
+        .send({ state: { bad: true } });
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 503 when service is unavailable", async () => {
+      const nullApp = buildApp(null);
+      const remoteDoc = new CRDTDocument("s1", "B");
+      const res = await request(nullApp)
+        .post("/api/sessions/s1/crdt-merge")
+        .send({ state: remoteDoc.toState() });
+      expect(res.status).toBe(503);
+    });
+  });
+
+  describe("GET /api/sessions/:id/crdt-peers", () => {
+    it("returns empty array for session with no peers in crdt state", async () => {
+      const res = await request(app).get("/api/sessions/s1/crdt-peers");
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+    });
+
+    it("returns peer list for active crdt_p2p session", async () => {
+      service.setSyncMode("s1", "crdt_p2p");
+      const res = await request(app).get("/api/sessions/s1/crdt-peers");
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].peerId).toBe("peer-B");
+    });
+
+    it("returns 503 when service is unavailable", async () => {
+      const nullApp = buildApp(null);
+      const res = await request(nullApp).get("/api/sessions/s1/crdt-peers");
+      expect(res.status).toBe(503);
+    });
+  });
+
+  describe("POST /api/sessions/:id/crdt-mode", () => {
+    it("switches to crdt_p2p mode", async () => {
+      const res = await request(app)
+        .post("/api/sessions/s1/crdt-mode")
+        .send({ mode: "crdt_p2p" });
+      expect(res.status).toBe(200);
+      expect(res.body.syncMode).toBe("crdt_p2p");
+      expect(res.body.state).toBeDefined();
+    });
+
+    it("switches back to single_writer mode", async () => {
+      service.setSyncMode("s1", "crdt_p2p");
+      const res = await request(app)
+        .post("/api/sessions/s1/crdt-mode")
+        .send({ mode: "single_writer" });
+      expect(res.status).toBe(200);
+      expect(res.body.syncMode).toBe("single_writer");
+    });
+
+    it("returns 400 for invalid mode", async () => {
+      const res = await request(app)
+        .post("/api/sessions/s1/crdt-mode")
+        .send({ mode: "invalid_mode" });
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 503 when service is unavailable", async () => {
+      const nullApp = buildApp(null);
+      const res = await request(nullApp)
+        .post("/api/sessions/s1/crdt-mode")
+        .send({ mode: "crdt_p2p" });
+      expect(res.status).toBe(503);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements five mathematically correct CRDT types: G-Counter, PN-Counter, LWW-Register, OR-Set, LWW-Map — each with `merge`, `toState`, `fromState`, and `value` methods that satisfy commutativity, associativity, and idempotency
- Adds `CRDTDocument` — a compound document composing all five CRDTs to represent shared session state (participants, stageOutputs, stageStatuses, votes, tags, metadata) with a vector clock for causal ordering
- Adds `CRDTSyncManager` — state-based and delta-based sync with configurable anti-entropy periodic broadcast
- Adds `CRDTPeerSyncService` — integrates with existing `FederationManager` transport via `crdt:push` / `crdt:ack` messages; sessions default to `single_writer` mode, opt-in to `crdt_p2p` per session
- Adds 4 API routes: `GET /api/sessions/:id/crdt-state`, `POST /api/sessions/:id/crdt-merge`, `GET /api/sessions/:id/crdt-peers`, `POST /api/sessions/:id/crdt-mode`
- Adds 22 CRDT type definitions to `shared/types.ts`
- 86 new tests covering CRDT mathematical properties, concurrent-peer convergence (3-way gossip), vector clock causality, all API endpoints (success + error paths)

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 4054/4054 tests pass (181 files), 86 new
- [x] CRDT merge commutativity: `merge(A,B) == merge(B,A)` for all types
- [x] CRDT merge associativity: `merge(merge(A,B),C) == merge(A,merge(B,C))`
- [x] CRDT merge idempotency: `merge(A,A) == A`
- [x] 3-peer convergence test: all replicas reach same state after full gossip
- [x] OR-Set concurrent add/remove: add wins over concurrent remove
- [x] LWW-Register tie-breaking: deterministic nodeId lexicographic ordering
- [x] Vector clock causality: before/after/concurrent/equal detection
- [x] API 503 when service unavailable, 409 on mode mismatch, 400 on invalid input
- [x] No regressions on existing 3968 tests