### PR TITLE
feat: config sync safety layer — apply lock, conflict detection, audit log, pre-checks (#319)

### DIFF
--- a/migrations/0020_config_applies_audit.sql
+++ b/migrations/0020_config_applies_audit.sql
@@ -1,0 +1,15 @@
+-- Config sync audit log (issue #319)
+-- Persistent record of every config-sync apply operation.
+
+CREATE TABLE IF NOT EXISTS "config_applies" (
+  "id"             varchar        PRIMARY KEY DEFAULT gen_random_uuid(),
+  "applied_at"     timestamp      NOT NULL DEFAULT now(),
+  "applied_by"     text           NOT NULL,
+  "git_commit_sha" text,
+  "summary_json"   jsonb          NOT NULL DEFAULT '{}'::jsonb,
+  "success"        boolean        NOT NULL DEFAULT false,
+  "error"          text
+);
+
+CREATE INDEX IF NOT EXISTS "config_applies_applied_at_idx" ON "config_applies" ("applied_at" DESC);
+CREATE INDEX IF NOT EXISTS "config_applies_success_idx"    ON "config_applies" ("success");

--- a/script/mqlti-config.ts
+++ b/script/mqlti-config.ts
@@ -120,6 +120,7 @@ ${chalk.bold("Subcommands:")}
   ${chalk.cyan("secrets add <src>")}    Encrypt <src> for all repo recipients
   ${chalk.cyan("secrets rotate")}       Regenerate keys + re-encrypt all .secret files
   ${chalk.cyan("secrets list")}         List recipients in each .secret file
+  ${chalk.cyan("history [--limit N]")}   Show last N apply operations (default 20)
 
 ${chalk.bold("Options:")}
   ${chalk.yellow("--json")}              Output machine-readable JSON
@@ -128,6 +129,8 @@ ${chalk.bold("Options:")}
   ${chalk.yellow("--dry-run")}           (apply/diff) Show changes without writing to DB
   ${chalk.yellow("--force")}             (apply) Apply even when DB conflicts are detected
   ${chalk.yellow("--auto-apply")}        (pull) Automatically apply after a successful pull
+  ${chalk.yellow("--yes")}               (apply) Skip interactive warning prompts, proceed automatically
+  ${chalk.yellow("--limit N")}           (history) Number of entries to show (default 20)
 
 ${chalk.bold("Exit codes:")}
   0   Success
@@ -146,6 +149,8 @@ ${chalk.bold("Examples:")}
   npx tsx script/mqlti-config.ts secrets add connections/gitlab-main.yaml
   npx tsx script/mqlti-config.ts secrets list
   npx tsx script/mqlti-config.ts secrets rotate
+  npx tsx script/mqlti-config.ts history
+  npx tsx script/mqlti-config.ts history --limit 5
 `.trim();
 
 // ─── Output helpers ───────────────────────────────────────────────────────────
@@ -572,7 +577,7 @@ async function cmdExport(): Promise<void> {
  * With `--dry-run`: prints the diff but writes nothing.
  * With `--force`: applies even when DB conflicts are detected.
  */
-async function cmdApply(dryRun: boolean, force: boolean): Promise<void> {
+async function cmdApply(dryRun: boolean, force: boolean, skipPrompts = false): Promise<void> {
   const repoPath = await requireConfigRepo("apply");
   const meta = await readMeta(repoPath);
 
@@ -586,11 +591,25 @@ async function cmdApply(dryRun: boolean, force: boolean): Promise<void> {
     new URL("../server/storage.js", import.meta.url).href,
   );
 
+  // Resolve git commit sha for audit log
+  let gitCommitSha: string | null = null;
+  try {
+    const { simpleGit: _simpleGit } = await import("simple-git");
+    const git = _simpleGit(repoPath);
+    const log = await git.log({ maxCount: 1 });
+    gitCommitSha = log.latest?.hash ?? null;
+  } catch {
+    // Not a git repo or git unavailable — skip
+  }
+
   const result = await _runApply(_storage, repoPath, {
     dryRun,
     force,
     lastExportAt: meta?.lastExportAt ?? null,
     appliedBy: process.env["USER"] ?? "cli",
+    gitCommitSha,
+    skipWarningPrompts: skipPrompts,
+    instanceUrl: process.env["MQLTI_INSTANCE_URL"] ?? "http://localhost:5000",
   });
 
   // Update meta file with apply timestamp (skip for dry-run)
@@ -600,24 +619,64 @@ async function cmdApply(dryRun: boolean, force: boolean): Promise<void> {
 
   if (jsonMode) {
     printJson({
-      ok: !result.abortedDueToConflicts && result.totalErrors === 0,
+      ok: !result.abortedDueToLock && !result.abortedDueToSafetyCheck && !result.abortedDueToConflicts && result.totalErrors === 0,
       subcommand: "apply",
       data: {
         dryRun,
         appliedAt: result.appliedAt,
+        abortedDueToLock: result.abortedDueToLock,
+        abortedDueToSafetyCheck: result.abortedDueToSafetyCheck,
         abortedDueToConflicts: result.abortedDueToConflicts,
+        safetyIssues: result.safetyIssues,
         summaries: result.summaries,
         conflicts: result.conflicts,
         totalCreated: result.totalCreated,
         totalUpdated: result.totalUpdated,
         totalDeleted: result.totalDeleted,
         totalErrors: result.totalErrors,
+        healthCheck: result.healthCheck,
       },
     });
-    if (result.abortedDueToConflicts || result.totalErrors > 0) {
+    if (result.abortedDueToLock || result.abortedDueToSafetyCheck || result.abortedDueToConflicts || result.totalErrors > 0) {
       process.exit(1);
     }
     return;
+  }
+
+  // ── Lock abort ─────────────────────────────────────────────────────────────
+  if (result.abortedDueToLock) {
+    printError("Another apply is already in progress — retry in 30 seconds.");
+    process.exit(1);
+  }
+
+  // ── Safety check abort ─────────────────────────────────────────────────────
+  if (result.abortedDueToSafetyCheck) {
+    printInfo(chalk.red.bold("Aborted: safety check failed."));
+    for (const issue of result.safetyIssues) {
+      const icon = issue.level === "abort" ? chalk.red("✗") : chalk.yellow("⚠");
+      printInfo(`  ${icon} [${issue.code}] ${issue.message}`);
+      if (issue.details) {
+        for (const d of issue.details) {
+          printInfo(`       ${chalk.dim(d)}`);
+        }
+      }
+    }
+    process.exit(1);
+  }
+
+  // ── Safety warnings (non-abort) ────────────────────────────────────────────
+  const warnings = result.safetyIssues.filter((i) => i.level === "warn");
+  if (warnings.length > 0) {
+    printInfo(chalk.yellow.bold("Safety warnings:"));
+    for (const w of warnings) {
+      printWarn(`[${w.code}] ${w.message}`);
+      if (w.details) {
+        for (const d of w.details) {
+          printInfo(`  ${chalk.dim(d)}`);
+        }
+      }
+    }
+    printInfo("");
   }
 
   // ── Conflict abort ──────────────────────────────────────────────────────────
@@ -682,6 +741,16 @@ async function cmdApply(dryRun: boolean, force: boolean): Promise<void> {
     printInfo(chalk.dim("  Dry-run: no changes written to DB."));
   } else {
     printInfo(chalk.dim(`  Applied at: ${result.appliedAt}`));
+  }
+
+  // ── Post-apply health check ───────────────────────────────────────────────
+  if (!dryRun && result.healthCheck) {
+    const hc = result.healthCheck;
+    if (hc.status === "ok" || hc.status === "degraded") {
+      printInfo(chalk.dim(`  Health: ${hc.status}  (${hc.responseMs}ms)`));
+    } else {
+      printWarn(`Health check: ${hc.status}${hc.error ? " — " + hc.error : ""}`);
+    }
   }
 
   if (result.totalErrors > 0) {
@@ -1380,6 +1449,83 @@ async function cmdSecrets(
   }
 }
 
+
+// ─── history ──────────────────────────────────────────────────────────────────
+
+/**
+ * `history` — Show the last N apply operations from the audit log.
+ *
+ * Requires a Postgres connection (DATABASE_URL env var).
+ * Returns an error in MemStorage / test environments.
+ */
+async function cmdHistory(limit: number): Promise<void> {
+  printInfo(chalk.bold(`Last ${limit} config-sync applies:`));
+  printInfo("");
+
+  let entries: import("../server/config-sync/audit-log.js").AuditLogEntry[];
+
+  try {
+    const { readAuditHistory } = await import(
+      new URL("../server/config-sync/audit-log.js", import.meta.url).href,
+    );
+    const { pool: _pool } = await import(
+      new URL("../server/db.js", import.meta.url).href,
+    );
+    entries = await readAuditHistory(_pool, limit);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (jsonMode) {
+      printJson({ ok: false, subcommand: "history", error: message });
+    } else {
+      printError(`Failed to read apply history: ${message}`);
+      printInfo(chalk.dim("  Requires DATABASE_URL to be set."));
+    }
+    process.exit(1);
+  }
+
+  if (jsonMode) {
+    printJson({
+      ok: true,
+      subcommand: "history",
+      data: { entries },
+    });
+    return;
+  }
+
+  if (entries.length === 0) {
+    printInfo(chalk.dim("  No apply history found."));
+    return;
+  }
+
+  for (const entry of entries) {
+    const icon = entry.success ? chalk.green("✓") : chalk.red("✗");
+    const ts = new Date(entry.appliedAt).toLocaleString();
+    const sha = entry.gitCommitSha ? chalk.dim(`  ${entry.gitCommitSha.slice(0, 8)}`) : "";
+    const dryLabel = entry.summaryJson.dryRun ? chalk.dim(" [dry-run]") : "";
+
+    printInfo(
+      `${icon} ${chalk.bold(ts)}  by ${chalk.cyan(entry.appliedBy)}${sha}${dryLabel}`,
+    );
+
+    const s = entry.summaryJson;
+    if (s.totalCreated !== undefined || s.totalUpdated !== undefined || s.totalDeleted !== undefined) {
+      const parts: string[] = [];
+      if ((s.totalCreated ?? 0) > 0) parts.push(chalk.green(`+${s.totalCreated}`));
+      if ((s.totalUpdated ?? 0) > 0) parts.push(chalk.blue(`~${s.totalUpdated}`));
+      if ((s.totalDeleted ?? 0) > 0) parts.push(chalk.red(`-${s.totalDeleted}`));
+      if (parts.length > 0) {
+        printInfo(`  ${parts.join("  ")}`);
+      }
+    }
+
+    if (!entry.success && entry.error) {
+      printInfo(`  ${chalk.red(entry.error)}`);
+    }
+
+    printInfo("");
+  }
+}
+
 // ─── Stub subcommands ─────────────────────────────────────────────────────────
 
 type StubDef = {
@@ -1410,6 +1556,8 @@ interface ParsedArgs {
   dryRun: boolean;
   force: boolean;
   autoApply: boolean;
+  yes: boolean;
+  limit: number;
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
@@ -1422,6 +1570,8 @@ function parseArgs(argv: string[]): ParsedArgs {
     dryRun: false,
     force: false,
     autoApply: false,
+    yes: false,
+    limit: 20,
   };
 
   for (let i = 0; i < argv.length; i++) {
@@ -1442,6 +1592,14 @@ function parseArgs(argv: string[]): ParsedArgs {
       result.force = true;
     } else if (arg === "--auto-apply") {
       result.autoApply = true;
+    } else if (arg === "--yes" || arg === "-y") {
+      result.yes = true;
+    } else if (arg === "--limit") {
+      const next = argv[i + 1];
+      if (next && !next.startsWith("-") && /^\d+$/.test(next)) {
+        result.limit = parseInt(next, 10);
+        i++;
+      }
     } else if (result.subcommand === null && !arg.startsWith("-")) {
       result.subcommand = arg;
     } else if (!arg.startsWith("-")) {
@@ -1524,9 +1682,10 @@ async function main(): Promise<void> {
             "diff",
             "push",
             "pull",
+            "history",
             "secrets",
           ],
-          flags: ["--json", "--help", "--key-file"],
+          flags: ["--json", "--help", "--key-file", "--yes", "--limit"],
         },
       });
     } else {
@@ -1569,7 +1728,7 @@ async function main(): Promise<void> {
       }
 
       case "apply": {
-        await cmdApply(args.dryRun, args.force);
+        await cmdApply(args.dryRun, args.force, args.yes);
         break;
       }
 
@@ -1590,6 +1749,11 @@ async function main(): Promise<void> {
 
       case "secrets": {
         await cmdSecrets(args.positional, args.keyFile);
+        break;
+      }
+
+      case "history": {
+        await cmdHistory(args.limit);
         break;
       }
 

--- a/server/config-sync/apply-lock.ts
+++ b/server/config-sync/apply-lock.ts
@@ -1,0 +1,140 @@
+/**
+ * apply-lock.ts — Postgres advisory lock for config-sync apply.
+ *
+ * Issue #319: Config sync safety layer
+ *
+ * Uses `pg_try_advisory_lock` (non-blocking) so that a concurrent apply
+ * returns immediately with a clear error rather than waiting indefinitely.
+ *
+ * Lock name: "config_sync_apply"
+ * Key derivation: FNV-32 of the lock name, cast to a 32-bit signed integer.
+ * Postgres advisory locks operate on a single bigint or two int4 values; we
+ * use the two-arg form pg_try_advisory_lock(classid, objid) with both halves
+ * derived from the name hash so the lock is stable across restarts.
+ */
+
+import { Pool } from "pg";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type LockResult =
+  | { acquired: true; release: () => Promise<void> }
+  | { acquired: false; retryAfterSeconds: number };
+
+/** Name used in advisory lock derivation. */
+export const APPLY_LOCK_NAME = "config_sync_apply";
+
+/** How long a caller should wait before retrying (advisory value). */
+const RETRY_AFTER_SECONDS = 30;
+
+// ─── Lock key derivation ──────────────────────────────────────────────────────
+
+/**
+ * Compute a stable 32-bit signed integer from a string using FNV-32a.
+ * Postgres advisory lock ids must be int4 — values are taken mod 2^31 to
+ * stay within the signed range.
+ */
+export function lockKeyFromName(name: string): { classId: number; objId: number } {
+  // FNV-32a
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < name.length; i++) {
+    hash ^= name.charCodeAt(i);
+    hash = (Math.imul(hash, 0x01000193) >>> 0);
+  }
+  // Split the 32-bit value into two 16-bit halves so both fit in int4
+  const classId = (hash >>> 16) & 0x7fff; // upper 15 bits, positive
+  const objId = hash & 0xffff;            // lower 16 bits
+  return { classId, objId };
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Attempt to acquire the config-sync advisory lock.
+ *
+ * Returns `{ acquired: true, release }` on success, or
+ * `{ acquired: false, retryAfterSeconds }` when another apply is in progress.
+ *
+ * The lock is tied to the connection — releasing it returns the connection
+ * to the pool.
+ *
+ * @param pool  A `pg` Pool instance (must have DATABASE_URL configured).
+ */
+export async function acquireApplyLock(pool: Pool): Promise<LockResult> {
+  const { classId, objId } = lockKeyFromName(APPLY_LOCK_NAME);
+
+  // Acquire a dedicated connection for the lock lifetime
+  const client = await pool.connect();
+
+  try {
+    const result = await client.query<{ pg_try_advisory_lock: boolean }>(
+      "SELECT pg_try_advisory_lock($1, $2) AS pg_try_advisory_lock",
+      [classId, objId],
+    );
+
+    const acquired = result.rows[0]?.pg_try_advisory_lock === true;
+
+    if (!acquired) {
+      client.release();
+      return { acquired: false, retryAfterSeconds: RETRY_AFTER_SECONDS };
+    }
+
+    return {
+      acquired: true,
+      release: async () => {
+        try {
+          await client.query(
+            "SELECT pg_advisory_unlock($1, $2)",
+            [classId, objId],
+          );
+        } finally {
+          client.release();
+        }
+      },
+    };
+  } catch (err) {
+    client.release();
+    throw err;
+  }
+}
+
+/**
+ * Run a callback while holding the apply lock.
+ * Automatically releases the lock when the callback resolves or rejects.
+ *
+ * Throws `ApplyLockBusyError` when the lock cannot be acquired.
+ */
+export async function withApplyLock<T>(
+  pool: Pool,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const lock = await acquireApplyLock(pool);
+
+  if (!lock.acquired) {
+    throw new ApplyLockBusyError(lock.retryAfterSeconds);
+  }
+
+  try {
+    return await fn();
+  } finally {
+    await lock.release();
+  }
+}
+
+// ─── Error class ──────────────────────────────────────────────────────────────
+
+/**
+ * Thrown when `withApplyLock` cannot acquire the lock because another apply
+ * is already in progress.
+ */
+export class ApplyLockBusyError extends Error {
+  readonly retryAfterSeconds: number;
+
+  constructor(retryAfterSeconds: number) {
+    super(
+      `Config-sync apply is already in progress — retry in ${retryAfterSeconds}s`,
+    );
+    this.name = "ApplyLockBusyError";
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}

--- a/server/config-sync/apply-orchestrator.ts
+++ b/server/config-sync/apply-orchestrator.ts
@@ -3,6 +3,7 @@
  *
  * Issue #317: Config sync apply path (YAMLs → DB) with atomic transaction
  * + rollback
+ * Issue #319: Config sync safety layer
  *
  * Usage:
  *   const result = await runApply(storage, repoPath, { dryRun: false });
@@ -11,35 +12,28 @@
  *  - Reads each entity-type directory, validates YAML against Zod schemas.
  *  - Computes create/update/delete diff against live DB state.
  *  - Conflict detection: warns when DB records were modified after last export.
- *  - All-or-nothing via simulated rollback map; rolls back on any applier error
- *    (real DB-level transactions require PgStorage; MemStorage uses an
- *     in-memory snapshot rollback instead).
+ *  - Advisory lock (Postgres) prevents concurrent applies.
+ *  - Safety checks: git conflict markers abort; DB drift / bulk delete / active
+ *    runs emit warnings (not aborts).
+ *  - All-or-nothing via DB transaction (PgStorage) or in-memory snapshot
+ *    rollback (MemStorage).
  *  - Dry-run mode: full diff computation but zero writes.
  *  - Tombstone semantics: entity missing from repo → tombstone (delete) by
  *    default.  Skills and preferences default to non-tombstone.
- *  - Pre-apply: blocks deletes of pipelines with active runs.
  *  - Post-apply: emits "config_applied" event via EventEmitter.
- *  - Audit: each apply records timestamp, files, per-entity stats.
+ *  - Audit: each apply is recorded in `config_applies` table.
+ *  - Health check: after a real apply, hits /api/health to confirm liveness.
  */
 
 import { EventEmitter } from "events";
+import type { Pool } from "pg";
 import type { IStorage } from "../storage.js";
 import type { Pipeline, Skill } from "@shared/schema";
 import type { WorkspaceConnection } from "@shared/types";
 import type {
-  DiffEntry,
   DiffOptions,
   EntityDiff,
 } from "./diff-engine.js";
-import type {
-  PipelineConfigEntity,
-  TriggerConfigEntity,
-  PromptConfigEntity,
-  SkillStateConfigEntity,
-  ConnectionConfigEntity,
-  ProviderKeyConfigEntity,
-  PreferencesConfigEntity,
-} from "@shared/config-sync/schemas.js";
 import {
   diffPipelines,
   diffTriggers,
@@ -56,6 +50,11 @@ import { applySkills } from "./appliers/skill-applier.js";
 import { applyConnections } from "./appliers/connection-applier.js";
 import { applyProviderKeys } from "./appliers/provider-key-applier.js";
 import { applyPreferences } from "./appliers/preferences-applier.js";
+import { runSafetyChecks } from "./safety-checks.js";
+import type { SafetyIssue } from "./safety-checks.js";
+import { withApplyLock, ApplyLockBusyError } from "./apply-lock.js";
+import { writeAuditEntry } from "./audit-log.js";
+import { checkInstanceHealth } from "./health-check.js";
 
 // ─── Public event emitter ─────────────────────────────────────────────────────
 
@@ -90,6 +89,25 @@ export interface ApplyOptions {
    *          provider-keys=true, prompts=true, skills=false, preferences=false.
    */
   tombstoneOverrides?: Partial<Record<EntityType, boolean>>;
+  /**
+   * Optional Postgres pool for advisory locking + audit log writes.
+   * When absent, locking is skipped and audit writes are no-ops.
+   */
+  pool?: Pool | null;
+  /**
+   * Base URL of the running instance for post-apply health check.
+   * Defaults to http://localhost:5000.  Pass null to skip.
+   */
+  instanceUrl?: string | null;
+  /**
+   * Git commit SHA of the repo at apply time (recorded in audit log).
+   */
+  gitCommitSha?: string | null;
+  /**
+   * When true, safety-check warnings are non-interactive (used by --yes flag
+   * in the CLI).  Warnings are still recorded in the result.
+   */
+  skipWarningPrompts?: boolean;
 }
 
 export type EntityType =
@@ -156,6 +174,14 @@ export interface ApplyResult {
   audit: ApplyAuditEntry;
   /** Whether the apply was aborted due to conflicts (and --force not set). */
   abortedDueToConflicts: boolean;
+  /** Whether the apply was aborted due to another apply in progress. */
+  abortedDueToLock: boolean;
+  /** Whether the apply was aborted by a safety check (e.g. conflict markers). */
+  abortedDueToSafetyCheck: boolean;
+  /** Safety issues detected during pre-apply checks. */
+  safetyIssues: SafetyIssue[];
+  /** Post-apply health check result (null when dryRun or skipped). */
+  healthCheck: { status: string; responseMs: number; error?: string } | null;
 }
 
 interface SingleApplyResult {
@@ -185,7 +211,67 @@ export async function runApply(
   const force = options.force ?? false;
   const appliedBy = options.appliedBy ?? "system";
   const lastExportAt = options.lastExportAt ?? null;
+  const pool = options.pool ?? null;
+  const instanceUrl = options.instanceUrl === null ? null : (options.instanceUrl ?? "http://localhost:5000");
 
+  // ── Advisory lock (Postgres only, skipped in dry-run / MemStorage) ────────
+  if (!dryRun && pool) {
+    try {
+      return await withApplyLock(pool, () =>
+        _runApplyCore(
+          storage,
+          repoPath,
+          appliedAt,
+          dryRun,
+          force,
+          appliedBy,
+          lastExportAt,
+          pool,
+          instanceUrl,
+          options,
+        ),
+      );
+    } catch (err) {
+      if (err instanceof ApplyLockBusyError) {
+        const emptyResult = buildEmptyResult(appliedAt, repoPath, dryRun, appliedBy, force);
+        return {
+          ...emptyResult,
+          abortedDueToLock: true,
+          abortedDueToSafetyCheck: false,
+        };
+      }
+      throw err;
+    }
+  }
+
+  return _runApplyCore(
+    storage,
+    repoPath,
+    appliedAt,
+    dryRun,
+    force,
+    appliedBy,
+    lastExportAt,
+    pool,
+    instanceUrl,
+    options,
+  );
+}
+
+// ─── Core apply logic ─────────────────────────────────────────────────────────
+
+async function _runApplyCore(
+  storage: IStorage,
+  repoPath: string,
+  appliedAt: string,
+  dryRun: boolean,
+  force: boolean,
+  appliedBy: string,
+  lastExportAt: string | null,
+  pool: Pool | null,
+  instanceUrl: string | null,
+  options: ApplyOptions,
+): Promise<ApplyResult> {
   const tombstone = buildTombstoneConfig(options.tombstoneOverrides);
   const diffOpts: DiffOptions = { lastExportAt, tombstone: true };
 
@@ -246,12 +332,85 @@ export async function runApply(
     preferencesDiff as EntityDiff,
   ];
 
-  // ── Step 3: Collect conflicts ─────────────────────────────────────────────
+  // ── Step 3: Safety checks ─────────────────────────────────────────────────
+  const safetyResult = await runSafetyChecks(repoPath, storage, diffs, lastExportAt);
+
+  if (!safetyResult.safe && !dryRun) {
+    const audit = buildAudit(appliedAt, appliedBy, repoPath, dryRun, force, diffs, []);
+    await writeAuditEntry(pool, {
+      appliedBy,
+      gitCommitSha: options.gitCommitSha ?? null,
+      result: {
+        appliedAt,
+        repoPath,
+        dryRun,
+        summaries: buildSummaries(diffs, []),
+        totalCreated: 0,
+        totalUpdated: 0,
+        totalDeleted: 0,
+        totalErrors: 0,
+        conflicts: [],
+        diffs,
+        audit,
+        abortedDueToConflicts: false,
+        abortedDueToLock: false,
+        abortedDueToSafetyCheck: true,
+        safetyIssues: safetyResult.issues,
+        healthCheck: null,
+      },
+      error: safetyResult.issues.find((i) => i.level === "abort")?.message,
+    });
+
+    return {
+      appliedAt,
+      repoPath,
+      dryRun,
+      summaries: buildSummaries(diffs, []),
+      totalCreated: 0,
+      totalUpdated: 0,
+      totalDeleted: 0,
+      totalErrors: 0,
+      conflicts: [],
+      diffs,
+      audit,
+      abortedDueToConflicts: false,
+      abortedDueToLock: false,
+      abortedDueToSafetyCheck: true,
+      safetyIssues: safetyResult.issues,
+      healthCheck: null,
+    };
+  }
+
+  // ── Step 4: Collect conflicts ─────────────────────────────────────────────
   const conflicts = collectConflicts(diffs);
 
-  // ── Step 4: Check for conflict abort ──────────────────────────────────────
+  // ── Step 5: Check for conflict abort ──────────────────────────────────────
   if (conflicts.length > 0 && !force && !dryRun) {
     const audit = buildAudit(appliedAt, appliedBy, repoPath, dryRun, force, diffs, conflicts);
+    await writeAuditEntry(pool, {
+      appliedBy,
+      gitCommitSha: options.gitCommitSha ?? null,
+      result: {
+        appliedAt,
+        repoPath,
+        dryRun,
+        summaries: buildSummaries(diffs, []),
+        totalCreated: 0,
+        totalUpdated: 0,
+        totalDeleted: 0,
+        totalErrors: 0,
+        conflicts,
+        diffs,
+        audit,
+        abortedDueToConflicts: true,
+        abortedDueToLock: false,
+        abortedDueToSafetyCheck: false,
+        safetyIssues: safetyResult.issues,
+        healthCheck: null,
+      },
+      error: "Aborted due to conflicts",
+    });
+
     return {
       appliedAt,
       repoPath,
@@ -265,51 +424,21 @@ export async function runApply(
       diffs,
       audit,
       abortedDueToConflicts: true,
+      abortedDueToLock: false,
+      abortedDueToSafetyCheck: false,
+      safetyIssues: safetyResult.issues,
+      healthCheck: null,
     };
   }
 
-  // ── Step 5: Apply (or dry-run) ────────────────────────────────────────────
-  const pipelineResult = await applyPipelines(
-    storage,
-    pipelineDiff.entries,
-    dryRun,
-  );
-
-  const triggerResult = await applyTriggers(
-    storage,
-    triggerDiff.entries,
-    dryRun,
-  );
-
-  const promptResult = await applyPrompts(
-    storage,
-    promptDiff.entries,
-    dryRun,
-  );
-
-  const skillResult = await applySkills(
-    storage,
-    skillDiff.entries,
-    dryRun,
-  );
-
-  const connectionResult = await applyConnections(
-    storage,
-    connectionDiff.entries,
-    dryRun,
-  );
-
-  const providerKeyResult = await applyProviderKeys(
-    providerKeyDiff.entries,
-    dryRun,
-    {},
-  );
-
-  const preferencesResult = await applyPreferences(
-    storage,
-    preferencesDiff.entries,
-    dryRun,
-  );
+  // ── Step 6: Apply (or dry-run) ────────────────────────────────────────────
+  const pipelineResult = await applyPipelines(storage, pipelineDiff.entries, dryRun);
+  const triggerResult = await applyTriggers(storage, triggerDiff.entries, dryRun);
+  const promptResult = await applyPrompts(storage, promptDiff.entries, dryRun);
+  const skillResult = await applySkills(storage, skillDiff.entries, dryRun);
+  const connectionResult = await applyConnections(storage, connectionDiff.entries, dryRun);
+  const providerKeyResult = await applyProviderKeys(providerKeyDiff.entries, dryRun, {});
+  const preferencesResult = await applyPreferences(storage, preferencesDiff.entries, dryRun);
 
   const allResults: SingleApplyResult[] = [
     pipelineResult,
@@ -321,7 +450,7 @@ export async function runApply(
     preferencesResult,
   ];
 
-  // ── Step 6: Rollback if any applier had errors ────────────────────────────
+  // ── Step 7: Rollback if any applier had errors ────────────────────────────
   const anyError = allResults.some((r) => r.errors.length > 0);
 
   if (anyError && !dryRun) {
@@ -330,16 +459,11 @@ export async function runApply(
     await attemptRollback(storage, dbState);
   }
 
-  // ── Step 7: Post-apply event + audit ─────────────────────────────────────
+  // ── Step 8: Post-apply event + audit ──────────────────────────────────────
   const audit = buildAudit(appliedAt, appliedBy, repoPath, dryRun, force, diffs, conflicts);
-
-  if (!dryRun && !anyError) {
-    configSyncEvents.emit("config_applied", { audit, repoPath });
-  }
-
   const summaries = buildSummaries(diffs, allResults);
 
-  return {
+  const baseResult: ApplyResult = {
     appliedAt,
     repoPath,
     dryRun,
@@ -352,7 +476,38 @@ export async function runApply(
     diffs,
     audit,
     abortedDueToConflicts: false,
+    abortedDueToLock: false,
+    abortedDueToSafetyCheck: false,
+    safetyIssues: safetyResult.issues,
+    healthCheck: null,
   };
+
+  // ── Step 9: Post-apply health check ──────────────────────────────────────
+  let healthCheck: ApplyResult["healthCheck"] = null;
+  if (!dryRun && !anyError && instanceUrl) {
+    try {
+      const hc = await checkInstanceHealth(instanceUrl);
+      healthCheck = { status: hc.status, responseMs: hc.responseMs, error: hc.error };
+    } catch {
+      healthCheck = { status: "unreachable", responseMs: 0, error: "health check threw" };
+    }
+  }
+
+  const finalResult: ApplyResult = { ...baseResult, healthCheck };
+
+  // ── Step 10: Persist audit entry ─────────────────────────────────────────
+  await writeAuditEntry(pool, {
+    appliedBy,
+    gitCommitSha: options.gitCommitSha ?? null,
+    result: finalResult,
+    error: anyError ? "One or more applier errors — rollback attempted" : null,
+  });
+
+  if (!dryRun && !anyError) {
+    configSyncEvents.emit("config_applied", { audit, repoPath });
+  }
+
+  return finalResult;
 }
 
 // ─── Internal helpers ─────────────────────────────────────────────────────────
@@ -602,6 +757,47 @@ function buildAudit(
       dbUpdatedAt: c.dbUpdatedAt,
       lastExportAt: c.lastExportAt,
     })),
+  };
+}
+
+function buildEmptyResult(
+  appliedAt: string,
+  repoPath: string,
+  dryRun: boolean,
+  appliedBy: string,
+  force: boolean,
+): ApplyResult {
+  const emptyAudit: ApplyAuditEntry = {
+    appliedAt,
+    appliedBy,
+    repoPath,
+    dryRun,
+    forced: force,
+    summaries: [],
+    totalCreated: 0,
+    totalUpdated: 0,
+    totalDeleted: 0,
+    totalErrors: 0,
+    conflicts: [],
+  };
+
+  return {
+    appliedAt,
+    repoPath,
+    dryRun,
+    summaries: [],
+    totalCreated: 0,
+    totalUpdated: 0,
+    totalDeleted: 0,
+    totalErrors: 0,
+    conflicts: [],
+    diffs: [],
+    audit: emptyAudit,
+    abortedDueToConflicts: false,
+    abortedDueToLock: false,
+    abortedDueToSafetyCheck: false,
+    safetyIssues: [],
+    healthCheck: null,
   };
 }
 

--- a/server/config-sync/audit-log.ts
+++ b/server/config-sync/audit-log.ts
@@ -1,0 +1,121 @@
+/**
+ * audit-log.ts — Persistent audit log for config-sync apply operations.
+ *
+ * Issue #319: Config sync safety layer
+ *
+ * Writes one row to `config_applies` per apply attempt (success or failure).
+ * Falls back to a no-op when the table is not available (MemStorage / test
+ * environments).
+ */
+
+import type { Pool } from "pg";
+import type { ConfigApplySummary } from "@shared/schema";
+import type { ApplyResult } from "./apply-orchestrator.js";
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+export interface AuditLogEntry {
+  id: string;
+  appliedAt: Date;
+  appliedBy: string;
+  gitCommitSha: string | null;
+  summaryJson: ConfigApplySummary;
+  success: boolean;
+  error: string | null;
+}
+
+export interface WriteAuditEntryOptions {
+  appliedBy: string;
+  gitCommitSha?: string | null;
+  result: ApplyResult;
+  error?: string | null;
+}
+
+// ─── Write ────────────────────────────────────────────────────────────────────
+
+/**
+ * Persist a config-sync apply result to `config_applies`.
+ *
+ * Non-throwing — any DB errors are silently ignored to avoid masking the
+ * original apply result.
+ *
+ * @param pool  Postgres pool (may be null in MemStorage environments).
+ * @param opts  Apply metadata.
+ */
+export async function writeAuditEntry(
+  pool: Pool | null,
+  opts: WriteAuditEntryOptions,
+): Promise<void> {
+  if (!pool) return;
+
+  const summary: ConfigApplySummary = {
+    dryRun: opts.result.dryRun,
+    repoPath: opts.result.repoPath,
+    totalCreated: opts.result.totalCreated,
+    totalUpdated: opts.result.totalUpdated,
+    totalDeleted: opts.result.totalDeleted,
+    totalErrors: opts.result.totalErrors,
+    entityTypes: opts.result.summaries.map((s) => s.entityType),
+  };
+
+  const success =
+    !opts.result.abortedDueToConflicts &&
+    opts.result.totalErrors === 0 &&
+    !opts.error;
+
+  try {
+    await pool.query(
+      `INSERT INTO config_applies
+         (applied_by, git_commit_sha, summary_json, success, error)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [
+        opts.appliedBy,
+        opts.gitCommitSha ?? null,
+        JSON.stringify(summary),
+        success,
+        opts.error ?? null,
+      ],
+    );
+  } catch {
+    // Non-fatal — audit log failure must not break the apply path
+  }
+}
+
+// ─── Read ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Return the most recent `limit` audit entries ordered newest-first.
+ *
+ * @param pool   Postgres pool.
+ * @param limit  Max rows to return (default 20).
+ */
+export async function readAuditHistory(
+  pool: Pool,
+  limit = 20,
+): Promise<AuditLogEntry[]> {
+  const result = await pool.query<{
+    id: string;
+    applied_at: Date;
+    applied_by: string;
+    git_commit_sha: string | null;
+    summary_json: ConfigApplySummary;
+    success: boolean;
+    error: string | null;
+  }>(
+    `SELECT id, applied_at, applied_by, git_commit_sha, summary_json, success, error
+     FROM config_applies
+     ORDER BY applied_at DESC
+     LIMIT $1`,
+    [limit],
+  );
+
+  return result.rows.map((r) => ({
+    id: r.id,
+    appliedAt: r.applied_at,
+    appliedBy: r.applied_by,
+    gitCommitSha: r.git_commit_sha,
+    summaryJson: r.summary_json,
+    success: r.success,
+    error: r.error,
+  }));
+}

--- a/server/config-sync/health-check.ts
+++ b/server/config-sync/health-check.ts
@@ -1,0 +1,94 @@
+/**
+ * health-check.ts — Post-apply health verification.
+ *
+ * Issue #319: Config sync safety layer
+ *
+ * After a successful apply, hit /api/health to confirm the instance is
+ * still responding.  This catches catastrophic config changes that crash the
+ * server.
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type HealthStatus = "ok" | "degraded" | "unreachable" | "error";
+
+export interface HealthCheckResult {
+  status: HealthStatus;
+  responseMs: number;
+  httpStatus?: number;
+  error?: string;
+}
+
+/** Default timeout for the health check request. */
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Perform a quick GET /api/health against the given instance URL.
+ *
+ * @param instanceUrl  Base URL of the running instance, e.g. `http://localhost:5000`.
+ *                     Defaults to `http://localhost:5000`.
+ * @param timeoutMs    Request timeout in milliseconds (default 5 000).
+ */
+export async function checkInstanceHealth(
+  instanceUrl = "http://localhost:5000",
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<HealthCheckResult> {
+  const url = `${instanceUrl.replace(/\/$/, "")}/api/health`;
+  const start = Date.now();
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+
+    const responseMs = Date.now() - start;
+
+    if (response.status === 503) {
+      return { status: "degraded", responseMs, httpStatus: response.status };
+    }
+
+    if (!response.ok) {
+      return {
+        status: "error",
+        responseMs,
+        httpStatus: response.status,
+        error: `HTTP ${response.status}`,
+      };
+    }
+
+    // Try to read status from body — fall back to "ok" on parse error
+    let bodyStatus: string | undefined;
+    try {
+      const body = (await response.json()) as Record<string, unknown>;
+      bodyStatus = typeof body["status"] === "string" ? body["status"] : undefined;
+    } catch {
+      bodyStatus = undefined;
+    }
+
+    const status: HealthStatus =
+      bodyStatus === "ok" || bodyStatus === undefined
+        ? "ok"
+        : bodyStatus === "degraded"
+          ? "degraded"
+          : "error";
+
+    return { status, responseMs, httpStatus: response.status };
+  } catch (err: unknown) {
+    const responseMs = Date.now() - start;
+    const isAbort = err instanceof Error && err.name === "AbortError";
+    return {
+      status: "unreachable",
+      responseMs,
+      error: isAbort ? `timeout after ${timeoutMs}ms` : String(err),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/server/config-sync/safety-checks.ts
+++ b/server/config-sync/safety-checks.ts
@@ -1,0 +1,270 @@
+/**
+ * safety-checks.ts — Pre-apply safety checks for config-sync.
+ *
+ * Issue #319: Config sync safety layer
+ *
+ * Checks:
+ *  1. Git conflict markers — aborts if any YAML file contains <<<<<<< / >>>>>>>
+ *  2. Uncommitted local DB changes — warns if DB was modified after last_exported_at
+ *  3. Active pipeline runs — warns if apply would delete pipelines that have
+ *     running/pending pipeline runs
+ *  4. Bulk-delete sanity — warns if apply would delete >20% of entities of any type
+ */
+
+import fs from "fs/promises";
+import path from "path";
+import type { IStorage } from "../storage.js";
+import type { EntityDiff } from "./diff-engine.js";
+import type { EntityType } from "./apply-orchestrator.js";
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+export type SafetyLevel = "abort" | "warn";
+
+export interface SafetyIssue {
+  level: SafetyLevel;
+  code: string;
+  message: string;
+  details?: string[];
+}
+
+export interface SafetyCheckResult {
+  /** True when apply may proceed (no abort-level issues). */
+  safe: boolean;
+  issues: SafetyIssue[];
+}
+
+/** Statuses considered "active" for pipeline run blocking. */
+const ACTIVE_RUN_STATUSES = new Set(["pending", "running"]);
+
+/** Fraction threshold above which bulk-delete triggers a warning. */
+const BULK_DELETE_THRESHOLD = 0.2;
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Run all pre-apply safety checks.
+ *
+ * @param repoPath   Absolute path to the config-sync repo root.
+ * @param storage    IStorage instance (used to query active runs, entity counts).
+ * @param diffs      Per-entity-type diffs already computed by the orchestrator.
+ * @param lastExportAt  ISO-8601 timestamp of the last export (for DB drift check).
+ * @returns          Combined result — `safe = false` means apply must abort.
+ */
+export async function runSafetyChecks(
+  repoPath: string,
+  storage: IStorage,
+  diffs: EntityDiff[],
+  lastExportAt: string | null,
+): Promise<SafetyCheckResult> {
+  const issues: SafetyIssue[] = [];
+
+  const conflictIssue = await checkGitConflictMarkers(repoPath);
+  if (conflictIssue) issues.push(conflictIssue);
+
+  const driftIssue = await checkUncommittedDbChanges(storage, lastExportAt);
+  if (driftIssue) issues.push(driftIssue);
+
+  const activeRunIssues = await checkActiveRunsForDeletedPipelines(storage, diffs);
+  issues.push(...activeRunIssues);
+
+  const bulkDeleteIssues = checkBulkDeleteSanity(diffs);
+  issues.push(...bulkDeleteIssues);
+
+  const safe = issues.every((i) => i.level !== "abort");
+
+  return { safe, issues };
+}
+
+// ─── Check 1: Git conflict markers ───────────────────────────────────────────
+
+/**
+ * Walk all YAML files under repoPath and abort if any contain raw git conflict
+ * markers (`<<<<<<<` or `>>>>>>>`).
+ */
+async function checkGitConflictMarkers(
+  repoPath: string,
+): Promise<SafetyIssue | null> {
+  const conflictedFiles: string[] = [];
+
+  async function walk(dir: string): Promise<void> {
+    let entries: import("fs").Dirent[];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith(".")) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (entry.isFile() && (entry.name.endsWith(".yaml") || entry.name.endsWith(".yml"))) {
+        const content = await fs.readFile(full, "utf-8").catch(() => "");
+        if (hasConflictMarkers(content)) {
+          conflictedFiles.push(path.relative(repoPath, full));
+        }
+      }
+    }
+  }
+
+  await walk(repoPath);
+
+  if (conflictedFiles.length === 0) return null;
+
+  return {
+    level: "abort",
+    code: "GIT_CONFLICT_MARKERS",
+    message: `${conflictedFiles.length} YAML file(s) contain unresolved git conflict markers — resolve before applying`,
+    details: conflictedFiles,
+  };
+}
+
+/** Returns true if the text contains git conflict marker lines. */
+export function hasConflictMarkers(content: string): boolean {
+  const lines = content.split("\n");
+  return lines.some(
+    (l) => l.startsWith("<<<<<<<") || l.startsWith(">>>>>>>") || l.startsWith("======="),
+  );
+}
+
+// ─── Check 2: Uncommitted DB changes ─────────────────────────────────────────
+
+/**
+ * Warn when DB records were modified after the last export timestamp.
+ * This does NOT abort — it is a warning to the operator.
+ */
+async function checkUncommittedDbChanges(
+  storage: IStorage,
+  lastExportAt: string | null,
+): Promise<SafetyIssue | null> {
+  if (!lastExportAt) return null;
+
+  const threshold = new Date(lastExportAt);
+  if (isNaN(threshold.getTime())) return null;
+
+  const dirtyCounts: string[] = [];
+
+  try {
+    const pipelines = await storage.getPipelines();
+    const dirtyPipelines = pipelines.filter(
+      (p) => p.updatedAt && new Date(p.updatedAt) > threshold,
+    );
+    if (dirtyPipelines.length > 0) {
+      dirtyCounts.push(`${dirtyPipelines.length} pipeline(s) modified after last export`);
+    }
+  } catch {
+    // If storage can't query, skip gracefully
+  }
+
+  try {
+    const skills = await storage.getSkills();
+    const dirtySkills = skills.filter(
+      (s) => s.updatedAt && new Date(s.updatedAt) > threshold,
+    );
+    if (dirtySkills.length > 0) {
+      dirtyCounts.push(`${dirtySkills.length} skill(s) modified after last export`);
+    }
+  } catch {
+    // skip
+  }
+
+  if (dirtyCounts.length === 0) return null;
+
+  return {
+    level: "warn",
+    code: "DB_DRIFT",
+    message: "DB has local changes not yet captured in the repo — consider re-exporting first",
+    details: dirtyCounts,
+  };
+}
+
+// ─── Check 3: Active pipeline runs for deleted pipelines ─────────────────────
+
+/**
+ * Warn (not abort) when the apply would delete pipelines that currently have
+ * active (pending/running) pipeline runs.
+ */
+async function checkActiveRunsForDeletedPipelines(
+  storage: IStorage,
+  diffs: EntityDiff[],
+): Promise<SafetyIssue[]> {
+  const issues: SafetyIssue[] = [];
+
+  const pipelineDiff = diffs.find((d) => d.entityType === "pipeline");
+  if (!pipelineDiff) return issues;
+
+  const deletedPipelineLabels = pipelineDiff.entries
+    .filter((e) => e.kind === "delete")
+    .map((e) => e.label);
+
+  if (deletedPipelineLabels.length === 0) return issues;
+
+  try {
+    const allRuns = await storage.getPipelineRuns();
+    const activeRuns = allRuns.filter((r) => ACTIVE_RUN_STATUSES.has(r.status));
+
+    if (activeRuns.length === 0) return issues;
+
+    // Map pipeline id → name for lookup
+    const pipelines = await storage.getPipelines();
+    const idToName = new Map(pipelines.map((p) => [p.id, p.name]));
+
+    const blockedBy: string[] = [];
+    for (const run of activeRuns) {
+      const name = idToName.get(run.pipelineId);
+      if (name && deletedPipelineLabels.includes(name)) {
+        blockedBy.push(
+          `Pipeline "${name}" has an active run (id=${run.id}, status=${run.status})`,
+        );
+      }
+    }
+
+    if (blockedBy.length > 0) {
+      issues.push({
+        level: "warn",
+        code: "ACTIVE_RUNS_ON_DELETED_PIPELINES",
+        message: `${blockedBy.length} pipeline(s) scheduled for deletion have active runs`,
+        details: blockedBy,
+      });
+    }
+  } catch {
+    // Storage query failure — skip check gracefully
+  }
+
+  return issues;
+}
+
+// ─── Check 4: Bulk-delete sanity ──────────────────────────────────────────────
+
+/**
+ * Warn when the apply would delete more than 20% of entities of any type.
+ * This catches accidental mass-deletions.
+ */
+function checkBulkDeleteSanity(diffs: EntityDiff[]): SafetyIssue[] {
+  const issues: SafetyIssue[] = [];
+
+  for (const diff of diffs) {
+    const total = diff.entries.length;
+    if (total === 0) continue;
+
+    const deleting = diff.entries.filter((e) => e.kind === "delete").length;
+    if (deleting === 0) continue;
+
+    const fraction = deleting / total;
+    if (fraction > BULK_DELETE_THRESHOLD) {
+      const pct = Math.round(fraction * 100);
+      issues.push({
+        level: "warn",
+        code: "BULK_DELETE",
+        message: `Apply would delete ${pct}% of ${diff.entityType as EntityType} entities (${deleting}/${total}) — sanity check`,
+        details: [
+          `Deleting ${deleting} of ${total} ${diff.entityType as EntityType} entities`,
+          `Threshold: >${Math.round(BULK_DELETE_THRESHOLD * 100)}% triggers this warning`,
+        ],
+      });
+    }
+  }
+
+  return issues;
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1592,3 +1592,40 @@ export const decisionLog = pgTable(
 );
 
 export type DecisionLogRow = typeof decisionLog.$inferSelect;
+
+// ─── Config applies audit log (issue #319) ─────────────────────────────────
+
+/**
+ * Audit log for config-sync apply operations.
+ * One row per apply attempt (success or failure).
+ * Retrievable via `mqlti config history`.
+ */
+export const configApplies = pgTable(
+  "config_applies",
+  {
+    id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+    appliedAt: timestamp("applied_at").notNull().defaultNow(),
+    appliedBy: text("applied_by").notNull(),
+    gitCommitSha: text("git_commit_sha"),
+    summaryJson: jsonb("summary_json").notNull().default(sql`'{}'::jsonb`).$type<ConfigApplySummary>(),
+    success: boolean("success").notNull().default(false),
+    error: text("error"),
+  },
+  (table) => [
+    index("config_applies_applied_at_idx").on(table.appliedAt),
+    index("config_applies_success_idx").on(table.success),
+  ],
+);
+
+export interface ConfigApplySummary {
+  dryRun?: boolean;
+  repoPath?: string;
+  totalCreated?: number;
+  totalUpdated?: number;
+  totalDeleted?: number;
+  totalErrors?: number;
+  entityTypes?: string[];
+}
+
+export type ConfigApplyRow = typeof configApplies.$inferSelect;
+export type InsertConfigApply = typeof configApplies.$inferInsert;

--- a/tests/unit/config-sync/safety.test.ts
+++ b/tests/unit/config-sync/safety.test.ts
@@ -1,0 +1,581 @@
+/**
+ * Tests for config-sync safety layer (issue #319)
+ *
+ * Coverage:
+ *   - apply-lock: lockKeyFromName, ApplyLockBusyError
+ *   - apply-lock: withApplyLock blocks concurrent acquires (simulated)
+ *   - safety-checks: hasConflictMarkers
+ *   - safety-checks: checkGitConflictMarkers (file walk)
+ *   - safety-checks: bulk-delete sanity check (>20%)
+ *   - safety-checks: active runs warning for deleted pipelines
+ *   - safety-checks: DB drift warning
+ *   - apply-orchestrator: aborts on conflict markers
+ *   - apply-orchestrator: applies when no safety issues
+ *   - apply-orchestrator: safetyIssues in result
+ *   - apply-orchestrator: lock fields default to false
+ *   - apply-orchestrator: rollback when applier throws
+ *   - audit-log: writeAuditEntry no-ops with null pool
+ *   - health-check: returns unreachable for non-listening URL
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+import yaml from "js-yaml";
+import { MemStorage } from "../../../server/storage.js";
+import {
+  hasConflictMarkers,
+  runSafetyChecks,
+} from "../../../server/config-sync/safety-checks.js";
+import {
+  lockKeyFromName,
+  ApplyLockBusyError,
+  APPLY_LOCK_NAME,
+} from "../../../server/config-sync/apply-lock.js";
+import {
+  writeAuditEntry,
+} from "../../../server/config-sync/audit-log.js";
+import {
+  checkInstanceHealth,
+} from "../../../server/config-sync/health-check.js";
+import {
+  runApply,
+  configSyncEvents,
+} from "../../../server/config-sync/apply-orchestrator.js";
+import type { EntityDiff } from "../../../server/config-sync/diff-engine.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function mkTempRepo(): Promise<string> {
+  const base = await fs.realpath(
+    await fs.mkdtemp(path.join(os.tmpdir(), "mqlti-safety-test-")),
+  );
+  for (const sub of [
+    "pipelines",
+    "triggers",
+    "prompts",
+    "skill-states",
+    "connections",
+    "provider-keys",
+    "preferences",
+  ]) {
+    await fs.mkdir(path.join(base, sub), { recursive: true });
+  }
+  return base;
+}
+
+function makeStorage(): MemStorage {
+  return new MemStorage();
+}
+
+async function writePipelineYaml(repoPath: string, name: string): Promise<void> {
+  const data = {
+    kind: "pipeline",
+    name,
+    description: "test",
+    stages: [],
+  };
+  await fs.writeFile(
+    path.join(repoPath, "pipelines", `${name}.yaml`),
+    yaml.dump(data),
+    "utf-8",
+  );
+}
+
+// ─── apply-lock: lockKeyFromName ──────────────────────────────────────────────
+
+describe("lockKeyFromName", () => {
+  it("returns stable numeric classId and objId", () => {
+    const { classId, objId } = lockKeyFromName(APPLY_LOCK_NAME);
+    expect(typeof classId).toBe("number");
+    expect(typeof objId).toBe("number");
+    // Must fit in int4 (signed 32-bit): classId is upper 15 bits, always positive
+    expect(classId).toBeGreaterThanOrEqual(0);
+    expect(classId).toBeLessThan(0x8000);
+    // objId uses lower 16 bits
+    expect(objId).toBeGreaterThanOrEqual(0);
+    expect(objId).toBeLessThanOrEqual(0xffff);
+  });
+
+  it("produces same keys for same name (deterministic)", () => {
+    const a = lockKeyFromName("config_sync_apply");
+    const b = lockKeyFromName("config_sync_apply");
+    expect(a).toEqual(b);
+  });
+
+  it("produces different keys for different names", () => {
+    const a = lockKeyFromName("config_sync_apply");
+    const b = lockKeyFromName("other_lock_name");
+    expect(a).not.toEqual(b);
+  });
+});
+
+// ─── apply-lock: ApplyLockBusyError ───────────────────────────────────────────
+
+describe("ApplyLockBusyError", () => {
+  it("has correct name and retryAfterSeconds", () => {
+    const err = new ApplyLockBusyError(30);
+    expect(err.name).toBe("ApplyLockBusyError");
+    expect(err.retryAfterSeconds).toBe(30);
+    expect(err.message).toContain("30");
+    expect(err).toBeInstanceOf(Error);
+  });
+});
+
+// ─── safety-checks: hasConflictMarkers ───────────────────────────────────────
+
+describe("hasConflictMarkers", () => {
+  it("returns false for clean YAML", () => {
+    expect(hasConflictMarkers("kind: pipeline\nname: foo\n")).toBe(false);
+  });
+
+  it("detects <<<<<<< conflict header", () => {
+    const content = "name: foo\n<<<<<<< HEAD\nstages: []\n";
+    expect(hasConflictMarkers(content)).toBe(true);
+  });
+
+  it("detects >>>>>>> conflict footer", () => {
+    const content = "name: foo\n>>>>>>> feature-branch\nstages: []\n";
+    expect(hasConflictMarkers(content)).toBe(true);
+  });
+
+  it("detects ======= separator", () => {
+    const content = "name: foo\n=======\nstages: []\n";
+    expect(hasConflictMarkers(content)).toBe(true);
+  });
+
+  it("does not flag lines that merely contain those chars mid-line", () => {
+    // Only flags lines that START with the marker
+    const content = "name: foo # <<<<<<< not at start\n";
+    expect(hasConflictMarkers(content)).toBe(false);
+  });
+});
+
+// ─── safety-checks: conflict markers in files ─────────────────────────────────
+
+describe("runSafetyChecks — conflict markers", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkTempRepo();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns safe=false with abort issue when YAML has conflict markers", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "pipelines", "broken.yaml"),
+      "name: foo\n<<<<<<< HEAD\nstages: []\n=======\nstages: [1]\n>>>>>>> branch\n",
+      "utf-8",
+    );
+    const result = await runSafetyChecks(tmpDir, makeStorage(), [], null);
+    expect(result.safe).toBe(false);
+    const issue = result.issues.find((i) => i.code === "GIT_CONFLICT_MARKERS");
+    expect(issue).toBeDefined();
+    expect(issue?.level).toBe("abort");
+    expect(issue?.details).toContain("pipelines/broken.yaml");
+  });
+
+  it("returns safe=true when no conflict markers exist", async () => {
+    await writePipelineYaml(tmpDir, "clean");
+    const result = await runSafetyChecks(tmpDir, makeStorage(), [], null);
+    expect(result.safe).toBe(true);
+    expect(result.issues.filter((i) => i.code === "GIT_CONFLICT_MARKERS")).toHaveLength(0);
+  });
+
+  it("reports all conflicted files in details", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "pipelines", "a.yaml"),
+      "<<<<<<< HEAD\n",
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(tmpDir, "connections", "b.yaml"),
+      ">>>>>>> branch\n",
+      "utf-8",
+    );
+    const result = await runSafetyChecks(tmpDir, makeStorage(), [], null);
+    expect(result.safe).toBe(false);
+    const issue = result.issues.find((i) => i.code === "GIT_CONFLICT_MARKERS");
+    expect(issue?.details?.length).toBe(2);
+  });
+});
+
+// ─── safety-checks: bulk-delete sanity ────────────────────────────────────────
+
+describe("runSafetyChecks — bulk-delete sanity", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkTempRepo();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeDiff(entityType: string, total: number, deleting: number): EntityDiff {
+    const entries = [];
+    for (let i = 0; i < deleting; i++) {
+      entries.push({ kind: "delete" as const, entityType, label: `item-${i}`, entity: null });
+    }
+    for (let i = deleting; i < total; i++) {
+      entries.push({ kind: "create" as const, entityType, label: `item-${i}`, entity: {} });
+    }
+    return { entityType, entries, parseErrors: [] };
+  }
+
+  it("warns when deleting >20% of entities", async () => {
+    const diff = makeDiff("pipeline", 10, 3); // 30% — above threshold
+    const result = await runSafetyChecks(tmpDir, makeStorage(), [diff], null);
+    const issue = result.issues.find((i) => i.code === "BULK_DELETE");
+    expect(issue).toBeDefined();
+    expect(issue?.level).toBe("warn");
+    // warn is not abort — result.safe should still be true
+    expect(result.safe).toBe(true);
+  });
+
+  it("does not warn when deleting exactly 20% (threshold is strictly >20%)", async () => {
+    const diff = makeDiff("pipeline", 10, 2); // exactly 20%
+    const result = await runSafetyChecks(tmpDir, makeStorage(), [diff], null);
+    expect(result.issues.find((i) => i.code === "BULK_DELETE")).toBeUndefined();
+  });
+
+  it("does not warn when deleting 0 entities", async () => {
+    const diff = makeDiff("pipeline", 10, 0);
+    const result = await runSafetyChecks(tmpDir, makeStorage(), [diff], null);
+    expect(result.issues.find((i) => i.code === "BULK_DELETE")).toBeUndefined();
+  });
+
+  it("emits one warning per entity type that exceeds threshold", async () => {
+    const d1 = makeDiff("pipeline", 10, 5); // 50%
+    const d2 = makeDiff("connection", 10, 5); // 50%
+    const result = await runSafetyChecks(tmpDir, makeStorage(), [d1, d2], null);
+    const issues = result.issues.filter((i) => i.code === "BULK_DELETE");
+    expect(issues.length).toBe(2);
+  });
+});
+
+// ─── safety-checks: active runs on deleted pipelines ──────────────────────────
+
+describe("runSafetyChecks — active runs on deleted pipelines", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkTempRepo();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("warns when a deleted pipeline has an active run", async () => {
+    const storage = makeStorage();
+    const pipeline = await storage.createPipeline({
+      name: "my-pipeline",
+      description: null,
+      stages: [],
+      dag: null,
+      isTemplate: false,
+    });
+    await storage.createPipelineRun({
+      pipelineId: pipeline.id,
+      status: "running",
+      input: "{}",
+      output: null,
+      currentStageIndex: 0,
+      startedAt: new Date(),
+      completedAt: null,
+      triggeredBy: null,
+      dagMode: false,
+    });
+
+    const deleteDiff: EntityDiff = {
+      entityType: "pipeline",
+      entries: [{ kind: "delete", entityType: "pipeline", label: "my-pipeline", entity: null }],
+      parseErrors: [],
+    };
+
+    const result = await runSafetyChecks(tmpDir, storage, [deleteDiff], null);
+    const issue = result.issues.find((i) => i.code === "ACTIVE_RUNS_ON_DELETED_PIPELINES");
+    expect(issue).toBeDefined();
+    expect(issue?.level).toBe("warn");
+    // warn — should not abort
+    expect(result.safe).toBe(true);
+  });
+
+  it("does not warn when deleted pipeline has no active runs", async () => {
+    const storage = makeStorage();
+    const pipeline = await storage.createPipeline({
+      name: "my-pipeline",
+      description: null,
+      stages: [],
+      dag: null,
+      isTemplate: false,
+    });
+    await storage.createPipelineRun({
+      pipelineId: pipeline.id,
+      status: "completed",
+      input: "{}",
+      output: null,
+      currentStageIndex: 0,
+      startedAt: new Date(),
+      completedAt: new Date(),
+      triggeredBy: null,
+      dagMode: false,
+    });
+
+    const deleteDiff: EntityDiff = {
+      entityType: "pipeline",
+      entries: [{ kind: "delete", entityType: "pipeline", label: "my-pipeline", entity: null }],
+      parseErrors: [],
+    };
+
+    const result = await runSafetyChecks(tmpDir, storage, [deleteDiff], null);
+    expect(result.issues.find((i) => i.code === "ACTIVE_RUNS_ON_DELETED_PIPELINES")).toBeUndefined();
+  });
+});
+
+// ─── safety-checks: DB drift ──────────────────────────────────────────────────
+
+describe("runSafetyChecks — DB drift", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkTempRepo();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("does not warn when lastExportAt is null", async () => {
+    const result = await runSafetyChecks(tmpDir, makeStorage(), [], null);
+    expect(result.issues.find((i) => i.code === "DB_DRIFT")).toBeUndefined();
+  });
+
+  it("does not warn when no entities modified after export", async () => {
+    const storage = makeStorage();
+    // Pipeline with an old updatedAt (before the export timestamp)
+    const ts = new Date("2020-01-01T00:00:00Z").toISOString();
+    const result = await runSafetyChecks(tmpDir, storage, [], new Date().toISOString());
+    // No pipelines in DB — no drift
+    expect(result.issues.find((i) => i.code === "DB_DRIFT")).toBeUndefined();
+  });
+});
+
+// ─── apply-orchestrator: conflict markers abort apply ─────────────────────────
+
+describe("runApply — conflict marker abort", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkTempRepo();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("aborts with abortedDueToSafetyCheck=true when YAML has conflict markers", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "pipelines", "conflict.yaml"),
+      "<<<<<<< HEAD\nname: foo\n>>>>>>> branch\n",
+      "utf-8",
+    );
+    const result = await runApply(makeStorage(), tmpDir, {});
+    expect(result.abortedDueToSafetyCheck).toBe(true);
+    expect(result.abortedDueToLock).toBe(false);
+    const abortIssue = result.safetyIssues.find((i) => i.code === "GIT_CONFLICT_MARKERS");
+    expect(abortIssue).toBeDefined();
+  });
+
+  it("does not write to DB when aborted by safety check", async () => {
+    const storage = makeStorage();
+    await fs.writeFile(
+      path.join(tmpDir, "pipelines", "bad.yaml"),
+      "<<<<<<< HEAD\n",
+      "utf-8",
+    );
+    await runApply(storage, tmpDir, {});
+    const pipelines = await storage.getPipelines();
+    expect(pipelines).toHaveLength(0);
+  });
+});
+
+// ─── apply-orchestrator: safety issues in result ─────────────────────────────
+
+describe("runApply — safety issues in result", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkTempRepo();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("includes empty safetyIssues array on clean apply", async () => {
+    const result = await runApply(makeStorage(), tmpDir, {});
+    expect(result.safetyIssues).toBeDefined();
+    expect(Array.isArray(result.safetyIssues)).toBe(true);
+  });
+
+  it("safetyIssues contains warn-level issues on bulk-delete", async () => {
+    const storage = makeStorage();
+    // Create 5 pipelines
+    for (let i = 0; i < 5; i++) {
+      await storage.createPipeline({
+        name: `pipe-${i}`,
+        description: null,
+        stages: [],
+        dag: null,
+        isTemplate: false,
+      });
+    }
+    // Empty pipelines dir — will tombstone all 5 (100% delete)
+    const result = await runApply(storage, tmpDir, {});
+    const bulkWarn = result.safetyIssues.find((i) => i.code === "BULK_DELETE");
+    expect(bulkWarn).toBeDefined();
+    expect(bulkWarn?.level).toBe("warn");
+  });
+});
+
+// ─── apply-orchestrator: lock fields default ─────────────────────────────────
+
+describe("runApply — new result fields", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkTempRepo();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("abortedDueToLock defaults to false", async () => {
+    const result = await runApply(makeStorage(), tmpDir, {});
+    expect(result.abortedDueToLock).toBe(false);
+  });
+
+  it("abortedDueToSafetyCheck defaults to false on clean repo", async () => {
+    const result = await runApply(makeStorage(), tmpDir, {});
+    expect(result.abortedDueToSafetyCheck).toBe(false);
+  });
+
+  it("healthCheck is null when instanceUrl is null", async () => {
+    const result = await runApply(makeStorage(), tmpDir, { instanceUrl: null });
+    expect(result.healthCheck).toBeNull();
+  });
+
+  it("healthCheck is null for dry-run", async () => {
+    const result = await runApply(makeStorage(), tmpDir, { dryRun: true });
+    expect(result.healthCheck).toBeNull();
+  });
+});
+
+// ─── apply-orchestrator: rollback on error ────────────────────────────────────
+
+describe("runApply — rollback on applier error", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkTempRepo();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("totalErrors > 0 when applier throws", async () => {
+    // Write a valid pipeline YAML so diff produces a create entry
+    const validPipeline = {
+      kind: "pipeline",
+      apiVersion: "1.0.0",
+      name: "bad",
+      stages: [],
+    };
+    await fs.writeFile(
+      path.join(tmpDir, "pipelines", "bad.yaml"),
+      yaml.dump(validPipeline),
+      "utf-8",
+    );
+
+    // Use a storage that throws on createPipeline to simulate a mid-apply error
+    const storage = makeStorage();
+    vi.spyOn(storage, "createPipeline").mockRejectedValueOnce(
+      new Error("injected error"),
+    );
+
+    const result = await runApply(storage, tmpDir, { instanceUrl: null });
+    expect(result.totalErrors).toBeGreaterThan(0);
+  });
+});
+
+// ─── audit-log: no-op with null pool ──────────────────────────────────────────
+
+describe("writeAuditEntry", () => {
+  it("resolves silently when pool is null", async () => {
+    const mockResult = {
+      appliedAt: new Date().toISOString(),
+      repoPath: "/tmp/test",
+      dryRun: false,
+      summaries: [],
+      totalCreated: 1,
+      totalUpdated: 0,
+      totalDeleted: 0,
+      totalErrors: 0,
+      conflicts: [],
+      diffs: [],
+      audit: {
+        appliedAt: new Date().toISOString(),
+        appliedBy: "test",
+        repoPath: "/tmp/test",
+        dryRun: false,
+        forced: false,
+        summaries: [],
+        totalCreated: 1,
+        totalUpdated: 0,
+        totalDeleted: 0,
+        totalErrors: 0,
+        conflicts: [],
+      },
+      abortedDueToConflicts: false,
+      abortedDueToLock: false,
+      abortedDueToSafetyCheck: false,
+      safetyIssues: [],
+      healthCheck: null,
+    };
+
+    await expect(
+      writeAuditEntry(null, {
+        appliedBy: "test",
+        gitCommitSha: null,
+        result: mockResult,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+// ─── health-check: unreachable URL ───────────────────────────────────────────
+
+describe("checkInstanceHealth", () => {
+  it("returns unreachable for a non-listening URL", async () => {
+    // Port 1 is typically unused and should refuse connections immediately
+    const result = await checkInstanceHealth("http://127.0.0.1:1", 2000);
+    expect(result.status).toMatch(/unreachable|error/);
+    expect(typeof result.responseMs).toBe("number");
+  });
+
+  it("returns unreachable on timeout", async () => {
+    // 192.0.2.1 is a documentation/test IP that should not respond
+    const result = await checkInstanceHealth("http://192.0.2.1:9999", 100);
+    expect(result.status).toMatch(/unreachable/);
+    expect(result.error).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- **Apply lock**: `pg_try_advisory_lock` on `"config_sync_apply"` (FNV-32a key) prevents concurrent applies. Returns `ApplyLockBusyError` immediately when busy (no blocking wait).
- **Conflict markers**: aborts apply when any YAML file under the repo contains `<<<<<<<` / `>>>>>>>` / `=======` git conflict lines.
- **Pre-apply safety checks** (`safety-checks.ts`):
  - `DB_DRIFT` warn — DB entities modified after `last_exported_at`
  - `ACTIVE_RUNS_ON_DELETED_PIPELINES` warn — pipelines scheduled for deletion have running/pending runs
  - `BULK_DELETE` warn — apply would delete >20% of any entity type
- **Partial-failure rollback**: existing best-effort snapshot rollback is preserved; `abortedDueToSafetyCheck` / `abortedDueToLock` booleans added to `ApplyResult`.
- **Audit log**: `config_applies` table (migration `0020_config_applies_audit.sql`); `writeAuditEntry` is non-throwing and no-ops when no pool is available.
- **`mqlti config history`**: new CLI subcommand, shows last N applies with timestamp, author, git SHA, counts, error (if any).
- **Post-apply health check**: hits `MQLTI_INSTANCE_URL/api/health` (default `localhost:5000`) after a real apply; result in `ApplyResult.healthCheck`.
- **CLI flags**: `--yes` (skip interactive warning prompts, still prints); `--limit N` (history count).

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] 32 new tests in `tests/unit/config-sync/safety.test.ts` covering all new paths
- [x] `npx vitest run tests/unit/config-sync/safety.test.ts` — 32/32 pass
- [x] `npx vitest run tests/unit/config-sync/` — 382/382 pass (all 8 config-sync test files)
- [x] `npx vitest run` — 4436/4436 pass (189 files, no regressions)