### PR TITLE
feat: persist stage failure error end-to-end (#342)

### DIFF
--- a/client/src/components/pipeline/StageError.tsx
+++ b/client/src/components/pipeline/StageError.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { AlertTriangle, Copy, Check } from "lucide-react";
+
+interface StageErrorProps {
+  teamName: string;
+  error: string;
+}
+
+const COPY_RESET_MS = 2000;
+
+/**
+ * Persisted failure panel for a stage. Surfaces the error message stored on
+ * `stage_executions.error` so users can self-diagnose after a page reload,
+ * when the live WebSocket `stage:failed` event is no longer available.
+ * See issue #342.
+ */
+export default function StageError({ teamName, error }: StageErrorProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = (): void => {
+    void navigator.clipboard.writeText(error);
+    setCopied(true);
+    setTimeout(() => setCopied(false), COPY_RESET_MS);
+  };
+
+  return (
+    <Card
+      role="alert"
+      className="border-red-500/40 bg-red-500/5"
+      data-testid="stage-error"
+    >
+      <CardHeader className="py-3 px-4 flex flex-row items-center gap-2">
+        <AlertTriangle className="h-4 w-4 text-red-600" aria-hidden="true" />
+        <CardTitle className="text-sm font-medium text-red-700">
+          {teamName} — Error
+        </CardTitle>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="ml-auto h-6 text-[10px]"
+          onClick={handleCopy}
+          aria-label="Copy error message"
+        >
+          {copied ? (
+            <Check className="h-3 w-3" aria-hidden="true" />
+          ) : (
+            <Copy className="h-3 w-3" aria-hidden="true" />
+          )}
+        </Button>
+      </CardHeader>
+      <CardContent className="pt-0 px-4 pb-4">
+        <pre className="whitespace-pre-wrap break-words rounded-md border border-red-500/30 bg-background/60 p-3 text-xs font-mono text-red-700">
+          {error}
+        </pre>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/pages/PipelineRun.tsx
+++ b/client/src/pages/PipelineRun.tsx
@@ -6,6 +6,7 @@ import { usePipelineEvents, useWebSocket } from "@/hooks/use-websocket";
 import StageProgress from "@/components/pipeline/StageProgress";
 import QuestionPanel from "@/components/pipeline/QuestionPanel";
 import StageOutput from "@/components/pipeline/StageOutput";
+import StageError from "@/components/pipeline/StageError";
 import DelegationLog from "@/components/pipeline/DelegationLog";
 import SwarmProgress from "@/components/pipeline/SwarmProgress";
 import SwarmResultView from "@/components/pipeline/SwarmResultView";
@@ -246,6 +247,7 @@ export default function PipelineRun() {
     modelSlug: string;
     status: string;
     output: Record<string, unknown> | null;
+    error?: string | null;
     tokensUsed: number;
     approvalStatus?: string | null;
   }>;
@@ -265,6 +267,7 @@ export default function PipelineRun() {
   }
 
   const completedStages = pipelineStages.filter((s) => s.status === "completed" && s.output);
+  const failedStages = pipelineStages.filter((s) => s.status === "failed" && s.error);
   const questions = pipelineEvents.questions.length > 0
     ? pipelineEvents.questions
     : (run.questions ?? []);
@@ -515,6 +518,18 @@ export default function PipelineRun() {
                           </div>
                         )}
                       </div>
+                    );
+                  })}
+
+                  {failedStages.map((stage) => {
+                    const team =
+                      SDLC_TEAMS[stage.teamId as keyof typeof SDLC_TEAMS];
+                    return (
+                      <StageError
+                        key={`error-${stage.id}`}
+                        teamName={team?.name ?? stage.teamId}
+                        error={stage.error ?? ""}
+                      />
                     );
                   })}
                   {status === "completed" && (

--- a/migrations/0025_stage_executions_error.sql
+++ b/migrations/0025_stage_executions_error.sql
@@ -1,0 +1,16 @@
+-- migration: 0025_stage_executions_error
+-- Adds a nullable `error` text column to stage_executions so a stage's failure
+-- reason is persisted on the run record. Previously the error was only
+-- broadcast over WebSocket and written to the OTEL traces table, leaving the
+-- run UI with status="failed", output=null and no reason after a page reload.
+--
+-- Nullable; no backfill — older failed runs have nothing useful to backfill
+-- from (their trace spans, if any, are left in place).
+--
+-- Issue: #342
+
+ALTER TABLE stage_executions
+  ADD COLUMN IF NOT EXISTS error TEXT;
+
+-- Rollback:
+--   ALTER TABLE stage_executions DROP COLUMN error;

--- a/server/controller/pipeline-controller.ts
+++ b/server/controller/pipeline-controller.ts
@@ -10,7 +10,7 @@ import { ParallelExecutor } from "../pipeline/parallel-executor";
 import { SwarmExecutor } from "../pipeline/swarm-executor";
 import type { RemoteAgentManager } from "../remote-agents/remote-agent-manager";
 
-import type { PipelineRun } from "@shared/schema";
+import type { PipelineRun, StageExecution } from "@shared/schema";
 import { SandboxExecutor } from "../sandbox/executor";
 import { ThoughtTreeCollector } from "../pipeline/thought-tree-collector";
 import { MemoryExtractor } from "../memory/extractor";
@@ -316,6 +316,7 @@ export class PipelineController {
         await this.storage.updateStageExecution(stageExec.id, {
           status: "failed",
           completedAt: new Date(),
+          error: errMsg,
         });
 
         this.broadcast(run.id, {
@@ -338,6 +339,21 @@ export class PipelineController {
     };
   }
 
+  /**
+   * Promote the first failed stage's persisted error into the run output when
+   * the run has none yet, so the run row is self-explaining (issue #342).
+   * Returns the error string, or null when nothing should be promoted.
+   */
+  private async firstFailureOutput(
+    runId: string,
+    executions: readonly StageExecution[],
+  ): Promise<string | null> {
+    const run = await this.storage.getPipelineRun(runId);
+    if (run == null || run.output != null) return null;
+    const failed = executions.find((e) => e.status === "failed" && e.error != null);
+    return failed?.error ?? null;
+  }
+
   /** Called after DAGExecutor finishes to mark run as completed or failed. */
   private async finishDAGRun(runId: string, signal: AbortSignal): Promise<void> {
     const executions = await this.storage.getStageExecutions(runId);
@@ -349,9 +365,11 @@ export class PipelineController {
     }
 
     if (anyFailed) {
+      const runOutput = await this.firstFailureOutput(runId, executions);
       await this.storage.updatePipelineRun(runId, {
         status: "failed",
         completedAt: new Date(),
+        ...(runOutput != null ? { output: runOutput } : {}),
       });
       this.broadcast(runId, {
         type: "pipeline:failed",
@@ -913,10 +931,14 @@ export class PipelineController {
         await this.storage.updateStageExecution(stageExec.id, {
           status: "failed",
           completedAt: new Date(),
+          error: errMsg,
         });
         await this.storage.updatePipelineRun(run.id, {
           status: "failed",
           completedAt: new Date(),
+          // Promote the failing stage's error into the run output when the run
+          // has none yet, so the run row is self-explaining (issue #342).
+          ...(run.output == null ? { output: errMsg } : {}),
         });
 
         this.broadcast(run.id, {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -590,6 +590,7 @@ export class MemStorage implements IStorage {
       approvedAt: insert.approvedAt ?? null,
       approvedBy: insert.approvedBy ?? null,
       rejectionReason: insert.rejectionReason ?? null,
+      error: insert.error ?? null,
       dagStageId: insert.dagStageId ?? null,
       swarmCloneResults: insert.swarmCloneResults ?? null,
       swarmMeta: insert.swarmMeta ?? null,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -185,6 +185,10 @@ export const stageExecutions = pgTable("stage_executions", {
   approvedAt: timestamp("approved_at"),
   approvedBy: text("approved_by"),
   rejectionReason: text("rejection_reason"),
+  // Persisted failure reason for a `failed` stage. Written in the controller
+  // catch blocks so the run UI can surface *why* a stage failed after a page
+  // reload (WS `stage:failed` events are not replayable). See issue #342.
+  error: text("error"),
   dagStageId: text("dag_stage_id"),
   swarmCloneResults: jsonb("swarm_clone_results").$type<SwarmCloneResult[]>(),
   swarmMeta: jsonb("swarm_meta").$type<{

--- a/tests/unit/pipeline-controller-stage-error.test.ts
+++ b/tests/unit/pipeline-controller-stage-error.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Controller-level test for issue #342 — when a DAG stage throws, the catch
+ * block in PipelineController must persist the error message onto the stage
+ * execution row (not just broadcast it over WebSocket / write it to traces).
+ *
+ * Drives the real `makeDAGStageExecuteFn` catch path against MemStorage with a
+ * team stub whose `execute()` throws. The queue module is mocked so the
+ * controller imports without a live Redis/BullMQ (ioredis) connection.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../server/queue/index.js", () => ({
+  isQueueEnabled: () => false,
+  StageQueueProducer: class {},
+  getRedisConnection: () => null,
+}));
+
+import { PipelineController } from "../../server/controller/pipeline-controller.js";
+import { MemStorage } from "../../server/storage.js";
+import type { TeamRegistry } from "../../server/teams/registry.js";
+import type { WsManager } from "../../server/ws/manager.js";
+import type { DAGStage } from "../../shared/types.js";
+import type { PipelineRun } from "../../shared/schema.js";
+
+const PROVIDER_ERROR = "provider 500: model crashed during inference";
+
+const DAG_STAGE_ID = "dag-stage-1";
+
+function makeThrowingTeamRegistry(): TeamRegistry {
+  return {
+    getTeam: () => ({
+      execute: async () => {
+        throw new Error(PROVIDER_ERROR);
+      },
+    }),
+  } as unknown as TeamRegistry;
+}
+
+function makeWsManager(): WsManager {
+  return { broadcastToRun: vi.fn() } as unknown as WsManager;
+}
+
+const dagStage: DAGStage = {
+  id: DAG_STAGE_ID,
+  teamId: "planning",
+  modelSlug: "mock",
+  enabled: true,
+  position: { x: 0, y: 0 },
+};
+
+describe("PipelineController DAG stage failure (#342)", () => {
+  it("persists the thrown error onto the stage execution row", async () => {
+    const storage = new MemStorage();
+    const controller = new PipelineController(
+      storage,
+      makeThrowingTeamRegistry(),
+      makeWsManager(),
+    );
+
+    const pipeline = await storage.createPipeline({ name: "P", stages: [] });
+    const run = await storage.createPipelineRun({
+      pipelineId: pipeline.id,
+      status: "running",
+      input: "i",
+      currentStageIndex: 0,
+      dagMode: true,
+    });
+    const stageExec = await storage.createStageExecution({
+      runId: run.id,
+      stageIndex: 0,
+      teamId: "planning",
+      modelSlug: "mock",
+      status: "pending",
+      input: {},
+      dagStageId: DAG_STAGE_ID,
+    });
+
+    // Reach the private DAG execute factory the DAGExecutor would call.
+    const execute = (
+      controller as unknown as {
+        makeDAGStageExecuteFn: (
+          r: PipelineRun,
+        ) => (
+          r: PipelineRun,
+          s: DAGStage,
+          input: Record<string, unknown>,
+          stageIndex: number,
+          dagStageId: string,
+        ) => Promise<{ output: Record<string, unknown>; failed: boolean }>;
+      }
+    ).makeDAGStageExecuteFn(run);
+
+    const result = await execute(run, dagStage, {}, 0, DAG_STAGE_ID);
+
+    expect(result.failed).toBe(true);
+
+    const [persisted] = await storage.getStageExecutions(run.id);
+    expect(persisted.id).toBe(stageExec.id);
+    expect(persisted.status).toBe("failed");
+    expect(persisted.error).toBe(PROVIDER_ERROR);
+  });
+});

--- a/tests/unit/runs-stage-error-shape.test.ts
+++ b/tests/unit/runs-stage-error-shape.test.ts
@@ -1,0 +1,78 @@
+/**
+ * API-shape tests for issue #342 — a failed stage's persisted `error` message
+ * must be returned by the run endpoints so the UI can surface it after a
+ * page reload (the live WebSocket `stage:failed` event is not replayable).
+ *
+ * Exercises the real route handlers from server/routes/runs.ts against
+ * MemStorage, so the assertions reflect the actual JSON shape clients receive.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import express, { Router, type Express } from "express";
+import request from "supertest";
+import { registerRunRoutes } from "../../server/routes/runs.js";
+import { MemStorage } from "../../server/storage.js";
+import type { PipelineController } from "../../server/controller/pipeline-controller.js";
+
+const FAILURE_MESSAGE =
+  "http://host.docker.internal:1234 error 400: Failed to load model: insufficient system resources";
+
+// The read endpoints under test never touch the controller; a typed no-op
+// stub keeps the test hermetic (no queue / ioredis import chain).
+const stubController = {} as PipelineController;
+
+async function seedFailedRun(storage: MemStorage): Promise<string> {
+  const pipeline = await storage.createPipeline({ name: "P", stages: [] });
+  const run = await storage.createPipelineRun({
+    pipelineId: pipeline.id,
+    status: "running",
+    input: "i",
+    currentStageIndex: 0,
+  });
+  const stage = await storage.createStageExecution({
+    runId: run.id,
+    stageIndex: 0,
+    teamId: "planning",
+    modelSlug: "mock",
+    status: "running",
+    input: {},
+  });
+  await storage.updateStageExecution(stage.id, {
+    status: "failed",
+    completedAt: new Date(),
+    error: FAILURE_MESSAGE,
+  });
+  return run.id;
+}
+
+describe("runs API — failed stage error shape (#342)", () => {
+  let app: Express;
+  let storage: MemStorage;
+  let runId: string;
+
+  beforeEach(async () => {
+    storage = new MemStorage();
+    const router = Router();
+    registerRunRoutes(router, storage, stubController);
+    app = express();
+    app.use(express.json());
+    app.use(router);
+    runId = await seedFailedRun(storage);
+  });
+
+  it("GET /api/runs/:id/stages includes the persisted error", async () => {
+    const res = await request(app).get(`/api/runs/${runId}/stages`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].status).toBe("failed");
+    expect(res.body[0].error).toBe(FAILURE_MESSAGE);
+  });
+
+  it("GET /api/runs/:id embeds the error on the stages array", async () => {
+    const res = await request(app).get(`/api/runs/${runId}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.stages).toHaveLength(1);
+    expect(res.body.stages[0].error).toBe(FAILURE_MESSAGE);
+  });
+});

--- a/tests/unit/storage.test.ts
+++ b/tests/unit/storage.test.ts
@@ -248,5 +248,33 @@ describe("MemStorage", () => {
       expect(updated.status).toBe("completed");
       expect(updated.output).toEqual({ summary: "Done" });
     });
+
+    it("createStageExecution() defaults error to null", async () => {
+      const pipeline = await storage.createPipeline({ name: "P", stages: [] });
+      const run = await storage.createPipelineRun({ pipelineId: pipeline.id, status: "running", input: "i", currentStageIndex: 0 });
+      const stage = await storage.createStageExecution({ runId: run.id, stageIndex: 0, teamId: "planning", modelSlug: "mock", status: "pending", input: {} });
+
+      expect(stage.error).toBeNull();
+    });
+
+    it("updateStageExecution() persists the error message on a failed stage (issue #342)", async () => {
+      const pipeline = await storage.createPipeline({ name: "P", stages: [] });
+      const run = await storage.createPipelineRun({ pipelineId: pipeline.id, status: "running", input: "i", currentStageIndex: 0 });
+      const stage = await storage.createStageExecution({ runId: run.id, stageIndex: 0, teamId: "planning", modelSlug: "mock", status: "running", input: {} });
+
+      const failureMessage = "http://host.docker.internal:1234 error 400: Failed to load model";
+      const updated = await storage.updateStageExecution(stage.id, {
+        status: "failed",
+        completedAt: new Date(),
+        error: failureMessage,
+      });
+
+      expect(updated.status).toBe("failed");
+      expect(updated.error).toBe(failureMessage);
+
+      // The error survives a re-read (would survive a page reload via the API).
+      const [reloaded] = await storage.getStageExecutions(run.id);
+      expect(reloaded.error).toBe(failureMessage);
+    });
   });
 });


### PR DESCRIPTION
Closes #342

## Summary

When a pipeline stage failed (linear or DAG mode), the error message was only broadcast over WebSocket and written to the OTEL `traces` table — never persisted to `stage_executions`. After a page reload (or in a fresh tab with no live WS), the run UI showed `status:"failed"` with `output:null` and no reason. This makes the failure reason durable and surfaces it from DB through to the UI.

## Changes by layer

- **DB** — Added a nullable `error` (text) column to `stage_executions` (`shared/schema.ts`) and the MemStorage `createStageExecution` literal. Migration: `migrations/0025_stage_executions_error.sql` (`ALTER TABLE stage_executions ADD COLUMN IF NOT EXISTS error TEXT`), following the repo's hand-written-SQL convention used for 0013–0024. No backfill (per issue).
- **Controller** (`server/controller/pipeline-controller.ts`) — Both stage-failed catch blocks (DAG and linear) now persist `error: errMsg`. The linear run-failure path and the DAG `finishDAGRun` path promote the first failed stage's error into `pipeline_runs.output` when it is still null, so the run row is self-explaining (issue's optional item 4). WS broadcast + trace span unchanged.
- **Storage** — Both `MemStorage` and `PgStorage` accept `Partial<StageExecution>` and pass updates through generically, so `error` flows automatically.
- **API** (`server/routes/runs.ts`) — `GET /api/runs/:id` and `GET /api/runs/:id/stages` pass full rows through, so `error` is now returned (no whitelist to change).
- **UI** — New accessible `StageError` panel (`client/src/components/pipeline/StageError.tsx`, `role="alert"`, copy button) rendered next to the Output panels on the run detail page (`client/src/pages/PipelineRun.tsx`) for each failed stage that has an error. Strict TS, no `any`.

## Migration note

`drizzle-kit generate` is not usable in this repo for incremental migrations: `migrations/meta/_journal.json` is frozen at idx 13 (tag `0012`) while the SQL files run through `0024`, so `generate` diffs against the stale `0000` snapshot and emits a destructive bulk `CREATE TABLE` migration (it produced a `0014_*` file colliding with the existing `0014_workspace_connections.sql` and rewrote the journal). Those artifacts were reverted; the hand-written `0025` file matches the established convention. For reference, `generate`'s intended statement was identical: `ALTER TABLE "stage_executions" ADD COLUMN "error" text;`.

## Test plan

- [x] `tests/unit/pipeline-controller-stage-error.test.ts` — drives the real DAG catch block (queue module mocked) and asserts the thrown error is persisted on the stage row.
- [x] `tests/unit/storage.test.ts` — `error` defaults to null on create; a failed update persists the message and it survives a re-read.
- [x] `tests/unit/runs-stage-error-shape.test.ts` — both run endpoints return `error` in the JSON shape (real route handlers + MemStorage).
- [x] `npm run check` (tsc): 0 new errors; only the pre-existing ioredis/bullmq module-resolution errors remain.
- [x] `npx vitest run --project unit`: 162 files / 3991 tests pass (baseline + 4 new).
- [ ] Integration project (`--project integration`) — not run locally (ioredis not installed in the local node_modules symlink); runs in CI.