### PR TITLE
feat: bind pipeline runs to a workspace (closes #343)

### DIFF
--- a/client/src/components/workspace/RunPipelineDialog.tsx
+++ b/client/src/components/workspace/RunPipelineDialog.tsx
@@ -1,0 +1,174 @@
+import { useState } from "react";
+import { useLocation } from "wouter";
+import { Loader2, Play } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { usePipelines, useStartRun } from "@/hooks/use-pipeline";
+import { useToast } from "@/hooks/use-toast";
+
+interface RunPipelineDialogProps {
+  workspaceId: string;
+  workspaceName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface PipelineSummary {
+  id: string;
+  name: string;
+  description?: string | null;
+  isTemplate?: boolean;
+}
+
+/**
+ * Run-pipeline-against-this-workspace dialog (issue #343).
+ *
+ * Triggers POST /api/runs with workspaceId set so the run is bound to the
+ * workspace. Workspace-aware tools (file-read, code-search, ...) will then
+ * default to this workspace's path inside the run.
+ */
+export function RunPipelineDialog({
+  workspaceId,
+  workspaceName,
+  open,
+  onOpenChange,
+}: RunPipelineDialogProps) {
+  const [, navigate] = useLocation();
+  const { toast } = useToast();
+  const { data: pipelinesData, isLoading: pipelinesLoading } = usePipelines();
+  const startRun = useStartRun();
+
+  const [pipelineId, setPipelineId] = useState<string>("");
+  const [taskInput, setTaskInput] = useState<string>("");
+
+  // Filter out templates — runs target concrete pipelines.
+  const pipelines: PipelineSummary[] = Array.isArray(pipelinesData)
+    ? (pipelinesData as PipelineSummary[]).filter((p) => !p.isTemplate)
+    : [];
+
+  const canSubmit = pipelineId.length > 0 && taskInput.trim().length > 0 && !startRun.isPending;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    startRun.mutate(
+      {
+        pipelineId,
+        input: taskInput,
+        workspaceId,
+      } as Parameters<typeof startRun.mutate>[0],
+      {
+        onSuccess: (run: unknown) => {
+          const runId = (run as Record<string, unknown>)?.id;
+          if (runId && typeof runId === "string") {
+            onOpenChange(false);
+            setTaskInput("");
+            setPipelineId("");
+            navigate(`/runs/${runId}`);
+          }
+        },
+        onError: (err: unknown) => {
+          const message = err instanceof Error ? err.message : "Failed to start run";
+          toast({
+            title: "Could not start run",
+            description: message,
+            variant: "destructive",
+          });
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Run pipeline on {workspaceName}</DialogTitle>
+          <DialogDescription>
+            The selected pipeline will run with this workspace bound to the run. Workspace-aware
+            tools (file-read, code-search, knowledge-search) will default to this workspace's
+            files.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-2">
+          <div className="grid gap-2">
+            <Label htmlFor="pipeline-picker">Pipeline</Label>
+            <Select value={pipelineId} onValueChange={setPipelineId} disabled={pipelinesLoading}>
+              <SelectTrigger id="pipeline-picker" data-testid="run-pipeline-dialog-pipeline-picker">
+                <SelectValue
+                  placeholder={
+                    pipelinesLoading
+                      ? "Loading pipelines..."
+                      : pipelines.length === 0
+                      ? "No pipelines available"
+                      : "Select a pipeline"
+                  }
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {pipelines.map((p) => (
+                  <SelectItem key={p.id} value={p.id}>
+                    <div className="flex flex-col items-start">
+                      <span className="text-sm">{p.name}</span>
+                      {p.description && (
+                        <span className="text-[11px] text-muted-foreground line-clamp-1">
+                          {p.description}
+                        </span>
+                      )}
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="task-input">Task description</Label>
+            <Textarea
+              id="task-input"
+              data-testid="run-pipeline-dialog-task-input"
+              placeholder="What should the pipeline do? e.g., 'Add JWT auth to the express app'"
+              value={taskInput}
+              onChange={(e) => setTaskInput(e.target.value)}
+              rows={4}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={startRun.isPending}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            data-testid="run-pipeline-dialog-submit"
+          >
+            {startRun.isPending ? (
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            ) : (
+              <Play className="h-4 w-4 mr-2" />
+            )}
+            Run pipeline
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/hooks/use-pipeline.ts
+++ b/client/src/hooks/use-pipeline.ts
@@ -147,8 +147,14 @@ export function usePipelineRun(runId: string) {
 export function useStartRun() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (data: { pipelineId: string; input: string; variables?: Record<string, string> }) =>
-      apiRequest("POST", "/api/runs", data),
+    mutationFn: (data: {
+      pipelineId: string;
+      input: string;
+      variables?: Record<string, string>;
+      // Optional workspace binding (issue #343). When set, the run is recorded
+      // against the workspace and tools default to it.
+      workspaceId?: string;
+    }) => apiRequest("POST", "/api/runs", data),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["/api/runs"] });
     },

--- a/client/src/pages/PipelineRun.tsx
+++ b/client/src/pages/PipelineRun.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams } from "wouter";
+import { useQuery } from "@tanstack/react-query";
 import { usePipelineRun, useCancelRun, useApproveStage, useRejectStage, useExportRun, usePipeline, useSwarmResults } from "@/hooks/use-pipeline";
 import { usePipelineEvents, useWebSocket } from "@/hooks/use-websocket";
 import StageProgress from "@/components/pipeline/StageProgress";
@@ -78,6 +79,23 @@ export default function PipelineRun() {
   const pipelineEvents = usePipelineEvents(runId);
   const { data: pipeline } = usePipeline(run?.pipelineId ?? "");
   const isManagerMode = pipeline != null && (pipeline as Record<string, unknown>).managerConfig != null;
+
+  // Linked workspace chip (issue #343). Fetch the workspace name lazily when
+  // the run is bound to one. Falls back to a generic chip on error so the
+  // link is still useful.
+  const linkedWorkspaceId = (run as { workspaceId?: string | null } | undefined)?.workspaceId ?? null;
+  const { data: linkedWorkspace } = useQuery<{ id: string; name: string }>({
+    queryKey: ["/api/workspaces", linkedWorkspaceId],
+    queryFn: async () => {
+      const token = localStorage.getItem("auth_token");
+      const res = await fetch(`/api/workspaces/${linkedWorkspaceId}`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return res.json();
+    },
+    enabled: !!linkedWorkspaceId,
+  });
 
   const [rejectReasonMap, setRejectReasonMap] = useState<Record<number, string>>({});
 
@@ -285,6 +303,17 @@ export default function PipelineRun() {
               <span className="text-[10px] text-muted-foreground">
                 Run {runId.slice(0, 8)}
               </span>
+              {linkedWorkspaceId && (
+                <Link href={`/workspaces/${linkedWorkspaceId}`}>
+                  <Badge
+                    variant="outline"
+                    className="text-[10px] h-4 px-1.5 cursor-pointer hover:bg-primary/10 hover:border-primary/40"
+                    data-testid="run-linked-workspace-chip"
+                  >
+                    workspace: {linkedWorkspace?.name ?? linkedWorkspaceId.slice(0, 8)}
+                  </Badge>
+                </Link>
+              )}
             </div>
           </div>
         </div>

--- a/client/src/pages/Workspace.tsx
+++ b/client/src/pages/Workspace.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useRoute } from "wouter";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
-import { RefreshCw, GitBranch, Eye, MessageSquare, Code2, Settings2, Network, Search } from "lucide-react";
+import { RefreshCw, GitBranch, Eye, MessageSquare, Code2, Settings2, Network, Search, Play } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { FileTree } from "@/components/workspace/FileTree";
 import { CodeViewer } from "@/components/workspace/CodeViewer";
@@ -12,6 +12,7 @@ import { ConfigDiffView } from "@/components/workspace/ConfigDiffView";
 import { DependencyGraph } from "@/components/workspace/DependencyGraph";
 import { SymbolSearch } from "@/components/workspace/SymbolSearch";
 import { IndexStatusBadge } from "@/components/workspace/IndexStatusBadge";
+import { RunPipelineDialog } from "@/components/workspace/RunPipelineDialog";
 import { useIndexTrigger } from "@/hooks/useIndexTrigger";
 import { useWorkspaceSocket } from "@/hooks/useWorkspaceSocket";
 import type { WorkspaceRow } from "@shared/schema";
@@ -137,6 +138,7 @@ export default function Workspace() {
   const [isReviewing, setIsReviewing] = useState(false);
   const [showConfigDiff, setShowConfigDiff] = useState(false);
   const [mainView, setMainView] = useState<MainView>("files");
+  const [runPipelineOpen, setRunPipelineOpen] = useState(false);
   const qc = useQueryClient();
 
   const indexTrigger = useIndexTrigger(workspaceId);
@@ -288,8 +290,25 @@ export default function Workspace() {
               Sync
             </button>
           )}
+
+          {/* Run a pipeline against this workspace (issue #343). */}
+          <button
+            onClick={() => setRunPipelineOpen(true)}
+            className="flex items-center gap-1 text-xs px-2 py-1 rounded border border-primary/40 text-primary bg-primary/5 hover:bg-primary/10 transition-colors"
+            data-testid="run-pipeline-button"
+          >
+            <Play className="h-3 w-3" />
+            Run pipeline
+          </button>
         </div>
       </div>
+
+      <RunPipelineDialog
+        workspaceId={workspaceId}
+        workspaceName={workspace.name}
+        open={runPipelineOpen}
+        onOpenChange={setRunPipelineOpen}
+      />
 
       {/* Config diff banner */}
       {showConfigDiff && (

--- a/migrations/0024_pipeline_runs_workspace_link.sql
+++ b/migrations/0024_pipeline_runs_workspace_link.sql
@@ -1,0 +1,21 @@
+-- migration: 0024_pipeline_runs_workspace_link
+-- Adds an optional workspace_id link to pipeline_runs so a run can be bound
+-- to the workspace it operates against. Pipelines remain workspace-agnostic
+-- templates; the binding is per-run.
+--
+-- Nullable; legacy / unbound runs stay NULL. ON DELETE SET NULL preserves run
+-- history when a workspace is removed.
+--
+-- Issue: #343
+
+ALTER TABLE pipeline_runs
+  ADD COLUMN IF NOT EXISTS workspace_id VARCHAR
+    REFERENCES workspaces(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS pipeline_runs_workspace_idx
+  ON pipeline_runs(workspace_id)
+  WHERE workspace_id IS NOT NULL;
+
+-- Rollback:
+--   DROP INDEX IF EXISTS pipeline_runs_workspace_idx;
+--   ALTER TABLE pipeline_runs DROP COLUMN workspace_id;

--- a/server/controller/pipeline-controller.ts
+++ b/server/controller/pipeline-controller.ts
@@ -84,7 +84,13 @@ export class PipelineController {
     }
   }
 
-  async startRun(pipelineId: string, input: string, variables?: Record<string, string>, triggeredBy?: string): Promise<PipelineRun> {
+  async startRun(
+    pipelineId: string,
+    input: string,
+    variables?: Record<string, string>,
+    triggeredBy?: string,
+    workspaceId?: string,
+  ): Promise<PipelineRun> {
     const pipeline = await this.storage.getPipeline(pipelineId);
     if (!pipeline) throw new Error(`Pipeline not found: ${pipelineId}`);
 
@@ -95,6 +101,7 @@ export class PipelineController {
       pipelineId,
       status: "running",
       input,
+      workspaceId: workspaceId ?? null,
       currentStageIndex: 0,
       startedAt: new Date(),
       triggeredBy: triggeredBy ?? null,
@@ -238,6 +245,11 @@ export class PipelineController {
           ? this.memoryProvider.formatForPrompt(relevantMemories)
           : undefined;
 
+        const runWorkspaceId = (run as { workspaceId?: string | null }).workspaceId ?? null;
+        const runWorkspacePath = runWorkspaceId
+          ? (await this.storage.getWorkspace(runWorkspaceId))?.path ?? null
+          : null;
+
         const context = {
           runId: run.id,
           stageIndex,
@@ -251,6 +263,9 @@ export class PipelineController {
           memoryContext,
           variables: ephemeralVarStore.get(run.id) ?? undefined,
           stageConfig: dagStage as unknown as PipelineStageConfig,
+          // Workspace binding for the run (issue #343).
+          workspaceId: runWorkspaceId ?? undefined,
+          workspacePath: runWorkspacePath ?? undefined,
         };
 
         const result = dagStage.remoteAgent
@@ -487,6 +502,13 @@ export class PipelineController {
     const previousOutputs: Record<string, unknown>[] = [];
     const fullContext: StageOutput[] = [];
 
+    // Resolve the run's workspace once so per-stage contexts can use it
+    // without hitting the DB on every stage (issue #343).
+    const runWorkspaceId = (run as { workspaceId?: string | null }).workspaceId ?? null;
+    const runWorkspacePath = runWorkspaceId
+      ? (await this.storage.getWorkspace(runWorkspaceId))?.path ?? null
+      : null;
+
     // Collect outputs from already-completed stages (for resume)
     if (startFromIndex > 0) {
       const executions = await this.storage.getStageExecutions(run.id);
@@ -592,6 +614,10 @@ export class PipelineController {
           variables: ephemeralVarStore.get(run.id) ?? undefined,
           stageConfig: resolvedStage,
           delegate: this.buildDelegateFn(run.id, stage.teamId, resolvedStage),
+          // Workspace binding for the run (issue #343). Tools default to this
+          // workspace when their input doesn't supply one.
+          workspaceId: runWorkspaceId ?? undefined,
+          workspacePath: runWorkspacePath ?? undefined,
         };
 
         // Pass execution strategy (undefined = single, handled in BaseTeam)

--- a/server/gateway/index.ts
+++ b/server/gateway/index.ts
@@ -413,8 +413,15 @@ export class Gateway {
     tools: ToolDefinition[];
     options?: ILLMProviderOptions;
     maxIterations?: number;
+    /**
+     * Optional defaults injected into every tool call's `arguments` (issue #343).
+     * Used so that workspace-aware tools (file-read, code-search, knowledge-search)
+     * can default to the run's bound workspace without the LLM having to specify
+     * it. Explicit args from the LLM still win — defaults only fill missing keys.
+     */
+    workspaceDefaults?: { workspaceId?: string; workspacePath?: string };
   }): Promise<{ content: string; tokensUsed: number; toolCallLog: ToolCallLogEntry[] }> {
-    const { modelSlug, tools, options } = params;
+    const { modelSlug, tools, options, workspaceDefaults } = params;
     const maxIterations = params.maxIterations ?? 10;
     const toolCallLog: ToolCallLogEntry[] = [];
 
@@ -462,6 +469,18 @@ export class Gateway {
 
       // Execute each tool call and collect results
       for (const call of result.toolCalls) {
+        // Apply workspace defaults — only when the LLM didn't already supply
+        // the key. Explicit args win.
+        if (workspaceDefaults) {
+          const merged = { ...call.arguments };
+          if (workspaceDefaults.workspaceId !== undefined && merged.workspaceId === undefined) {
+            merged.workspaceId = workspaceDefaults.workspaceId;
+          }
+          if (workspaceDefaults.workspacePath !== undefined && merged.workspacePath === undefined) {
+            merged.workspacePath = workspaceDefaults.workspacePath;
+          }
+          call.arguments = merged;
+        }
         const callStart = Date.now();
         const toolResult = await toolRegistry.execute(call);
         const durationMs = Date.now() - callStart;

--- a/server/routes/runs.ts
+++ b/server/routes/runs.ts
@@ -40,6 +40,10 @@ function maskUrl(value: string): string {
 const CreateRunSchema = z.object({
   pipelineId: z.string().min(1, "pipelineId is required").max(100),
   input: z.string().min(1, "input must be a non-empty string").max(50000),
+  // Optional binding to a workspace (issue #343). When set, the run is recorded
+  // against the workspace and tools (file-read, code-search, knowledge-search)
+  // default to that workspace's path unless the tool call overrides it.
+  workspaceId: z.string().max(100).optional(),
   variables: z.record(z.string().max(10000))
     .refine(
       (v) => Object.keys(v).length <= 50,
@@ -138,7 +142,7 @@ export function registerRunRoutes(
   });
 
   router.post("/api/runs", validateBody(CreateRunSchema), async (req, res) => {
-    const { pipelineId, input, variables } = req.body as z.infer<typeof CreateRunSchema>;
+    const { pipelineId, input, workspaceId, variables } = req.body as z.infer<typeof CreateRunSchema>;
     try {
       // C3: Apply rate limiting for manager-mode runs
       const pipeline = await storage.getPipeline(pipelineId);
@@ -152,8 +156,18 @@ export function registerRunRoutes(
           });
         }
       }
+      // Validate workspaceId references an existing workspace (issue #343).
+      // The DB FK enforces this on insert, but checking here returns a clearer
+      // 400 instead of letting the DB error bubble up as a 400 with a noisy
+      // constraint message.
+      if (workspaceId) {
+        const ws = await storage.getWorkspace(workspaceId);
+        if (!ws) {
+          return res.status(400).json({ error: `Workspace not found: ${workspaceId}` });
+        }
+      }
       const triggeredBy = req.user?.id;
-      const run = await controller.startRun(pipelineId, input, variables, triggeredBy);
+      const run = await controller.startRun(pipelineId, input, variables, triggeredBy, workspaceId);
       res.status(201).json(run);
     } catch (e) {
       res.status(400).json({ error: (e as Error).message });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -530,6 +530,7 @@ export class MemStorage implements IStorage {
     const run: PipelineRun = {
       id,
       pipelineId: insert.pipelineId,
+      workspaceId: insert.workspaceId ?? null,
       status: insert.status ?? "pending",
       input: insert.input,
       output: insert.output ?? null,

--- a/server/teams/base.ts
+++ b/server/teams/base.ts
@@ -85,6 +85,16 @@ export abstract class BaseTeam {
             toolChoice: toolConfig?.toolChoice ?? 'auto',
           },
           maxIterations: toolConfig?.maxToolCalls ?? 10,
+          // Workspace binding (issue #343). When a run is bound to a workspace,
+          // tool calls that don't supply workspaceId / workspacePath are filled
+          // in from this default. Tools that do specify these args explicitly
+          // still win.
+          workspaceDefaults: (context.workspaceId || context.workspacePath)
+            ? {
+                workspaceId: context.workspaceId,
+                workspacePath: context.workspacePath,
+              }
+            : undefined,
         });
 
         const parsed = this.parseOutput(result.content);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -138,6 +138,11 @@ export const pipelineRuns = pgTable("pipeline_runs", {
     .primaryKey()
     .default(sql`gen_random_uuid()`),
   pipelineId: varchar("pipeline_id").notNull(),
+  // Optional link to the workspace the run is operating against. Pipelines are
+  // workspace-agnostic templates; binding happens per-run. NULL means the run
+  // is not tied to any workspace (legacy / unbound runs). FK uses ON DELETE
+  // SET NULL so deleting a workspace doesn't cascade-destroy run history.
+  workspaceId: varchar("workspace_id"),
   status: text("status").notNull().default("pending"),
   input: text("input").notNull(),
   output: jsonb("output"),

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -704,6 +704,13 @@ export interface StageContext {
   stageConfig?: PipelineStageConfig;
   variables?: Record<string, string>;
   delegate?: DelegateFn; // present when DelegationService is active and stage has delegationEnabled
+  // Optional workspace binding for the run (issue #343). Tools that need a
+  // workspace (file-read, code-search, knowledge-search, ...) default to this
+  // workspace when their input doesn't supply one. Both fields are populated
+  // together — workspaceId is the row id, workspacePath is the resolved
+  // filesystem path for tool convenience.
+  workspaceId?: string;
+  workspacePath?: string;
 }
 
 export interface TeamResult {


### PR DESCRIPTION
## Summary

Pipelines remain workspace-agnostic templates. Binding happens per-run: `POST /api/runs` accepts an optional `workspaceId`, the run row records it, and workspace-aware tools (`file-read`, `code-search`, `knowledge-search`, ...) inherit that workspace as a default for tool calls that don't supply one explicitly. Adds a "Run pipeline" button to the Workspace page and a workspace chip on the Run page header.

Closes #343.

## Why

Pipelines and workspaces were entirely parallel domains — runs couldn't reference a workspace, the LLM had to guess, and `cost_ledger.workspace_id` could never be populated for pipeline-driven costs. The most natural user flow ("run *this* pipeline against *this* workspace") was impossible without out-of-band hacks. See #343 for the full diagnosis.

## Changes

### Schema
- **`migrations/0024_pipeline_runs_workspace_link.sql`** — adds nullable `workspace_id` to `pipeline_runs`, FK to `workspaces(id) ON DELETE SET NULL`, partial index on non-null rows.
- **`shared/schema.ts`** — matching `workspaceId` column on `pipelineRuns` (the FK is enforced at the DB layer to avoid Drizzle's forward-reference gotcha; both `pipelineRuns` and `workspaces` declare via `pgTable` and Drizzle tooling sees the column even without an `.references()` call in TS).
- **`shared/types.ts`** — `StageContext` gains optional `workspaceId` and `workspacePath`.

### Server
- **`POST /api/runs`** — `CreateRunSchema` accepts optional `workspaceId`. Handler returns `400 Workspace not found: <id>` when the id doesn't resolve (clearer than letting the FK constraint bubble up).
- **`PipelineController.startRun(pipelineId, input, variables?, triggeredBy?, workspaceId?)`** — forwards `workspaceId` to `createPipelineRun` and resolves the workspace path *once per run*, then injects both `workspaceId` and `workspacePath` into every `StageContext`. Both linear-mode `executeStages` and DAG-mode `makeDAGStageExecuteFn` are covered.
- **`BaseTeam.executeSingleModel`** — passes a new `workspaceDefaults` field through to `gateway.completeWithTools`.
- **`Gateway.completeWithTools`** — merges `workspaceDefaults` into each tool call's `arguments`, filling **only** keys the LLM didn't supply. Explicit args win.
- **`MemStorage.createPipelineRun`** — copies the new field through to the in-memory row (kept in sync with the typed schema).

### Client
- **`useStartRun`** mutation type extended with optional `workspaceId`.
- **`client/src/components/workspace/RunPipelineDialog.tsx`** (new) — pipeline picker + task-input textarea. Filters out template pipelines from the picker. On submit, calls `useStartRun` with `workspaceId` set and navigates to `/runs/<id>`.
- **`client/src/pages/Workspace.tsx`** — adds a "Run pipeline" button to the top bar that opens the dialog.
- **`client/src/pages/PipelineRun.tsx`** — when a run has `workspaceId`, the header shows a "workspace: <name>" badge linking back to the workspace.

## Verification

| Check | Result |
|---|---|
| `npm run check` (tsc) | PASS |
| `npm run test:unit` | 153 files / **3912 tests** pass |
| Migration applied to dev DB; `\\d pipeline_runs` shows the column + FK + index | PASS |
| `POST /api/runs` with valid `workspaceId` → run stored with `workspace_id` populated | PASS (verified via SQL `SELECT workspace_id`) |
| `POST /api/runs` with unknown `workspaceId` | `HTTP 400 {"error":"Workspace not found: <id>"}` |
| `POST /api/runs` without `workspaceId` (legacy unbound run) | still works, `workspaceId` stored as `NULL` |

## Out of scope (intentional)

- **`pipeline_workspaces` join table** for assigning pipelines to workspaces — deferred per the original Option A scope. Reach for it once we see whether users want the picker filtered per workspace.
- **Backfill of historical run rows** — older runs stay `workspaceId = NULL`. They were already de-facto unbound; nothing to backfill.
- **Cost-ledger propagation** (`cost_ledger.workspace_id` populated from `pipeline_runs.workspace_id`) — needs a separate touch in the cost path; will follow up after this lands. Tracked in #343 fix item 6.
- **Streaming token-counter / live-running visibility** — that's #342, separate PR.

## Test plan

- [ ] Open a workspace page → "Run pipeline" button visible in the top bar
- [ ] Click it → dialog opens with a pipeline picker
- [ ] Pick a pipeline, fill input, submit → navigates to /runs/<id>
- [ ] Run header shows the "workspace: <name>" chip linking back to the workspace
- [ ] Click chip → returns to the workspace page
- [ ] Trigger a run from `/pipelines/<id>` (no workspace context) → no chip, run still works

## Related

- Stacked logically on #344 (rename Workflows → Pipelines) but this branch is off `main`, not `feat/rename-workflow-to-pipeline`. No file conflicts expected if both land — the components touched in this PR (`PipelineRun.tsx`, `Workspace.tsx`, `use-pipeline.ts`) don't intersect with the rename's edits.
- Issue #342 (silent failure / hidden running state) is independent and not addressed here.