### PR TITLE
feat: live run-activity observability view + WsManager subscribe hardening

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -44,6 +44,7 @@ import TaskGroupTrace from "@/pages/TaskGroupTrace";
 import { WorkspaceTracesPage, WorkspaceTraceDetailPage } from "@/pages/WorkspaceTraces";
 import Costs from "@/pages/Costs";
 import ConfigSync from "@/pages/ConfigSync";
+import Activity from "@/pages/Activity";
 
 function ProtectedRouter() {
   const { user, isLoading } = useAuth();
@@ -150,6 +151,9 @@ function ProtectedRouter() {
         )} />
         <Route path="/privacy" component={() => (
           <ErrorBoundary><Privacy /></ErrorBoundary>
+        )} />
+        <Route path="/activity" component={() => (
+          <ErrorBoundary><Activity /></ErrorBoundary>
         )} />
         <Route path="/stats" component={() => (
           <ErrorBoundary><Statistics /></ErrorBoundary>

--- a/client/src/components/layout/MainLayout.tsx
+++ b/client/src/components/layout/MainLayout.tsx
@@ -28,6 +28,7 @@ import {
   Radio,
   Newspaper,
   Bot,
+  Activity,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePendingQuestions } from "@/hooks/use-pipeline";
@@ -66,6 +67,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
     },
     { icon: ListChecks, label: "Task Groups", href: "/task-groups" },
     { icon: Zap, label: "Triggers", href: "/triggers" },
+    { icon: Activity, label: "Live Activity", href: "/activity" },
     { icon: FolderGit2, label: "Workspace", href: "/workspaces" },
     // Show "Connections", "Inventory", "Knowledge Base", and "Traces" sub-items
     // when inside a workspace

--- a/client/src/hooks/use-activity.ts
+++ b/client/src/hooks/use-activity.ts
@@ -1,0 +1,118 @@
+/**
+ * useActivity — the MULTI-run sibling of usePipelineEvents (use-websocket.ts).
+ *
+ * usePipelineEvents owns ONE run's full event stream; useActivity owns the
+ * read-only "what's running right now" lens across ALL of the caller's active
+ * runs. It seeds from the polled `GET /api/activity` snapshot (the source of
+ * truth, which adds/removes rows) and merges the additive live WS deltas onto
+ * the already-known rows, keyed by runId, between refetches.
+ *
+ * Shape:
+ *   - useQuery(["/api/activity"]) with a refetchInterval fallback (5s) so a row
+ *     that emits no WS events (consensus is poll-only) still refreshes, and so
+ *     rows that started/ended get added/removed.
+ *   - on each snapshot, subscribe to EXACTLY the snapshot's runIds (the server
+ *     rejects subscribing to runs you don't own) and unsubscribe the rest.
+ *   - wsClient.onAny → mergeWsEvent folds status/model/progress onto the live
+ *     rows; the next refetch reconciles.
+ *
+ * The merge/grouping/subscription logic is pure (see @/lib/activity) and unit
+ * tested; this hook is the thin React/WS wiring.
+ */
+import { useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/queryClient";
+import { wsClient } from "@/lib/websocket";
+import type { WsEvent } from "@shared/types";
+import {
+  mergeWsEvent,
+  snapshotRunIds,
+  type ActivitySnapshot,
+  type LiveActivityRun,
+} from "@/lib/activity";
+
+/** Snapshot poll interval (fallback refresh; also reconciles WS drift). */
+export const ACTIVITY_REFETCH_INTERVAL_MS = 5_000;
+
+export interface UseActivityResult {
+  runs: LiveActivityRun[];
+  isAdmin: boolean;
+  truncated: boolean;
+  isLoading: boolean;
+  error: unknown;
+  /** Live WS connection state — surfaced so the page can warn on disconnect. */
+  isConnected: boolean;
+}
+
+export function useActivity(): UseActivityResult {
+  const query = useQuery<ActivitySnapshot>({
+    queryKey: ["/api/activity"],
+    queryFn: () => apiRequest("GET", "/api/activity").then((r) => r.json()),
+    refetchInterval: ACTIVITY_REFETCH_INTERVAL_MS,
+    refetchIntervalInBackground: false,
+  });
+
+  // The live, WS-merged view of the rows. Seeded from each snapshot; folded by
+  // wsClient.onAny between refetches.
+  const [rows, setRows] = useState<LiveActivityRun[]>([]);
+  const [isConnected, setIsConnected] = useState(wsClient.isConnected);
+
+  // Snapshot rows reseed the live view (snapshot is the source of truth).
+  const snapshot = query.data;
+  useEffect(() => {
+    if (!snapshot) return;
+    setRows(snapshot.runs as LiveActivityRun[]);
+  }, [snapshot]);
+
+  // Subscribe to EXACTLY the snapshot's runIds (ownership-scoped); the WsClient
+  // de-dupes subscribe() and re-subscribes on reconnect. Track what we've
+  // subscribed to so we can unsubscribe rows that left the snapshot.
+  const subscribedRef = useRef<Set<string>>(new Set());
+  const ids = snapshot ? snapshotRunIds(snapshot.runs) : [];
+  const idsKey = ids.join(",");
+
+  useEffect(() => {
+    wsClient.connect();
+    const wanted = new Set(idsKey ? idsKey.split(",") : []);
+    const current = subscribedRef.current;
+
+    for (const id of wanted) {
+      if (!current.has(id)) wsClient.subscribe(id);
+    }
+    for (const id of current) {
+      if (!wanted.has(id)) wsClient.unsubscribe(id);
+    }
+    subscribedRef.current = wanted;
+  }, [idsKey]);
+
+  // Merge live deltas + track connection state.
+  useEffect(() => {
+    wsClient.connect();
+    const onEvent = (event: WsEvent) => {
+      setIsConnected(wsClient.isConnected);
+      setRows((prev) => mergeWsEvent(prev, event));
+    };
+    const unsub = wsClient.onAny(onEvent);
+    setIsConnected(wsClient.isConnected);
+    return () => {
+      unsub();
+    };
+  }, []);
+
+  // Unsubscribe everything on unmount (leaving the page).
+  useEffect(() => {
+    return () => {
+      for (const id of subscribedRef.current) wsClient.unsubscribe(id);
+      subscribedRef.current = new Set();
+    };
+  }, []);
+
+  return {
+    runs: rows,
+    isAdmin: snapshot?.isAdmin ?? false,
+    truncated: snapshot?.truncated ?? false,
+    isLoading: query.isLoading,
+    error: query.error,
+    isConnected,
+  };
+}

--- a/client/src/lib/activity.ts
+++ b/client/src/lib/activity.ts
@@ -1,0 +1,213 @@
+/**
+ * Pure helpers + UI-facing types for the read-only "Live Activity" debugging
+ * lens (GET /api/activity + the live WS deltas).
+ *
+ * Mirrors the lib/orchestrator.ts / lib/news.ts model: the page + hook are thin,
+ * and the logic that actually matters — the multi-run merge-by-runId reducer
+ * that folds live WS deltas onto the polled snapshot, the mode grouping, the
+ * runId set for ownership-scoped subscription, and the small display helpers —
+ * lives here as pure functions that are unit-tested without a DOM renderer (the
+ * repo has no jsdom; see tests/unit/orchestrator-ui.test.ts).
+ *
+ * SECURITY: every field surfaced through the Activity lens is metadata only and
+ * ENUM/system-derived (mode, status, agent/team id, model slug, ids). The
+ * backend already strips transcripts/prompts/task text. Components still render
+ * every string as INERT React text (never via dangerouslySetInnerHTML).
+ */
+import type {
+  ActivityRun,
+  ActivitySnapshot,
+  ActivityMode,
+  WsEvent,
+} from "@shared/types";
+
+export type { ActivityRun, ActivitySnapshot, ActivityMode };
+
+/** The fixed display order of the mode groups on the page. */
+export const ACTIVITY_MODE_ORDER: readonly ActivityMode[] = [
+  "pipeline",
+  "manager",
+  "orchestrator",
+  "consensus",
+] as const;
+
+/** Human label for each mode group. */
+export const ACTIVITY_MODE_LABELS: Record<ActivityMode, string> = {
+  pipeline: "Pipelines",
+  manager: "Manager loops",
+  orchestrator: "Orchestrator runs",
+  consensus: "Consensus runs",
+};
+
+/** A mode group with its rows, ready to render. */
+export interface ActivityGroup {
+  mode: ActivityMode;
+  label: string;
+  runs: ActivityRun[];
+}
+
+/**
+ * Group the rows by mode in the fixed ACTIVITY_MODE_ORDER. Empty groups are
+ * omitted so the page only renders modes that actually have active runs.
+ */
+export function groupByMode(runs: readonly ActivityRun[]): ActivityGroup[] {
+  return ACTIVITY_MODE_ORDER.map((mode) => ({
+    mode,
+    label: ACTIVITY_MODE_LABELS[mode],
+    runs: runs.filter((r) => r.mode === mode),
+  })).filter((g) => g.runs.length > 0);
+}
+
+/**
+ * The set of runIds the caller is allowed to subscribe to over WS. The server
+ * now rejects subscribing to runs you don't own, so this is exactly the snapshot
+ * rows — never a guessed/derived id.
+ */
+export function snapshotRunIds(runs: readonly ActivityRun[]): string[] {
+  return runs.map((r) => r.runId);
+}
+
+/** Read a string field from an untrusted WS payload, or null. */
+function payloadString(
+  payload: Record<string, unknown>,
+  key: string,
+): string | null {
+  const v = payload[key];
+  return typeof v === "string" ? v : null;
+}
+
+/** Read a finite number field from an untrusted WS payload, or null. */
+function payloadNumber(
+  payload: Record<string, unknown>,
+  key: string,
+): number | null {
+  const v = payload[key];
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+/** A row carrying the live pulse timestamp the page uses to show "live now". */
+export interface LiveActivityRun extends ActivityRun {
+  /** Epoch ms of the last live WS delta merged onto this row; undefined if none. */
+  lastDeltaAt?: number;
+}
+
+/**
+ * Immutably merge a single live WS event onto the current rows, keyed by
+ * `event.runId`. Only the three additive live signals are merged:
+ *
+ *  - `stage:progress`     → refreshes currentUnit.modelSlug, marks "running",
+ *                           bumps the live `lastDeltaAt` pulse.
+ *  - `manager:decision`   → refreshes currentUnit.modelSlug + agent (teamId),
+ *                           marks "running", bumps the pulse.
+ *  - `orchestrator:step`  → updates currentUnit.label/agent/modelSlug/status from
+ *                           the step metadata, bumps the pulse.
+ *
+ * Events for a runId NOT present in the snapshot are ignored (we only know about
+ * — and only subscribe to — runs the snapshot returned). Events without a runId,
+ * or of any other type, are passed through unchanged. The function never mutates
+ * its input and never throws on a malformed payload.
+ *
+ * The merge is intentionally additive/best-effort: the periodic snapshot refetch
+ * is the source of truth (it adds/removes rows); WS deltas only keep already-known
+ * rows feeling live between refetches. Consensus emits no WS events, so consensus
+ * rows are refresh-only by construction.
+ */
+export function mergeWsEvent(
+  runs: readonly LiveActivityRun[],
+  event: WsEvent,
+  /** Monotonic timestamp (ms) used for the live pulse; injectable for tests. */
+  now: number = Date.now(),
+): LiveActivityRun[] {
+  const runId = event.runId;
+  if (!runId) return runs as LiveActivityRun[];
+  if (
+    event.type !== "stage:progress" &&
+    event.type !== "manager:decision" &&
+    event.type !== "orchestrator:step"
+  ) {
+    return runs as LiveActivityRun[];
+  }
+
+  const idx = runs.findIndex((r) => r.runId === runId);
+  if (idx === -1) return runs as LiveActivityRun[];
+
+  const next = applyDelta(runs[idx], event, now);
+  const copy = runs.slice();
+  copy[idx] = next;
+  return copy;
+}
+
+function applyDelta(
+  row: LiveActivityRun,
+  event: WsEvent,
+  now: number,
+): LiveActivityRun {
+  const payload = event.payload ?? {};
+  const prevUnit = row.currentUnit;
+
+  if (event.type === "orchestrator:step") {
+    const label = stepIndexLabel(payloadNumber(payload, "stepIndex"));
+    const type = payloadString(payload, "type");
+    const status =
+      payloadString(payload, "status") ?? prevUnit?.status ?? "running";
+    return {
+      ...row,
+      currentUnit: {
+        label: label ?? prevUnit?.label ?? "Step",
+        agent: type ?? prevUnit?.agent ?? "orchestrator",
+        modelSlug:
+          payloadString(payload, "modelSlug") ?? prevUnit?.modelSlug ?? null,
+        status,
+      },
+      lastDeltaAt: now,
+    };
+  }
+
+  // stage:progress / manager:decision: keep the snapshot-derived label, refresh
+  // the model + mark running. manager:decision also re-attributes the agent when
+  // the payload carries a teamId.
+  const teamId = payloadString(payload, "teamId");
+  const modelSlug = payloadString(payload, "modelSlug");
+  const baseUnit =
+    prevUnit ?? { label: row.title, agent: "agent", modelSlug: null, status: "running" };
+
+  return {
+    ...row,
+    currentUnit: {
+      label: baseUnit.label,
+      agent:
+        event.type === "manager:decision" && teamId ? teamId : baseUnit.agent,
+      modelSlug: modelSlug ?? baseUnit.modelSlug,
+      status: "running",
+    },
+    lastDeltaAt: now,
+  };
+}
+
+/** "Step 0" → "Step 1" (1-based, human) for an orchestrator step index. */
+function stepIndexLabel(stepIndex: number | null): string | null {
+  if (stepIndex === null) return null;
+  return `Step ${stepIndex + 1}`;
+}
+
+/** Freshness window for the "live now" pulse. */
+export const LIVE_PULSE_WINDOW_MS = 10_000;
+
+/**
+ * Whether a row counts as "live now": it has had a WS delta within the freshness
+ * window. Pure so the page can decide the pulse without a clock side-effect.
+ */
+export function isLiveNow(
+  row: LiveActivityRun,
+  now: number = Date.now(),
+): boolean {
+  return (
+    typeof row.lastDeltaAt === "number" &&
+    now - row.lastDeltaAt <= LIVE_PULSE_WINDOW_MS
+  );
+}
+
+/** Display a model slug, or an em-dash placeholder when unknown. */
+export function displayModel(modelSlug: string | null | undefined): string {
+  return modelSlug && modelSlug.length > 0 ? modelSlug : "—";
+}

--- a/client/src/pages/Activity.tsx
+++ b/client/src/pages/Activity.tsx
@@ -1,0 +1,269 @@
+/**
+ * Activity — a read-only "Live Activity" debugging lens at /activity.
+ *
+ * Shows what's running RIGHT NOW across the four run modes (pipeline / manager /
+ * orchestrator / consensus): for each active run, the current unit's label, the
+ * agent/role, the model, and a status badge, with a live pulse when WS deltas
+ * are flowing. The owner column is shown only to admins.
+ *
+ * Data flow: useActivity() seeds from the polled GET /api/activity snapshot and
+ * merges the additive live WS deltas (stage:progress / manager:decision /
+ * orchestrator:step) onto the rows. Consensus emits no WS events, so its rows
+ * are refresh-only — covered by the 5s refetch.
+ *
+ * SECURITY: every string rendered here is run metadata only (mode, status,
+ * agent/team id, model slug, ids) and is rendered as INERT React text. There is
+ * no HTML sink and no transcript/prompt/task text (the backend strips those).
+ */
+import type { ReactNode } from "react";
+import { useMemo } from "react";
+import { Activity as ActivityIcon, WifiOff, AlertTriangle, Loader2 } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { useActivity } from "@/hooks/use-activity";
+import {
+  groupByMode,
+  displayModel,
+  isLiveNow,
+  type ActivityGroup,
+  type LiveActivityRun,
+} from "@/lib/activity";
+
+// ─── Status pill ────────────────────────────────────────────────────────────────
+// Run + unit statuses are open `string`s on the contract (RunStatus | string,
+// StageStatus | OrchestratorStepStatus | phase). Key the known ones to a colour;
+// anything else falls back to a neutral, still-inert pill.
+
+const STATUS_CLASS: Record<string, string> = {
+  pending: "bg-muted text-muted-foreground border-border",
+  planning: "bg-muted text-muted-foreground border-border",
+  running: "bg-amber-500/15 text-amber-600 border-amber-500/30",
+  executing: "bg-amber-500/15 text-amber-600 border-amber-500/30",
+  paused: "bg-sky-500/15 text-sky-600 border-sky-500/30",
+  awaiting_approval: "bg-sky-500/15 text-sky-600 border-sky-500/30",
+  completed: "bg-emerald-500/15 text-emerald-600 border-emerald-500/30",
+  failed: "bg-destructive/15 text-destructive border-destructive/30",
+  rejected: "bg-destructive/15 text-destructive border-destructive/30",
+  cancelled: "bg-muted text-muted-foreground/70 border-border",
+  skipped: "bg-muted text-muted-foreground/70 border-border",
+};
+
+function StatusPill({ status }: { status: string }) {
+  const className =
+    STATUS_CLASS[status] ?? "bg-muted text-muted-foreground border-border";
+  return (
+    <Badge variant="outline" className={cn("font-medium", className)} data-status={status}>
+      {status}
+    </Badge>
+  );
+}
+
+// ─── States (loading / empty / error / disconnected) ──────────────────────────────
+
+function CenteredState({
+  icon,
+  title,
+  description,
+  tone = "muted",
+}: {
+  icon: ReactNode;
+  title: string;
+  description?: string;
+  tone?: "muted" | "destructive";
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-2 rounded-xl border border-dashed py-16 text-center",
+        tone === "destructive"
+          ? "border-destructive/40 text-destructive"
+          : "border-border text-muted-foreground",
+      )}
+      role="status"
+    >
+      <div aria-hidden>{icon}</div>
+      <p className="text-sm font-medium">{title}</p>
+      {description && <p className="max-w-md text-xs text-muted-foreground">{description}</p>}
+    </div>
+  );
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return "Could not load activity.";
+}
+
+// ─── Run row ──────────────────────────────────────────────────────────────────────
+
+interface RunRowProps {
+  run: LiveActivityRun;
+  isAdmin: boolean;
+  now: number;
+}
+
+function RunRow({ run, isAdmin, now }: RunRowProps) {
+  const unit = run.currentUnit;
+  const live = isLiveNow(run, now);
+  const unitStatus = unit?.status ?? run.status;
+
+  return (
+    <tr className="border-t border-border align-top">
+      <td className="px-3 py-2">
+        <div className="flex items-center gap-2">
+          <span
+            aria-hidden
+            className={cn(
+              "h-1.5 w-1.5 shrink-0 rounded-full",
+              live ? "bg-emerald-500 motion-safe:animate-pulse" : "bg-muted-foreground/30",
+            )}
+          />
+          <span className="flex flex-col">
+            <span className="text-sm font-medium leading-tight">{run.title}</span>
+            <span className="font-mono text-[10px] text-muted-foreground">{run.runId}</span>
+          </span>
+        </div>
+      </td>
+      <td className="px-3 py-2 text-sm">{unit ? unit.label : "—"}</td>
+      <td className="px-3 py-2 text-sm">{unit ? unit.agent : "—"}</td>
+      <td className="px-3 py-2">
+        <span className="font-mono text-xs text-muted-foreground">
+          {displayModel(unit?.modelSlug)}
+        </span>
+      </td>
+      <td className="px-3 py-2">
+        <StatusPill status={unitStatus} />
+      </td>
+      {isAdmin && (
+        <td className="px-3 py-2">
+          <span className="font-mono text-xs text-muted-foreground">
+            {run.ownerId ?? "—"}
+          </span>
+        </td>
+      )}
+    </tr>
+  );
+}
+
+function GroupTable({
+  group,
+  isAdmin,
+  now,
+}: {
+  group: ActivityGroup;
+  isAdmin: boolean;
+  now: number;
+}) {
+  const headingId = `activity-group-${group.mode}`;
+  return (
+    <Card aria-labelledby={headingId}>
+      <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0 py-4">
+        <CardTitle id={headingId} className="text-sm">
+          {group.label}
+        </CardTitle>
+        <Badge variant="secondary" className="tabular-nums">
+          {group.runs.length}
+        </Badge>
+      </CardHeader>
+      <CardContent className="px-0 pb-2">
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse text-left">
+            <caption className="sr-only">{`Active ${group.label.toLowerCase()}`}</caption>
+            <thead>
+              <tr className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                <th scope="col" className="px-3 pb-2 font-medium">Run</th>
+                <th scope="col" className="px-3 pb-2 font-medium">Current unit</th>
+                <th scope="col" className="px-3 pb-2 font-medium">Agent</th>
+                <th scope="col" className="px-3 pb-2 font-medium">Model</th>
+                <th scope="col" className="px-3 pb-2 font-medium">Status</th>
+                {isAdmin && (
+                  <th scope="col" className="px-3 pb-2 font-medium">Owner</th>
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {group.runs.map((run) => (
+                <RunRow key={run.runId} run={run} isAdmin={isAdmin} now={now} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Page ────────────────────────────────────────────────────────────────────────
+
+export default function Activity() {
+  const { runs, isAdmin, truncated, isLoading, error, isConnected } = useActivity();
+
+  // A single render-time clock for the live pulse so every row agrees. The 5s
+  // refetch + WS events drive re-renders, which is frequent enough for a 10s
+  // pulse window.
+  const now = Date.now();
+  const groups = useMemo(() => groupByMode(runs), [runs]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="flex items-center gap-3 border-b border-border px-6 py-4">
+        <ActivityIcon className="h-5 w-5 text-muted-foreground" aria-hidden />
+        <h1 className="text-lg font-semibold tracking-tight">Live Activity</h1>
+        {!isConnected && (
+          <span
+            className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-xs font-medium text-amber-600"
+            role="status"
+          >
+            <WifiOff className="h-3.5 w-3.5" aria-hidden />
+            Live updates disconnected — polling
+          </span>
+        )}
+      </header>
+
+      <div className="flex-1 overflow-auto p-6">
+        <div className="mx-auto flex max-w-4xl flex-col gap-4">
+          <p className="text-sm text-muted-foreground">
+            Read-only view of currently active runs. Refreshes every 5s and merges
+            live updates. Metadata only — no transcripts.
+          </p>
+
+          {truncated && (
+            <div
+              className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-600"
+              role="status"
+            >
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0" aria-hidden />
+              The list was capped. Some active runs are not shown.
+            </div>
+          )}
+
+          {isLoading ? (
+            <CenteredState
+              icon={<Loader2 className="h-5 w-5 motion-safe:animate-spin" />}
+              title="Loading activity…"
+            />
+          ) : error ? (
+            <CenteredState
+              tone="destructive"
+              icon={<AlertTriangle className="h-5 w-5" />}
+              title="Could not load activity"
+              description={errorMessage(error)}
+            />
+          ) : groups.length === 0 ? (
+            <CenteredState
+              icon={<ActivityIcon className="h-5 w-5" />}
+              title="No active runs"
+              description="Nothing is running right now. This view updates automatically when a run starts."
+            />
+          ) : (
+            <div className="flex flex-col gap-4">
+              {groups.map((group) => (
+                <GroupTable key={group.mode} group={group} isAdmin={isAdmin} now={now} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/design/live-run-activity-ui.md
+++ b/docs/design/live-run-activity-ui.md
@@ -1,0 +1,329 @@
+# Live Run Activity UI — Design
+
+**Status**: Proposed
+**Author**: solution-architect (DESIGN phase)
+**Date**: 2026-06-11
+**Issue/Feature**: Live "what's happening right now" observability surface for debugging across all run modes.
+
+---
+
+## 1. Context & Goal
+
+A consolidated **Live Activity** surface that answers, at a glance and updating live:
+
+- **Which runs are active right now** (across all modes).
+- **Who is working on each step** — the agent/team/role.
+- **Which model** that step is using.
+- **The current status** — running / paused / awaiting-approval / completed / failed.
+
+Purpose is **visual debugging** — "see what's actually going on" — not a heavy bespoke dashboard.
+
+This is a **read-only observability lens** over data that already exists. The design deliberately **reuses** the in-memory active-run registries + existing per-run/stage/step storage + the existing WS stream, and adds the **minimum** new surface (one snapshot endpoint, one thin live-merge hook, one page) plus the **minimum** payload additions to close real gaps.
+
+### Run modes in scope
+
+| Mode | Controller | Per-unit storage | "Active" registry |
+|------|-----------|------------------|-------------------|
+| Pipeline (linear + DAG) | `PipelineController` | `stage_executions` | `PipelineController.activeRuns` |
+| Manager | `PipelineController` → `ManagerAgent` | `manager_iterations` | `PipelineController.activeRuns` |
+| Orchestrator | `PipelineController` → `OrchestratorAgent` | `orchestrator_steps` | `PipelineController.activeRuns` (registered at `pipeline-controller.ts:1142`) |
+| Consensus | `ConsensusController` | `consensus_rounds` | `ConsensusController.activeRuns` (`consensus-controller.ts:38`) |
+
+Key structural fact: **every mode's `runId` is a `pipeline_runs.id`.** `orchestrator_runs.runId`, `consensus_runs.runId`, and `manager_iterations.runId` all FK to `pipeline_runs.id`. Therefore **`pipeline_runs.triggeredBy` is the single source of run ownership** for all four modes (`shared/schema.ts:152`). This makes a uniform owner/admin authZ check trivial.
+
+---
+
+## 2. Data-Source Map (per mode: where agent/role + model + status live, and what is MISSING)
+
+> Legend: ✅ present in a row/event we can read · ⚠️ present in storage but NOT in any live WS event · ❌ missing entirely (must be added).
+
+### 2.1 Pipeline mode (linear + DAG)
+
+| Field | Source (file:field) | Live WS? |
+|-------|--------------------|----------|
+| **run id / status** | `pipeline_runs.status` (`shared/schema.ts:146`); WS `pipeline:started/completed/failed/cancelled` (`pipeline-controller.ts:138,452,462`) | ✅ |
+| **agent / role** | `stage_executions.teamId` (`shared/schema.ts:173`). Live: `stage:started`/`stage:completed`/`stage:awaiting_approval` payloads all carry `teamId` (`pipeline-controller.ts:237,323,943`) | ✅ |
+| **model** | `stage_executions.modelSlug` (`shared/schema.ts:174`). Live: `stage:started` payload carries `modelSlug` (`pipeline-controller.ts:238,278,701`) | ✅ (on `stage:started`) |
+| **status (per stage)** | `stage_executions.status` (`shared/schema.ts:175`); live via the `stage:*` event type itself | ✅ |
+| **live progress text** | WS `stage:progress` payload `{ stageIndex, teamId, deltaText, cumulativeChars }` (`pipeline-controller.ts:1414-1418`) | ⚠️ **`modelSlug` is MISSING from this payload** |
+
+**GAP P-1 (must fix):** `stage:progress` carries `teamId` but **not `modelSlug`**. The Activity row's "model" column would be blank for a stage that is mid-stream if the row was first seen via `stage:progress` (e.g. page opened mid-run). The snapshot endpoint covers the cold-load case (it reads `modelSlug` from the row), but the live-only path is incomplete. **Add `modelSlug` to the `stage:progress` payload** in `buildStreamingBlock` (`pipeline-controller.ts:1412`). It is already in scope there via the stage config; thread it through `buildStreamingBlock`'s signature (which currently takes `teamId` but not `modelSlug`).
+
+### 2.2 Manager mode
+
+| Field | Source (file:field) | Live WS? |
+|-------|--------------------|----------|
+| **run id / status** | `pipeline_runs.status`; manager settles run status in `pipeline-controller.ts:157-171` | ✅ |
+| **agent / role (current team)** | `manager_iterations.decision.teamId` (`ManagerDecision.teamId`, `shared/types.ts:1536`). Live: `manager:decision` payload carries `teamId` (`manager-agent.ts:397`) | ✅ |
+| **status (current)** | Derived: a `manager:decision` with `action:"dispatch"` ⇒ running team `teamId`; `manager:complete`/`manager:error` ⇒ terminal (`manager-agent.ts:392,415,430`) | ✅ |
+| **model** | The model the dispatched team uses is resolved from **config** (per-team default / `ManagerConfig`), NOT stored on the iteration row and NOT in the `manager:decision` payload | ❌ **MISSING everywhere** |
+
+**GAP M-1 (must fix, small):** Manager mode has no per-iteration model anywhere — not on `manager_iterations`, not on the `manager:decision` event. The cheapest correct fix: **add `modelSlug` to the `manager:decision` WS payload** (`manager-agent.ts:386`) sourcing it from the same place the agent resolves the team's model before dispatch. For the snapshot/cold-load path, the manager has no per-step row to read a model from, so the snapshot will report the manager's **current team** and resolve its model from config (`SDLC_TEAMS[teamId].defaultModelSlug`, `shared/constants.ts:247`) or the `ManagerConfig` stage override when present. Document this as "best-effort model for manager mode."
+
+### 2.3 Orchestrator mode
+
+| Field | Source (file:field) | Live WS? |
+|-------|--------------------|----------|
+| **run id / status** | `orchestrator_runs.status` (`shared/schema.ts:761`); WS `orchestrator:plan/completed/failed/cancelled` (`orchestrator-agent.ts:159,281,298,310`) | ✅ |
+| **agent / role (step type)** | `orchestrator_steps.type` ∈ {research, analyze-code, debate, ground, synthesize} (`shared/schema.ts:792`) | ⚠️ **No per-step WS event** (see O-1) |
+| **status (per step)** | `orchestrator_steps.status` (`shared/schema.ts:794`), written in `runStep` (`orchestrator-agent.ts:227,237,245`) | ⚠️ **No per-step WS event** |
+| **model** | Fixed per step type via `OrchestratorModels` slugs (`orchestrator-agent.ts:32-39`): plan→`planModelSlug`, synthesize→`synthesizeModelSlug`, debate→proposer/critic/judge slugs. NOT stored on the step row | ⚠️ derivable from step `type` + run config; not in any event |
+
+**GAP O-1 (must fix, small):** `runStep` (`orchestrator-agent.ts:220`) updates `orchestrator_steps` status to `running`/`completed`/`failed` but **broadcasts nothing**. The only orchestrator WS events are run-lifecycle (`plan/completed/failed/cancelled`). The client `use-orchestrator.ts` already leans on the shared `stage:progress` event for live step progress (`use-orchestrator.ts:226`), but `stage:progress` is only emitted by the pipeline streaming path, not by orchestrator steps — so orchestrator per-step transitions are effectively **poll-only today**. Minimal fix: **emit a lightweight `orchestrator:step` WS event** in `runStep` on the running/completed/failed transitions, payload `{ stepIndex, type, status, modelSlug }` where `modelSlug` is the fixed slug for that step `type`. (Add `orchestrator:step` to the `WsEventType` union.) The snapshot endpoint covers cold-load by reading `orchestrator_steps` + mapping `type → model` from the run's caps/config.
+
+### 2.4 Consensus mode
+
+| Field | Source (file:field) | Live WS? |
+|-------|--------------------|----------|
+| **run id / status** | `consensus_runs.status` ∈ deliberating/resolved/unresolved/cancelled/failed (`shared/schema.ts:913`) | ❌ no WS |
+| **agent / role (phase)** | `consensus_rounds.phase` ∈ blind/review/adjudication (`shared/schema.ts:945`) | ❌ no WS |
+| **model** | `claudeModelSlug` for blind/adjudication (`consensus-engine.ts:49,258,318`); voter slugs for review (resolved from the antigravity roster) | ❌ no WS |
+| **status (round)** | implied by which `consensus_rounds` rows exist + `consensus_runs.status` | ❌ no WS |
+
+**GAP C-1 (largest gap):** **Consensus emits ZERO WS events.** There are no `consensus:*` members in the `WsEventType` union (`shared/types.ts:424-516`) and no `broadcast`/`wsManager` calls in `consensus-engine.ts` or `consensus-controller.ts`. Consensus is **entirely poll-only** today. Two options:
+
+- **C-1a (recommended for MVP):** Activity shows consensus runs from the **snapshot endpoint** (reads `consensus_runs` + latest `consensus_rounds` row → current phase + model + status). Live freshness for consensus comes from the **poll fallback** (§5.3), not WS. No new WS surface. Smallest blast radius; keeps the just-shipped consensus engine untouched.
+- **C-1b (follow-up):** Add `consensus:round` / `consensus:phase` / `consensus:settled` WS events. Larger change to a freshly-reviewed security-sensitive module; defer unless live consensus updates are explicitly required.
+
+**Decision:** ship **C-1a** now; track C-1b as a follow-up. This keeps the consensus engine (which has strict fail-closed/no-self-approval invariants) out of this change's blast radius.
+
+### 2.5 Gap summary
+
+| Gap | Mode | Severity | Fix |
+|-----|------|----------|-----|
+| P-1 | Pipeline | Low | Add `modelSlug` to `stage:progress` payload |
+| M-1 | Manager | Medium | Add `modelSlug` to `manager:decision` payload; snapshot derives model from config |
+| O-1 | Orchestrator | Medium | Emit new `orchestrator:step` WS event with `{ stepIndex, type, status, modelSlug }` |
+| C-1 | Consensus | High (no live) | MVP = snapshot + poll only (C-1a); WS events deferred (C-1b) |
+
+The **snapshot endpoint** is the common floor that makes every mode render correctly on cold load regardless of WS coverage. The WS additions (P-1/M-1/O-1) are pure additive enrichments for live freshness.
+
+---
+
+## 3. Backend Design
+
+### 3.1 Authoritative "active runs" source
+
+There is **no** DB query for "runs where status=running and owner=X" (only `getPipelineRuns(pipelineId?)`, `getPipelineRun(id)`, and by-runId accessors for the mode rows). Inventing one would be lossy (DB status lags the in-memory truth; a run can be `running` in the row after its controller has moved on).
+
+The **authoritative live truth** is the two in-memory registries:
+- `PipelineController.activeRuns: Map<runId, AbortController>` (`pipeline-controller.ts:42`) — covers pipeline + manager + orchestrator.
+- `ConsensusController.activeRuns: Map<runId, AbortController>` (`consensus-controller.ts:38`) — covers consensus.
+
+**New (small) public accessors** — add `getActiveRunIds(): string[]` to each controller (both registries are currently `private`; `PipelineController` already exposes `isRunActive(runId)` at line 1377, so this is a natural sibling). No registry restructuring.
+
+### 3.2 Snapshot endpoint
+
+```
+GET /api/activity
+```
+
+**Auth scoping (owner/admin):** reuse the **exact `authorizeRun` idiom** already implemented (and duplicated) in `server/routes/orchestrator.ts:53` and `server/routes/consensus.ts:44`:
+- 401 if `!req.user`.
+- A user sees **only runs whose `pipeline_runs.triggeredBy === req.user.id`**.
+- `req.user.role === "admin"` sees **all** active runs.
+- `triggeredBy == null` (ownerless) runs are **never** shown to non-admins (matches the stricter orchestrator/consensus rule — transcripts/activity are never world-readable).
+
+> **Refactor note (Security task):** `authorizeRun` is currently copy-pasted in two route files with identical logic. Extract it to a shared helper (e.g. `server/routes/authorize-run.ts`) and have orchestrator/consensus/activity all import it. This avoids a third copy and is the DRY-correct move.
+
+**Algorithm:**
+1. Collect candidate active run ids: `pipelineController.getActiveRunIds()` ∪ `consensusController.getActiveRunIds()`.
+2. For each runId: load `pipeline_runs` row → apply owner/admin filter (drop if not visible). This is the single ownership gate for all modes.
+3. Classify mode + build the current-unit summary from the **already-loaded mode rows**:
+   - **consensus** present (`getConsensusRun`) → phase from latest `consensus_rounds` row; model = `claudeModelSlug` (blind/adjudication) or "voters" (review); status = `consensus_runs.status`.
+   - else **orchestrator** present (`getOrchestratorRun`) → current step = the `orchestrator_steps` row with `status="running"` (else last completed); agent = step `type`; model = `type→slug` map; status = step status.
+   - else **manager** (run has `manager_iterations` / managerConfig) → current = latest `manager_iterations.decision.teamId`; model = config-resolved (best-effort, M-1); status derived from run + last decision action.
+   - else **pipeline** → current stage = `stage_executions` row with `status="running"` (else `currentStageIndex`); agent = `teamId`; model = `modelSlug`; status = stage status.
+4. Return the envelope.
+
+**Response shape** (`ApiResponse<T>` envelope per project patterns):
+
+```ts
+// shared/types.ts — new
+export type ActivityMode = "pipeline" | "manager" | "orchestrator" | "consensus";
+
+export interface ActivityUnit {
+  /** Human label of the current unit: stage index, step index, or round number. */
+  label: string;          // e.g. "Stage 3", "Step 2", "Round 1 · review"
+  /** Agent/team/role/phase identifier — ENUM-derived, never untrusted text. */
+  agent: string;          // teamId | orchestrator step type | consensus phase
+  /** Model slug for this unit (best-effort for manager mode). */
+  modelSlug: string | null;
+  /** Status of this unit. */
+  status: string;         // StageStatus | OrchestratorStepStatus | ConsensusRoundPhase-derived
+}
+
+export interface ActivityRun {
+  runId: string;
+  mode: ActivityMode;
+  /** Run-level title/label. NEVER the raw task/decision text (see security). */
+  title: string;          // e.g. pipeline name, or "Orchestrator run" — metadata only
+  runStatus: RunStatus | string;
+  workspaceId: string | null;
+  current: ActivityUnit | null;
+  startedAt: string | null;
+  /** Owner id — present for admins only (so admins can attribute runs). */
+  ownerId?: string | null;
+}
+
+export interface ActivitySnapshot {
+  runs: ActivityRun[];
+  /** Whether the caller is admin (so the FE can show owner column). */
+  isAdmin: boolean;
+}
+```
+
+**Security — payload is metadata-only (scrubbed):**
+- **No transcripts, no prompts, no decision/task text, no step output, no reasoning.** The activity payload carries only: run id, mode, enum-derived agent/role/phase, model slug, status, timestamps, workspace id. `title` is a non-sensitive label (pipeline name / mode name) — explicitly **not** the user's free-text task or `decisionText`.
+- Model slugs and team/step/phase identifiers are **enum-derived**, so there is no untrusted-text leak vector. If any string that could carry user/model text were ever added, it MUST pass `scrubSecrets` (`server/gateway/secret-scrub.ts:74`) — but the MVP shape avoids needing it.
+- Rate-limit the endpoint (reuse `checkManagerRunRateLimit` idiom or a light limiter) since it's pollable.
+
+**Reuse vs new (backend):**
+- **Reuse:** `authorizeRun` idiom, `pipeline_runs.triggeredBy` ownership, `getPipelineRun`/`getOrchestratorRun`/`getConsensusRun`/`getStageExecutions`/`getManagerIterations`/`getOrchestratorSteps`, `SDLC_TEAMS[teamId].defaultModelSlug`, `scrubSecrets`, `ApiResponse` envelope.
+- **New (small):** `getActiveRunIds()` on both controllers; one route file `server/routes/activity.ts`; the `Activity*` types; the extracted shared `authorizeRun`; the type→model map for orchestrator (a tiny pure helper, testable).
+
+### 3.3 Which WS events drive live updates
+
+The Activity FE subscribes to the **existing** WS stream (no new global channel). For each run in the snapshot, the FE issues `wsClient.subscribe(runId)` and updates that row from:
+
+| Event | Drives |
+|-------|--------|
+| `pipeline:started/completed/failed/cancelled` | run status |
+| `stage:started` | current stage + agent + **model** + running |
+| `stage:progress` | current stage + agent (+ **model** after P-1) — keeps the row "live" |
+| `stage:completed/failed/awaiting_approval` | stage status transitions |
+| `manager:decision` | current team + (+ **model** after M-1) + running |
+| `manager:complete/error` | run terminal |
+| `orchestrator:plan/completed/failed/cancelled` | run status |
+| `orchestrator:step` (**new, O-1**) | current step + type + **model** + status |
+| consensus | **none today** — poll fallback only (C-1a) |
+
+---
+
+## 4. Frontend Design
+
+### 4.1 Route & placement
+
+- **New route:** `/activity` in `client/src/App.tsx` (sibling of `/pipelines`), wrapped in `ErrorBoundary`, page `client/src/pages/Activity.tsx`.
+- **Nav:** add one item to `navItems` in `client/src/components/layout/MainLayout.tsx:58` (e.g. `{ icon: Activity, label: "Live Activity", href: "/activity" }`, lucide `Activity`/`Radio` icon).
+- It is a **page**, not a dashboard widget (the brief allows either; a dedicated page is cleaner for a debugging lens and avoids cluttering the Dashboard). A small "N runs active" count could later link from the Dashboard.
+
+### 4.2 Row model & grouping
+
+Runs grouped by `mode` (Pipeline / Manager / Orchestrator / Consensus sections). Each **row** shows:
+
+| Column | Source (FE) |
+|--------|-------------|
+| run id / title | `ActivityRun.title` + short id |
+| current unit | `ActivityUnit.label` (e.g. "Stage 3", "Round 1 · review") |
+| **agent / role** | `ActivityUnit.agent` — rendered via reused badges |
+| **model** | `ActivityUnit.modelSlug` (muted "—" when null) |
+| **status** | status badge (reused) |
+| live progress | reuse `stage:progress` rendering (a thin progress/“streaming…” indicator) |
+| owner (admin only) | `ActivityRun.ownerId` when `isAdmin` |
+
+### 4.3 Component reuse
+
+- **Status badges:** reuse `StepStatusBadge` / `StepTypeBadge` from `client/src/components/orchestrator/StepBadges.tsx` (already pure, enum-only, `motion-safe:animate-pulse` on running, reduced-motion-aware) — these are the closest existing "agent + status" badges and were explicitly built to render only enum-derived labels (never untrusted text), which matches our security posture.
+- **Base UI:** `@/components/ui/badge`, `@/components/ui/card` (the "SurfaceCard" role) for each mode section, `cn` from `@/lib/utils`.
+- **Run status meta:** reuse `RUN_STATUS_META` / `STEP_STATUS_META` color maps from the orchestrator lib (`client/src/lib/orchestrator.ts`) rather than inventing a new color scheme.
+- **Tokens/a11y:** existing CSS tokens; `data-testid` on rows/badges (matches existing convention) for QA hooks.
+
+### 4.4 Live-update wiring
+
+A new thin hook `client/src/hooks/use-activity.ts`:
+1. **Initial load + fallback:** TanStack Query `useQuery(["/api/activity"])` via the existing `getQueryFn` (`client/src/lib/queryClient.ts:39`), with `refetchInterval` (e.g. 5 s) as the **poll fallback** (and the **only** freshness source for consensus, C-1a).
+2. **Live merge:** on snapshot load, for each `runId` call `wsClient.subscribe(runId)`; register a single `wsClient.onAny(handler)` (`client/src/lib/websocket.ts:74`) that merges events into the in-memory row map by `event.runId` (immutable `Map` updates, mirroring `usePipelineEvents` in `use-websocket.ts:88` but **multi-run** — i.e. NOT filtered to a single `runId`).
+3. **Cleanup:** on unmount / when a run leaves the snapshot, `wsClient.unsubscribe(runId)` and remove the row.
+
+> Reuse note: `usePipelineEvents` (`use-websocket.ts:74`) is the per-run reducer. `use-activity.ts` is its multi-run sibling: same event→state mapping, keyed by `runId` instead of stage index, and seeded by the snapshot rather than starting empty.
+
+### 4.5 Empty / loading / error states
+
+- **Loading:** skeleton rows (reduced-motion-safe) while the first `/api/activity` resolves.
+- **Empty:** "No runs are active right now." (the common, healthy case) with a hint linking to `/pipelines`.
+- **Error:** the `ErrorBoundary` wrapper + a small inline retry; a 401 falls through to the existing auth redirect.
+- **WS disconnected:** show a subtle "reconnecting…" indicator (the poll keeps data fresh meanwhile — graceful degradation).
+
+---
+
+## 5. Live-update mechanism (summary)
+
+1. **Snapshot first** (`GET /api/activity`) for the authoritative owner-scoped list + cold-load current unit for every mode (including consensus).
+2. **WS for live deltas** — subscribe per visible `runId`, merge `stage:*` / `manager:*` / `orchestrator:*` (+ new `orchestrator:step`) events. No new global WS channel; reuse `wsClient`.
+3. **Poll as fallback** — `refetchInterval` keeps the list correct (runs starting/ending) and is the sole freshness path for consensus until C-1b.
+
+### 5.1 AuthZ on the WS path (important)
+
+`WsManager.broadcastToRun` only delivers to clients that explicitly `subscribe` to a `runId`, but **the WS `subscribe` handler performs NO ownership check** (`server/ws/manager.ts:38-54`) — any authenticated socket can subscribe to any `runId`. This is a **pre-existing** posture (the single-run views already rely on it). The Activity feature **must not widen** it: the FE only ever subscribes to run ids returned by the **owner-scoped** `/api/activity` snapshot, so a user never learns another user's run ids through Activity. Closing the WS-subscribe IDOR is **out of scope** here but should be flagged to the Lead (see Open Questions) — and is a strong argument for adding an owner check in the WS `subscribe` handler as a separate hardening task.
+
+---
+
+## 6. Task Breakdown (ordered, file-owned, small units)
+
+> Standards apply to every code task: TDD ≥80% on new modules, no `any`, reuse-first, a11y, owner/admin scoping, no secret/transcript leak. Server runs on host (`make dev`), never Docker. Feature branch + PR, no AI mentions.
+
+### Phase 0 — Shared contract (BE, blocks all)
+- **T0.1 (BE)** — Add `ActivityMode`, `ActivityUnit`, `ActivityRun`, `ActivitySnapshot` to `shared/types.ts`. Add `orchestrator:step` to the `WsEventType` union. *Owns:* `shared/types.ts`.
+
+### Phase 1 — Backend snapshot
+- **T1.1 (Security/BE)** — Extract the duplicated `authorizeRun` into `server/routes/authorize-run.ts`; update `server/routes/orchestrator.ts` + `server/routes/consensus.ts` to import it (behavior-preserving; existing route tests must stay green). *Owns:* new file + the two route files (import lines only). **TDD:** unit tests for 401/404/403/owner/admin/null-owner.
+- **T1.2 (BE)** — Add `getActiveRunIds(): string[]` to `PipelineController` (`server/controller/pipeline-controller.ts`) and `ConsensusController` (`server/consensus/consensus-controller.ts`). *Owns:* those two files. **TDD:** registry add/remove reflected.
+- **T1.3 (BE)** — Pure helper `server/routes/activity-model-map.ts`: `orchestratorStepModel(type, models)` and `managerTeamModel(teamId, config)` (best-effort). *Owns:* new file. **TDD:** table test over all step types + team ids.
+- **T1.4 (BE)** — `server/routes/activity.ts`: `GET /api/activity` — collect active ids from both controllers, owner/admin-filter via shared `authorizeRun` logic + `pipeline_runs.triggeredBy`, build `ActivityRun[]` per §3.2, metadata-only payload (no transcripts), rate-limited. Register in `server/routes.ts`. *Owns:* new file + one registration line in `routes.ts`. **TDD (integration):** 401; user sees only own runs; admin sees all; null-owner hidden from non-admin; each mode classified correctly; **no transcript/prompt/output field present in the response** (explicit assertion).
+
+### Phase 2 — Backend WS gap fixes (additive, parallel-safe after Phase 0)
+- **T2.1 (BE)** — P-1: thread `modelSlug` into `buildStreamingBlock` and add it to the `stage:progress` payload (`server/controller/pipeline-controller.ts:1397-1420`). *Owns:* that method. **TDD:** progress event includes `modelSlug`.
+- **T2.2 (BE)** — M-1: add `modelSlug` to the `manager:decision` payload (`server/pipeline/manager-agent.ts:386`), sourced from the resolved team model. *Owns:* that method. **TDD:** decision event includes `modelSlug`.
+- **T2.3 (BE)** — O-1: emit `orchestrator:step` in `runStep` on running/completed/failed with `{ stepIndex, type, status, modelSlug }` (`server/orchestrator/orchestrator-agent.ts:220-252`). *Owns:* that method. **TDD:** event emitted on each transition with correct model-for-type; abort path emits nothing/cancelled consistently.
+
+### Phase 3 — Frontend
+- **T3.1 (FE)** — `client/src/hooks/use-activity.ts`: snapshot `useQuery` + `refetchInterval` + multi-run `wsClient.onAny` merge + per-run subscribe/unsubscribe. *Owns:* new file. **TDD:** snapshot seeds rows; a `stage:started` event updates the matching row's model/status; a run leaving the snapshot unsubscribes; events for unknown runIds are ignored.
+- **T3.2 (FE)** — `client/src/pages/Activity.tsx`: page grouping rows by mode, reusing `StepStatusBadge`/`StepTypeBadge` + `ui/card` + `ui/badge`; admin-only owner column; loading/empty/error/disconnected states; `data-testid`s. *Owns:* new file.
+- **T3.3 (FE)** — Wire the route in `client/src/App.tsx` and the nav item in `client/src/components/layout/MainLayout.tsx`. *Owns:* those two files (additive).
+
+### Phase 4 — QA
+- **T4.1 (QA/E2E)** — Playwright: start a pipeline run → `/activity` shows it with team + model + running badge; status flips to completed live; a second user does **not** see it; admin sees both. *Owns:* `tests/e2e/activity.spec.ts` (or repo E2E location).
+- **T4.2 (QA)** — Verify ≥80% coverage on new modules (`activity.ts`, `use-activity.ts`, `activity-model-map.ts`, `authorize-run.ts`); a11y pass (keyboard, reduced-motion, contrast) on `/activity`.
+
+**Ordering:** T0.1 → {T1.1, T1.2, T1.3} → T1.4 (and Phase 2 in parallel with Phase 1 after T0.1) → Phase 3 → Phase 4. Phase 2 is independent additive enrichment; the FE works on snapshot+poll even if Phase 2 slips (consensus already relies on poll-only).
+
+---
+
+## 7. Risks & Open Questions (for the Lead)
+
+1. **Per-user vs admin-all scoping** *(recommend, needs sign-off)* — Proposed: a user sees only their own active runs (`triggeredBy === user.id`); admin sees all; ownerless runs hidden from non-admins. This matches the **stricter** orchestrator/consensus idiom (`triggeredBy == null` ⇒ deny). Confirm admins should see all (the debugging value is highest for admins/operators). Should the admin view include `ownerId` per row (proposed: yes)?
+
+2. **modelSlug / agent already in WS events?** *(answered by study)* — Mostly **no** for the live path:
+   - `stage:started` ✅ has `modelSlug`; `stage:progress` ❌ (P-1).
+   - `manager:decision` ❌ no model (M-1).
+   - Orchestrator ❌ has **no per-step event at all** (O-1).
+   - Consensus ❌ has **no WS events at all** (C-1).
+   The snapshot endpoint closes all cold-load gaps; the WS additions (Phase 2) are additive. Lead to confirm Phase 2 is in-scope now vs deferred (FE works without it via poll).
+
+3. **Consensus live updates (C-1)** — MVP is **snapshot + poll only** (C-1a) to keep the just-shipped, security-sensitive consensus engine out of the blast radius. Adding `consensus:*` WS events (C-1b) is a follow-up. Confirm poll-only consensus freshness is acceptable for MVP.
+
+4. **Performance with many concurrent runs** — `/api/activity` does O(active-runs) row lookups (a handful of `get*` calls per run). With many runs this is N small queries. Mitigations if needed: cap the number of rows returned, add a short server-side cache (e.g. 1–2 s) keyed by user, and tune the FE `refetchInterval`. The WS path is already bounded (per-run subscribe; only visible runs). Lead to set an expected concurrency ceiling.
+
+5. **WS subscribe IDOR (pre-existing)** — `WsManager`'s `subscribe` handler performs **no ownership check** (`server/ws/manager.ts:38`); any authed socket can subscribe to any `runId`. Activity does not widen this (it only subscribes to owner-scoped ids), but it makes the gap more visible. **Out of scope** here — flag whether to open a separate hardening task to add an owner check in the WS `subscribe` handler.
+
+6. **"Active" definition** — Driven by the in-memory `activeRuns` registries (the live truth), not DB status. A run mid-`awaiting_approval` (paused) is still in `activeRuns` (pipeline) — good, we want to show it. Confirm paused/awaiting-approval runs should appear in Activity (proposed: yes — that's exactly the "what's stuck" debugging signal). Edge: a process restart clears the in-memory registries, so in-flight runs from before a restart won't appear until/unless re-driven — acceptable for a live-debugging lens; document it.
+
+---
+
+## 8. Reuse Inventory (no reinvention)
+
+| Need | Reused symbol / file |
+|------|----------------------|
+| Run ownership | `pipeline_runs.triggeredBy` (`shared/schema.ts:152`) |
+| AuthZ idiom | `authorizeRun` (`server/routes/orchestrator.ts:53`, `consensus.ts:44`) → extract shared |
+| Active-run truth | `PipelineController.activeRuns` / `ConsensusController.activeRuns` |
+| Per-mode rows | `getStageExecutions`, `getOrchestratorSteps`, `getManagerIterations`, `getConsensusRun`/`getOrchestratorRun` |
+| Team→model default | `SDLC_TEAMS[teamId].defaultModelSlug` (`shared/constants.ts:247`) |
+| Secret scrub | `scrubSecrets` / `scrubAndTruncate` (`server/gateway/secret-scrub.ts`) |
+| WS client | `wsClient` (`client/src/lib/websocket.ts`) — `onAny`, `subscribe` |
+| Per-run reducer pattern | `usePipelineEvents` (`client/src/hooks/use-websocket.ts:74`) |
+| Status/agent badges | `StepStatusBadge` / `StepTypeBadge` (`client/src/components/orchestrator/StepBadges.tsx`) |
+| Status color maps | `RUN_STATUS_META` / `STEP_STATUS_META` (`client/src/lib/orchestrator.ts`) |
+| Query/fetch | `getQueryFn` / `queryClient` (`client/src/lib/queryClient.ts`) |
+| API envelope | `ApiResponse<T>` (project patterns) |

--- a/server/consensus/consensus-controller.ts
+++ b/server/consensus/consensus-controller.ts
@@ -146,6 +146,14 @@ export class ConsensusController {
   cancel(runId: string): void {
     this.activeRuns.get(runId)?.abort();
   }
+
+  /**
+   * Read-only snapshot of the active consensus run ids. Used by the
+   * /api/activity observability lens. Does not expose the AbortControllers.
+   */
+  getActiveRunIds(): string[] {
+    return [...this.activeRuns.keys()];
+  }
 }
 
 /**

--- a/server/controller/pipeline-controller.ts
+++ b/server/controller/pipeline-controller.ts
@@ -268,7 +268,7 @@ export class PipelineController {
           ? (await this.storage.getWorkspace(runWorkspaceId))?.path ?? null
           : null;
 
-        const streamingBlock = this.buildStreamingBlock(run.id, stageIndex, dagStage.teamId, stageExec.id, signal);
+        const streamingBlock = this.buildStreamingBlock(run.id, stageIndex, dagStage.teamId, dagStage.modelSlug, stageExec.id, signal);
         stageCoalescer = streamingBlock.coalescer;
 
         const context = {
@@ -691,7 +691,7 @@ export class PipelineController {
         // Apply skill settings (if a skill is assigned to this stage)
         const resolvedStage = await this.applySkill(stage);
 
-        const streamingBlock = this.buildStreamingBlock(run.id, i, stage.teamId, stageExec.id, signal);
+        const streamingBlock = this.buildStreamingBlock(run.id, i, stage.teamId, resolvedStage.modelSlug, stageExec.id, signal);
         stageCoalescer = streamingBlock.coalescer;
 
         const context = {
@@ -1378,6 +1378,15 @@ export class PipelineController {
     return this.activeRuns.has(runId);
   }
 
+  /**
+   * Read-only snapshot of the active run ids (pipeline + manager + orchestrator
+   * all register here). Used by the /api/activity observability lens. Does not
+   * mutate or expose the AbortControllers.
+   */
+  getActiveRunIds(): string[] {
+    return [...this.activeRuns.keys()];
+  }
+
   private broadcast(runId: string, event: WsEvent): void {
     this.wsManager.broadcastToRun(runId, event);
   }
@@ -1398,6 +1407,7 @@ export class PipelineController {
     runId: string,
     stageIndex: number,
     teamId: string,
+    modelSlug: string,
     stageExecutionId: string | undefined,
     signal: AbortSignal,
   ): { streaming?: StreamingStageOptions; coalescer?: StageProgressCoalescer } {
@@ -1414,7 +1424,7 @@ export class PipelineController {
         type: "stage:progress",
         runId,
         stageExecutionId,
-        payload: { stageIndex, teamId, deltaText, cumulativeChars },
+        payload: { stageIndex, teamId, modelSlug, deltaText, cumulativeChars },
         timestamp: new Date().toISOString(),
       });
     });

--- a/server/orchestrator/orchestrator-agent.ts
+++ b/server/orchestrator/orchestrator-agent.ts
@@ -22,7 +22,7 @@
 import type { IStorage } from "../storage";
 import type { WsManager } from "../ws/manager";
 import type { Gateway } from "../gateway/index";
-import type { OrchestratorStepArgs, ProviderMessage } from "@shared/types";
+import type { OrchestratorStepArgs, OrchestratorStepStatus, OrchestratorStepType, ProviderMessage } from "@shared/types";
 import { isAbortError } from "../controller/stage-progress.js";
 import { scrubAndTruncate, scrubSecrets } from "../gateway/secret-scrub.js";
 import { parsePlan } from "./plan-schema.js";
@@ -219,7 +219,7 @@ export class OrchestratorAgent {
 
   private async runStep(
     runId: string,
-    step: { id: string; type: string; args: OrchestratorStepArgs },
+    step: { id: string; stepIndex: number; type: OrchestratorStepType; args: OrchestratorStepArgs },
     caps: OrchestratorCaps,
     budget: TokenBudget,
     signal: AbortSignal,
@@ -228,6 +228,9 @@ export class OrchestratorAgent {
       status: "running",
       startedAt: new Date(),
     });
+    // O-1: surface a lightweight, metadata-only per-step event for the Activity
+    // lens (the only orchestrator WS events otherwise are run-lifecycle).
+    this.broadcastStep(runId, step.stepIndex, step.type, "running");
 
     const ctx: StepContext = { runId, stepId: step.id, caps, budget, signal };
 
@@ -241,14 +244,32 @@ export class OrchestratorAgent {
         completedAt: new Date(),
       });
       await this.deps.storage.updateOrchestratorRun(runId, { totalTokensUsed: budget.total });
+      this.broadcastStep(runId, step.stepIndex, step.type, "completed");
     } catch (err) {
       await this.deps.storage.updateOrchestratorStep(step.id, {
         status: "failed",
         error: scrubAndTruncate(String(err)),
         completedAt: new Date(),
       });
+      this.broadcastStep(runId, step.stepIndex, step.type, "failed");
       throw err;
     }
+  }
+
+  /**
+   * O-1: emit the metadata-only `orchestrator:step` event. The model is the
+   * fixed slug for the step's type (debate → proposer; everything else →
+   * synthesize-class). Never carries step args/output.
+   */
+  private broadcastStep(
+    runId: string,
+    stepIndex: number,
+    type: OrchestratorStepType,
+    status: OrchestratorStepStatus,
+  ): void {
+    const modelSlug =
+      type === "debate" ? this.deps.models.proposerModelSlug : this.deps.models.synthesizeModelSlug;
+    this.broadcast(runId, "orchestrator:step", { stepIndex, type, status, modelSlug });
   }
 
   private dispatch(args: OrchestratorStepArgs, ctx: StepContext): Promise<StepResult> {

--- a/server/pipeline/manager-agent.ts
+++ b/server/pipeline/manager-agent.ts
@@ -388,6 +388,11 @@ Respond ONLY with the JSON object. No markdown, no explanation outside the JSON.
     decision: ManagerDecision,
     tokensUsed: number,
   ): void {
+    // M-1: best-effort model for the dispatched team (Activity lens). The manager
+    // does not persist a per-iteration model; resolve the team's SDLC default.
+    const modelSlug = decision.teamId
+      ? SDLC_TEAMS[decision.teamId as keyof typeof SDLC_TEAMS]?.defaultModelSlug ?? null
+      : null;
     this.wsManager.broadcastToRun(runId, {
       type: "manager:decision",
       runId,
@@ -395,6 +400,7 @@ Respond ONLY with the JSON object. No markdown, no explanation outside the JSON.
         iterationNumber: decision.iterationNumber,
         action: decision.action,
         teamId: decision.teamId,
+        modelSlug,
         task: decision.task,
         reasoning: decision.reasoning,
         tokensUsed,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -31,6 +31,7 @@ import { ManagerAgent } from "./pipeline/manager-agent";
 import { buildOrchestratorAgent } from "./orchestrator/build-agent";
 import { registerOrchestratorRoutes } from "./routes/orchestrator";
 import { registerConsensusRoutes } from "./routes/consensus";
+import { registerActivityRoutes } from "./routes/activity";
 import { ConsensusController } from "./consensus/consensus-controller";
 import { registerDAGRoutes } from "./routes/dag";
 import { registerTraceRoutes } from "./routes/traces";
@@ -95,7 +96,8 @@ export async function registerRoutes(
   app: Express,
 ): Promise<Server> {
   // Initialize core systems
-  const wsManager = new WsManager(httpServer);
+  // Pass storage so WsManager.subscribe can enforce per-run ownership (IDOR fix).
+  const wsManager = new WsManager(httpServer, storage);
   const gateway = new Gateway(storage);
   const teamRegistry = new TeamRegistry(gateway, wsManager);
   const delegationService = new DelegationService(storage, teamRegistry, wsManager, gateway);
@@ -115,6 +117,7 @@ export async function registerRoutes(
   // Register protected route groups — all require authentication
   app.use("/api/pipelines", requireAuth);
   app.use("/api/runs", requireAuth);
+  app.use("/api/activity", requireAuth);
   app.use("/api/models", requireAuth);
   app.use("/api/gateway", requireAuth);
   app.use("/api/settings", requireAuth);
@@ -153,6 +156,20 @@ export async function registerRoutes(
   registerPipelineRoutes(app, storage, gateway);
   registerOrchestratorRoutes(app, storage, controller);
   registerConsensusRoutes(app, storage, consensusController);
+  // Live Activity observability lens (read-only, owner/admin-scoped, metadata-only).
+  // Model slugs mirror buildOrchestratorAgent + the consensus controller wiring.
+  registerActivityRoutes(app, storage, {
+    pipelineController: controller,
+    consensusController,
+    orchestratorModels: {
+      planModelSlug: process.env.ORCHESTRATOR_PLAN_MODEL ?? "claude-opus",
+      synthesizeModelSlug: process.env.ORCHESTRATOR_PLAN_MODEL ?? "claude-opus",
+      proposerModelSlug: process.env.ORCHESTRATOR_PLAN_MODEL ?? "claude-opus",
+      criticModelSlug: process.env.ORCHESTRATOR_CRITIC_MODEL ?? "gemini-flash",
+      judgeModelSlug: process.env.ORCHESTRATOR_PLAN_MODEL ?? "claude-opus",
+    },
+    consensusClaudeModelSlug: process.env.CONSENSUS_CLAUDE_MODEL ?? "claude-opus",
+  });
   registerRunRoutes(app, storage, controller);
   registerChatRoutes(app, storage, gateway, wsManager);
   registerGatewayRoutes(app, gateway);

--- a/server/routes/activity-model-map.ts
+++ b/server/routes/activity-model-map.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure, side-effect-free model-derivation helpers for the /api/activity lens.
+ *
+ * The Activity snapshot reports the model slug a run's CURRENT unit is using.
+ * For modes where the model is not persisted on the per-unit row, we derive it
+ * from an ENUM (orchestrator step type / SDLC team id) — never from untrusted
+ * text. Best-effort: returns null when the enum value is unknown rather than
+ * guessing, so the FE renders a muted "—".
+ *
+ * Callers: server/routes/activity.ts.
+ */
+import { SDLC_TEAMS } from "@shared/constants";
+import type { OrchestratorStepType } from "@shared/types";
+
+/** The fixed orchestrator slugs the engine pins per step type. */
+export interface ActivityOrchestratorModels {
+  planModelSlug: string;
+  synthesizeModelSlug: string;
+  proposerModelSlug: string;
+  criticModelSlug: string;
+  judgeModelSlug: string;
+}
+
+/**
+ * The model slug a single orchestrator step of `type` runs on.
+ *
+ * research / analyze-code / ground / synthesize all run through the
+ * synthesize-class model; debate is multi-model — we report the proposer slug
+ * as the representative model for the row. Unknown type → null (best-effort).
+ */
+export function orchestratorStepModel(
+  type: OrchestratorStepType,
+  models: ActivityOrchestratorModels,
+): string | null {
+  switch (type) {
+    case "research":
+    case "analyze-code":
+    case "ground":
+    case "synthesize":
+      return models.synthesizeModelSlug;
+    case "debate":
+      return models.proposerModelSlug;
+    default:
+      // Defensive: an enum we don't recognise → no guess.
+      return null;
+  }
+}
+
+/**
+ * Best-effort model for a manager-dispatched team. The manager does not persist
+ * a per-iteration model anywhere, so the snapshot resolves the team's SDLC
+ * default. Unknown/custom team id (or undefined) → null.
+ */
+export function managerTeamModel(teamId: string | undefined): string | null {
+  if (!teamId) return null;
+  const team = SDLC_TEAMS[teamId as keyof typeof SDLC_TEAMS];
+  return team?.defaultModelSlug ?? null;
+}

--- a/server/routes/activity.ts
+++ b/server/routes/activity.ts
@@ -1,0 +1,261 @@
+/**
+ * GET /api/activity — the read-only "Live Activity" observability lens.
+ *
+ * Returns an owner/admin-scoped snapshot of the runs that are active RIGHT NOW
+ * across all four modes (pipeline / manager / orchestrator / consensus). The
+ * authoritative live truth is the in-memory activeRuns registries of the two
+ * controllers — NOT a DB status query (which lags the controllers).
+ *
+ * Scoping (shared authorizeRun rule, applied per run):
+ *   - 401 if unauthenticated;
+ *   - a non-admin sees ONLY runs whose pipeline_runs.triggeredBy === their id;
+ *   - an admin sees ALL active runs and each row carries `ownerId`;
+ *   - ownerless (triggeredBy == null) runs are HIDDEN from non-admins.
+ *
+ * Security — METADATA ONLY. Every row carries only: run id, mode, an
+ * enum-derived label/agent/phase, a model slug, a status, a timestamp, and the
+ * workspace id. NO transcript, prompt, task text, decision text, step output,
+ * or reasoning ever enters this payload. `title` is a non-sensitive mode/name
+ * label, never the user's free-text input.
+ *
+ * Mounted under the `/api/activity` requireAuth prefix in server/routes.ts.
+ */
+import type { Router, Request, Response } from "express";
+import type { IStorage } from "../storage";
+import type { PipelineController } from "../controller/pipeline-controller";
+import type { ConsensusController } from "../consensus/consensus-controller";
+import type {
+  ActivityMode,
+  ActivityRun,
+  ActivityUnit,
+  ActivitySnapshot,
+} from "@shared/types";
+import {
+  orchestratorStepModel,
+  managerTeamModel,
+  type ActivityOrchestratorModels,
+} from "./activity-model-map.js";
+
+/** Hard cap on returned rows; we log (never silently drop) when we truncate. */
+const MAX_ACTIVITY_ROWS = 200;
+
+export interface ActivityRouteDeps {
+  pipelineController: Pick<PipelineController, "getActiveRunIds">;
+  consensusController: Pick<ConsensusController, "getActiveRunIds">;
+  /** Fixed orchestrator model slugs (matches buildOrchestratorAgent). */
+  orchestratorModels: ActivityOrchestratorModels;
+  /** Claude slug the consensus engine pins for blind/adjudication. */
+  consensusClaudeModelSlug: string;
+}
+
+/** Build the current-unit summary for a CONSENSUS run (metadata only). */
+async function consensusUnit(
+  storage: IStorage,
+  runId: string,
+  claudeModelSlug: string,
+): Promise<{ unit: ActivityUnit | null; status: string }> {
+  const run = await storage.getConsensusRun(runId);
+  const rounds = await storage.getConsensusRounds(runId);
+  const latest = rounds.length > 0 ? rounds[rounds.length - 1] : undefined;
+  const status = run?.status ?? "deliberating";
+  if (!latest) {
+    return { unit: { label: "Round 0", agent: "consensus", modelSlug: null, status }, status };
+  }
+  // review phase = the voter roster; blind/adjudication = Claude.
+  const modelSlug = latest.phase === "review" ? null : claudeModelSlug;
+  const agent = latest.phase === "review" ? "voters" : latest.phase;
+  return {
+    unit: {
+      label: `Round ${latest.round} · ${latest.phase}`,
+      agent,
+      modelSlug,
+      status,
+    },
+    status,
+  };
+}
+
+/** Build the current-unit summary for an ORCHESTRATOR run (metadata only). */
+async function orchestratorUnit(
+  storage: IStorage,
+  runId: string,
+  models: ActivityOrchestratorModels,
+): Promise<{ unit: ActivityUnit | null; status: string }> {
+  const run = await storage.getOrchestratorRun(runId);
+  const steps = await storage.getOrchestratorSteps(runId);
+  const status = run?.status ?? "executing";
+  // Current step = the running one, else the last completed/known step.
+  const running = steps.find((s) => s.status === "running");
+  const current = running ?? (steps.length > 0 ? steps[steps.length - 1] : undefined);
+  if (!current) return { unit: null, status };
+  return {
+    unit: {
+      label: `Step ${current.stepIndex + 1}`,
+      agent: current.type,
+      modelSlug: orchestratorStepModel(current.type, models),
+      status: current.status,
+    },
+    status,
+  };
+}
+
+/** Build the current-unit summary for a MANAGER run (best-effort model). */
+async function managerUnit(
+  storage: IStorage,
+  runId: string,
+  runStatus: string,
+): Promise<{ unit: ActivityUnit | null; status: string } | null> {
+  const iterations = await storage.getManagerIterations(runId);
+  if (iterations.length === 0) return null;
+  const latest = iterations[iterations.length - 1];
+  const teamId = latest.decision?.teamId;
+  return {
+    unit: {
+      label: `Iteration ${latest.iterationNumber}`,
+      agent: teamId ?? latest.decision?.action ?? "manager",
+      modelSlug: managerTeamModel(teamId),
+      status: runStatus,
+    },
+    status: runStatus,
+  };
+}
+
+/** Build the current-unit summary for a PIPELINE run (linear or DAG). */
+async function pipelineUnit(
+  storage: IStorage,
+  runId: string,
+  currentStageIndex: number,
+  runStatus: string,
+): Promise<{ unit: ActivityUnit | null; status: string }> {
+  const stages = await storage.getStageExecutions(runId);
+  const running = stages.find((s) => s.status === "running");
+  const current =
+    running ?? stages.find((s) => s.stageIndex === currentStageIndex) ?? undefined;
+  if (!current) return { unit: null, status: runStatus };
+  return {
+    unit: {
+      label: `Stage ${current.stageIndex + 1}`,
+      agent: current.teamId,
+      modelSlug: current.modelSlug ?? null,
+      status: current.status,
+    },
+    status: runStatus,
+  };
+}
+
+/**
+ * Classify a run by mode and build its metadata-only Activity row. Returns null
+ * when the run can't be classified (e.g. the row vanished mid-request).
+ */
+async function buildActivityRun(
+  storage: IStorage,
+  deps: ActivityRouteDeps,
+  runId: string,
+  ownerId: string | null,
+  isAdmin: boolean,
+): Promise<ActivityRun | null> {
+  const run = await storage.getPipelineRun(runId);
+  if (!run) return null;
+
+  let mode: ActivityMode;
+  let title: string;
+  let unitResult: { unit: ActivityUnit | null; status: string };
+
+  const consensus = await storage.getConsensusRun(runId);
+  if (consensus) {
+    mode = "consensus";
+    title = "Consensus run";
+    unitResult = await consensusUnit(storage, runId, deps.consensusClaudeModelSlug);
+  } else {
+    const orchestrator = await storage.getOrchestratorRun(runId);
+    if (orchestrator) {
+      mode = "orchestrator";
+      title = "Orchestrator run";
+      unitResult = await orchestratorUnit(storage, runId, deps.orchestratorModels);
+    } else {
+      const managerResult = await managerUnit(storage, runId, run.status);
+      if (managerResult) {
+        mode = "manager";
+        title = "Manager run";
+        unitResult = managerResult;
+      } else {
+        mode = "pipeline";
+        title = "Pipeline run";
+        unitResult = await pipelineUnit(
+          storage,
+          runId,
+          run.currentStageIndex,
+          run.status,
+        );
+      }
+    }
+  }
+
+  const row: ActivityRun = {
+    runId,
+    mode,
+    title,
+    status: unitResult.status,
+    workspaceId: run.workspaceId ?? null,
+    currentUnit: unitResult.unit,
+    startedAt: run.startedAt ? run.startedAt.toISOString() : null,
+  };
+  // Owner attribution is admin-only.
+  if (isAdmin) row.ownerId = ownerId;
+  return row;
+}
+
+export function registerActivityRoutes(
+  router: Router,
+  storage: IStorage,
+  deps: ActivityRouteDeps,
+): void {
+  router.get("/api/activity", async (req: Request, res: Response) => {
+    if (!req.user?.id) {
+      return res.status(401).json({ error: "Authentication required" });
+    }
+    const userId = req.user.id;
+    const isAdmin = req.user.role === "admin";
+
+    try {
+      // Union the two registries (pipeline+manager+orchestrator ∪ consensus).
+      const candidateIds = [
+        ...deps.pipelineController.getActiveRunIds(),
+        ...deps.consensusController.getActiveRunIds(),
+      ];
+      const uniqueIds = [...new Set(candidateIds)];
+
+      const rows: ActivityRun[] = [];
+      let truncated = false;
+
+      for (const runId of uniqueIds) {
+        const run = await storage.getPipelineRun(runId);
+        if (!run) continue; // registry/DB raced — skip.
+
+        // Single ownership gate for ALL modes via pipeline_runs.triggeredBy.
+        const isOwner = run.triggeredBy != null && run.triggeredBy === userId;
+        if (!isAdmin && !isOwner) continue; // hides others' + ownerless from non-admins.
+
+        if (rows.length >= MAX_ACTIVITY_ROWS) {
+          truncated = true;
+          break;
+        }
+
+        const row = await buildActivityRun(storage, deps, runId, run.triggeredBy, isAdmin);
+        if (row) rows.push(row);
+      }
+
+      if (truncated) {
+        console.warn(
+          `[activity] row cap hit: ${uniqueIds.length} candidate active runs > ${MAX_ACTIVITY_ROWS} cap; response truncated`,
+        );
+      }
+
+      const snapshot: ActivitySnapshot = { runs: rows, isAdmin, truncated };
+      return res.json(snapshot);
+    } catch {
+      // Generic — never leak internal detail.
+      return res.status(500).json({ error: "Failed to load activity" });
+    }
+  });
+}

--- a/server/routes/authorize-run.ts
+++ b/server/routes/authorize-run.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared run-authorization helper (extracted from the byte-identical inline
+ * copies that lived in routes/orchestrator.ts and routes/consensus.ts).
+ *
+ * Resolves owner-or-admin access for a run keyed by pipeline_runs.id — the
+ * single source of ownership for ALL run modes (orchestrator/consensus/manager
+ * runs all FK their runId to pipeline_runs.id, so triggeredBy is authoritative).
+ *
+ * Ordering (preserved exactly): 401 unauth → 404 missing → 403 non-owner.
+ * STRICTER than the manager idiom: triggeredBy == null is DENIED unless admin
+ * (transcripts/activity are never world-readable).
+ *
+ * On success returns { ownerId }; on failure it writes the status + a generic
+ * body to `res` and returns null (the caller must early-return).
+ *
+ * Callers: routes/orchestrator.ts, routes/consensus.ts, routes/activity.ts.
+ */
+import type { Request, Response } from "express";
+import type { IStorage } from "../storage";
+
+export interface AuthorizeRunOptions {
+  /**
+   * Optional secondary existence check for mode-specific runs. When provided and
+   * it resolves to a falsy value, the result is 404 (mirrors the prior inline
+   * `if (!run || !orch)` / `if (!run || !consensus)` behavior). Omit it for the
+   * activity lens, which only needs the parent pipeline_runs row.
+   */
+  requireModeRow?: (storage: IStorage, runId: string) => Promise<unknown>;
+}
+
+export interface AuthorizedRun {
+  /** The run's owner id (pipeline_runs.triggeredBy); null for ownerless runs (admin-only). */
+  ownerId: string | null;
+}
+
+export async function authorizeRun(
+  req: Request,
+  res: Response,
+  storage: IStorage,
+  runId: string,
+  options: AuthorizeRunOptions = {},
+): Promise<AuthorizedRun | null> {
+  // 401 first — unauth takes precedence over existence.
+  if (!req.user?.id) {
+    res.status(401).json({ error: "Authentication required" });
+    return null;
+  }
+
+  const run = await storage.getPipelineRun(runId);
+  const modeRow = run && options.requireModeRow ? await options.requireModeRow(storage, runId) : true;
+  if (!run || !modeRow) {
+    res.status(404).json({ error: "Run not found" });
+    return null;
+  }
+
+  const isAdmin = req.user.role === "admin";
+  const isOwner = run.triggeredBy != null && run.triggeredBy === req.user.id;
+  // Deny when ownerless (stricter than manager) unless admin.
+  if (!isAdmin && !isOwner) {
+    res.status(403).json({ error: "Forbidden" });
+    return null;
+  }
+
+  return { ownerId: run.triggeredBy };
+}

--- a/server/routes/consensus.ts
+++ b/server/routes/consensus.ts
@@ -21,6 +21,7 @@ import type { ConsensusController } from "../consensus/consensus-controller";
 import { validateBody } from "../middleware/validate.js";
 import { checkManagerRunRateLimit } from "./runs.js";
 import { configLoader } from "../config/loader.js";
+import { authorizeRun as sharedAuthorizeRun } from "./authorize-run.js";
 
 const ConsensusCapsSchema = z
   .object({
@@ -37,38 +38,18 @@ const StartConsensusSchema = z.object({
 });
 
 /**
- * Resolve auth for a consensus run. Returns the owner on success, or sends the
- * correct status (401/404/403) and returns null. STRICTER than the manager
- * idiom: triggeredBy == null is DENIED (unless admin).
+ * Resolve auth for a consensus run via the shared helper, also requiring the
+ * consensus_runs row to exist (404 otherwise). Behavior-preserving wrapper.
  */
-async function authorizeRun(
+function authorizeRun(
   req: Request,
   res: Response,
   storage: IStorage,
   runId: string,
 ): Promise<{ ownerId: string | null } | null> {
-  // 401 first — unauth takes precedence over existence.
-  if (!req.user?.id) {
-    res.status(401).json({ error: "Authentication required" });
-    return null;
-  }
-
-  const run = await storage.getPipelineRun(runId);
-  const consensus = run ? await storage.getConsensusRun(runId) : undefined;
-  if (!run || !consensus) {
-    res.status(404).json({ error: "Run not found" });
-    return null;
-  }
-
-  const isAdmin = req.user.role === "admin";
-  const isOwner = run.triggeredBy != null && run.triggeredBy === req.user.id;
-  // Deny when ownerless (stricter than manager) unless admin.
-  if (!isAdmin && !isOwner) {
-    res.status(403).json({ error: "Forbidden" });
-    return null;
-  }
-
-  return { ownerId: run.triggeredBy };
+  return sharedAuthorizeRun(req, res, storage, runId, {
+    requireModeRow: (s, id) => s.getConsensusRun(id),
+  });
 }
 
 export function registerConsensusRoutes(

--- a/server/routes/orchestrator.ts
+++ b/server/routes/orchestrator.ts
@@ -22,6 +22,7 @@ import { validateBody } from "../middleware/validate.js";
 import { checkManagerRunRateLimit } from "./runs.js";
 import { configLoader } from "../config/loader.js";
 import { StepSchema } from "../orchestrator/plan-schema.js";
+import { authorizeRun as sharedAuthorizeRun } from "./authorize-run.js";
 
 const CapsSchema = z
   .object({
@@ -46,38 +47,18 @@ const ApprovePlanSchema = z.object({
 });
 
 /**
- * Resolve auth for an orchestrator run. Returns the run owner on success, or
- * sends the correct status (401/404/403) and returns null. STRICTER than the
- * manager idiom: triggeredBy == null is DENIED (unless admin).
+ * Resolve auth for an orchestrator run via the shared helper, also requiring the
+ * orchestrator_runs row to exist (404 otherwise). Behavior-preserving wrapper.
  */
-async function authorizeRun(
+function authorizeRun(
   req: Request,
   res: Response,
   storage: IStorage,
   runId: string,
 ): Promise<{ ownerId: string | null } | null> {
-  // 401 first — unauth takes precedence over existence.
-  if (!req.user?.id) {
-    res.status(401).json({ error: "Authentication required" });
-    return null;
-  }
-
-  const run = await storage.getPipelineRun(runId);
-  const orch = run ? await storage.getOrchestratorRun(runId) : undefined;
-  if (!run || !orch) {
-    res.status(404).json({ error: "Run not found" });
-    return null;
-  }
-
-  const isAdmin = req.user.role === "admin";
-  const isOwner = run.triggeredBy != null && run.triggeredBy === req.user.id;
-  // Deny when ownerless (stricter than manager) unless admin.
-  if (!isAdmin && !isOwner) {
-    res.status(403).json({ error: "Forbidden" });
-    return null;
-  }
-
-  return { ownerId: run.triggeredBy };
+  return sharedAuthorizeRun(req, res, storage, runId, {
+    requireModeRow: (s, id) => s.getOrchestratorRun(id),
+  });
 }
 
 export function registerOrchestratorRoutes(

--- a/server/ws/manager.ts
+++ b/server/ws/manager.ts
@@ -1,6 +1,7 @@
 import { WebSocketServer, WebSocket } from "ws";
 import type { Server, IncomingMessage } from "http";
-import type { WsEvent } from "@shared/types";
+import type { WsEvent, User } from "@shared/types";
+import type { IStorage } from "../storage";
 import { authService } from "../auth/service";
 
 function extractTokenFromRequest(req: IncomingMessage): string | null {
@@ -14,15 +15,26 @@ function extractTokenFromRequest(req: IncomingMessage): string | null {
   return null;
 }
 
+/** A socket that carries its authenticated user (set on connection). */
+type AuthedSocket = WebSocket & { user?: User };
+
 export class WsManager {
   private wss: WebSocketServer;
   private subscriptions: Map<string, Set<WebSocket>>;
+  private storage?: IStorage;
 
-  constructor(httpServer: Server) {
+  /**
+   * @param storage Optional storage used to enforce per-run ownership on
+   *   `subscribe` messages (IDOR hardening). When omitted (e.g. some unit
+   *   tests), the low-level subscribe registry still works but the ownership
+   *   gate cannot resolve a run → it fails closed (denies).
+   */
+  constructor(httpServer: Server, storage?: IStorage) {
     this.wss = new WebSocketServer({ server: httpServer, path: "/ws" });
     this.subscriptions = new Map();
+    this.storage = storage;
 
-    this.wss.on("connection", async (ws, req) => {
+    this.wss.on("connection", async (ws: AuthedSocket, req) => {
       const token = extractTokenFromRequest(req);
       if (!token) {
         ws.close(4001, "Unauthorized");
@@ -34,22 +46,27 @@ export class WsManager {
         ws.close(4001, "Unauthorized");
         return;
       }
+      // Pin the authed user to the socket so subscribe can authorize per-run.
+      ws.user = user;
 
       ws.on("message", (data) => {
+        let msg: { type: string; runId?: string };
         try {
-          const msg = JSON.parse(data.toString()) as {
-            type: string;
-            runId?: string;
-          };
-
-          if (msg.type === "subscribe" && msg.runId) {
-            this.subscribe(ws, msg.runId);
-          }
-          if (msg.type === "unsubscribe" && msg.runId) {
-            this.unsubscribe(ws, msg.runId);
-          }
+          msg = JSON.parse(data.toString()) as { type: string; runId?: string };
         } catch {
           // ignore malformed messages
+          return;
+        }
+
+        if (msg.type === "subscribe" && msg.runId) {
+          // IDOR hardening: a socket may only subscribe to a run it owns (or
+          // any run if admin). Async ownership check; never throws to the loop.
+          void this.authorizeAndSubscribe(ws, ws.user, msg.runId).catch(() => {
+            /* fail closed — never crash the socket on an authz error */
+          });
+        }
+        if (msg.type === "unsubscribe" && msg.runId) {
+          this.unsubscribe(ws, msg.runId);
         }
       });
 
@@ -57,6 +74,31 @@ export class WsManager {
         this.removeClient(ws);
       });
     });
+  }
+
+  /**
+   * Ownership-gated subscribe (the only path the live socket uses). Resolves the
+   * run via pipeline_runs.triggeredBy — the single ownership source for ALL run
+   * modes — and registers the socket only when the user is the owner or an
+   * admin. Ownerless runs are denied to non-admins. Returns whether it
+   * subscribed. Fails closed when storage/user are unavailable.
+   */
+  async authorizeAndSubscribe(
+    ws: WebSocket,
+    user: User | undefined,
+    runId: string,
+  ): Promise<boolean> {
+    if (!user?.id || !this.storage) return false;
+
+    const run = await this.storage.getPipelineRun(runId);
+    if (!run) return false;
+
+    const isAdmin = user.role === "admin";
+    const isOwner = run.triggeredBy != null && run.triggeredBy === user.id;
+    if (!isAdmin && !isOwner) return false;
+
+    this.subscribe(ws, runId);
+    return true;
   }
 
   subscribe(ws: WebSocket, runId: string): void {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -479,6 +479,12 @@ export type WsEventType =
   | "manager:decision"
   | "manager:complete"
   | "manager:error"
+  // ─── Orchestrator (debate-research) run-mode events ──────────────────
+  | "orchestrator:plan"
+  | "orchestrator:step"
+  | "orchestrator:completed"
+  | "orchestrator:failed"
+  | "orchestrator:cancelled"
   | "workspace:index_start"
   | "workspace:index_progress"
   | "workspace:index_complete"
@@ -3076,3 +3082,57 @@ export type ConsensusRunStatus =
 
 /** Phase of a single consensus round row. */
 export type ConsensusRoundPhase = "blind" | "review" | "adjudication";
+
+
+// ─── Live Run Activity (read-only observability lens) ───────────────
+//
+// The /api/activity snapshot + the WS events that keep it live. STRICTLY
+// METADATA-ONLY: these shapes intentionally carry no transcript, prompt, task
+// text, decision text, step output, or reasoning. Every string is either an
+// id, an enum-derived label, or a model slug.
+
+/** Which run mode an active run belongs to. */
+export type ActivityMode = "pipeline" | "manager" | "orchestrator" | "consensus";
+
+/** The current unit of work inside a run (stage / iteration / step / round). */
+export interface ActivityUnit {
+  /** Human label of the current unit, e.g. "Stage 3", "Step 2", "Round 1 · review". */
+  label: string;
+  /** Agent/team/role/phase identifier — ENUM-derived, never untrusted text. */
+  agent: string;
+  /** Model slug for this unit (best-effort / null for manager mode when unknown). */
+  modelSlug: string | null;
+  /** Status of this unit (StageStatus | OrchestratorStepStatus | phase-derived). */
+  status: string;
+}
+
+/** One active run as seen through the Activity lens. Metadata only. */
+export interface ActivityRun {
+  runId: string;
+  mode: ActivityMode;
+  /** Run-level label (mode name / pipeline name). NEVER the raw task text. */
+  title: string;
+  status: RunStatus | string;
+  workspaceId: string | null;
+  currentUnit: ActivityUnit | null;
+  startedAt: string | null;
+  /** Owner id — present for admins only (so admins can attribute runs). */
+  ownerId?: string | null;
+}
+
+/** The /api/activity response payload. */
+export interface ActivitySnapshot {
+  runs: ActivityRun[];
+  /** Whether the caller is admin (FE shows the owner column). */
+  isAdmin: boolean;
+  /** True iff the row count was capped (the FE can surface a "showing N of more"). */
+  truncated: boolean;
+}
+
+/** Payload of the new `orchestrator:step` WS event (O-1). Metadata only. */
+export interface OrchestratorStepEventPayload {
+  stepIndex: number;
+  type: OrchestratorStepType;
+  status: OrchestratorStepStatus;
+  modelSlug: string | null;
+}

--- a/tests/integration/activity/routes.test.ts
+++ b/tests/integration/activity/routes.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Integration tests for GET /api/activity — the read-only Live Activity lens.
+ *
+ * Covers: 401 unauth; owner sees only their own active runs; non-owner does NOT
+ * see others'; ownerless hidden from non-admin; admin sees all + ownerId;
+ * each mode classified with the right current-unit + model; the payload is
+ * METADATA-ONLY (no transcript/output/decisionText/reasoning/prompt); and the
+ * row cap truncates + logs.
+ *
+ * supertest over MemStorage with stub controllers whose getActiveRunIds() drive
+ * the candidate set. No CLI / network / real DB.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import request from "supertest";
+import express from "express";
+import type { Router } from "express";
+import { MemStorage } from "../../../server/storage.js";
+import { registerActivityRoutes } from "../../../server/routes/activity.js";
+import type { ActivityRouteDeps } from "../../../server/routes/activity.js";
+import type { User, UserRole } from "../../../shared/types.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+const ORCH_MODELS = {
+  planModelSlug: "claude-opus",
+  synthesizeModelSlug: "claude-opus",
+  proposerModelSlug: "claude-opus",
+  criticModelSlug: "gemini-flash",
+  judgeModelSlug: "claude-opus",
+};
+
+interface BuildOpts {
+  userId?: string;
+  role?: UserRole;
+  noUser?: boolean;
+  activePipelineManagerOrch?: string[];
+  activeConsensus?: string[];
+}
+
+function buildApp(storage: MemStorage, opts: BuildOpts = {}) {
+  const deps: ActivityRouteDeps = {
+    pipelineController: { getActiveRunIds: () => opts.activePipelineManagerOrch ?? [] },
+    consensusController: { getActiveRunIds: () => opts.activeConsensus ?? [] },
+    orchestratorModels: ORCH_MODELS,
+    consensusClaudeModelSlug: "claude-opus",
+  };
+
+  const user: User = {
+    id: opts.noUser ? (undefined as unknown as string) : opts.userId ?? "owner",
+    email: "a@x.com",
+    name: "A",
+    isActive: true,
+    role: opts.role ?? "user",
+    lastLoginAt: null,
+    createdAt: new Date(0),
+  };
+
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (opts.noUser) req.user = undefined as never;
+    else req.user = user;
+    next();
+  });
+  registerActivityRoutes(app as unknown as Router, storage, deps);
+  return app;
+}
+
+/** Seed a pipeline run + a running stage. Returns the runId. */
+async function seedPipeline(
+  storage: MemStorage,
+  triggeredBy: string | null,
+): Promise<string> {
+  const run = await storage.createPipelineRun({
+    pipelineId: "p1",
+    status: "running",
+    input: "SECRET TASK TEXT do not leak",
+    currentStageIndex: 1,
+    startedAt: new Date(),
+    triggeredBy,
+    dagMode: false,
+  });
+  await storage.createStageExecution({
+    runId: run.id,
+    stageIndex: 1,
+    teamId: "coding",
+    modelSlug: "claude-sonnet",
+    status: "running",
+    input: { secret: "stage prompt should never appear" },
+  });
+  return run.id;
+}
+
+async function seedOrchestrator(storage: MemStorage, triggeredBy: string): Promise<string> {
+  const run = await storage.createPipelineRun({
+    pipelineId: "orch1",
+    status: "running",
+    input: "orchestrator task secret",
+    currentStageIndex: 0,
+    startedAt: new Date(),
+    triggeredBy,
+    dagMode: false,
+  });
+  await storage.createOrchestratorRun({ runId: run.id, task: "secret", status: "executing" });
+  await storage.createOrchestratorStep({
+    runId: run.id,
+    stepIndex: 0,
+    type: "debate",
+    args: { type: "debate", question: "secret question" },
+    status: "running",
+  });
+  return run.id;
+}
+
+async function seedConsensus(storage: MemStorage, triggeredBy: string): Promise<string> {
+  const run = await storage.createPipelineRun({
+    pipelineId: "cons1",
+    status: "running",
+    input: "consensus decision secret",
+    currentStageIndex: 0,
+    startedAt: new Date(),
+    triggeredBy,
+    dagMode: false,
+  });
+  await storage.createConsensusRun({
+    runId: run.id,
+    decisionText: "secret decision text",
+    status: "deliberating",
+  });
+  await storage.createConsensusRound({
+    runId: run.id,
+    round: 1,
+    phase: "review",
+    tokensUsed: 0,
+  });
+  return run.id;
+}
+
+async function seedManager(storage: MemStorage, triggeredBy: string): Promise<string> {
+  const run = await storage.createPipelineRun({
+    pipelineId: "mgr1",
+    status: "running",
+    input: "manager goal secret",
+    currentStageIndex: 0,
+    startedAt: new Date(),
+    triggeredBy,
+    dagMode: false,
+  });
+  await storage.createManagerIteration({
+    runId: run.id,
+    iterationNumber: 1,
+    decision: {
+      action: "dispatch",
+      teamId: "development",
+      task: "SECRET manager task",
+      reasoning: "SECRET reasoning that must not leak",
+      iterationNumber: 1,
+    },
+    tokensUsed: 5,
+    decisionDurationMs: 10,
+  });
+  return run.id;
+}
+
+describe("GET /api/activity — auth", () => {
+  it("401 when unauthenticated", async () => {
+    const storage = new MemStorage();
+    const app = buildApp(storage, { noUser: true });
+    const res = await request(app).get("/api/activity");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/activity — owner scoping", () => {
+  it("owner sees only their own active runs (not others')", async () => {
+    const storage = new MemStorage();
+    const mine = await seedPipeline(storage, "owner");
+    const theirs = await seedPipeline(storage, "someone-else");
+
+    const app = buildApp(storage, {
+      userId: "owner",
+      role: "user",
+      activePipelineManagerOrch: [mine, theirs],
+    });
+    const res = await request(app).get("/api/activity");
+    expect(res.status).toBe(200);
+    const ids = res.body.runs.map((r: { runId: string }) => r.runId);
+    expect(ids).toEqual([mine]);
+    expect(res.body.isAdmin).toBe(false);
+  });
+
+  it("ownerless runs are hidden from a non-admin", async () => {
+    const storage = new MemStorage();
+    const ownerless = await seedPipeline(storage, null);
+    const app = buildApp(storage, {
+      userId: "owner",
+      role: "user",
+      activePipelineManagerOrch: [ownerless],
+    });
+    const res = await request(app).get("/api/activity");
+    expect(res.body.runs).toEqual([]);
+  });
+
+  it("a non-owner does NOT see another user's run", async () => {
+    const storage = new MemStorage();
+    const theirs = await seedPipeline(storage, "owner");
+    const app = buildApp(storage, {
+      userId: "intruder",
+      role: "user",
+      activePipelineManagerOrch: [theirs],
+    });
+    const res = await request(app).get("/api/activity");
+    expect(res.body.runs).toEqual([]);
+  });
+});
+
+describe("GET /api/activity — admin scoping", () => {
+  it("admin sees ALL active runs (incl. ownerless) with ownerId per row", async () => {
+    const storage = new MemStorage();
+    const a = await seedPipeline(storage, "owner");
+    const b = await seedPipeline(storage, "someone-else");
+    const c = await seedPipeline(storage, null);
+
+    const app = buildApp(storage, {
+      userId: "boss",
+      role: "admin",
+      activePipelineManagerOrch: [a, b, c],
+    });
+    const res = await request(app).get("/api/activity");
+    expect(res.status).toBe(200);
+    expect(res.body.isAdmin).toBe(true);
+    expect(res.body.runs).toHaveLength(3);
+    const owners = res.body.runs.map((r: { ownerId: string | null }) => r.ownerId).sort();
+    expect(owners).toEqual([null, "owner", "someone-else"]);
+  });
+});
+
+describe("GET /api/activity — mode classification + current unit", () => {
+  it("classifies a pipeline run with stage + model", async () => {
+    const storage = new MemStorage();
+    const id = await seedPipeline(storage, "owner");
+    const app = buildApp(storage, { userId: "owner", activePipelineManagerOrch: [id] });
+    const res = await request(app).get("/api/activity");
+    const row = res.body.runs[0];
+    expect(row.mode).toBe("pipeline");
+    expect(row.currentUnit.agent).toBe("coding");
+    expect(row.currentUnit.modelSlug).toBe("claude-sonnet");
+    expect(row.currentUnit.label).toBe("Stage 2");
+    expect(row.currentUnit.status).toBe("running");
+  });
+
+  it("classifies an orchestrator run with step type + model", async () => {
+    const storage = new MemStorage();
+    const id = await seedOrchestrator(storage, "owner");
+    const app = buildApp(storage, { userId: "owner", activePipelineManagerOrch: [id] });
+    const res = await request(app).get("/api/activity");
+    const row = res.body.runs[0];
+    expect(row.mode).toBe("orchestrator");
+    expect(row.currentUnit.agent).toBe("debate");
+    expect(row.currentUnit.modelSlug).toBe("claude-opus");
+    expect(row.currentUnit.label).toBe("Step 1");
+  });
+
+  it("classifies a consensus run with phase + voter model", async () => {
+    const storage = new MemStorage();
+    const id = await seedConsensus(storage, "owner");
+    const app = buildApp(storage, { userId: "owner", activeConsensus: [id] });
+    const res = await request(app).get("/api/activity");
+    const row = res.body.runs[0];
+    expect(row.mode).toBe("consensus");
+    expect(row.currentUnit.agent).toBe("voters");
+    expect(row.currentUnit.modelSlug).toBeNull(); // review phase = voter roster
+    expect(row.currentUnit.label).toBe("Round 1 · review");
+  });
+
+  it("classifies a manager run with team + best-effort model", async () => {
+    const storage = new MemStorage();
+    const id = await seedManager(storage, "owner");
+    const app = buildApp(storage, { userId: "owner", activePipelineManagerOrch: [id] });
+    const res = await request(app).get("/api/activity");
+    const row = res.body.runs[0];
+    expect(row.mode).toBe("manager");
+    expect(row.currentUnit.agent).toBe("development");
+    expect(row.currentUnit.modelSlug).toBe("claude-sonnet"); // SDLC development default
+    expect(row.currentUnit.label).toBe("Iteration 1");
+  });
+});
+
+describe("GET /api/activity — metadata-only (security)", () => {
+  it("leaks NO transcript/output/decisionText/reasoning/prompt/task text", async () => {
+    const storage = new MemStorage();
+    const p = await seedPipeline(storage, "owner");
+    const m = await seedManager(storage, "owner");
+    const c = await seedConsensus(storage, "owner");
+    const o = await seedOrchestrator(storage, "owner");
+
+    const app = buildApp(storage, {
+      userId: "owner",
+      role: "admin",
+      activePipelineManagerOrch: [p, m, o],
+      activeConsensus: [c],
+    });
+    const res = await request(app).get("/api/activity");
+    const serialized = JSON.stringify(res.body);
+
+    // No free-text / sensitive field names or values anywhere in the payload.
+    for (const banned of [
+      "SECRET",
+      "decisionText",
+      "decision_text",
+      "reasoning",
+      "transcript",
+      "prompt",
+      "do not leak",
+      "secret question",
+    ]) {
+      expect(serialized).not.toContain(banned);
+    }
+
+    // Positive: each row exposes only the metadata keys.
+    for (const row of res.body.runs) {
+      expect(Object.keys(row).sort()).toEqual(
+        ["currentUnit", "mode", "ownerId", "runId", "startedAt", "status", "title", "workspaceId"].sort(),
+      );
+      if (row.currentUnit) {
+        expect(Object.keys(row.currentUnit).sort()).toEqual(
+          ["agent", "label", "modelSlug", "status"].sort(),
+        );
+      }
+    }
+  });
+});
+
+describe("GET /api/activity — row cap", () => {
+  it("truncates + logs when the candidate set exceeds the cap", async () => {
+    const storage = new MemStorage();
+    const ids: string[] = [];
+    for (let i = 0; i < 205; i++) ids.push(await seedPipeline(storage, "owner"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const app = buildApp(storage, {
+      userId: "owner",
+      role: "user",
+      activePipelineManagerOrch: ids,
+    });
+    const res = await request(app).get("/api/activity");
+    expect(res.body.runs.length).toBe(200);
+    expect(res.body.truncated).toBe(true);
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/activity-ui.test.ts
+++ b/tests/unit/activity-ui.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Unit tests for the Live Activity UI logic (frontend).
+ *
+ * Like orchestrator-ui.test.ts / news-ui.test.ts, these exercise the PURE
+ * helpers that back the page + hook — the multi-run merge-by-runId reducer that
+ * folds live WS deltas onto the polled snapshot, the mode grouping, the
+ * ownership-scoped subscription id set, the live-pulse predicate, and the model
+ * display helper — without a DOM renderer (the repo has no jsdom).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  mergeWsEvent,
+  groupByMode,
+  snapshotRunIds,
+  isLiveNow,
+  displayModel,
+  ACTIVITY_MODE_ORDER,
+  LIVE_PULSE_WINDOW_MS,
+  type LiveActivityRun,
+} from "@/lib/activity";
+import type { ActivityRun, ActivityMode, WsEvent } from "@shared/types";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const NOW = 1_000_000;
+
+function makeRun(overrides: Partial<ActivityRun> = {}): LiveActivityRun {
+  return {
+    runId: "run-1",
+    mode: "pipeline",
+    title: "Build feature",
+    status: "running",
+    workspaceId: null,
+    startedAt: null,
+    currentUnit: {
+      label: "Stage 1",
+      agent: "backend",
+      modelSlug: "claude-opus",
+      status: "running",
+    },
+    ...overrides,
+  };
+}
+
+function ev(
+  type: WsEvent["type"],
+  runId: string | undefined,
+  payload: Record<string, unknown> = {},
+): WsEvent {
+  return { type, runId, payload, timestamp: "2026-06-11T00:00:00.000Z" };
+}
+
+// ─── mergeWsEvent: the multi-run merge-by-runId reducer ─────────────────────────
+
+describe("mergeWsEvent — keying by runId", () => {
+  it("merges a stage:progress delta onto ONLY the matching run", () => {
+    const rows = [makeRun({ runId: "a" }), makeRun({ runId: "b" })];
+    const next = mergeWsEvent(
+      rows,
+      ev("stage:progress", "b", { teamId: "qa", modelSlug: "gpt-x" }),
+      NOW,
+    );
+
+    // 'a' is untouched (same reference), 'b' is updated.
+    expect(next[0]).toBe(rows[0]);
+    expect(next[1].currentUnit?.modelSlug).toBe("gpt-x");
+    expect(next[1].lastDeltaAt).toBe(NOW);
+  });
+
+  it("returns the SAME array reference when the runId is not in the snapshot", () => {
+    const rows = [makeRun({ runId: "a" })];
+    const next = mergeWsEvent(rows, ev("stage:progress", "ghost", {}), NOW);
+    expect(next).toBe(rows);
+  });
+
+  it("ignores events without a runId", () => {
+    const rows = [makeRun({ runId: "a" })];
+    expect(mergeWsEvent(rows, ev("stage:progress", undefined, {}), NOW)).toBe(rows);
+  });
+
+  it("ignores non-live event types (passes the array through unchanged)", () => {
+    const rows = [makeRun({ runId: "a" })];
+    expect(mergeWsEvent(rows, ev("pipeline:completed", "a", {}), NOW)).toBe(rows);
+    expect(mergeWsEvent(rows, ev("chat:message", "a", {}), NOW)).toBe(rows);
+  });
+
+  it("does not mutate the input row or array", () => {
+    const rows = [makeRun({ runId: "a" })];
+    const before = JSON.stringify(rows);
+    mergeWsEvent(rows, ev("stage:progress", "a", { modelSlug: "z" }), NOW);
+    expect(JSON.stringify(rows)).toBe(before);
+  });
+});
+
+describe("mergeWsEvent — stage:progress", () => {
+  it("refreshes the model and marks the unit running, keeping the label", () => {
+    const rows = [makeRun({ runId: "a" })];
+    const next = mergeWsEvent(
+      rows,
+      ev("stage:progress", "a", { modelSlug: "new-model" }),
+      NOW,
+    );
+    expect(next[0].currentUnit).toMatchObject({
+      label: "Stage 1",
+      agent: "backend",
+      modelSlug: "new-model",
+      status: "running",
+    });
+  });
+
+  it("keeps the prior model when the payload omits modelSlug", () => {
+    const rows = [makeRun({ runId: "a" })];
+    const next = mergeWsEvent(rows, ev("stage:progress", "a", {}), NOW);
+    expect(next[0].currentUnit?.modelSlug).toBe("claude-opus");
+  });
+});
+
+describe("mergeWsEvent — manager:decision", () => {
+  it("re-attributes the agent to the payload teamId and refreshes the model", () => {
+    const rows = [makeRun({ runId: "a", mode: "manager" })];
+    const next = mergeWsEvent(
+      rows,
+      ev("manager:decision", "a", { teamId: "frontend", modelSlug: "m" }),
+      NOW,
+    );
+    expect(next[0].currentUnit).toMatchObject({
+      agent: "frontend",
+      modelSlug: "m",
+      status: "running",
+    });
+  });
+});
+
+describe("mergeWsEvent — orchestrator:step", () => {
+  it("derives a 1-based label, sets agent=type, status, and model", () => {
+    const rows = [makeRun({ runId: "a", mode: "orchestrator" })];
+    const next = mergeWsEvent(
+      rows,
+      ev("orchestrator:step", "a", {
+        stepIndex: 2,
+        type: "debate",
+        status: "running",
+        modelSlug: "proposer-model",
+      }),
+      NOW,
+    );
+    expect(next[0].currentUnit).toEqual({
+      label: "Step 3",
+      agent: "debate",
+      modelSlug: "proposer-model",
+      status: "running",
+    });
+    expect(next[0].lastDeltaAt).toBe(NOW);
+  });
+
+  it("tolerates a malformed payload without throwing (falls back to prev unit)", () => {
+    const rows = [makeRun({ runId: "a" })];
+    const next = mergeWsEvent(
+      rows,
+      ev("orchestrator:step", "a", { stepIndex: "nope", modelSlug: 123 }),
+      NOW,
+    );
+    expect(next[0].currentUnit?.label).toBe("Stage 1"); // fell back to prev
+    expect(next[0].currentUnit?.modelSlug).toBe("claude-opus"); // bad number ignored
+  });
+});
+
+// ─── groupByMode ────────────────────────────────────────────────────────────────
+
+describe("groupByMode", () => {
+  it("groups in the fixed mode order and omits empty modes", () => {
+    const rows = [
+      makeRun({ runId: "c1", mode: "consensus" }),
+      makeRun({ runId: "p1", mode: "pipeline" }),
+      makeRun({ runId: "p2", mode: "pipeline" }),
+    ];
+    const groups = groupByMode(rows);
+    expect(groups.map((g) => g.mode)).toEqual(["pipeline", "consensus"]);
+    expect(groups[0].runs).toHaveLength(2);
+    expect(groups[1].runs).toHaveLength(1);
+  });
+
+  it("returns [] for no rows (drives the empty state)", () => {
+    expect(groupByMode([])).toEqual([]);
+  });
+
+  it("covers all four contract modes in ACTIVITY_MODE_ORDER", () => {
+    const modes: ActivityMode[] = ["pipeline", "manager", "orchestrator", "consensus"];
+    expect([...ACTIVITY_MODE_ORDER].sort()).toEqual([...modes].sort());
+  });
+});
+
+// ─── snapshotRunIds (ownership-scoped subscription set) ──────────────────────────
+
+describe("snapshotRunIds", () => {
+  it("returns exactly the snapshot runIds (never derived/guessed)", () => {
+    const rows = [makeRun({ runId: "a" }), makeRun({ runId: "b" })];
+    expect(snapshotRunIds(rows)).toEqual(["a", "b"]);
+  });
+
+  it("is empty for an empty snapshot", () => {
+    expect(snapshotRunIds([])).toEqual([]);
+  });
+});
+
+// ─── isLiveNow (live pulse) ─────────────────────────────────────────────────────
+
+describe("isLiveNow", () => {
+  it("is false when no WS delta has ever landed", () => {
+    expect(isLiveNow(makeRun(), NOW)).toBe(false);
+  });
+
+  it("is true within the freshness window and false past it", () => {
+    const row = makeRun({ runId: "a" });
+    const live = mergeWsEvent([row], ev("stage:progress", "a", {}), NOW)[0];
+    expect(isLiveNow(live, NOW)).toBe(true);
+    expect(isLiveNow(live, NOW + LIVE_PULSE_WINDOW_MS)).toBe(true);
+    expect(isLiveNow(live, NOW + LIVE_PULSE_WINDOW_MS + 1)).toBe(false);
+  });
+});
+
+// ─── displayModel ────────────────────────────────────────────────────────────────
+
+describe("displayModel", () => {
+  it("shows the slug when present", () => {
+    expect(displayModel("claude-opus")).toBe("claude-opus");
+  });
+
+  it("shows an em-dash for null / undefined / empty", () => {
+    expect(displayModel(null)).toBe("—");
+    expect(displayModel(undefined)).toBe("—");
+    expect(displayModel("")).toBe("—");
+  });
+});
+
+// ─── Admin-only owner column (presence of ownerId) ───────────────────────────────
+// The page renders the Owner column iff isAdmin; the data contract is that
+// ownerId is present only for admins. These assert the row data the column reads.
+
+describe("ownerId attribution (admin-only column data)", () => {
+  it("carries ownerId on admin rows", () => {
+    const row = makeRun({ runId: "a", ownerId: "user-42" });
+    expect(row.ownerId).toBe("user-42");
+  });
+
+  it("is absent/undefined on non-admin rows", () => {
+    const row = makeRun({ runId: "a" });
+    expect(row.ownerId).toBeUndefined();
+  });
+});

--- a/tests/unit/controller/active-run-ids.test.ts
+++ b/tests/unit/controller/active-run-ids.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for the read-only getActiveRunIds() accessors added to
+ * PipelineController and ConsensusController for the /api/activity lens.
+ *
+ * The accessor must reflect adds + removes from the private in-memory
+ * `activeRuns` registry (the authoritative live truth) without mutating it.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { PipelineController } from "../../../server/controller/pipeline-controller.js";
+import { ConsensusController } from "../../../server/consensus/consensus-controller.js";
+
+/** Reach the private registry to simulate runs starting/finishing. */
+function registryOf(c: { getActiveRunIds(): string[] }): Map<string, AbortController> {
+  return (c as unknown as { activeRuns: Map<string, AbortController> }).activeRuns;
+}
+
+const wsStub = { broadcastToRun: vi.fn(), broadcastGlobal: vi.fn() } as never;
+
+describe("PipelineController.getActiveRunIds", () => {
+  function make(): PipelineController {
+    return new PipelineController({} as never, {} as never, wsStub);
+  }
+
+  it("starts empty", () => {
+    expect(make().getActiveRunIds()).toEqual([]);
+  });
+
+  it("reflects adds and removes", () => {
+    const c = make();
+    const reg = registryOf(c);
+    reg.set("run-a", new AbortController());
+    reg.set("run-b", new AbortController());
+    expect(c.getActiveRunIds().sort()).toEqual(["run-a", "run-b"]);
+
+    reg.delete("run-a");
+    expect(c.getActiveRunIds()).toEqual(["run-b"]);
+  });
+
+  it("returns a copy that does not mutate the registry", () => {
+    const c = make();
+    registryOf(c).set("run-a", new AbortController());
+    const ids = c.getActiveRunIds();
+    ids.push("phantom");
+    expect(c.getActiveRunIds()).toEqual(["run-a"]);
+  });
+
+  it("agrees with isRunActive", () => {
+    const c = make();
+    registryOf(c).set("run-x", new AbortController());
+    expect(c.isRunActive("run-x")).toBe(true);
+    expect(c.getActiveRunIds()).toContain("run-x");
+  });
+});
+
+describe("ConsensusController.getActiveRunIds", () => {
+  function make(): ConsensusController {
+    return new ConsensusController(
+      {} as never,
+      {} as never,
+      { claudeModelSlug: "claude-opus" },
+      () => Promise.resolve([]),
+    );
+  }
+
+  it("starts empty", () => {
+    expect(make().getActiveRunIds()).toEqual([]);
+  });
+
+  it("reflects adds and removes", () => {
+    const c = make();
+    const reg = registryOf(c);
+    reg.set("c-1", new AbortController());
+    expect(c.getActiveRunIds()).toEqual(["c-1"]);
+    reg.delete("c-1");
+    expect(c.getActiveRunIds()).toEqual([]);
+  });
+});

--- a/tests/unit/routes/activity-model-map.test.ts
+++ b/tests/unit/routes/activity-model-map.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for the pure Activity model-derivation helpers
+ * (server/routes/activity-model-map.ts).
+ *
+ * These map an ENUM (orchestrator step type / SDLC team id) to a best-effort
+ * model slug. No I/O, no untrusted text — table tests over every enum member.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  orchestratorStepModel,
+  managerTeamModel,
+  type ActivityOrchestratorModels,
+} from "../../../server/routes/activity-model-map.js";
+import { SDLC_TEAMS } from "../../../shared/constants.js";
+import type { OrchestratorStepType } from "../../../shared/types.js";
+
+const MODELS: ActivityOrchestratorModels = {
+  planModelSlug: "plan-m",
+  synthesizeModelSlug: "synth-m",
+  proposerModelSlug: "prop-m",
+  criticModelSlug: "crit-m",
+  judgeModelSlug: "judge-m",
+};
+
+describe("orchestratorStepModel", () => {
+  const cases: Array<[OrchestratorStepType, string]> = [
+    ["research", "synth-m"],
+    ["analyze-code", "synth-m"],
+    ["ground", "synth-m"],
+    ["synthesize", "synth-m"],
+    ["debate", "prop-m"],
+  ];
+
+  for (const [type, expected] of cases) {
+    it(`maps "${type}" → ${expected}`, () => {
+      expect(orchestratorStepModel(type, MODELS)).toBe(expected);
+    });
+  }
+
+  it("returns null for an unknown step type (defensive)", () => {
+    expect(orchestratorStepModel("nope" as OrchestratorStepType, MODELS)).toBeNull();
+  });
+});
+
+describe("managerTeamModel", () => {
+  it("resolves the SDLC default model for a known team id", () => {
+    const teamId = Object.keys(SDLC_TEAMS)[0];
+    expect(managerTeamModel(teamId)).toBe(
+      SDLC_TEAMS[teamId as keyof typeof SDLC_TEAMS].defaultModelSlug,
+    );
+  });
+
+  it("covers EVERY SDLC team id", () => {
+    for (const [teamId, team] of Object.entries(SDLC_TEAMS)) {
+      expect(managerTeamModel(teamId)).toBe(team.defaultModelSlug);
+    }
+  });
+
+  it("returns null for an unknown/custom team id (best-effort)", () => {
+    expect(managerTeamModel("custom-team")).toBeNull();
+  });
+
+  it("returns null when the team id is undefined", () => {
+    expect(managerTeamModel(undefined)).toBeNull();
+  });
+});

--- a/tests/unit/routes/authorize-run.test.ts
+++ b/tests/unit/routes/authorize-run.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for the shared authorizeRun helper (server/routes/authorize-run.ts).
+ *
+ * Parity with the prior inline copies in routes/orchestrator.ts + routes/consensus.ts:
+ *   - 401 takes precedence over existence (unauth → 401 even for a real run),
+ *   - 404 when the run (or the required mode row) is missing,
+ *   - 403 for a non-owner non-admin,
+ *   - DENY when triggeredBy == null for non-admins (stricter rule),
+ *   - admin sees everything (incl. ownerless),
+ *   - owner sees their own run.
+ * On success returns { ownerId }; on failure sends the status and returns null.
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { Request, Response } from "express";
+import { authorizeRun } from "../../../server/routes/authorize-run.js";
+
+interface FakeRun {
+  id: string;
+  triggeredBy: string | null;
+}
+
+function makeRes(): { res: Response; statusCalls: number[]; jsonBodies: unknown[] } {
+  const statusCalls: number[] = [];
+  const jsonBodies: unknown[] = [];
+  const res = {
+    status(code: number) {
+      statusCalls.push(code);
+      return this;
+    },
+    json(body: unknown) {
+      jsonBodies.push(body);
+      return this;
+    },
+  } as unknown as Response;
+  return { res, statusCalls, jsonBodies };
+}
+
+function makeReq(user?: { id?: string; role?: string }): Request {
+  return { user } as unknown as Request;
+}
+
+function makeStorage(run: FakeRun | undefined, modeRow?: unknown) {
+  return {
+    getPipelineRun: vi.fn(async () => run),
+    getModeRow: vi.fn(async () => modeRow),
+  };
+}
+
+describe("authorizeRun", () => {
+  it("401 when unauthenticated (precedence over existence)", async () => {
+    const storage = makeStorage({ id: "r1", triggeredBy: "owner" });
+    const { res, statusCalls } = makeRes();
+    const out = await authorizeRun(makeReq(undefined), res, storage as never, "r1");
+    expect(out).toBeNull();
+    expect(statusCalls).toEqual([401]);
+  });
+
+  it("404 when the pipeline run is missing", async () => {
+    const storage = makeStorage(undefined);
+    const { res, statusCalls } = makeRes();
+    const out = await authorizeRun(makeReq({ id: "u1", role: "user" }), res, storage as never, "missing");
+    expect(out).toBeNull();
+    expect(statusCalls).toEqual([404]);
+  });
+
+  it("404 when the run exists but the required mode row is missing", async () => {
+    const storage = makeStorage({ id: "r1", triggeredBy: "u1" }, undefined);
+    const { res, statusCalls } = makeRes();
+    const out = await authorizeRun(
+      makeReq({ id: "u1", role: "user" }),
+      res,
+      storage as never,
+      "r1",
+      { requireModeRow: (s, id) => s.getModeRow(id) },
+    );
+    expect(out).toBeNull();
+    expect(statusCalls).toEqual([404]);
+  });
+
+  it("403 for a non-owner non-admin", async () => {
+    const storage = makeStorage({ id: "r1", triggeredBy: "owner" });
+    const { res, statusCalls } = makeRes();
+    const out = await authorizeRun(makeReq({ id: "intruder", role: "user" }), res, storage as never, "r1");
+    expect(out).toBeNull();
+    expect(statusCalls).toEqual([403]);
+  });
+
+  it("403 (deny) when triggeredBy == null for a non-admin", async () => {
+    const storage = makeStorage({ id: "r1", triggeredBy: null });
+    const { res, statusCalls } = makeRes();
+    const out = await authorizeRun(makeReq({ id: "u1", role: "user" }), res, storage as never, "r1");
+    expect(out).toBeNull();
+    expect(statusCalls).toEqual([403]);
+  });
+
+  it("allows the owner and returns their ownerId", async () => {
+    const storage = makeStorage({ id: "r1", triggeredBy: "u1" });
+    const { res, statusCalls } = makeRes();
+    const out = await authorizeRun(makeReq({ id: "u1", role: "user" }), res, storage as never, "r1");
+    expect(statusCalls).toEqual([]);
+    expect(out).toEqual({ ownerId: "u1" });
+  });
+
+  it("allows an admin to see another user's run", async () => {
+    const storage = makeStorage({ id: "r1", triggeredBy: "owner" });
+    const { res, statusCalls } = makeRes();
+    const out = await authorizeRun(makeReq({ id: "boss", role: "admin" }), res, storage as never, "r1");
+    expect(statusCalls).toEqual([]);
+    expect(out).toEqual({ ownerId: "owner" });
+  });
+
+  it("allows an admin to see an ownerless run", async () => {
+    const storage = makeStorage({ id: "r1", triggeredBy: null });
+    const { res, statusCalls } = makeRes();
+    const out = await authorizeRun(makeReq({ id: "boss", role: "admin" }), res, storage as never, "r1");
+    expect(statusCalls).toEqual([]);
+    expect(out).toEqual({ ownerId: null });
+  });
+
+  it("mode row present passes through to the authz gate (owner)", async () => {
+    const storage = makeStorage({ id: "r1", triggeredBy: "u1" }, { exists: true });
+    const { res, statusCalls } = makeRes();
+    const out = await authorizeRun(
+      makeReq({ id: "u1", role: "user" }),
+      res,
+      storage as never,
+      "r1",
+      { requireModeRow: (s, id) => s.getModeRow(id) },
+    );
+    expect(statusCalls).toEqual([]);
+    expect(out).toEqual({ ownerId: "u1" });
+  });
+});

--- a/tests/unit/ws/activity-ws-surfacing.test.ts
+++ b/tests/unit/ws/activity-ws-surfacing.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for the additive WS surfacing the Activity lens relies on:
+ *   - P-1: stage:progress now carries modelSlug,
+ *   - O-1: a new orchestrator:step event {stepIndex, type, status, modelSlug}.
+ *
+ * (M-1 manager:decision modelSlug is covered in tests/integration/manager-mode.)
+ *
+ * Each controller/agent is constructed with a capturing wsManager double; we
+ * drive the smallest path that emits the event. No CLI/network/DB.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { PipelineController } from "../../../server/controller/pipeline-controller.js";
+import { OrchestratorAgent } from "../../../server/orchestrator/orchestrator-agent.js";
+import type { WsEvent } from "../../../shared/types.js";
+import { configLoader } from "../../../server/config/loader.js";
+
+interface Captured {
+  runId: string;
+  event: WsEvent;
+}
+
+function capturingWs(sink: Captured[]) {
+  return {
+    broadcastToRun: (runId: string, event: WsEvent) => sink.push({ runId, event }),
+    broadcastGlobal: vi.fn(),
+  } as never;
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("P-1 — stage:progress carries modelSlug", () => {
+  beforeEach(() => {
+    const base = configLoader.get();
+    vi.spyOn(configLoader, "get").mockReturnValue({
+      ...base,
+      pipeline: {
+        ...base.pipeline,
+        streaming: {
+          enabled: true,
+          wsProgressFlushMs: 0,
+          idleTimeoutMs: 1000,
+          overallTimeoutMs: 1000,
+          maxOutputBytes: 100000,
+        },
+      },
+    } as never);
+  });
+
+  it("includes modelSlug in the stage:progress payload", () => {
+    const sink: Captured[] = [];
+    const controller = new PipelineController({} as never, {} as never, capturingWs(sink));
+
+    const build = (controller as unknown as {
+      buildStreamingBlock: (
+        runId: string,
+        stageIndex: number,
+        teamId: string,
+        modelSlug: string,
+        stageExecutionId: string | undefined,
+        signal: AbortSignal,
+      ) => { coalescer?: { push: (d: string, c: number) => void; flush?: () => void } };
+    }).buildStreamingBlock(
+      "run-1",
+      2,
+      "coding",
+      "claude-sonnet",
+      "exec-1",
+      new AbortController().signal,
+    );
+
+    build.coalescer?.push("hello", 5);
+    build.coalescer?.flush?.();
+
+    const progress = sink.find((c) => c.event.type === "stage:progress");
+    expect(progress).toBeTruthy();
+    expect(progress!.event.payload).toMatchObject({
+      stageIndex: 2,
+      teamId: "coding",
+      modelSlug: "claude-sonnet",
+    });
+  });
+});
+
+describe("O-1 — orchestrator:step event", () => {
+  function makeAgent(sink: Captured[], executors: Record<string, unknown>) {
+    const storage = {
+      updateOrchestratorStep: vi.fn(async () => undefined),
+      updateOrchestratorRun: vi.fn(async () => undefined),
+      getOrchestratorSteps: vi.fn(async () => []),
+    };
+    const agent = new OrchestratorAgent({
+      storage: storage as never,
+      wsManager: capturingWs(sink),
+      gateway: {} as never,
+      stepExecutors: executors as never,
+      models: {
+        planModelSlug: "claude-opus",
+        synthesizeModelSlug: "claude-opus",
+        proposerModelSlug: "claude-opus",
+        criticModelSlug: "gemini-flash",
+        judgeModelSlug: "claude-opus",
+      },
+    });
+    return { agent, storage };
+  }
+
+  it("emits running + completed orchestrator:step with the right shape", async () => {
+    const sink: Captured[] = [];
+    const { agent } = makeAgent(sink, {
+      debate: vi.fn(async () => ({ output: { ok: true }, tokensUsed: 1 })),
+    });
+    const budget = { add: vi.fn(), total: 1 } as never;
+
+    await (agent as unknown as {
+      runStep: (
+        runId: string,
+        step: { id: string; stepIndex: number; type: string; args: unknown },
+        caps: unknown,
+        budget: unknown,
+        signal: AbortSignal,
+      ) => Promise<void>;
+    }).runStep(
+      "run-1",
+      { id: "s1", stepIndex: 0, type: "debate", args: { type: "debate", question: "q" } },
+      { stepOutputMaxBytes: 100000 } as never,
+      budget,
+      new AbortController().signal,
+    );
+
+    const steps = sink.filter((c) => c.event.type === "orchestrator:step");
+    expect(steps.length).toBeGreaterThanOrEqual(2);
+    expect(steps[0].event.payload).toMatchObject({
+      stepIndex: 0,
+      type: "debate",
+      status: "running",
+      modelSlug: "claude-opus",
+    });
+    const completed = steps.find((s) => (s.event.payload as { status: string }).status === "completed");
+    expect(completed).toBeTruthy();
+    expect(completed!.event.payload).toMatchObject({ stepIndex: 0, type: "debate", modelSlug: "claude-opus" });
+  });
+
+  it("emits a failed orchestrator:step when the step throws", async () => {
+    const sink: Captured[] = [];
+    const { agent } = makeAgent(sink, {
+      ground: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    });
+
+    await expect(
+      (agent as unknown as { runStep: (...a: unknown[]) => Promise<void> }).runStep(
+        "run-1",
+        { id: "s1", stepIndex: 1, type: "ground", args: { type: "ground", query: "q" } },
+        { stepOutputMaxBytes: 100000 },
+        { add: vi.fn(), total: 0 },
+        new AbortController().signal,
+      ),
+    ).rejects.toThrow();
+
+    const failed = sink.find(
+      (c) => c.event.type === "orchestrator:step" && (c.event.payload as { status: string }).status === "failed",
+    );
+    expect(failed).toBeTruthy();
+    expect(failed!.event.payload).toMatchObject({ stepIndex: 1, type: "ground" });
+  });
+});

--- a/tests/unit/ws/ws-manager.test.ts
+++ b/tests/unit/ws/ws-manager.test.ts
@@ -16,19 +16,21 @@
  *   - emitted event shape is preserved exactly (JSON.stringify matches)
  *   - subscriber for a different runId does not receive the event
  *   - closed/closing WebSocket stubs are skipped during broadcast
+ *   - authorizeAndSubscribe enforces owner/admin ownership (IDOR hardening)
  */
 import { describe, it, expect, vi } from "vitest";
 import { createServer } from "http";
+import type { IStorage } from "../../../server/storage.js";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
  * Create a WsManager with a real (non-listening) HTTP server.
  */
-async function createManager() {
+async function createManager(storage?: IStorage) {
   const { WsManager } = await import("../../../server/ws/manager.js");
   const httpServer = createServer();
-  const manager = new WsManager(httpServer);
+  const manager = new WsManager(httpServer, storage);
   return { manager, httpServer };
 }
 
@@ -48,6 +50,13 @@ function makeEvent(runId: string) {
     payload: {},
     timestamp: new Date().toISOString(),
   };
+}
+
+/** A storage double exposing only getPipelineRun for ownership checks. */
+function storageWithRun(triggeredBy: string | null): IStorage {
+  return {
+    getPipelineRun: vi.fn(async () => ({ id: "r", triggeredBy })),
+  } as unknown as IStorage;
 }
 
 // ─── subscribe + broadcastToRun ───────────────────────────────────────────────
@@ -205,5 +214,55 @@ describe("WsManager — non-OPEN WebSocket states are skipped", () => {
 
     expect(openWs.send).toHaveBeenCalledTimes(1);
     expect(closedWs.send).toHaveBeenCalledTimes(0);
+  });
+});
+
+// ─── authorizeAndSubscribe — ownership gate (IDOR hardening) ──────────────────
+
+describe("WsManager.authorizeAndSubscribe — ownership gate", () => {
+  const owner = { id: "owner", role: "user" } as never;
+  const intruder = { id: "intruder", role: "user" } as never;
+  const admin = { id: "boss", role: "admin" } as never;
+
+  it("allows the owner to subscribe to their own run", async () => {
+    const { manager } = await createManager(storageWithRun("owner"));
+    const ws = makeFakeWs();
+    const ok = await manager.authorizeAndSubscribe(ws as never, owner, "run-x");
+    expect(ok).toBe(true);
+    manager.broadcastToRun("run-x", makeEvent("run-x"));
+    expect(ws.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("REJECTS a non-owner subscribing to another user's run (and does not register)", async () => {
+    const { manager } = await createManager(storageWithRun("owner"));
+    const ws = makeFakeWs();
+    const ok = await manager.authorizeAndSubscribe(ws as never, intruder, "run-x");
+    expect(ok).toBe(false);
+    manager.broadcastToRun("run-x", makeEvent("run-x"));
+    expect(ws.send).toHaveBeenCalledTimes(0);
+  });
+
+  it("allows an admin to subscribe to any run", async () => {
+    const { manager } = await createManager(storageWithRun("owner"));
+    const ws = makeFakeWs();
+    const ok = await manager.authorizeAndSubscribe(ws as never, admin, "run-x");
+    expect(ok).toBe(true);
+    manager.broadcastToRun("run-x", makeEvent("run-x"));
+    expect(ws.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("REJECTS subscribing to an ownerless run as a non-admin", async () => {
+    const { manager } = await createManager(storageWithRun(null));
+    const ws = makeFakeWs();
+    const ok = await manager.authorizeAndSubscribe(ws as never, owner, "run-x");
+    expect(ok).toBe(false);
+  });
+
+  it("REJECTS subscribing to a missing run", async () => {
+    const storage = { getPipelineRun: vi.fn(async () => undefined) } as unknown as IStorage;
+    const { manager } = await createManager(storage);
+    const ws = makeFakeWs();
+    const ok = await manager.authorizeAndSubscribe(ws as never, owner, "missing");
+    expect(ok).toBe(false);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -97,6 +97,11 @@ export default defineConfig({
         "server/consensus/consensus-engine.ts",
         "server/consensus/consensus-controller.ts",
         "server/routes/consensus.ts",
+        // live-run-activity-ui (new modules ≥80%).
+        "server/routes/activity.ts",
+        "server/routes/activity-model-map.ts",
+        "server/routes/authorize-run.ts",
+        "server/ws/manager.ts",
       ],
       exclude: ["server/**/*.test.ts", "server/index.ts", "server/vite.ts"],
     },


### PR DESCRIPTION
A read-only **Live Activity** page for debugging: see what's running now, **who is working** (agent/role), **which model**, and **status** — live, across all run modes (pipeline/manager/orchestrator/consensus).

## Backend
- **GET /api/activity** — owner/admin-scoped snapshot of currently-active runs (in-memory registries), filtered by `pipeline_runs.triggeredBy` (non-admin: own only; admin: all + `ownerId`; null-owner hidden from non-admins). **Metadata-only** — runId/mode/mode-literal-title/status/workspaceId/currentUnit{label,agent,modelSlug,status}/startedAt; **never** task text/transcript/output/decisionText/reasoning. Row cap 200 + `truncated` (logged).
- Extracted shared **authorize-run.ts** (orchestrator+consensus delegate; identical 401→404→403, deny-null-owner). `getActiveRunIds()` on both controllers.
- WS model/agent surfacing: `modelSlug` in `stage:progress` + `manager:decision`; new `orchestrator:step`.
- **Security: WsManager.subscribe IDOR hardening** — authed user pinned post-auth; every subscribe routes through an owner/admin ownership gate (fails closed). Previously any authed socket could subscribe to any runId and receive its content-bearing deltas.

## Frontend
`/activity` page + nav; `use-activity` = snapshot useQuery + 5s refetch + `wsClient.onAny` merge keyed by runId (subscribes only to snapshot runIds); rows grouped by mode (agent/model/status/live-progress), `ownerId` admin-only; explicit loading/empty/error/disconnected states.

## Gates
- **Security PASS** (veto): cross-tenant scoping, metadata-only no-leak (exact key allowlist test), WS-IDOR fix complete + not bypassable; no CRITICAL/HIGH/MEDIUM.
- **QA PASS**: tsc clean; unit **4755**; activity(11)+orchestrator+consensus+manager integration green; coverage activity 97% / authorize-run 100% / model-map 100% (ws/manager IDOR-gate fully tested; connection-handler layer needs live WS — documented).

Builds on the run modes #364-#367; observability over all of them.