### PR TITLE
feat: add mqlti config CLI subcommand (#314)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "@types/prismjs": "^1.26.6",
         "bcryptjs": "^3.0.3",
         "bullmq": "^5.71.1",
+        "chalk": "^5.6.2",
         "chokidar": "^5.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -5782,6 +5783,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chokidar": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@types/prismjs": "^1.26.6",
     "bcryptjs": "^3.0.3",
     "bullmq": "^5.71.1",
+    "chalk": "^5.6.2",
     "chokidar": "^5.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/script/mqlti-config.ts
+++ b/script/mqlti-config.ts
@@ -1,0 +1,572 @@
+#!/usr/bin/env tsx
+/**
+ * mqlti config — Config-sync CLI subcommand
+ *
+ * Usage:
+ *   npx tsx script/mqlti-config.ts <subcommand> [options]
+ *   npx tsx script/mqlti-config.ts --help
+ *
+ * Subcommands:
+ *   init <path>   Create a new config-sync repository
+ *   status        Show sync state and git status
+ *   export        [stub] Export live config to YAML files
+ *   apply         [stub] Apply YAML files to running instance
+ *   diff          [stub] Show diff between local YAML and live config
+ *   push          [stub] Push local changes to remote git
+ *   pull          [stub] Pull remote changes and apply
+ *   secrets       [stub] Manage secret references
+ *
+ * Flags:
+ *   --json        Output machine-readable JSON
+ *   --help, -h    Show help
+ *
+ * Exit codes:
+ *   0 — success
+ *   1 — user error (bad args, bad state)
+ *   2 — internal error (unexpected exception)
+ */
+
+import fs from "fs/promises";
+import path from "path";
+import { existsSync } from "fs";
+import simpleGit from "simple-git";
+import yaml from "js-yaml";
+import chalk from "chalk";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** All entity directory names that init creates. */
+const ENTITY_DIRS = [
+  "pipelines",
+  "triggers",
+  "connections",
+  "provider-keys",
+  "prompts",
+  "skill-states",
+  "preferences",
+] as const;
+
+/** Name of the per-repo meta file. */
+const META_FILE_NAME = ".mqlti-config.yaml";
+
+/** Version of the meta schema used in this tool. */
+const META_SCHEMA_VERSION = "1.0.0";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface MetaFile {
+  schemaVersion: string;
+  createdAt: string;
+  lastExportAt: string | null;
+  lastApplyAt: string | null;
+  lastPushAt: string | null;
+  lastPullAt: string | null;
+}
+
+interface JsonResult {
+  ok: boolean;
+  subcommand: string;
+  data?: unknown;
+  error?: string;
+}
+
+// ─── Help text ────────────────────────────────────────────────────────────────
+
+const HELP_TEXT = `
+${chalk.bold("mqlti config")} — Config-sync CLI
+
+${chalk.bold("Usage:")}
+  npx tsx script/mqlti-config.ts <subcommand> [options]
+
+${chalk.bold("Subcommands:")}
+  ${chalk.cyan("init <path>")}     Create a config-sync repository at <path>
+  ${chalk.cyan("status")}          Show git state and sync timestamps
+  ${chalk.cyan("export")}          Export live config to YAML (requires #315)
+  ${chalk.cyan("apply")}           Apply YAML to running instance (requires #316)
+  ${chalk.cyan("diff")}            Diff local YAML vs live config (requires #317)
+  ${chalk.cyan("push")}            Push local changes to remote git (requires #318)
+  ${chalk.cyan("pull")}            Pull remote changes and apply (requires #319)
+  ${chalk.cyan("secrets")}         Manage secret references (requires #320)
+
+${chalk.bold("Options:")}
+  ${chalk.yellow("--json")}           Output machine-readable JSON
+  ${chalk.yellow("--help, -h")}       Show this help message
+
+${chalk.bold("Exit codes:")}
+  0   Success
+  1   User error (bad arguments, bad state)
+  2   Internal error (unexpected exception)
+
+${chalk.bold("Examples:")}
+  npx tsx script/mqlti-config.ts init ./my-config-repo
+  npx tsx script/mqlti-config.ts status
+  npx tsx script/mqlti-config.ts status --json
+`.trim();
+
+// ─── Output helpers ───────────────────────────────────────────────────────────
+
+let jsonMode = false;
+
+function setJsonMode(value: boolean): void {
+  jsonMode = value;
+}
+
+function printJson(result: JsonResult): void {
+  console.log(JSON.stringify(result, null, 2));
+}
+
+function printSuccess(message: string): void {
+  if (!jsonMode) console.log(chalk.green("✓") + " " + message);
+}
+
+function printInfo(message: string): void {
+  if (!jsonMode) console.log(message);
+}
+
+function printError(message: string): void {
+  if (!jsonMode) {
+    console.error(chalk.red("✗") + " " + message);
+  }
+}
+
+function printWarn(message: string): void {
+  if (!jsonMode) {
+    console.warn(chalk.yellow("⚠") + " " + message);
+  }
+}
+
+// ─── Meta file helpers ────────────────────────────────────────────────────────
+
+function buildInitialMeta(): MetaFile {
+  return {
+    schemaVersion: META_SCHEMA_VERSION,
+    createdAt: new Date().toISOString(),
+    lastExportAt: null,
+    lastApplyAt: null,
+    lastPushAt: null,
+    lastPullAt: null,
+  };
+}
+
+async function writeMeta(repoPath: string, meta: MetaFile): Promise<void> {
+  const metaPath = path.join(repoPath, META_FILE_NAME);
+  const content = [
+    "# mqlti config-sync repository metadata",
+    "# Do not edit manually — managed by `mqlti config` CLI",
+    yaml.dump(meta, { lineWidth: 100 }).trim(),
+  ].join("\n") + "\n";
+  await fs.writeFile(metaPath, content, "utf-8");
+}
+
+async function readMeta(repoPath: string): Promise<MetaFile | null> {
+  const metaPath = path.join(repoPath, META_FILE_NAME);
+  try {
+    const raw = await fs.readFile(metaPath, "utf-8");
+    const parsed = yaml.load(raw);
+    if (parsed == null || typeof parsed !== "object") return null;
+    return parsed as MetaFile;
+  } catch {
+    return null;
+  }
+}
+
+async function findConfigRepo(): Promise<string | null> {
+  // Walk up from CWD looking for a directory containing META_FILE_NAME
+  let dir = process.cwd();
+  for (let i = 0; i < 10; i++) {
+    if (existsSync(path.join(dir, META_FILE_NAME))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+// ─── init ─────────────────────────────────────────────────────────────────────
+
+async function cmdInit(targetPath: string): Promise<void> {
+  const repoPath = path.resolve(targetPath);
+
+  // Create root directory if it doesn't exist
+  await fs.mkdir(repoPath, { recursive: true });
+
+  // Refuse to re-init if meta file already exists
+  const existingMeta = await readMeta(repoPath);
+  if (existingMeta !== null) {
+    if (jsonMode) {
+      printJson({
+        ok: false,
+        subcommand: "init",
+        error: `Config repo already initialised at ${repoPath}`,
+      });
+    } else {
+      printError(`Config repo already initialised at ${repoPath}`);
+      printInfo(`  Run ${chalk.cyan("mqlti config status")} to see current state.`);
+    }
+    process.exit(1);
+  }
+
+  // Create entity subdirectories
+  for (const dir of ENTITY_DIRS) {
+    const fullDir = path.join(repoPath, dir);
+    await fs.mkdir(fullDir, { recursive: true });
+    // Write a .gitkeep so git tracks the empty directory
+    await fs.writeFile(path.join(fullDir, ".gitkeep"), "");
+  }
+
+  // Create public-keys directory
+  const pkDir = path.join(repoPath, "public-keys");
+  await fs.mkdir(pkDir, { recursive: true });
+  await fs.writeFile(path.join(pkDir, ".gitkeep"), "");
+
+  // Write .gitignore
+  const gitignoreContent = [
+    "# mqlti config-sync — never commit plaintext secrets",
+    "*.secret",
+    "*.key",
+    "*.pem",
+    ".env",
+    ".env.*",
+    "# OS noise",
+    ".DS_Store",
+    "Thumbs.db",
+  ].join("\n") + "\n";
+  await fs.writeFile(path.join(repoPath, ".gitignore"), gitignoreContent, "utf-8");
+
+  // Write meta file
+  const meta = buildInitialMeta();
+  await writeMeta(repoPath, meta);
+
+  // Run git init
+  const git = simpleGit(repoPath);
+  await git.init();
+
+  if (jsonMode) {
+    printJson({
+      ok: true,
+      subcommand: "init",
+      data: {
+        path: repoPath,
+        entityDirs: [...ENTITY_DIRS],
+        metaFile: META_FILE_NAME,
+        createdAt: meta.createdAt,
+      },
+    });
+  } else {
+    printSuccess(`Initialised config repo at ${chalk.bold(repoPath)}`);
+    printInfo("");
+    printInfo("  Directories created:");
+    for (const dir of ENTITY_DIRS) {
+      printInfo(`    ${chalk.dim(dir + "/")}`);
+    }
+    printInfo(`    ${chalk.dim("public-keys/")}`);
+    printInfo("");
+    printInfo(`  ${chalk.dim(META_FILE_NAME)} — sync metadata`);
+    printInfo(`  ${chalk.dim(".gitignore")}        — blocks secret files`);
+    printInfo("");
+    printInfo(`  Git repository initialised.`);
+    printInfo(`  Next: run ${chalk.cyan("mqlti config status")} to verify.`);
+  }
+}
+
+// ─── status ───────────────────────────────────────────────────────────────────
+
+async function cmdStatus(): Promise<void> {
+  const repoPath = await findConfigRepo();
+  if (repoPath === null) {
+    if (jsonMode) {
+      printJson({
+        ok: false,
+        subcommand: "status",
+        error:
+          "No config repo found. Run `mqlti config init <path>` to create one.",
+      });
+    } else {
+      printError("No config repo found in current directory or any parent.");
+      printInfo(
+        `  Run ${chalk.cyan("mqlti config init <path>")} to create one.`,
+      );
+    }
+    process.exit(1);
+  }
+
+  const meta = await readMeta(repoPath);
+  if (meta === null) {
+    if (jsonMode) {
+      printJson({
+        ok: false,
+        subcommand: "status",
+        error: `Could not read ${META_FILE_NAME} at ${repoPath}`,
+      });
+    } else {
+      printError(`Could not read ${META_FILE_NAME} at ${repoPath}`);
+    }
+    process.exit(2);
+  }
+
+  // Query git state
+  const git = simpleGit(repoPath);
+  let gitInfo: {
+    branch: string;
+    dirty: boolean;
+    ahead: number;
+    behind: number;
+    staged: number;
+    unstaged: number;
+    untracked: number;
+  };
+
+  try {
+    const [statusResult, branchResult] = await Promise.all([
+      git.status(),
+      git.branchLocal(),
+    ]);
+
+    gitInfo = {
+      branch: branchResult.current ?? "(detached)",
+      dirty: !statusResult.isClean(),
+      ahead: statusResult.ahead,
+      behind: statusResult.behind,
+      staged: statusResult.staged.length,
+      unstaged:
+        statusResult.modified.length +
+        statusResult.deleted.length +
+        statusResult.renamed.length,
+      untracked: statusResult.not_added.length,
+    };
+  } catch {
+    // Git repo may exist but have no commits yet
+    gitInfo = {
+      branch: "(no commits yet)",
+      dirty: false,
+      ahead: 0,
+      behind: 0,
+      staged: 0,
+      unstaged: 0,
+      untracked: 0,
+    };
+  }
+
+  if (jsonMode) {
+    printJson({
+      ok: true,
+      subcommand: "status",
+      data: {
+        repoPath,
+        git: gitInfo,
+        sync: {
+          lastExportAt: meta.lastExportAt,
+          lastApplyAt: meta.lastApplyAt,
+          lastPushAt: meta.lastPushAt,
+          lastPullAt: meta.lastPullAt,
+        },
+        meta: {
+          schemaVersion: meta.schemaVersion,
+          createdAt: meta.createdAt,
+        },
+      },
+    });
+    return;
+  }
+
+  // Human-readable output
+  printInfo(chalk.bold("Config repo: ") + repoPath);
+  printInfo("");
+
+  // Git section
+  printInfo(chalk.bold("Git state:"));
+  const branchLabel =
+    gitInfo.branch === "(no commits yet)" || gitInfo.branch === "(detached)"
+      ? chalk.yellow(gitInfo.branch)
+      : chalk.cyan(gitInfo.branch);
+  printInfo(`  Branch:    ${branchLabel}`);
+
+  const dirtyLabel = gitInfo.dirty ? chalk.yellow("dirty") : chalk.green("clean");
+  printInfo(`  Worktree:  ${dirtyLabel}`);
+
+  if (gitInfo.staged > 0) {
+    printInfo(`  Staged:    ${chalk.yellow(String(gitInfo.staged))} file(s)`);
+  }
+  if (gitInfo.unstaged > 0) {
+    printInfo(`  Modified:  ${chalk.yellow(String(gitInfo.unstaged))} file(s)`);
+  }
+  if (gitInfo.untracked > 0) {
+    printInfo(`  Untracked: ${chalk.yellow(String(gitInfo.untracked))} file(s)`);
+  }
+
+  if (gitInfo.ahead > 0 || gitInfo.behind > 0) {
+    const parts: string[] = [];
+    if (gitInfo.ahead > 0)
+      parts.push(chalk.cyan(`↑${gitInfo.ahead} ahead`));
+    if (gitInfo.behind > 0)
+      parts.push(chalk.yellow(`↓${gitInfo.behind} behind`));
+    printInfo(`  Remote:    ${parts.join(", ")}`);
+  } else if (
+    gitInfo.branch !== "(no commits yet)" &&
+    gitInfo.branch !== "(detached)"
+  ) {
+    printInfo(`  Remote:    ${chalk.green("up to date")}`);
+  }
+
+  printInfo("");
+
+  // Sync timestamps section
+  printInfo(chalk.bold("Sync timestamps:"));
+  const fmt = (ts: string | null): string =>
+    ts === null ? chalk.dim("never") : chalk.white(ts);
+  printInfo(`  Last export: ${fmt(meta.lastExportAt)}`);
+  printInfo(`  Last apply:  ${fmt(meta.lastApplyAt)}`);
+  printInfo(`  Last push:   ${fmt(meta.lastPushAt)}`);
+  printInfo(`  Last pull:   ${fmt(meta.lastPullAt)}`);
+
+  printInfo("");
+  printInfo(
+    chalk.dim(`Schema version: ${meta.schemaVersion}  |  Created: ${meta.createdAt}`),
+  );
+}
+
+// ─── Stub subcommands ─────────────────────────────────────────────────────────
+
+type StubDef = {
+  name: string;
+  issueRef: string;
+};
+
+const STUBS: StubDef[] = [
+  { name: "export", issueRef: "#315" },
+  { name: "apply", issueRef: "#316" },
+  { name: "diff", issueRef: "#317" },
+  { name: "push", issueRef: "#318" },
+  { name: "pull", issueRef: "#319" },
+  { name: "secrets", issueRef: "#320" },
+];
+
+function runStub(name: string, issueRef: string): never {
+  const message = `Not yet implemented — requires ${issueRef}`;
+  if (jsonMode) {
+    printJson({ ok: false, subcommand: name, error: message });
+  } else {
+    printWarn(`${chalk.bold(`mqlti config ${name}`)}: ${message}`);
+  }
+  process.exit(1);
+}
+
+// ─── Argument parsing ─────────────────────────────────────────────────────────
+
+interface ParsedArgs {
+  subcommand: string | null;
+  positional: string[];
+  json: boolean;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const result: ParsedArgs = {
+    subcommand: null,
+    positional: [],
+    json: false,
+    help: false,
+  };
+
+  for (const arg of argv) {
+    if (arg === "--json") {
+      result.json = true;
+    } else if (arg === "--help" || arg === "-h") {
+      result.help = true;
+    } else if (result.subcommand === null && !arg.startsWith("-")) {
+      result.subcommand = arg;
+    } else if (!arg.startsWith("-")) {
+      result.positional.push(arg);
+    }
+  }
+
+  return result;
+}
+
+// ─── Entry point ──────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  // argv[0] = node, argv[1] = script path
+  const args = parseArgs(process.argv.slice(2));
+
+  setJsonMode(args.json);
+
+  // Help or no subcommand
+  if (args.help || args.subcommand === null) {
+    if (jsonMode) {
+      printJson({
+        ok: true,
+        subcommand: "help",
+        data: {
+          subcommands: ["init", "status", "export", "apply", "diff", "push", "pull", "secrets"],
+          flags: ["--json", "--help"],
+        },
+      });
+    } else {
+      console.log(HELP_TEXT);
+    }
+    process.exit(args.subcommand === null && !args.help ? 1 : 0);
+  }
+
+  try {
+    switch (args.subcommand) {
+      case "init": {
+        const targetPath = args.positional[0];
+        if (!targetPath) {
+          if (jsonMode) {
+            printJson({
+              ok: false,
+              subcommand: "init",
+              error: "Missing required argument: <path>",
+            });
+          } else {
+            printError(
+              `Missing required argument: ${chalk.bold("<path>")}`,
+            );
+            printInfo(
+              `  Usage: ${chalk.cyan("npx tsx script/mqlti-config.ts init <path>")}`,
+            );
+          }
+          process.exit(1);
+        }
+        await cmdInit(targetPath);
+        break;
+      }
+
+      case "status": {
+        await cmdStatus();
+        break;
+      }
+
+      default: {
+        const stub = STUBS.find((s) => s.name === args.subcommand);
+        if (stub) {
+          runStub(stub.name, stub.issueRef);
+        }
+        if (jsonMode) {
+          printJson({
+            ok: false,
+            subcommand: args.subcommand,
+            error: `Unknown subcommand: ${args.subcommand}`,
+          });
+        } else {
+          printError(`Unknown subcommand: ${chalk.bold(args.subcommand)}`);
+          printInfo(
+            `  Run ${chalk.cyan("npx tsx script/mqlti-config.ts --help")} for usage.`,
+          );
+        }
+        process.exit(1);
+      }
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (jsonMode) {
+      printJson({ ok: false, subcommand: args.subcommand ?? "", error: message });
+    } else {
+      printError(`Internal error: ${message}`);
+    }
+    process.exit(2);
+  }
+}
+
+main();

--- a/tests/unit/config-sync/mqlti-config.test.ts
+++ b/tests/unit/config-sync/mqlti-config.test.ts
@@ -1,0 +1,411 @@
+/**
+ * Tests for script/mqlti-config.ts (issue #314)
+ *
+ * Coverage:
+ *   - init: creates correct directory structure, meta file, .gitignore, git repo
+ *   - init: refuses to re-init an already-initialised repo
+ *   - init: requires <path> argument, exits 1 without it
+ *   - init --json: machine-readable output
+ *   - status: reads meta file, shows git state
+ *   - status --json: machine-readable output
+ *   - status: exits 1 when no config repo found
+ *   - stubs: exit 1, print "Not yet implemented — requires #NNN"
+ *   - stubs --json: machine-readable error output
+ *   - unknown subcommand: exits 1
+ *   - --help / no args: shows usage, exits 0 / 1 respectively
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+
+const execFileAsync = promisify(execFile);
+
+const SCRIPT = path.resolve(
+  __dirname,
+  "../../../script/mqlti-config.ts",
+);
+
+// ─── Runner helpers ───────────────────────────────────────────────────────────
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+async function runCli(
+  args: string[],
+  cwd?: string,
+): Promise<RunResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      "npx",
+      ["tsx", SCRIPT, ...args],
+      {
+        cwd: cwd ?? os.tmpdir(),
+        env: { ...process.env, NO_COLOR: "1", FORCE_COLOR: "0" },
+      },
+    );
+    return { stdout, stderr, exitCode: 0 };
+  } catch (err: unknown) {
+    const e = err as {
+      stdout?: string;
+      stderr?: string;
+      code?: number;
+    };
+    return {
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? "",
+      exitCode: e.code ?? 1,
+    };
+  }
+}
+
+// ─── Temp directory management ────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "mqlti-test-")));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+// ─── help / no-args ───────────────────────────────────────────────────────────
+
+describe("help and no-args", () => {
+  it("exits 0 and prints usage when --help is passed", async () => {
+    const { exitCode, stdout } = await runCli(["--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("mqlti config");
+    expect(stdout).toContain("init");
+    expect(stdout).toContain("status");
+  });
+
+  it("exits 0 and prints usage when -h is passed", async () => {
+    const { exitCode, stdout } = await runCli(["-h"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Usage:");
+  });
+
+  it("exits 1 when no subcommand is given", async () => {
+    const { exitCode, stdout } = await runCli([]);
+    expect(exitCode).toBe(1);
+    // Still prints help
+    expect(stdout).toContain("mqlti config");
+  });
+
+  it("--help --json returns structured JSON with subcommand list", async () => {
+    const { exitCode, stdout } = await runCli(["--help", "--json"]);
+    expect(exitCode).toBe(0);
+    const json = JSON.parse(stdout);
+    expect(json.ok).toBe(true);
+    expect(json.subcommand).toBe("help");
+    expect(json.data.subcommands).toContain("init");
+    expect(json.data.subcommands).toContain("status");
+  });
+});
+
+// ─── init ─────────────────────────────────────────────────────────────────────
+
+describe("init", () => {
+  it("creates the target directory if it does not exist", async () => {
+    const target = path.join(tmpDir, "new-repo");
+    const { exitCode } = await runCli(["init", target]);
+    expect(exitCode).toBe(0);
+    const stat = await fs.stat(target);
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  it("creates all entity subdirectories", async () => {
+    const target = path.join(tmpDir, "repo");
+    await runCli(["init", target]);
+
+    const expectedDirs = [
+      "pipelines",
+      "triggers",
+      "connections",
+      "provider-keys",
+      "prompts",
+      "skill-states",
+      "preferences",
+      "public-keys",
+    ];
+    for (const dir of expectedDirs) {
+      const stat = await fs.stat(path.join(target, dir));
+      expect(stat.isDirectory()).toBe(true);
+    }
+  });
+
+  it("places a .gitkeep in every entity directory", async () => {
+    const target = path.join(tmpDir, "repo");
+    await runCli(["init", target]);
+
+    for (const dir of ["pipelines", "triggers", "public-keys"]) {
+      const keepPath = path.join(target, dir, ".gitkeep");
+      await expect(fs.access(keepPath)).resolves.toBeUndefined();
+    }
+  });
+
+  it("creates .mqlti-config.yaml with correct schema version", async () => {
+    const target = path.join(tmpDir, "repo");
+    await runCli(["init", target]);
+
+    const metaRaw = await fs.readFile(
+      path.join(target, ".mqlti-config.yaml"),
+      "utf-8",
+    );
+    expect(metaRaw).toContain("schemaVersion: 1.0.0");
+    expect(metaRaw).toContain("createdAt:");
+    expect(metaRaw).toContain("lastExportAt: null");
+    expect(metaRaw).toContain("lastApplyAt: null");
+    expect(metaRaw).toContain("lastPushAt: null");
+    expect(metaRaw).toContain("lastPullAt: null");
+  });
+
+  it("creates .gitignore that blocks secret files", async () => {
+    const target = path.join(tmpDir, "repo");
+    await runCli(["init", target]);
+
+    const gitignore = await fs.readFile(
+      path.join(target, ".gitignore"),
+      "utf-8",
+    );
+    expect(gitignore).toContain("*.secret");
+    expect(gitignore).toContain("*.key");
+    expect(gitignore).toContain(".env");
+  });
+
+  it("initialises a git repository (.git directory exists)", async () => {
+    const target = path.join(tmpDir, "repo");
+    await runCli(["init", target]);
+
+    const gitDir = path.join(target, ".git");
+    const stat = await fs.stat(gitDir);
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  it("exits 0 and prints success message", async () => {
+    const target = path.join(tmpDir, "repo");
+    const { exitCode, stdout } = await runCli(["init", target]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/config repo/i);
+  });
+
+  it("exits 1 when called without a path argument", async () => {
+    const { exitCode, stderr, stdout } = await runCli(["init"]);
+    expect(exitCode).toBe(1);
+    const combined = stdout + stderr;
+    expect(combined).toMatch(/missing.*argument|<path>/i);
+  });
+
+  it("exits 1 and errors when the repo is already initialised", async () => {
+    const target = path.join(tmpDir, "repo");
+    await runCli(["init", target]);
+    const { exitCode, stdout, stderr } = await runCli(["init", target]);
+    expect(exitCode).toBe(1);
+    const combined = stdout + stderr;
+    expect(combined).toMatch(/already initialised/i);
+  });
+
+  it("init --json returns structured success JSON", async () => {
+    const target = path.join(tmpDir, "repo");
+    const { exitCode, stdout } = await runCli(["init", target, "--json"]);
+    expect(exitCode).toBe(0);
+    const json = JSON.parse(stdout);
+    expect(json.ok).toBe(true);
+    expect(json.subcommand).toBe("init");
+    expect(json.data.path).toBe(target);
+    expect(Array.isArray(json.data.entityDirs)).toBe(true);
+    expect(json.data.entityDirs).toContain("pipelines");
+    expect(json.data.entityDirs).toContain("triggers");
+    expect(json.data.metaFile).toBe(".mqlti-config.yaml");
+    expect(typeof json.data.createdAt).toBe("string");
+  });
+
+  it("init --json exits 1 with error JSON when path missing", async () => {
+    const { exitCode, stdout } = await runCli(["init", "--json"]);
+    expect(exitCode).toBe(1);
+    const json = JSON.parse(stdout);
+    expect(json.ok).toBe(false);
+    expect(json.subcommand).toBe("init");
+    expect(typeof json.error).toBe("string");
+  });
+
+  it("init --json exits 1 with error JSON when already initialised", async () => {
+    const target = path.join(tmpDir, "repo");
+    await runCli(["init", target]);
+    const { exitCode, stdout } = await runCli(["init", target, "--json"]);
+    expect(exitCode).toBe(1);
+    const json = JSON.parse(stdout);
+    expect(json.ok).toBe(false);
+    expect(json.error).toMatch(/already initialised/i);
+  });
+});
+
+// ─── status ───────────────────────────────────────────────────────────────────
+
+describe("status", () => {
+  it("exits 1 with error when no config repo is found", async () => {
+    // Run from an empty tmpDir with no .mqlti-config.yaml
+    const { exitCode, stdout, stderr } = await runCli(["status"], tmpDir);
+    expect(exitCode).toBe(1);
+    const combined = stdout + stderr;
+    expect(combined).toMatch(/no config repo/i);
+  });
+
+  it("exits 0 and shows repo path after init", async () => {
+    const target = path.join(tmpDir, "repo");
+    await runCli(["init", target]);
+    const { exitCode, stdout } = await runCli(["status"], target);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain(target);
+  });
+
+  it("shows git branch info after init", async () => {
+    const target = path.join(tmpDir, "repo");
+    await runCli(["init", target]);
+    const { exitCode, stdout } = await runCli(["status"], target);
+    expect(exitCode).toBe(0);
+    // Either shows branch name or "(no commits yet)"
+    expect(stdout).toMatch(/branch|no commits/i);
+  });
+
+  it("shows sync timestamps (all null after init)", async () => {
+    const target = path.join(tmpDir, "repo");
+    await runCli(["init", target]);
+    const { stdout } = await runCli(["status"], target);
+    expect(stdout).toContain("Last export:");
+    expect(stdout).toContain("Last apply:");
+    expect(stdout).toContain("Last push:");
+    expect(stdout).toContain("Last pull:");
+    // All should show "never" since no sync has occurred
+    expect(stdout).toMatch(/never/i);
+  });
+
+  it("status --json returns structured JSON", async () => {
+    const target = path.join(tmpDir, "repo");
+    await runCli(["init", target]);
+    const { exitCode, stdout } = await runCli(["status", "--json"], target);
+    expect(exitCode).toBe(0);
+    const json = JSON.parse(stdout);
+    expect(json.ok).toBe(true);
+    expect(json.subcommand).toBe("status");
+    expect(json.data.repoPath).toBe(target);
+    expect(typeof json.data.git.branch).toBe("string");
+    expect(typeof json.data.git.dirty).toBe("boolean");
+    expect(typeof json.data.git.ahead).toBe("number");
+    expect(typeof json.data.git.behind).toBe("number");
+    expect(json.data.sync.lastExportAt).toBeNull();
+    expect(json.data.sync.lastApplyAt).toBeNull();
+    expect(json.data.sync.lastPushAt).toBeNull();
+    expect(json.data.sync.lastPullAt).toBeNull();
+    expect(json.data.meta.schemaVersion).toBe("1.0.0");
+    expect(typeof json.data.meta.createdAt).toBe("string");
+  });
+
+  it("status --json exits 1 with error JSON when no repo found", async () => {
+    const { exitCode, stdout } = await runCli(["status", "--json"], tmpDir);
+    expect(exitCode).toBe(1);
+    const json = JSON.parse(stdout);
+    expect(json.ok).toBe(false);
+    expect(json.subcommand).toBe("status");
+    expect(typeof json.error).toBe("string");
+    expect(json.error).toMatch(/no config repo/i);
+  });
+});
+
+// ─── Stub subcommands ─────────────────────────────────────────────────────────
+
+describe("stub subcommands", () => {
+  const stubs = [
+    { name: "export", issue: "#315" },
+    { name: "apply", issue: "#316" },
+    { name: "diff", issue: "#317" },
+    { name: "push", issue: "#318" },
+    { name: "pull", issue: "#319" },
+    { name: "secrets", issue: "#320" },
+  ] as const;
+
+  for (const { name, issue } of stubs) {
+    it(`${name}: exits 1 and prints "Not yet implemented — requires ${issue}"`, async () => {
+      const { exitCode, stdout, stderr } = await runCli([name]);
+      expect(exitCode).toBe(1);
+      const combined = stdout + stderr;
+      expect(combined).toContain("Not yet implemented");
+      expect(combined).toContain(issue);
+    });
+
+    it(`${name} --json: exits 1 with structured JSON error`, async () => {
+      const { exitCode, stdout } = await runCli([name, "--json"]);
+      expect(exitCode).toBe(1);
+      const json = JSON.parse(stdout);
+      expect(json.ok).toBe(false);
+      expect(json.subcommand).toBe(name);
+      expect(json.error).toContain("Not yet implemented");
+      expect(json.error).toContain(issue);
+    });
+  }
+});
+
+// ─── Unknown subcommand ───────────────────────────────────────────────────────
+
+describe("unknown subcommand", () => {
+  it("exits 1 and prints error for unknown subcommand", async () => {
+    const { exitCode, stdout, stderr } = await runCli(["nonexistent"]);
+    expect(exitCode).toBe(1);
+    const combined = stdout + stderr;
+    expect(combined).toMatch(/unknown subcommand/i);
+  });
+
+  it("unknown --json: exits 1 with structured JSON error", async () => {
+    const { exitCode, stdout } = await runCli(["nonexistent", "--json"]);
+    expect(exitCode).toBe(1);
+    const json = JSON.parse(stdout);
+    expect(json.ok).toBe(false);
+    expect(json.subcommand).toBe("nonexistent");
+    expect(json.error).toMatch(/unknown subcommand/i);
+  });
+});
+
+// ─── Exit code contract ───────────────────────────────────────────────────────
+
+describe("exit code contract", () => {
+  it("init success → exit 0", async () => {
+    const target = path.join(tmpDir, "exit-code-test");
+    const { exitCode } = await runCli(["init", target]);
+    expect(exitCode).toBe(0);
+  });
+
+  it("init without path → exit 1 (user error)", async () => {
+    const { exitCode } = await runCli(["init"]);
+    expect(exitCode).toBe(1);
+  });
+
+  it("status without repo → exit 1 (user error)", async () => {
+    const { exitCode } = await runCli(["status"], tmpDir);
+    expect(exitCode).toBe(1);
+  });
+
+  it("stub subcommand → exit 1 (user error, not yet implemented)", async () => {
+    const { exitCode } = await runCli(["export"]);
+    expect(exitCode).toBe(1);
+  });
+
+  it("unknown subcommand → exit 1", async () => {
+    const { exitCode } = await runCli(["bogus"]);
+    expect(exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `script/mqlti-config.ts` — the `mqlti config` CLI subcommand (issue #314)
- `init <path>`: fully working — creates config repo with all entity dirs (`pipelines/`, `triggers/`, `connections/`, `provider-keys/`, `prompts/`, `skill-states/`, `preferences/`, `public-keys/`), `.mqlti-config.yaml` meta file, `.gitignore` (blocks `*.secret`, `*.key`, `.env`), runs `git init`
- `status`: fully working — shows git state (branch, dirty/clean, ahead/behind, staged/unstaged/untracked) and sync timestamps from `.mqlti-config.yaml`
- `export`, `apply`, `diff`, `push`, `pull`, `secrets`: stubs that print "Not yet implemented — requires #NNN" and exit 1
- `--json` flag on every subcommand for machine-readable output
- Exit codes: 0 success, 1 user error, 2 internal error
- Help text on `--help`/`-h` and no-args invocation

Closes #314

## Test plan

- [ ] `npx tsc --noEmit` passes with 0 errors
- [ ] `npx vitest run tests/unit/config-sync/mqlti-config.test.ts` — 41 tests all pass
- [ ] `npx vitest run` — 184 test files, 4199 tests all pass
- [ ] Manual: `npx tsx script/mqlti-config.ts --help` prints usage
- [ ] Manual: `npx tsx script/mqlti-config.ts init /tmp/test-repo` creates correct structure
- [ ] Manual: `npx tsx script/mqlti-config.ts status` in the init'd dir shows git + sync state
- [ ] Manual: `npx tsx script/mqlti-config.ts export` exits 1 with stub message