### PR TITLE
feat: stream CLI-backed pipeline stages (fixes the 120s stage timeout)

### DIFF
--- a/docs/design/streaming-stage-execution.md
+++ b/docs/design/streaming-stage-execution.md
@@ -1,0 +1,303 @@
+# Design: Streaming Stage Execution + Long-Call Timeout Policy
+
+- **Status**: Proposed (DESIGN phase — no implementation in this doc)
+- **Branch**: `feature/streaming-stage-execution`
+- **Author**: solution-architect
+- **Date**: 2026-06-09
+- **Related**: provider allowlist work (subscription CLIs only — `feature/limit-providers-to-cli`), which put real `claude`/`agy` models on the SDLC stage hot path and surfaced this bug.
+
+## 1. Context & Problem (proven-live)
+
+SDLC pipeline stages execute LLM calls through the gateway using **blocking** `complete()` / `completeWithTools()`. CLI-backed providers shell out via `spawnCli()` with `DEFAULT_TIMEOUT_MS = 120_000` (`server/gateway/providers/cli-spawn.ts:17`). A real subscription-CLI model (`claude -p`, `agy --print`) on a substantial planning prompt routinely exceeds 120s of wall-clock for a SINGLE blocking call, so the stage fails with:
+
+```
+CLI timed out after 120000ms
+```
+
+Observed: run `6078ba0b` failed at stage 0 (planning). Because the planning team has tools enabled by default (`DEFAULT_TEAM_TOOLS.planning = ['web_search','knowledge_search','memory_search']`, `server/teams/base.ts:11`), stage 0 goes through `completeWithTools()` → `provider.complete()` → blocking `spawnCli` → 120s cap → failure. **multiqlti currently cannot complete ANY real-model SDLC task.**
+
+The 120s wall-clock cap is the wrong model for a long, legitimately-running streamed LLM call: a planning turn can stream tokens for minutes while making continuous progress. We need to (a) stream the stage call so output arrives incrementally, and (b) replace the single wall-clock cap **on the stage path only** with an **idle (inactivity) timeout + a generous overall cap**.
+
+### Why this is safe to scope narrowly
+
+The 120s blocking `spawnCli` default is correct for *short* callers (e.g. `Gateway.testProvider()`, `server/gateway/index.ts:423` — a `"ping"` health check; and `agy models` / `claude` model discovery). Those MUST keep the existing blocking path and short default. Only the **pipeline stage** call path changes.
+
+## 2. Call-Site Map (where stages drive the gateway)
+
+### 2.1 The single chokepoint — `BaseTeam.execute()`
+
+Every pipeline stage converges on `BaseTeam.execute()` (`server/teams/base.ts:41`). Both orchestration paths call it:
+
+| Orchestration path | File:line | Calls |
+| --- | --- | --- |
+| DAG executor stage fn | `server/controller/pipeline-controller.ts:280` | `team.execute(stageInput, context, dagStage.executionStrategy)` |
+| Linear `executeStages` (swarm-off branch) | `server/controller/pipeline-controller.ts:756` | `team.execute(...)` |
+| Linear `executeStages` (parallel-null branch) | `server/controller/pipeline-controller.ts:774` | `team.execute(...)` |
+| Parallel sub-task | `server/pipeline/parallel-executor.ts:300` | `team.execute(subtaskInput, subtaskContext)` |
+| Swarm agent | `server/pipeline/swarm-executor.ts:299` | `team.execute(...)` |
+| Delegation | `server/pipeline/delegation-service.ts:115` | `team.execute(...)` |
+
+`BaseTeam.execute()` → `executeSingleModel()` (`server/teams/base.ts:57`) makes the actual gateway call, choosing between two blocking entry points:
+
+- **Tool path** (`base.ts:78`): `gateway.completeWithTools({...})` — used when the team/stage has tools (planning, architecture, development, code_review, deployment, monitoring all have defaults). **This is the path stage 0 takes and where the failure occurs.**
+- **Plain path** (`base.ts:113`): `gateway.complete({...})` — used when no tools are enabled (e.g. a stage that disabled tools).
+- **Strategy path** (`base.ts:146`): `executeWithStrategy()` → `StrategyExecutor` → many `gateway.complete()` calls (`server/services/strategy-executor.ts:84,118,155,215,256,290,340`). Each of those is a stage-originated LLM call too.
+
+### 2.2 Gateway entry points (blocking today)
+
+- `Gateway.complete()` — `server/gateway/index.ts:260`; calls `provider.complete(modelId, messages, {...})` at `index.ts:314`.
+- `Gateway.completeWithTools()` — `server/gateway/index.ts:500`; tool loop calling `provider.complete(...)` at `index.ts:538` (NO streaming today).
+- `Gateway.stream()` — `server/gateway/index.ts:374`; already streams, already consumed by chat/code-chat. **Reuse target.**
+
+### 2.3 Provider streaming primitives (reuse)
+
+- `ClaudeCliProvider.stream()` — `server/gateway/providers/claude-cli.ts:180`; runs `claude -p --output-format stream-json --verbose` via `streamCliLines()` and yields incremental text deltas from `assistant` events (`iterateStream()`, `claude-cli.ts:191`).
+- `streamCliLines()` — `cli-spawn.ts:185`; spawns, splits stdout into JSONL lines, honors `signal` + a single wall-clock `timeoutMs`. **The timeout here is what we extend to idle+overall.**
+- `AntigravityProvider.stream()` — `antigravity.ts:111`; emulated one-shot (yields the full completion once). Kept; its timeout must be made adequate (see §4.4).
+
+### 2.4 Existing streaming consumers (mirror this pattern)
+
+- `server/routes/chat.ts:226` — SSE: `for await (const chunk of gateway.stream({...})) res.write(...)`.
+- `server/workspace/code-chat.ts:100` — same accumulate-chunks pattern.
+- `server/routes/gateway.ts:84` — SSE passthrough.
+- `BaseTeam.executeStream()` (`server/teams/base.ts:168`) — **defined but currently consumed by NOBODY** in the pipeline. We will build the stage streaming path adjacent to it (see §3).
+
+### 2.5 Callers that must NOT change (keep blocking 120s)
+
+- `Gateway.testProvider()` — `server/gateway/index.ts:423` → `provider.complete(...)` (the `"ping"` health check).
+- Model discovery: `ClaudeCliProvider.listModels()` (`claude-cli.ts:212`), `listAntigravityModels()` (`antigravity-cli.ts:187`).
+- All non-stage `gateway.complete()` users that are inherently short.
+
+## 3. Design: Streaming Stage Execution
+
+### 3.1 New gateway methods (additive — do not change existing `complete`/`stream`)
+
+Add two streaming-aware gateway methods so the stage path consumes deltas while the existing `complete`/`completeWithTools`/`stream` keep their exact current behavior (backward-compat, §6).
+
+```
+Gateway.completeStreaming(
+  request: GatewayRequest,
+  privacyOptions?,
+  loggingOptions?,
+  streamOptions?: StageStreamOptions,   // { onDelta, signal, idleTimeoutMs, overallTimeoutMs, maxOutputBytes }
+): Promise<GatewayResponse>
+```
+
+- Resolves provider/model exactly like `complete()` (`index.ts:265-270`), runs the SAME budget pre-check (`index.ts:289`), anonymization (`index.ts:276`), and `logRequest()` (success+error) as `complete()`. DRY: extract the shared resolve/budget/anonymize/log scaffolding from `complete()` into private helpers and have both `complete()` and `completeStreaming()` use them.
+- Instead of `await provider.complete(...)`, it does:
+  ```
+  for await (const delta of provider.stream(modelId, messages, providerOpts)) {
+    accumulator.push(delta)      // bounded — see §5.2
+    streamOptions?.onDelta?.(delta, accumulator.length)
+  }
+  ```
+  then returns `{ content: accumulator.text(), tokensUsed, modelSlug, finishReason: "stop" }`. Token usage from streaming is not always available per-delta; record what the provider exposes (Claude CLI `result` event carries usage; Antigravity estimates from bytes) and fall back to a length-based estimate, mirroring `parseCompleteOutput` (`claude-cli.ts:106`). **Never silently zero it without a comment.**
+- `providerOpts` carries the **new** `idleTimeoutMs`, `overallTimeoutMs`, `maxOutputBytes`, and `signal` (see §4.1, §7).
+
+```
+Gateway.completeWithToolsStreaming(params, streamOptions?): Promise<{ content; tokensUsed; toolCallLog }>
+```
+
+- Same tool loop as `completeWithTools()` (`index.ts:500`), but **each assistant turn is obtained via streaming** rather than `provider.complete(...)`. See §3.3 for the interleaved tool-event handling — this is the load-bearing part.
+
+### 3.2 Stage path wiring
+
+`BaseTeam.executeSingleModel()` (`server/teams/base.ts:57`) is the only place that needs re-pointing:
+
+- **Tool path** (`base.ts:78`): `gateway.completeWithTools(...)` → `gateway.completeWithToolsStreaming(..., streamOptions)`.
+- **Plain path** (`base.ts:113`): `gateway.complete(...)` → `gateway.completeStreaming(..., streamOptions)`.
+- **Strategy path**: `StrategyExecutor` sub-calls re-point from `gateway.complete()` to `gateway.completeStreaming()` (same `streamOptions`), so long strategy stages also get the idle+overall policy. (Lower priority than the tool path; can be a follow-up task — see §8.)
+
+`streamOptions.onDelta` emits incremental WS progress (§3.4). `streamOptions.signal` is the run abort signal threaded from the controller (§3.5). The idle/overall/maxOutput values come from config (§4.2).
+
+`BaseTeam` gets the values from a new optional `StageContext.streaming` block (carrying `signal`, `onDelta`, and the resolved timeout/limit numbers), populated by the pipeline-controller when it builds `context`. The existing `executeStream()` (`base.ts:168`) stays for chat-style single-model streaming; the stage path uses the new accumulate-to-result methods because stages need the FULL assembled text + tool loop + the `TeamResult` shape, not a raw chunk generator.
+
+### 3.3 Tool loop while streaming (`claude -p stream-json` semantics)
+
+`claude -p --output-format stream-json --verbose` emits a JSONL event stream. The relevant event types for a tool-using turn:
+
+- `assistant` events whose `message.content` blocks may be `{type:"text"}` (assistant prose) and/or `{type:"tool_use", id, name, input}` (a tool call the model wants run).
+- a terminal `result` event (`subtype`, `is_error`, `result`, `usage`) — already parsed by `parseCompleteOutput` (`claude-cli.ts:106`).
+
+Current `ClaudeCliProvider.iterateStream()` (`claude-cli.ts:191`) extracts ONLY `text` blocks. For the streaming tool loop we need the provider to surface tool-use blocks AND text deltas AND the final usage. Design:
+
+1. **New provider streaming-events API (additive):** add `ClaudeCliProvider.streamEvents(modelId, messages, opts): AsyncGenerator<ProviderStreamEvent>` where
+   ```
+   type ProviderStreamEvent =
+     | { kind: "text-delta"; text: string }
+     | { kind: "tool-call"; call: ToolCall }
+     | { kind: "done"; tokensUsed: number; finishReason: "stop" | "tool_use" }
+   ```
+   This is built by extending the existing `iterateStream` JSONL parse: text blocks → `text-delta` (incremental, same prefix-diff logic as `claude-cli.ts:198`), `tool_use` blocks → `tool-call`, the `result` event → `done` with usage. Reuses `streamCliLines` + `parseLine` + `assistantText`; adds tool-block extraction.
+2. **`Gateway.completeWithToolsStreaming` loop** (mirrors `completeWithTools` `index.ts:532`):
+   - For each iteration, consume `provider.streamEvents(...)`:
+     - on `text-delta` → append to the turn's assistant text buffer and call `onDelta` (WS progress).
+     - on `tool-call` → collect into `pendingToolCalls`.
+     - on `done` → finishReason decides:
+       - if `finishReason !== "tool_use"` or no tool calls → return assembled content + accumulated `toolCallLog` (same exit as `index.ts:554`).
+       - else → push the assistant message (text + `toolCalls`), execute each tool via `toolRegistry.execute(call)` exactly as `index.ts:566-595` (incl. `workspaceDefaults` merge at `index.ts:569-578` and `toolCallLog` push at `index.ts:583`), append `tool` result messages, loop.
+   - `maxIterations` honored (`index.ts:519`, default 10) with the SAME terminal fallback (`index.ts:599-602`).
+3. **Provider capability fallback.** Providers whose `stream()` is emulated and have no tool channel (AntigravityProvider — `antigravity.ts` documents "tool calling is NOT supported", one-shot print) **cannot** do a streamed tool loop. `completeWithToolsStreaming` MUST detect "no `streamEvents` / no tool support" and fall back to the existing blocking `completeWithTools()` path for that provider, BUT run it under the new idle/overall timeout budget (Antigravity already accepts `options.timeoutMs` → set it to the overall cap). This keeps Antigravity working without a fake tool stream. Capability is detected via an optional `supportsStreamingToolLoop` flag / presence of `streamEvents` on the provider instance (duck-typed like the existing `"listModels" in provider` check at `index.ts:473`).
+
+> **Open question for the Lead (flagged in §9):** exact `tool_use` block shape and whether `claude -p stream-json` emits partial `input_json` deltas for tool args (streaming tool-argument assembly) vs a single complete `tool_use` block per `assistant` event. The design assumes **complete tool-use blocks per assistant event** (no partial-arg reassembly). If partial deltas occur, the provider layer must buffer tool-arg JSON until the block closes before emitting `tool-call`. This needs a quick empirical check against the installed CLI before implementation.
+
+### 3.4 WS progress over the EXISTING channel
+
+`stage:progress` already exists in the `WsEventType` union (`shared/types.ts:430`) and is currently **emitted by nobody** — a ready-made slot. No new channel.
+
+- The pipeline-controller passes an `onDelta` callback into `StageContext.streaming.onDelta` that calls the existing private `broadcast(runId, event)` (`pipeline-controller.ts:1163` → `wsManager.broadcastToRun`).
+- Event shape (conforms to `WsEvent`, `shared/types.ts`):
+  ```
+  { type: "stage:progress", runId, stageExecutionId,
+    payload: { stageIndex, teamId, deltaText, cumulativeChars }, timestamp }
+  ```
+- **Throttling/coalescing (memory + WS-flood safety):** do NOT emit one WS frame per token. Coalesce deltas and flush on a small interval (e.g. ~250ms) OR every N chars, whichever first — a named constant, not a magic number. Send `deltaText` (the coalesced slice) not the full cumulative buffer, so frame size stays bounded. The client appends; `cumulativeChars` lets the client show progress without us shipping the whole buffer each frame.
+- Backward-compat: `stage:started` / `stage:completed` / `stage:failed` remain exactly as today (`pipeline-controller.ts:297,331,908`); `stage:progress` is purely additive. Existing clients that don't handle `stage:progress` ignore it.
+
+### 3.5 Abort on run-cancel / client-disconnect (the gap to close)
+
+Today the per-run `AbortController` exists (`pipeline-controller.ts:35` `activeRuns`, created `:138`, `cancelRun()` calls `abort()` `:1096-1099`) and the signal is threaded into `executeStages(run, stages, signal)` and `executeDAG(...)`. BUT it is only checked **between** stages (`if (signal.aborted) return` at `:594`, `:962`); it is **NOT** passed into `team.execute()` → gateway → provider. So a cancel during a long stage call does nothing until the (now very long) call returns. **This design closes that gap.**
+
+- Thread the run's `AbortSignal` through: `pipeline-controller` (it already holds it) → `StageContext.streaming.signal` → `BaseTeam.executeSingleModel` → `gateway.completeStreaming/completeWithToolsStreaming` → `provider.stream/streamEvents` → `streamCliLines`/`spawnCli` (both already honor `request.signal`: `cli-spawn.ts:166,225`).
+- On abort: `streamCliLines` already kills the child (`SIGTERM` then `SIGKILL`, `cli-spawn.ts:221-223`) and throws `CliExecutionError("CLI request aborted")`. The gateway streaming method must let that error propagate → stage fails with a clear "run cancelled" message (NOT swallowed). When a run is cancelled deliberately, the controller already distinguishes cancel from failure; map the aborted error to the cancelled status rather than a hard failure where appropriate.
+- **Client-disconnect:** the SSE/WS layer (chat path) is unaffected. For the stage path, run-cancel IS the disconnect signal (a pipeline run is server-driven, not tied to one socket); no new disconnect plumbing needed beyond the existing `cancelRun`.
+- The `ILLMProvider.stream()` contract doc currently says *"callers do not cancel mid-stream"* (`shared/types.ts:769`). **This design changes that contract** — update the doc comment: callers MAY abort mid-stream via `options.signal`; providers MUST terminate the child and stop yielding. This is a deliberate, documented contract change.
+
+## 4. Timeout Policy
+
+### 4.1 Model: idle timeout + overall cap (replaces single wall-clock on the stage path)
+
+Two independent timers, both configurable:
+
+- **Idle / inactivity timeout** (`idleTimeoutMs`): reset on **every received chunk** (every stdout `data` in `streamCliLines`, every yielded delta). Fires only when NO output has arrived for this window → "CLI idle for {idleTimeoutMs}ms (no output)". Catches a genuinely hung/stuck CLI quickly without penalizing a slow-but-progressing stream. Default: **60s** (tunable; see risk #5 re first-token latency).
+- **Overall cap** (`overallTimeoutMs`): absolute wall-clock ceiling for the whole streamed call, regardless of activity. Generous. Default: **600s (10 min)** (tunable). Prevents an infinite-but-trickling stream from running forever.
+
+A call fails when EITHER timer fires. Both produce distinct, non-swallowed `CliExecutionError` messages.
+
+### 4.2 Config keys (new `pipeline.streaming` section in `server/config/schema.ts`)
+
+There is no `pipeline` config section today (verified). Add one, with env overrides via the existing config loader:
+
+```
+pipeline: z.object({
+  streaming: z.object({
+    enabled: z.boolean().default(true),               // kill-switch → blocking fallback
+    idleTimeoutMs: z.coerce.number().int().positive().default(60_000),
+    overallTimeoutMs: z.coerce.number().int().positive().default(600_000),
+    maxOutputBytes: z.coerce.number().int().positive().default(8 * 1024 * 1024), // 8 MiB, matches Antigravity MAX_OUTPUT_BYTES
+    wsProgressFlushMs: z.coerce.number().int().positive().default(250),
+  }).default({}),
+}).default({}),
+```
+
+Env (through the loader's existing mapping): `PIPELINE_STREAMING_ENABLED`, `PIPELINE_STREAMING_IDLE_TIMEOUT_MS`, `PIPELINE_STREAMING_OVERALL_TIMEOUT_MS`, `PIPELINE_STREAMING_MAX_OUTPUT_BYTES`, `PIPELINE_STREAMING_WS_PROGRESS_FLUSH_MS`. (Follow the existing schema's `z.coerce.number()` + env-mapping convention already used for `antigravity.timeoutMs` at `schema.ts:61` and `memory...timeoutMs` at `schema.ts:143`.)
+
+### 4.3 `streamCliLines` / cli-spawn changes (additive, default-preserving)
+
+Extend `CliSpawnRequest` (`cli-spawn.ts:40`) with optional `idleTimeoutMs` and `maxOutputBytes`. In `streamCliLines` (`cli-spawn.ts:185`):
+
+- Keep the existing single `timeoutMs` timer meaning = **overall cap** (preserve the `timeoutMs` field so `spawnCli` and short callers are untouched).
+- Add an **idle timer**: armed on start, **cleared+rearmed on each stdout `data` event** (`cli-spawn.ts:228`). On fire: same kill sequence as the existing timeout (`cli-spawn.ts:215-219`) → `fail(new CliExecutionError("CLI idle for {ms}ms", null, stderr))`.
+- Add a **byte cap** (`maxOutputBytes`): track cumulative stdout bytes; if exceeded → kill child + `fail(new CliExecutionError("CLI output exceeded {n} bytes", null, stderr))`. (§5.2)
+- `spawnCli` (`cli-spawn.ts:132`, the BLOCKING short-caller helper) is **unchanged** — keeps `DEFAULT_TIMEOUT_MS = 120_000` and no idle timer. **Only `streamCliLines` gains idle+byte-cap**, and only stage calls reach it with the new values.
+
+### 4.4 Antigravity (emulated stream) timeout
+
+`AntigravityProvider.stream()` is one-shot (`antigravity.ts:111-118`) → there are no chunks to reset an idle timer on, so "idle timeout" is N/A. For Antigravity stage calls, apply the **overall cap** as its `options.timeoutMs` (it already plumbs `options?.timeoutMs ?? this.timeoutMs` → `invokeAntigravityCli` → `execFile {timeout}` at `antigravity-cli.ts:143`). So a long Antigravity planning call also gets the generous overall budget instead of 120s. `MAX_OUTPUT_BYTES` (8 MiB, `antigravity-cli.ts:52`) already bounds its buffer — align our `maxOutputBytes` default to it.
+
+## 5. Progress + Memory Safety (no swallowed errors)
+
+### 5.1 No swallowed errors
+
+- A mid-stream provider/CLI error (non-zero exit, idle fire, overall fire, byte-cap, abort) MUST reject the gateway streaming method, which MUST propagate to the stage → `updateStageExecution(status:"failed", error: <clear message>)` and a `stage:failed` WS event (the existing failure path at `pipeline-controller.ts:322-348` / `:946+`). NEVER `catch {}` to an empty/partial success.
+- **Capture partial output if useful:** when a stream fails after producing some text, include a short, truncated preview of the partial assistant text in the stage error (e.g. last N chars) so the failure is diagnosable — but the stage still FAILS. Do not promote partial output to a successful stage result.
+- Distinguish **idle**, **overall**, **byte-cap**, **abort/cancel**, and **CLI non-zero** in the error message text (separate constants), so operators can tell a hung model from a slow one from a cancel.
+
+### 5.2 Bounded in-memory accumulation
+
+- The streamed assistant text is accumulated to assemble the final `content`. Bound it: track cumulative bytes; if it exceeds `pipeline.streaming.maxOutputBytes` (default 8 MiB), **abort the stream and fail the stage** ("CLI output exceeded {n} bytes") — do NOT keep growing an unbounded string. Enforced at TWO layers: in `streamCliLines` (raw stdout bytes, §4.3) and in the gateway accumulator (assembled text), since the parsed text can differ from raw stdout.
+- The WS progress path sends **coalesced delta slices**, never the full cumulative buffer per frame (§3.4) — so progress emission is O(1) memory per frame.
+- Tool loop: `toolCallLog` and the `messages` array grow per iteration but are already bounded by `maxIterations` (default 10). Tool RESULT content fed back is already produced by `toolRegistry.execute` — no new unbounded source.
+
+### 5.3 Concurrency unchanged
+
+`ConcurrencyLimiter` (`cli-spawn.ts:62`, default 4) still gates spawns. Streaming calls hold a slot for their (now longer) duration — acceptable; the cap prevents fork bombs. Note for ops: with long streamed stages, 4 concurrent is the effective stage parallelism for CLI providers; surfaced as a known tuning knob (not changed here).
+
+## 6. Backward Compatibility
+
+- `Gateway.complete()`, `completeWithTools()`, `stream()` keep their EXACT current signatures and behavior. New methods are additive.
+- Chat (`server/routes/chat.ts`), code-chat (`server/workspace/code-chat.ts`), gateway SSE (`server/routes/gateway.ts`) consume `gateway.stream()` — untouched.
+- Non-CLI / non-streaming-tool providers: `completeWithToolsStreaming` falls back to blocking `completeWithTools` under the overall budget (§3.3). MockProvider already streams (`mock.ts:273-281`, 30ms/chunk) → works with the new path unchanged; great for tests (§9).
+- Kill-switch: `pipeline.streaming.enabled=false` makes `BaseTeam.executeSingleModel` use the OLD blocking `complete`/`completeWithTools`. Instant revert with no code change if streaming regresses.
+- `stage:progress` is additive; old clients ignore unknown event types.
+
+## 7. Reuse vs. New
+
+**Reused (no rewrite):**
+- `gateway.stream()` semantics & provider resolution (`index.ts:374`).
+- `ClaudeCliProvider.stream()` + `iterateStream()` JSONL parsing (`claude-cli.ts:180,191`) — extended for events, not replaced.
+- `streamCliLines()` spawn/line-split/abort machinery (`cli-spawn.ts:185`) — extended with idle + byte-cap.
+- `spawnCli()` + 120s default — UNCHANGED, kept for short callers.
+- WS `broadcast()` (`pipeline-controller.ts:1163`) + `wsManager.broadcastToRun` + the existing `stage:progress` event slot (`shared/types.ts:430`).
+- Per-run `AbortController` (`pipeline-controller.ts:35,138,1096`) — now threaded all the way down.
+- `completeWithTools` tool-loop logic, `workspaceDefaults` merge, `toolCallLog` (`index.ts:500-602`) — mirrored in the streaming variant.
+- SSE accumulate pattern from `chat.ts:226` — the consumption shape we mirror.
+- Config conventions: `z.coerce.number()` + env mapping (`schema.ts:61,143`).
+- MockProvider slow-chunk stream (`mock.ts:273-281`) for tests.
+
+**New:**
+- `Gateway.completeStreaming()` + `Gateway.completeWithToolsStreaming()` (+ extracted shared resolve/budget/anonymize/log helpers, DRY out of `complete()`).
+- `ClaudeCliProvider.streamEvents()` emitting `ProviderStreamEvent` (text-delta / tool-call / done) + the `ProviderStreamEvent` type (in `shared/types.ts`).
+- Optional provider capability marker `supportsStreamingToolLoop` (duck-typed).
+- `idleTimeoutMs` + `maxOutputBytes` on `CliSpawnRequest`; idle timer + byte-cap inside `streamCliLines`.
+- `StageContext.streaming` block (`signal`, `onDelta`, resolved timeout/limit numbers) in `shared/types.ts`; populated in `pipeline-controller` where `context` is built (`:260`, `:664`).
+- `pipeline.streaming` config section + env keys (`schema.ts`).
+- WS `stage:progress` emission + client handler.
+- Extend `ILLMProviderOptions` (`shared/types.ts:740`) with `signal?: AbortSignal`, `idleTimeoutMs?: number`, `maxOutputBytes?: number`; update the `stream()` contract doc (`:769`).
+
+## 8. Task Breakdown (ordered, file-owned, TDD ≥80% on changed modules)
+
+Units kept small (<800-line files, <30-line funcs). Owner tags: **BE**=Backend, **QA**=Test, **SEC**=Security, **DO**=DevOps.
+
+### Phase 0 — Types & config (no behavior change; unblocks everything)
+- **T1 [BE]** `shared/types.ts`: add `signal?`, `idleTimeoutMs?`, `maxOutputBytes?` to `ILLMProviderOptions`; add `ProviderStreamEvent` union; add `StageContext.streaming` optional block; update `stream()` contract doc comment. *(no deps)*
+- **T2 [BE]** `server/config/schema.ts` + loader: add `pipeline.streaming` section + env mapping; defaults per §4.2. **[QA]** schema unit tests (defaults, env coercion, bounds). *(no deps; parallel with T1)*
+
+### Phase 1 — cli-spawn idle + byte-cap (the timeout primitive)
+- **T3 [BE]** `cli-spawn.ts`: extend `CliSpawnRequest` with `idleTimeoutMs`/`maxOutputBytes`; add idle timer (reset on stdout `data`) + cumulative-byte cap in `streamCliLines`; keep `spawnCli` + 120s default unchanged. Distinct error messages (idle/overall/byte-cap). *(deps: T1)*
+- **T4 [QA]** `tests/unit/providers/cli-spawn.test.ts`: extend existing mocked-spawn suite (EventEmitter fake child, fake timers — pattern already in this file). Cases: idle fires when no data within window; idle resets on data (slow-but-progressing stream survives past old-120s using fake-timer advance); overall cap fires; byte-cap fires + kills child; abort still works; `spawnCli` defaults UNCHANGED. *(deps: T3; co-developed TDD)*
+- **T5 [SEC]** Review T3: ensure child is always killed on every failure branch (no orphan/zombie), no `maxBuffer`-style unbounded growth, signal listener removed in `finally`, no error swallowed. *(deps: T3)*
+
+### Phase 2 — provider streaming events
+- **T6 [BE]** `claude-cli.ts`: add `streamEvents()` (text-delta / tool-call / done) reusing `streamCliLines`+`parseLine`+`assistantText`, adding `tool_use` block extraction and `result`-event usage; thread `idleTimeoutMs`/`maxOutputBytes`/`signal` into the `CliSpawnRequest`. Keep existing `stream()`/`complete()`. *(deps: T1, T3)*
+- **T7 [QA]** `tests/unit/providers/claude-cli.test.ts`: extend with JSONL fixtures — text-only stream → deltas+done; interleaved tool_use → tool-call events then done(`tool_use`); malformed line skipped; usage parsed from `result`. *(deps: T6)*
+- **T8 [BE]** `antigravity.ts`: mark no streaming-tool support; ensure `stream()`/`complete()` accept the overall-cap `timeoutMs`. (Mostly verification + a capability flag.) **[QA]** test that Antigravity stage calls get the overall cap, not 120s. *(deps: T1)*
+
+### Phase 3 — gateway streaming methods
+- **T9 [BE]** `server/gateway/index.ts`: extract shared resolve/budget/anonymize/log helpers from `complete()` (DRY, behavior-preserving); add `completeStreaming()` consuming `provider.stream()` with bounded accumulator + `onDelta` + idle/overall/byte budget + abort; same logging (success+error) as `complete()`. *(deps: T1, T3)*
+- **T10 [BE]** `server/gateway/index.ts`: add `completeWithToolsStreaming()` — streamed tool loop per §3.3 (consume `streamEvents`, execute tools via `toolRegistry`, `workspaceDefaults` merge, `toolCallLog`, `maxIterations`); capability fallback to blocking `completeWithTools` under overall cap for non-streaming-tool providers. *(deps: T6, T9)*
+- **T11 [QA]** `tests/unit/...gateway streaming`: (a) `completeStreaming` assembles full text from deltas, emits onDelta, enforces byte cap (fails), propagates mid-stream error (no swallow), aborts on signal; (b) `completeWithToolsStreaming` runs a streamed tool turn end-to-end against a fake `streamEvents` provider (tool-call → toolRegistry → tool result → final text), respects maxIterations, falls back for a no-stream-tool provider. *(deps: T9, T10)*
+- **T12 [SEC]** Review gateway streaming: budget pre-check still runs before any spawn; anonymize/rehydrate parity with `complete()`; abort = clear error not silent partial; partial-output preview is truncated (no unbounded/raw leak); logRequest records error status. *(deps: T9, T10)*
+
+### Phase 4 — stage wiring + WS progress
+- **T13 [BE]** `server/teams/base.ts`: re-point `executeSingleModel` tool path → `completeWithToolsStreaming`, plain path → `completeStreaming`; pass `StageContext.streaming` (signal/onDelta/limits); honor `pipeline.streaming.enabled` kill-switch (old blocking path when false). Keep `executeStream` as-is. *(deps: T9, T10)*
+- **T14 [BE]** `server/controller/pipeline-controller.ts`: when building `context` (linear `:664` + DAG `:260`), populate `streaming` with the run `AbortSignal` (already held), an `onDelta` that emits coalesced `stage:progress` via `broadcast()` (flush per `wsProgressFlushMs`), and resolved config limits. No change to `stage:started/completed/failed`. *(deps: T13)*
+- **T15 [QA]** `tests/unit/teams` + controller test: stage path now calls the streaming gateway methods; `stage:progress` emitted (coalesced) and `stage:completed` still emitted; kill-switch routes to blocking; **abort during a stage stops the call and fails/cancels the stage** (closes the §3.5 gap). *(deps: T13, T14)*
+- **T16 [BE]** Client: handle `stage:progress` (append `deltaText`, show progress) in the run view. **[QA]** light component/unit test. *(deps: T14; can parallel with T15)*
+
+### Phase 5 — the headline deterministic test + ops
+- **T17 [QA]** **">120s succeeds" deterministic test** (§9): a mock streaming provider that yields slow chunks; with **fake timers** (`vi.useFakeTimers` + `vi.advanceTimersByTimeAsync`, already used in `tests/unit/delegation-cross-instance.test.ts`), advance virtual time well past 120s while emitting a chunk inside each idle window → stage COMPLETES (proves idle-reset beats the old 120s cap). Companion: no chunk for > idleTimeoutMs → fails with idle error. *(deps: T13)*
+- **T18 [DO]** Document the new env knobs in deployment docs (`docs/DEPLOYMENT_HOST.md` etc.) + `.env` example; note `make infra-up`/`make dev` host-run (never Docker), and the concurrency tuning note (§5.3). *(deps: T2)*
+- **T19 [DO/QA]** Optional E2E smoke (manual/gated): a real planning stage with `claude` that previously timed out at 120s now completes via streaming. Gated behind a real-CLI env flag so CI without the CLI is unaffected. *(deps: T13, T14)*
+
+**Parallelization:** T1 ∥ T2 (Phase 0). After T1: T3 (Phase 1) and T8 (Antigravity) parallel. T6 needs T3. T9 needs T3; T10 needs T6+T9. Phase 4 (T13/T14) needs T9+T10. QA tasks co-developed with their BE task (TDD red→green). SEC reviews (T5, T12) gate before merge. Client T16 parallel with T15.
+
+## 9. Risks & Open Questions (for the Lead)
+
+1. **[HIGH] `claude -p stream-json` tool-use event shape (load-bearing for §3.3).** Need an empirical capture of a tool-using `claude -p --output-format stream-json --verbose` run to confirm: (a) tool calls arrive as complete `{type:"tool_use", id, name, input}` blocks in `assistant` events (design assumes this) vs. streamed partial `input_json` deltas needing reassembly; (b) whether feeding tool RESULTS back across a fresh `claude -p` invocation preserves tool-call context, since each `claude -p` is a NEW non-interactive process — our tool loop re-invokes the CLI per iteration with the growing `messages` transcript (same as today's blocking `completeWithTools`, which already re-invokes per iteration). **Mitigation:** the streamed tool loop mirrors the existing blocking loop's per-iteration re-invocation; if partial tool-arg deltas exist, buffer them in `streamEvents` until the block closes. Recommend a 1-hour spike before Phase 2.
+2. **[HIGH] Deterministic ">120s succeeds" test.** Real CLIs are non-deterministic and slow. **Approach (T17):** a `SlowMockStreamingProvider` registered in the test gateway that yields a chunk every virtual `idleTimeoutMs - epsilon`, driven by `vi.useFakeTimers()`/`advanceTimersByTimeAsync` (pattern proven in `tests/unit/delegation-cross-instance.test.ts:113,429`). Advance virtual time to e.g. 5 minutes; assert stage completes. This tests OUR idle/overall logic deterministically without a real CLI. The real-CLI case is the gated E2E smoke (T19).
+3. **[MED] Token usage accuracy under streaming.** Streamed deltas may not carry per-chunk token counts; Claude CLI's `result` event has `usage` (parse it via the `done` event); Antigravity estimates from bytes. Cost ledger (`index.ts:353`) currently records `completionTokens: result.tokensUsed`. Ensure the streaming methods still surface a real/estimated `tokensUsed` and keep the ledger working — flagged so cost reporting doesn't silently zero out.
+4. **[MED] Strategy-executor path.** `StrategyExecutor` makes many `gateway.complete()` calls for multi-model stages (debate/voting). Re-pointing those to `completeStreaming` is in scope but lower priority than the tool path (the proven failure). Decide: do it in this PR (T9 makes it cheap) or fast-follow. Recommend: include the re-point but keep strategy intermediate steps as WS strategy events (as today), only adding idle/overall budget.
+5. **[MED] Idle/overall defaults.** 60s idle / 600s overall are starting points. A very large planning prompt's FIRST token can itself take >60s (model "thinking" before any stdout). **Mitigation:** consider a longer **first-chunk** grace (separate from steady-state idle) OR set idle default high enough (e.g. 120s) to cover first-token latency. Lead to confirm defaults; they're config so tunable in prod without a deploy.
+6. **[LOW] WS frame volume.** Coalescing (§3.4, `wsProgressFlushMs=250`) bounds frames; confirm the client handles partial-append correctly and there's no per-frame full-buffer send.
+7. **[LOW] Concurrency under long streams.** 4 concurrent CLI procs (§5.3) becomes the stage parallelism ceiling for long streamed stages. Acceptable for now; documented (T18). Revisit if SDLC runs need more parallel CLI stages.

--- a/server/config/loader.ts
+++ b/server/config/loader.ts
@@ -134,6 +134,18 @@ const ENV_MAPPINGS: EnvMapping[] = [
   { envKey: "MULTI_MEMORY_RETRIEVAL_OMNISCIENCE_TOKEN_ENV",    configPath: ["memory", "retrieval", "omniscience", "tokenEnv"],          kind: "string"  },
   { envKey: "MULTI_MEMORY_RETRIEVAL_OMNISCIENCE_STRATEGY",     configPath: ["memory", "retrieval", "omniscience", "retrievalStrategy"], kind: "string"  },
   { envKey: "MULTI_MEMORY_RETRIEVAL_OMNISCIENCE_TIMEOUT_MS",   configPath: ["memory", "retrieval", "omniscience", "timeoutMs"],         kind: "number"  },
+
+  // Pipeline stage streaming (streaming-stage-execution).
+  { envKey: "PIPELINE_STREAMING_ENABLED",              configPath: ["pipeline", "streaming", "enabled"],          kind: "boolean" },
+  { envKey: "PIPELINE_STREAMING_IDLE_TIMEOUT_MS",      configPath: ["pipeline", "streaming", "idleTimeoutMs"],    kind: "number"  },
+  { envKey: "PIPELINE_STREAMING_OVERALL_TIMEOUT_MS",   configPath: ["pipeline", "streaming", "overallTimeoutMs"], kind: "number"  },
+  { envKey: "PIPELINE_STREAMING_MAX_OUTPUT_BYTES",     configPath: ["pipeline", "streaming", "maxOutputBytes"],   kind: "number"  },
+  { envKey: "PIPELINE_STREAMING_WS_PROGRESS_FLUSH_MS", configPath: ["pipeline", "streaming", "wsProgressFlushMs"],kind: "number"  },
+  { envKey: "MULTI_PIPELINE_STREAMING_ENABLED",              configPath: ["pipeline", "streaming", "enabled"],          kind: "boolean" },
+  { envKey: "MULTI_PIPELINE_STREAMING_IDLE_TIMEOUT_MS",      configPath: ["pipeline", "streaming", "idleTimeoutMs"],    kind: "number"  },
+  { envKey: "MULTI_PIPELINE_STREAMING_OVERALL_TIMEOUT_MS",   configPath: ["pipeline", "streaming", "overallTimeoutMs"], kind: "number"  },
+  { envKey: "MULTI_PIPELINE_STREAMING_MAX_OUTPUT_BYTES",     configPath: ["pipeline", "streaming", "maxOutputBytes"],   kind: "number"  },
+  { envKey: "MULTI_PIPELINE_STREAMING_WS_PROGRESS_FLUSH_MS", configPath: ["pipeline", "streaming", "wsProgressFlushMs"],kind: "number"  },
 ];
 
 /**

--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -153,6 +153,27 @@ export const ConfigSchema = z.object({
       }).default({}),
     }).default({}),
   }).default({}),
+  /**
+   * Pipeline stage streaming (streaming-stage-execution). Replaces the blocking
+   * 120s wall-clock cap on the stage LLM path with an idle + overall timeout
+   * model, bounds output, and gates WS progress emission. Bounds (.min/.max)
+   * are enforced at load so a misconfig can NEVER disable the overall cap or
+   * set an absurd buffer (Security M1).
+   */
+  pipeline: z.object({
+    streaming: z.object({
+      /** Kill-switch: false → BaseTeam uses the old blocking complete/completeWithTools path. */
+      enabled: z.boolean().default(true),
+      /** Idle (inactivity) timeout; reset on each chunk. 1s..10min. */
+      idleTimeoutMs: z.coerce.number().int().min(1_000).max(600_000).default(60_000),
+      /** Overall wall-clock cap; never reset by chunks. 10s..1h. */
+      overallTimeoutMs: z.coerce.number().int().min(10_000).max(3_600_000).default(600_000),
+      /** Cumulative output byte cap. 64KiB..64MiB (default 8MiB). */
+      maxOutputBytes: z.coerce.number().int().min(65_536).max(67_108_864).default(8_388_608),
+      /** WS stage:progress coalescing flush interval. 50ms..5s. */
+      wsProgressFlushMs: z.coerce.number().int().min(50).max(5_000).default(250),
+    }).default({}),
+  }).default({}),
 });
 
 export type AppConfig = z.infer<typeof ConfigSchema>;

--- a/server/controller/pipeline-controller.ts
+++ b/server/controller/pipeline-controller.ts
@@ -25,6 +25,10 @@ import type { ManagerConfig } from "@shared/types";
 import type { Tracer } from "../tracing/tracer";
 import { exportTrace } from "../tracing/otlp-exporter";
 import { isQueueEnabled, StageQueueProducer, getRedisConnection } from "../queue/index.js";
+import { StageProgressCoalescer, isAbortError } from "./stage-progress.js";
+import { scrubAndTruncate } from "../gateway/secret-scrub.js";
+import { configLoader } from "../config/loader.js";
+import type { StreamingStageOptions } from "@shared/types";
 
 interface ApprovalHandle {
   resolve: (approved: boolean) => void;
@@ -165,7 +169,7 @@ export class PipelineController {
 
     if (dag != null) {
       // ── DAG mode ──
-      const executeStage = this.makeDAGStageExecuteFn(run);
+      const executeStage = this.makeDAGStageExecuteFn(run, abortController.signal);
       this.dagExecutor
         .executeDAG(run, dag, abortController.signal, executeStage)
         .then(() => this.finishDAGRun(run.id, abortController.signal))
@@ -198,7 +202,7 @@ export class PipelineController {
    * Creates a StageExecuteFn bound to this controller for use by DAGExecutor.
    * The DAG executor calls this for each stage it wants to run.
    */
-  private makeDAGStageExecuteFn(run: PipelineRun): StageExecuteFn {
+  private makeDAGStageExecuteFn(run: PipelineRun, signal: AbortSignal): StageExecuteFn {
     return async (
       _run: PipelineRun,
       dagStage: DAGStage,
@@ -237,6 +241,7 @@ export class PipelineController {
         ? this.tracer?.startSpan(traceId, `${dagStage.id ?? dagStage.teamId}.execute`)
         : undefined;
 
+      let stageCoalescer: StageProgressCoalescer | undefined;
       try {
         const team = this.teamRegistry.getTeam(dagStage.teamId);
         const numericRunId = this.hashRunId(run.id);
@@ -257,6 +262,9 @@ export class PipelineController {
           ? (await this.storage.getWorkspace(runWorkspaceId))?.path ?? null
           : null;
 
+        const streamingBlock = this.buildStreamingBlock(run.id, stageIndex, dagStage.teamId, stageExec.id, signal);
+        stageCoalescer = streamingBlock.coalescer;
+
         const context = {
           runId: run.id,
           stageIndex,
@@ -273,11 +281,17 @@ export class PipelineController {
           // Workspace binding for the run (issue #343).
           workspaceId: runWorkspaceId ?? undefined,
           workspacePath: runWorkspacePath ?? undefined,
+          // Streaming stage execution (undefined when kill-switch off).
+          streaming: streamingBlock.streaming,
         };
 
         const result = dagStage.remoteAgent
           ? await this.executeRemoteStage(dagStage.remoteAgent, stageInput, run.id, stageExec.id)
           : await team.execute(stageInput, context, dagStage.executionStrategy);
+
+        // Stage produced a result — flush+close the WS-progress coalescer (B1:
+        // mirror the linear success path so the coalescer's timer never leaks).
+        stageCoalescer?.close();
 
         const newMemories = await this.memoryExtractor.extractFromStageResult(
           dagStage.teamId,
@@ -320,23 +334,32 @@ export class PipelineController {
 
         return { output: result.output, failed: false };
       } catch (error) {
-        const errMsg = error instanceof Error ? error.message : "Unknown error";
+        // B1: flush+close the coalescer on the error path too (no leaked timer).
+        stageCoalescer?.close();
+        // Scrub secret env values + keep the 256-char truncation before the
+        // error reaches storage, the WS payload, or the tracer (M2).
+        const errMsg = scrubAndTruncate(error instanceof Error ? error.message : "Unknown error");
+        // A deliberate cancel/abort maps to "cancelled", not "failed" (H3) —
+        // mirror the linear path. Partial streamed output is never promoted.
+        const aborted = isAbortError(error);
 
         await this.storage.updateStageExecution(stageExec.id, {
-          status: "failed",
+          status: aborted ? "cancelled" : "failed",
           completedAt: new Date(),
           error: errMsg,
         });
 
         this.broadcast(run.id, {
-          type: "stage:failed",
+          type: aborted ? "pipeline:cancelled" : "stage:failed",
           runId: run.id,
           stageExecutionId: stageExec.id,
-          payload: { error: errMsg, stageIndex, dagStageId },
+          payload: aborted
+            ? { reason: errMsg, cancelledStageIndex: stageIndex, dagStageId }
+            : { error: errMsg, stageIndex, dagStageId },
           timestamp: new Date().toISOString(),
         });
 
-        // Tracing: end stage span on error (security: truncate error to 256 chars)
+        // Tracing: end stage span on error (already scrubbed + truncated).
         if (stageSpanId) {
           this.tracer?.endSpan(stageSpanId, "error", {
             errorMessage: errMsg.slice(0, 256),
@@ -633,6 +656,7 @@ export class PipelineController {
         ? this.tracer?.startSpan(linearTraceId, `${stage.teamId}.execute`)
         : undefined;
 
+      let stageCoalescer: StageProgressCoalescer | undefined;
       try {
         const team = this.teamRegistry.getTeam(stage.teamId);
 
@@ -661,6 +685,9 @@ export class PipelineController {
         // Apply skill settings (if a skill is assigned to this stage)
         const resolvedStage = await this.applySkill(stage);
 
+        const streamingBlock = this.buildStreamingBlock(run.id, i, stage.teamId, stageExec.id, signal);
+        stageCoalescer = streamingBlock.coalescer;
+
         const context = {
           runId: run.id,
           stageIndex: i,
@@ -684,6 +711,9 @@ export class PipelineController {
           // workspace when their input doesn't supply one.
           workspaceId: runWorkspaceId ?? undefined,
           workspacePath: runWorkspacePath ?? undefined,
+          // Streaming stage execution: run AbortSignal + coalesced WS progress
+          // + resolved idle/overall/byte limits (undefined when kill-switch off).
+          streaming: streamingBlock.streaming,
         };
 
         // Pass execution strategy (undefined = single, handled in BaseTeam)
@@ -774,6 +804,10 @@ export class PipelineController {
             : await team.execute(stageInput, context, resolvedStage.executionStrategy);
         }
         }
+
+        // Flush + close the WS-progress coalescer now the stage produced a
+        // result (no further deltas). Idempotent; also closed in catch.
+        stageCoalescer?.close();
 
         // Collect thought tree from stage output
         const collector = new ThoughtTreeCollector();
@@ -975,39 +1009,57 @@ export class PipelineController {
           });
         }
       } catch (error) {
-        const errMsg =
-          error instanceof Error ? error.message : "Unknown error";
+        // Flush+close any progress coalescer (idempotent) before settling.
+        stageCoalescer?.close();
+        // Scrub secret env values from the error before it reaches storage, WS,
+        // logs, or the tracer (Security M2); keep the 256-char truncation.
+        const errMsg = scrubAndTruncate(error instanceof Error ? error.message : "Unknown error");
+        // A deliberate cancel/abort maps to "cancelled", not "failed" (H3). The
+        // partial streamed output is NOT promoted as an authoritative result.
+        const aborted = isAbortError(error);
+        const stageStatus = aborted ? "cancelled" : "failed";
+        const runStatus = aborted ? "cancelled" : "failed";
 
         await this.storage.updateStageExecution(stageExec.id, {
-          status: "failed",
+          status: stageStatus,
           completedAt: new Date(),
           error: errMsg,
         });
         await this.storage.updatePipelineRun(run.id, {
-          status: "failed",
+          status: runStatus,
           completedAt: new Date(),
           // Promote the failing stage's error into the run output when the run
-          // has none yet, so the run row is self-explaining (issue #342).
+          // has none yet, so the run row is self-explaining (issue #342). For a
+          // cancel we still record the scrubbed reason (never partial output).
           ...(run.output == null ? { output: errMsg } : {}),
         });
 
         await this.captureStageLesson(stageExec.id);
 
-        this.broadcast(run.id, {
-          type: "stage:failed",
-          runId: run.id,
-          stageExecutionId: stageExec.id,
-          payload: { error: errMsg, stageIndex: i },
-          timestamp: new Date().toISOString(),
-        });
-        this.broadcast(run.id, {
-          type: "pipeline:failed",
-          runId: run.id,
-          payload: { error: errMsg, failedStageIndex: i },
-          timestamp: new Date().toISOString(),
-        });
+        if (aborted) {
+          this.broadcast(run.id, {
+            type: "pipeline:cancelled",
+            runId: run.id,
+            payload: { reason: errMsg, cancelledStageIndex: i },
+            timestamp: new Date().toISOString(),
+          });
+        } else {
+          this.broadcast(run.id, {
+            type: "stage:failed",
+            runId: run.id,
+            stageExecutionId: stageExec.id,
+            payload: { error: errMsg, stageIndex: i },
+            timestamp: new Date().toISOString(),
+          });
+          this.broadcast(run.id, {
+            type: "pipeline:failed",
+            runId: run.id,
+            payload: { error: errMsg, failedStageIndex: i },
+            timestamp: new Date().toISOString(),
+          });
+        }
 
-        // Tracing: end stage span on error (security: truncate to 256 chars)
+        // Tracing: end stage span on error (already scrubbed + truncated).
         if (linearStageSpanId) {
           this.tracer?.endSpan(linearStageSpanId, "error", {
             errorMessage: errMsg.slice(0, 256),
@@ -1162,6 +1214,53 @@ export class PipelineController {
 
   private broadcast(runId: string, event: WsEvent): void {
     this.wsManager.broadcastToRun(runId, event);
+  }
+
+  /**
+   * Build the per-stage streaming block (streaming-stage-execution). Returns the
+   * StreamingStageOptions threaded into the stage call (run AbortSignal +
+   * coalesced onDelta + resolved idle/overall/byte limits) plus the coalescer
+   * so the caller can flush+close it when the stage settles. Returns undefined
+   * when the kill-switch (pipeline.streaming.enabled) is off → blocking path.
+   *
+   * The onDelta path is run-scoped: it broadcasts `stage:progress` via the
+   * existing run-scoped `broadcast(runId, ...)` (wsManager.broadcastToRun),
+   * coalesced and secret-scrubbed, sending the delta SLICE + cumulativeChars
+   * (never the full buffer).
+   */
+  private buildStreamingBlock(
+    runId: string,
+    stageIndex: number,
+    teamId: string,
+    stageExecutionId: string | undefined,
+    signal: AbortSignal,
+  ): { streaming?: StreamingStageOptions; coalescer?: StageProgressCoalescer } {
+    let cfg;
+    try {
+      cfg = configLoader.get().pipeline.streaming;
+    } catch {
+      return {};
+    }
+    if (!cfg.enabled) return {};
+
+    const coalescer = new StageProgressCoalescer(cfg.wsProgressFlushMs, (deltaText, cumulativeChars) => {
+      this.broadcast(runId, {
+        type: "stage:progress",
+        runId,
+        stageExecutionId,
+        payload: { stageIndex, teamId, deltaText, cumulativeChars },
+        timestamp: new Date().toISOString(),
+      });
+    });
+
+    const streaming: StreamingStageOptions = {
+      signal,
+      onDelta: (delta, cumulativeChars) => coalescer.push(delta, cumulativeChars),
+      idleTimeoutMs: cfg.idleTimeoutMs,
+      overallTimeoutMs: cfg.overallTimeoutMs,
+      maxOutputBytes: cfg.maxOutputBytes,
+    };
+    return { streaming, coalescer };
   }
 
     private buildDelegateFn(

--- a/server/controller/stage-progress.ts
+++ b/server/controller/stage-progress.ts
@@ -1,0 +1,79 @@
+/**
+ * Coalesced WS stage-progress emission + abort classification for the streaming
+ * stage path (streaming-stage-execution, T14 / Security L2 / H3).
+ *
+ * The gateway's onDelta fires per provider chunk (potentially per token). To
+ * avoid a WS flood and unbounded per-frame payloads we COALESCE deltas and
+ * flush on a timer (wsProgressFlushMs). Each frame carries the coalesced delta
+ * SLICE plus a cumulative char count — never the whole assembled buffer. All
+ * text is secret-scrubbed before it leaves the process (M2).
+ */
+import { scrubAndTruncate } from "../gateway/secret-scrub";
+
+/** Emit a coalesced progress frame (delta slice + cumulative chars). */
+export type ProgressFlushFn = (deltaText: string, cumulativeChars: number) => void;
+
+/**
+ * Buffers deltas and flushes the concatenated slice every flushMs. The slice is
+ * scrubbed+truncated per flush so secrets never leak and frames stay bounded.
+ */
+export class StageProgressCoalescer {
+  private pending = "";
+  private cumulativeChars = 0;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private closed = false;
+
+  constructor(
+    private readonly flushMs: number,
+    private readonly emit: ProgressFlushFn,
+  ) {}
+
+  /** Record a delta. Resets/arms the flush timer; never emits synchronously. */
+  push(delta: string, cumulativeChars: number): void {
+    if (this.closed) return;
+    this.pending += delta;
+    this.cumulativeChars = cumulativeChars;
+    if (this.timer === null) {
+      this.timer = setTimeout(() => this.flush(), this.flushMs);
+    }
+  }
+
+  /** Flush any pending buffer immediately (also called by the timer). */
+  flush(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    if (this.pending.length === 0) return;
+    const slice = scrubAndTruncate(this.pending);
+    this.pending = "";
+    this.emit(slice, this.cumulativeChars);
+  }
+
+  /** Final flush + stop accepting further deltas (idempotent). */
+  close(): void {
+    if (this.closed) return;
+    this.flush();
+    this.closed = true;
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}
+
+/**
+ * True when an error represents a deliberate cancellation/abort (so the stage
+ * maps to "cancelled" rather than "failed", H3). Matches the CLI abort error
+ * name/message and AbortError.
+ */
+export function isAbortError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  // Prefer the error class: our CliAbortError and the platform AbortError are
+  // the authoritative abort signals. We also match our OWN exact abort message
+  // (providers that throw a plain Error on abort) — but NOT a loose "aborted"
+  // substring, so model output that merely contains the word is not
+  // misclassified as a cancellation (LOW finding).
+  if (error.name === "CliAbortError" || error.name === "AbortError") return true;
+  return error.message === "CLI request aborted";
+}

--- a/server/gateway/index.ts
+++ b/server/gateway/index.ts
@@ -1,7 +1,8 @@
 import type { IStorage } from "../storage";
 import { toolRegistry } from "../tools/index";
-import type { GatewayRequest, GatewayResponse, ILLMProvider, ILLMProviderOptions, PrivacySettings, ProviderMessage, ToolDefinition, ToolCallLogEntry } from "@shared/types";
+import type { GatewayRequest, GatewayResponse, ILLMProvider, IStreamingToolProvider, ILLMProviderOptions, PrivacySettings, ProviderMessage, ProviderStreamEvent, StreamingStageOptions, ToolCall, ToolDefinition, ToolCallLogEntry } from "@shared/types";
 import { MockProvider } from "./providers/mock";
+import { scrubAndTruncate } from "./secret-scrub";
 import { VllmProvider } from "./providers/vllm";
 import { OllamaProvider } from "./providers/ollama";
 import { ClaudeProvider } from "./providers/claude";
@@ -183,6 +184,15 @@ export class Gateway {
    */
   connectLmStudio(endpoint: string): void {
     this.registry.set("lmstudio", new LmStudioProvider(endpoint));
+  }
+
+  /**
+   * Register a provider under an explicit key. General-purpose seam (mirrors
+   * connectLmStudio) used by streaming tests and any caller that constructs a
+   * provider instance directly.
+   */
+  registerProvider(key: string, provider: ILLMProvider): void {
+    this.registry.set(key, provider);
   }
 
   /** Resolve the ILLMProvider for a model record's provider string. */
@@ -599,6 +609,324 @@ export class Gateway {
     // Max iterations reached — return final content from last assistant message
     const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant');
     const content = lastAssistant && 'content' in lastAssistant ? lastAssistant.content : '';
+    return { content, tokensUsed: totalTokensUsed, toolCallLog };
+  }
+
+
+  // ─── Streaming stage execution (streaming-stage-execution) ──────────────────
+
+  /** Cap (bytes) on the assembled streamed text, mirroring the CLI byte cap. */
+  private static readonly DEFAULT_STREAM_MAX_BYTES = 8 * 1024 * 1024;
+
+  /** Resolve provider key + native model id for a request (shared by complete*). */
+  private resolveTarget(
+    modelSlug: string,
+    explicitProvider: string | undefined,
+    explicitModelId: string | undefined,
+    model: { provider?: string; modelId?: string | null; name?: string } | undefined,
+  ): { providerKey: string; modelId: string; provider: ILLMProvider | null } {
+    const providerKey = explicitProvider ?? model?.provider ?? "mock";
+    const modelId = explicitModelId ?? model?.modelId ?? model?.name ?? modelSlug;
+    return { providerKey, modelId, provider: this.getProvider(providerKey) };
+  }
+
+  /** Apply anonymization to messages when privacy is enabled (no mutation). */
+  private maybeAnonymize(
+    messages: ProviderMessage[],
+    privacy: PrivacySettings | undefined,
+    sessionId: string,
+  ): ProviderMessage[] {
+    if (!this.shouldAnonymize(privacy)) return messages;
+    return messages.map((m) => ({
+      ...m,
+      content: this.anonymizer.anonymize(
+        (m as { content: string }).content,
+        sessionId,
+        privacy!.level,
+        privacy!.vaultTtlMs,
+      ).anonymizedText,
+    })) as unknown as ProviderMessage[];
+  }
+
+  /** Budget pre-call check (throws on hard-block). Shared with complete(). */
+  private async budgetPreCheck(
+    request: { modelSlug: string; maxTokens?: number; messages: ReadonlyArray<{ content: string }> },
+    providerKey: string,
+    workspaceId: string | undefined,
+  ): Promise<void> {
+    if (!workspaceId) return;
+    const budgetCheck = await this.costService.checkBudget({
+      workspaceId,
+      provider: providerKey,
+      model: request.modelSlug,
+      estimatedPromptTokens: request.messages.reduce(
+        (sum, m) => sum + Math.ceil(((m as { content: string }).content ?? "").length / 4),
+        0,
+      ),
+      estimatedCompletionTokens: request.maxTokens ?? 500,
+    });
+    if (budgetCheck.warning) console.warn("[gateway] Budget check:", budgetCheck.warning);
+    if (!budgetCheck.allowed) throw new Error(`[budget-exceeded] ${budgetCheck.warning}`);
+  }
+
+  /** Invoke an onDelta callback without letting its errors break the stream. */
+  private safeOnDelta(
+    onDelta: StreamingStageOptions["onDelta"],
+    delta: string,
+    cumulativeChars: number,
+  ): void {
+    if (!onDelta) return;
+    try {
+      onDelta(delta, cumulativeChars);
+    } catch (cbErr) {
+      console.warn("[gateway] stage onDelta callback threw (ignored):", cbErr);
+    }
+  }
+
+  /**
+   * Streaming-aware sibling of complete(). Consumes provider.stream(), assembles
+   * the full content from deltas (bounded), and surfaces idle/overall/byte-cap/
+   * abort/non-zero failures by REJECTING (never a partial success). Records
+   * usage and logs success+error exactly like complete().
+   */
+  async completeStreaming(
+    request: GatewayRequest,
+    privacyOptions?: GatewayPrivacyOptions,
+    loggingOptions?: GatewayLoggingOptions,
+    streamOptions?: StreamingStageOptions,
+  ): Promise<GatewayResponse> {
+    const model = await this.storage.getModelBySlug(request.modelSlug);
+    const { providerKey, modelId, provider } = this.resolveTarget(
+      request.modelSlug,
+      request.provider,
+      request.modelId,
+      model,
+    );
+
+    const privacy = privacyOptions?.privacy;
+    const sessionId = privacyOptions?.sessionId ?? crypto.randomUUID();
+    const messages = this.maybeAnonymize(request.messages as ProviderMessage[], privacy, sessionId);
+
+    await this.budgetPreCheck(request, providerKey, loggingOptions?.workspaceId);
+
+    const maxBytes = streamOptions?.maxOutputBytes ?? Gateway.DEFAULT_STREAM_MAX_BYTES;
+    const providerOpts: ILLMProviderOptions = {
+      maxTokens: request.maxTokens,
+      temperature: request.temperature,
+      signal: streamOptions?.signal,
+      idleTimeoutMs: streamOptions?.idleTimeoutMs,
+      timeoutMs: streamOptions?.overallTimeoutMs,
+      maxOutputBytes: maxBytes,
+    };
+
+    const start = Date.now();
+    let assembled = "";
+    let assembledBytes = 0;
+    try {
+      const iter = provider
+        ? provider.stream(modelId, messages, providerOpts)
+        : this.mockProvider.stream(messages);
+      for await (const delta of iter) {
+        assembledBytes += Buffer.byteLength(delta);
+        if (assembledBytes > maxBytes) {
+          throw new Error(`Assembled stream output exceeded ${maxBytes} bytes`);
+        }
+        assembled += delta;
+        this.safeOnDelta(streamOptions?.onDelta, delta, assembled.length);
+      }
+    } catch (err) {
+      const latencyMs = Date.now() - start;
+      await this.logRequest({
+        modelSlug: request.modelSlug,
+        providerKey,
+        messages,
+        options: { ...request, ...loggingOptions },
+        latencyMs,
+        status: "error",
+        errorMessage: scrubAndTruncate(String(err)),
+      });
+      throw err;
+    }
+
+    const latencyMs = Date.now() - start;
+    const content = this.shouldAnonymize(privacy)
+      ? this.anonymizer.rehydrate(assembled, sessionId)
+      : assembled;
+    // Streamed text deltas do not carry per-chunk token counts; estimate from
+    // assembled length so the cost ledger never silently records zero.
+    const tokensUsed = Math.max(1, Math.ceil(content.length / 4));
+
+    await this.logRequest({
+      modelSlug: request.modelSlug,
+      providerKey,
+      messages,
+      options: { ...request, ...loggingOptions },
+      result: { content, tokensUsed, inputTokens: 0, outputTokens: tokensUsed },
+      latencyMs,
+      status: "success",
+    });
+
+    if (loggingOptions?.workspaceId) {
+      void this.costService.recordCost({
+        workspaceId: loggingOptions.workspaceId,
+        provider: providerKey,
+        model: request.modelSlug,
+        pipelineRunId: loggingOptions.runId ?? null,
+        stageId: loggingOptions.stageId ?? null,
+        promptTokens: 0,
+        completionTokens: tokensUsed,
+      });
+    }
+
+    return { content, tokensUsed, modelSlug: request.modelSlug, finishReason: "stop" };
+  }
+
+  /** Duck-typed check: does the provider expose a streamEvents tool channel? */
+  private supportsStreamingToolLoop(
+    provider: ILLMProvider | null,
+  ): provider is ILLMProvider & IStreamingToolProvider {
+    return (
+      provider !== null &&
+      typeof (provider as unknown as { streamEvents?: unknown }).streamEvents === "function"
+    );
+  }
+
+  /**
+   * Validate a streamed/unvalidated tool call's args against the tool's declared
+   * parameters + a bound size BEFORE executing (Security C1 — toolRegistry does
+   * NOT validate). For the enabled CLI providers this is moot (no multiqlti
+   * tool-calls), but the guard is implemented in the tool-loop path regardless.
+   */
+  private validateToolCallArgs(call: ToolCall, tools: ToolDefinition[]): void {
+    const def = tools.find((t) => t.name === call.name);
+    if (!def) {
+      throw new Error(`[tool-validation] Unknown tool "${call.name}" requested by model`);
+    }
+    const serialized = JSON.stringify(call.arguments ?? {});
+    if (serialized.length > 64 * 1024) {
+      throw new Error(`[tool-validation] Tool "${call.name}" arguments exceed 64KiB`);
+    }
+    const schema = def.inputSchema as { properties?: Record<string, unknown> } | undefined;
+    if (schema?.properties && call.arguments) {
+      const allowed = new Set(Object.keys(schema.properties));
+      for (const key of Object.keys(call.arguments)) {
+        // Permit workspace defaults injected by the caller.
+        if (key === "workspaceId" || key === "workspacePath") continue;
+        if (!allowed.has(key)) {
+          throw new Error(
+            `[tool-validation] Tool "${call.name}" got unexpected argument "${key}"`,
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Streaming-aware tool loop. Each assistant turn is obtained via the
+   * provider's streamEvents channel; tool-use events are executed via
+   * toolRegistry (with C1 arg validation + workspace-default merge) and fed
+   * back. Providers without a streamEvents channel fall back to the blocking
+   * completeWithTools under the overall cap. maxIterations is honored.
+   */
+  async completeWithToolsStreaming(
+    params: {
+      modelSlug: string;
+      provider?: string;
+      modelId?: string;
+      messages: ProviderMessage[];
+      tools: ToolDefinition[];
+      options?: ILLMProviderOptions;
+      maxIterations?: number;
+      workspaceDefaults?: { workspaceId?: string; workspacePath?: string };
+    },
+    streamOptions?: StreamingStageOptions,
+  ): Promise<{ content: string; tokensUsed: number; toolCallLog: ToolCallLogEntry[] }> {
+    const { tools, options, workspaceDefaults } = params;
+    const maxIterations = params.maxIterations ?? 10;
+    const toolCallLog: ToolCallLogEntry[] = [];
+
+    const model = await this.storage.getModelBySlug(params.modelSlug);
+    const { modelId, provider } = this.resolveTarget(
+      params.modelSlug,
+      params.provider,
+      params.modelId,
+      model,
+    );
+
+    // Capability fallback: no streamEvents → blocking tool loop under overall cap.
+    if (!this.supportsStreamingToolLoop(provider)) {
+      return this.completeWithTools({
+        ...params,
+        options: {
+          ...options,
+          timeoutMs: streamOptions?.overallTimeoutMs ?? options?.timeoutMs,
+        },
+      });
+    }
+
+    const providerOpts: ILLMProviderOptions = {
+      ...options,
+      tools,
+      toolChoice: options?.toolChoice ?? "auto",
+      signal: streamOptions?.signal,
+      idleTimeoutMs: streamOptions?.idleTimeoutMs,
+      timeoutMs: streamOptions?.overallTimeoutMs ?? options?.timeoutMs,
+      maxOutputBytes: streamOptions?.maxOutputBytes,
+    };
+
+    const messages: ProviderMessage[] = [...params.messages];
+    let totalTokensUsed = 0;
+    let cumulativeChars = 0;
+    let iteration = 0;
+
+    while (iteration < maxIterations) {
+      iteration++;
+      let turnText = "";
+      const pendingToolCalls: ToolCall[] = [];
+      let finishReason: "stop" | "tool_use" = "stop";
+
+      for await (const event of provider.streamEvents(modelId, messages, providerOpts)) {
+        if (event.kind === "text-delta") {
+          turnText += event.text;
+          cumulativeChars += event.text.length;
+          this.safeOnDelta(streamOptions?.onDelta, event.text, cumulativeChars);
+        } else if (event.kind === "tool-call") {
+          pendingToolCalls.push(event.call);
+        } else {
+          totalTokensUsed += event.tokensUsed;
+          finishReason = event.finishReason;
+        }
+      }
+
+      if (finishReason !== "tool_use" || pendingToolCalls.length === 0) {
+        return { content: turnText, tokensUsed: totalTokensUsed, toolCallLog };
+      }
+
+      messages.push({ role: "assistant", content: turnText, toolCalls: pendingToolCalls });
+
+      for (const call of pendingToolCalls) {
+        const merged = { ...call.arguments };
+        if (workspaceDefaults) {
+          if (workspaceDefaults.workspaceId !== undefined && merged.workspaceId === undefined) {
+            merged.workspaceId = workspaceDefaults.workspaceId;
+          }
+          if (workspaceDefaults.workspacePath !== undefined && merged.workspacePath === undefined) {
+            merged.workspacePath = workspaceDefaults.workspacePath;
+          }
+        }
+        const validatedCall: ToolCall = { ...call, arguments: merged };
+        this.validateToolCallArgs(validatedCall, tools);
+
+        const callStart = Date.now();
+        const toolResult = await toolRegistry.execute(validatedCall);
+        const durationMs = Date.now() - callStart;
+        toolCallLog.push({ iteration, call: validatedCall, result: toolResult, durationMs });
+        messages.push({ role: "tool", toolCallId: toolResult.toolCallId, content: toolResult.content });
+      }
+    }
+
+    const lastAssistant = [...messages].reverse().find((m) => m.role === "assistant");
+    const content = lastAssistant && "content" in lastAssistant ? lastAssistant.content : "";
     return { content, tokensUsed: totalTokensUsed, toolCallLog };
   }
 

--- a/server/gateway/providers/claude-cli.ts
+++ b/server/gateway/providers/claude-cli.ts
@@ -13,8 +13,10 @@
  */
 import type {
   ILLMProvider,
+  IStreamingToolProvider,
   ILLMProviderOptions,
   ProviderMessage,
+  ProviderStreamEvent,
   ToolCall,
 } from "@shared/types";
 import {
@@ -54,9 +56,24 @@ interface ClaudeCliResult {
   usage?: { input_tokens?: number; output_tokens?: number };
 }
 
+interface ClaudeCliContentBlock {
+  type: string;
+  text?: string;
+  id?: string;
+  name?: string;
+  input?: Record<string, unknown>;
+}
+
 interface ClaudeCliAssistantEvent {
   type: "assistant";
-  message?: { content?: Array<{ type: string; text?: string }> };
+  message?: { content?: ClaudeCliContentBlock[] };
+}
+
+interface ClaudeCliResultEvent {
+  type: "result";
+  stop_reason?: string;
+  subtype?: string;
+  usage?: { input_tokens?: number; output_tokens?: number };
 }
 
 export interface ClaudeCliOptions {
@@ -103,6 +120,18 @@ function assistantText(event: ClaudeCliAssistantEvent): string {
     .join("");
 }
 
+/** Extract tool_use blocks from an `assistant` event as ToolCalls. */
+function assistantToolCalls(event: ClaudeCliAssistantEvent): ToolCall[] {
+  const blocks = event.message?.content ?? [];
+  return blocks
+    .filter((b) => b.type === "tool_use" && typeof b.id === "string" && typeof b.name === "string")
+    .map((b) => ({
+      id: b.id as string,
+      name: b.name as string,
+      arguments: (b.input ?? {}) as Record<string, unknown>,
+    }));
+}
+
 /** Parse the single JSON object emitted by `--output-format json`. */
 export function parseCompleteOutput(stdout: string): {
   content: string;
@@ -125,7 +154,7 @@ export function parseCompleteOutput(stdout: string): {
   return { content, tokensUsed, finishReason: "stop" };
 }
 
-export class ClaudeCliProvider implements ILLMProvider {
+export class ClaudeCliProvider implements ILLMProvider, IStreamingToolProvider {
   private readonly binary: string;
   private readonly limiter: ConcurrencyLimiter;
 
@@ -157,7 +186,13 @@ export class ClaudeCliProvider implements ILLMProvider {
       binary: this.binary,
       args,
       stdin: renderPrompt(messages),
+      // For the streaming stage path the gateway supplies the overall cap as
+      // timeoutMs plus idleTimeoutMs/maxOutputBytes/signal. Short callers omit
+      // them, keeping the 120s default and no idle/byte caps (H2).
       timeoutMs: options?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      idleTimeoutMs: options?.idleTimeoutMs,
+      maxOutputBytes: options?.maxOutputBytes,
+      signal: options?.signal,
     };
   }
 
@@ -189,18 +224,88 @@ export class ClaudeCliProvider implements ILLMProvider {
 
   /** Convert JSONL `assistant` events into incremental text deltas. */
   private async *iterateStream(request: CliSpawnRequest): AsyncGenerator<string> {
-    let previous = "";
-    for await (const line of streamCliLines(request)) {
-      const parsed = parseLine(line);
-      if (!parsed || parsed.type !== "assistant") continue;
-      const full = assistantText(parsed as unknown as ClaudeCliAssistantEvent);
-      if (full.length === 0 || full === previous) continue;
-      if (full.startsWith(previous)) {
-        yield full.slice(previous.length);
-      } else {
-        yield full;
+    // B2: hold a ConcurrencyLimiter slot for the FULL generator lifetime so
+    // long-running streaming stages cannot fork unbounded children. Acquired
+    // before the first spawn; released in finally on complete/error/early-return.
+    const release = await this.limiter.acquireSlot();
+    try {
+      let previous = "";
+      for await (const line of streamCliLines(request)) {
+        const parsed = parseLine(line);
+        if (!parsed || parsed.type !== "assistant") continue;
+        const full = assistantText(parsed as unknown as ClaudeCliAssistantEvent);
+        if (full.length === 0 || full === previous) continue;
+        if (full.startsWith(previous)) {
+          yield full.slice(previous.length);
+        } else {
+          yield full;
+        }
+        previous = full;
       }
-      previous = full;
+    } finally {
+      release();
+    }
+  }
+
+  /**
+   * Streamed event channel for the gateway tool loop (streaming-stage-execution).
+   * Reuses the JSONL line stream: `assistant` text blocks → incremental
+   * text-delta events (same prefix-diff as iterateStream), `tool_use` blocks →
+   * tool-call events, and the terminal `result` event → a single done event
+   * carrying usage + the model's stop reason. Per the spike, the enabled CLI
+   * providers do not receive multiqlti tool definitions, so in practice the
+   * stream is text + a stop result; the tool-call branch is kept correct for
+   * any provider that does emit tool_use blocks.
+   */
+  async *streamEvents(
+    modelId: string,
+    messages: ProviderMessage[],
+    options?: ILLMProviderOptions,
+  ): AsyncGenerator<ProviderStreamEvent> {
+    const args = this.baseArgs(modelId, messages, "stream-json");
+    const request = this.buildRequest(args, messages, options);
+
+    // B2: hold a limiter slot for the FULL generator lifetime (see iterateStream).
+    const release = await this.limiter.acquireSlot();
+    try {
+      let previousText = "";
+      let tokensUsed = 0;
+      let finishReason: "stop" | "tool_use" = "stop";
+      let sawResult = false;
+
+      for await (const line of streamCliLines(request)) {
+        const parsed = parseLine(line);
+        if (!parsed) continue;
+
+        if (parsed.type === "assistant") {
+          const event = parsed as unknown as ClaudeCliAssistantEvent;
+          const full = assistantText(event);
+          if (full.length > 0 && full !== previousText) {
+            const delta = full.startsWith(previousText) ? full.slice(previousText.length) : full;
+            previousText = full;
+            yield { kind: "text-delta", text: delta };
+          }
+          for (const call of assistantToolCalls(event)) {
+            yield { kind: "tool-call", call };
+          }
+          continue;
+        }
+
+        if (parsed.type === "result") {
+          const result = parsed as unknown as ClaudeCliResultEvent;
+          const usage = result.usage ?? {};
+          tokensUsed = (usage.input_tokens ?? 0) + (usage.output_tokens ?? 0);
+          finishReason = result.stop_reason === "tool_use" || result.subtype === "tool_use" ? "tool_use" : "stop";
+          sawResult = true;
+        }
+      }
+
+      // Always emit a terminal done so the gateway loop can finalize; if the CLI
+      // closed without a result event, fall back to a stop with the tokens seen.
+      void sawResult;
+      yield { kind: "done", tokensUsed, finishReason };
+    } finally {
+      release();
     }
   }
 

--- a/server/gateway/providers/cli-spawn.ts
+++ b/server/gateway/providers/cli-spawn.ts
@@ -10,12 +10,23 @@
  *   - Enforce a per-process timeout and honour an optional AbortSignal.
  *   - Cap the number of concurrently running child processes.
  *   - Surface a clear, typed error when the binary is missing (ENOENT).
+ *
+ * `streamCliLines` additionally enforces, for the long-running stage path
+ * (streaming-stage-execution): an idle (inactivity) timeout, an independent
+ * overall wall-clock cap, a cumulative output byte cap, and a max single-line
+ * length guard. Every failure path settles exactly once and kills the child
+ * with SIGTERM→SIGKILL escalation (Security C2/C3/H1/H3/H4).
  */
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
+import { scrubSecrets } from "../secret-scrub";
 
 const DEFAULT_MAX_CONCURRENCY = 4;
 const DEFAULT_TIMEOUT_MS = 120_000;
 const SIGKILL_GRACE_MS = 2_000;
+/** Default cap on a single newline-less line (no-newline flood guard, H4). */
+const DEFAULT_MAX_LINE_BYTES = 1_048_576; // 1 MiB
+/** Default cumulative output cap (matches Antigravity MAX_OUTPUT_BYTES). */
+const DEFAULT_MAX_OUTPUT_BYTES = 8 * 1024 * 1024; // 8 MiB
 
 /** Thrown when the underlying CLI binary is not installed / not on PATH. */
 export class CliNotInstalledError extends Error {
@@ -37,6 +48,46 @@ export class CliExecutionError extends Error {
   }
 }
 
+/** Distinct failure class: no output for the idle window (hung CLI). */
+export class CliIdleTimeoutError extends CliExecutionError {
+  constructor(idleTimeoutMs: number, stderr: string) {
+    super(`CLI idle for ${idleTimeoutMs}ms (no output)`, null, stderr);
+    this.name = "CliIdleTimeoutError";
+  }
+}
+
+/** Distinct failure class: overall wall-clock cap exceeded. */
+export class CliOverallTimeoutError extends CliExecutionError {
+  constructor(overallTimeoutMs: number, stderr: string) {
+    super(`CLI exceeded overall cap of ${overallTimeoutMs}ms`, null, stderr);
+    this.name = "CliOverallTimeoutError";
+  }
+}
+
+/** Distinct failure class: cumulative output byte cap exceeded. */
+export class CliByteCapError extends CliExecutionError {
+  constructor(maxOutputBytes: number, stderr: string) {
+    super(`CLI output exceeded ${maxOutputBytes} bytes`, null, stderr);
+    this.name = "CliByteCapError";
+  }
+}
+
+/** Distinct failure class: a single line exceeded the max line length. */
+export class CliLineCapError extends CliExecutionError {
+  constructor(maxLineBytes: number, stderr: string) {
+    super(`CLI emitted a line exceeding ${maxLineBytes} bytes (no newline)`, null, stderr);
+    this.name = "CliLineCapError";
+  }
+}
+
+/** Distinct failure class: caller aborted the request mid-flight. */
+export class CliAbortError extends CliExecutionError {
+  constructor(stderr: string) {
+    super("CLI request aborted", null, stderr);
+    this.name = "CliAbortError";
+  }
+}
+
 export interface CliSpawnRequest {
   /** Binary name or absolute path (e.g. "claude"). */
   binary: string;
@@ -44,8 +95,21 @@ export interface CliSpawnRequest {
   args: string[];
   /** Data written to the child's stdin, then closed. */
   stdin: string;
-  /** Per-process timeout in milliseconds. */
+  /**
+   * Overall wall-clock cap in ms. For `spawnCli` this is the only timeout
+   * (default 120s, short callers). For `streamCliLines` it is the overall cap
+   * that is NEVER reset by chunks.
+   */
   timeoutMs?: number;
+  /**
+   * Idle (inactivity) timeout in ms (streamCliLines only). Reset on each stdout
+   * chunk. Fires only when no output has arrived for this window.
+   */
+  idleTimeoutMs?: number;
+  /** Cumulative stdout byte cap (streamCliLines only). */
+  maxOutputBytes?: number;
+  /** Max single newline-less line length (streamCliLines only, H4). */
+  maxLineBytes?: number;
   /** Cancels the child when aborted. */
   signal?: AbortSignal;
   /** Extra env vars merged over process.env. */
@@ -74,6 +138,21 @@ export class ConcurrencyLimiter {
     }
   }
 
+  /**
+   * Acquire a slot for a manually-managed lifetime (e.g. an async generator that
+   * holds the slot until it completes/errors/early-returns). Returns an
+   * idempotent release callback the caller MUST invoke in a finally block.
+   */
+  async acquireSlot(): Promise<() => void> {
+    await this.acquire();
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.release();
+    };
+  }
+
   private acquire(): Promise<void> {
     if (this.active < this.max) {
       this.active += 1;
@@ -90,6 +169,19 @@ export class ConcurrencyLimiter {
     }
     this.active -= 1;
   }
+}
+
+/**
+ * SIGTERM the child, then SIGKILL after the grace window (C3). The SIGKILL is
+ * unconditional: a sent SIGTERM flips child.killed even while the process is
+ * still alive, so guarding the SIGKILL on !child.killed would defeat the
+ * escalation. SIGKILL on an already-dead pid is a harmless no-op.
+ */
+function killWithEscalation(child: ChildProcess): void {
+  child.kill("SIGTERM");
+  setTimeout(() => {
+    child.kill("SIGKILL");
+  }, SIGKILL_GRACE_MS);
 }
 
 function rejectOnSpawnError(
@@ -118,7 +210,7 @@ function settleClose(
   }
   reject(
     new CliExecutionError(
-      `CLI exited with code ${code ?? "null"}${stderr ? `: ${stderr.trim()}` : ""}`,
+      `CLI exited with code ${code ?? "null"}${stderr ? `: ${scrubSecrets(stderr.trim())}` : ""}`,
       code,
       stderr,
     ),
@@ -127,7 +219,9 @@ function settleClose(
 
 /**
  * Spawn a CLI process, feed `stdin`, and resolve with its captured output.
- * Buffers stdout/stderr in memory — intended for bounded CLI responses.
+ * Buffers stdout/stderr in memory — intended for bounded CLI responses
+ * (short callers: health-check ping, model discovery). Keeps the 120s default
+ * and NO idle/byte caps — those belong to the streaming stage path only (H2).
  */
 export function spawnCli(request: CliSpawnRequest): Promise<CliSpawnResult> {
   const timeoutMs = request.timeoutMs ?? DEFAULT_TIMEOUT_MS;
@@ -151,13 +245,12 @@ export function spawnCli(request: CliSpawnRequest): Promise<CliSpawnResult> {
     };
 
     const onAbort = (): void => {
-      child.kill("SIGTERM");
-      finish(() => reject(new CliExecutionError("CLI request aborted", null, stderr)));
+      killWithEscalation(child);
+      finish(() => reject(new CliAbortError(stderr)));
     };
 
     const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      setTimeout(() => child.kill("SIGKILL"), SIGKILL_GRACE_MS);
+      killWithEscalation(child);
       finish(() =>
         reject(new CliExecutionError(`CLI timed out after ${timeoutMs}ms`, null, stderr)),
       );
@@ -179,13 +272,23 @@ export function spawnCli(request: CliSpawnRequest): Promise<CliSpawnResult> {
 
 /**
  * Spawn a CLI process and yield its stdout split into complete lines as they
- * arrive. Used for `--output-format stream-json` (JSONL). The child is killed
- * on abort/timeout; a non-zero exit after streaming rejects the generator.
+ * arrive. Used for `--output-format stream-json` (JSONL).
+ *
+ * Timeout model (streaming-stage-execution): an idle timer reset on each chunk,
+ * an independent overall cap armed once at spawn, a cumulative byte cap, and a
+ * max single-line guard. Every failure path settles exactly once via `settle()`
+ * (clears both timers, removes the abort listener, kills the child with
+ * SIGTERM→SIGKILL escalation), so there are no leaked timers/listeners and the
+ * child is never orphaned (C2/C3).
  */
 export async function* streamCliLines(
   request: CliSpawnRequest,
 ): AsyncGenerator<string> {
-  const timeoutMs = request.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const overallTimeoutMs = request.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const idleTimeoutMs = request.idleTimeoutMs;
+  const maxOutputBytes = request.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+  const maxLineBytes = request.maxLineBytes ?? DEFAULT_MAX_LINE_BYTES;
+
   const child = spawn(request.binary, request.args, {
     env: { ...process.env, ...request.env },
     stdio: ["pipe", "pipe", "pipe"],
@@ -194,9 +297,12 @@ export async function* streamCliLines(
   const queue: string[] = [];
   let buffer = "";
   let stderr = "";
+  let totalBytes = 0;
   let done = false;
   let failure: Error | null = null;
+  let settled = false;
   let wake: (() => void) | null = null;
+  let idleTimer: ReturnType<typeof setTimeout> | null = null;
 
   const signalReady = (): void => {
     if (wake) {
@@ -206,26 +312,71 @@ export async function* streamCliLines(
     }
   };
 
-  const fail = (err: Error): void => {
-    failure = err;
+  // Single idempotent settle: clears both timers, removes the abort listener,
+  // and (for termination paths) kills the child with SIGTERM→SIGKILL — exactly
+  // once on EVERY exit path. `kill` is false only for a clean self-exit where
+  // the child is already gone (avoids scheduling a stray post-exit SIGKILL).
+  const settle = (err: Error | null, kill = true): void => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(overallTimer);
+    if (idleTimer) clearTimeout(idleTimer);
+    request.signal?.removeEventListener("abort", onAbort);
+    if (kill) killWithEscalation(child);
+    if (err) failure = err;
     done = true;
     signalReady();
   };
 
-  const timer = setTimeout(() => {
-    child.kill("SIGTERM");
-    setTimeout(() => child.kill("SIGKILL"), SIGKILL_GRACE_MS);
-    fail(new CliExecutionError(`CLI timed out after ${timeoutMs}ms`, null, stderr));
-  }, timeoutMs);
+  // Normal completion path (child closed on its own): flush the remaining
+  // buffer, then settle exactly once WITHOUT killing — the child already exited.
+  const settleNormal = (code: number | null): void => {
+    if (settled) return;
+    if (buffer.length > 0) {
+      queue.push(buffer);
+      buffer = "";
+    }
+    const err =
+      code !== 0 && code !== null
+        ? new CliExecutionError(
+            `CLI exited with code ${code}${stderr ? `: ${scrubSecrets(stderr.trim())}` : ""}`,
+            code,
+            stderr,
+          )
+        : null;
+    settle(err, false);
+  };
+
+  const armIdle = (): void => {
+    if (idleTimeoutMs === undefined) return;
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      settle(new CliIdleTimeoutError(idleTimeoutMs, stderr));
+    }, idleTimeoutMs);
+  };
+
+  const overallTimer = setTimeout(() => {
+    settle(new CliOverallTimeoutError(overallTimeoutMs, stderr));
+  }, overallTimeoutMs);
 
   const onAbort = (): void => {
-    child.kill("SIGTERM");
-    fail(new CliExecutionError("CLI request aborted", null, stderr));
+    settle(new CliAbortError(stderr));
   };
   request.signal?.addEventListener("abort", onAbort, { once: true });
 
+  armIdle();
+
   child.stderr.on("data", (chunk: Buffer) => (stderr += chunk.toString()));
   child.stdout.on("data", (chunk: Buffer) => {
+    if (settled) return;
+    armIdle(); // reset idle timer on every chunk (overall cap untouched)
+
+    totalBytes += chunk.length;
+    if (totalBytes > maxOutputBytes) {
+      settle(new CliByteCapError(maxOutputBytes, stderr));
+      return;
+    }
+
     buffer += chunk.toString();
     let idx = buffer.indexOf("\n");
     while (idx !== -1) {
@@ -233,30 +384,21 @@ export async function* streamCliLines(
       buffer = buffer.slice(idx + 1);
       idx = buffer.indexOf("\n");
     }
+    // Guard a newline-less flood: the unflushed tail must stay bounded (H4).
+    if (buffer.length > maxLineBytes) {
+      settle(new CliLineCapError(maxLineBytes, stderr));
+      return;
+    }
     signalReady();
   });
   child.on("error", (err: NodeJS.ErrnoException) =>
-    fail(
+    settle(
       err.code === "ENOENT"
         ? new CliNotInstalledError(request.binary)
         : new CliExecutionError(`Failed to spawn "${request.binary}": ${err.message}`, null, ""),
     ),
   );
-  child.on("close", (code) => {
-    if (buffer.length > 0) {
-      queue.push(buffer);
-      buffer = "";
-    }
-    if (code !== 0 && code !== null) {
-      failure = new CliExecutionError(
-        `CLI exited with code ${code}${stderr ? `: ${stderr.trim()}` : ""}`,
-        code,
-        stderr,
-      );
-    }
-    done = true;
-    signalReady();
-  });
+  child.on("close", (code) => settleNormal(code));
 
   child.stdin.end(request.stdin);
 
@@ -270,8 +412,8 @@ export async function* streamCliLines(
     }
     if (failure) throw failure;
   } finally {
-    clearTimeout(timer);
-    request.signal?.removeEventListener("abort", onAbort);
-    if (!child.killed) child.kill("SIGTERM");
+    // Defensive: if the consumer breaks early, settle (idempotent) so timers /
+    // the abort listener are cleared and the child is killed.
+    settle(null);
   }
 }

--- a/server/gateway/secret-scrub.ts
+++ b/server/gateway/secret-scrub.ts
@@ -1,0 +1,94 @@
+/**
+ * Secret scrubbing for streamed/partial output, CLI stderr, error messages, WS
+ * progress/failure payloads, logs, the tracer, and promoted run output
+ * (streaming-stage-execution, Security M2).
+ *
+ * The spawned CLI child inherits the full {...process.env}, so secret values
+ * (OMNISCIENCE_TOKEN, JWT_SECRET, *_API_KEY, ...) can in principle echo back
+ * through stdout/stderr. Before any of that text crosses a trust boundary we
+ * replace the literal VALUE of each known secret env var with a redaction
+ * marker. We deliberately scrub by value (not by guessing token shapes) so we
+ * only ever redact things that are genuinely secrets on this host.
+ */
+
+/** Existing preview/truncation contract — keep at 256 chars. */
+export const MAX_PREVIEW_CHARS = 256;
+
+const REDACTION = "[REDACTED]";
+
+/**
+ * Env var names whose values must be scrubbed. We match by exact name
+ * (OMNISCIENCE_TOKEN, JWT_SECRET, ENCRYPTION_KEY) and by suffix family
+ * (*_API_KEY, *_SECRET, *_TOKEN, *_PASSWORD). Short values (< 6 chars) are
+ * skipped to avoid mass false-positive redaction of ordinary prose.
+ */
+const EXPLICIT_SECRET_NAMES: ReadonlySet<string> = new Set([
+  "OMNISCIENCE_TOKEN",
+  "JWT_SECRET",
+  "ENCRYPTION_KEY",
+  "FEDERATION_CLUSTER_SECRET",
+  "ANTHROPIC_API_KEY",
+]);
+
+const SECRET_NAME_SUFFIXES: readonly string[] = [
+  "_API_KEY",
+  "_SECRET",
+  "_TOKEN",
+  "_PASSWORD",
+];
+
+const MIN_SECRET_LENGTH = 6;
+
+function isSecretName(name: string): boolean {
+  if (EXPLICIT_SECRET_NAMES.has(name)) return true;
+  return SECRET_NAME_SUFFIXES.some((suffix) => name.endsWith(suffix));
+}
+
+/** Escape a literal string for safe use inside a RegExp. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Collect the current set of secret VALUES present in process.env. Read fresh
+ * each call (cheap; env is small) so tests and runtime env changes are honored.
+ */
+function collectSecretValues(): string[] {
+  const values: string[] = [];
+  const env = process.env;
+  for (const name of Object.keys(env)) {
+    if (!isSecretName(name)) continue;
+    const value = env[name];
+    if (typeof value === "string" && value.length >= MIN_SECRET_LENGTH) {
+      values.push(value);
+    }
+  }
+  // Longest first so a secret that is a prefix of another doesn't leave a tail.
+  return values.sort((a, b) => b.length - a.length);
+}
+
+/**
+ * Replace every occurrence of a known secret env value in `input` with
+ * [REDACTED]. Non-string input coerces to "" (never throws).
+ */
+export function scrubSecrets(input: string): string {
+  if (typeof input !== "string") return "";
+  if (input.length === 0) return input;
+  let out = input;
+  for (const secret of collectSecretValues()) {
+    if (!out.includes(secret)) continue;
+    out = out.replace(new RegExp(escapeRegExp(secret), "g"), REDACTION);
+  }
+  return out;
+}
+
+/**
+ * Scrub secrets, then truncate to MAX_PREVIEW_CHARS. Use for any partial-output
+ * preview / stderr fragment that enters an error, WS payload, log, or trace.
+ */
+export function scrubAndTruncate(input: string): string {
+  const scrubbed = scrubSecrets(input);
+  return scrubbed.length > MAX_PREVIEW_CHARS
+    ? scrubbed.slice(0, MAX_PREVIEW_CHARS)
+    : scrubbed;
+}

--- a/server/teams/base.ts
+++ b/server/teams/base.ts
@@ -3,6 +3,7 @@ import type { Gateway } from "../gateway/index";
 import type { WsManager } from "../ws/manager";
 import type { TeamConfig, StageContext, TeamResult, ExecutionStrategy, ProviderMessage, TeamId } from "@shared/types";
 import { StrategyExecutor } from "../services/strategy-executor";
+import { configLoader } from "../config/loader";
 
 const CONTEXT_STAGES_TO_SHOW = 3;
 const CONTEXT_TRUNCATE_CHARS = 500;
@@ -75,14 +76,14 @@ export abstract class BaseTeam {
       );
 
       if (tools.length > 0) {
-        const result = await this.gateway.completeWithTools({
+        const toolParams = {
           modelSlug: context.modelSlug || this.config.defaultModelSlug,
           messages,
           tools,
           options: {
             temperature: context.temperature,
             maxTokens: context.maxTokens,
-            toolChoice: toolConfig?.toolChoice ?? 'auto',
+            toolChoice: toolConfig?.toolChoice ?? 'auto' as const,
           },
           maxIterations: toolConfig?.maxToolCalls ?? 10,
           // Workspace binding (issue #343). When a run is bound to a workspace,
@@ -95,7 +96,14 @@ export abstract class BaseTeam {
                 workspacePath: context.workspacePath,
               }
             : undefined,
-        });
+        };
+        // Streaming stage path (streaming-stage-execution): when enabled and the
+        // controller supplied a streaming block, stream the tool turns under the
+        // idle/overall budget. Any stream error/timeout/abort REJECTS — the
+        // stage must throw, never return a partial TeamResult (H3).
+        const result = this.useStreaming(context)
+          ? await this.gateway.completeWithToolsStreaming(toolParams, context.streaming)
+          : await this.gateway.completeWithTools(toolParams);
 
         const parsed = this.parseOutput(result.content);
         const questions = this.extractQuestions(parsed);
@@ -110,22 +118,23 @@ export abstract class BaseTeam {
       }
     }
 
-    const response = await this.gateway.complete(
-      {
-        modelSlug: context.modelSlug || this.config.defaultModelSlug,
-        messages,
-        temperature: context.temperature,
-        maxTokens: context.maxTokens,
-      },
-      context.privacySettings
-        ? { privacy: context.privacySettings, sessionId: context.sessionId }
-        : undefined,
-      {
-        runId: context.runId,
-        stageExecutionId: context.stageExecutionId,
-        teamId: this.config.id,
-      },
-    );
+    const request = {
+      modelSlug: context.modelSlug || this.config.defaultModelSlug,
+      messages,
+      temperature: context.temperature,
+      maxTokens: context.maxTokens,
+    };
+    const privacyOpts = context.privacySettings
+      ? { privacy: context.privacySettings, sessionId: context.sessionId }
+      : undefined;
+    const loggingOpts = {
+      runId: context.runId,
+      stageExecutionId: context.stageExecutionId,
+      teamId: this.config.id,
+    };
+    const response = this.useStreaming(context)
+      ? await this.gateway.completeStreaming(request, privacyOpts, loggingOpts, context.streaming)
+      : await this.gateway.complete(request, privacyOpts, loggingOpts);
 
     const parsed = this.parseOutput(response.content);
     const questions = this.extractQuestions(parsed);
@@ -136,6 +145,21 @@ export abstract class BaseTeam {
       raw: response.content,
       questions: questions.length > 0 ? questions : undefined,
     };
+  }
+
+  /**
+   * Stage-streaming gate (streaming-stage-execution kill-switch). Streaming is
+   * used only when BOTH the controller supplied a `context.streaming` block
+   * AND `pipeline.streaming.enabled` is true. When false → the blocking
+   * complete/completeWithTools path is used unchanged (instant revert).
+   */
+  private useStreaming(context: StageContext): boolean {
+    if (!context.streaming) return false;
+    try {
+      return configLoader.get().pipeline.streaming.enabled === true;
+    } catch {
+      return false;
+    }
   }
 
   private async executeWithStrategy(

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -719,6 +719,12 @@ export interface StageContext {
   // filesystem path for tool convenience.
   workspaceId?: string;
   workspacePath?: string;
+  /**
+   * Stage streaming controls (streaming-stage-execution). Populated by the
+   * pipeline-controller: the run AbortSignal, a coalesced WS-progress onDelta,
+   * and the resolved idle/overall/byte limits. Absent → blocking fallback.
+   */
+  streaming?: StreamingStageOptions;
 }
 
 export interface TeamResult {
@@ -752,6 +758,22 @@ export interface ILLMProviderOptions {
   tools?: ToolDefinition[];
   /** How the model chooses tools. */
   toolChoice?: 'auto' | 'none' | 'required';
+  /**
+   * Abort signal for mid-stream cancellation. Providers MUST terminate the
+   * underlying child/request and stop yielding when this fires.
+   */
+  signal?: AbortSignal;
+  /**
+   * Idle (inactivity) timeout in ms for streaming calls: reset on every
+   * received chunk. Fires only when NO output has arrived for this window.
+   * Independent of timeoutMs (which is the overall cap on the stream path).
+   */
+  idleTimeoutMs?: number;
+  /**
+   * Cumulative output byte cap for streaming calls. When exceeded the child is
+   * killed and the call fails. Bounds in-memory accumulation (DoS guard).
+   */
+  maxOutputBytes?: number;
 }
 
 export interface ILLMProvider {
@@ -766,13 +788,56 @@ export interface ILLMProvider {
 
   /**
    * Streaming completion. Yields text delta chunks as they arrive.
-   * The generator MUST be exhaustible — callers do not cancel mid-stream.
+   *
+   * Cancellation contract (changed for streaming-stage-execution): callers MAY
+   * abort mid-stream via options.signal. Providers MUST terminate the
+   * underlying child/request and stop yielding when the signal fires. The
+   * generator is otherwise exhaustible.
    */
   stream(
     modelId: string,
     messages: ProviderMessage[],
     options?: ILLMProviderOptions,
   ): AsyncGenerator<string>;
+}
+
+// ─── Streaming Provider Events (streaming-stage-execution) ───────────────────
+
+/**
+ * Discriminated event emitted by a provider's optional streamEvents() channel.
+ * Lets the gateway run a tool loop while streaming: text deltas arrive
+ * incrementally, tool-use blocks surface as discrete calls, and a terminal
+ * 'done' carries usage + the model's stop reason.
+ */
+export type ProviderStreamEvent =
+  | { kind: 'text-delta'; text: string }
+  | { kind: 'tool-call'; call: ToolCall }
+  | { kind: 'done'; tokensUsed: number; finishReason: 'stop' | 'tool_use' };
+
+/**
+ * Optional provider capability (duck-typed). A provider that emits
+ * ProviderStreamEvent supports the streamed tool loop. Providers without it
+ * (e.g. emulated one-shot streams) fall back to the blocking tool path.
+ */
+export interface IStreamingToolProvider {
+  streamEvents(
+    modelId: string,
+    messages: ProviderMessage[],
+    options?: ILLMProviderOptions,
+  ): AsyncGenerator<ProviderStreamEvent>;
+}
+
+/**
+ * Stage-streaming options threaded controller → BaseTeam → gateway → provider.
+ * onDelta receives the coalesced/raw delta plus cumulative char count so the
+ * controller can emit bounded WS progress without shipping the whole buffer.
+ */
+export interface StreamingStageOptions {
+  signal?: AbortSignal;
+  onDelta?: (deltaText: string, cumulativeChars: number) => void;
+  idleTimeoutMs?: number;
+  overallTimeoutMs?: number;
+  maxOutputBytes?: number;
 }
 
 // ─── Strategy Preset (existing usage in constants.ts) ────────────────────────

--- a/tests/unit/config/pipeline-streaming-schema.test.ts
+++ b/tests/unit/config/pipeline-streaming-schema.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for the `pipeline.streaming` config section (streaming-stage-execution, M1).
+ *
+ * Validates defaults and the zod .min()/.max() bounds so a misconfiguration can
+ * never disable the overall cap or set an absurd buffer. Tests parse against the
+ * ConfigSchema directly (no env / no file IO) for determinism.
+ */
+import { describe, it, expect } from "vitest";
+import { ConfigSchema } from "../../../server/config/schema.js";
+
+describe("pipeline.streaming config schema — defaults", () => {
+  it("applies the documented defaults when nothing is set", () => {
+    const cfg = ConfigSchema.parse({});
+    expect(cfg.pipeline.streaming).toEqual({
+      enabled: true,
+      idleTimeoutMs: 60_000,
+      overallTimeoutMs: 600_000,
+      maxOutputBytes: 8 * 1024 * 1024,
+      wsProgressFlushMs: 250,
+    });
+  });
+
+  it("accepts a fully-specified in-range override", () => {
+    const cfg = ConfigSchema.parse({
+      pipeline: {
+        streaming: {
+          enabled: false,
+          idleTimeoutMs: 30_000,
+          overallTimeoutMs: 1_200_000,
+          maxOutputBytes: 1_048_576,
+          wsProgressFlushMs: 500,
+        },
+      },
+    });
+    expect(cfg.pipeline.streaming.enabled).toBe(false);
+    expect(cfg.pipeline.streaming.idleTimeoutMs).toBe(30_000);
+    expect(cfg.pipeline.streaming.overallTimeoutMs).toBe(1_200_000);
+  });
+
+  it("coerces numeric strings (env-style) for the timeout knobs", () => {
+    const cfg = ConfigSchema.parse({
+      pipeline: { streaming: { idleTimeoutMs: "45000", overallTimeoutMs: "900000" } },
+    });
+    expect(cfg.pipeline.streaming.idleTimeoutMs).toBe(45_000);
+    expect(cfg.pipeline.streaming.overallTimeoutMs).toBe(900_000);
+  });
+});
+
+describe("pipeline.streaming config schema — bounds rejection (M1)", () => {
+  const cases: Array<{ name: string; patch: Record<string, unknown> }> = [
+    { name: "idle below min", patch: { idleTimeoutMs: 999 } },
+    { name: "idle above max", patch: { idleTimeoutMs: 600_001 } },
+    { name: "overall below min", patch: { overallTimeoutMs: 9_999 } },
+    { name: "overall above max", patch: { overallTimeoutMs: 3_600_001 } },
+    { name: "maxOutputBytes below min", patch: { maxOutputBytes: 65_535 } },
+    { name: "maxOutputBytes above max", patch: { maxOutputBytes: 67_108_865 } },
+    { name: "flush below min", patch: { wsProgressFlushMs: 49 } },
+    { name: "flush above max", patch: { wsProgressFlushMs: 5_001 } },
+  ];
+
+  for (const { name, patch } of cases) {
+    it(`rejects ${name}`, () => {
+      const result = ConfigSchema.safeParse({ pipeline: { streaming: patch } });
+      expect(result.success).toBe(false);
+    });
+  }
+
+  it("rejects a non-integer idle timeout", () => {
+    const result = ConfigSchema.safeParse({
+      pipeline: { streaming: { idleTimeoutMs: 60_000.5 } },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/unit/gateway/completeStreaming.test.ts
+++ b/tests/unit/gateway/completeStreaming.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for Gateway.completeStreaming (streaming-stage-execution, T11a).
+ *
+ * Asserts: assembled text == concatenated deltas; onDelta receives coalesced
+ * cumulative-char counts; a mid-stream provider error rejects (no partial
+ * success); abort via signal rejects; usage is recorded (not zeroed).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  buildTestGateway,
+  SlowMockStreamingProvider,
+  MidStreamErrorProvider,
+  NeverEndingStreamingProvider,
+  TEST_MODEL_SLUG,
+} from "../helpers/streaming-test-utils.js";
+
+function request() {
+  return { modelSlug: TEST_MODEL_SLUG, messages: [{ role: "user", content: "hi" }] };
+}
+
+describe("Gateway.completeStreaming", () => {
+  it("assembles the full content from concatenated deltas", async () => {
+    const gateway = buildTestGateway(new SlowMockStreamingProvider(["Hel", "lo ", "world"], 0));
+    const seen: string[] = [];
+    const res = await gateway.completeStreaming(request(), undefined, undefined, {
+      onDelta: (delta) => seen.push(delta),
+    });
+    expect(res.content).toBe("Hello world");
+    expect(seen.join("")).toBe("Hello world");
+  });
+
+  it("reports a monotonically increasing cumulativeChars via onDelta", async () => {
+    const gateway = buildTestGateway(new SlowMockStreamingProvider(["ab", "cd", "ef"], 0));
+    const cumulative: number[] = [];
+    await gateway.completeStreaming(request(), undefined, undefined, {
+      onDelta: (_d, chars) => cumulative.push(chars),
+    });
+    expect(cumulative).toEqual([2, 4, 6]);
+  });
+
+  it("surfaces a non-zero token estimate from streamed text (does not silently zero)", async () => {
+    // The plain stream() channel yields only text deltas (no usage), so the
+    // gateway must fall back to a length-based estimate, never a silent zero.
+    const gateway = buildTestGateway(new SlowMockStreamingProvider(["x".repeat(40)], 0, 123));
+    const res = await gateway.completeStreaming(request());
+    expect(res.tokensUsed).toBeGreaterThan(0);
+    expect(res.tokensUsed).toBe(Math.ceil(40 / 4));
+  });
+
+  it("rejects on a mid-stream error and does NOT return a partial success", async () => {
+    const gateway = buildTestGateway(new MidStreamErrorProvider("boom-xyz"));
+    await expect(gateway.completeStreaming(request())).rejects.toThrow(/boom-xyz/);
+  });
+
+  it("fails when assembled output exceeds the byte cap", async () => {
+    const gateway = buildTestGateway(new SlowMockStreamingProvider(["x".repeat(200)], 0));
+    await expect(
+      gateway.completeStreaming(request(), undefined, undefined, { maxOutputBytes: 64 }),
+    ).rejects.toThrow(/exceeded/i);
+  });
+
+  it("aborts mid-stream when the signal fires", async () => {
+    const gateway = buildTestGateway(new NeverEndingStreamingProvider());
+    const controller = new AbortController();
+    const promise = gateway.completeStreaming(request(), undefined, undefined, {
+      signal: controller.signal,
+    });
+    setTimeout(() => controller.abort(), 20);
+    await expect(promise).rejects.toThrow(/aborted/i);
+  });
+
+  it("does not throw from onDelta callbacks back into the stream", async () => {
+    const gateway = buildTestGateway(new SlowMockStreamingProvider(["a", "b"], 0));
+    const res = await gateway.completeStreaming(request(), undefined, undefined, {
+      onDelta: () => {
+        throw new Error("callback should be isolated");
+      },
+    });
+    expect(res.content).toBe("ab");
+  });
+});

--- a/tests/unit/gateway/completeWithToolsStreaming.test.ts
+++ b/tests/unit/gateway/completeWithToolsStreaming.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for Gateway.completeWithToolsStreaming (streaming-stage-execution, T11b).
+ *
+ * Asserts: a streamed tool turn runs end-to-end (tool-call → toolRegistry →
+ * tool result → final text); maxIterations is honored; a provider WITHOUT a
+ * streamEvents channel falls back to the blocking completeWithTools path.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  buildTestGateway,
+  ScriptedToolStreamProvider,
+  SlowMockStreamingProvider,
+  ev,
+  TEST_MODEL_SLUG,
+} from "../helpers/streaming-test-utils.js";
+import { toolRegistry } from "../../../server/tools/index.js";
+import type { ToolDefinition } from "../../../shared/types.js";
+
+const TOOL: ToolDefinition = {
+  name: "echo_tool",
+  description: "echoes its input",
+  inputSchema: { type: "object", properties: { value: { type: "string" } } },
+  source: "builtin",
+};
+
+function params() {
+  return {
+    modelSlug: TEST_MODEL_SLUG,
+    messages: [{ role: "user" as const, content: "use the tool" }],
+    tools: [TOOL],
+    maxIterations: 5,
+  };
+}
+
+describe("Gateway.completeWithToolsStreaming", () => {
+  beforeEach(() => {
+    toolRegistry.register({
+      definition: TOOL,
+      execute: async (args) => `echoed:${String(args.value ?? "")}`,
+    });
+  });
+  afterEach(() => toolRegistry.unregister("echo_tool"));
+
+  it("runs a streamed tool turn end-to-end and returns the final assistant text", async () => {
+    const provider = new ScriptedToolStreamProvider([
+      // Turn 1: model asks for the tool.
+      [
+        ev.text("let me check"),
+        ev.tool({ id: "c1", name: "echo_tool", arguments: { value: "hi" } }),
+        ev.done("tool_use", 7),
+      ],
+      // Turn 2: model produces the final answer.
+      [ev.text("final answer"), ev.done("stop", 5)],
+    ]);
+    const gateway = buildTestGateway(provider);
+    const res = await gateway.completeWithToolsStreaming(params());
+    expect(res.content).toBe("final answer");
+    expect(res.toolCallLog).toHaveLength(1);
+    expect(res.toolCallLog[0].result.content).toBe("echoed:hi");
+    expect(res.tokensUsed).toBe(12);
+  });
+
+  it("forwards onDelta text from each streamed turn", async () => {
+    const provider = new ScriptedToolStreamProvider([[ev.text("hello"), ev.done("stop", 3)]]);
+    const gateway = buildTestGateway(provider);
+    const seen: string[] = [];
+    const res = await gateway.completeWithToolsStreaming(params(), {
+      onDelta: (d) => seen.push(d),
+    });
+    expect(seen.join("")).toBe("hello");
+    expect(res.content).toBe("hello");
+  });
+
+  it("terminates at maxIterations when the model never stops calling tools", async () => {
+    // Every turn keeps asking for the tool.
+    const provider = new ScriptedToolStreamProvider([
+      [ev.tool({ id: "c", name: "echo_tool", arguments: { value: "loop" } }), ev.done("tool_use", 1)],
+    ]);
+    const gateway = buildTestGateway(provider);
+    const res = await gateway.completeWithToolsStreaming({
+      ...params(),
+      maxIterations: 3,
+    });
+    // Loop bounded: 3 tool executions, then a terminal return.
+    expect(res.toolCallLog.length).toBe(3);
+  });
+
+  it("falls back to the blocking tool path for a provider without streamEvents", async () => {
+    // SlowMockStreamingProvider has no streamEvents → capability fallback.
+    const gateway = buildTestGateway(new SlowMockStreamingProvider(["ignored"], 0, 9));
+    const res = await gateway.completeWithToolsStreaming(params());
+    // Fallback uses complete() (no tool calls) → returns its content.
+    expect(typeof res.content).toBe("string");
+    expect(res.toolCallLog).toEqual([]);
+  });
+
+  it("REJECTS an oversized tool-call (>64KiB args) and does NOT execute the tool (C1)", async () => {
+    // Re-register echo_tool with a spy so we can assert it is never executed.
+    const execSpy = vi.fn(async (args: Record<string, unknown>) => `echoed:${String(args.value ?? "")}`);
+    toolRegistry.unregister("echo_tool");
+    toolRegistry.register({ definition: TOOL, execute: execSpy });
+
+    const huge = "x".repeat(70 * 1024); // > 64 KiB serialized
+    const provider = new ScriptedToolStreamProvider([
+      [ev.tool({ id: "big", name: "echo_tool", arguments: { value: huge } }), ev.done("tool_use", 1)],
+    ]);
+    const gateway = buildTestGateway(provider);
+
+    await expect(gateway.completeWithToolsStreaming(params())).rejects.toThrow(/\[tool-validation\].*64KiB/);
+    expect(execSpy).not.toHaveBeenCalled();
+  });
+
+  it("merges workspaceDefaults into a tool-call missing workspaceId before executing", async () => {
+    // Capture the args the tool actually received.
+    const execSpy = vi.fn(async (args: Record<string, unknown>) => `ws:${String(args.workspaceId ?? "none")}`);
+    toolRegistry.unregister("echo_tool");
+    // Allow workspaceId on the schema so the C1 validator does not reject it.
+    const wsTool: ToolDefinition = {
+      ...TOOL,
+      inputSchema: { type: "object", properties: { value: { type: "string" }, workspaceId: { type: "string" } } },
+    };
+    toolRegistry.register({ definition: wsTool, execute: execSpy });
+
+    const provider = new ScriptedToolStreamProvider([
+      // Tool-call omits workspaceId → should be filled from workspaceDefaults.
+      [ev.tool({ id: "w1", name: "echo_tool", arguments: { value: "v" } }), ev.done("tool_use", 1)],
+      [ev.text("done"), ev.done("stop", 1)],
+    ]);
+    const gateway = buildTestGateway(provider);
+
+    const res = await gateway.completeWithToolsStreaming({
+      ...params(),
+      tools: [wsTool],
+      workspaceDefaults: { workspaceId: "ws-1" },
+    });
+
+    // The merged workspaceId reached the executed tool...
+    expect(execSpy).toHaveBeenCalledOnce();
+    expect(execSpy.mock.calls[0][0].workspaceId).toBe("ws-1");
+    // ...and is recorded in the toolCallLog's call arguments.
+    expect(res.toolCallLog[0].call.arguments.workspaceId).toBe("ws-1");
+  });
+});

--- a/tests/unit/gateway/secret-scrub.test.ts
+++ b/tests/unit/gateway/secret-scrub.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for the secret-scrub utility (streaming-stage-execution, Security M2).
+ *
+ * Scrubs the VALUES of known secret env vars (OMNISCIENCE_TOKEN, JWT_SECRET,
+ * anything matching *_API_KEY / *_SECRET / *_TOKEN that is present in
+ * process.env) from any string that is about to enter an error message, a WS
+ * progress/failure payload, a log line, the tracer, or promoted run output —
+ * and applies the existing 256-char truncation.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  scrubSecrets,
+  scrubAndTruncate,
+  MAX_PREVIEW_CHARS,
+} from "../../../server/gateway/secret-scrub.js";
+
+describe("scrubSecrets", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("replaces a known secret env value with a redaction marker", () => {
+    vi.stubEnv("OMNISCIENCE_TOKEN", "tok-abc123-supersecret");
+    const out = scrubSecrets("partial output leaked tok-abc123-supersecret here");
+    expect(out).not.toContain("tok-abc123-supersecret");
+    expect(out).toContain("[REDACTED]");
+  });
+
+  it("scrubs *_API_KEY values", () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-proj-xyz-9988");
+    const out = scrubSecrets("error: sk-proj-xyz-9988 was used");
+    expect(out).not.toContain("sk-proj-xyz-9988");
+  });
+
+  it("scrubs JWT_SECRET values", () => {
+    vi.stubEnv("JWT_SECRET", "jwt-signing-secret-value-1234567890");
+    const out = scrubSecrets("token signed with jwt-signing-secret-value-1234567890");
+    expect(out).not.toContain("jwt-signing-secret-value-1234567890");
+  });
+
+  it("scrubs multiple distinct secrets in one string", () => {
+    vi.stubEnv("OMNISCIENCE_TOKEN", "AAA-secret");
+    vi.stubEnv("GROK_API_KEY", "BBB-secret");
+    const out = scrubSecrets("a=AAA-secret b=BBB-secret");
+    expect(out).not.toContain("AAA-secret");
+    expect(out).not.toContain("BBB-secret");
+  });
+
+  it("leaves text without secrets unchanged", () => {
+    vi.stubEnv("OMNISCIENCE_TOKEN", "zzz-secret");
+    expect(scrubSecrets("nothing to see here")).toBe("nothing to see here");
+  });
+
+  it("ignores empty / very-short env values to avoid mass false redaction", () => {
+    vi.stubEnv("SOME_TOKEN", "ab");
+    const out = scrubSecrets("the value ab appears in normal prose");
+    expect(out).toBe("the value ab appears in normal prose");
+  });
+
+  it("handles non-string input by coercing safely", () => {
+    expect(scrubSecrets(undefined as unknown as string)).toBe("");
+  });
+});
+
+describe("scrubAndTruncate", () => {
+  beforeEach(() => vi.stubEnv("OMNISCIENCE_TOKEN", "tok-secret-9999"));
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("scrubs then truncates to MAX_PREVIEW_CHARS", () => {
+    const long = "x".repeat(MAX_PREVIEW_CHARS + 100);
+    const out = scrubAndTruncate(long);
+    expect(out.length).toBeLessThanOrEqual(MAX_PREVIEW_CHARS);
+  });
+
+  it("scrubs even when the secret sits past the truncation boundary head", () => {
+    const out = scrubAndTruncate("tok-secret-9999 then a lot of text");
+    expect(out).not.toContain("tok-secret-9999");
+  });
+
+  it("MAX_PREVIEW_CHARS keeps the existing 256-char contract", () => {
+    expect(MAX_PREVIEW_CHARS).toBe(256);
+  });
+});

--- a/tests/unit/helpers/streaming-test-utils.ts
+++ b/tests/unit/helpers/streaming-test-utils.ts
@@ -1,0 +1,179 @@
+/**
+ * Shared test doubles + builders for the streaming-stage-execution suites.
+ *
+ * Provides fake streaming providers (slow/oversized/never-ending/mid-stream
+ * error/tool-emitting), a minimal in-memory storage stub, a Gateway builder
+ * that registers a fake provider, and a StageContext factory. No real CLI,
+ * DB, or network is touched.
+ */
+import { vi } from "vitest";
+import { Gateway } from "../../../server/gateway/index.js";
+import type {
+  ILLMProvider,
+  ILLMProviderOptions,
+  ProviderMessage,
+  ProviderStreamEvent,
+  StageContext,
+  ToolCall,
+} from "../../../shared/types.js";
+
+export const TEST_PROVIDER_KEY = "test-stream";
+export const TEST_MODEL_SLUG = "test-model";
+
+/** Minimal IStorage stub: only the methods the gateway streaming path touches. */
+export function makeStorageStub(): Record<string, unknown> {
+  return {
+    getModelBySlug: vi.fn(async (slug: string) => ({
+      slug,
+      provider: TEST_PROVIDER_KEY,
+      modelId: slug,
+      name: slug,
+    })),
+    createLlmRequest: vi.fn(async () => ({ id: "req-1" })),
+  };
+}
+
+/** Build a Gateway with `provider` registered under TEST_PROVIDER_KEY. */
+export function buildTestGateway(provider: ILLMProvider): Gateway {
+  const storage = makeStorageStub();
+  const gateway = new Gateway(storage as never);
+  gateway.registerProvider(TEST_PROVIDER_KEY, provider);
+  return gateway;
+}
+
+export function makeContext(overrides: Partial<StageContext> = {}): StageContext {
+  return {
+    runId: "run-1",
+    stageIndex: 0,
+    stageExecutionId: "stage-1",
+    modelSlug: TEST_MODEL_SLUG,
+    previousOutputs: [],
+    fullContext: [],
+    ...overrides,
+  };
+}
+
+/** Yields fixed text chunks, one per `chunkDelayMs` (real or fake timers). */
+export class SlowMockStreamingProvider implements ILLMProvider {
+  constructor(
+    private readonly chunks: string[],
+    private readonly chunkDelayMs: number,
+    private readonly tokensUsed = 42,
+  ) {}
+
+  async complete(): Promise<{ content: string; tokensUsed: number; finishReason: "stop" }> {
+    return { content: this.chunks.join(""), tokensUsed: this.tokensUsed, finishReason: "stop" };
+  }
+
+  async *stream(
+    _modelId: string,
+    _messages: ProviderMessage[],
+    _options?: ILLMProviderOptions,
+  ): AsyncGenerator<string> {
+    for (const chunk of this.chunks) {
+      await new Promise((r) => setTimeout(r, this.chunkDelayMs));
+      yield chunk;
+    }
+  }
+}
+
+/** Emits one chunk well beyond a byte cap to exercise gateway-level bounding. */
+export class OversizedStreamingProvider implements ILLMProvider {
+  constructor(private readonly totalBytes: number) {}
+
+  async complete(): Promise<{ content: string; tokensUsed: number; finishReason: "stop" }> {
+    return { content: "x".repeat(this.totalBytes), tokensUsed: 1, finishReason: "stop" };
+  }
+
+  async *stream(): AsyncGenerator<string> {
+    // 64 KiB chunks until the total is exceeded.
+    const chunk = "x".repeat(65_536);
+    let sent = 0;
+    while (sent <= this.totalBytes) {
+      yield chunk;
+      sent += chunk.length;
+    }
+  }
+}
+
+/** Honors options.signal: rejects with an abort error when aborted mid-stream. */
+export class NeverEndingStreamingProvider implements ILLMProvider {
+  async complete(): Promise<{ content: string; tokensUsed: number; finishReason: "stop" }> {
+    return { content: "", tokensUsed: 0, finishReason: "stop" };
+  }
+
+  async *stream(
+    _modelId: string,
+    _messages: ProviderMessage[],
+    options?: ILLMProviderOptions,
+  ): AsyncGenerator<string> {
+    while (true) {
+      if (options?.signal?.aborted) {
+        throw new Error("CLI request aborted");
+      }
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(resolve, 10);
+        options?.signal?.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            reject(new Error("CLI request aborted"));
+          },
+          { once: true },
+        );
+      });
+      yield "tick";
+    }
+  }
+}
+
+/** Yields a couple of deltas, then throws mid-stream (no partial success). */
+export class MidStreamErrorProvider implements ILLMProvider {
+  constructor(private readonly errorMessage = "mid-stream boom") {}
+
+  async complete(): Promise<{ content: string; tokensUsed: number; finishReason: "stop" }> {
+    return { content: "partial", tokensUsed: 1, finishReason: "stop" };
+  }
+
+  async *stream(): AsyncGenerator<string> {
+    yield "par";
+    yield "tial";
+    throw new Error(this.errorMessage);
+  }
+}
+
+/**
+ * Streaming-tool provider: replays a scripted set of streamEvents per gateway
+ * iteration. Each call to streamEvents() shifts the next script entry.
+ */
+export class ScriptedToolStreamProvider implements ILLMProvider {
+  private turn = 0;
+
+  constructor(private readonly script: ProviderStreamEvent[][]) {}
+
+  async complete(): Promise<{ content: string; tokensUsed: number; finishReason: "stop" }> {
+    return { content: "", tokensUsed: 0, finishReason: "stop" };
+  }
+
+  // eslint-disable-next-line require-yield
+  async *stream(): AsyncGenerator<string> {
+    // Not used by the tool path.
+  }
+
+  async *streamEvents(): AsyncGenerator<ProviderStreamEvent> {
+    const events = this.script[Math.min(this.turn, this.script.length - 1)];
+    this.turn += 1;
+    for (const ev of events) yield ev;
+  }
+}
+
+/** Convenience builders for ProviderStreamEvent scripts. */
+export const ev = {
+  text: (text: string): ProviderStreamEvent => ({ kind: "text-delta", text }),
+  tool: (call: ToolCall): ProviderStreamEvent => ({ kind: "tool-call", call }),
+  done: (finishReason: "stop" | "tool_use", tokensUsed = 10): ProviderStreamEvent => ({
+    kind: "done",
+    finishReason,
+    tokensUsed,
+  }),
+};

--- a/tests/unit/pipeline/dag-stage-abort.test.ts
+++ b/tests/unit/pipeline/dag-stage-abort.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Unit test — DAG stage path abort parity (streaming-stage-execution, B1).
+ *
+ * Drives the REAL makeDAGStageExecuteFn closure (not just isAbortError) and
+ * asserts the DAG error path mirrors the linear path:
+ *   - an aborted stage → status "cancelled" (NOT "failed")
+ *   - the error message is secret-scrubbed before it reaches storage/WS/tracer
+ *   - a "pipeline:cancelled" WS event is emitted (not "stage:failed")
+ *   - the StageProgressCoalescer's flush timer is cleared (no leaked timer)
+ *
+ * node:child_process is not involved; the team's execute() throws directly.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { PipelineController } from "../../../server/controller/pipeline-controller.js";
+import { configLoader } from "../../../server/config/loader.js";
+import type { DAGStage } from "../../../shared/types.js";
+import type { PipelineRun } from "../../../shared/schema.js";
+
+interface RecordedUpdate {
+  status?: string;
+  error?: string;
+}
+
+function buildController() {
+  const updates: RecordedUpdate[] = [];
+  const events: Array<{ type: string; payload: Record<string, unknown> }> = [];
+
+  const storage = {
+    getStageExecutions: vi.fn(async () => [{ id: "se-1", dagStageId: "dag-1", stageIndex: 0, runId: "run-1" }]),
+    updateStageExecution: vi.fn(async (_id: string, patch: RecordedUpdate) => {
+      updates.push(patch);
+    }),
+    getStageExecution: vi.fn(async () => null),
+    getPipelineRun: vi.fn(async () => null),
+    getWorkspace: vi.fn(async () => undefined),
+    upsertMemory: vi.fn(async () => undefined),
+  };
+
+  const failingTeam = {
+    execute: vi.fn(async () => {
+      // AbortError (classified as a cancel) whose message embeds a secret so we
+      // can assert BOTH the abort→cancelled mapping AND the M2 scrub on the same
+      // DAG flow. (CliAbortError has a fixed message, so it cannot carry one.)
+      const err = new Error("aborted; partial leak leaking-secret-VALUE-123456");
+      err.name = "AbortError";
+      throw err;
+    }),
+  };
+  const teamRegistry = { getTeam: vi.fn(() => failingTeam) };
+  const wsManager = {
+    broadcastToRun: vi.fn((_runId: string, event: { type: string; payload: Record<string, unknown> }) => {
+      events.push({ type: event.type, payload: event.payload });
+    }),
+  };
+
+  const controller = new PipelineController(
+    storage as never,
+    teamRegistry as never,
+    wsManager as never,
+  );
+
+  // Override deep collaborators the DAG fn touches so we don't need real DBs.
+  (controller as unknown as { memoryProvider: unknown }).memoryProvider = {
+    getRelevantMemories: vi.fn(async () => []),
+    formatForPrompt: vi.fn(() => ""),
+  };
+  (controller as unknown as { memoryExtractor: unknown }).memoryExtractor = {
+    extractFromStageResult: vi.fn(async () => []),
+  };
+  (controller as unknown as { captureStageLesson: () => Promise<void> }).captureStageLesson =
+    vi.fn(async () => undefined);
+
+  return { controller, storage, events, updates };
+}
+
+const RUN = { id: "run-1", pipelineId: "pipe-1" } as unknown as PipelineRun;
+const DAG_STAGE = { id: "dag-1", teamId: "planning", modelSlug: "claude-sonnet" } as unknown as DAGStage;
+
+describe("DAG stage path — abort parity (B1)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Kill-switch ON so the streaming block + coalescer are created.
+    vi.spyOn(configLoader, "get").mockReturnValue({
+      pipeline: {
+        streaming: {
+          enabled: true,
+          idleTimeoutMs: 60_000,
+          overallTimeoutMs: 600_000,
+          maxOutputBytes: 8_388_608,
+          wsProgressFlushMs: 250,
+        },
+      },
+    } as never);
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+  });
+
+  it("maps an aborted DAG stage to cancelled, scrubs the error, and clears the coalescer timer", async () => {
+    vi.stubEnv("JWT_SECRET", "leaking-secret-VALUE-123456");
+    const { controller, events, updates } = buildController();
+    const signal = new AbortController().signal;
+
+    // Reach into the private factory and invoke the stage closure directly.
+    const makeFn = (controller as unknown as {
+      makeDAGStageExecuteFn: (run: PipelineRun, signal: AbortSignal) => (
+        run: PipelineRun,
+        dagStage: DAGStage,
+        input: Record<string, unknown>,
+        stageIndex: number,
+        dagStageId: string,
+      ) => Promise<{ output: Record<string, unknown>; failed: boolean }>;
+    }).makeDAGStageExecuteFn.bind(controller);
+
+    const stageFn = makeFn(RUN, signal);
+    const result = await stageFn(RUN, DAG_STAGE, { taskDescription: "x" }, 0, "dag-1");
+
+    // Stage reported failed (DAG executor contract) but status is "cancelled".
+    expect(result.failed).toBe(true);
+    const cancelled = updates.find((u) => u.status === "cancelled");
+    expect(cancelled, "stage should be marked cancelled, not failed").toBeDefined();
+    expect(updates.some((u) => u.status === "failed")).toBe(false);
+
+    // Error scrubbed before reaching storage.
+    expect(cancelled?.error).not.toContain("leaking-secret-VALUE-123456");
+    expect(cancelled?.error).toContain("[REDACTED]");
+
+    // A pipeline:cancelled event was emitted, not stage:failed.
+    expect(events.some((e) => e.type === "pipeline:cancelled")).toBe(true);
+    expect(events.some((e) => e.type === "stage:failed")).toBe(false);
+
+    // Coalescer timer cleared: advancing time fires no further timers / errors.
+    expect(() => vi.advanceTimersByTime(600_000)).not.toThrow();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/tests/unit/pipeline/stage-abort.test.ts
+++ b/tests/unit/pipeline/stage-abort.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests — stage abort/cancel mapping (streaming-stage-execution, T15 / H3).
+ *
+ * - isAbortError classifies CLI abort / AbortError / "aborted" messages so the
+ *   controller maps them to "cancelled" not "failed".
+ * - A cancel mid-stream propagates an abort error out of the gateway streaming
+ *   method (so the stage throws → cancelled), and the provider stops yielding.
+ */
+import { describe, it, expect } from "vitest";
+import { isAbortError } from "../../../server/controller/stage-progress.js";
+import { CliAbortError, CliIdleTimeoutError } from "../../../server/gateway/providers/cli-spawn.js";
+import {
+  buildTestGateway,
+  NeverEndingStreamingProvider,
+  TEST_MODEL_SLUG,
+} from "../helpers/streaming-test-utils.js";
+
+describe("isAbortError", () => {
+  it("classifies a CliAbortError as an abort", () => {
+    expect(isAbortError(new CliAbortError(""))).toBe(true);
+  });
+
+  it("classifies a DOMException-style AbortError as an abort", () => {
+    const err = new Error("The operation was aborted");
+    err.name = "AbortError";
+    expect(isAbortError(err)).toBe(true);
+  });
+
+  it("classifies a plain Error with the exact CLI abort message", () => {
+    expect(isAbortError(new Error("CLI request aborted"))).toBe(true);
+  });
+
+  it("does NOT classify model text that merely contains 'aborted' (LOW)", () => {
+    expect(isAbortError(new Error("the build was aborted by the linter step"))).toBe(false);
+  });
+
+  it("does NOT classify an idle timeout as an abort (it is a failure)", () => {
+    expect(isAbortError(new CliIdleTimeoutError(60_000, ""))).toBe(false);
+  });
+
+  it("does NOT classify a generic error or non-error as an abort", () => {
+    expect(isAbortError(new Error("boom"))).toBe(false);
+    expect(isAbortError("aborted-but-not-an-error")).toBe(false);
+  });
+});
+
+describe("cancel mid-stream propagates an abort (stage → cancelled)", () => {
+  it("rejects the streaming gateway call when the run signal aborts", async () => {
+    const gateway = buildTestGateway(new NeverEndingStreamingProvider());
+    const controller = new AbortController();
+    const promise = gateway.completeStreaming(
+      { modelSlug: TEST_MODEL_SLUG, messages: [{ role: "user", content: "go" }] },
+      undefined,
+      undefined,
+      { signal: controller.signal },
+    );
+    setTimeout(() => controller.abort(), 20);
+    const err = await promise.catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(isAbortError(err)).toBe(true);
+  });
+});

--- a/tests/unit/pipeline/stage-ws-progress.test.ts
+++ b/tests/unit/pipeline/stage-ws-progress.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests — StageProgressCoalescer (streaming-stage-execution, T15 / L2).
+ *
+ * Coalesced emission (≤ one frame per flush window), delta SLICE not the full
+ * buffer, secret-scrub applied to frames, idempotent close with a final flush.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { StageProgressCoalescer } from "../../../server/controller/stage-progress.js";
+
+describe("StageProgressCoalescer", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+  });
+
+  it("coalesces many deltas into a single frame per flush window", () => {
+    const frames: Array<{ delta: string; chars: number }> = [];
+    const c = new StageProgressCoalescer(250, (delta, chars) => frames.push({ delta, chars }));
+
+    c.push("a", 1);
+    c.push("b", 2);
+    c.push("c", 3);
+    expect(frames).toHaveLength(0); // nothing yet — buffered
+
+    vi.advanceTimersByTime(250);
+    expect(frames).toHaveLength(1);
+    expect(frames[0].delta).toBe("abc"); // coalesced slice
+    expect(frames[0].chars).toBe(3); // cumulative count
+  });
+
+  it("emits at most one frame per flush window across multiple windows", () => {
+    const frames: string[] = [];
+    const c = new StageProgressCoalescer(100, (delta) => frames.push(delta));
+
+    c.push("x", 1);
+    vi.advanceTimersByTime(100);
+    c.push("y", 2);
+    vi.advanceTimersByTime(100);
+
+    expect(frames).toEqual(["x", "y"]);
+  });
+
+  it("sends the delta slice, never the full cumulative buffer", () => {
+    const frames: string[] = [];
+    const c = new StageProgressCoalescer(100, (delta) => frames.push(delta));
+
+    c.push("first", 5);
+    vi.advanceTimersByTime(100);
+    c.push("second", 11);
+    vi.advanceTimersByTime(100);
+
+    // Second frame is only "second" — NOT "firstsecond".
+    expect(frames[1]).toBe("second");
+  });
+
+  it("scrubs secret env values from emitted frames", () => {
+    vi.stubEnv("OMNISCIENCE_TOKEN", "tok-leak-1234");
+    const frames: string[] = [];
+    const c = new StageProgressCoalescer(50, (delta) => frames.push(delta));
+    c.push("prefix tok-leak-1234 suffix", 27);
+    vi.advanceTimersByTime(50);
+    expect(frames[0]).not.toContain("tok-leak-1234");
+    expect(frames[0]).toContain("[REDACTED]");
+  });
+
+  it("flushes any pending buffer on close exactly once", () => {
+    const frames: string[] = [];
+    const c = new StageProgressCoalescer(10_000, (delta) => frames.push(delta));
+    c.push("pending", 7);
+    c.close();
+    c.close(); // idempotent
+    expect(frames).toEqual(["pending"]);
+  });
+
+  it("ignores deltas pushed after close", () => {
+    const frames: string[] = [];
+    const c = new StageProgressCoalescer(50, (delta) => frames.push(delta));
+    c.close();
+    c.push("late", 4);
+    vi.advanceTimersByTime(50);
+    expect(frames).toEqual([]);
+  });
+});

--- a/tests/unit/providers/claude-cli-streaming-concurrency.test.ts
+++ b/tests/unit/providers/claude-cli-streaming-concurrency.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit test — streaming spawns honor the ConcurrencyLimiter (streaming-stage-execution, B2).
+ *
+ * The streaming paths (stream() / streamEvents()) must hold a limiter slot for
+ * the FULL lifetime of the async generator: with maxConcurrency = N, only N
+ * child processes may be spawned at once; further concurrent streaming stages
+ * QUEUE until a slot frees. `node:child_process` is mocked.
+ */
+import { EventEmitter } from "node:events";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const spawnMock = vi.fn();
+vi.mock("node:child_process", () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+import { ClaudeCliProvider } from "../../../server/gateway/providers/claude-cli.js";
+import type { ProviderMessage } from "../../../shared/types.js";
+
+interface FakeChild extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  stdin: { end: (data: string) => void };
+  kill: (signal?: string) => boolean;
+  killed: boolean;
+}
+
+function makeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.killed = false;
+  child.kill = vi.fn(() => {
+    child.killed = true;
+    return true;
+  });
+  child.stdin = { end: vi.fn() };
+  return child;
+}
+
+const USER_MSG: ProviderMessage[] = [{ role: "user", content: "hi" }];
+
+describe("ClaudeCliProvider streaming concurrency (B2)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("spawns at most maxConcurrency streaming children at once; the rest queue", async () => {
+    const MAX = 2;
+    const provider = new ClaudeCliProvider({ maxConcurrency: MAX });
+    const children: FakeChild[] = [];
+
+    spawnMock.mockImplementation(() => {
+      const child = makeChild();
+      children.push(child);
+      return child;
+    });
+
+    // Start 5 concurrent stream() consumers; do NOT let any finish yet.
+    const consumers = Array.from({ length: 5 }, () =>
+      (async () => {
+        for await (const _c of provider.stream("claude-sonnet", USER_MSG)) {
+          void _c;
+        }
+      })(),
+    );
+
+    // Let microtasks settle: acquire() resolves synchronously only for the
+    // first MAX; the rest stay queued (no spawn yet).
+    await new Promise((r) => setImmediate(r));
+    expect(spawnMock).toHaveBeenCalledTimes(MAX);
+    expect(children.length).toBe(MAX);
+
+    // Close the first MAX children → frees slots → queued ones spawn.
+    children.slice(0, MAX).forEach((c) => c.emit("close", 0));
+    await new Promise((r) => setImmediate(r));
+    expect(spawnMock).toHaveBeenCalledTimes(MAX * 2);
+
+    // Close the rest and the final one to drain.
+    children.forEach((c) => c.emit("close", 0));
+    await new Promise((r) => setImmediate(r));
+    children.forEach((c) => c.emit("close", 0));
+    await Promise.all(consumers);
+    expect(spawnMock).toHaveBeenCalledTimes(5);
+  });
+
+  it("releases the slot when the streaming generator errors", async () => {
+    const provider = new ClaudeCliProvider({ maxConcurrency: 1 });
+    const c1 = makeChild();
+    const c2 = makeChild();
+    spawnMock.mockReturnValueOnce(c1).mockReturnValueOnce(c2);
+
+    const first = (async () => {
+      for await (const _c of provider.stream("claude-sonnet", USER_MSG)) void _c;
+    })();
+    await new Promise((r) => setImmediate(r));
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    // First stream fails (non-zero exit) → must release the slot in finally.
+    c1.emit("close", 1);
+    await first.catch(() => undefined);
+
+    // A second stream can now spawn (slot was released despite the error).
+    const second = (async () => {
+      for await (const _c of provider.stream("claude-sonnet", USER_MSG)) void _c;
+    })();
+    await new Promise((r) => setImmediate(r));
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    c2.emit("close", 0);
+    await second;
+  });
+});

--- a/tests/unit/providers/claude-cli.test.ts
+++ b/tests/unit/providers/claude-cli.test.ts
@@ -327,6 +327,115 @@ describe("ClaudeCliProvider — stream()", () => {
   });
 });
 
+// ─── streamEvents() — text-delta / tool-call / done (streaming-stage-execution) ─
+
+describe("ClaudeCliProvider — streamEvents()", () => {
+  let provider: ClaudeCliProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new ClaudeCliProvider();
+  });
+
+  function assistantTextLine(text: string): string {
+    return JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text }] } }) + "\n";
+  }
+  function assistantToolLine(id: string, name: string, input: Record<string, unknown>): string {
+    return JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", id, name, input }] } }) + "\n";
+  }
+  function resultLine(reason: "stop" | "tool_use", inTok = 10, outTok = 5): string {
+    return JSON.stringify({ type: "result", subtype: reason === "tool_use" ? "tool_use" : "success", stop_reason: reason, usage: { input_tokens: inTok, output_tokens: outTok } }) + "\n";
+  }
+
+  async function collectEvents(messages: ProviderMessage[]) {
+    const events = [];
+    for await (const ev of provider.streamEvents("claude-sonnet", messages)) events.push(ev);
+    return events;
+  }
+
+  it("emits incremental text deltas then a done(stop) with parsed usage", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => {
+        child.stdout.emit("data", Buffer.from(assistantTextLine("Hello")));
+        child.stdout.emit("data", Buffer.from(assistantTextLine("Hello world")));
+        child.stdout.emit("data", Buffer.from(resultLine("stop", 12, 8)));
+        child.emit("close", 0);
+      });
+      return child;
+    });
+
+    const events = await collectEvents(USER_MSG);
+    const deltas = events.filter((e) => e.kind === "text-delta").map((e) => (e as { text: string }).text);
+    expect(deltas.join("")).toBe("Hello world");
+    const done = events.find((e) => e.kind === "done") as { kind: "done"; tokensUsed: number; finishReason: string };
+    expect(done.finishReason).toBe("stop");
+    expect(done.tokensUsed).toBe(20);
+  });
+
+  it("surfaces tool_use blocks as tool-call events then done(tool_use)", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => {
+        child.stdout.emit("data", Buffer.from(assistantTextLine("calling a tool")));
+        child.stdout.emit("data", Buffer.from(assistantToolLine("call-1", "web_search", { query: "x" })));
+        child.stdout.emit("data", Buffer.from(resultLine("tool_use")));
+        child.emit("close", 0);
+      });
+      return child;
+    });
+
+    const events = await collectEvents(USER_MSG);
+    const toolCalls = events.filter((e) => e.kind === "tool-call");
+    expect(toolCalls).toHaveLength(1);
+    const call = (toolCalls[0] as { call: { id: string; name: string; arguments: Record<string, unknown> } }).call;
+    expect(call.id).toBe("call-1");
+    expect(call.name).toBe("web_search");
+    expect(call.arguments).toEqual({ query: "x" });
+    const done = events.find((e) => e.kind === "done") as { kind: "done"; finishReason: string };
+    expect(done.finishReason).toBe("tool_use");
+  });
+
+  it("skips malformed JSONL lines without throwing", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => {
+        child.stdout.emit("data", Buffer.from("not-json\n"));
+        child.stdout.emit("data", Buffer.from(assistantTextLine("ok")));
+        child.stdout.emit("data", Buffer.from(resultLine("stop")));
+        child.emit("close", 0);
+      });
+      return child;
+    });
+
+    const events = await collectEvents(USER_MSG);
+    const deltas = events.filter((e) => e.kind === "text-delta").map((e) => (e as { text: string }).text);
+    expect(deltas.join("")).toBe("ok");
+  });
+
+  it("threads idleTimeoutMs / maxOutputBytes / signal into the spawn request", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => child.emit("close", 0));
+      return child;
+    });
+    const controller = new AbortController();
+    const events = [];
+    for await (const ev of provider.streamEvents("claude-sonnet", USER_MSG, {
+      idleTimeoutMs: 1234,
+      maxOutputBytes: 4096,
+      timeoutMs: 99999,
+      signal: controller.signal,
+    })) {
+      events.push(ev);
+    }
+    // The spawn happened (args build) and verbose stream-json was requested.
+    const [, args] = spawnMock.mock.calls[0] as [string, string[]];
+    expect(args).toContain("--verbose");
+    expect(args[args.indexOf("--output-format") + 1]).toBe("stream-json");
+  });
+});
+
 // ─── Anthropic SDK guarantee ─────────────────────────────────────────────────
 
 describe("CLI mode — 0 Anthropic API usage", () => {

--- a/tests/unit/providers/cli-spawn.test.ts
+++ b/tests/unit/providers/cli-spawn.test.ts
@@ -19,6 +19,11 @@ import {
   ConcurrencyLimiter,
   CliNotInstalledError,
   CliExecutionError,
+  CliIdleTimeoutError,
+  CliOverallTimeoutError,
+  CliByteCapError,
+  CliLineCapError,
+  CliAbortError,
 } from "../../../server/gateway/providers/cli-spawn.js";
 
 interface FakeChild extends EventEmitter {
@@ -43,6 +48,15 @@ function makeChild(): FakeChild {
 }
 
 const REQ = { binary: "claude", args: ["-p"], stdin: "hi" } as const;
+
+const NL = "\n";
+
+/** Drain a generator to completion, collecting yielded lines. */
+async function drain(gen: AsyncGenerator<string>): Promise<string[]> {
+  const lines: string[] = [];
+  for await (const line of gen) lines.push(line);
+  return lines;
+}
 
 describe("spawnCli", () => {
   beforeEach(() => vi.clearAllMocks());
@@ -122,43 +136,212 @@ describe("spawnCli", () => {
     await expect(promise).rejects.toThrow(/aborted/i);
     expect(child.kill).toHaveBeenCalledWith("SIGTERM");
   });
+
+  it("escalates SIGTERM to SIGKILL on abort (C3)", async () => {
+    vi.useFakeTimers();
+    const child = makeChild();
+    spawnMock.mockImplementation(() => child);
+    const controller = new AbortController();
+
+    const promise = spawnCli({ ...REQ, signal: controller.signal });
+    const expectation = expect(promise).rejects.toThrow(/aborted/i);
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(2_001);
+    await expectation;
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("keeps the 120s default timeout (regression — short callers, H2)", async () => {
+    vi.useFakeTimers();
+    const child = makeChild();
+    spawnMock.mockImplementation(() => child); // never emits close
+    const promise = spawnCli({ ...REQ });
+    const expectation = expect(promise).rejects.toThrow(/timed out after 120000ms/);
+    await vi.advanceTimersByTimeAsync(120_001);
+    await expectation;
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
 });
 
 describe("streamCliLines", () => {
   beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.useRealTimers());
 
   it("yields complete lines split on newlines, including a trailing partial", async () => {
     const child = makeChild();
     spawnMock.mockImplementation(() => {
       setImmediate(() => {
-        child.stdout.emit("data", Buffer.from("a\nb\nc"));
+        child.stdout.emit("data", Buffer.from("a" + NL + "b" + NL + "c"));
         child.emit("close", 0);
       });
       return child;
     });
 
-    const lines: string[] = [];
-    for await (const line of streamCliLines({ ...REQ })) lines.push(line);
-    expect(lines).toEqual(["a", "b", "c"]);
+    expect(await drain(streamCliLines({ ...REQ }))).toEqual(["a", "b", "c"]);
   });
 
   it("throws CliExecutionError on a non-zero exit after streaming", async () => {
     const child = makeChild();
     spawnMock.mockImplementation(() => {
       setImmediate(() => {
-        child.stdout.emit("data", Buffer.from("partial\n"));
+        child.stdout.emit("data", Buffer.from("partial" + NL));
         child.stderr.emit("data", Buffer.from("oops"));
         child.emit("close", 1);
       });
       return child;
     });
+    await expect(drain(streamCliLines({ ...REQ }))).rejects.toBeInstanceOf(CliExecutionError);
+  });
 
-    const run = async (): Promise<void> => {
-      for await (const _line of streamCliLines({ ...REQ })) {
-        void _line;
+  // ── Idle timeout (H1) ──────────────────────────────────────────────────────
+  it("fires the idle timeout when no data arrives within the window", async () => {
+    vi.useFakeTimers();
+    const child = makeChild();
+    spawnMock.mockImplementation(() => child); // silent, never closes
+    const gen = streamCliLines({ ...REQ, idleTimeoutMs: 5_000, timeoutMs: 600_000 });
+    const expectation = expect(drain(gen)).rejects.toBeInstanceOf(CliIdleTimeoutError);
+    await vi.advanceTimersByTimeAsync(5_001);
+    await expectation;
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("resets the idle timer on each chunk so a slow-but-progressing stream survives past 120s (H1)", async () => {
+    vi.useFakeTimers();
+    const child = makeChild();
+    spawnMock.mockImplementation(() => child);
+    const gen = streamCliLines({ ...REQ, idleTimeoutMs: 5_000, timeoutMs: 600_000 });
+    const collected: string[] = [];
+    const consume = (async () => {
+      for await (const line of gen) collected.push(line);
+    })();
+    // Emit a line every 4s (< 5s idle) for 130s total — well past the old 120s cap.
+    for (let t = 0; t < 130_000; t += 4_000) {
+      child.stdout.emit("data", Buffer.from("line" + String(t) + NL));
+      await vi.advanceTimersByTimeAsync(4_000);
+    }
+    child.emit("close", 0);
+    await vi.advanceTimersByTimeAsync(0);
+    await consume;
+    expect(collected.length).toBeGreaterThan(30);
+    expect(child.kill).not.toHaveBeenCalledWith("SIGKILL");
+  });
+
+  // ── Overall cap (H1): fires despite continuous chunks ───────────────────────
+  it("fires the overall cap even while chunks keep arriving (H1)", async () => {
+    vi.useFakeTimers();
+    const child = makeChild();
+    spawnMock.mockImplementation(() => child);
+    const gen = streamCliLines({ ...REQ, idleTimeoutMs: 60_000, timeoutMs: 20_000 });
+    const collected: string[] = [];
+    let caught: unknown = null;
+    const consume = (async () => {
+      try {
+        for await (const line of gen) collected.push(line);
+      } catch (e) {
+        caught = e;
       }
-    };
-    await expect(run()).rejects.toBeInstanceOf(CliExecutionError);
+    })();
+    // Chunk every 2s (idle never fires) but overall cap is 20s.
+    for (let t = 0; t < 30_000; t += 2_000) {
+      child.stdout.emit("data", Buffer.from("c" + String(t) + NL));
+      await vi.advanceTimersByTimeAsync(2_000);
+    }
+    await consume;
+    expect(caught).toBeInstanceOf(CliOverallTimeoutError);
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  // ── Byte cap (C2/H4) ────────────────────────────────────────────────────────
+  it("kills + fails with CliByteCapError when cumulative stdout exceeds maxOutputBytes", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => {
+        child.stdout.emit("data", Buffer.from("x".repeat(50) + NL));
+        child.stdout.emit("data", Buffer.from("y".repeat(50) + NL));
+      });
+      return child;
+    });
+    await expect(
+      drain(streamCliLines({ ...REQ, maxOutputBytes: 64 })),
+    ).rejects.toBeInstanceOf(CliByteCapError);
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  // ── Line cap (H4): no-newline flood ─────────────────────────────────────────
+  it("kills + fails with CliLineCapError when a single line exceeds the max line length", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => {
+        // No newline — would grow the buffer unboundedly.
+        child.stdout.emit("data", Buffer.from("z".repeat(200)));
+      });
+      return child;
+    });
+    await expect(
+      drain(streamCliLines({ ...REQ, maxLineBytes: 100 })),
+    ).rejects.toBeInstanceOf(CliLineCapError);
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  // ── Abort (C3) ──────────────────────────────────────────────────────────────
+  it("kills + fails with CliAbortError when the AbortSignal fires, escalating to SIGKILL", async () => {
+    vi.useFakeTimers();
+    const child = makeChild();
+    spawnMock.mockImplementation(() => child);
+    const controller = new AbortController();
+    const gen = streamCliLines({ ...REQ, signal: controller.signal, timeoutMs: 600_000 });
+    const expectation = expect(drain(gen)).rejects.toBeInstanceOf(CliAbortError);
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(2_001);
+    await expectation;
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  // ── Single settle / cleanup (C2): no leaked listeners/timers ─────────────────
+  it("settles exactly once and removes the abort listener on normal close", async () => {
+    vi.useFakeTimers();
+    const child = makeChild();
+    const controller = new AbortController();
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+    spawnMock.mockImplementation(() => child);
+
+    const collected: string[] = [];
+    const consume = (async () => {
+      for await (const line of streamCliLines({
+        ...REQ,
+        signal: controller.signal,
+        idleTimeoutMs: 5_000,
+        timeoutMs: 600_000,
+      })) {
+        collected.push(line);
+      }
+    })();
+
+    // Emit a line then close on the SAME child (generator already attached).
+    child.stdout.emit("data", Buffer.from("ok" + NL));
+    child.emit("close", 0);
+    await vi.advanceTimersByTimeAsync(0);
+    await consume;
+
+    expect(collected).toEqual(["ok"]);
+    expect(removeSpy).toHaveBeenCalledWith("abort", expect.any(Function));
+    // No pending idle/overall timer should fire post-settle (would re-kill).
+    child.kill.mockClear();
+    await vi.advanceTimersByTimeAsync(600_001);
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it("maps ENOENT to CliNotInstalledError", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() =>
+        child.emit("error", Object.assign(new Error("ENOENT"), { code: "ENOENT" })),
+      );
+      return child;
+    });
+    await expect(drain(streamCliLines({ ...REQ }))).rejects.toBeInstanceOf(CliNotInstalledError);
   });
 });
 

--- a/tests/unit/providers/streaming-stage-execution.headline.test.ts
+++ b/tests/unit/providers/streaming-stage-execution.headline.test.ts
@@ -1,0 +1,118 @@
+/**
+ * HEADLINE deterministic test (streaming-stage-execution, T17 / PR gate).
+ *
+ * Proves the old 120s blocking wall-clock cap is GONE: a streamed stage call
+ * that runs for ~599s of virtual time — emitting a chunk inside every idle
+ * window — COMPLETES. Driven entirely by vi.useFakeTimers + advanceTimersByTimeAsync
+ * (no real CLI, no real wall-clock). Companion: a genuine stall (no output past
+ * the idle window) FAILS with the idle-timeout error.
+ *
+ * Exercises the REAL idle/overall timer logic in streamCliLines via the
+ * ClaudeCliProvider.stream() path with node:child_process mocked.
+ */
+import { EventEmitter } from "node:events";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const spawnMock = vi.fn();
+vi.mock("node:child_process", () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+import { ClaudeCliProvider } from "../../../server/gateway/providers/claude-cli.js";
+import { CliIdleTimeoutError } from "../../../server/gateway/providers/cli-spawn.js";
+import type { ProviderMessage } from "../../../shared/types.js";
+
+interface FakeChild extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  stdin: { end: (data: string) => void };
+  kill: (signal?: string) => boolean;
+  killed: boolean;
+}
+
+function makeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.killed = false;
+  child.kill = vi.fn(() => {
+    child.killed = true;
+    return true;
+  });
+  child.stdin = { end: vi.fn() };
+  return child;
+}
+
+function assistantLine(text: string): string {
+  return JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text }] } }) + "\n";
+}
+
+const USER_MSG: ProviderMessage[] = [{ role: "user", content: "long planning prompt" }];
+
+const IDLE_MS = 60_000; // 60s idle window
+const OVERALL_MS = 600_000; // 10 min overall cap
+const CHUNK_EVERY_MS = 50_000; // < idle window, so idle never fires
+const TOTAL_VIRTUAL_MS = 599_000; // ~599s — far beyond the old 120s cap
+
+describe("HEADLINE: a >120s streamed stage completes (idle-reset beats old cap)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("completes a ~599s stream that emits a chunk inside every idle window", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => child);
+    const provider = new ClaudeCliProvider();
+
+    const chunks: string[] = [];
+    const consume = (async () => {
+      for await (const chunk of provider.stream("claude-sonnet", USER_MSG, {
+        idleTimeoutMs: IDLE_MS,
+        timeoutMs: OVERALL_MS,
+      })) {
+        chunks.push(chunk);
+      }
+    })();
+
+    // Emit growing assistant text every CHUNK_EVERY_MS for ~599s of virtual time.
+    let accumulated = "";
+    let n = 0;
+    for (let t = CHUNK_EVERY_MS; t <= TOTAL_VIRTUAL_MS; t += CHUNK_EVERY_MS) {
+      n += 1;
+      accumulated += `tok${n} `;
+      child.stdout.emit("data", Buffer.from(assistantLine(accumulated)));
+      await vi.advanceTimersByTimeAsync(CHUNK_EVERY_MS);
+    }
+    child.emit("close", 0);
+    await vi.advanceTimersByTimeAsync(0);
+    await consume;
+
+    // Stream completed (no throw) and produced incremental deltas across >120s.
+    expect(chunks.length).toBeGreaterThan(5);
+    expect(chunks.join("")).toContain("tok1");
+    // Crucially: the child was NEVER killed (no timeout fired).
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it("COMPANION: a genuine stall past the idle window fails with the idle-timeout error", async () => {
+    const child = makeChild();
+    spawnMock.mockImplementation(() => child); // silent — no chunks ever
+    const provider = new ClaudeCliProvider();
+
+    const consume = (async () => {
+      for await (const _chunk of provider.stream("claude-sonnet", USER_MSG, {
+        idleTimeoutMs: IDLE_MS,
+        timeoutMs: OVERALL_MS,
+      })) {
+        void _chunk;
+      }
+    })();
+
+    const expectation = expect(consume).rejects.toBeInstanceOf(CliIdleTimeoutError);
+    await vi.advanceTimersByTimeAsync(IDLE_MS + 1);
+    await expectation;
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+});

--- a/tests/unit/teams/stage-streaming-wiring.test.ts
+++ b/tests/unit/teams/stage-streaming-wiring.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests — BaseTeam stage streaming wiring (streaming-stage-execution, T15).
+ *
+ * Verifies that executeSingleModel routes to the streaming gateway methods when
+ * context.streaming is present and the kill-switch is on, routes to the blocking
+ * methods when the kill-switch is off, threads signal/onDelta/limits, and
+ * THROWS (never returns a partial TeamResult) on a stream error (H3).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CustomTeam } from "../../../server/teams/custom.js";
+import { configLoader } from "../../../server/config/loader.js";
+import type { StageContext, TeamConfig, StreamingStageOptions } from "../../../shared/types.js";
+
+const baseConfig: TeamConfig = {
+  id: "custom_test",
+  name: "Test Custom",
+  description: "Test",
+  defaultModelSlug: "mock",
+  systemPromptTemplate: "Default template prompt.",
+  inputSchema: {},
+  outputSchema: {},
+  tools: [],
+  color: "violet",
+  icon: "⚙️",
+};
+
+function makeGateway() {
+  return {
+    complete: vi.fn().mockResolvedValue({ content: '{"summary":"blocking"}', tokensUsed: 10 }),
+    completeWithTools: vi
+      .fn()
+      .mockResolvedValue({ content: '{"summary":"blocking-tools"}', tokensUsed: 10, toolCallLog: [] }),
+    completeStreaming: vi.fn().mockResolvedValue({ content: '{"summary":"streamed"}', tokensUsed: 20 }),
+    completeWithToolsStreaming: vi
+      .fn()
+      .mockResolvedValue({ content: '{"summary":"streamed-tools"}', tokensUsed: 20, toolCallLog: [] }),
+  };
+}
+
+function makeContext(streaming?: StreamingStageOptions, overrides?: Partial<StageContext>): StageContext {
+  return {
+    runId: "run-1",
+    stageIndex: 0,
+    modelSlug: "mock",
+    previousOutputs: [],
+    // Disable tools by default so we hit the plain path unless asked otherwise.
+    stageConfig: { teamId: "custom_test", modelSlug: "mock", enabled: true, tools: { enabled: false } },
+    streaming,
+    ...overrides,
+  };
+}
+
+describe("BaseTeam stage streaming wiring", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    // Force streaming kill-switch ON for these tests.
+    vi.spyOn(configLoader, "get").mockReturnValue({
+      pipeline: { streaming: { enabled: true } },
+    } as never);
+  });
+
+  it("routes the plain path to completeStreaming when context.streaming is present", async () => {
+    const gateway = makeGateway();
+    const team = new CustomTeam(gateway as never, baseConfig);
+    const onDelta = vi.fn();
+    const result = await team.execute({ taskDescription: "x" }, makeContext({ onDelta }));
+    expect(gateway.completeStreaming).toHaveBeenCalledOnce();
+    expect(gateway.complete).not.toHaveBeenCalled();
+    expect(result.raw).toContain("streamed");
+  });
+
+  it("passes signal + streaming limits through to the gateway", async () => {
+    const gateway = makeGateway();
+    const team = new CustomTeam(gateway as never, baseConfig);
+    const controller = new AbortController();
+    const streaming: StreamingStageOptions = {
+      signal: controller.signal,
+      onDelta: vi.fn(),
+      idleTimeoutMs: 1111,
+      overallTimeoutMs: 2222,
+      maxOutputBytes: 4096,
+    };
+    await team.execute({ taskDescription: "x" }, makeContext(streaming));
+    const callArgs = gateway.completeStreaming.mock.calls[0];
+    const passedStreamOpts = callArgs[3] as StreamingStageOptions;
+    expect(passedStreamOpts.signal).toBe(controller.signal);
+    expect(passedStreamOpts.idleTimeoutMs).toBe(1111);
+    expect(passedStreamOpts.overallTimeoutMs).toBe(2222);
+  });
+
+  it("uses the BLOCKING path when the kill-switch is off", async () => {
+    vi.spyOn(configLoader, "get").mockReturnValue({
+      pipeline: { streaming: { enabled: false } },
+    } as never);
+    const gateway = makeGateway();
+    const team = new CustomTeam(gateway as never, baseConfig);
+    await team.execute({ taskDescription: "x" }, makeContext({ onDelta: vi.fn() }));
+    expect(gateway.complete).toHaveBeenCalledOnce();
+    expect(gateway.completeStreaming).not.toHaveBeenCalled();
+  });
+
+  it("uses the BLOCKING path when context.streaming is absent", async () => {
+    const gateway = makeGateway();
+    const team = new CustomTeam(gateway as never, baseConfig);
+    await team.execute({ taskDescription: "x" }, makeContext(undefined));
+    expect(gateway.complete).toHaveBeenCalledOnce();
+    expect(gateway.completeStreaming).not.toHaveBeenCalled();
+  });
+
+  it("THROWS (no partial TeamResult) when the stream rejects (H3)", async () => {
+    const gateway = makeGateway();
+    gateway.completeStreaming.mockRejectedValue(new Error("CLI idle for 60000ms (no output)"));
+    const team = new CustomTeam(gateway as never, baseConfig);
+    await expect(
+      team.execute({ taskDescription: "x" }, makeContext({ onDelta: vi.fn() })),
+    ).rejects.toThrow(/idle/i);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,6 +40,13 @@ export default defineConfig({
       // Full server coverage (routes/chat, workspace, tools, ws) is tracked in
       // nightly CI once those modules gain test suites.
       include: [
+        // streaming-stage-execution: changed modules (>=80% lines targeted).
+        "server/gateway/providers/cli-spawn.ts",
+        "server/gateway/providers/claude-cli.ts",
+        "server/gateway/secret-scrub.ts",
+        "server/gateway/index.ts",
+        "server/teams/base.ts",
+        "server/controller/stage-progress.ts",
         "server/privacy/**/*.ts",
         "server/memory/extractor.ts",
         "server/routes/privacy.ts",


### PR DESCRIPTION
## Summary
Pipeline stages drove the gateway via **blocking `complete()` with a 120s CLI cap**. With stages now pointed at real subscription-CLI models (Claude `claude -p`, Antigravity `agy`), a substantial planning prompt exceeds 120s → the stage fails `"CLI timed out after 120000ms"` (proven live: run `6078ba0b` failed at stage 0). So multiqlti couldn't complete **any** real-model task. This streams the stage LLM call with a timeout policy fit for long streamed calls.

## Changes
- **`cli-spawn.streamCliLines`**: idle timeout (reset per chunk) + **unconditional overall cap** (armed once, never reset) + cumulative **byte-cap** + **max-line guard**; a **single idempotent `settle()`** clears both timers + the abort listener and kills the child exactly once; **SIGTERM→SIGKILL** on every kill path.
- **Gateway**: additive `completeStreaming` / `completeWithToolsStreaming` (existing `complete`/`completeWithTools`/`stream` untouched) consuming the provider `stream()`; usage recorded; a **mid-stream error rejects** (no partial promoted as authoritative); streamed tool-call args **validated + 64KiB-capped** before `toolRegistry.execute`.
- **`teams/base`**: stage execution re-pointed to streaming behind a `pipeline.streaming.enabled` **kill-switch**; the **short-call path** (provider ping / model discovery) keeps the 120s blocking cap.
- **Controller + `stage-progress`**: coalesced `stage:progress` WS events (delta slices, not full buffer); **abort → cancelled** on BOTH linear and DAG paths; secret-scrubbed error messages.
- **Concurrency**: streaming spawns hold a `ConcurrencyLimiter` slot for the generator's full lifetime (no unbounded `claude`/`agy` children).
- **`secret-scrub`**: strip env secret values (OMNISCIENCE_TOKEN / JWT_SECRET / *_API_KEY) from previews / WS / logs / promoted run output.
- **Config**: `pipeline.streaming` knobs (idle 1k–600k, overall 10k–3.6M, maxBytes 64KiB–64MiB, flush 50–5k) with zod min/max bounds.

## Quality gates
- **Security review (veto): PASS** — all 9 design must-fixes implemented (C1 tool-arg validation, C2 idempotent settle, C3 SIGKILL escalation, H1 unconditional overall cap, H2 short-call 120s preserved, H3 abort→cancelled + no partial-success on linear **and** DAG, H4 byte+line caps, M1 config bounds, M2 secret scrub). Two HIGH blockers found mid-review (DAG-path parity, streaming concurrency gating) were fixed + tested and the veto cleared.
- **QA: PASS (gate green)** — Unit **4382** pass; headline test proves a ~550s stream (past the old 120s cap) completes; every failure class (idle/overall/byte-cap/abort/non-zero) surfaces a distinct typed error; coverage cli-spawn 99% / claude-cli 99% / stage-progress 93% / secret-scrub 100%. `test:integration` shows only the pre-existing `EADDRINUSE :5000` flake (confirmed against the clean base — not a regression).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run test:unit` (4382, incl. headline + all streaming files; no real CLI needed)
- [x] `npm run test:coverage` (changed modules ≥80%)
- [ ] Live smoke: re-run a real SDLC stage on a claude-* model and confirm it streams past 120s (host)
- [ ] `RUN_WS_E2E=1` / `RUN_E2E_CLI=1` smokes (gated, not in PR gate)

## Follow-ups (non-blocking, noted by QA/Security)
- Tighten the plain-stream token estimate to use the provider `result`-event usage (cost attribution); expand pre-existing `base.ts` helper coverage.