### PR TITLE
fix: workspace-scope legacy knowledge routes (IDOR, closes #358)

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -170,7 +170,7 @@ export async function registerRoutes(
   registerCostRoutes(app, storage);
   registerWorkspaceToolRoutes(app, storage);
   registerMcpRoutes(app as unknown as Router, storage, controller);
-  registerKnowledgeRoutes(app as unknown as Router);  // Bug #309: was imported but not called
+  registerKnowledgeRoutes(app as unknown as Router, storage);  // Bug #309: was imported but not called; #358: workspace-scoped
   const knowledgeRefreshScheduler = initRefreshScheduler(storage);
   registerPracticeCardRoutes(
     app as unknown as Router,

--- a/server/routes/knowledge.ts
+++ b/server/routes/knowledge.ts
@@ -1,7 +1,7 @@
 /**
  * Knowledge management API — RAG chunk ingestion, search, and source management.
  *
- * Routes:
+ * Routes (ALL workspace-scoped under requireAuth, registered in routes.ts):
  *   GET    /api/workspaces/:id/knowledge/sources     — list indexed sources
  *   GET    /api/workspaces/:id/knowledge/search      — semantic search preview
  *   POST   /api/workspaces/:id/knowledge/ingest      — ingest text as chunks
@@ -9,15 +9,73 @@
  *   GET    /api/workspaces/:id/knowledge/config      — get embedding config
  *   PUT    /api/workspaces/:id/knowledge/config      — update embedding config
  *   POST   /api/workspaces/:id/knowledge/re-embed    — re-embed all chunks (async job)
+ *
+ * Security (issue #358 — authenticated IDOR fix):
+ *   Every route resolves the `:id` workspace via storage.getWorkspace and gates
+ *   on its ownerId BEFORE touching the vector store. Mirrors the practice-card
+ *   routes (requireOwnerOrRole(() => ws.ownerId, ...)) and the orchestrator
+ *   authorizeRun / workspaces.getOwnedWorkspace idiom:
+ *     - Ordering: 401 (unauth, via requireAuth) → 404 (missing) → 403 (non-owner).
+ *     - null-owner is DENIED for non-admins (stricter, matches orchestrator +
+ *       Phase 6.9 getOwnedWorkspace IDOR prevention). Admins may still access.
+ *     - Reads (search, sources, config read) and mutations alike require
+ *       owner-or-admin — knowledge chunks are private workspace data.
+ *   Client errors stay generic; internal detail is logged server-side only.
  */
-import { Router } from "express";
+import type { Router, Request, Response } from "express";
 import { z } from "zod";
+import type { IStorage } from "../storage";
 import { VectorStore } from "../memory/vector-store";
 import { TextChunker } from "../memory/chunker";
 import { EmbeddingProviderFactory, DEFAULT_EMBEDDING_CONFIG } from "../memory/embeddings";
-import type { EmbeddingProviderConfig } from "../memory/embeddings";
+import type { EmbeddingProvider, EmbeddingProviderConfig } from "../memory/embeddings";
 import { CHUNK_SOURCE_TYPES, EMBEDDING_PROVIDERS } from "@shared/schema";
+import type { EmbeddingProviderConfigRow } from "@shared/schema";
 import type { ChunkSourceType } from "../memory/chunker";
+
+// ─── Injectable dependencies (so tests can avoid Ollama / pgvector) ────────────
+
+/**
+ * The subset of VectorStore behaviour the routes depend on. Injecting it keeps
+ * production behaviour identical (default = real VectorStore) while letting the
+ * IDOR auth-gate tests run over an in-memory mock with no DB.
+ */
+export interface KnowledgeStore {
+  listSources(
+    workspaceId: string,
+  ): Promise<Array<{ sourceType: ChunkSourceType; sourceId: string; count: number }>>;
+  search(
+    workspaceId: string,
+    queryEmbedding: number[],
+    options: { topK?: number; sourceTypes?: ChunkSourceType[]; minScore?: number },
+  ): Promise<Array<Record<string, unknown>>>;
+  insertChunks(rows: Array<Record<string, unknown>>): Promise<Array<{ id: string }>>;
+  deleteBySource(
+    workspaceId: string,
+    sourceType: ChunkSourceType,
+    sourceId: string,
+  ): Promise<number>;
+  countChunks(workspaceId: string): Promise<number>;
+  getEmbeddingConfig(workspaceId: string): Promise<EmbeddingProviderConfigRow | null>;
+  upsertEmbeddingConfig(
+    workspaceId: string,
+    cfg: { provider: string; model: string; dimensions: number; options?: Record<string, string> },
+  ): Promise<EmbeddingProviderConfigRow>;
+}
+
+export interface KnowledgeDeps {
+  /** Factory for a per-request vector store. Defaults to a real VectorStore. */
+  createStore: () => KnowledgeStore;
+  /** Factory for an embedding provider from a config. Defaults to the real factory. */
+  createEmbeddingProvider: (config: EmbeddingProviderConfig) => EmbeddingProvider;
+}
+
+function defaultDeps(): KnowledgeDeps {
+  return {
+    createStore: () => new VectorStore() as unknown as KnowledgeStore,
+    createEmbeddingProvider: (config) => EmbeddingProviderFactory.create(config),
+  };
+}
 
 // ─── Validation schemas ───────────────────────────────────────────────────────
 
@@ -43,42 +101,101 @@ const configBodySchema = z.object({
   options: z.record(z.string()).optional(),
 });
 
+// ─── Authorization helper ──────────────────────────────────────────────────────
+
+function logServerError(context: string, err: unknown): void {
+  const detail = err instanceof Error ? err.message : String(err);
+  // Detail stays server-side only; clients get a generic message.
+  console.warn(`[knowledge] ${context}: ${detail}`);
+}
+
+/**
+ * Resolve the `:id` workspace and authorize the caller against its ownerId.
+ *
+ * Returns the resolved workspace id on success, or sends the correct status
+ * (401 → 404 → 403) and returns null. Knowledge chunks are private workspace
+ * data, so the gate is owner-OR-admin for BOTH reads and mutations, and
+ * null-owner is DENIED for non-admins (matching orchestrator authorizeRun and
+ * workspaces.getOwnedWorkspace IDOR prevention).
+ */
+async function authorizeWorkspace(
+  req: Request,
+  res: Response,
+  storage: IStorage,
+): Promise<string | null> {
+  // 401 first — unauth takes precedence over existence.
+  const user = req.user;
+  if (!user?.id) {
+    res.status(401).json({ error: "Unauthorized" });
+    return null;
+  }
+
+  const ws = await storage.getWorkspace(String(req.params.id));
+  if (!ws) {
+    res.status(404).json({ error: "Workspace not found" });
+    return null;
+  }
+
+  const isAdmin = user.role === "admin";
+  // Deny ownerless workspaces for non-admins (stricter; no implicit access).
+  const isOwner = ws.ownerId != null && ws.ownerId === user.id;
+  if (!isAdmin && !isOwner) {
+    res.status(403).json({ error: "Forbidden" });
+    return null;
+  }
+
+  return ws.id;
+}
+
+/** Resolve the embedding config for a workspace, falling back to the default. */
+async function resolveEmbeddingConfig(
+  store: KnowledgeStore,
+  workspaceId: string,
+): Promise<EmbeddingProviderConfig> {
+  const configRow = await store.getEmbeddingConfig(workspaceId);
+  if (!configRow) return DEFAULT_EMBEDDING_CONFIG;
+  return {
+    provider: configRow.provider as EmbeddingProviderConfig["provider"],
+    model: configRow.model,
+    dimensions: configRow.dimensions,
+    options: configRow.config as Record<string, string> | undefined,
+  };
+}
+
 // ─── Route registration ───────────────────────────────────────────────────────
 
-export function registerKnowledgeRoutes(app: Router): void {
+export function registerKnowledgeRoutes(
+  app: Router,
+  storage: IStorage,
+  deps: KnowledgeDeps = defaultDeps(),
+): void {
   // GET /api/workspaces/:id/knowledge/sources
   app.get("/api/workspaces/:id/knowledge/sources", async (req, res) => {
-    const { id: workspaceId } = req.params;
+    const workspaceId = await authorizeWorkspace(req, res, storage);
+    if (!workspaceId) return;
     try {
-      const store = new VectorStore();
+      const store = deps.createStore();
       const sources = await store.listSources(workspaceId);
       return res.json(sources);
-    } catch {
+    } catch (err) {
+      logServerError("list sources failed", err);
       return res.status(500).json({ error: "Failed to list knowledge sources" });
     }
   });
 
   // GET /api/workspaces/:id/knowledge/search
   app.get("/api/workspaces/:id/knowledge/search", async (req, res) => {
-    const { id: workspaceId } = req.params;
+    const workspaceId = await authorizeWorkspace(req, res, storage);
+    if (!workspaceId) return;
     const parsed = searchQuerySchema.safeParse(req.query);
     if (!parsed.success) {
       return res.status(400).json({ error: parsed.error.flatten() });
     }
 
     try {
-      const store = new VectorStore();
-      const configRow = await store.getEmbeddingConfig(workspaceId);
-      const embeddingConfig: EmbeddingProviderConfig = configRow
-        ? {
-            provider: configRow.provider as EmbeddingProviderConfig["provider"],
-            model: configRow.model,
-            dimensions: configRow.dimensions,
-            options: configRow.config as Record<string, string> | undefined,
-          }
-        : DEFAULT_EMBEDDING_CONFIG;
-
-      const provider = EmbeddingProviderFactory.create(embeddingConfig);
+      const store = deps.createStore();
+      const embeddingConfig = await resolveEmbeddingConfig(store, workspaceId);
+      const provider = deps.createEmbeddingProvider(embeddingConfig);
       const queryEmbedding = await provider.embed(parsed.data.q);
 
       const results = await store.search(workspaceId, queryEmbedding, {
@@ -89,13 +206,15 @@ export function registerKnowledgeRoutes(app: Router): void {
 
       return res.json(results);
     } catch (err) {
-      return res.status(500).json({ error: `Search failed: ${(err as Error).message}` });
+      logServerError("search failed", err);
+      return res.status(500).json({ error: "Search failed" });
     }
   });
 
   // POST /api/workspaces/:id/knowledge/ingest
   app.post("/api/workspaces/:id/knowledge/ingest", async (req, res) => {
-    const { id: workspaceId } = req.params;
+    const workspaceId = await authorizeWorkspace(req, res, storage);
+    if (!workspaceId) return;
     const parsed = ingestBodySchema.safeParse(req.body);
     if (!parsed.success) {
       return res.status(400).json({ error: parsed.error.flatten() });
@@ -104,18 +223,9 @@ export function registerKnowledgeRoutes(app: Router): void {
     const { sourceType, sourceId, text, metadata, replace } = parsed.data;
 
     try {
-      const store = new VectorStore();
-      const configRow = await store.getEmbeddingConfig(workspaceId);
-      const embeddingConfig: EmbeddingProviderConfig = configRow
-        ? {
-            provider: configRow.provider as EmbeddingProviderConfig["provider"],
-            model: configRow.model,
-            dimensions: configRow.dimensions,
-            options: configRow.config as Record<string, string> | undefined,
-          }
-        : DEFAULT_EMBEDDING_CONFIG;
-
-      const provider = EmbeddingProviderFactory.create(embeddingConfig);
+      const store = deps.createStore();
+      const embeddingConfig = await resolveEmbeddingConfig(store, workspaceId);
+      const provider = deps.createEmbeddingProvider(embeddingConfig);
       const chunker = new TextChunker({ maxChunkTokens: 512, overlapTokens: 64 });
 
       if (replace) {
@@ -148,55 +258,63 @@ export function registerKnowledgeRoutes(app: Router): void {
 
       return res.status(201).json({ inserted: inserted.length, chunks: inserted.map((r) => r.id) });
     } catch (err) {
-      return res.status(500).json({ error: `Ingest failed: ${(err as Error).message}` });
+      logServerError("ingest failed", err);
+      return res.status(500).json({ error: "Ingest failed" });
     }
   });
 
   // DELETE /api/workspaces/:id/knowledge/sources/:type/:sourceId
   app.delete("/api/workspaces/:id/knowledge/sources/:type/:sourceId", async (req, res) => {
-    const { id: workspaceId, type, sourceId } = req.params;
+    const workspaceId = await authorizeWorkspace(req, res, storage);
+    if (!workspaceId) return;
+    const { type, sourceId } = req.params;
 
     if (!CHUNK_SOURCE_TYPES.includes(type as ChunkSourceType)) {
       return res.status(400).json({ error: `Invalid source type: ${type}` });
     }
 
     try {
-      const store = new VectorStore();
+      const store = deps.createStore();
       const deleted = await store.deleteBySource(workspaceId, type as ChunkSourceType, sourceId);
       return res.json({ deleted });
-    } catch {
+    } catch (err) {
+      logServerError("delete source failed", err);
       return res.status(500).json({ error: "Failed to delete knowledge source" });
     }
   });
 
   // GET /api/workspaces/:id/knowledge/config
   app.get("/api/workspaces/:id/knowledge/config", async (req, res) => {
-    const { id: workspaceId } = req.params;
+    const workspaceId = await authorizeWorkspace(req, res, storage);
+    if (!workspaceId) return;
     try {
-      const store = new VectorStore();
+      const store = deps.createStore();
       const config = await store.getEmbeddingConfig(workspaceId);
       return res.json(config ?? { provider: "ollama", model: "nomic-embed-text", dimensions: 768 });
-    } catch {
+    } catch (err) {
+      logServerError("get config failed", err);
       return res.status(500).json({ error: "Failed to get embedding config" });
     }
   });
 
   // PUT /api/workspaces/:id/knowledge/config
   app.put("/api/workspaces/:id/knowledge/config", async (req, res) => {
-    const { id: workspaceId } = req.params;
+    const workspaceId = await authorizeWorkspace(req, res, storage);
+    if (!workspaceId) return;
     const parsed = configBodySchema.safeParse(req.body);
     if (!parsed.success) {
       return res.status(400).json({ error: parsed.error.flatten() });
     }
 
     try {
-      const store = new VectorStore();
+      const store = deps.createStore();
       const row = await store.upsertEmbeddingConfig(workspaceId, {
         ...parsed.data,
         options: parsed.data.options,
       });
       return res.json(row);
-    } catch {
+    } catch (err) {
+      logServerError("update config failed", err);
       return res.status(500).json({ error: "Failed to update embedding config" });
     }
   });
@@ -204,18 +322,20 @@ export function registerKnowledgeRoutes(app: Router): void {
   // POST /api/workspaces/:id/knowledge/re-embed
   // Triggers a background re-embedding job when provider/model changes.
   app.post("/api/workspaces/:id/knowledge/re-embed", async (req, res) => {
-    const { id: workspaceId } = req.params;
+    const workspaceId = await authorizeWorkspace(req, res, storage);
+    if (!workspaceId) return;
     try {
-      const store = new VectorStore();
+      const store = deps.createStore();
       const count = await store.countChunks(workspaceId);
 
       // Fire-and-forget: re-embed in background. We acknowledge immediately.
-      reEmbedWorkspace(workspaceId).catch((err) => {
-        console.warn(`[knowledge] re-embed failed for workspace ${workspaceId}:`, err);
+      reEmbedWorkspace(workspaceId, deps).catch((err) => {
+        logServerError(`re-embed failed for workspace ${workspaceId}`, err);
       });
 
       return res.json({ accepted: true, totalChunks: count });
-    } catch {
+    } catch (err) {
+      logServerError("start re-embed failed", err);
       return res.status(500).json({ error: "Failed to start re-embed job" });
     }
   });
@@ -227,23 +347,14 @@ export function registerKnowledgeRoutes(app: Router): void {
  * Re-embed all chunks in a workspace using the current provider config.
  * Processes in batches to avoid memory pressure.
  */
-async function reEmbedWorkspace(workspaceId: string): Promise<void> {
+async function reEmbedWorkspace(workspaceId: string, deps: KnowledgeDeps): Promise<void> {
   const { db } = await import("../db.js");
   const { memoryChunks } = await import("@shared/schema");
-  const { eq, isNotNull, sql: drizzleSql } = await import("drizzle-orm");
+  const { eq, sql: drizzleSql } = await import("drizzle-orm");
 
-  const store = new VectorStore();
-  const configRow = await store.getEmbeddingConfig(workspaceId);
-  const embeddingConfig: EmbeddingProviderConfig = configRow
-    ? {
-        provider: configRow.provider as EmbeddingProviderConfig["provider"],
-        model: configRow.model,
-        dimensions: configRow.dimensions,
-        options: configRow.config as Record<string, string> | undefined,
-      }
-    : DEFAULT_EMBEDDING_CONFIG;
-
-  const provider = EmbeddingProviderFactory.create(embeddingConfig);
+  const store = deps.createStore();
+  const embeddingConfig = await resolveEmbeddingConfig(store, workspaceId);
+  const provider = deps.createEmbeddingProvider(embeddingConfig);
 
   const BATCH = 50;
   let offset = 0;

--- a/tests/helpers/test-knowledge-legacy-app.ts
+++ b/tests/helpers/test-knowledge-legacy-app.ts
@@ -1,0 +1,170 @@
+/**
+ * Test app factory for the LEGACY knowledge routes (server/routes/knowledge.ts).
+ *
+ * Issue #358: those routes were behind requireAuth but did NOT verify the
+ * `:id` workspace belongs to the caller (authenticated IDOR). This factory
+ * builds an express app over MemStorage with an INJECTED in-memory knowledge
+ * store + deterministic embedding factory, so the integration tests can
+ * exercise the workspace-scoping auth gate (404 → null-owner deny → 403 →
+ * owner/admin allowed) without Ollama or pgvector.
+ *
+ * The authenticated user is injected by role and may own the seeded workspace,
+ * so the requireOwnerOrRole path is covered. An `x-test-unauth` header strips
+ * the user to model an unauthenticated request (401 ordering).
+ */
+import express from "express";
+import type { Router } from "express";
+import { MemStorage } from "../../server/storage.js";
+import {
+  registerKnowledgeRoutes,
+  type KnowledgeDeps,
+  type KnowledgeStore,
+} from "../../server/routes/knowledge.js";
+import type { EmbeddingProviderConfig } from "../../server/memory/embeddings.js";
+import type { ChunkSourceType } from "../../server/memory/chunker.js";
+import type { User, UserRole } from "../../shared/types.js";
+
+export interface LegacyKnowledgeTestAppOptions {
+  role?: UserRole;
+  userId?: string;
+  /** When true, the injected user owns the seeded workspace. */
+  ownsWorkspace?: boolean;
+  /** Owner id for the seeded workspace. Overrides ownsWorkspace when provided. */
+  workspaceOwnerId?: string | null;
+  /** Strip the authenticated user (model an unauthenticated request → 401). */
+  unauth?: boolean;
+}
+
+export interface LegacyKnowledgeTestApp {
+  app: express.Express;
+  storage: MemStorage;
+  workspaceId: string;
+  /** Records of every mock-store interaction (for cross-workspace isolation assertions). */
+  calls: KnowledgeStoreCalls;
+}
+
+/** Observable record of every mock-store interaction. */
+export interface KnowledgeStoreCalls {
+  listSources: string[];
+  search: string[];
+  insertChunks: Array<Record<string, unknown>>;
+  deleteBySource: Array<{ workspaceId: string; sourceType: string; sourceId: string }>;
+  getEmbeddingConfig: string[];
+  upsertEmbeddingConfig: string[];
+  countChunks: string[];
+}
+
+const DEFAULT_OWNER = "someone-else";
+
+function makeMockStore(calls: KnowledgeStoreCalls): KnowledgeStore {
+  return {
+    async listSources(workspaceId) {
+      calls.listSources.push(workspaceId);
+      return [];
+    },
+    async search(workspaceId) {
+      calls.search.push(workspaceId);
+      return [];
+    },
+    async insertChunks(rows) {
+      calls.insertChunks.push(...rows);
+      return rows.map((_, i) => ({ id: `chunk-${i}` }));
+    },
+    async deleteBySource(workspaceId, sourceType, sourceId) {
+      calls.deleteBySource.push({ workspaceId, sourceType, sourceId });
+      return 0;
+    },
+    async countChunks(workspaceId) {
+      calls.countChunks.push(workspaceId);
+      return 0;
+    },
+    async getEmbeddingConfig(workspaceId) {
+      calls.getEmbeddingConfig.push(workspaceId);
+      return null;
+    },
+    async upsertEmbeddingConfig(workspaceId, cfg) {
+      calls.upsertEmbeddingConfig.push(workspaceId);
+      return {
+        id: "cfg-1",
+        workspaceId,
+        provider: cfg.provider,
+        model: cfg.model,
+        dimensions: cfg.dimensions,
+        config: cfg.options ?? {},
+        createdAt: new Date(0),
+        updatedAt: new Date(0),
+      } as never;
+    },
+  };
+}
+
+export async function createLegacyKnowledgeTestApp(
+  opts: LegacyKnowledgeTestAppOptions = {},
+): Promise<LegacyKnowledgeTestApp> {
+  const role: UserRole = opts.role ?? "admin";
+  const userId = opts.userId ?? "test-user-id";
+
+  const storage = new MemStorage();
+
+  const ownerId =
+    opts.workspaceOwnerId !== undefined
+      ? opts.workspaceOwnerId
+      : opts.ownsWorkspace
+        ? userId
+        : DEFAULT_OWNER;
+
+  const workspace = await storage.createWorkspace({
+    name: "Legacy KB Workspace",
+    type: "local",
+    path: "/tmp/legacy-kb",
+    branch: "main",
+    status: "active",
+    ownerId,
+  });
+
+  const user: User = {
+    id: userId,
+    email: "legacy-kb@example.com",
+    name: "Legacy KB User",
+    isActive: true,
+    role,
+    lastLoginAt: null,
+    createdAt: new Date(0),
+  };
+
+  const calls: KnowledgeStoreCalls = {
+    listSources: [],
+    search: [],
+    insertChunks: [],
+    deleteBySource: [],
+    getEmbeddingConfig: [],
+    upsertEmbeddingConfig: [],
+    countChunks: [],
+  };
+
+  const deps: KnowledgeDeps = {
+    createStore: () => makeMockStore(calls),
+    createEmbeddingProvider: (_config: EmbeddingProviderConfig) => ({
+      name: "ollama",
+      model: "mock-embed",
+      dimensions: 4,
+      embed: async (_text: string) => new Array(4).fill(0.1),
+      embedBatch: async (texts: string[]) => texts.map(() => new Array(4).fill(0.1)),
+    }),
+  };
+
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (!opts.unauth && req.headers["x-test-unauth"] !== "1") {
+      req.user = user;
+    }
+    next();
+  });
+
+  registerKnowledgeRoutes(app as unknown as Router, storage, deps);
+
+  return { app, storage, workspaceId: workspace.id, calls };
+}
+
+export type { ChunkSourceType };

--- a/tests/integration/knowledge/legacy-routes-idor.test.ts
+++ b/tests/integration/knowledge/legacy-routes-idor.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Integration tests for the LEGACY knowledge routes (server/routes/knowledge.ts).
+ *
+ * Issue #358 — authenticated IDOR: every /api/workspaces/:id/knowledge/* route
+ * was behind requireAuth but did NOT verify the `:id` workspace belongs to the
+ * caller, so any authenticated `user` could read/search/ingest/re-embed/delete
+ * chunks in ANY workspace by supplying another workspace's id.
+ *
+ * These tests assert the workspace-scoping gate on EVERY route:
+ *   - owner (non-admin)      → allowed (200/201/expected)
+ *   - non-owner `user`       → 403
+ *   - admin on another's ws  → allowed
+ *   - missing workspace      → 404
+ *   - unauthenticated        → 401 (and 401 precedes 404 in ordering)
+ *   - null-owner workspace   → 403 (chosen policy: DENY null-owner, matching
+ *                              orchestrator authorizeRun + workspaces
+ *                              getOwnedWorkspace; admin still allowed)
+ *
+ * Plus cross-workspace isolation: user A cannot reach user B's workspace, and
+ * when denied, the underlying store is NEVER touched (no leak / no write).
+ *
+ * supertest over the test-knowledge-legacy-app factory (MemStorage + injected
+ * in-memory store + deterministic embedding factory). No CLI / network / DB.
+ */
+import { describe, it, expect } from "vitest";
+import request from "supertest";
+import {
+  createLegacyKnowledgeTestApp,
+  type KnowledgeStoreCalls,
+  type LegacyKnowledgeTestAppOptions,
+} from "../../helpers/test-knowledge-legacy-app";
+
+const MISSING = "does-not-exist";
+
+function ingestBody() {
+  return {
+    sourceType: "document",
+    sourceId: "src-1",
+    text: "Pin terraform module sources to a version.",
+    metadata: {},
+    replace: false,
+  };
+}
+
+function configBody() {
+  return { provider: "ollama", model: "nomic-embed-text", dimensions: 768 };
+}
+
+// ─── Route descriptors: exercised by the shared gate-matrix below ──────────────
+
+interface RouteCase {
+  name: string;
+  method: "get" | "post" | "put" | "delete";
+  path: (ws: string) => string;
+  body?: () => Record<string, unknown>;
+  /** Expected status for the legitimate owner/admin happy path. */
+  ok: number;
+  query?: Record<string, string>;
+  /** Which store call records a touch for this route (cross-ws isolation check). */
+  touch: (calls: KnowledgeStoreCalls) => unknown[];
+}
+
+const ROUTES: RouteCase[] = [
+  {
+    name: "GET sources (read)",
+    method: "get",
+    path: (ws) => `/api/workspaces/${ws}/knowledge/sources`,
+    ok: 200,
+    touch: (c) => c.listSources,
+  },
+  {
+    name: "GET search (read)",
+    method: "get",
+    path: (ws) => `/api/workspaces/${ws}/knowledge/search`,
+    query: { q: "terraform" },
+    ok: 200,
+    touch: (c) => c.search,
+  },
+  {
+    name: "POST ingest (mutation)",
+    method: "post",
+    path: (ws) => `/api/workspaces/${ws}/knowledge/ingest`,
+    body: ingestBody,
+    ok: 201,
+    touch: (c) => c.insertChunks,
+  },
+  {
+    name: "DELETE source (mutation)",
+    method: "delete",
+    path: (ws) => `/api/workspaces/${ws}/knowledge/sources/document/src-1`,
+    ok: 200,
+    touch: (c) => c.deleteBySource,
+  },
+  {
+    name: "GET config (read)",
+    method: "get",
+    path: (ws) => `/api/workspaces/${ws}/knowledge/config`,
+    ok: 200,
+    touch: (c) => c.getEmbeddingConfig,
+  },
+  {
+    name: "PUT config (mutation)",
+    method: "put",
+    path: (ws) => `/api/workspaces/${ws}/knowledge/config`,
+    body: configBody,
+    ok: 200,
+    touch: (c) => c.upsertEmbeddingConfig,
+  },
+  {
+    name: "POST re-embed (mutation)",
+    method: "post",
+    path: (ws) => `/api/workspaces/${ws}/knowledge/re-embed`,
+    ok: 200,
+    touch: (c) => c.countChunks,
+  },
+];
+
+function send(
+  app: import("express").Express,
+  route: RouteCase,
+  ws: string,
+  opts: { unauth?: boolean } = {},
+) {
+  let req = request(app)[route.method](route.path(ws));
+  if (route.query) req = req.query(route.query);
+  if (opts.unauth) req = req.set("x-test-unauth", "1");
+  if (route.body) req = req.send(route.body());
+  return req;
+}
+
+function build(opts: LegacyKnowledgeTestAppOptions) {
+  return createLegacyKnowledgeTestApp(opts);
+}
+
+describe("legacy knowledge routes — IDOR workspace-scoping gate (#358)", () => {
+  for (const route of ROUTES) {
+    describe(route.name, () => {
+      it("allows a non-admin workspace OWNER", async () => {
+        const { app, workspaceId } = await build({ role: "user", ownsWorkspace: true });
+        const res = await send(app, route, workspaceId);
+        expect(res.status).toBe(route.ok);
+      });
+
+      it("allows an admin on another user's workspace", async () => {
+        const { app, workspaceId } = await build({ role: "admin", workspaceOwnerId: "other" });
+        const res = await send(app, route, workspaceId);
+        expect(res.status).toBe(route.ok);
+      });
+
+      it("rejects a non-owner `user` with 403 and never touches the store", async () => {
+        const { app, workspaceId, calls } = await build({
+          role: "user",
+          userId: "user-A",
+          workspaceOwnerId: "user-B",
+        });
+        const res = await send(app, route, workspaceId);
+        expect(res.status).toBe(403);
+        expect(route.touch(calls)).toHaveLength(0);
+      });
+
+      it("404s on a missing workspace", async () => {
+        const { app } = await build({ role: "admin" });
+        const res = await send(app, route, MISSING);
+        expect(res.status).toBe(404);
+      });
+
+      it("401s when unauthenticated", async () => {
+        const { app, workspaceId } = await build({ role: "user", ownsWorkspace: true });
+        const res = await send(app, route, workspaceId, { unauth: true });
+        expect(res.status).toBe(401);
+      });
+
+      it("401 precedes 404 (unauth on a missing workspace)", async () => {
+        const { app } = await build({ role: "admin" });
+        const res = await send(app, route, MISSING, { unauth: true });
+        expect(res.status).toBe(401);
+      });
+
+      it("denies a null-owner workspace with 403 for a non-admin (chosen policy)", async () => {
+        const { app, workspaceId, calls } = await build({
+          role: "user",
+          userId: "user-A",
+          workspaceOwnerId: null,
+        });
+        const res = await send(app, route, workspaceId);
+        expect(res.status).toBe(403);
+        expect(route.touch(calls)).toHaveLength(0);
+      });
+
+      it("admin may access a null-owner workspace", async () => {
+        const { app, workspaceId } = await build({ role: "admin", workspaceOwnerId: null });
+        const res = await send(app, route, workspaceId);
+        expect(res.status).toBe(route.ok);
+      });
+    });
+  }
+});
+
+describe("legacy knowledge routes — cross-workspace isolation", () => {
+  it("user A cannot READ (search) into user B's workspace", async () => {
+    const { app, workspaceId, calls } = await createLegacyKnowledgeTestApp({
+      role: "user",
+      userId: "user-A",
+      workspaceOwnerId: "user-B",
+    });
+    const res = await request(app)
+      .get(`/api/workspaces/${workspaceId}/knowledge/search`)
+      .query({ q: "secret" });
+    expect(res.status).toBe(403);
+    expect(calls.search).toHaveLength(0);
+  });
+
+  it("user A cannot READ (sources) into user B's workspace", async () => {
+    const { app, workspaceId, calls } = await createLegacyKnowledgeTestApp({
+      role: "user",
+      userId: "user-A",
+      workspaceOwnerId: "user-B",
+    });
+    const res = await request(app).get(`/api/workspaces/${workspaceId}/knowledge/sources`);
+    expect(res.status).toBe(403);
+    expect(calls.listSources).toHaveLength(0);
+  });
+
+  it("user A cannot INGEST into user B's workspace", async () => {
+    const { app, workspaceId, calls } = await createLegacyKnowledgeTestApp({
+      role: "user",
+      userId: "user-A",
+      workspaceOwnerId: "user-B",
+    });
+    const res = await request(app)
+      .post(`/api/workspaces/${workspaceId}/knowledge/ingest`)
+      .send(ingestBody());
+    expect(res.status).toBe(403);
+    expect(calls.insertChunks).toHaveLength(0);
+  });
+
+  it("the legitimate owner ingest still writes through to the store", async () => {
+    const { app, workspaceId, calls } = await createLegacyKnowledgeTestApp({
+      role: "user",
+      userId: "owner-X",
+      ownsWorkspace: true,
+    });
+    const res = await request(app)
+      .post(`/api/workspaces/${workspaceId}/knowledge/ingest`)
+      .send(ingestBody());
+    expect(res.status).toBe(201);
+    expect(calls.insertChunks.length).toBeGreaterThan(0);
+    for (const chunk of calls.insertChunks) {
+      expect(chunk.workspaceId).toBe(workspaceId);
+    }
+  });
+});
+
+describe("legacy knowledge routes — generic client errors (no internal leak)", () => {
+  it("returns a generic 403 body with no internal detail when denied", async () => {
+    const { app, workspaceId } = await createLegacyKnowledgeTestApp({
+      role: "user",
+      userId: "user-A",
+      workspaceOwnerId: "user-B",
+    });
+    const res = await request(app)
+      .get(`/api/workspaces/${workspaceId}/knowledge/search`)
+      .query({ q: "x" });
+    expect(res.status).toBe(403);
+    expect(JSON.stringify(res.body)).not.toMatch(/stack|Error:|node_modules|pgvector|ollama/i);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -62,6 +62,7 @@ export default defineConfig({
         "server/knowledge/safe-fetch.ts",
         "server/knowledge/practice-card-service.ts",
         "server/routes/practice-cards.ts",
+        "server/routes/knowledge.ts",
         "server/knowledge/diff-engine.ts",
         "server/knowledge/compliance-mapper.ts",
         "server/knowledge/refresh-scheduler.ts",


### PR DESCRIPTION
## Summary
Closes #358 (HIGH authenticated IDOR). The `/api/workspaces/:id/knowledge/{search,ingest,re-embed,sources,config}` routes were behind `requireAuth` but never verified the `:id` workspace belonged to the caller — any authenticated user could read/search/ingest/re-embed/delete chunks in **any** workspace.

## Fix
- Shared `authorizeWorkspace` gate on **all 7** legacy knowledge routes: resolve `getWorkspace(:id)` → owner-or-admin, ordering **401 → 404 → 403**, generic client errors, **deny null-owner** for non-admins (consistent with `orchestrator.authorizeRun` + `workspaces.getOwnedWorkspace`). The gate runs **before any store access** — a denied request never touches the knowledge store.
- Search/ingest/re-embed logic unchanged; the legit owner/admin path is identical.
- `registerKnowledgeRoutes(app, storage, deps?)` gains an injectable store for testability; production passes no `deps` → the real VectorStore/embedding factory (no bypass).

## Quality gates
- **Security PASS** (veto) — 7/7 routes gated before data access, no ungated route, no read-then-check, no existence leak, no prod bypass via injectable deps; null-owner deny matches the codebase idiom.
- `tsc --noEmit` clean · `npm run test:unit` 4681 · **61** IDOR integration tests (per-route owner/admin/non-owner-403+store-untouched/404/401/401-before-404/null-owner) + cross-workspace isolation + generic-error no-leak · knowledge integration 110 green.