### PR TITLE
feat(memory): Track A — Omniscience world-knowledge retrieval behind feature flag

### DIFF
--- a/server/config/loader.ts
+++ b/server/config/loader.ts
@@ -121,6 +121,19 @@ const ENV_MAPPINGS: EnvMapping[] = [
   { envKey: "MULTI_FEDERATION_CLUSTER_SECRET",       configPath: ["federation", "clusterSecret"],                 kind: "string"  },
   { envKey: "MULTI_FEDERATION_PORT",                 configPath: ["federation", "listenPort"],                    kind: "number"  },
   { envKey: "MULTI_FEDERATION_PEERS",                configPath: ["federation", "peers"],                         kind: "csv"     },
+
+  // Memory / retrieval backend (memory-architecture ADR, Track A).
+  // NOTE: the Omniscience auth TOKEN is intentionally NOT mapped here — it is
+  // read directly from process.env at call time (see schema `memory.retrieval.
+  // omniscience.tokenEnv`) so it never lands in the validated/cached config.
+  { envKey: "MULTI_MEMORY_RETRIEVAL_BACKEND",                  configPath: ["memory", "retrieval", "backend"],                          kind: "string"  },
+  { envKey: "MULTI_MEMORY_RETRIEVAL_OMNISCIENCE_TRANSPORT",    configPath: ["memory", "retrieval", "omniscience", "transport"],         kind: "string"  },
+  { envKey: "MULTI_MEMORY_RETRIEVAL_OMNISCIENCE_COMMAND",      configPath: ["memory", "retrieval", "omniscience", "command"],           kind: "string"  },
+  { envKey: "MULTI_MEMORY_RETRIEVAL_OMNISCIENCE_ARGS",         configPath: ["memory", "retrieval", "omniscience", "args"],              kind: "csv"     },
+  { envKey: "MULTI_MEMORY_RETRIEVAL_OMNISCIENCE_ENDPOINT",     configPath: ["memory", "retrieval", "omniscience", "endpoint"],          kind: "string"  },
+  { envKey: "MULTI_MEMORY_RETRIEVAL_OMNISCIENCE_TOKEN_ENV",    configPath: ["memory", "retrieval", "omniscience", "tokenEnv"],          kind: "string"  },
+  { envKey: "MULTI_MEMORY_RETRIEVAL_OMNISCIENCE_STRATEGY",     configPath: ["memory", "retrieval", "omniscience", "retrievalStrategy"], kind: "string"  },
+  { envKey: "MULTI_MEMORY_RETRIEVAL_OMNISCIENCE_TIMEOUT_MS",   configPath: ["memory", "retrieval", "omniscience", "timeoutMs"],         kind: "number"  },
 ];
 
 /**

--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -95,6 +95,55 @@ export const ConfigSchema = z.object({
   encryption: z.object({
     key: z.string().min(32).optional(),
   }).default({}),
+  /**
+   * Memory / retrieval backend selection (memory-architecture ADR, Track A).
+   *
+   * `retrieval.backend` selects the world-knowledge retrieval path:
+   *   - "local"        — existing pgvector RAG (default, fallback).
+   *   - "omniscience"  — Omniscience MCP `search` tool.
+   *
+   * Nothing changes by default: the backend is "local" unless explicitly
+   * switched. When "omniscience" is selected the Retriever calls Omniscience
+   * and falls back to local pgvector on any error.
+   *
+   * The Omniscience auth token is NEVER stored in config — it is read at
+   * call time from the OMNISCIENCE_TOKEN environment variable (the var name
+   * is configurable via `tokenEnv`).
+   */
+  memory: z.object({
+    retrieval: z.object({
+      backend: z.enum(["local", "omniscience"]).default("local"),
+      omniscience: z.object({
+        /** MCP transport used to reach Omniscience. */
+        transport: z.enum(["stdio", "streamable-http"]).default("stdio"),
+        /** Command to spawn the Omniscience MCP server (stdio transport). */
+        command: z.string().optional(),
+        /** Arguments for the stdio command. */
+        args: z.array(z.string()).default([]),
+        /** Endpoint URL for the streamable-http transport. */
+        endpoint: z.preprocess(
+          (v) => (v === "" ? undefined : v),
+          z.string().url().optional(),
+        ),
+        /**
+         * Name of the environment variable that holds the Omniscience auth
+         * token (scopes: search, sources:read). The token value itself is
+         * never persisted in config. Defaults to OMNISCIENCE_TOKEN.
+         */
+        tokenEnv: z.string().default("OMNISCIENCE_TOKEN"),
+        /**
+         * Default retrieval strategy passed to Omniscience `search`. The
+         * contract accepts structural/keyword/auto and downgrades unknown
+         * strategies to "hybrid" in v0.1 (we preserve the contract).
+         */
+        retrievalStrategy: z
+          .enum(["hybrid", "structural", "keyword", "auto"])
+          .default("hybrid"),
+        /** Request timeout in milliseconds. */
+        timeoutMs: z.coerce.number().int().positive().default(15_000),
+      }).default({}),
+    }).default({}),
+  }).default({}),
 });
 
 export type AppConfig = z.infer<typeof ConfigSchema>;

--- a/server/memory/omniscience-connection.ts
+++ b/server/memory/omniscience-connection.ts
@@ -1,0 +1,157 @@
+/**
+ * Omniscience MCP connection wiring (memory-architecture ADR, Track A).
+ *
+ * Builds an OmniscienceProvider from the validated app config:
+ *   - opens a dedicated MCP Client to Omniscience over stdio OR streamable-http,
+ *   - injects the auth token (read from env at call time, never persisted),
+ *   - exposes an OmniscienceToolCaller that invokes the `search` tool and
+ *     returns its text payload for the provider to validate + map.
+ *
+ * Auth contract (Omniscience ADR 0004):
+ *   - stdio           → token passed via env (OMNISCIENCE_TOKEN by default),
+ *   - streamable-http → Authorization: Bearer <token> request header.
+ * Token scopes: search, sources:read.
+ */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { AppConfig } from "../config/schema.js";
+import {
+  OmniscienceProvider,
+  OMNISCIENCE_SEARCH_TOOL,
+  type OmniscienceToolCaller,
+} from "./omniscience-provider.js";
+
+type OmniscienceConfig = AppConfig["memory"]["retrieval"]["omniscience"];
+
+const CLIENT_NAME = "multiqlti-omniscience-client";
+const CLIENT_VERSION = "1.0.0";
+
+/**
+ * Read the Omniscience auth token from the configured env var.
+ * Throws when the backend is selected but no token is present — fail fast with a
+ * clear, secret-free message.
+ */
+export function resolveOmniscienceToken(cfg: OmniscienceConfig): string {
+  const token = process.env[cfg.tokenEnv];
+  if (!token) {
+    throw new Error(
+      `Omniscience backend selected but auth token env "${cfg.tokenEnv}" is not set`,
+    );
+  }
+  return token;
+}
+
+/** Build the MCP transport for the configured Omniscience connection + token. */
+export function buildOmniscienceTransport(
+  cfg: OmniscienceConfig,
+  token: string,
+): Transport {
+  if (cfg.transport === "stdio") {
+    if (!cfg.command) {
+      throw new Error("Omniscience stdio transport requires `command`");
+    }
+    return new StdioClientTransport({
+      command: cfg.command,
+      args: cfg.args,
+      env: { ...sanitizedEnv(), [cfg.tokenEnv]: token },
+    });
+  }
+  if (!cfg.endpoint) {
+    throw new Error("Omniscience streamable-http transport requires `endpoint`");
+  }
+  return new StreamableHTTPClientTransport(new URL(cfg.endpoint), {
+    requestInit: { headers: { Authorization: `Bearer ${token}` } },
+  });
+}
+
+/** process.env with undefined values dropped, typed for the stdio transport. */
+function sanitizedEnv(): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (typeof value === "string") out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Wrap an MCP Client into the narrow OmniscienceToolCaller seam.
+ * Extracts the text payload from the tool result, mirroring McpClientManager.
+ */
+export function makeToolCaller(client: Client): OmniscienceToolCaller {
+  return async (toolName, args) => {
+    const result = await client.callTool({ name: toolName, arguments: args });
+    return extractText(result);
+  };
+}
+
+/** A connected Omniscience provider plus a disposer to close the transport. */
+export interface OmniscienceConnection {
+  provider: OmniscienceProvider;
+  close: () => Promise<void>;
+}
+
+/**
+ * Connect to Omniscience and return a ready OmniscienceProvider.
+ * Caller owns the lifecycle and must invoke `close()` on shutdown.
+ */
+export async function connectOmniscience(
+  cfg: OmniscienceConfig,
+): Promise<OmniscienceConnection> {
+  const token = resolveOmniscienceToken(cfg);
+  const transport = buildOmniscienceTransport(cfg, token);
+  const client = new Client(
+    { name: CLIENT_NAME, version: CLIENT_VERSION },
+    { capabilities: {} },
+  );
+  await client.connect(transport);
+
+  const provider = new OmniscienceProvider(makeToolCaller(client), {
+    retrievalStrategy: cfg.retrievalStrategy,
+  });
+
+  return {
+    provider,
+    close: async () => {
+      await client.close();
+    },
+  };
+}
+
+/** Whether the Omniscience backend is selected in config. */
+export function isOmniscienceSelected(config: AppConfig): boolean {
+  return config.memory.retrieval.backend === "omniscience";
+}
+
+/** Tool name used by the provider — re-exported for connection-level config UIs. */
+export const OMNISCIENCE_TOOL_NAME = OMNISCIENCE_SEARCH_TOOL;
+
+// ─── Internal ────────────────────────────────────────────────────────────────────
+
+interface TextBlock {
+  type: "text";
+  text: string;
+}
+
+/** Extract concatenated text from an MCP tool result content array. */
+function extractText(result: unknown): string {
+  if (typeof result !== "object" || result === null || !("content" in result)) {
+    return "";
+  }
+  const content = (result as { content: unknown }).content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter(isTextBlock)
+    .map((block) => block.text)
+    .join("\n");
+}
+
+function isTextBlock(block: unknown): block is TextBlock {
+  return (
+    typeof block === "object" &&
+    block !== null &&
+    (block as { type?: unknown }).type === "text" &&
+    typeof (block as { text?: unknown }).text === "string"
+  );
+}

--- a/server/memory/omniscience-provider.ts
+++ b/server/memory/omniscience-provider.ts
@@ -1,0 +1,266 @@
+/**
+ * OmniscienceProvider — world-knowledge retrieval via Omniscience's MCP `search`
+ * tool (memory-architecture ADR, Track A).
+ *
+ * Contract-first: built against Omniscience ADR 0004's stable `search` contract
+ * while Omniscience itself is pre-v0.1. The provider:
+ *   - calls the `search` MCP tool with { query, retrieval_strategy, as_of, ... },
+ *   - validates the returned chunk+citation payload at the boundary (zod),
+ *   - maps results into the existing RetrievalResult shape so the Retriever can
+ *     route to it transparently.
+ *
+ * Auth: the token is read from the configured env var at call time and passed to
+ * the transport (stdio env / streamable-http Authorization header) by the
+ * connection layer. It is NEVER hardcoded or persisted in config.
+ */
+import { z } from "zod";
+import type { RetrievalOptions, RetrievedChunk, RetrievalResult } from "./retriever.js";
+import type { ChunkSourceType } from "./chunker.js";
+
+// ─── Contract: search tool params (Omniscience ADR 0004) ───────────────────────
+
+/**
+ * Retrieval strategy accepted by Omniscience `search`. v0.1 implements only
+ * "hybrid"; structural/keyword/auto are accepted-and-downgraded server-side.
+ * We preserve the full contract so callers can pass any of them.
+ */
+export type OmniscienceRetrievalStrategy =
+  | "hybrid"
+  | "structural"
+  | "keyword"
+  | "auto";
+
+export const OMNISCIENCE_SEARCH_TOOL = "search" as const;
+
+/** Arguments sent to the Omniscience `search` MCP tool. */
+export interface OmniscienceSearchParams {
+  query: string;
+  /** Defaults to "hybrid". Unknown strategies downgrade server-side. */
+  retrieval_strategy: OmniscienceRetrievalStrategy;
+  /** Bitemporal anchor (ISO-8601 datetime). Optional. */
+  as_of?: string;
+  /** Max number of chunks to return. */
+  limit?: number;
+  /** Source-type filters mapped from RetrievalOptions.filter. */
+  filters?: { source_types?: string[] };
+}
+
+// ─── Boundary validation: search tool result ───────────────────────────────────
+
+/**
+ * A single citation attached to a chunk. Omniscience returns chunks WITH
+ * citations; the caller LLM synthesizes from them.
+ */
+const citationSchema = z.object({
+  source_id: z.string(),
+  source_type: z.string().optional(),
+  uri: z.string().optional(),
+  title: z.string().optional(),
+  locator: z.string().optional(),
+});
+
+const searchResultChunkSchema = z.object({
+  id: z.string(),
+  text: z.string(),
+  score: z.number(),
+  source_id: z.string().optional(),
+  source_type: z.string().optional(),
+  citations: z.array(citationSchema).optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+const searchResultSchema = z.object({
+  chunks: z.array(searchResultChunkSchema),
+});
+
+export type OmniscienceSearchResult = z.infer<typeof searchResultSchema>;
+type OmniscienceChunk = z.infer<typeof searchResultChunkSchema>;
+
+// ─── Tool caller seam ──────────────────────────────────────────────────────────
+
+/**
+ * Minimal seam over the MCP client: invoke the named tool with arguments and
+ * return the raw text payload. The real implementation wraps
+ * McpClientManager.callTool; tests inject a mock. Keeping this narrow keeps the
+ * provider decoupled from transport/connection lifecycle.
+ */
+export type OmniscienceToolCaller = (
+  toolName: string,
+  args: Record<string, unknown>,
+) => Promise<string>;
+
+// ─── Constants ──────────────────────────────────────────────────────────────────
+
+const DEFAULT_TOP_K = 5;
+const DEFAULT_MAX_TOKENS = 2000;
+const CHARS_PER_TOKEN = 4;
+
+/** Map an Omniscience source_type string onto our ChunkSourceType union. */
+const SOURCE_TYPE_MAP: Record<string, ChunkSourceType> = {
+  code: "code",
+  document: "document",
+  doc: "document",
+  docs: "document",
+  incident: "document",
+  infra: "document",
+  pipeline_run: "pipeline_run",
+  memory_entry: "memory_entry",
+};
+
+function mapSourceType(raw: string | undefined): ChunkSourceType {
+  if (!raw) return "document";
+  return SOURCE_TYPE_MAP[raw] ?? "document";
+}
+
+// ─── Provider ────────────────────────────────────────────────────────────────────
+
+export interface OmniscienceProviderOptions {
+  /** Default retrieval strategy when the caller does not specify one. */
+  retrievalStrategy?: OmniscienceRetrievalStrategy;
+}
+
+export class OmniscienceProvider {
+  private readonly defaultStrategy: OmniscienceRetrievalStrategy;
+
+  constructor(
+    private readonly callTool: OmniscienceToolCaller,
+    options: OmniscienceProviderOptions = {},
+  ) {
+    this.defaultStrategy = options.retrievalStrategy ?? "hybrid";
+  }
+
+  /**
+   * Retrieve world-knowledge context from Omniscience. Mirrors
+   * Retriever.retrieveContext so the Retriever can route to it transparently.
+   * Throws on transport / validation failure — the Retriever catches and falls
+   * back to local pgvector.
+   */
+  async retrieveContext(options: RetrievalOptions): Promise<RetrievalResult> {
+    const params = buildSearchParams(options, this.defaultStrategy);
+    const raw = await this.callTool(
+      OMNISCIENCE_SEARCH_TOOL,
+      params as unknown as Record<string, unknown>,
+    );
+    const result = parseSearchResult(raw);
+    return toRetrievalResult(result, options);
+  }
+}
+
+// ─── Param building ──────────────────────────────────────────────────────────────
+
+/** Build the `search` tool arguments from RetrievalOptions, preserving the contract. */
+export function buildSearchParams(
+  options: RetrievalOptions,
+  defaultStrategy: OmniscienceRetrievalStrategy,
+): OmniscienceSearchParams {
+  const params: OmniscienceSearchParams = {
+    query: options.query,
+    retrieval_strategy: options.retrievalStrategy ?? defaultStrategy,
+    limit: options.topK ?? DEFAULT_TOP_K,
+  };
+  if (options.asOf) params.as_of = options.asOf;
+  if (options.filter && options.filter.length > 0) {
+    params.filters = { source_types: options.filter };
+  }
+  return params;
+}
+
+// ─── Boundary parsing ────────────────────────────────────────────────────────────
+
+/**
+ * Parse + validate the raw tool text into a typed search result.
+ * The MCP client returns tool output as a text payload; Omniscience emits JSON.
+ */
+export function parseSearchResult(raw: string): OmniscienceSearchResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("Omniscience search returned non-JSON payload");
+  }
+  const validated = searchResultSchema.safeParse(parsed);
+  if (!validated.success) {
+    throw new Error(
+      `Omniscience search response failed validation: ${validated.error.issues
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join("; ")}`,
+    );
+  }
+  return validated.data;
+}
+
+// ─── Mapping to RetrievalResult ──────────────────────────────────────────────────
+
+function toRetrievedChunk(chunk: OmniscienceChunk): RetrievedChunk {
+  const metadata: Record<string, unknown> = { ...(chunk.metadata ?? {}) };
+  if (chunk.citations && chunk.citations.length > 0) {
+    metadata.citations = chunk.citations;
+  }
+  metadata.backend = "omniscience";
+  return {
+    id: chunk.id,
+    sourceType: mapSourceType(chunk.source_type),
+    sourceId: chunk.source_id ?? chunk.id,
+    chunkText: chunk.text,
+    score: chunk.score,
+    metadata,
+  };
+}
+
+/** Apply the token budget and format the context, mirroring the local Retriever. */
+function toRetrievalResult(
+  result: OmniscienceSearchResult,
+  options: RetrievalOptions,
+): RetrievalResult {
+  const maxChars = (options.maxTokens ?? DEFAULT_MAX_TOKENS) * CHARS_PER_TOKEN;
+  const selected: RetrievedChunk[] = [];
+  let usedChars = 0;
+
+  for (const chunk of result.chunks) {
+    const mapped = toRetrievedChunk(chunk);
+    if (usedChars + mapped.chunkText.length > maxChars && selected.length > 0) break;
+    selected.push(mapped);
+    usedChars += mapped.chunkText.length;
+  }
+
+  return {
+    chunks: selected,
+    context: formatOmniscienceContext(selected),
+    tokensUsed: Math.ceil(usedChars / CHARS_PER_TOKEN),
+  };
+}
+
+/** Format chunks into an LLM-ready context block, surfacing citations. */
+export function formatOmniscienceContext(chunks: RetrievedChunk[]): string {
+  if (chunks.length === 0) return "";
+  const lines: string[] = ["## Relevant Context\n"];
+  for (const chunk of chunks) {
+    lines.push(`[${chunk.sourceType}:${chunk.sourceId}] (score: ${chunk.score.toFixed(2)})`);
+    lines.push(chunk.chunkText.trim());
+    const cites = chunk.metadata.citations;
+    if (Array.isArray(cites) && cites.length > 0) {
+      const formatted = formatCitations(cites);
+      if (formatted) lines.push(formatted);
+    }
+    lines.push("");
+  }
+  return lines.join("\n").trimEnd();
+}
+
+function formatCitations(citations: unknown[]): string {
+  const refs = citations
+    .map((c) => (isCitation(c) ? c.uri ?? c.title ?? c.source_id : undefined))
+    .filter((s): s is string => typeof s === "string");
+  return refs.length > 0 ? `Sources: ${refs.join(", ")}` : "";
+}
+
+function isCitation(
+  value: unknown,
+): value is { source_id: string; uri?: string; title?: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "source_id" in value &&
+    typeof (value as { source_id: unknown }).source_id === "string"
+  );
+}

--- a/server/memory/retriever.ts
+++ b/server/memory/retriever.ts
@@ -3,10 +3,16 @@
  *
  * retrieveContext() embeds the query, searches the vector store, applies a
  * token budget, and returns formatted context chunks ready for LLM injection.
+ *
+ * Routing (memory-architecture ADR, Track A): when an Omniscience provider is
+ * wired in (feature flag `memory.retrieval.backend = "omniscience"`), the
+ * Retriever delegates world-knowledge retrieval to it and falls back to the
+ * local pgvector path on any error. By default (no provider) it uses pgvector.
  */
 import type { EmbeddingProvider } from "./embeddings.js";
 import type { VectorStore, VectorSearchResult } from "./vector-store.js";
 import type { ChunkSourceType } from "./chunker.js";
+import type { OmniscienceProvider, OmniscienceRetrievalStrategy } from "./omniscience-provider.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -20,6 +26,16 @@ export interface RetrievalOptions {
   maxTokens?: number;
   /** Minimum similarity score (0–1). */
   minScore?: number;
+  /**
+   * Bitemporal anchor (ISO-8601 datetime) passed through to Omniscience
+   * `search`. Ignored by the local pgvector path.
+   */
+  asOf?: string;
+  /**
+   * Retrieval strategy passed through to Omniscience `search`. Ignored by the
+   * local pgvector path. Unknown strategies downgrade server-side to "hybrid".
+   */
+  retrievalStrategy?: OmniscienceRetrievalStrategy;
 }
 
 export interface RetrievedChunk {
@@ -45,16 +61,41 @@ const CHARS_PER_TOKEN = 4;
 const DEFAULT_TOP_K = 5;
 const DEFAULT_MAX_TOKENS = 2000;
 const DEFAULT_MIN_SCORE = 0.3;
+const MIN_TRUNCATION_CHARS = 40;
 
 // ─── Retriever ────────────────────────────────────────────────────────────────
 
 export class Retriever {
+  /**
+   * @param embeddingProvider — embeds queries for the local pgvector path.
+   * @param vectorStore       — local pgvector store (default + fallback backend).
+   * @param omniscience       — optional Omniscience provider; when present the
+   *   Retriever routes to it and falls back to local pgvector on error.
+   */
   constructor(
     private readonly embeddingProvider: EmbeddingProvider,
     private readonly vectorStore: VectorStore,
+    private readonly omniscience?: OmniscienceProvider,
   ) {}
 
   async retrieveContext(options: RetrievalOptions): Promise<RetrievalResult> {
+    if (this.omniscience) {
+      try {
+        return await this.omniscience.retrieveContext(options);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        // Graceful fallback: log and use local pgvector. Never throw to the
+        // caller just because the optional world-knowledge backend is down.
+        console.warn(
+          `[retriever] Omniscience retrieval failed, falling back to local pgvector: ${msg}`,
+        );
+      }
+    }
+    return this.retrieveLocal(options);
+  }
+
+  /** Local pgvector retrieval path (default backend + Omniscience fallback). */
+  private async retrieveLocal(options: RetrievalOptions): Promise<RetrievalResult> {
     const topK = options.topK ?? DEFAULT_TOP_K;
     const maxTokens = options.maxTokens ?? DEFAULT_MAX_TOKENS;
     const minScore = options.minScore ?? DEFAULT_MIN_SCORE;
@@ -70,44 +111,55 @@ export class Retriever {
       minScore,
     });
 
-    // Apply token budget: include chunks in order of relevance until budget exhausted.
-    const selectedChunks: RetrievedChunk[] = [];
-    let usedChars = 0;
+    const selectedChunks = selectWithinBudget(searchResults, maxChars);
+    const usedChars = selectedChunks.reduce((sum, c) => sum + c.chunkText.length, 0);
 
-    for (const result of searchResults) {
-      const chunkChars = result.chunkText.length;
-      if (usedChars + chunkChars > maxChars && selectedChunks.length > 0) {
-        // Partial inclusion: truncate the last chunk to fit within budget.
-        const remaining = maxChars - usedChars;
-        if (remaining > 40) {
-          selectedChunks.push({
-            id: result.id,
-            sourceType: result.sourceType,
-            sourceId: result.sourceId,
-            chunkText: result.chunkText.slice(0, remaining) + "…",
-            score: result.score,
-            metadata: result.metadata,
-          });
-          usedChars += remaining;
-        }
-        break;
-      }
-      selectedChunks.push({
-        id: result.id,
-        sourceType: result.sourceType,
-        sourceId: result.sourceId,
-        chunkText: result.chunkText,
-        score: result.score,
-        metadata: result.metadata,
-      });
-      usedChars += chunkChars;
-    }
-
-    const context = formatContext(selectedChunks);
-    const tokensUsed = Math.ceil(usedChars / CHARS_PER_TOKEN);
-
-    return { chunks: selectedChunks, context, tokensUsed };
+    return {
+      chunks: selectedChunks,
+      context: formatContext(selectedChunks),
+      tokensUsed: Math.ceil(usedChars / CHARS_PER_TOKEN),
+    };
   }
+}
+
+// ─── Token budget ───────────────────────────────────────────────────────────────
+
+/**
+ * Select chunks in relevance order until the character budget is exhausted,
+ * truncating the final chunk to fit when there is meaningful room left.
+ */
+function selectWithinBudget(
+  results: VectorSearchResult[],
+  maxChars: number,
+): RetrievedChunk[] {
+  const selected: RetrievedChunk[] = [];
+  let usedChars = 0;
+
+  for (const result of results) {
+    const chunkChars = result.chunkText.length;
+    if (usedChars + chunkChars > maxChars && selected.length > 0) {
+      const remaining = maxChars - usedChars;
+      if (remaining > MIN_TRUNCATION_CHARS) {
+        selected.push(toChunk(result, result.chunkText.slice(0, remaining) + "…"));
+      }
+      break;
+    }
+    selected.push(toChunk(result, result.chunkText));
+    usedChars += chunkChars;
+  }
+
+  return selected;
+}
+
+function toChunk(result: VectorSearchResult, chunkText: string): RetrievedChunk {
+  return {
+    id: result.id,
+    sourceType: result.sourceType,
+    sourceId: result.sourceId,
+    chunkText,
+    score: result.score,
+    metadata: result.metadata,
+  };
 }
 
 // ─── Formatting ───────────────────────────────────────────────────────────────

--- a/tests/helpers/mock-omniscience.ts
+++ b/tests/helpers/mock-omniscience.ts
@@ -1,0 +1,146 @@
+/**
+ * Mock Omniscience `search` MCP tool (memory-architecture ADR, Track A).
+ *
+ * A contract-faithful test double of Omniscience ADR 0004's `search` tool — no
+ * live Omniscience needed. It:
+ *   - enforces the tool name `search`,
+ *   - validates params (required `query`; `retrieval_strategy` enum with the
+ *     v0.1 downgrade of structural/keyword/auto → hybrid; optional ISO-8601
+ *     `as_of`; optional limit/filters),
+ *   - returns citation-bearing chunk results as the JSON text payload an MCP
+ *     tool call would yield.
+ *
+ * Exposes:
+ *   - `makeMockOmniscienceCaller()` → an OmniscienceToolCaller for the provider,
+ *   - `lastCall` capture so tests can assert what params were passed through.
+ */
+import { z } from "zod";
+import type { OmniscienceToolCaller } from "../../server/memory/omniscience-provider";
+
+// ─── Contract param validation (server side) ────────────────────────────────────
+
+const REQUESTED_STRATEGIES = ["hybrid", "structural", "keyword", "auto"] as const;
+/** v0.1 only truly implements hybrid; everything else downgrades to it. */
+const EFFECTIVE_STRATEGIES = ["hybrid"] as const;
+
+type RequestedStrategy = (typeof REQUESTED_STRATEGIES)[number];
+type EffectiveStrategy = (typeof EFFECTIVE_STRATEGIES)[number];
+
+const searchParamsSchema = z.object({
+  query: z.string().min(1),
+  retrieval_strategy: z.enum(REQUESTED_STRATEGIES).default("hybrid"),
+  as_of: z.string().datetime().optional(),
+  limit: z.number().int().positive().optional(),
+  filters: z.object({ source_types: z.array(z.string()).optional() }).optional(),
+});
+
+export type MockSearchParams = z.infer<typeof searchParamsSchema>;
+
+/**
+ * Downgrade any requested strategy to the v0.1 effective strategy (hybrid).
+ * The requested value is intentionally ignored — that IS the contract behavior.
+ */
+export function downgradeStrategy(_requested: RequestedStrategy): EffectiveStrategy {
+  return "hybrid";
+}
+
+// ─── Result shaping ─────────────────────────────────────────────────────────────
+
+export interface MockChunk {
+  id: string;
+  text: string;
+  score: number;
+  source_id?: string;
+  source_type?: string;
+  citations?: Array<{ source_id: string; uri?: string; title?: string }>;
+  metadata?: Record<string, unknown>;
+}
+
+/** Default citation-bearing fixture chunks. */
+export function defaultMockChunks(): MockChunk[] {
+  return [
+    {
+      id: "c1",
+      text: "The retry policy uses exponential backoff with a 1s base.",
+      score: 0.92,
+      source_id: "src-retry",
+      source_type: "code",
+      citations: [
+        { source_id: "src-retry", uri: "git://repo/server/retry.ts#L10", title: "retry.ts" },
+      ],
+      metadata: { commit: "abc123" },
+    },
+    {
+      id: "c2",
+      text: "Incident #42: backoff misconfiguration caused a thundering herd.",
+      score: 0.81,
+      source_id: "inc-42",
+      source_type: "incident",
+      citations: [{ source_id: "inc-42", title: "Incident 42 postmortem" }],
+    },
+  ];
+}
+
+// ─── Captured call ───────────────────────────────────────────────────────────────
+
+export interface CapturedCall {
+  toolName: string;
+  params: MockSearchParams;
+  /** The effective strategy after v0.1 downgrade. */
+  effectiveStrategy: EffectiveStrategy;
+}
+
+export interface MockOmniscienceOptions {
+  /** Chunks to return; defaults to defaultMockChunks(). */
+  chunks?: MockChunk[];
+  /** When set, the caller rejects with this error (to test fallback). */
+  failWith?: Error;
+  /** When true, return malformed (non-contract) JSON to test boundary validation. */
+  returnMalformed?: boolean;
+}
+
+/**
+ * Build an OmniscienceToolCaller backed by the mock. The returned object also
+ * carries `lastCall` for assertions.
+ */
+export function makeMockOmniscienceCaller(
+  options: MockOmniscienceOptions = {},
+): OmniscienceToolCaller & { lastCall: CapturedCall | null } {
+  const state: { lastCall: CapturedCall | null } = { lastCall: null };
+
+  const caller = (async (toolName: string, args: Record<string, unknown>) => {
+    if (options.failWith) throw options.failWith;
+
+    if (toolName !== "search") {
+      throw new Error(`Mock Omniscience only implements "search", got "${toolName}"`);
+    }
+
+    const parsed = searchParamsSchema.safeParse(args);
+    if (!parsed.success) {
+      throw new Error(
+        `Mock Omniscience param validation failed: ${parsed.error.issues
+          .map((i) => `${i.path.join(".")}: ${i.message}`)
+          .join("; ")}`,
+      );
+    }
+
+    const effectiveStrategy = downgradeStrategy(parsed.data.retrieval_strategy);
+    state.lastCall = { toolName, params: parsed.data, effectiveStrategy };
+
+    if (options.returnMalformed) {
+      return JSON.stringify({ results: "not the contract shape" });
+    }
+
+    const chunks = options.chunks ?? defaultMockChunks();
+    const limited =
+      parsed.data.limit !== undefined ? chunks.slice(0, parsed.data.limit) : chunks;
+    return JSON.stringify({ chunks: limited });
+  }) as OmniscienceToolCaller & { lastCall: CapturedCall | null };
+
+  Object.defineProperty(caller, "lastCall", {
+    get: () => state.lastCall,
+    enumerable: true,
+  });
+
+  return caller;
+}

--- a/tests/unit/rag/omniscience-connection.test.ts
+++ b/tests/unit/rag/omniscience-connection.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for the Omniscience MCP connection wiring (memory-architecture ADR,
+ * Track A).
+ *
+ * Covers the pure, transport-independent seams:
+ *   - token resolution from the configured env var (never hardcoded),
+ *   - transport selection (stdio vs streamable-http) + required-field errors,
+ *   - the flag helper,
+ *   - the tool-caller text extraction over a fake MCP client.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import {
+  resolveOmniscienceToken,
+  buildOmniscienceTransport,
+  makeToolCaller,
+  isOmniscienceSelected,
+} from "../../../server/memory/omniscience-connection";
+import { ConfigSchema, type AppConfig } from "../../../server/config/schema";
+
+type OmniscienceConfig = AppConfig["memory"]["retrieval"]["omniscience"];
+
+function omniscienceConfig(overrides: Partial<OmniscienceConfig> = {}): OmniscienceConfig {
+  const base = ConfigSchema.parse({}).memory.retrieval.omniscience;
+  return { ...base, ...overrides };
+}
+
+const SAVED_ENV = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...SAVED_ENV };
+});
+
+describe("resolveOmniscienceToken", () => {
+  it("reads the token from the configured env var", () => {
+    process.env.OMNISCIENCE_TOKEN = "test-token-value";
+    expect(resolveOmniscienceToken(omniscienceConfig())).toBe("test-token-value");
+  });
+
+  it("honors a custom tokenEnv name", () => {
+    delete process.env.OMNISCIENCE_TOKEN;
+    process.env.CUSTOM_OMNI_TOKEN = "custom-token";
+    expect(
+      resolveOmniscienceToken(omniscienceConfig({ tokenEnv: "CUSTOM_OMNI_TOKEN" })),
+    ).toBe("custom-token");
+  });
+
+  it("throws (secret-free) when the token env is unset", () => {
+    delete process.env.OMNISCIENCE_TOKEN;
+    expect(() => resolveOmniscienceToken(omniscienceConfig())).toThrow(
+      /OMNISCIENCE_TOKEN.*not set/,
+    );
+  });
+});
+
+describe("buildOmniscienceTransport", () => {
+  it("builds a stdio transport when transport=stdio and command is set", () => {
+    const transport = buildOmniscienceTransport(
+      omniscienceConfig({ transport: "stdio", command: "omniscience-mcp", args: ["--serve"] }),
+      "tok",
+    );
+    expect(transport).toBeInstanceOf(StdioClientTransport);
+  });
+
+  it("throws when stdio transport lacks a command", () => {
+    expect(() =>
+      buildOmniscienceTransport(omniscienceConfig({ transport: "stdio" }), "tok"),
+    ).toThrow(/requires `command`/);
+  });
+
+  it("builds a streamable-http transport with the endpoint", () => {
+    const transport = buildOmniscienceTransport(
+      omniscienceConfig({
+        transport: "streamable-http",
+        endpoint: "https://omni.example.com/mcp",
+      }),
+      "tok",
+    );
+    expect(transport).toBeInstanceOf(StreamableHTTPClientTransport);
+  });
+
+  it("throws when streamable-http transport lacks an endpoint", () => {
+    expect(() =>
+      buildOmniscienceTransport(omniscienceConfig({ transport: "streamable-http" }), "tok"),
+    ).toThrow(/requires `endpoint`/);
+  });
+});
+
+describe("makeToolCaller", () => {
+  it("extracts concatenated text from the MCP tool result", async () => {
+    const fakeClient = {
+      callTool: async () => ({
+        content: [
+          { type: "text", text: "line one" },
+          { type: "image", data: "ignored" },
+          { type: "text", text: "line two" },
+        ],
+      }),
+    } as unknown as Client;
+
+    const caller = makeToolCaller(fakeClient);
+    const out = await caller("search", { query: "x" });
+
+    expect(out).toBe("line one\nline two");
+  });
+
+  it("returns an empty string when the result has no content array", async () => {
+    const fakeClient = { callTool: async () => ({}) } as unknown as Client;
+    const caller = makeToolCaller(fakeClient);
+    expect(await caller("search", {})).toBe("");
+  });
+});
+
+describe("isOmniscienceSelected", () => {
+  it("is false by default (local backend)", () => {
+    expect(isOmniscienceSelected(ConfigSchema.parse({}))).toBe(false);
+  });
+
+  it("is true when the backend flag selects omniscience", () => {
+    const config = ConfigSchema.parse({
+      memory: { retrieval: { backend: "omniscience" } },
+    });
+    expect(isOmniscienceSelected(config)).toBe(true);
+  });
+});

--- a/tests/unit/rag/omniscience-provider.test.ts
+++ b/tests/unit/rag/omniscience-provider.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Contract tests for OmniscienceProvider (memory-architecture ADR, Track A).
+ *
+ * Drives the provider against the mock Omniscience `search` tool double and
+ * proves:
+ *   - it calls the `search` tool with contract-correct params,
+ *   - it passes as_of + retrieval_strategy through,
+ *   - it preserves the strategy contract (strategy reaches the server even when
+ *     v0.1 downgrades it),
+ *   - it maps chunk+citation results into RetrievalResult,
+ *   - it validates the response shape at the boundary and throws on malformed
+ *     payloads (so the Retriever can fall back).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  OmniscienceProvider,
+  buildSearchParams,
+  parseSearchResult,
+  formatOmniscienceContext,
+} from "../../../server/memory/omniscience-provider";
+import type { RetrievalOptions } from "../../../server/memory/retriever";
+import {
+  makeMockOmniscienceCaller,
+  defaultMockChunks,
+} from "../../helpers/mock-omniscience";
+
+function baseOptions(overrides: Partial<RetrievalOptions> = {}): RetrievalOptions {
+  return { query: "how does retry work", workspaceId: "ws-1", ...overrides };
+}
+
+describe("OmniscienceProvider.retrieveContext", () => {
+  it("calls the `search` tool with the query and default hybrid strategy", async () => {
+    const caller = makeMockOmniscienceCaller();
+    const provider = new OmniscienceProvider(caller);
+
+    await provider.retrieveContext(baseOptions());
+
+    expect(caller.lastCall?.toolName).toBe("search");
+    expect(caller.lastCall?.params.query).toBe("how does retry work");
+    expect(caller.lastCall?.params.retrieval_strategy).toBe("hybrid");
+  });
+
+  it("passes as_of (bitemporal anchor) through to search", async () => {
+    const caller = makeMockOmniscienceCaller();
+    const provider = new OmniscienceProvider(caller);
+    const asOf = "2026-01-15T00:00:00.000Z";
+
+    await provider.retrieveContext(baseOptions({ asOf }));
+
+    expect(caller.lastCall?.params.as_of).toBe(asOf);
+  });
+
+  it("passes a non-hybrid retrieval_strategy through (server downgrades it)", async () => {
+    const caller = makeMockOmniscienceCaller();
+    const provider = new OmniscienceProvider(caller);
+
+    await provider.retrieveContext(baseOptions({ retrievalStrategy: "structural" }));
+
+    // Contract preserved: the requested strategy reaches the server …
+    expect(caller.lastCall?.params.retrieval_strategy).toBe("structural");
+    // … and the server downgrades it to hybrid in v0.1.
+    expect(caller.lastCall?.effectiveStrategy).toBe("hybrid");
+  });
+
+  it("uses the provider default strategy when caller omits one", async () => {
+    const caller = makeMockOmniscienceCaller();
+    const provider = new OmniscienceProvider(caller, { retrievalStrategy: "auto" });
+
+    await provider.retrieveContext(baseOptions());
+
+    expect(caller.lastCall?.params.retrieval_strategy).toBe("auto");
+  });
+
+  it("passes source-type filters and limit through", async () => {
+    const caller = makeMockOmniscienceCaller();
+    const provider = new OmniscienceProvider(caller);
+
+    await provider.retrieveContext(baseOptions({ filter: ["code"], topK: 1 }));
+
+    expect(caller.lastCall?.params.filters?.source_types).toEqual(["code"]);
+    expect(caller.lastCall?.params.limit).toBe(1);
+  });
+
+  it("maps chunk results into RetrievedChunk with score and source", async () => {
+    const provider = new OmniscienceProvider(makeMockOmniscienceCaller());
+
+    const result = await provider.retrieveContext(baseOptions());
+
+    expect(result.chunks).toHaveLength(2);
+    expect(result.chunks[0].id).toBe("c1");
+    expect(result.chunks[0].sourceType).toBe("code");
+    expect(result.chunks[0].sourceId).toBe("src-retry");
+    expect(result.chunks[0].score).toBeCloseTo(0.92);
+    expect(result.chunks[0].chunkText).toContain("exponential backoff");
+  });
+
+  it("preserves citations in chunk metadata", async () => {
+    const provider = new OmniscienceProvider(makeMockOmniscienceCaller());
+
+    const result = await provider.retrieveContext(baseOptions());
+
+    const citations = result.chunks[0].metadata.citations;
+    expect(Array.isArray(citations)).toBe(true);
+    expect((citations as unknown[]).length).toBe(1);
+    expect(result.chunks[0].metadata.backend).toBe("omniscience");
+  });
+
+  it("surfaces citations in the formatted context", async () => {
+    const provider = new OmniscienceProvider(makeMockOmniscienceCaller());
+
+    const result = await provider.retrieveContext(baseOptions());
+
+    expect(result.context).toContain("## Relevant Context");
+    expect(result.context).toContain("Sources:");
+    expect(result.context).toContain("git://repo/server/retry.ts#L10");
+  });
+
+  it("maps an unknown source_type to document", async () => {
+    const caller = makeMockOmniscienceCaller({
+      chunks: [{ id: "x", text: "t", score: 0.5, source_type: "wiki" }],
+    });
+    const provider = new OmniscienceProvider(caller);
+
+    const result = await provider.retrieveContext(baseOptions());
+
+    expect(result.chunks[0].sourceType).toBe("document");
+  });
+
+  it("returns empty result when search yields no chunks", async () => {
+    const provider = new OmniscienceProvider(makeMockOmniscienceCaller({ chunks: [] }));
+
+    const result = await provider.retrieveContext(baseOptions());
+
+    expect(result.chunks).toHaveLength(0);
+    expect(result.context).toBe("");
+    expect(result.tokensUsed).toBe(0);
+  });
+
+  it("throws when the search response is malformed (boundary validation)", async () => {
+    const provider = new OmniscienceProvider(
+      makeMockOmniscienceCaller({ returnMalformed: true }),
+    );
+
+    await expect(provider.retrieveContext(baseOptions())).rejects.toThrow(
+      /failed validation/i,
+    );
+  });
+
+  it("propagates transport errors so the Retriever can fall back", async () => {
+    const provider = new OmniscienceProvider(
+      makeMockOmniscienceCaller({ failWith: new Error("connection refused") }),
+    );
+
+    await expect(provider.retrieveContext(baseOptions())).rejects.toThrow(
+      /connection refused/,
+    );
+  });
+});
+
+describe("buildSearchParams", () => {
+  it("defaults limit to topK and strategy to the provided default", () => {
+    const params = buildSearchParams(baseOptions(), "keyword");
+    expect(params.retrieval_strategy).toBe("keyword");
+    expect(params.limit).toBe(5);
+    expect(params.as_of).toBeUndefined();
+  });
+
+  it("omits filters when no filter is set", () => {
+    const params = buildSearchParams(baseOptions(), "hybrid");
+    expect(params.filters).toBeUndefined();
+  });
+});
+
+describe("parseSearchResult", () => {
+  it("rejects non-JSON payloads", () => {
+    expect(() => parseSearchResult("<<not json>>")).toThrow(/non-JSON/i);
+  });
+
+  it("accepts a contract-shaped payload", () => {
+    const raw = JSON.stringify({ chunks: defaultMockChunks() });
+    const result = parseSearchResult(raw);
+    expect(result.chunks).toHaveLength(2);
+  });
+});
+
+describe("formatOmniscienceContext", () => {
+  it("returns an empty string for no chunks", () => {
+    expect(formatOmniscienceContext([])).toBe("");
+  });
+});

--- a/tests/unit/rag/retriever-routing.test.ts
+++ b/tests/unit/rag/retriever-routing.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Routing tests for Retriever ↔ OmniscienceProvider (memory-architecture ADR,
+ * Track A).
+ *
+ * Proves the feature-flag routing behavior:
+ *   - with no Omniscience provider → uses local pgvector (default),
+ *   - with an Omniscience provider → routes to it,
+ *   - on Omniscience error → falls back to local pgvector (graceful, no throw).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Retriever } from "../../../server/memory/retriever";
+import { OmniscienceProvider } from "../../../server/memory/omniscience-provider";
+import type { EmbeddingProvider } from "../../../server/memory/embeddings";
+import type { VectorStore, VectorSearchResult } from "../../../server/memory/vector-store";
+import { makeMockOmniscienceCaller } from "../../helpers/mock-omniscience";
+
+function makeVec(len = 768): number[] {
+  return Array.from({ length: len }, (_, i) => i / len);
+}
+
+function localResult(id: string, text: string): VectorSearchResult {
+  return {
+    id,
+    workspaceId: "ws-1",
+    sourceType: "document",
+    sourceId: `local-${id}`,
+    chunkText: text,
+    score: 0.7,
+    metadata: { backend: "local" },
+    ts: new Date(),
+  };
+}
+
+function makeEmbeddingProvider(): EmbeddingProvider {
+  return {
+    name: "ollama",
+    model: "nomic-embed-text",
+    dimensions: 768,
+    embed: vi.fn().mockResolvedValue(makeVec()),
+    embedBatch: vi.fn().mockResolvedValue([makeVec()]),
+  };
+}
+
+function makeVectorStore(results: VectorSearchResult[]): VectorStore {
+  return {
+    search: vi.fn().mockResolvedValue(results),
+    insertChunk: vi.fn(),
+    insertChunks: vi.fn(),
+    deleteBySource: vi.fn(),
+    deleteByWorkspace: vi.fn(),
+    countChunks: vi.fn().mockResolvedValue(0),
+    listSources: vi.fn().mockResolvedValue([]),
+    getEmbeddingConfig: vi.fn().mockResolvedValue(null),
+    upsertEmbeddingConfig: vi.fn(),
+  } as unknown as VectorStore;
+}
+
+describe("Retriever routing (feature flag)", () => {
+  let embedding: EmbeddingProvider;
+  let store: VectorStore;
+
+  beforeEach(() => {
+    embedding = makeEmbeddingProvider();
+    store = makeVectorStore([localResult("1", "local pgvector chunk")]);
+  });
+
+  it("uses local pgvector when no Omniscience provider is wired (default)", async () => {
+    const retriever = new Retriever(embedding, store);
+
+    const result = await retriever.retrieveContext({ query: "q", workspaceId: "ws-1" });
+
+    expect(store.search).toHaveBeenCalledTimes(1);
+    expect(result.chunks[0].metadata.backend).toBe("local");
+  });
+
+  it("routes to Omniscience when a provider is wired", async () => {
+    const omniscience = new OmniscienceProvider(makeMockOmniscienceCaller());
+    const retriever = new Retriever(embedding, store, omniscience);
+
+    const result = await retriever.retrieveContext({ query: "q", workspaceId: "ws-1" });
+
+    // Local store was never consulted; results came from Omniscience.
+    expect(store.search).not.toHaveBeenCalled();
+    expect(result.chunks[0].metadata.backend).toBe("omniscience");
+  });
+
+  it("falls back to local pgvector when Omniscience errors (graceful)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const failing = new OmniscienceProvider(
+      makeMockOmniscienceCaller({ failWith: new Error("omniscience down") }),
+    );
+    const retriever = new Retriever(embedding, store, failing);
+
+    const result = await retriever.retrieveContext({ query: "q", workspaceId: "ws-1" });
+
+    // Did not throw; local backend served the request.
+    expect(store.search).toHaveBeenCalledTimes(1);
+    expect(result.chunks[0].metadata.backend).toBe("local");
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("falling back to local pgvector"),
+    );
+    warn.mockRestore();
+  });
+
+  it("falls back to local when Omniscience returns a malformed payload", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const malformed = new OmniscienceProvider(
+      makeMockOmniscienceCaller({ returnMalformed: true }),
+    );
+    const retriever = new Retriever(embedding, store, malformed);
+
+    const result = await retriever.retrieveContext({ query: "q", workspaceId: "ws-1" });
+
+    expect(result.chunks[0].metadata.backend).toBe("local");
+    vi.restoreAllMocks();
+  });
+
+  it("passes as_of and strategy through the Retriever to Omniscience", async () => {
+    const caller = makeMockOmniscienceCaller();
+    const retriever = new Retriever(embedding, store, new OmniscienceProvider(caller));
+
+    await retriever.retrieveContext({
+      query: "q",
+      workspaceId: "ws-1",
+      asOf: "2026-02-01T12:00:00.000Z",
+      retrievalStrategy: "keyword",
+    });
+
+    expect(caller.lastCall?.params.as_of).toBe("2026-02-01T12:00:00.000Z");
+    expect(caller.lastCall?.params.retrieval_strategy).toBe("keyword");
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Track A** of the memory-architecture ADR (`docs/decisions/memory-architecture.md`): world-knowledge retrieval via **Omniscience's MCP `search` tool**, plugged into the existing `Retriever`. **Contract-first** against Omniscience ADR 0004 + a mock server (Omniscience is pre-v0.1, not live). **Feature-flagged**: nothing changes by default — local pgvector stays the default backend and the graceful fallback.

## What's in scope

### Provider (`server/memory/omniscience-provider.ts`)
- `OmniscienceProvider.retrieveContext()` mirrors the `Retriever` signature so routing is transparent.
- Calls the `search` tool with `{ query, retrieval_strategy, as_of?, limit, filters }` through a narrow `OmniscienceToolCaller` seam (decoupled from transport/lifecycle).
- Preserves the **strategy contract**: `structural`/`keyword`/`auto` are passed through (server downgrades to `hybrid` in v0.1). Passes the bitemporal `as_of` anchor through.
- Validates the chunk+citation response at the **boundary** (zod), maps to `RetrievedChunk`/`RetrievalResult`, surfaces citations in metadata and the formatted context. Strict TS, `unknown` + narrowing for external payloads.

### Connection / auth (`server/memory/omniscience-connection.ts`)
- Supports **both** transports: stdio (token via env) and streamable-http (`Authorization: Bearer <token>`).
- Token read from `process.env[tokenEnv]` (default `OMNISCIENCE_TOKEN`) at call time — **never hardcoded, never persisted** in config. Scopes per ADR: `search`, `sources:read`.

### Feature flag (`server/config/schema.ts` + `loader.ts`)
- New `memory.retrieval.backend: "local" | "omniscience"` (**default `"local"`**) plus `memory.retrieval.omniscience.{transport,command,args,endpoint,tokenEnv,retrievalStrategy,timeoutMs}`.
- `MULTI_MEMORY_RETRIEVAL_*` env mappings added. The auth token is deliberately NOT mapped into config.
- **Touches `server/config/schema.ts` (shared-ish file)** — additive `memory` section only, no behavior change for existing config.

### Routing + fallback (`server/memory/retriever.ts`)
- `Retriever` gains an optional 3rd ctor arg (the provider). Routes to Omniscience only when wired; otherwise the existing pgvector path. On **any** Omniscience error → graceful fallback to local pgvector (logged).
- **Does NOT remove** the pgvector path, `server/memory` internals, or the `server/workspace` indexer — connector cutover is a later track.

### Mock + contract tests
- `tests/helpers/mock-omniscience.ts`: contract-faithful `search` double (tool-name enforcement, param validation incl. ISO-8601 `as_of` + strategy-downgrade, citation-bearing results, failure/malformed modes). No live Omniscience needed.
- 3 suites prove: result mapping, flag routing, `as_of`/strategy pass-through, boundary validation, and fallback-on-error.

## Verification
- `npm run check` (tsc): 0 new errors; only the 5 pre-existing ioredis/bullmq module-resolution errors remain.
- `npx vitest run --project unit`: **165 files / 4024 tests GREEN** (baseline 162/3991 + 3 files / +33 tests).
- New-logic coverage: provider 100% lines, connection 80.5% lines (only the live-transport `connectOmniscience` block uncovered — needs a real MCP server), overall 92%+.
- Integration project not run locally (`ioredis` absent in the local symlink — env-only, runs in CI).

## Related
- ADR: `docs/decisions/memory-architecture.md` (Track A)
- Omniscience ADR 0004 (`search` contract), ADR 0015 (multiqlti as MCP consumer)

DO NOT MERGE until Omniscience `search` is verified in staging (per ADR rollout).