### PR TITLE
test: close consensus engine coverage gaps (controller + engine)

### DIFF
--- a/tests/unit/consensus/consensus-controller.test.ts
+++ b/tests/unit/consensus/consensus-controller.test.ts
@@ -12,6 +12,7 @@ import { configLoader } from "../../../server/config/loader.js";
 import type { GatewayRequest, GatewayResponse } from "../../../shared/types.js";
 import type { Gateway } from "../../../server/gateway/index.js";
 import { VOTER_ROSTER } from "../../../server/consensus/consensus-voters.js";
+import type { ListModelSlugs } from "../../../server/consensus/consensus-voters.js";
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -44,6 +45,15 @@ function makeGateway(verdict: string, throwOnComplete = false): Gateway {
 
 const MODELS = { claudeModelSlug: "claude-opus" };
 const liveAll = () => Promise.resolve([...VOTER_ROSTER]);
+
+/**
+ * Reach the controller's DEFAULT live-discovery slug source (the 4th-arg default,
+ * `() => defaultLiveSlugs(this.gateway)`) without re-exporting the private module
+ * function. Constructed with only 3 args so the default binding is installed.
+ */
+function defaultSlugSource(ctrl: ConsensusController): ListModelSlugs {
+  return (ctrl as unknown as { readonly listModelSlugs: ListModelSlugs }).listModelSlugs;
+}
 
 describe("ConsensusController — kill-switch", () => {
   it("throws when consensus is disabled (defense-in-depth with the route 503)", async () => {
@@ -104,10 +114,112 @@ describe("ConsensusController — settle paths", () => {
   });
 });
 
+describe("ConsensusController — defaultLiveSlugs (live-discovery fallback)", () => {
+  it("happy parse: discovered antigravity models → their slugs (no injected roster source)", async () => {
+    enableConsensus(true);
+    // Only 3 args → the controller installs its DEFAULT live-discovery source.
+    const ctrl = new ConsensusController(new MemStorage(), makeGateway("APPROVE"), MODELS);
+    const slugs = await defaultSlugSource(ctrl)();
+    expect([...slugs]).toEqual([...VOTER_ROSTER]);
+  });
+
+  it("catch branch: a throwing discoverModels degrades to [] (defensive, never throws)", async () => {
+    enableConsensus(true);
+    const boomGateway = {
+      async complete(req: GatewayRequest): Promise<GatewayResponse> {
+        return { content: "{}", tokensUsed: 1, modelSlug: req.modelSlug, finishReason: "stop" };
+      },
+      async discoverModels(): Promise<never> {
+        throw new Error("discover boom");
+      },
+    } as unknown as Gateway;
+    const ctrl = new ConsensusController(new MemStorage(), boomGateway, MODELS);
+
+    await expect(defaultSlugSource(ctrl)()).resolves.toEqual([]); // no-throw, empty roster
+  });
+
+  it("missing/non-array antigravity entry → [] (no slugs invented)", async () => {
+    enableConsensus(true);
+    const noEntryGateway = {
+      async complete(req: GatewayRequest): Promise<GatewayResponse> {
+        return { content: "{}", tokensUsed: 1, modelSlug: req.modelSlug, finishReason: "stop" };
+      },
+      async discoverModels() {
+        return { someOtherProvider: { available: true, models: [{ slug: "x" }] } };
+      },
+    } as unknown as Gateway;
+    const ctrl = new ConsensusController(new MemStorage(), noEntryGateway, MODELS);
+    await expect(defaultSlugSource(ctrl)()).resolves.toEqual([]);
+  });
+});
+
 describe("ConsensusController — cancel", () => {
   it("cancel() on an unknown run is a no-op (does not throw)", () => {
     enableConsensus(true);
     const ctrl = new ConsensusController(new MemStorage(), makeGateway("APPROVE"), MODELS, liveAll);
     expect(() => ctrl.cancel("nope")).not.toThrow();
+  });
+
+  it("cancel() on an ACTIVE (not-yet-settled) run settles cancelled with NO partial verdict", async () => {
+    enableConsensus(true);
+    const storage = new MemStorage();
+
+    // A gateway whose FIRST complete() (the blind verdict) blocks until released,
+    // so the run is genuinely in-flight (row created, engine running, not settled)
+    // when we cancel(). Releasing it lets the engine reach its abort-aware stop check.
+    let releaseFirst!: () => void;
+    let firstCallStarted!: () => void;
+    const blocked = new Promise<void>((r) => (releaseFirst = r));
+    const started = new Promise<void>((r) => (firstCallStarted = r));
+    let sawFirst = false;
+    const gateway = {
+      async complete(req: GatewayRequest): Promise<GatewayResponse> {
+        if (!sawFirst) {
+          sawFirst = true;
+          firstCallStarted();
+          await blocked; // hold the run open across the cancel()
+        }
+        const isVoter = req.provider === "antigravity";
+        return {
+          content: isVoter
+            ? JSON.stringify({ verdict: "APPROVE", critical_issues: [] })
+            : JSON.stringify({ verdict: "APPROVE" }),
+          tokensUsed: 1,
+          modelSlug: req.modelSlug,
+          finishReason: "stop",
+        };
+      },
+      async discoverModels() {
+        return { antigravity: { available: true, models: VOTER_ROSTER.map((slug) => ({ slug })) } };
+      },
+    } as unknown as Gateway;
+
+    const ctrl = new ConsensusController(storage, gateway, MODELS, liveAll);
+
+    // Capture the runId the controller creates (the parent row id is the run id).
+    let capturedRunId = "";
+    const realCreate = storage.createPipelineRun.bind(storage);
+    vi.spyOn(storage, "createPipelineRun").mockImplementation(async (data) => {
+      const row = await realCreate(data);
+      capturedRunId = row.id;
+      return row;
+    });
+
+    const runPromise = ctrl.startConsensusRun({ decisionText: "d" }, "u1");
+
+    await started; // the run is in-flight: row exists, blind call blocked, not settled
+    expect(capturedRunId).not.toBe("");
+
+    ctrl.cancel(capturedRunId); // abort the in-flight run
+    releaseFirst(); // let the blocked call resolve so the engine reaches its stop check
+
+    const result = await runPromise;
+    expect(result.status).toBe("cancelled");
+
+    const cr = await storage.getConsensusRun(capturedRunId);
+    expect(cr?.status).toBe("cancelled");
+    expect(cr?.finalVerdict).toBeNull(); // C1: no partial verdict promoted
+    const parent = await storage.getPipelineRun(capturedRunId);
+    expect(parent?.status).toBe("cancelled");
   });
 });

--- a/tests/unit/consensus/consensus-engine-budget-stop.test.ts
+++ b/tests/unit/consensus/consensus-engine-budget-stop.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Gap-2 coverage: the ConsensusEngine round-boundary stop branch for
+ * decideStop reason "budget".
+ *
+ * In production this branch is unreachable because the engine passes
+ * `budgetExhausted: false` to shouldStop (the C2 ceiling is enforced eagerly by
+ * TokenBudget.checkBefore(), which THROWS a TokenCeilingError before any round
+ * boundary). To exercise the engine's defensive handling of a non-throwing
+ * `{stop:true, reason:"budget"}` decision (consensus-engine.ts lines ~197-205),
+ * we stub the shared `shouldStop` seam so it returns that decision directly.
+ *
+ * The assertion is the safety contract: a budget stop settles UNRESOLVED with a
+ * null finalVerdict — a partial / would-be APPROVE is NEVER promoted — and no
+ * TokenCeilingError was thrown (the run returns an outcome, it does not reject).
+ *
+ * The mock is file-scoped (vi.mock is hoisted), so this lives in its own file to
+ * avoid altering the real-policy assertions in consensus-engine.test.ts.
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { StopDecision } from "../../../server/orchestrator/deliberation/stop-policy.js";
+
+// Stub the shared termination seam to force a non-throwing budget stop, keeping
+// the sibling export intact (the engine only uses shouldStop, but we preserve
+// the real module shape rather than blank it out).
+vi.mock("../../../server/orchestrator/deliberation/deliberation-controller.js", async (importActual) => {
+  const actual = await importActual<
+    typeof import("../../../server/orchestrator/deliberation/deliberation-controller.js")
+  >();
+  const budgetStop: StopDecision = { stop: true, reason: "budget", confidence: "low" };
+  return {
+    ...actual,
+    shouldStop: vi.fn((): StopDecision => budgetStop),
+  };
+});
+
+import { MemStorage } from "../../../server/storage.js";
+import { ConsensusEngine } from "../../../server/consensus/consensus-engine.js";
+import { ConsensusVoters, VOTER_ROSTER } from "../../../server/consensus/consensus-voters.js";
+import { TokenBudget } from "../../../server/orchestrator/orchestrator-config.js";
+import type { GatewayRequest, GatewayResponse } from "../../../shared/types.js";
+import type { Gateway } from "../../../server/gateway/index.js";
+
+const CLAUDE = "claude-opus";
+
+/**
+ * Voters + Claude all APPROVE — so the ONLY thing that can block a resolve is the
+ * stubbed budget stop (proving it pre-empts a would-be APPROVE).
+ */
+function makeApprovingGateway(): Gateway {
+  return {
+    async complete(req: GatewayRequest): Promise<GatewayResponse> {
+      const isVoter = req.provider === "antigravity";
+      return {
+        content: isVoter
+          ? JSON.stringify({ verdict: "APPROVE", critical_issues: [] })
+          : JSON.stringify({ verdict: "APPROVE" }),
+        tokensUsed: 1,
+        modelSlug: req.modelSlug,
+        finishReason: "stop",
+      };
+    },
+  } as unknown as Gateway;
+}
+
+async function seedRun(storage: MemStorage): Promise<string> {
+  const run = await storage.createPipelineRun({
+    pipelineId: "consensus:budget-test",
+    status: "running",
+    input: "decision",
+    triggeredBy: "u1",
+  });
+  await storage.createConsensusRun({ runId: run.id, decisionText: "d", status: "deliberating" });
+  return run.id;
+}
+
+describe("ConsensusEngine — budget stop on a round boundary (no TokenCeilingError throw)", () => {
+  it('a non-throwing decideStop {reason:"budget"} settles unresolved, finalVerdict null (no partial promoted)', async () => {
+    const storage = new MemStorage();
+    const runId = await seedRun(storage);
+    const budget = new TokenBudget(1_000_000); // far from its ceiling — no throw
+    const voters = new ConsensusVoters(makeApprovingGateway(), () => Promise.resolve([...VOTER_ROSTER]));
+    const engine = new ConsensusEngine({
+      gateway: makeApprovingGateway(),
+      storage,
+      voters,
+      models: { claudeModelSlug: CLAUDE },
+    });
+
+    const outcome = await engine.run({
+      runId,
+      decisionText: "d",
+      // minRounds 1 so the first round can reach the (stubbed) stop check.
+      caps: {
+        maxRounds: 3,
+        voterCount: 5,
+        maxTotalTokens: 1_000_000,
+        overallTimeoutMs: 1_800_000,
+        voterTimeoutMs: 90_000,
+        minRounds: 1,
+      },
+      budget,
+    });
+
+    expect(outcome.status).toBe("unresolved");
+    expect(outcome.stopReason).toBe("budget");
+    expect(outcome.confidence).toBe("low");
+    expect(outcome.finalVerdict).toBeNull(); // C2: no partial / would-be APPROVE promoted
+    expect(outcome.roundsRun).toBe(1);
+    // The budget never hit its ceiling — this exercised the defensive branch,
+    // NOT the TokenCeilingError throw path.
+    expect(budget.total).toBeLessThan(1_000_000);
+  });
+});

--- a/tests/unit/consensus/consensus-engine.test.ts
+++ b/tests/unit/consensus/consensus-engine.test.ts
@@ -15,7 +15,8 @@
  *   - unresolved-at-cap (never auto-approve on exhaustion);
  *   - dismissal-without-justification keeps the issue OPEN (fail-closed);
  *   - poisoned decisionText (forged sentinel / END delimiter) leaves the
- *     structural control unmoved.
+ *     structural control unmoved;
+ *   - wall-clock timeout backstop on a round boundary (no TokenCeilingError throw).
  */
 import { describe, it, expect } from "vitest";
 import { MemStorage } from "../../../server/storage.js";
@@ -353,5 +354,41 @@ describe("ConsensusEngine — poisoned decisionText (structural control unmoved)
     });
     expect(outcome.status).toBe("unresolved");
     expect(outcome.finalVerdict).toBeNull();
+  });
+});
+
+describe("ConsensusEngine — wall-clock timeout stop on a round boundary (no throw)", () => {
+  // The overall-timeout backstop is decideStop precedence step 3 — above the
+  // min-rounds floor and the stability stop. It fires on the round boundary
+  // WITHOUT any TokenCeilingError throw (TokenBudget is nowhere near its ceiling).
+  // A negative overallTimeoutMs makes `elapsedMs (>=0) > overallTimeoutMs` hold
+  // deterministically regardless of execution speed — exercising the engine's
+  // `reason:"timeout"` → unresolved branch (never auto-approve; no partial verdict).
+  it('settles unresolved with stopReason "timeout" and finalVerdict null (no TokenCeilingError)', async () => {
+    const storage = new MemStorage();
+    const runId = await seedRun(storage);
+    const hooks: ScriptHooks = {
+      trace: [],
+      // All four structural conditions WOULD otherwise resolve — proving the
+      // timeout backstop pre-empts a would-be APPROVE rather than promoting it.
+      voterVerdict: () => "APPROVE",
+      blind: "APPROVE",
+      adjudication: () => ({ verdict: "APPROVE" }),
+    };
+    const budget = new TokenBudget(1_000_000);
+    const outcome = await makeEngine(makeScriptedGateway(hooks), storage).run({
+      runId,
+      decisionText: "d",
+      caps: caps({ minRounds: 2, maxRounds: 3, overallTimeoutMs: -1 }),
+      budget,
+    });
+
+    expect(outcome.status).toBe("unresolved");
+    expect(outcome.stopReason).toBe("timeout");
+    expect(outcome.confidence).toBe("low");
+    expect(outcome.finalVerdict).toBeNull();
+    expect(outcome.roundsRun).toBe(1); // step-3 backstop fires above the min-rounds floor
+    // No TokenCeilingError path was taken — the budget barely moved.
+    expect(budget.total).toBeLessThan(1_000_000);
   });
 });


### PR DESCRIPTION
Closes the two non-blocking coverage gaps QA flagged on the merged consensus engine (PR #367). **Test-only**, no source change.

- **consensus-controller** ~74% → **100%** lines: `defaultLiveSlugs()` happy-parse + catch (throwing `discoverModels` → `[]`) + non-array entry; `cancel()` on an actively-running run → settles `cancelled`, `finalVerdict` null.
- **consensus-engine** ~74% → **93.7%** lines: `decideStop` step-3 timeout on a round boundary (overallTimeoutMs:-1) with no `TokenCeilingError` → unresolved/timeout/null; the defensive (prod-unreachable) budget-stop branch isolated via a file-scoped `shouldStop` mock → documented no-promote.

tsc clean; unit green (75 consensus tests).