### PR TITLE
chore: host dev workflow + macOS reusePort fix + pgvector image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,65 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# multiqlti — host-dev workflow
+#
+# Infra (Postgres + Redis) runs in Docker; the multiqlti SERVER runs on the host
+# so the `claude` (anthropic CLI mode) and `agy` (antigravity) providers — which
+# are host-installed binaries — are reachable. Running the server inside the
+# Linux container fails: it can't see the host PATH, and `agy` is a macOS-native
+# binary that won't execute there.
+#
+# Full manual: docs/DEPLOYMENT_HOST.md
+#
+# Typical flow:   make infra-up   →   make dev
+# ─────────────────────────────────────────────────────────────────────────────
+
+SHELL   := /bin/bash
+COMPOSE := docker compose
+INFRA   := postgres redis
+
+.DEFAULT_GOAL := help
+
+.PHONY: help doctor infra-up infra-down infra-restart infra-logs ps dev run start build clean nuke
+
+help: ## Show this help
+	@echo "multiqlti — infra in Docker, server on host. Targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-14s\033[0m %s\n",$$1,$$2}'
+
+doctor: ## Check host prerequisites (claude, agy, node) and infra ports
+	@command -v claude >/dev/null 2>&1 && echo "claude     : $$(claude --version 2>/dev/null)" || echo "claude     : MISSING (anthropic CLI provider will fail)"
+	@command -v agy    >/dev/null 2>&1 && echo "agy        : $$(agy --version 2>/dev/null)"    || echo "agy        : MISSING (antigravity provider will fail)"
+	@command -v node   >/dev/null 2>&1 && echo "node       : $$(node -v)"                      || echo "node       : MISSING"
+	@command -v docker >/dev/null 2>&1 && (docker info >/dev/null 2>&1 && echo "docker     : daemon up" || echo "docker     : daemon DOWN") || echo "docker     : MISSING"
+	@nc -z localhost 5432 2>/dev/null && echo "pg :5432   : open"    || echo "pg :5432   : closed  (run 'make infra-up')"
+	@nc -z localhost 6379 2>/dev/null && echo "redis :6379: open"    || echo "redis :6379: closed  (run 'make infra-up')"
+
+infra-up: ## Start ONLY the infra (Postgres + Redis) in Docker
+	$(COMPOSE) up -d $(INFRA)
+
+infra-down: ## Stop the infra containers (data volumes are preserved)
+	$(COMPOSE) stop $(INFRA)
+
+infra-restart: infra-down infra-up ## Restart the infra containers
+
+infra-logs: ## Tail the infra container logs
+	$(COMPOSE) logs -f $(INFRA)
+
+ps: ## Show container status
+	$(COMPOSE) ps
+
+dev: ## Run the server on the host in dev mode (hot reload) — needs `make infra-up`
+	./scripts/dev-host.sh dev
+
+run: dev ## Alias for `dev`
+
+start: ## Build + run the production bundle on the host — needs `make infra-up`
+	./scripts/dev-host.sh start
+
+build: ## Build the production bundle only (no run)
+	npm run build
+
+clean: ## Stop and remove infra containers (volumes/data preserved)
+	$(COMPOSE) down
+
+nuke: ## Stop and remove infra containers AND delete data volumes (DESTRUCTIVE)
+	$(COMPOSE) down -v

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
 
   # ── PostgreSQL ──────────────────────────────────────────────────────────────
   postgres:
-    image: postgres:16-alpine
+    image: pgvector/pgvector:pg16
     profiles: [full, cloud-only, dev]
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-multiqlti}

--- a/docs/DEPLOYMENT_HOST.md
+++ b/docs/DEPLOYMENT_HOST.md
@@ -1,0 +1,174 @@
+# Host deployment — server on host, infra in Docker
+
+This is the deployment mode to use **on a developer machine (macOS) where the
+`claude` and `agy` CLIs are installed**. The multiqlti server runs directly on
+the host; only Postgres and Redis run in Docker.
+
+For the fully containerised production setup see
+[DEPLOYMENT_DOCKER.md](DEPLOYMENT_DOCKER.md); for Kubernetes see
+[DEPLOYMENT_K8S.md](DEPLOYMENT_K8S.md).
+
+---
+
+## Why the server cannot run in Docker here
+
+multiqlti's default LLM providers do **not** call a cloud HTTP API — they shell
+out to **locally installed CLI binaries**:
+
+| Provider key            | Default                        | Spawns binary | Auth source                     |
+| ----------------------- | ------------------------------ | ------------- | ------------------------------- |
+| `anthropic`             | `mode: "cli"`                  | `claude`      | `~/.claude` (host login)        |
+| `antigravity` / `google`| `enabled: true`                | `agy`         | `~/.gemini/antigravity-cli`     |
+
+- `server/gateway/providers/claude-cli.ts` → `spawn("claude", …)`
+- `server/gateway/providers/antigravity-cli.ts` → `execFile("agy", …)`
+
+The production image (`Dockerfile`) is `node:20-alpine` with only `git` added —
+neither binary exists inside it. A container also has its own filesystem and
+PATH, so it can never see the host's `~/.local/bin/claude` / `~/.local/bin/agy`.
+Worse, **`agy` is a macOS-native binary** and would not execute inside a Linux
+container even if mounted. Hence the server must run on the host, where both
+binaries and their auth live.
+
+Symptom when run in Docker:
+
+```
+Error: CLI binary "claude" is not installed or not on PATH
+Error: Antigravity CLI binary not found on PATH. Install Antigravity and run `agy install`.
+```
+
+---
+
+## Prerequisites
+
+- Node.js (the repo's `node_modules` already installed via `npm install`)
+- Docker (daemon running)
+- `claude` on PATH and logged in — verify: `claude --version`
+- `agy` on PATH and logged in — verify: `agy --version`
+- A populated `.env` (copy from `.env.example`; needs at least
+  `POSTGRES_PASSWORD` and `JWT_SECRET`)
+
+Run the built-in check:
+
+```bash
+make doctor
+```
+
+Example healthy output:
+
+```
+claude     : 2.1.167 (Claude Code)
+agy        : 1.0.5
+node       : v26.0.0
+docker     : daemon up
+pg :5432   : open
+redis :6379: open
+```
+
+---
+
+## Quick start
+
+```bash
+cd project/multiqlti
+
+make infra-up    # start ONLY Postgres + Redis in Docker
+make dev         # run the server on the host (hot reload)
+```
+
+The server listens on `http://localhost:${APP_PORT}` (default **5050**, from
+`.env`). Open it directly — there is no Caddy in front in this mode.
+
+To stop:
+
+```bash
+make infra-down  # stop the containers (data preserved)
+```
+
+---
+
+## How it is wired
+
+Two host-local files (both gitignored) make this work:
+
+### `docker-compose.override.yml`
+
+Auto-loaded by `docker compose` next to `docker-compose.yml`. It publishes the
+Postgres port to the host so the host-run server can connect (Redis already
+publishes `6379`):
+
+```yaml
+services:
+  postgres:
+    ports:
+      - "5432:5432"
+```
+
+The base `multiqlti` and `caddy` services have `profiles:` set, so they only
+start when their profile is active. `make infra-up` runs
+`docker compose up -d postgres redis` — naming the services explicitly starts
+**only** those two, leaving the app/caddy services down.
+
+### `scripts/dev-host.sh`
+
+Launches the server on the host. It:
+
+1. Sources `.env` (the Node app has no `dotenv` dependency, so env must be
+   exported explicitly).
+2. Overrides the in-container hostnames with host-published ports:
+   - `DATABASE_URL` → `postgres://…@localhost:5432/…`
+   - `REDIS_URL`    → `redis://localhost:6379`
+   - `PORT`         → `${APP_PORT:-5050}`
+3. Warns if `claude` / `agy` are missing from PATH.
+4. Runs the server. Mode is selected by an optional argument:
+   - `./scripts/dev-host.sh dev` — hot-reload dev server (`npm run dev`)
+   - `./scripts/dev-host.sh start` — build, then run the prod bundle (`npm start`)
+
+---
+
+## Makefile reference
+
+| Target           | Description                                                            |
+| ---------------- | ---------------------------------------------------------------------- |
+| `make help`      | List all targets (default goal)                                        |
+| `make doctor`    | Check host prerequisites (`claude`, `agy`, `node`, docker, infra ports)|
+| `make infra-up`  | Start only Postgres + Redis in Docker                                  |
+| `make infra-down`| Stop the infra containers (data preserved)                             |
+| `make infra-restart` | Restart the infra containers                                       |
+| `make infra-logs`| Tail the infra container logs                                          |
+| `make ps`        | Show container status                                                  |
+| `make dev`       | Run the server on the host in dev mode (hot reload)                    |
+| `make run`       | Alias for `make dev`                                                    |
+| `make start`     | Build + run the production bundle on the host                          |
+| `make build`     | Build the production bundle only (no run)                              |
+| `make clean`     | `docker compose down` (data volumes preserved)                         |
+| `make nuke`      | `docker compose down -v` — **deletes data volumes (destructive)**      |
+
+---
+
+## Production / containerised alternative
+
+If you do **not** need the subscription CLIs (e.g. CI, a Linux server), switch
+the two providers to their HTTP API paths instead and run everything in Docker
+per [DEPLOYMENT_DOCKER.md](DEPLOYMENT_DOCKER.md):
+
+- Anthropic via API: set `providers.anthropic.mode: "api"` (env
+  `MULTI_PROVIDERS_ANTHROPIC_MODE=api`) and provide `ANTHROPIC_API_KEY`.
+- Gemini via API: disable Antigravity (`ANTIGRAVITY_ENABLED=false`) and set
+  `GOOGLE_API_KEY`.
+
+This trades the zero-token subscription access for billed API usage, but needs
+no host binaries.
+
+---
+
+## Troubleshooting
+
+| Symptom                                              | Cause / fix                                                                 |
+| ---------------------------------------------------- | --------------------------------------------------------------------------- |
+| `CLI binary "claude" is not installed`               | You're running the server in Docker, or `claude` not on PATH. Run on host; `make doctor`. |
+| `Antigravity CLI binary not found`                   | Same as above for `agy`. `agy` cannot run in a Linux container at all.       |
+| `... is not logged in` / `unauthorized`              | Run `claude` / `agy` once interactively on the host to authenticate.        |
+| Server starts but DB calls fail / MemStorage mode    | `DATABASE_URL` not reaching the app, or `make infra-up` not run. Check `make doctor` ports. |
+| `pg :5432 closed`                                    | Run `make infra-up`; confirm `docker-compose.override.yml` publishes 5432.   |
+| Port 5050 already in use                             | Change `APP_PORT` in `.env`.                                                 |

--- a/scripts/dev-host.sh
+++ b/scripts/dev-host.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Run the multiqlti server ON THE HOST (not in Docker).
+#
+# Why: the `anthropic` provider runs in CLI mode (spawns `claude`) and the
+# `antigravity` provider spawns `agy`. Both are host-installed binaries with
+# host-side auth (~/.claude, ~/.gemini/antigravity-cli). A Linux container
+# cannot see them on its PATH, and `agy` is a macOS-native binary that would
+# not execute inside the container anyway. So the server has to run on the host.
+#
+# Infra (Postgres + Redis) still runs in Docker. Start it first:
+#     docker compose up -d postgres redis
+#
+# Then run this script from the multiqlti root:
+#     ./scripts/dev-host.sh
+#
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# ── Load .env (the same file docker compose uses) so we reuse its secrets ──────
+# The Node app does NOT auto-load .env (no dotenv dependency), so we export it
+# here for the host process.
+if [ -f .env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ./.env
+  set +a
+fi
+
+# ── Point the app at the Dockerised infra via host-published ports ────────────
+# Inside Docker the app reaches the DB at host `postgres`; on the host that name
+# does not resolve, so override it to localhost:5432 (published by the override
+# compose file). Same for Redis on localhost:6379.
+export DATABASE_URL="postgres://${POSTGRES_USER:-multiqlti}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@localhost:5432/${POSTGRES_DB:-multiqlti}"
+export REDIS_URL="redis://localhost:6379"
+export PORT="${APP_PORT:-5050}"
+
+# ── Verify the CLI providers' binaries are reachable on the host PATH ─────────
+missing=0
+if ! command -v claude >/dev/null 2>&1; then
+  echo "WARN: 'claude' not on PATH — the anthropic (CLI mode) provider will fail." >&2
+  missing=1
+fi
+if ! command -v agy >/dev/null 2>&1; then
+  echo "WARN: 'agy' not on PATH — the antigravity provider will fail." >&2
+  missing=1
+fi
+[ "$missing" -eq 0 ] && echo "OK: claude + agy found on PATH."
+
+# ── Launch ────────────────────────────────────────────────────────────────────
+# Optional arg selects the run mode:
+#   (none) | dev  → hot-reload dev server (tsx)
+#   start         → build the production bundle, then run it (node dist/index.cjs)
+MODE="${1:-dev}"
+case "$MODE" in
+  dev)
+    echo "Starting multiqlti [dev] on http://localhost:${PORT} (DB: localhost:5432, Redis: localhost:6379)"
+    exec npm run dev
+    ;;
+  start)
+    echo "Building, then starting multiqlti [prod] on http://localhost:${PORT} (DB: localhost:5432, Redis: localhost:6379)"
+    npm run build
+    exec npm start
+    ;;
+  *)
+    echo "Usage: $0 [dev|start]" >&2
+    exit 2
+    ;;
+esac

--- a/server/index.ts
+++ b/server/index.ts
@@ -137,7 +137,10 @@ export { getFederationManager };
     {
       port,
       host: "0.0.0.0",
-      ...(config.server.nodeEnv === "production" && { reusePort: true }),
+      // SO_REUSEPORT is unsupported on macOS (listen throws ENOTSUP), so only
+      // enable it for production on non-Darwin hosts (Linux containers/k8s).
+      ...(config.server.nodeEnv === "production" &&
+        process.platform !== "darwin" && { reusePort: true }),
     },
     () => {
       log(`serving on port ${port}`);


### PR DESCRIPTION
## Summary
Run the multiqlti **server on the host** (so the CLI-backed providers `claude` and `agy` are reachable — a Linux container can't see them, and `agy` is a macOS-native binary) while **infra stays in Docker**.

## Changes
- **`Makefile`** + **`scripts/dev-host.sh`**: `make infra-up` boots Postgres+Redis in Docker; `make dev`/`make start` run the server on the host with host-published DB/Redis ports; `make doctor` checks prerequisites. dev-host.sh loads `.env`, points the app at `localhost` infra, verifies `claude`/`agy` on PATH.
- **`server/index.ts`**: only set `SO_REUSEPORT` in production on **non-Darwin** hosts — it throws `ENOTSUP` on macOS and broke host runs.
- **`docker-compose.yml`**: postgres image → `pgvector/pgvector:pg16` (pgvector is required by the RAG/embeddings store).
- **`docs/DEPLOYMENT_HOST.md`**: the host workflow guide (why + how + troubleshooting).

## Test plan
- [x] `make doctor` reports claude/agy/node/docker + infra ports
- [x] `make infra-up && make start` → server boots on host, migrations/health OK
- [x] `npm run build` + prod start succeeds on macOS (reusePort no longer throws)

## Notes
Independent of #357 (knowledge base) and #359 (model discovery); disjoint file set. `docker-compose.override.yml` (host-local) stays gitignored.