### PR TITLE
docs: add config sync documentation (#320)

### DIFF
--- a/docs/config-sync/README.md
+++ b/docs/config-sync/README.md
@@ -1,0 +1,74 @@
+# Config Sync
+
+Config sync lets you version-control your Multiqlti instance configuration in a git repository and apply it across multiple machines. Pipelines, triggers, connections, and other entities are stored as YAML files. A CLI (`mqlti config`) exports from the database, applies changes back, and handles encryption for sensitive values.
+
+## What syncs
+
+| Entity kind | Directory | Tombstone on delete | Notes |
+|---|---|---|---|
+| `pipeline` | `pipelines/` | Yes | Full pipeline definition including stages and DAG |
+| `trigger` | `triggers/` | Yes | All four trigger types (schedule, webhook, github_event, file_change) |
+| `prompt` | `prompts/` | Yes | Skills that carry a `systemPromptOverride` |
+| `skill-state` | `skill-states/` | No | Installed skill lock file — absence does not delete skills |
+| `connection` | `connections/` | Yes | Non-secret config only; credentials go in `.secret` files |
+| `provider-key` | `provider-keys/` | Yes | Reference expressions only (`${env:…}`, `${file:…}`, `${vault:…}`) |
+| `preferences` | `preferences/` | No | UI preferences; absence does not reset preferences |
+
+## What does not sync
+
+**Pipeline run history** — runs are live operational data, not configuration. They are never exported or applied.
+
+**Workspace code / editor state** — the workspace file system is isolated per session and is not part of the config-sync contract.
+
+**Raw API credentials** — `connection` and `provider-key` entities carry only references or non-secret config. The actual secrets are encrypted with `mqlti config secrets add` and live in `.secret` files committed alongside the YAML. See [secrets.md](./secrets.md) for the cryptographic protocol.
+
+## Repository layout
+
+After `mqlti config init`:
+
+```
+my-config-repo/
+├── .mqlti-config.yaml      # sync metadata (lastExportAt, lastApplyAt, …)
+├── .gitignore              # blocks *.key, *.pem, .env
+├── public-keys/            # one JSON file per enrolled machine
+├── pipelines/
+├── triggers/
+├── connections/
+├── provider-keys/
+├── prompts/
+├── skill-states/
+└── preferences/
+```
+
+Each entity lives in its own `.yaml` file named after the entity. The file name is derived from the entity's display name. One file per entity is the default; the exporter never colocates multiple entities in a single file.
+
+## Threat model summary
+
+The threat model is defined in full in [secrets.md](./secrets.md#threat-model). Key points:
+
+- The git repository (including remotes, CI logs, and GitHub) may be read by anyone. Secrets committed in plaintext are a security incident. This is prevented by two mechanisms: the `.gitignore` blocks source files, and `secrets add` produces `.secret` files containing only AES-256-GCM ciphertext.
+- `.secret` files are safe to commit. They are decryptable only by machines whose X25519 public key was enrolled before encryption.
+- Tampering with a `.secret` file is detected at decryption time via AES-256-GCM authentication tags.
+- The advisory lock (`pg_try_advisory_lock`) prevents two concurrent `apply` runs from corrupting the database.
+- Git conflict markers in YAML files abort `apply` before any database write occurs.
+
+## CLI quick reference
+
+```
+npx tsx script/mqlti-config.ts <subcommand> [options]
+
+Subcommands:
+  init <path>                  Create a new config-sync repository
+  status                       Show git state and sync timestamps
+  export                       Export live DB state to YAML files
+  apply [--dry-run] [--force]  Apply YAML files to the running instance
+  diff                         Show diff between YAML repo and live DB
+  push                         Export + commit + push to remote git
+  pull [--auto-apply]          Pull remote changes; optionally apply
+  secrets add <src>            Encrypt a file for all repo recipients
+  secrets rotate               Regenerate machine keys + re-encrypt all .secret files
+  secrets list                 List recipients in each .secret file
+  history [--limit N]          Show last N apply operations (default 20)
+```
+
+See [getting-started.md](./getting-started.md) for a step-by-step walkthrough, [schemas.md](./schemas.md) for the per-entity YAML format, and [troubleshooting.md](./troubleshooting.md) for common failure modes.

--- a/docs/config-sync/getting-started.md
+++ b/docs/config-sync/getting-started.md
@@ -1,0 +1,191 @@
+# Getting Started with Config Sync
+
+This guide walks through every common setup scenario from scratch.
+
+## Prerequisites
+
+- `npx tsx` available (comes with the project's dev dependencies)
+- A running Multiqlti instance (for `export` and `apply`)
+- Git installed and configured
+
+The config CLI is at `script/mqlti-config.ts`. All examples below run it as:
+
+```bash
+npx tsx script/mqlti-config.ts <subcommand>
+```
+
+## Bootstrapping the first machine
+
+### 1. Create the config repository
+
+```bash
+npx tsx script/mqlti-config.ts init ./my-config-repo
+```
+
+This creates:
+- The directory structure (`pipelines/`, `triggers/`, `connections/`, etc.)
+- `.mqlti-config.yaml` — sync metadata
+- `.gitignore` — blocks `*.key`, `*.pem`, `.env.*`
+- A git repository (`git init`)
+
+### 2. Generate and enroll your machine key
+
+```bash
+cd my-config-repo
+npx tsx script/mqlti-config.ts secrets rotate
+```
+
+This generates an X25519 key pair and writes:
+- Private key → `~/.config/mqlti/age-keys.txt` (mode 0600, never committed)
+- Public key → `public-keys/<hostname>.json` (commit this)
+
+### 3. Export your current instance config
+
+```bash
+npx tsx script/mqlti-config.ts export
+```
+
+This reads from the running Multiqlti database and writes YAML files into the entity directories. The `lastExportAt` timestamp is updated in `.mqlti-config.yaml`.
+
+### 4. Encrypt any secret files
+
+If any connection or other entity file contains sensitive values that you moved into a separate file, encrypt it:
+
+```bash
+npx tsx script/mqlti-config.ts secrets add connections/gitlab-main.yaml
+```
+
+This produces `connections/gitlab-main.yaml.secret` and adds the plaintext file to `.gitignore`.
+
+### 5. Push to remote
+
+Add a remote and push:
+
+```bash
+git remote add origin git@github.com:your-org/your-config-repo.git
+npx tsx script/mqlti-config.ts push
+```
+
+`push` runs `export`, commits, and pushes in one step. If the export was already done, it commits whatever changed.
+
+Check the status at any time:
+
+```bash
+npx tsx script/mqlti-config.ts status
+```
+
+## Setting up a second machine (clone + apply)
+
+### 1. Clone the config repository
+
+```bash
+git clone git@github.com:your-org/your-config-repo.git my-config-repo
+cd my-config-repo
+```
+
+### 2. Generate a key for this machine
+
+```bash
+npx tsx script/mqlti-config.ts secrets rotate
+```
+
+This writes the new public key to `public-keys/<this-hostname>.json`. Commit and push it:
+
+```bash
+git add public-keys/
+git commit -m "chore: enroll <this-hostname>"
+git push
+```
+
+### 3. Re-encrypt secrets from an enrolled machine
+
+The new machine's public key is now in the repo, but existing `.secret` files do not yet include it as a recipient. An already-enrolled machine must re-encrypt:
+
+```bash
+# On the first (already-enrolled) machine
+git pull
+npx tsx script/mqlti-config.ts secrets rotate
+git add public-keys/ **/*.secret
+git commit -m "chore: add <new-hostname> as secret recipient"
+git push
+```
+
+### 4. Pull the updated secrets and apply
+
+Back on the new machine:
+
+```bash
+git pull
+npx tsx script/mqlti-config.ts apply
+```
+
+`apply` reads the YAML files, diffs them against the live database, and writes only the delta. The new machine can now decrypt secrets because its public key was added in step 3.
+
+## Adding a third machine
+
+The process is identical to adding a second machine. The only difference is that more `.secret` files may need re-encryption. `secrets rotate` re-encrypts all `.secret` files found under the repo root in one pass, so no manual enumeration is needed.
+
+## Key rotation
+
+To rotate your key (e.g. after a suspected private key compromise):
+
+```bash
+# On the affected machine
+npx tsx script/mqlti-config.ts secrets rotate
+git add public-keys/ **/*.secret
+git commit -m "security: rotate secrets for <hostname>"
+git push
+```
+
+`secrets rotate` replaces `~/.config/mqlti/age-keys.txt` with a new key pair, overwrites `public-keys/<hostname>.json`, and re-encrypts every `.secret` file in the repo. Anyone holding only the old private key can no longer decrypt after the rotated files are pushed.
+
+If you want to revoke a machine entirely (e.g. a decommissioned laptop), delete its `public-keys/<hostname>.json` file, then run `secrets rotate` on any remaining enrolled machine to re-encrypt without the removed recipient.
+
+## Daily workflow
+
+### Push today's changes
+
+```bash
+npx tsx script/mqlti-config.ts push
+```
+
+`push` exports, commits, and pushes in one step.
+
+### Pull and apply changes from another machine
+
+```bash
+npx tsx script/mqlti-config.ts pull --auto-apply
+```
+
+`pull` fetches and rebases. With `--auto-apply` it immediately runs `apply`. Without the flag it prints a reminder to run `apply` manually.
+
+### Preview what would change before applying
+
+```bash
+npx tsx script/mqlti-config.ts diff
+```
+
+### Apply with confirmation prompts suppressed (CI / automation)
+
+```bash
+npx tsx script/mqlti-config.ts apply --yes
+```
+
+`--yes` skips interactive safety warning prompts. Safety checks still run; only `abort`-level checks stop the apply.
+
+### View apply history
+
+```bash
+npx tsx script/mqlti-config.ts history
+npx tsx script/mqlti-config.ts history --limit 5
+```
+
+Requires `DATABASE_URL` to be set. Shows the last N apply operations with timestamps, operator, git commit SHA, and change counts.
+
+## Environment variables
+
+| Variable | Used by | Description |
+|---|---|---|
+| `DATABASE_URL` | `apply`, `history` | Postgres connection string; enables advisory locking and audit log |
+| `MQLTI_INSTANCE_URL` | `apply` | Base URL for post-apply health check (default: `http://localhost:5000`) |
+| `USER` | `apply` | Recorded as `appliedBy` in the audit log (set automatically by the OS) |

--- a/docs/config-sync/schemas.md
+++ b/docs/config-sync/schemas.md
@@ -1,0 +1,278 @@
+# Config Sync YAML Schemas
+
+Every file in a config-sync repository is a YAML document that serialises one entity. All entities share two required top-level fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `kind` | string (discriminator) | Identifies the entity type. Must be one of the values below. |
+| `apiVersion` | semver string | Schema version for this entity. Current value for all kinds: `"1.0.0"`. |
+
+Unknown fields are rejected at parse time. The Zod schemas in `shared/config-sync/schemas.ts` use `.strict()` throughout — any extra key is a validation error and the entity is skipped during `apply`.
+
+---
+
+## Sync matrix
+
+| `kind` | Directory | Tombstone default | Identified by |
+|---|---|---|---|
+| `pipeline` | `pipelines/` | Yes | `name` |
+| `trigger` | `triggers/` | Yes | Filename slug (pipeline name + trigger type + ID prefix) |
+| `prompt` | `prompts/` | Yes | `name` |
+| `skill-state` | `skill-states/` | No | Filename |
+| `connection` | `connections/` | Yes | `name` |
+| `provider-key` | `provider-keys/` | Yes | `provider` |
+| `preferences` | `preferences/` | No | `scope` + optional `userId` |
+
+**Tombstone** means that if a YAML file is absent from the repository, the corresponding entity is deleted from the database during `apply`. Kinds with tombstone = No are additive only; removing the file does not delete from the database.
+
+---
+
+## `pipeline`
+
+```yaml
+kind: pipeline
+apiVersion: "1.0.0"
+name: code-review-pipeline
+description: Optional description (max 2000 chars)
+isTemplate: false
+stages:
+  - teamId: architecture
+    modelSlug: claude-sonnet-4-6
+    enabled: true
+    temperature: 0.3
+    maxTokens: 4096
+    approvalRequired: false
+    executionStrategy: single  # single | moa | debate | voting
+```
+
+With a DAG layout:
+
+```yaml
+kind: pipeline
+apiVersion: "1.0.0"
+name: dag-pipeline
+stages: []
+dag:
+  stages:
+    - id: stage-a
+      teamId: research
+      modelSlug: claude-sonnet-4-6
+      enabled: true
+      position: { x: 100, y: 200 }
+    - id: stage-b
+      teamId: synthesis
+      modelSlug: claude-sonnet-4-6
+      enabled: true
+      position: { x: 400, y: 200 }
+  edges:
+    - id: edge-1
+      from: stage-a
+      to: stage-b
+```
+
+See `docs/config-sync/examples/pipeline.yaml` for a fuller example.
+
+---
+
+## `trigger`
+
+Triggers reference a pipeline by name via `pipelineRef`. Four `config.type` values are supported.
+
+**schedule**
+
+```yaml
+kind: trigger
+apiVersion: "1.0.0"
+pipelineRef: code-review-pipeline
+enabled: true
+config:
+  type: schedule
+  cron: "0 9 * * 1-5"
+  timezone: "America/New_York"
+  input: "Run scheduled code health check"  # optional
+```
+
+**webhook**
+
+```yaml
+kind: trigger
+apiVersion: "1.0.0"
+pipelineRef: code-review-pipeline
+enabled: true
+config:
+  type: webhook
+```
+
+**github_event**
+
+```yaml
+kind: trigger
+apiVersion: "1.0.0"
+pipelineRef: code-review-pipeline
+enabled: true
+config:
+  type: github_event
+  repository: "my-org/my-repo"   # must be owner/repo format
+  events:
+    - pull_request
+    - push
+  refFilter: "refs/heads/main"   # optional
+```
+
+**file_change**
+
+```yaml
+kind: trigger
+apiVersion: "1.0.0"
+pipelineRef: code-review-pipeline
+enabled: false
+config:
+  type: file_change
+  watchPath: /workspace/src
+  patterns:
+    - "**/*.ts"
+    - "!**/*.test.ts"
+  debounceMs: 1000               # optional
+  input: "File changed"          # optional
+```
+
+---
+
+## `prompt`
+
+Prompts map to skills that carry a `systemPromptOverride`.
+
+```yaml
+kind: prompt
+apiVersion: "1.0.0"
+name: senior-code-reviewer
+description: Optional description
+defaultPrompt: |
+  You are a senior code reviewer. Focus on security and maintainability.
+stageOverrides:
+  - teamId: architecture
+    systemPrompt: "Focus only on architectural concerns."
+tags:
+  - code-review
+  - security
+```
+
+---
+
+## `skill-state`
+
+The skill-state entity is a lock file snapshot of installed skills. It is intentionally non-tombstone: removing it does not uninstall skills.
+
+```yaml
+kind: skill-state
+apiVersion: "1.0.0"
+generatedAt: "2026-04-17T10:00:00.000Z"
+skills:
+  - id: skill-abc123
+    name: code-analyzer
+    version: "1.2.0"
+    source: market        # builtin | market | git | local
+    externalId: "market/code-analyzer"
+    autoUpdate: false
+    installedAt: "2026-01-01T00:00:00.000Z"
+```
+
+`source` values:
+- `builtin` — shipped with the instance
+- `market` — installed from the skill marketplace
+- `git` — installed from a git URL
+- `local` — installed from a local path
+
+---
+
+## `connection`
+
+Connections store non-secret configuration only. API tokens, passwords, and other credentials must be placed in a `.secret` file (see [secrets.md](./secrets.md)).
+
+```yaml
+kind: connection
+apiVersion: "1.0.0"
+name: github-main
+type: github   # gitlab | github | kubernetes | aws | jira | grafana | generic_mcp
+workspaceRef: my-workspace
+status: active  # active | inactive
+config:
+  host: "https://api.github.com"
+  owner: "my-org"
+  repo: "my-repo"
+```
+
+The `config` map accepts any key-value pairs. What goes here depends on the connection type; there is no fixed schema for `config` beyond it being a non-secret map.
+
+---
+
+## `provider-key`
+
+Provider keys record which AI model provider a key belongs to and where to find the actual secret. The key material is never stored in the YAML file.
+
+```yaml
+kind: provider-key
+apiVersion: "1.0.0"
+provider: anthropic   # anthropic | google | openai | xai | mistral | groq | vllm | ollama | lmstudio
+secretRef: "${env:ANTHROPIC_API_KEY}"
+description: "Production Anthropic key for Claude models"
+enabled: true
+```
+
+`secretRef` must be a reference expression in one of three forms:
+
+| Form | Example | Resolution |
+|---|---|---|
+| `${env:NAME}` | `${env:ANTHROPIC_API_KEY}` | Read from environment variable at runtime |
+| `${file:path}` | `${file:./secrets/openai.key}` | Read from a file path relative to the repo |
+| `${vault:path}` | `${vault:secret/multiqlti/google-key}` | Read from HashiCorp Vault |
+
+---
+
+## `preferences`
+
+Preferences store UI and feature-flag settings. They are non-tombstone.
+
+```yaml
+kind: preferences
+apiVersion: "1.0.0"
+scope: global   # global | user
+ui:
+  theme: system   # light | dark | system
+  layout: default # default | compact | wide
+  featureFlags:
+    experimental-dag-editor: true
+extra:
+  customKey: customValue
+```
+
+For user-scoped preferences, add `userId`:
+
+```yaml
+kind: preferences
+apiVersion: "1.0.0"
+scope: user
+userId: "ws-abc123"
+ui:
+  theme: dark
+```
+
+---
+
+## Why pipeline runs and workspace code do not sync
+
+**Pipeline runs** are live operational records — they represent what happened, not how the instance is configured. Exporting and applying run history would create data conflicts across machines and make `apply` non-idempotent. Run history is queried via `mqlti config history` (which reads the audit log of `apply` operations, not pipeline execution records).
+
+**Workspace code** is ephemeral per-session state. It is not part of the declarative config contract and has no deterministic serialisation that would survive a round-trip through git.
+
+---
+
+## Adding a new entity kind
+
+1. Add a Zod schema in `shared/config-sync/schemas.ts` following the existing pattern: `z.object({ kind: z.literal("your-kind"), apiVersion: SemverSchema, … }).strict()`.
+2. Add the new schema to the `ConfigEntitySchema` discriminated union.
+3. Create a new exporter in `server/config-sync/exporters/` and a new applier in `server/config-sync/appliers/`.
+4. Register both in `export-orchestrator.ts` and `apply-orchestrator.ts`.
+5. Add the entity directory name to `ENTITY_DIRS` in `script/mqlti-config.ts` so `init` creates it.
+6. Add a row to the sync matrix above.
+7. Add an example file to `docs/config-sync/examples/`.

--- a/docs/config-sync/troubleshooting.md
+++ b/docs/config-sync/troubleshooting.md
@@ -1,0 +1,247 @@
+# Config Sync Troubleshooting
+
+## Apply failed
+
+### "Another apply is already in progress — retry in 30 seconds"
+
+`apply` uses a Postgres advisory lock (`pg_try_advisory_lock`) to prevent concurrent applies. If a previous run is still active, or if a previous run crashed without releasing its connection, the lock may still be held.
+
+**Check for stuck connections:**
+
+```sql
+SELECT pid, application_name, state, query_start, query
+FROM pg_stat_activity
+WHERE query ILIKE '%pg_advisory%';
+```
+
+If you see a connection that has been waiting for minutes and you are confident no apply is actually running, terminate it:
+
+```sql
+SELECT pg_terminate_backend(<pid>);
+```
+
+Then re-run `apply`.
+
+**If `DATABASE_URL` is not set**, the advisory lock is skipped entirely and this error will not appear.
+
+---
+
+### "Aborted: safety check failed — GIT_CONFLICT_MARKERS"
+
+One or more YAML files contain unresolved git conflict markers (`<<<<<<<`, `>>>>>>>`, `=======`).
+
+1. Run `git status` inside the config repo to identify conflicted files.
+2. Open each conflicted file and resolve the conflict manually — choose which version to keep and remove all marker lines.
+3. Stage and commit the resolved files.
+4. Re-run `apply`.
+
+`apply` performs this check before any database write. There is no flag to skip it.
+
+---
+
+### "Aborted: DB has out-of-band modifications since last export"
+
+The database was modified (via the UI or API) after the last `export` ran. The YAML files in the repo do not reflect those changes.
+
+**Option 1 — re-export first (recommended):**
+
+```bash
+npx tsx script/mqlti-config.ts export
+npx tsx script/mqlti-config.ts push
+```
+
+This captures the latest database state into the repo, then applies.
+
+**Option 2 — apply anyway and overwrite the DB changes:**
+
+```bash
+npx tsx script/mqlti-config.ts apply --force
+```
+
+`--force` applies the YAML as-is. Any changes made in the UI since the last export are overwritten.
+
+---
+
+### "Aborted due to conflicts — DB has modifications since last export"
+
+Similar to the previous case but specifically for named entities (pipelines, connections, etc.) that were edited in the UI after the last export. The entity's `updatedAt` in the database is newer than `lastExportAt`.
+
+The error output lists each conflicting entity with its `dbUpdatedAt` and `lastExportAt` timestamps.
+
+Resolution is the same: either re-export and push, or use `--force`.
+
+---
+
+### Apply exits with errors but some entities were written
+
+`apply` uses a best-effort rollback on error: it captures a snapshot of the database before writing and attempts to restore it if any applier fails. The rollback is not a true ACID transaction. If you see the message "Errors occurred — rollback attempted. DB state may be partially modified", check the entity-level error output to identify which entities failed, then inspect the database directly.
+
+For a clean recovery:
+1. Re-export the current database state: `npx tsx script/mqlti-config.ts export`
+2. Inspect the diff: `npx tsx script/mqlti-config.ts diff`
+3. Re-apply: `npx tsx script/mqlti-config.ts apply`
+
+---
+
+### Safety warnings appear but apply proceeds
+
+Safety warnings (level `warn`) are informational. They do not stop `apply`. Three warning codes exist:
+
+| Code | Meaning |
+|---|---|
+| `DB_DRIFT` | Pipelines or skills were modified in the DB after the last export |
+| `ACTIVE_RUNS_ON_DELETED_PIPELINES` | A pipeline being deleted has a pending/running run |
+| `BULK_DELETE` | The apply would delete more than 20% of entities of a given type |
+
+These are shown before any writes occur. Review them, then proceed or abort manually. Use `--yes` to suppress the interactive prompts in automation:
+
+```bash
+npx tsx script/mqlti-config.ts apply --yes
+```
+
+---
+
+## YAML merge conflicts
+
+Merge conflicts happen when two machines edit the same YAML file in parallel and both push. Git surfaces them as conflict markers in the file.
+
+**Resolution steps:**
+
+1. `git pull` — this will report conflicts.
+2. Open the conflicted file. It will look like:
+
+   ```
+   <<<<<<< HEAD
+   name: pipeline-v1
+   =======
+   name: pipeline-v2
+   >>>>>>> origin/main
+   ```
+
+3. Decide which version to keep (or manually merge the two). Remove all marker lines.
+4. `git add <file>` — stage the resolved file.
+5. `git rebase --continue` (if using rebase) or `git commit` (if using merge).
+6. Re-run `apply`.
+
+**Prevention:** Use `push` frequently. Short-lived divergence means fewer conflicts. If two machines need to own different sets of entities, organise them into separate config repos.
+
+---
+
+## New machine cannot decrypt secrets
+
+A new machine cannot decrypt `.secret` files unless its public key was enrolled and an existing keyholder ran `secrets rotate` to re-encrypt the files.
+
+**Check whether the machine's key is enrolled:**
+
+```bash
+npx tsx script/mqlti-config.ts secrets list
+```
+
+If `public-keys/<this-hostname>.json` does not appear in the recipient list for a `.secret` file, the machine was not enrolled at the time of last encryption.
+
+**Fix — from an already-enrolled machine:**
+
+```bash
+# Pull the new machine's public key
+git pull
+
+# Re-encrypt all .secret files to include the new machine
+npx tsx script/mqlti-config.ts secrets rotate
+
+git add public-keys/ **/*.secret
+git commit -m "chore: add <new-hostname> as secret recipient"
+git push
+```
+
+**Fix — on the new machine after the re-encryption is pushed:**
+
+```bash
+git pull
+# .secret files now include this machine as a recipient
+npx tsx script/mqlti-config.ts apply
+```
+
+If the private key file is missing on the new machine (`~/.config/mqlti/age-keys.txt`), run `secrets rotate` first to generate a new key pair and start the enrollment process.
+
+---
+
+## Corrupted lock file (`.mqlti-config.yaml`)
+
+`.mqlti-config.yaml` stores the sync timestamps (`lastExportAt`, `lastApplyAt`, `lastPushAt`, `lastPullAt`). It is a YAML file managed by the CLI and is not intended for manual editing.
+
+If it is corrupted or deleted:
+
+1. `status` will fail with "Could not read .mqlti-config.yaml".
+2. `apply` will proceed without conflict detection (treats all entities as new).
+
+**Recover a deleted meta file:**
+
+```bash
+# Run export — it will re-create the meta file with lastExportAt set
+npx tsx script/mqlti-config.ts export
+```
+
+**Recover a corrupted meta file:**
+
+Delete the file and re-export:
+
+```bash
+rm .mqlti-config.yaml
+npx tsx script/mqlti-config.ts export
+```
+
+The timestamps for `lastApplyAt`, `lastPushAt`, and `lastPullAt` are lost, but they are informational only. The most important timestamp for conflict detection is `lastExportAt`, which is restored by re-exporting.
+
+---
+
+## `mqlti config history` fails — "Requires DATABASE_URL to be set"
+
+The `history` subcommand reads the `config_applies` audit table in Postgres. It requires `DATABASE_URL` to be set in the environment.
+
+```bash
+DATABASE_URL=postgres://user:pass@localhost:5432/mydb \
+  npx tsx script/mqlti-config.ts history
+```
+
+If `DATABASE_URL` is not available (e.g. running against MemStorage in development), the command exits with code 1. This is expected.
+
+---
+
+## Health check warning after apply
+
+After a successful apply, the CLI hits `$MQLTI_INSTANCE_URL/api/health` (default `http://localhost:5000/api/health`). The result is informational and does not affect the apply outcome.
+
+Status values in the output:
+
+| Status | Meaning |
+|---|---|
+| `ok` | Instance responded within timeout |
+| `degraded` | Instance responded but reported degraded state |
+| `unreachable` | TCP connection failed or timed out |
+| `error` | HTTP request threw an unexpected error |
+
+If you see `unreachable` in environments where the instance is running but on a different port or host, set `MQLTI_INSTANCE_URL` correctly:
+
+```bash
+MQLTI_INSTANCE_URL=http://localhost:3000 \
+  npx tsx script/mqlti-config.ts apply
+```
+
+---
+
+## `push` fails — "No remote configured"
+
+`push` calls `git push` after committing. If no remote is set, it exits with exit code 1 and the hint "Add a remote".
+
+```bash
+git -C /path/to/config-repo remote add origin git@github.com:your-org/your-config-repo.git
+npx tsx script/mqlti-config.ts push
+```
+
+If the upstream branch is not set, use:
+
+```bash
+git -C /path/to/config-repo push --set-upstream origin main
+```
+
+Subsequent `push` calls will use the configured upstream.


### PR DESCRIPTION
## Summary

- Adds `docs/config-sync/README.md` — overview of what syncs, what doesn't, repo layout, and threat model summary
- Adds `docs/config-sync/getting-started.md` — step-by-step: bootstrap first machine, clone + apply on second machine, add third machine, key rotation, daily workflow, environment variables
- Adds `docs/config-sync/schemas.md` — sync matrix per entity kind, full YAML examples for all 7 kinds, why runs/workspace code don't sync, how to add a new entity kind
- Adds `docs/config-sync/troubleshooting.md` — apply failures, safety check aborts, YAML merge conflicts, new machine can't decrypt, corrupted lock file, history command without DB, health check warnings, push with no remote

`secrets.md` already existed from #315 and is cross-referenced but not modified.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified: 0 errors)
- [ ] All CLI commands and flags in the docs match the implementation in `script/mqlti-config.ts`
- [ ] All entity kinds in `schemas.md` match the Zod schemas in `shared/config-sync/schemas.ts`
- [ ] Safety check codes in `troubleshooting.md` match `safety-checks.ts` (`GIT_CONFLICT_MARKERS`, `DB_DRIFT`, `ACTIVE_RUNS_ON_DELETED_PIPELINES`, `BULK_DELETE`)
- [ ] Tombstone defaults in `schemas.md` match `buildTombstoneConfig()` in `apply-orchestrator.ts`