### PR TITLE
feat: discover chat models live from provider CLIs

### DIFF
--- a/client/src/hooks/use-pipeline.ts
+++ b/client/src/hooks/use-pipeline.ts
@@ -260,6 +260,10 @@ export function useStandaloneChat() {
     mutationFn: (data: {
       content: string;
       modelSlug?: string;
+      /** Explicit provider key for live-discovered models (no DB row). */
+      provider?: string;
+      /** Explicit provider-native model id/label for live-discovered models. */
+      modelId?: string;
       history?: Array<{ role: string; content: string }>;
     }) => apiRequest("POST", "/api/chat/standalone", data),
   });

--- a/client/src/pages/Chat.tsx
+++ b/client/src/pages/Chat.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Send, Bot, User, Settings2 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useModels, useStandaloneChat, useGatewayStatus } from "@/hooks/use-pipeline";
+import { useDiscoverProviderModels, useStandaloneChat } from "@/hooks/use-pipeline";
 
 interface ChatMsg {
   role: string;
@@ -37,27 +37,48 @@ const DEFAULT_GREETING: ChatMsg = {
   content: "Local environment initialized. Sandboxes are active. I am restricted from external network access. How can I help you today?",
 };
 
-type GatewayStatus = Record<string, boolean | string | null>;
-type ModelRecord = Record<string, unknown>;
+/** A model as surfaced by /api/providers/discover (CLI + remote providers). */
+interface DiscoveredModel {
+  id: string;
+  name: string;
+  provider: string;
+  modelId?: string;
+  slug?: string;
+  contextLimit?: number;
+}
+type DiscoverResponse = Record<
+  string,
+  { available: boolean; models?: DiscoveredModel[]; error?: string }
+>;
 
-function isProviderAvailable(provider: string, gatewayStatus: GatewayStatus | undefined): boolean {
-  if (!gatewayStatus) return true; // not yet loaded — don't hide anything
-  if (provider === "mock") return true;
-  return !!gatewayStatus[provider];
+/** Flatten the per-provider discover payload into a deduped, selectable list. */
+function flattenDiscovered(data: DiscoverResponse | undefined): DiscoveredModel[] {
+  if (!data) return [];
+  const seen = new Set<string>();
+  const out: DiscoveredModel[] = [];
+  for (const group of Object.values(data)) {
+    if (!group?.available || !Array.isArray(group.models)) continue;
+    for (const m of group.models) {
+      const slug = m.slug ?? m.id;
+      if (!slug || seen.has(slug)) continue;
+      seen.add(slug);
+      out.push({ ...m, slug });
+    }
+  }
+  return out;
 }
 
 export default function Chat() {
-  const { data: models } = useModels();
-  const { data: gatewayStatus } = useGatewayStatus();
+  // Models are pulled live from the provider CLIs (claude, agy) via the gateway,
+  // not from the (stale) DB catalog — see /api/providers/discover.
+  const { data: discovered, isLoading: modelsLoading } = useDiscoverProviderModels();
   const chatMutation = useStandaloneChat();
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  // Only show active models whose provider is actually configured (has API key / endpoint)
-  const modelList: ModelRecord[] = Array.isArray(models)
-    ? models.filter((m: ModelRecord) =>
-        m.isActive && isProviderAvailable(m.provider as string, gatewayStatus as GatewayStatus)
-      )
-    : [];
+  const modelList: DiscoveredModel[] = useMemo(
+    () => flattenDiscovered(discovered as DiscoverResponse | undefined),
+    [discovered],
+  );
 
   const [selectedModel, setSelectedModel] = useState<string>("");
   const [messages, setMessages] = useState<ChatMsg[]>(() => {
@@ -70,17 +91,17 @@ export default function Chat() {
   // Set default model once models are loaded
   useEffect(() => {
     if (!selectedModel && modelList.length > 0) {
-      setSelectedModel(modelList[0].slug as string);
+      setSelectedModel(modelList[0].slug ?? "");
     }
   }, [modelList, selectedModel]);
 
-  // If the selected model's provider loses its key, switch to first available
+  // If the selected model disappears from the discovered list, fall back to the first.
   useEffect(() => {
-    if (selectedModel && gatewayStatus && modelList.length > 0) {
-      const still = modelList.find((m) => (m.slug as string) === selectedModel);
-      if (!still) setSelectedModel(modelList[0].slug as string);
+    if (selectedModel && modelList.length > 0) {
+      const still = modelList.find((m) => m.slug === selectedModel);
+      if (!still) setSelectedModel(modelList[0].slug ?? "");
     }
-  }, [modelList, selectedModel, gatewayStatus]);
+  }, [modelList, selectedModel]);
 
   // Reset token counter when switching models
   useEffect(() => {
@@ -99,9 +120,9 @@ export default function Chat() {
     }
   }, [messages]);
 
-  const selectedModelData = modelList.find((m) => (m.slug as string) === selectedModel);
-  const contextLimit = (selectedModelData?.contextLimit as number) ?? 0;
-  const noModelsAvailable = !!gatewayStatus && modelList.length === 0;
+  const selectedModelData = modelList.find((m) => m.slug === selectedModel);
+  const contextLimit = selectedModelData?.contextLimit ?? 0;
+  const noModelsAvailable = !modelsLoading && modelList.length === 0;
   const canSend = !!selectedModel && !chatMutation.isPending && !!input.trim() && !noModelsAvailable;
 
   const handleSend = () => {
@@ -115,6 +136,8 @@ export default function Chat() {
       {
         content: input,
         modelSlug: selectedModel,
+        provider: selectedModelData?.provider,
+        modelId: selectedModelData?.modelId ?? selectedModelData?.id,
         history: updatedMessages.slice(-10),
       },
       {
@@ -174,9 +197,9 @@ export default function Chat() {
             </SelectTrigger>
             <SelectContent>
               {modelList.map((m) => (
-                <SelectItem key={m.slug as string} value={m.slug as string}>
-                  {m.name as string}
-                  <span className="text-muted-foreground ml-1">({m.provider as string})</span>
+                <SelectItem key={m.slug} value={m.slug ?? m.id}>
+                  {m.name}
+                  <span className="text-muted-foreground ml-1">({m.provider})</span>
                 </SelectItem>
               ))}
             </SelectContent>

--- a/server/gateway/index.ts
+++ b/server/gateway/index.ts
@@ -245,8 +245,9 @@ export class Gateway {
     loggingOptions?: GatewayLoggingOptions,
   ): Promise<GatewayResponse> {
     const model = await this.storage.getModelBySlug(request.modelSlug);
-    const providerKey = model?.provider ?? "mock";
-    const modelId = model?.modelId ?? model?.name ?? request.modelSlug;
+    // Explicit provider/modelId (live-discovered CLI models) win over the DB row.
+    const providerKey = request.provider ?? model?.provider ?? "mock";
+    const modelId = request.modelId ?? model?.modelId ?? model?.name ?? request.modelSlug;
 
     const provider = this.getProvider(providerKey);
 
@@ -357,8 +358,9 @@ export class Gateway {
     privacyOptions?: GatewayPrivacyOptions,
   ): AsyncGenerator<string> {
     const model = await this.storage.getModelBySlug(request.modelSlug);
-    const providerKey = model?.provider ?? "mock";
-    const modelId = model?.modelId ?? model?.name ?? request.modelSlug;
+    // Explicit provider/modelId (live-discovered CLI models) win over the DB row.
+    const providerKey = request.provider ?? model?.provider ?? "mock";
+    const modelId = request.modelId ?? model?.modelId ?? model?.name ?? request.modelSlug;
 
     const provider = this.getProvider(providerKey);
 
@@ -433,14 +435,28 @@ export class Gateway {
 
   async discoverModels(): Promise<Record<string, { available: boolean; models: unknown[]; error?: string }>> {
     const results: Record<string, { available: boolean; models: unknown[]; error?: string }> = {};
+    // Some provider instances are registered under multiple keys (e.g. the
+    // Antigravity provider is mirrored onto "google"). Cache by instance so we
+    // only spawn the CLI once and reuse the result across its aliases.
+    const cache = new Map<ILLMProvider, { models: unknown[]; error?: string }>();
 
     for (const [key, provider] of this.registry.entries()) {
       results[key] = { available: true, models: [] };
       if ("listModels" in provider && typeof (provider as unknown as { listModels: unknown }).listModels === "function") {
+        const cached = cache.get(provider);
+        if (cached) {
+          results[key].models = cached.models;
+          if (cached.error) results[key].error = cached.error;
+          continue;
+        }
         try {
-          results[key].models = await (provider as unknown as { listModels: () => Promise<unknown[]> }).listModels();
+          const models = await (provider as unknown as { listModels: () => Promise<unknown[]> }).listModels();
+          results[key].models = models;
+          cache.set(provider, { models });
         } catch (e) {
-          results[key].error = (e as Error).message;
+          const error = (e as Error).message;
+          results[key].error = error;
+          cache.set(provider, { models: [], error });
         }
       }
     }
@@ -455,6 +471,10 @@ export class Gateway {
    */
   async completeWithTools(params: {
     modelSlug: string;
+    /** Explicit provider key — wins over the DB lookup (live-discovered models). */
+    provider?: string;
+    /** Explicit provider-native model id/label — wins over the DB lookup. */
+    modelId?: string;
     messages: ProviderMessage[];
     tools: ToolDefinition[];
     options?: ILLMProviderOptions;
@@ -472,8 +492,9 @@ export class Gateway {
     const toolCallLog: ToolCallLogEntry[] = [];
 
     const model = await this.storage.getModelBySlug(modelSlug);
-    const providerKey = model?.provider ?? 'mock';
-    const modelId = model?.modelId ?? model?.name ?? modelSlug;
+    // Explicit provider/modelId (live-discovered CLI models) win over the DB row.
+    const providerKey = params.provider ?? model?.provider ?? 'mock';
+    const modelId = params.modelId ?? model?.modelId ?? model?.name ?? modelSlug;
     const provider = this.getProvider(providerKey);
 
     let messages: ProviderMessage[] = [...params.messages];

--- a/server/gateway/providers/antigravity-cli.ts
+++ b/server/gateway/providers/antigravity-cli.ts
@@ -174,3 +174,43 @@ export async function invokeAntigravityCli(
     releaseSlot();
   }
 }
+
+/**
+ * List the subscription model labels exposed by `agy models`.
+ *
+ * Output is one model label per line, e.g.
+ *   Gemini 3.5 Flash (Medium)
+ *   Claude Sonnet 4.6 (Thinking)
+ * Returned verbatim (trimmed, blanks dropped); each label is what the provider
+ * later passes back via `--model=<label>`.
+ */
+export async function listAntigravityModels(
+  binPath: string,
+  timeoutMs: number = DEFAULT_ANTIGRAVITY_TIMEOUT_MS,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  await acquireSlot();
+  try {
+    return await new Promise<string[]>((resolve, reject) => {
+      const child = execFile(
+        binPath,
+        ["models"],
+        { timeout: timeoutMs, maxBuffer: MAX_OUTPUT_BYTES, signal, shell: false },
+        (err, stdout, stderr) => {
+          if (err) {
+            reject(toCliError(err as NodeJS.ErrnoException, stderr ?? ""));
+            return;
+          }
+          const labels = (stdout ?? "")
+            .split("\n")
+            .map((line) => line.trim())
+            .filter((line) => line.length > 0);
+          resolve(labels);
+        },
+      );
+      child.stdin?.end();
+    });
+  } finally {
+    releaseSlot();
+  }
+}

--- a/server/gateway/providers/antigravity.ts
+++ b/server/gateway/providers/antigravity.ts
@@ -21,11 +21,21 @@ import type {
 } from "@shared/types";
 import {
   invokeAntigravityCli,
+  listAntigravityModels,
   AntigravityCliError,
   DEFAULT_ANTIGRAVITY_BIN,
   DEFAULT_ANTIGRAVITY_MODEL,
   DEFAULT_ANTIGRAVITY_TIMEOUT_MS,
 } from "./antigravity-cli";
+import type { RemoteModel } from "./ollama";
+
+/** Turn a CLI model label into a stable, URL-safe slug. */
+function slugifyModelLabel(label: string): string {
+  return label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
 
 /** Rough characters-per-token ratio for estimating usage from byte counts. */
 const CHARS_PER_TOKEN = 4;
@@ -105,5 +115,21 @@ export class AntigravityProvider implements ILLMProvider {
   ): AsyncGenerator<string> {
     const { content } = await this.complete(modelId, messages, options);
     if (content.length > 0) yield content;
+  }
+
+  /**
+   * List the subscription models reported by `agy models`. The label is used
+   * verbatim as the `modelId` (passed back via `--model=<label>`); a derived
+   * slug gives the client a stable identifier without a DB row.
+   */
+  async listModels(): Promise<RemoteModel[]> {
+    const labels = await listAntigravityModels(this.binPath, this.timeoutMs);
+    return labels.map((label) => ({
+      id: label,
+      name: label,
+      provider: "antigravity",
+      modelId: label,
+      slug: slugifyModelLabel(label),
+    }));
   }
 }

--- a/server/gateway/providers/claude-cli.ts
+++ b/server/gateway/providers/claude-cli.ts
@@ -23,11 +23,28 @@ import {
   streamCliLines,
   type CliSpawnRequest,
 } from "./cli-spawn";
+import type { RemoteModel } from "./ollama";
 
 const DEFAULT_BINARY = "claude";
 const DEFAULT_TIMEOUT_MS = 120_000;
 const DEFAULT_MAX_CONCURRENCY = 4;
 const ERROR_PREVIEW_CHARS = 200;
+
+/**
+ * Curated current Claude models surfaced through the subscription CLI. The CLI
+ * accepts short aliases (`opus`/`sonnet`/`haiku`) that always resolve to the
+ * latest build, so these `modelId`s stay valid across point releases.
+ */
+const CLAUDE_MODELS: ReadonlyArray<{
+  modelId: string;
+  slug: string;
+  name: string;
+  contextLimit: number;
+}> = [
+  { modelId: "opus", slug: "claude-opus", name: "Claude Opus", contextLimit: 200_000 },
+  { modelId: "sonnet", slug: "claude-sonnet", name: "Claude Sonnet", contextLimit: 200_000 },
+  { modelId: "haiku", slug: "claude-haiku", name: "Claude Haiku", contextLimit: 200_000 },
+];
 
 interface ClaudeCliResult {
   type: string;
@@ -185,5 +202,21 @@ export class ClaudeCliProvider implements ILLMProvider {
       }
       previous = full;
     }
+  }
+
+  /**
+   * The `claude` CLI has no model-listing command, so we expose a curated set
+   * of current models. `modelId` is an alias the CLI resolves to the latest
+   * build (so this list does not go stale as point releases ship).
+   */
+  async listModels(): Promise<RemoteModel[]> {
+    return CLAUDE_MODELS.map((m) => ({
+      id: m.modelId,
+      name: m.name,
+      provider: "anthropic",
+      modelId: m.modelId,
+      slug: m.slug,
+      contextLimit: m.contextLimit,
+    }));
   }
 }

--- a/server/gateway/providers/ollama.ts
+++ b/server/gateway/providers/ollama.ts
@@ -1,11 +1,17 @@
 export interface RemoteModel {
   id: string;
   name: string;
-  provider: "ollama";
+  provider: string;
   size?: number;
   parameterSize?: string;
   quantization?: string;
   family?: string;
+  /** Provider-native model id/label to pass back when invoking (CLI providers). */
+  modelId?: string;
+  /** Stable client-facing slug (CLI providers, which have no DB row). */
+  slug?: string;
+  /** Context window size, when known. */
+  contextLimit?: number;
 }
 
 export class OllamaProvider {

--- a/server/routes/chat.ts
+++ b/server/routes/chat.ts
@@ -43,20 +43,30 @@ const GetChatMessagesQuerySchema = z.object({
   limit: z.coerce.number().int().positive().max(500).optional(),
 });
 
+// Optional explicit routing for live-discovered models that have no DB row.
+const ProviderField = z.string().max(100).optional();
+const ModelIdField = z.string().max(200).optional();
+
 const SendChatSchema = z.object({
   content: z.string().min(1, "content is required").max(50000),
   modelSlug: z.string().max(200).optional(),
+  provider: ProviderField,
+  modelId: ModelIdField,
 });
 
 const StandaloneChatSchema = z.object({
   content: z.string().min(1, "content is required").max(50000),
   modelSlug: z.string().max(200).optional(),
+  provider: ProviderField,
+  modelId: ModelIdField,
   history: z.array(HistoryMessageSchema).max(100).optional(),
 });
 
 const StreamChatSchema = z.object({
   content: z.string().min(1, "content is required").max(50000),
   modelSlug: z.string().max(200).optional(),
+  provider: ProviderField,
+  modelId: ModelIdField,
   history: z.array(HistoryMessageSchema).max(100).optional(),
 });
 
@@ -178,6 +188,8 @@ export function registerChatRoutes(
     const tools = getPlatformToolDefinitions(userRole);
     const response = await gateway.completeWithTools({
       modelSlug: slug,
+      provider: body.provider,
+      modelId: body.modelId,
       messages,
       tools,
     });
@@ -211,7 +223,12 @@ export function registerChatRoutes(
     res.setHeader("Connection", "keep-alive");
 
     try {
-      for await (const chunk of gateway.stream({ modelSlug: slug, messages })) {
+      for await (const chunk of gateway.stream({
+        modelSlug: slug,
+        provider: body.provider,
+        modelId: body.modelId,
+        messages,
+      })) {
         res.write(`data: ${JSON.stringify({ chunk })}\n\n`);
       }
       res.write(`data: ${JSON.stringify({ done: true })}\n\n`);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -531,6 +531,14 @@ export interface GatewayRequest {
   stream?: boolean;
   /** Per-request timeout override in milliseconds */
   timeoutMs?: number;
+  /**
+   * Explicit provider key (e.g. "antigravity", "anthropic"). When set, it wins
+   * over the DB model lookup — used by live-discovered models that are not
+   * persisted in the `models` table.
+   */
+  provider?: string;
+  /** Explicit provider-native model id/label. Wins over the DB lookup. */
+  modelId?: string;
 }
 
 export interface GatewayResponse {


### PR DESCRIPTION
## Summary
The chat model dropdown showed a **stale hardcoded catalog** (old Claude/Gemini ids). This pulls the model list **live from the provider CLIs** so it reflects what the subscription actually offers.

## Changes
- `AntigravityProvider.listModels()` parses `agy models` (Gemini/Claude/GPT-OSS); `ClaudeCliProvider` exposes a curated current set (the `claude` CLI has no list command — uses stable aliases that don't go stale).
- `gateway.discoverModels()` dedupes provider instances registered under multiple keys (Antigravity is mirrored onto `google`) so the CLI is spawned once.
- Thread explicit `provider` + `modelId` through `GatewayRequest` and the chat routes so **live-discovered models resolve without a DB row** (DB lookup remains the fallback).
- Chat UI consumes `/api/providers/discover`, flattens + dedupes by slug, and sends `provider`+`modelId` on send.

## Test plan
- [x] `npx tsc --noEmit`
- [x] Manual: `agy models` parsed into provider/Gemini/Claude/GPT-OSS entries; `/api/providers/discover` returns the live set (auth-gated).
- [ ] Verify in UI: chat dropdown lists live CLI models.

## Notes
Independent of the active-knowledge-base PR (#357); disjoint file set.