### PR TITLE
feat: config sync YAML schemas per entity (#313)

### DIFF
--- a/docs/config-sync/examples/connection.yaml
+++ b/docs/config-sync/examples/connection.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://multiqlti.io/config-sync/schemas/config-entity.json
+# Example: connection entity (no secrets — those go in .secret / provider-key)
+kind: connection
+apiVersion: "1.0.0"
+name: github-main
+type: github
+workspaceRef: my-workspace
+status: active
+config:
+  host: "https://api.github.com"
+  owner: "my-org"
+  repo: "my-repo"
+
+---
+kind: connection
+apiVersion: "1.0.0"
+name: production-k8s
+type: kubernetes
+workspaceRef: my-workspace
+status: active
+config:
+  server: "https://k8s.example.com:6443"
+  namespace: production
+  insecureSkipTlsVerify: false
+
+---
+kind: connection
+apiVersion: "1.0.0"
+name: aws-prod
+type: aws
+workspaceRef: my-workspace
+status: active
+config:
+  region: us-east-1
+  accountId: "123456789012"
+  roleArn: "arn:aws:iam::123456789012:role/MultiqltiRole"

--- a/docs/config-sync/examples/pipeline.yaml
+++ b/docs/config-sync/examples/pipeline.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://multiqlti.io/config-sync/schemas/config-entity.json
+# Example: pipeline entity
+kind: pipeline
+apiVersion: "1.0.0"
+name: code-review-pipeline
+description: Automated code review with architecture and security stages
+isTemplate: false
+stages:
+  - teamId: architecture
+    modelSlug: claude-sonnet-4-6
+    enabled: true
+    temperature: 0.3
+    maxTokens: 4096
+    approvalRequired: false
+    executionStrategy: single
+
+  - teamId: code_review
+    modelSlug: claude-sonnet-4-6
+    enabled: true
+    temperature: 0.2
+    maxTokens: 8192
+    systemPromptOverride: |
+      You are a senior code reviewer. Focus on security vulnerabilities,
+      performance issues, and maintainability concerns.
+    approvalRequired: true
+
+  - teamId: testing
+    modelSlug: claude-sonnet-4-6
+    enabled: true
+    temperature: 0.1
+    maxTokens: 4096
+    allowedConnections:
+      - github-main

--- a/docs/config-sync/examples/preferences.yaml
+++ b/docs/config-sync/examples/preferences.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://multiqlti.io/config-sync/schemas/config-entity.json
+# Example: preferences entity — global scope
+kind: preferences
+apiVersion: "1.0.0"
+scope: global
+ui:
+  theme: dark
+  layout: default
+  featureFlags:
+    enableBetaDAGEditor: true
+    showCostEstimates: true
+    enableParallelExecution: false
+extra:
+  defaultTokenBudget: 50000
+  auditLogRetentionDays: 90
+
+---
+# Example: preferences entity — user scope
+kind: preferences
+apiVersion: "1.0.0"
+scope: user
+userId: "usr_abc123"
+ui:
+  theme: light
+  layout: compact
+  featureFlags:
+    enableBetaDAGEditor: false
+extra: {}

--- a/docs/config-sync/examples/prompt.yaml
+++ b/docs/config-sync/examples/prompt.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://multiqlti.io/config-sync/schemas/config-entity.json
+# Example: prompt entity
+kind: prompt
+apiVersion: "1.0.0"
+name: security-focused-review
+description: System prompts tuned for security-heavy code review pipelines
+defaultPrompt: |
+  You are a senior software engineer with deep expertise in security.
+  Always check for OWASP Top 10 vulnerabilities, injection attacks,
+  and insecure data handling patterns.
+stageOverrides:
+  - teamId: architecture
+    systemPrompt: |
+      You are a solutions architect reviewing system design for security.
+      Focus on: authentication flows, data boundary trust, least-privilege,
+      and attack surface minimisation.
+  - teamId: code_review
+    systemPrompt: |
+      You are a security code reviewer. For every function, check:
+      - Input validation and sanitisation
+      - SQL / command injection
+      - XSS and CSRF surfaces
+      - Secrets handling (never in code)
+      - Dependency vulnerabilities
+tags:
+  - security
+  - code-review
+  - owasp

--- a/docs/config-sync/examples/provider-key.yaml
+++ b/docs/config-sync/examples/provider-key.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://multiqlti.io/config-sync/schemas/config-entity.json
+# Example: provider-key entity
+# The actual key material is NEVER stored here. Use a reference expression.
+kind: provider-key
+apiVersion: "1.0.0"
+provider: anthropic
+secretRef: "${env:ANTHROPIC_API_KEY}"
+description: "Production Anthropic key for Claude models"
+enabled: true
+
+---
+kind: provider-key
+apiVersion: "1.0.0"
+provider: google
+secretRef: "${vault:secret/multiqlti/google-ai-key}"
+description: "Gemini API key stored in HashiCorp Vault"
+enabled: true
+
+---
+kind: provider-key
+apiVersion: "1.0.0"
+provider: openai
+secretRef: "${file:./secrets/openai.key}"
+description: "OpenAI key read from an encrypted file at deploy time"
+enabled: false

--- a/docs/config-sync/examples/skill-state.yaml
+++ b/docs/config-sync/examples/skill-state.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://multiqlti.io/config-sync/schemas/config-entity.json
+# Example: skill-state entity (lock-file)
+kind: skill-state
+apiVersion: "1.0.0"
+generatedAt: "2025-01-15T10:30:00.000Z"
+skills:
+  - id: "skill_ts_review_abc123"
+    name: "TypeScript Code Reviewer"
+    version: "2.1.0"
+    source: builtin
+    autoUpdate: false
+    installedAt: "2024-11-01T08:00:00.000Z"
+
+  - id: "skill_sec_scan_xyz456"
+    name: "Security Scanner"
+    version: "1.4.2"
+    source: market
+    externalId: "market:security-scanner:1.4.2"
+    registrySource: "official-registry"
+    autoUpdate: true
+    installedAt: "2025-01-10T14:20:00.000Z"
+
+  - id: "skill_custom_abc789"
+    name: "Custom Deploy Validator"
+    version: "0.3.1"
+    source: local
+    autoUpdate: false

--- a/docs/config-sync/examples/trigger.yaml
+++ b/docs/config-sync/examples/trigger.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://multiqlti.io/config-sync/schemas/config-entity.json
+# Example: trigger entity — schedule variant
+kind: trigger
+apiVersion: "1.0.0"
+pipelineRef: code-review-pipeline
+enabled: true
+config:
+  type: schedule
+  cron: "0 9 * * 1-5"
+  timezone: "America/New_York"
+  input: "Run scheduled code health check"
+
+---
+# Example: trigger entity — GitHub event variant
+kind: trigger
+apiVersion: "1.0.0"
+pipelineRef: code-review-pipeline
+enabled: true
+config:
+  type: github_event
+  repository: "my-org/my-repo"
+  events:
+    - pull_request
+    - push
+  refFilter: "refs/heads/main"
+
+---
+# Example: trigger entity — webhook variant
+kind: trigger
+apiVersion: "1.0.0"
+pipelineRef: code-review-pipeline
+enabled: true
+config:
+  type: webhook
+
+---
+# Example: trigger entity — file change variant
+kind: trigger
+apiVersion: "1.0.0"
+pipelineRef: code-review-pipeline
+enabled: false
+config:
+  type: file_change
+  watchPath: /workspace/src
+  patterns:
+    - "**/*.ts"
+    - "**/*.tsx"
+    - "!**/*.test.ts"
+  debounceMs: 1000
+  input: "File changed: {{filePath}}"

--- a/shared/config-sync/index.ts
+++ b/shared/config-sync/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Config Sync barrel export (issue #313)
+ */
+
+export * from "./schemas.js";
+export * from "./json-schema.js";

--- a/shared/config-sync/json-schema.ts
+++ b/shared/config-sync/json-schema.ts
@@ -1,0 +1,130 @@
+/**
+ * JSON Schema export for config-sync entities (issue #313)
+ *
+ * Generates JSON Schema 7 documents from the Zod schemas so that
+ * YAML Language Server (yaml-language-server) and other JSON Schema-aware
+ * tooling can provide IDE completion and validation for config-sync files.
+ *
+ * Each schema carries an `$id` and a `$schema` declaration for portability.
+ */
+
+import { zodToJsonSchema } from "zod-to-json-schema";
+import {
+  PipelineConfigEntitySchema,
+  TriggerConfigEntitySchema,
+  PromptConfigEntitySchema,
+  SkillStateConfigEntitySchema,
+  ConnectionConfigEntitySchema,
+  ProviderKeyConfigEntitySchema,
+  PreferencesConfigEntitySchema,
+  ConfigEntitySchema,
+} from "./schemas.js";
+
+/** Base URI used as the `$id` namespace for all generated schemas. */
+const BASE_URI = "https://multiqlti.io/config-sync/schemas";
+
+/** Options shared by every zodToJsonSchema call. */
+const BASE_OPTIONS = {
+  target: "jsonSchema7" as const,
+  strictUnions: true,
+};
+
+export function generatePipelineJsonSchema(): Record<string, unknown> {
+  return zodToJsonSchema(PipelineConfigEntitySchema, {
+    ...BASE_OPTIONS,
+    name: "PipelineConfigEntity",
+    $refStrategy: "none",
+  }) as Record<string, unknown>;
+}
+
+export function generateTriggerJsonSchema(): Record<string, unknown> {
+  return zodToJsonSchema(TriggerConfigEntitySchema, {
+    ...BASE_OPTIONS,
+    name: "TriggerConfigEntity",
+    $refStrategy: "none",
+  }) as Record<string, unknown>;
+}
+
+export function generatePromptJsonSchema(): Record<string, unknown> {
+  return zodToJsonSchema(PromptConfigEntitySchema, {
+    ...BASE_OPTIONS,
+    name: "PromptConfigEntity",
+    $refStrategy: "none",
+  }) as Record<string, unknown>;
+}
+
+export function generateSkillStateJsonSchema(): Record<string, unknown> {
+  return zodToJsonSchema(SkillStateConfigEntitySchema, {
+    ...BASE_OPTIONS,
+    name: "SkillStateConfigEntity",
+    $refStrategy: "none",
+  }) as Record<string, unknown>;
+}
+
+export function generateConnectionJsonSchema(): Record<string, unknown> {
+  return zodToJsonSchema(ConnectionConfigEntitySchema, {
+    ...BASE_OPTIONS,
+    name: "ConnectionConfigEntity",
+    $refStrategy: "none",
+  }) as Record<string, unknown>;
+}
+
+export function generateProviderKeyJsonSchema(): Record<string, unknown> {
+  return zodToJsonSchema(ProviderKeyConfigEntitySchema, {
+    ...BASE_OPTIONS,
+    name: "ProviderKeyConfigEntity",
+    $refStrategy: "none",
+  }) as Record<string, unknown>;
+}
+
+export function generatePreferencesJsonSchema(): Record<string, unknown> {
+  return zodToJsonSchema(PreferencesConfigEntitySchema, {
+    ...BASE_OPTIONS,
+    name: "PreferencesConfigEntity",
+    $refStrategy: "none",
+  }) as Record<string, unknown>;
+}
+
+/**
+ * Generate a combined JSON Schema containing all entity kinds as
+ * `definitions`, with the top-level schema being the `ConfigEntity`
+ * discriminated union.
+ *
+ * This is the schema you point YAML Language Server at:
+ *   `# yaml-language-server: $schema=https://multiqlti.io/config-sync/schemas/config-entity.json`
+ */
+export function generateConfigEntityJsonSchema(): Record<string, unknown> {
+  const schema = zodToJsonSchema(ConfigEntitySchema, {
+    ...BASE_OPTIONS,
+    name: "ConfigEntity",
+    $refStrategy: "none",
+    definitions: {
+      PipelineConfigEntity: PipelineConfigEntitySchema,
+      TriggerConfigEntity: TriggerConfigEntitySchema,
+      PromptConfigEntity: PromptConfigEntitySchema,
+      SkillStateConfigEntity: SkillStateConfigEntitySchema,
+      ConnectionConfigEntity: ConnectionConfigEntitySchema,
+      ProviderKeyConfigEntity: ProviderKeyConfigEntitySchema,
+      PreferencesConfigEntity: PreferencesConfigEntitySchema,
+    },
+  }) as Record<string, unknown>;
+
+  // Inject $id so tooling can resolve the schema by URL.
+  return {
+    $id: `${BASE_URI}/config-entity.json`,
+    ...schema,
+  };
+}
+
+/** Per-kind schema map for convenient iteration (e.g. writing files to disk). */
+export const KIND_SCHEMAS: Record<string, () => Record<string, unknown>> = {
+  pipeline: generatePipelineJsonSchema,
+  trigger: generateTriggerJsonSchema,
+  prompt: generatePromptJsonSchema,
+  "skill-state": generateSkillStateJsonSchema,
+  connection: generateConnectionJsonSchema,
+  "provider-key": generateProviderKeyJsonSchema,
+  preferences: generatePreferencesJsonSchema,
+};
+
+export { BASE_URI };

--- a/shared/config-sync/schemas.ts
+++ b/shared/config-sync/schemas.ts
@@ -1,0 +1,376 @@
+/**
+ * Config Sync YAML Schemas (issue #313)
+ *
+ * Zod schemas for every entity kind that can be serialised to / deserialised
+ * from a YAML config-sync file.  All entities carry:
+ *
+ *   - `kind`        — discriminator for the `ConfigEntity` union
+ *   - `apiVersion`  — semver string for future migration tooling
+ *
+ * Unknown (extra) fields are rejected by default because every schema is
+ * created with Zod's `strict()` — which mirrors the principle that the
+ * config format is an explicit contract, not a free-form bag.
+ */
+
+import { z } from "zod";
+
+// ─── Shared primitives ────────────────────────────────────────────────────────
+
+/**
+ * Semver string: MAJOR.MINOR.PATCH with optional pre-release / build.
+ * E.g.  "1.0.0", "2.3.1-beta.1+build.42"
+ */
+const SemverSchema = z
+  .string()
+  .regex(
+    /^\d+\.\d+\.\d+(-[\w.]+)?(\+[\w.]+)?$/,
+    "apiVersion must be a valid semver string (e.g. '1.0.0')",
+  );
+
+// ─── pipeline ─────────────────────────────────────────────────────────────────
+
+const ExecutionStrategyTypeSchema = z.enum([
+  "single",
+  "moa",
+  "debate",
+  "voting",
+]);
+
+const PipelineStageConfigSchema = z
+  .object({
+    teamId: z.string().min(1).max(100),
+    modelSlug: z.string().min(1).max(200),
+    systemPromptOverride: z.string().max(32_000).optional(),
+    temperature: z.number().min(0).max(2).optional(),
+    maxTokens: z.number().int().positive().optional(),
+    enabled: z.boolean().default(true),
+    approvalRequired: z.boolean().optional(),
+    executionStrategy: ExecutionStrategyTypeSchema.optional(),
+    skillId: z.string().optional(),
+    delegationEnabled: z.boolean().optional(),
+    allowedConnections: z.array(z.string()).optional(),
+  })
+  .strict();
+
+const DAGEdgeConditionSchema = z
+  .object({
+    field: z.string().min(1),
+    operator: z.enum(["eq", "neq", "gt", "lt", "contains", "exists"]),
+    value: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
+  })
+  .strict();
+
+const DAGEdgeSchema = z
+  .object({
+    id: z.string().min(1),
+    from: z.string().min(1),
+    to: z.string().min(1),
+    condition: DAGEdgeConditionSchema.optional(),
+    label: z.string().optional(),
+  })
+  .strict();
+
+const DAGStageSchema = z
+  .object({
+    id: z.string().min(1),
+    teamId: z.string().min(1).max(100),
+    modelSlug: z.string().min(1).max(200),
+    systemPromptOverride: z.string().max(32_000).optional(),
+    temperature: z.number().min(0).max(2).optional(),
+    maxTokens: z.number().int().positive().optional(),
+    enabled: z.boolean().default(true),
+    approvalRequired: z.boolean().optional(),
+    position: z.object({ x: z.number(), y: z.number() }).strict(),
+    label: z.string().optional(),
+    skillId: z.string().optional(),
+    allowedConnections: z.array(z.string()).optional(),
+  })
+  .strict();
+
+const PipelineDAGSchema = z
+  .object({
+    stages: z.array(DAGStageSchema),
+    edges: z.array(DAGEdgeSchema),
+  })
+  .strict();
+
+export const PipelineConfigEntitySchema = z
+  .object({
+    kind: z.literal("pipeline"),
+    apiVersion: SemverSchema,
+    name: z.string().min(1).max(200),
+    description: z.string().max(2000).optional(),
+    stages: z.array(PipelineStageConfigSchema).default([]),
+    dag: PipelineDAGSchema.optional(),
+    isTemplate: z.boolean().default(false),
+  })
+  .strict();
+
+export type PipelineConfigEntity = z.infer<typeof PipelineConfigEntitySchema>;
+
+// ─── trigger ──────────────────────────────────────────────────────────────────
+
+const ScheduleTriggerConfigSchema = z
+  .object({
+    type: z.literal("schedule"),
+    cron: z.string().min(9).max(100),
+    timezone: z.string().optional(),
+    input: z.string().optional(),
+  })
+  .strict();
+
+const WebhookTriggerConfigSchema = z
+  .object({
+    type: z.literal("webhook"),
+  })
+  .strict();
+
+const GitHubEventTriggerConfigSchema = z
+  .object({
+    type: z.literal("github_event"),
+    repository: z
+      .string()
+      .regex(/^[\w.-]+\/[\w.-]+$/, "repository must be 'owner/repo' format"),
+    events: z.array(z.string().min(1)).min(1),
+    refFilter: z.string().optional(),
+  })
+  .strict();
+
+const FileChangeTriggerConfigSchema = z
+  .object({
+    type: z.literal("file_change"),
+    watchPath: z.string().min(1),
+    patterns: z.array(z.string().min(1)).min(1),
+    debounceMs: z.number().int().min(0).optional(),
+    input: z.string().optional(),
+  })
+  .strict();
+
+export const TriggerConfigEntitySchema = z
+  .object({
+    kind: z.literal("trigger"),
+    apiVersion: SemverSchema,
+    pipelineRef: z.string().min(1).max(200),
+    enabled: z.boolean().default(true),
+    config: z.discriminatedUnion("type", [
+      ScheduleTriggerConfigSchema,
+      WebhookTriggerConfigSchema,
+      GitHubEventTriggerConfigSchema,
+      FileChangeTriggerConfigSchema,
+    ]),
+  })
+  .strict();
+
+export type TriggerConfigEntity = z.infer<typeof TriggerConfigEntitySchema>;
+
+// ─── prompt ───────────────────────────────────────────────────────────────────
+
+const PromptStageOverrideSchema = z
+  .object({
+    teamId: z.string().min(1).max(100),
+    systemPrompt: z.string().min(1).max(32_000),
+  })
+  .strict();
+
+export const PromptConfigEntitySchema = z
+  .object({
+    kind: z.literal("prompt"),
+    apiVersion: SemverSchema,
+    name: z.string().min(1).max(200),
+    description: z.string().max(2000).optional(),
+    /** Default system prompt applied to all stages unless overridden. */
+    defaultPrompt: z.string().max(32_000).optional(),
+    /** Per-stage system prompt overrides. */
+    stageOverrides: z.array(PromptStageOverrideSchema).default([]),
+    /** Tag set for discoverability / filtering. */
+    tags: z.array(z.string().min(1).max(100)).default([]),
+  })
+  .strict();
+
+export type PromptConfigEntity = z.infer<typeof PromptConfigEntitySchema>;
+
+// ─── skill-state ──────────────────────────────────────────────────────────────
+
+const InstalledSkillSchema = z
+  .object({
+    id: z.string().min(1),
+    name: z.string().min(1).max(200),
+    version: SemverSchema,
+    source: z.enum(["builtin", "market", "git", "local"]),
+    /** External registry identifier if source === "market". */
+    externalId: z.string().optional(),
+    /** External registry source adapter ID if source === "market". */
+    registrySource: z.string().optional(),
+    autoUpdate: z.boolean().default(false),
+    /** ISO-8601 timestamp of installation. */
+    installedAt: z.string().datetime().optional(),
+  })
+  .strict();
+
+export const SkillStateConfigEntitySchema = z
+  .object({
+    kind: z.literal("skill-state"),
+    apiVersion: SemverSchema,
+    /** Snapshot timestamp for this lock-file — ISO-8601. */
+    generatedAt: z.string().datetime(),
+    skills: z.array(InstalledSkillSchema),
+  })
+  .strict();
+
+export type SkillStateConfigEntity = z.infer<typeof SkillStateConfigEntitySchema>;
+
+// ─── connection ───────────────────────────────────────────────────────────────
+
+const CONNECTION_KINDS = [
+  "gitlab",
+  "github",
+  "kubernetes",
+  "aws",
+  "jira",
+  "grafana",
+  "generic_mcp",
+] as const;
+
+/**
+ * Config-sync representation of a workspace connection.
+ * Secrets are intentionally excluded — those live in a separate
+ * `.secret` file or environment variables.
+ */
+export const ConnectionConfigEntitySchema = z
+  .object({
+    kind: z.literal("connection"),
+    apiVersion: SemverSchema,
+    /** Display name of the connection. */
+    name: z.string().min(1).max(200),
+    type: z.enum(CONNECTION_KINDS),
+    workspaceRef: z.string().min(1).max(200),
+    /**
+     * Non-secret configuration (URL, project key, region, …).
+     * Secret values must NOT appear here — use provider-key references.
+     */
+    config: z.record(z.unknown()).default({}),
+    status: z.enum(["active", "inactive"]).default("active"),
+  })
+  .strict();
+
+export type ConnectionConfigEntity = z.infer<typeof ConnectionConfigEntitySchema>;
+
+// ─── provider-key ─────────────────────────────────────────────────────────────
+
+const API_PROVIDERS = [
+  "anthropic",
+  "google",
+  "openai",
+  "xai",
+  "mistral",
+  "groq",
+  "vllm",
+  "ollama",
+  "lmstudio",
+] as const;
+
+const SECRET_REF_REGEX = /^\$\{(env|file|vault):([^}]+)\}$/;
+
+/**
+ * A reference to an encrypted API key.
+ * The actual key material lives in a secrets store; this entity only records
+ * which provider it belongs to and how to locate the reference.
+ */
+export const ProviderKeyConfigEntitySchema = z
+  .object({
+    kind: z.literal("provider-key"),
+    apiVersion: SemverSchema,
+    provider: z.enum(API_PROVIDERS),
+    /**
+     * Reference expression pointing to the encrypted key.
+     * Must use one of: `${env:NAME}`, `${file:./path}`, `${vault:secret/path}`.
+     */
+    secretRef: z
+      .string()
+      .regex(
+        SECRET_REF_REGEX,
+        "secretRef must be a reference expression: ${env:NAME}, ${file:path}, or ${vault:path}",
+      ),
+    /** Human description (e.g. "Production Anthropic key"). */
+    description: z.string().max(500).optional(),
+    /** Whether this key is currently active. */
+    enabled: z.boolean().default(true),
+  })
+  .strict();
+
+export type ProviderKeyConfigEntity = z.infer<typeof ProviderKeyConfigEntitySchema>;
+
+// ─── preferences ──────────────────────────────────────────────────────────────
+
+const THEMES = ["light", "dark", "system"] as const;
+const LAYOUT_MODES = ["default", "compact", "wide"] as const;
+
+export const PreferencesConfigEntitySchema = z
+  .object({
+    kind: z.literal("preferences"),
+    apiVersion: SemverSchema,
+    /** Scope: "global" applies to all users; "user" scopes to a specific user ID. */
+    scope: z.enum(["global", "user"]).default("global"),
+    /** User ID when scope === "user". */
+    userId: z.string().optional(),
+    ui: z
+      .object({
+        theme: z.enum(THEMES).default("system"),
+        layout: z.enum(LAYOUT_MODES).default("default"),
+        /** Feature flags toggled in the UI. */
+        featureFlags: z.record(z.boolean()).default({}),
+      })
+      .strict()
+      .default({}),
+    /** Key-value pairs for additional preferences not covered by the `ui` block. */
+    extra: z.record(z.unknown()).default({}),
+  })
+  .strict();
+
+export type PreferencesConfigEntity = z.infer<typeof PreferencesConfigEntitySchema>;
+
+// ─── Discriminated union ──────────────────────────────────────────────────────
+
+/**
+ * Union of all config-sync entity kinds, discriminated by the `kind` field.
+ *
+ * Usage:
+ *   ```ts
+ *   const entity = ConfigEntitySchema.parse(yaml.load(content));
+ *   if (entity.kind === "pipeline") { ... }
+ *   ```
+ */
+export const ConfigEntitySchema = z.discriminatedUnion("kind", [
+  PipelineConfigEntitySchema,
+  TriggerConfigEntitySchema,
+  PromptConfigEntitySchema,
+  SkillStateConfigEntitySchema,
+  ConnectionConfigEntitySchema,
+  ProviderKeyConfigEntitySchema,
+  PreferencesConfigEntitySchema,
+]);
+
+export type ConfigEntity = z.infer<typeof ConfigEntitySchema>;
+
+/** Convenience type-guard helpers. */
+export function isPipelineEntity(e: ConfigEntity): e is PipelineConfigEntity {
+  return e.kind === "pipeline";
+}
+export function isTriggerEntity(e: ConfigEntity): e is TriggerConfigEntity {
+  return e.kind === "trigger";
+}
+export function isPromptEntity(e: ConfigEntity): e is PromptConfigEntity {
+  return e.kind === "prompt";
+}
+export function isSkillStateEntity(e: ConfigEntity): e is SkillStateConfigEntity {
+  return e.kind === "skill-state";
+}
+export function isConnectionEntity(e: ConfigEntity): e is ConnectionConfigEntity {
+  return e.kind === "connection";
+}
+export function isProviderKeyEntity(e: ConfigEntity): e is ProviderKeyConfigEntity {
+  return e.kind === "provider-key";
+}
+export function isPreferencesEntity(e: ConfigEntity): e is PreferencesConfigEntity {
+  return e.kind === "preferences";
+}

--- a/tests/unit/config-sync/json-schema.test.ts
+++ b/tests/unit/config-sync/json-schema.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for shared/config-sync/json-schema.ts (issue #313)
+ *
+ * Coverage:
+ *   - Each generator function returns an object (not undefined/null)
+ *   - Generated schemas contain a JSON Schema root structure
+ *     (object with `type`, `anyOf`, `oneOf`, `$ref`, or `definitions`)
+ *   - The combined schema carries the correct $id
+ *   - KIND_SCHEMAS map covers all entity kinds
+ *   - No generator throws at runtime
+ *
+ * Note: when a `name` option is passed to zodToJsonSchema the library wraps
+ * the schema in a definitions block and emits a `$ref` at the root.  The tests
+ * accept either the flat form (`type`/`anyOf`/`oneOf` at root) or the named
+ * form (`$ref` + `definitions` at root).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  generatePipelineJsonSchema,
+  generateTriggerJsonSchema,
+  generatePromptJsonSchema,
+  generateSkillStateJsonSchema,
+  generateConnectionJsonSchema,
+  generateProviderKeyJsonSchema,
+  generatePreferencesJsonSchema,
+  generateConfigEntityJsonSchema,
+  KIND_SCHEMAS,
+  BASE_URI,
+} from "../../../shared/config-sync/json-schema.js";
+
+/** True when the value looks like a valid JSON Schema root object. */
+function isJsonSchemaRoot(schema: Record<string, unknown>): boolean {
+  return (
+    "type" in schema ||
+    "anyOf" in schema ||
+    "oneOf" in schema ||
+    "$ref" in schema ||
+    "definitions" in schema ||
+    "$defs" in schema
+  );
+}
+
+describe("Per-kind JSON Schema generators", () => {
+  const generators = [
+    { name: "pipeline", fn: generatePipelineJsonSchema },
+    { name: "trigger", fn: generateTriggerJsonSchema },
+    { name: "prompt", fn: generatePromptJsonSchema },
+    { name: "skill-state", fn: generateSkillStateJsonSchema },
+    { name: "connection", fn: generateConnectionJsonSchema },
+    { name: "provider-key", fn: generateProviderKeyJsonSchema },
+    { name: "preferences", fn: generatePreferencesJsonSchema },
+  ];
+
+  for (const { name, fn } of generators) {
+    it(`${name}: does not throw`, () => {
+      expect(() => fn()).not.toThrow();
+    });
+
+    it(`${name}: returns a non-null object`, () => {
+      const schema = fn();
+      expect(schema).toBeDefined();
+      expect(typeof schema).toBe("object");
+      expect(schema).not.toBeNull();
+    });
+
+    it(`${name}: is a valid JSON Schema root object`, () => {
+      const schema = fn();
+      expect(isJsonSchemaRoot(schema)).toBe(true);
+    });
+
+    it(`${name}: carries a $schema or definitions hint`, () => {
+      const schema = fn();
+      // zod-to-json-schema always emits at least one of these
+      const hasMeta =
+        "$schema" in schema ||
+        "definitions" in schema ||
+        "$defs" in schema ||
+        "type" in schema;
+      expect(hasMeta).toBe(true);
+    });
+  }
+});
+
+describe("generateConfigEntityJsonSchema", () => {
+  it("does not throw", () => {
+    expect(() => generateConfigEntityJsonSchema()).not.toThrow();
+  });
+
+  it("carries the correct $id", () => {
+    const schema = generateConfigEntityJsonSchema();
+    expect(schema.$id).toBe(`${BASE_URI}/config-entity.json`);
+  });
+
+  it("is a valid JSON Schema root object", () => {
+    const schema = generateConfigEntityJsonSchema();
+    expect(typeof schema).toBe("object");
+    expect(isJsonSchemaRoot(schema)).toBe(true);
+  });
+
+  it("contains definitions block for discriminated variants", () => {
+    const schema = generateConfigEntityJsonSchema();
+    // Whether inline or named, the discriminated union creates a definitions block
+    const hasVariants =
+      Array.isArray(schema.anyOf) ||
+      Array.isArray(schema.oneOf) ||
+      typeof schema.definitions === "object" ||
+      typeof schema.$defs === "object";
+    expect(hasVariants).toBe(true);
+  });
+});
+
+describe("KIND_SCHEMAS map", () => {
+  const expectedKinds = [
+    "pipeline",
+    "trigger",
+    "prompt",
+    "skill-state",
+    "connection",
+    "provider-key",
+    "preferences",
+  ];
+
+  it("contains all expected kinds", () => {
+    for (const kind of expectedKinds) {
+      expect(KIND_SCHEMAS).toHaveProperty(kind);
+    }
+  });
+
+  it("every entry is a callable function", () => {
+    for (const [, fn] of Object.entries(KIND_SCHEMAS)) {
+      expect(typeof fn).toBe("function");
+      expect(() => fn()).not.toThrow();
+    }
+  });
+
+  it("covers exactly the expected set of kinds", () => {
+    const actual = new Set(Object.keys(KIND_SCHEMAS));
+    const expected = new Set(expectedKinds);
+    expect(actual).toEqual(expected);
+  });
+});

--- a/tests/unit/config-sync/schemas.test.ts
+++ b/tests/unit/config-sync/schemas.test.ts
@@ -1,0 +1,890 @@
+/**
+ * Tests for shared/config-sync/schemas.ts (issue #313)
+ *
+ * Coverage:
+ *   - Round-trip serialisation: valid entity → JSON → re-parse → deep-equal
+ *   - Unknown field rejection (strict mode)
+ *   - Missing required field rejection
+ *   - apiVersion format validation (must be semver)
+ *   - Discriminated union: correct kind dispatching, wrong kind rejection
+ *   - Per-entity: all required fields, optional defaults, nested validation
+ *   - ProviderKeyConfigEntity: secretRef accepts valid refs, rejects plaintext
+ *   - TriggerConfigEntity: all four trigger sub-types validated correctly
+ */
+
+import { describe, it, expect } from "vitest";
+import yaml from "js-yaml";
+import {
+  PipelineConfigEntitySchema,
+  TriggerConfigEntitySchema,
+  PromptConfigEntitySchema,
+  SkillStateConfigEntitySchema,
+  ConnectionConfigEntitySchema,
+  ProviderKeyConfigEntitySchema,
+  PreferencesConfigEntitySchema,
+  ConfigEntitySchema,
+  isPipelineEntity,
+  isTriggerEntity,
+  isPromptEntity,
+  isSkillStateEntity,
+  isConnectionEntity,
+  isProviderKeyEntity,
+  isPreferencesEntity,
+} from "../../../shared/config-sync/schemas.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Round-trip: parse `input` through `schema`, serialise to JSON, re-parse.
+ * Asserts the final value deep-equals what the schema returned on first parse.
+ */
+function roundTrip<T>(schema: { parse: (v: unknown) => T }, input: unknown): T {
+  const first = schema.parse(input);
+  const json = JSON.stringify(first);
+  const second = schema.parse(JSON.parse(json));
+  expect(second).toEqual(first);
+  return second;
+}
+
+/**
+ * Round-trip via YAML serialisation (simulates what the config-sync CLI does).
+ */
+function yamlRoundTrip<T>(schema: { parse: (v: unknown) => T }, input: unknown): T {
+  const first = schema.parse(input);
+  const yamlStr = yaml.dump(first);
+  const second = schema.parse(yaml.load(yamlStr));
+  expect(second).toEqual(first);
+  return second;
+}
+
+// ─── Shared: apiVersion format ────────────────────────────────────────────────
+
+describe("apiVersion validation", () => {
+  it("accepts valid semver strings", () => {
+    const valid = ["1.0.0", "0.1.2", "2.3.1-beta.1", "10.0.0+build.42"];
+    for (const v of valid) {
+      expect(() =>
+        PipelineConfigEntitySchema.parse({
+          kind: "pipeline",
+          apiVersion: v,
+          name: "test",
+          stages: [],
+        }),
+      ).not.toThrow();
+    }
+  });
+
+  it("rejects non-semver apiVersion", () => {
+    const invalid = ["v1", "1.0", "latest", "1.0.0.0"];
+    for (const v of invalid) {
+      expect(() =>
+        PipelineConfigEntitySchema.parse({
+          kind: "pipeline",
+          apiVersion: v,
+          name: "test",
+          stages: [],
+        }),
+      ).toThrow();
+    }
+  });
+});
+
+// ─── Unknown field rejection ───────────────────────────────────────────────────
+
+describe("unknown field rejection (strict mode)", () => {
+  it("rejects extra fields on pipeline", () => {
+    expect(() =>
+      PipelineConfigEntitySchema.parse({
+        kind: "pipeline",
+        apiVersion: "1.0.0",
+        name: "test",
+        stages: [],
+        unexpectedField: "should cause error",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects extra fields on preferences", () => {
+    expect(() =>
+      PreferencesConfigEntitySchema.parse({
+        kind: "preferences",
+        apiVersion: "1.0.0",
+        scope: "global",
+        ui: { theme: "dark", layout: "default", featureFlags: {} },
+        extra: {},
+        hackerField: true,
+      }),
+    ).toThrow();
+  });
+
+  it("rejects extra fields on pipeline stage", () => {
+    expect(() =>
+      PipelineConfigEntitySchema.parse({
+        kind: "pipeline",
+        apiVersion: "1.0.0",
+        name: "test",
+        stages: [
+          {
+            teamId: "code_review",
+            modelSlug: "claude-sonnet-4-6",
+            enabled: true,
+            unknownProp: "bad",
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+});
+
+// ─── pipeline ─────────────────────────────────────────────────────────────────
+
+describe("PipelineConfigEntitySchema", () => {
+  const minimal = {
+    kind: "pipeline" as const,
+    apiVersion: "1.0.0",
+    name: "my-pipeline",
+    stages: [],
+  };
+
+  it("parses minimal valid pipeline", () => {
+    const result = PipelineConfigEntitySchema.parse(minimal);
+    expect(result.kind).toBe("pipeline");
+    expect(result.name).toBe("my-pipeline");
+    expect(result.stages).toHaveLength(0);
+    expect(result.isTemplate).toBe(false); // default
+  });
+
+  it("round-trips via JSON", () => {
+    roundTrip(PipelineConfigEntitySchema, minimal);
+  });
+
+  it("round-trips via YAML", () => {
+    const full = {
+      ...minimal,
+      description: "A test pipeline",
+      isTemplate: true,
+      stages: [
+        {
+          teamId: "architecture",
+          modelSlug: "claude-sonnet-4-6",
+          enabled: true,
+          temperature: 0.3,
+          maxTokens: 4096,
+          approvalRequired: false,
+        },
+      ],
+    };
+    yamlRoundTrip(PipelineConfigEntitySchema, full);
+  });
+
+  it("rejects missing name", () => {
+    expect(() =>
+      PipelineConfigEntitySchema.parse({ ...minimal, name: undefined }),
+    ).toThrow();
+  });
+
+  it("rejects empty name", () => {
+    expect(() =>
+      PipelineConfigEntitySchema.parse({ ...minimal, name: "" }),
+    ).toThrow();
+  });
+
+  it("rejects invalid executionStrategy in stage", () => {
+    expect(() =>
+      PipelineConfigEntitySchema.parse({
+        ...minimal,
+        stages: [
+          {
+            teamId: "code_review",
+            modelSlug: "claude-sonnet-4-6",
+            enabled: true,
+            executionStrategy: "magic_mode",
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it("parses stage with all optional fields", () => {
+    const result = PipelineConfigEntitySchema.parse({
+      ...minimal,
+      stages: [
+        {
+          teamId: "code_review",
+          modelSlug: "claude-sonnet-4-6",
+          enabled: true,
+          temperature: 0.7,
+          maxTokens: 2048,
+          approvalRequired: true,
+          systemPromptOverride: "Custom prompt",
+          executionStrategy: "single",
+          skillId: "skill-123",
+          delegationEnabled: false,
+          allowedConnections: ["github-main"],
+        },
+      ],
+    });
+    expect(result.stages[0].allowedConnections).toEqual(["github-main"]);
+  });
+
+  it("defaults stage enabled to true", () => {
+    const result = PipelineConfigEntitySchema.parse({
+      ...minimal,
+      stages: [
+        { teamId: "architecture", modelSlug: "claude-sonnet-4-6" },
+      ],
+    });
+    expect(result.stages[0].enabled).toBe(true);
+  });
+
+  it("parses pipeline with DAG", () => {
+    const result = PipelineConfigEntitySchema.parse({
+      ...minimal,
+      dag: {
+        stages: [
+          {
+            id: "stage-1",
+            teamId: "architecture",
+            modelSlug: "claude-sonnet-4-6",
+            enabled: true,
+            position: { x: 0, y: 0 },
+          },
+        ],
+        edges: [
+          {
+            id: "edge-1",
+            from: "stage-1",
+            to: "stage-2",
+            condition: {
+              field: "output.status",
+              operator: "eq",
+              value: "ok",
+            },
+          },
+        ],
+      },
+    });
+    expect(result.dag?.stages).toHaveLength(1);
+    expect(result.dag?.edges[0].condition?.operator).toBe("eq");
+  });
+});
+
+// ─── trigger ──────────────────────────────────────────────────────────────────
+
+describe("TriggerConfigEntitySchema", () => {
+  it("parses schedule trigger", () => {
+    const result = TriggerConfigEntitySchema.parse({
+      kind: "trigger",
+      apiVersion: "1.0.0",
+      pipelineRef: "my-pipeline",
+      enabled: true,
+      config: {
+        type: "schedule",
+        cron: "0 9 * * 1-5",
+        timezone: "UTC",
+      },
+    });
+    expect(result.config.type).toBe("schedule");
+    if (result.config.type === "schedule") {
+      expect(result.config.cron).toBe("0 9 * * 1-5");
+    }
+  });
+
+  it("parses webhook trigger", () => {
+    const result = TriggerConfigEntitySchema.parse({
+      kind: "trigger",
+      apiVersion: "1.0.0",
+      pipelineRef: "my-pipeline",
+      config: { type: "webhook" },
+    });
+    expect(result.config.type).toBe("webhook");
+  });
+
+  it("parses github_event trigger", () => {
+    const result = TriggerConfigEntitySchema.parse({
+      kind: "trigger",
+      apiVersion: "1.0.0",
+      pipelineRef: "my-pipeline",
+      config: {
+        type: "github_event",
+        repository: "my-org/my-repo",
+        events: ["push", "pull_request"],
+      },
+    });
+    if (result.config.type === "github_event") {
+      expect(result.config.repository).toBe("my-org/my-repo");
+      expect(result.config.events).toContain("push");
+    }
+  });
+
+  it("parses file_change trigger", () => {
+    const result = TriggerConfigEntitySchema.parse({
+      kind: "trigger",
+      apiVersion: "1.0.0",
+      pipelineRef: "my-pipeline",
+      config: {
+        type: "file_change",
+        watchPath: "/workspace/src",
+        patterns: ["**/*.ts"],
+        debounceMs: 500,
+      },
+    });
+    if (result.config.type === "file_change") {
+      expect(result.config.patterns).toHaveLength(1);
+    }
+  });
+
+  it("rejects invalid github repository format", () => {
+    expect(() =>
+      TriggerConfigEntitySchema.parse({
+        kind: "trigger",
+        apiVersion: "1.0.0",
+        pipelineRef: "my-pipeline",
+        config: {
+          type: "github_event",
+          repository: "not-slash-format",
+          events: ["push"],
+        },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects github_event with empty events array", () => {
+    expect(() =>
+      TriggerConfigEntitySchema.parse({
+        kind: "trigger",
+        apiVersion: "1.0.0",
+        pipelineRef: "my-pipeline",
+        config: {
+          type: "github_event",
+          repository: "org/repo",
+          events: [],
+        },
+      }),
+    ).toThrow();
+  });
+
+  it("round-trips schedule trigger via JSON", () => {
+    roundTrip(TriggerConfigEntitySchema, {
+      kind: "trigger",
+      apiVersion: "1.0.0",
+      pipelineRef: "my-pipeline",
+      config: { type: "schedule", cron: "0 0 * * *" },
+    });
+  });
+
+  it("round-trips all trigger types via YAML", () => {
+    const types = [
+      { type: "schedule" as const, cron: "0 0 * * *" },
+      { type: "webhook" as const },
+      { type: "github_event" as const, repository: "a/b", events: ["push"] },
+      { type: "file_change" as const, watchPath: "/x", patterns: ["**"] },
+    ];
+    for (const config of types) {
+      yamlRoundTrip(TriggerConfigEntitySchema, {
+        kind: "trigger",
+        apiVersion: "1.0.0",
+        pipelineRef: "my-pipeline",
+        config,
+      });
+    }
+  });
+});
+
+// ─── prompt ───────────────────────────────────────────────────────────────────
+
+describe("PromptConfigEntitySchema", () => {
+  const minimal = {
+    kind: "prompt" as const,
+    apiVersion: "1.0.0",
+    name: "security-review",
+  };
+
+  it("parses minimal prompt", () => {
+    const result = PromptConfigEntitySchema.parse(minimal);
+    expect(result.stageOverrides).toHaveLength(0);
+    expect(result.tags).toHaveLength(0);
+  });
+
+  it("parses prompt with all fields", () => {
+    const result = PromptConfigEntitySchema.parse({
+      ...minimal,
+      description: "For security reviews",
+      defaultPrompt: "You are a security expert.",
+      stageOverrides: [
+        { teamId: "code_review", systemPrompt: "Focus on OWASP Top 10." },
+      ],
+      tags: ["security", "owasp"],
+    });
+    expect(result.stageOverrides).toHaveLength(1);
+    expect(result.tags).toContain("security");
+  });
+
+  it("round-trips via YAML", () => {
+    yamlRoundTrip(PromptConfigEntitySchema, {
+      ...minimal,
+      stageOverrides: [{ teamId: "architecture", systemPrompt: "You are an architect." }],
+      tags: ["architecture"],
+    });
+  });
+
+  it("rejects missing name", () => {
+    expect(() =>
+      PromptConfigEntitySchema.parse({ ...minimal, name: "" }),
+    ).toThrow();
+  });
+});
+
+// ─── skill-state ──────────────────────────────────────────────────────────────
+
+describe("SkillStateConfigEntitySchema", () => {
+  const minimal = {
+    kind: "skill-state" as const,
+    apiVersion: "1.0.0",
+    generatedAt: "2025-01-01T00:00:00.000Z",
+    skills: [],
+  };
+
+  it("parses empty skill list", () => {
+    const result = SkillStateConfigEntitySchema.parse(minimal);
+    expect(result.skills).toHaveLength(0);
+  });
+
+  it("parses skill with all fields", () => {
+    const result = SkillStateConfigEntitySchema.parse({
+      ...minimal,
+      skills: [
+        {
+          id: "skill-1",
+          name: "TypeScript Reviewer",
+          version: "2.0.0",
+          source: "builtin",
+          autoUpdate: false,
+          installedAt: "2025-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+    expect(result.skills[0].version).toBe("2.0.0");
+  });
+
+  it("rejects invalid skill source", () => {
+    expect(() =>
+      SkillStateConfigEntitySchema.parse({
+        ...minimal,
+        skills: [
+          { id: "skill-1", name: "X", version: "1.0.0", source: "unknown_source" },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects invalid skill version (non-semver)", () => {
+    expect(() =>
+      SkillStateConfigEntitySchema.parse({
+        ...minimal,
+        skills: [
+          { id: "skill-1", name: "X", version: "v1.2", source: "builtin" },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it("rejects invalid generatedAt (not ISO-8601)", () => {
+    expect(() =>
+      SkillStateConfigEntitySchema.parse({
+        ...minimal,
+        generatedAt: "not-a-date",
+      }),
+    ).toThrow();
+  });
+
+  it("round-trips via JSON", () => {
+    roundTrip(SkillStateConfigEntitySchema, {
+      ...minimal,
+      skills: [
+        { id: "skill-1", name: "X", version: "1.0.0", source: "market", autoUpdate: true },
+      ],
+    });
+  });
+});
+
+// ─── connection ───────────────────────────────────────────────────────────────
+
+describe("ConnectionConfigEntitySchema", () => {
+  const minimal = {
+    kind: "connection" as const,
+    apiVersion: "1.0.0",
+    name: "github-main",
+    type: "github" as const,
+    workspaceRef: "my-workspace",
+    config: {},
+  };
+
+  it("parses minimal connection", () => {
+    const result = ConnectionConfigEntitySchema.parse(minimal);
+    expect(result.status).toBe("active"); // default
+  });
+
+  it("parses connection with config", () => {
+    const result = ConnectionConfigEntitySchema.parse({
+      ...minimal,
+      config: { host: "https://api.github.com", owner: "my-org" },
+    });
+    expect(result.config).toHaveProperty("owner");
+  });
+
+  it("rejects unknown connection type", () => {
+    expect(() =>
+      ConnectionConfigEntitySchema.parse({ ...minimal, type: "slack" }),
+    ).toThrow();
+  });
+
+  it("rejects missing workspaceRef", () => {
+    expect(() =>
+      ConnectionConfigEntitySchema.parse({ ...minimal, workspaceRef: "" }),
+    ).toThrow();
+  });
+
+  it("round-trips via YAML", () => {
+    yamlRoundTrip(ConnectionConfigEntitySchema, {
+      ...minimal,
+      type: "kubernetes",
+      config: { server: "https://k8s.example.com", namespace: "prod" },
+      status: "inactive",
+    });
+  });
+
+  it("accepts all valid connection types", () => {
+    const types = ["gitlab", "github", "kubernetes", "aws", "jira", "grafana", "generic_mcp"] as const;
+    for (const type of types) {
+      expect(() =>
+        ConnectionConfigEntitySchema.parse({ ...minimal, type }),
+      ).not.toThrow();
+    }
+  });
+});
+
+// ─── provider-key ─────────────────────────────────────────────────────────────
+
+describe("ProviderKeyConfigEntitySchema", () => {
+  const minimal = {
+    kind: "provider-key" as const,
+    apiVersion: "1.0.0",
+    provider: "anthropic" as const,
+    secretRef: "${env:ANTHROPIC_API_KEY}",
+  };
+
+  it("parses valid provider-key", () => {
+    const result = ProviderKeyConfigEntitySchema.parse(minimal);
+    expect(result.enabled).toBe(true); // default
+  });
+
+  it("accepts all valid secretRef forms", () => {
+    const refs = [
+      "${env:ANTHROPIC_API_KEY}",
+      "${file:./secrets/key.txt}",
+      "${vault:secret/myapp/api-key}",
+    ];
+    for (const secretRef of refs) {
+      expect(() =>
+        ProviderKeyConfigEntitySchema.parse({ ...minimal, secretRef }),
+      ).not.toThrow();
+    }
+  });
+
+  it("rejects plaintext API key", () => {
+    expect(() =>
+      ProviderKeyConfigEntitySchema.parse({
+        ...minimal,
+        secretRef: "sk-ant-abc123plaintext",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects missing dollar-brace prefix", () => {
+    expect(() =>
+      ProviderKeyConfigEntitySchema.parse({
+        ...minimal,
+        secretRef: "env:MY_KEY",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects unknown provider", () => {
+    expect(() =>
+      ProviderKeyConfigEntitySchema.parse({
+        ...minimal,
+        provider: "cohere",
+      }),
+    ).toThrow();
+  });
+
+  it("accepts all valid providers", () => {
+    const providers = [
+      "anthropic", "google", "openai", "xai", "mistral", "groq", "vllm", "ollama", "lmstudio",
+    ] as const;
+    for (const provider of providers) {
+      expect(() =>
+        ProviderKeyConfigEntitySchema.parse({ ...minimal, provider }),
+      ).not.toThrow();
+    }
+  });
+
+  it("round-trips via JSON", () => {
+    roundTrip(ProviderKeyConfigEntitySchema, {
+      ...minimal,
+      description: "Production key",
+      enabled: false,
+    });
+  });
+});
+
+// ─── preferences ──────────────────────────────────────────────────────────────
+
+describe("PreferencesConfigEntitySchema", () => {
+  const minimal = {
+    kind: "preferences" as const,
+    apiVersion: "1.0.0",
+  };
+
+  it("parses minimal preferences with all defaults", () => {
+    const result = PreferencesConfigEntitySchema.parse(minimal);
+    expect(result.scope).toBe("global");
+    expect(result.ui.theme).toBe("system");
+    expect(result.ui.layout).toBe("default");
+    expect(result.ui.featureFlags).toEqual({});
+    expect(result.extra).toEqual({});
+  });
+
+  it("parses user-scoped preferences", () => {
+    const result = PreferencesConfigEntitySchema.parse({
+      ...minimal,
+      scope: "user",
+      userId: "usr_abc123",
+      ui: { theme: "dark", layout: "compact", featureFlags: { betaFeature: true } },
+    });
+    expect(result.scope).toBe("user");
+    expect(result.userId).toBe("usr_abc123");
+    expect(result.ui.featureFlags).toHaveProperty("betaFeature", true);
+  });
+
+  it("rejects invalid theme", () => {
+    expect(() =>
+      PreferencesConfigEntitySchema.parse({
+        ...minimal,
+        ui: { theme: "purple", layout: "default", featureFlags: {} },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects invalid layout", () => {
+    expect(() =>
+      PreferencesConfigEntitySchema.parse({
+        ...minimal,
+        ui: { theme: "dark", layout: "fullscreen", featureFlags: {} },
+      }),
+    ).toThrow();
+  });
+
+  it("round-trips via YAML", () => {
+    yamlRoundTrip(PreferencesConfigEntitySchema, {
+      ...minimal,
+      scope: "global",
+      ui: { theme: "dark", layout: "wide", featureFlags: { featureA: true, featureB: false } },
+      extra: { retentionDays: 30 },
+    });
+  });
+});
+
+// ─── ConfigEntity discriminated union ─────────────────────────────────────────
+
+describe("ConfigEntitySchema (discriminated union)", () => {
+  it("dispatches pipeline kind correctly", () => {
+    const entity = ConfigEntitySchema.parse({
+      kind: "pipeline",
+      apiVersion: "1.0.0",
+      name: "test",
+      stages: [],
+    });
+    expect(entity.kind).toBe("pipeline");
+    expect(isPipelineEntity(entity)).toBe(true);
+    expect(isTriggerEntity(entity)).toBe(false);
+  });
+
+  it("dispatches trigger kind correctly", () => {
+    const entity = ConfigEntitySchema.parse({
+      kind: "trigger",
+      apiVersion: "1.0.0",
+      pipelineRef: "my-pipeline",
+      config: { type: "webhook" },
+    });
+    expect(isTriggerEntity(entity)).toBe(true);
+    expect(isPipelineEntity(entity)).toBe(false);
+  });
+
+  it("dispatches prompt kind correctly", () => {
+    const entity = ConfigEntitySchema.parse({
+      kind: "prompt",
+      apiVersion: "1.0.0",
+      name: "test",
+    });
+    expect(isPromptEntity(entity)).toBe(true);
+  });
+
+  it("dispatches skill-state kind correctly", () => {
+    const entity = ConfigEntitySchema.parse({
+      kind: "skill-state",
+      apiVersion: "1.0.0",
+      generatedAt: "2025-01-01T00:00:00.000Z",
+      skills: [],
+    });
+    expect(isSkillStateEntity(entity)).toBe(true);
+  });
+
+  it("dispatches connection kind correctly", () => {
+    const entity = ConfigEntitySchema.parse({
+      kind: "connection",
+      apiVersion: "1.0.0",
+      name: "my-conn",
+      type: "github",
+      workspaceRef: "ws-1",
+      config: {},
+    });
+    expect(isConnectionEntity(entity)).toBe(true);
+  });
+
+  it("dispatches provider-key kind correctly", () => {
+    const entity = ConfigEntitySchema.parse({
+      kind: "provider-key",
+      apiVersion: "1.0.0",
+      provider: "anthropic",
+      secretRef: "${env:ANTHROPIC_API_KEY}",
+    });
+    expect(isProviderKeyEntity(entity)).toBe(true);
+  });
+
+  it("dispatches preferences kind correctly", () => {
+    const entity = ConfigEntitySchema.parse({
+      kind: "preferences",
+      apiVersion: "1.0.0",
+    });
+    expect(isPreferencesEntity(entity)).toBe(true);
+  });
+
+  it("rejects unknown kind", () => {
+    expect(() =>
+      ConfigEntitySchema.parse({
+        kind: "unknown-entity",
+        apiVersion: "1.0.0",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects missing kind", () => {
+    expect(() =>
+      ConfigEntitySchema.parse({
+        apiVersion: "1.0.0",
+        name: "test",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects wrong kind with correct schema shape", () => {
+    // Provide a valid pipeline body but claim it's a trigger
+    expect(() =>
+      ConfigEntitySchema.parse({
+        kind: "trigger",
+        apiVersion: "1.0.0",
+        name: "test",    // pipeline field, not valid for trigger
+        stages: [],
+      }),
+    ).toThrow();
+  });
+
+  it("round-trips all entity kinds via JSON", () => {
+    const entities = [
+      { kind: "pipeline", apiVersion: "1.0.0", name: "p", stages: [] },
+      { kind: "trigger", apiVersion: "1.0.0", pipelineRef: "p", config: { type: "webhook" } },
+      { kind: "prompt", apiVersion: "1.0.0", name: "pr" },
+      { kind: "skill-state", apiVersion: "1.0.0", generatedAt: "2025-01-01T00:00:00.000Z", skills: [] },
+      { kind: "connection", apiVersion: "1.0.0", name: "c", type: "github", workspaceRef: "ws", config: {} },
+      { kind: "provider-key", apiVersion: "1.0.0", provider: "anthropic", secretRef: "${env:KEY}" },
+      { kind: "preferences", apiVersion: "1.0.0" },
+    ];
+    for (const entity of entities) {
+      roundTrip(ConfigEntitySchema, entity);
+    }
+  });
+});
+
+// ─── Boundary / edge cases ────────────────────────────────────────────────────
+
+describe("Edge cases", () => {
+  it("rejects null input", () => {
+    expect(() => ConfigEntitySchema.parse(null)).toThrow();
+  });
+
+  it("rejects empty object", () => {
+    expect(() => ConfigEntitySchema.parse({})).toThrow();
+  });
+
+  it("rejects string input", () => {
+    expect(() => ConfigEntitySchema.parse("pipeline")).toThrow();
+  });
+
+  it("rejects array input", () => {
+    expect(() => ConfigEntitySchema.parse([])).toThrow();
+  });
+
+  it("pipeline: rejects stage temperature < 0", () => {
+    expect(() =>
+      PipelineConfigEntitySchema.parse({
+        kind: "pipeline",
+        apiVersion: "1.0.0",
+        name: "test",
+        stages: [
+          { teamId: "architecture", modelSlug: "claude-sonnet-4-6", temperature: -0.1, enabled: true },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it("pipeline: rejects stage temperature > 2", () => {
+    expect(() =>
+      PipelineConfigEntitySchema.parse({
+        kind: "pipeline",
+        apiVersion: "1.0.0",
+        name: "test",
+        stages: [
+          { teamId: "architecture", modelSlug: "claude-sonnet-4-6", temperature: 2.1, enabled: true },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it("pipeline: rejects negative maxTokens in stage", () => {
+    expect(() =>
+      PipelineConfigEntitySchema.parse({
+        kind: "pipeline",
+        apiVersion: "1.0.0",
+        name: "test",
+        stages: [
+          { teamId: "architecture", modelSlug: "claude-sonnet-4-6", maxTokens: -1, enabled: true },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it("skill-state: rejects skill installedAt with invalid datetime", () => {
+    expect(() =>
+      SkillStateConfigEntitySchema.parse({
+        kind: "skill-state",
+        apiVersion: "1.0.0",
+        generatedAt: "2025-01-01T00:00:00.000Z",
+        skills: [
+          { id: "s1", name: "X", version: "1.0.0", source: "builtin", installedAt: "not-a-date" },
+        ],
+      }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Zod schemas for all 7 config-sync entity kinds under `shared/config-sync/schemas.ts`
- Adds JSON Schema export helpers in `shared/config-sync/json-schema.ts` (via `zod-to-json-schema`) for YAML Language Server IDE completion
- Adds barrel export at `shared/config-sync/index.ts`
- Adds YAML examples in `docs/config-sync/examples/` for all entity kinds
- 104 unit tests covering round-trip, rejection, and union dispatch

## Entity kinds

| Kind | Description |
|------|-------------|
| `pipeline` | Pipeline definition with stages, DAG, execution strategy |
| `trigger` | Schedule / webhook / github_event / file_change triggers |
| `prompt` | Per-stage system prompt overrides |
| `skill-state` | Installed skills lock-file with versions |
| `connection` | External connection metadata (no secrets) |
| `provider-key` | Reference to encrypted API key via `${env/file/vault}` ref |
| `preferences` | UI theme, layout, feature flags (global or per-user) |

## Design decisions

- All schemas use `.strict()` — unknown fields are rejected
- Every entity has `kind` (discriminator) + `apiVersion` (semver)
- `ConfigEntitySchema` is a `z.discriminatedUnion("kind", […])` for single-parse dispatch
- `ProviderKeyConfigEntity.secretRef` rejects plaintext values (must be a `${env:…}`, `${file:…}`, or `${vault:…}` reference)
- `zod-to-json-schema` is already a transitive dependency — no new packages added

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run tests/unit/config-sync/` — 104 tests pass
- [x] `npx vitest run` — all 4158 tests pass (183 files)