### PR TITLE
fix(tests): repair 57 pre-existing unit failures (cost-service, mcp-audit, mqlti-config)

### DIFF
--- a/script/mqlti-config.ts
+++ b/script/mqlti-config.ts
@@ -34,7 +34,7 @@ import path from "path";
 import os from "os";
 import simpleGit from "simple-git";
 import yaml from "js-yaml";
-import chalk from "chalk";
+import chalk from "../server/config-sync/ansi-style.js";
 
 import {
   generateKeyPair,

--- a/server/config-sync/ansi-style.ts
+++ b/server/config-sync/ansi-style.ts
@@ -1,0 +1,78 @@
+/**
+ * Minimal, dependency-free ANSI styling helper.
+ *
+ * Provides a `chalk`-compatible subset (the styles the mqlti-config CLI uses)
+ * without pulling in the ESM-only `chalk` package. Each style is a chainable
+ * callable: `style.red("x")` and `style.red.bold("x")` both work.
+ *
+ * Colour output is disabled when `NO_COLOR` is set, when `FORCE_COLOR=0`, or
+ * when stdout is not a TTY — matching common CLI conventions.
+ */
+
+type StyleName =
+  | "bold"
+  | "dim"
+  | "red"
+  | "green"
+  | "yellow"
+  | "blue"
+  | "cyan"
+  | "white";
+
+/** ASCII escape (0x1b); built from charCode to avoid literal-encoding issues. */
+const ESC = String.fromCharCode(27);
+
+const CODES: Readonly<Record<StyleName, readonly [number, number]>> = {
+  bold: [1, 22],
+  dim: [2, 22],
+  red: [31, 39],
+  green: [32, 39],
+  yellow: [33, 39],
+  blue: [34, 39],
+  cyan: [36, 39],
+  white: [37, 39],
+} as const;
+
+const STYLE_NAMES = Object.keys(CODES) as readonly StyleName[];
+
+/** A callable styler that is also chainable across every supported style. */
+export type Styler = ((text: string) => string) & {
+  readonly [K in StyleName]: Styler;
+};
+
+function colorEnabled(): boolean {
+  if (process.env.NO_COLOR !== undefined) return false;
+  if (process.env.FORCE_COLOR === "0") return false;
+  if (process.env.FORCE_COLOR !== undefined) return true;
+  return Boolean(process.stdout.isTTY);
+}
+
+function code(value: number): string {
+  return `${ESC}[${value}m`;
+}
+
+function wrap(text: string, applied: readonly StyleName[]): string {
+  if (!colorEnabled() || applied.length === 0) return text;
+  const open = applied.map((name) => code(CODES[name][0])).join("");
+  const close = applied
+    .map((name) => code(CODES[name][1]))
+    .reverse()
+    .join("");
+  return `${open}${text}${close}`;
+}
+
+function makeStyler(applied: readonly StyleName[]): Styler {
+  const fn = ((text: string): string => wrap(text, applied)) as Styler;
+  for (const name of STYLE_NAMES) {
+    Object.defineProperty(fn, name, {
+      get: () => makeStyler([...applied, name]),
+      enumerable: true,
+    });
+  }
+  return fn;
+}
+
+/** Chalk-compatible default styler (subset of methods). */
+const style: Styler = makeStyler([]);
+
+export default style;

--- a/tests/unit/costs/cost-service.test.ts
+++ b/tests/unit/costs/cost-service.test.ts
@@ -333,6 +333,19 @@ describe("CostService.getSummary", () => {
   const WS = "ws-summary";
   const NOW = new Date("2026-04-15T12:00:00Z");
 
+  // Freeze the wall clock to NOW so ledger entries inserted via
+  // appendCostLedger receive ts === NOW (inside the queried period).
+  // Without this, rows get the real system time and fall outside the
+  // April-2026 window the assertions query, making aggregation flaky.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("19. empty workspace returns zero totals and empty series", async () => {
     const storage = makeStorage();
     const service = new CostService(storage);
@@ -456,6 +469,17 @@ describe("CostService.getSummary", () => {
 describe("CostService.exportCsv", () => {
   const WS = "ws-csv";
   const NOW = new Date("2026-04-15T12:00:00Z");
+
+  // Freeze the wall clock to NOW so ledger entries inserted via
+  // appendCostLedger receive ts === NOW (inside the queried period).
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
   it("25. empty period → CSV header only", async () => {
     const storage = makeStorage();

--- a/tests/unit/mcp-tool-call-audit.test.ts
+++ b/tests/unit/mcp-tool-call-audit.test.ts
@@ -258,8 +258,16 @@ describe("MemStorage.getConnectionUsageMetrics", () => {
   });
 
   it("computes callsPerDay correctly", async () => {
-    const day1 = new Date("2026-04-15T10:00:00Z");
-    const day2 = new Date("2026-04-16T10:00:00Z");
+    // Anchor both days relative to "now" so they stay inside the metrics
+    // rolling 30-day window (fixed calendar dates age out and flip isOrphan
+    // to true). Use a fixed 10:00 UTC hour to avoid the midnight day-bucket
+    // boundary, and derive expected date keys from the same dates.
+    const dayMs = 24 * 60 * 60 * 1000;
+    const base = new Date(`${new Date().toISOString().slice(0, 10)}T10:00:00Z`);
+    const day1 = new Date(base.getTime() - 6 * dayMs);
+    const day2 = new Date(base.getTime() - 5 * dayMs);
+    const day1Key = day1.toISOString().slice(0, 10);
+    const day2Key = day2.toISOString().slice(0, 10);
     for (let i = 0; i < 3; i++) {
       await storage.recordMcpToolCall(makeRecordInput({ connectionId: "conn-1", startedAt: day1 }));
     }
@@ -270,8 +278,8 @@ describe("MemStorage.getConnectionUsageMetrics", () => {
     const metrics = await storage.getConnectionUsageMetrics("conn-1");
     expect(metrics.isOrphan).toBe(false);
 
-    const day1Entry = metrics.callsPerDay.find((d) => d.date === "2026-04-15");
-    const day2Entry = metrics.callsPerDay.find((d) => d.date === "2026-04-16");
+    const day1Entry = metrics.callsPerDay.find((d) => d.date === day1Key);
+    const day2Entry = metrics.callsPerDay.find((d) => d.date === day2Key);
     expect(day1Entry?.count).toBe(3);
     expect(day2Entry?.count).toBe(5);
   });


### PR DESCRIPTION
## Что
Чинит 57 пред­существующих падающих unit-тестов на `main` (3 файла). Они блокировали `unit-integration` CI и мешали мержить открытые feature-PR (#346/#347/#348).

## Корневые причины (диагностика «тест vs код»)
1. **`tests/unit/costs/cost-service.test.ts`** (6) — *тест устарел*: фикстуры якорят `NOW=2026-04-15`, но `appendCostLedger` штампует `ts` по реальным часам → строки выпадали из запрашиваемого месяца. Фикс: `vi.useFakeTimers()` + `setSystemTime(NOW)`. Код cost-service корректен.
2. **`tests/unit/mcp-tool-call-audit.test.ts`** (1) — *тест устарел*: хардкод дат `2026-04-15/16` (~50 дней назад) → rolling-30d окно корректно помечало connection как orphan. Фикс: даты относительно `now`. Код корректен.
3. **`tests/unit/config-sync/mqlti-config.test.ts`** (~50) — *баг кода*: `script/mqlti-config.ts` импортил `chalk` (заявлен, но хрупко резолвится) → CLI падал при загрузке. Фикс: dependency-free `server/config-sync/ansi-style.ts` (chalk-совместимый), импорт переключён. 216 call-site без изменений.

## Проверка
- Полный unit-сьют: **3912 passed / 0 failed** (было 57 failed).
- `tsc`: без новых ошибок (только пред­существующие ioredis/bullmq в `server/queue/*`).
- Ни один ассерт не ослаблен/пропущен/удалён.
