### PR TITLE
fix: antigravity provider resolves catalog slug -> agy model label

### DIFF
--- a/server/gateway/providers/antigravity.ts
+++ b/server/gateway/providers/antigravity.ts
@@ -12,6 +12,17 @@
  *   - tool calling is NOT supported (the print transport has no tool channel);
  *     `complete()` always returns finishReason "stop" and no toolCalls.
  *   - `stream()` emulates streaming by yielding the full completion once.
+ *
+ * ── Model id resolution (fix/antigravity-model-label-resolution) ─────────────
+ * Callers pass either the catalog SLUG (e.g. "gemini-3-1-pro-low") OR the human
+ * LABEL (e.g. "Gemini 3.1 Pro (Low)"). The `agy` CLI only recognizes the LABEL;
+ * passing a slug makes `agy --print` drop into its default agentic mode and
+ * return empty stdout, which surfaces as `AntigravityCliError: empty output` and
+ * silently degrades every antigravity caller (consensus voters, the debate
+ * gemini critic, chat). `resolveModelLabel()` therefore maps an incoming id to a
+ * valid `agy` LABEL — using the live `agy models` label list — before invoking
+ * the CLI. The label list is loaded at most once (lazily, then cached); if it
+ * cannot be loaded the provider falls back gracefully without throwing.
  */
 import type {
   ILLMProvider,
@@ -40,6 +51,12 @@ function slugifyModelLabel(label: string): string {
 /** Rough characters-per-token ratio for estimating usage from byte counts. */
 const CHARS_PER_TOKEN = 4;
 
+/**
+ * Loads the live `agy models` LABELS. Injectable so tests can supply a fake
+ * roster (and assert it is called at most once). Defaults to the real CLI.
+ */
+export type ModelLabelLoader = () => Promise<string[]>;
+
 export interface AntigravityProviderConfig {
   /** Binary path or PATH-resolvable name. Defaults to "agy". */
   readonly binPath?: string;
@@ -47,6 +64,11 @@ export interface AntigravityProviderConfig {
   readonly defaultModel?: string;
   /** Default per-request timeout in milliseconds. */
   readonly timeoutMs?: number;
+  /**
+   * Override for the `agy models` label loader (testing/injection). Defaults to
+   * `listAntigravityModels(binPath, timeoutMs)`.
+   */
+  readonly loadModelLabels?: ModelLabelLoader;
 }
 
 /** Prefix a message with its role so the CLI sees clear turn boundaries. */
@@ -73,16 +95,79 @@ export class AntigravityProvider implements ILLMProvider {
   private readonly binPath: string;
   private readonly defaultModel: string;
   private readonly timeoutMs: number;
+  private readonly loadModelLabels: ModelLabelLoader;
+
+  /**
+   * Cached `agy models` LABELS. `undefined` until the first successful load;
+   * a failed load leaves it `undefined` so the next resolve retries (we do not
+   * permanently cache a failure — the CLI may simply have been mid-login).
+   */
+  private labelCache?: readonly string[];
+  /** In-flight load, so concurrent resolves share a single CLI call. */
+  private labelLoad?: Promise<readonly string[]>;
 
   constructor(config: AntigravityProviderConfig = {}) {
     this.binPath = config.binPath ?? DEFAULT_ANTIGRAVITY_BIN;
     this.defaultModel = config.defaultModel ?? DEFAULT_ANTIGRAVITY_MODEL;
     this.timeoutMs = config.timeoutMs ?? DEFAULT_ANTIGRAVITY_TIMEOUT_MS;
+    this.loadModelLabels =
+      config.loadModelLabels ??
+      (() => listAntigravityModels(this.binPath, this.timeoutMs));
   }
 
-  /** Resolve the subscription model label, preferring the caller's modelId. */
-  private resolveModel(modelId: string): string {
-    return modelId.trim().length > 0 ? modelId : this.defaultModel;
+  /**
+   * Return the cached `agy models` LABELS, loading them once on first use.
+   * Concurrent callers share the same in-flight load. On failure this returns
+   * `undefined` (the caller falls back gracefully) and clears the in-flight
+   * promise so a later resolve can retry — it never throws.
+   */
+  private async getModelLabels(): Promise<readonly string[] | undefined> {
+    if (this.labelCache) return this.labelCache;
+    if (!this.labelLoad) {
+      this.labelLoad = this.loadModelLabels()
+        .then((labels) => {
+          this.labelCache = labels;
+          return this.labelCache;
+        })
+        .finally(() => {
+          // Clear the in-flight handle so a failed load can be retried; on
+          // success the cache short-circuits before we ever reach here again.
+          this.labelLoad = undefined;
+        });
+    }
+    try {
+      return await this.labelLoad;
+    } catch {
+      // Graceful degradation: the label list is unavailable (CLI missing,
+      // not logged in, etc.). The caller falls back to the id/default.
+      return undefined;
+    }
+  }
+
+  /**
+   * Resolve an incoming model id (SLUG or LABEL) to a valid `agy` LABEL.
+   *
+   * Resolution order:
+   *   1. exact match against a known label  -> use it
+   *   2. some known label slugifies to the id -> use THAT label (slug -> label)
+   *   3. id is empty/whitespace               -> defaultModel
+   *   4. otherwise                            -> id as-is (last resort)
+   *
+   * Robust to the label cache being unavailable: with no labels it degrades to
+   * (3) for an empty id and (4) otherwise, and never throws.
+   */
+  async resolveModelLabel(modelId: string): Promise<string> {
+    const trimmed = modelId.trim();
+    const labels = await this.getModelLabels();
+
+    if (labels && trimmed.length > 0) {
+      if (labels.includes(trimmed)) return trimmed;
+      const bySlug = labels.find((label) => slugifyModelLabel(label) === trimmed);
+      if (bySlug) return bySlug;
+    }
+
+    if (trimmed.length === 0) return this.defaultModel;
+    return trimmed;
   }
 
   async complete(
@@ -94,9 +179,10 @@ export class AntigravityProvider implements ILLMProvider {
       throw new AntigravityCliError("AntigravityProvider: no messages to send");
     }
 
+    const model = await this.resolveModelLabel(modelId);
     const result = await invokeAntigravityCli({
       prompt: renderPrompt(messages),
-      model: this.resolveModel(modelId),
+      model,
       binPath: this.binPath,
       timeoutMs: options?.timeoutMs ?? this.timeoutMs,
       // Security H1: forward the caller abort signal so an aborted debate/

--- a/tests/unit/providers/antigravity-model-resolution.test.ts
+++ b/tests/unit/providers/antigravity-model-resolution.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Unit tests for AntigravityProvider model-id -> agy LABEL resolution
+ * (fix/antigravity-model-label-resolution).
+ *
+ * Root cause being fixed: callers (consensus voters, the debate gemini critic,
+ * chat) pass the catalog SLUG (e.g. "gemini-3-1-pro-low") as the model id, but
+ * the `agy` CLI only recognizes the HUMAN LABEL (e.g. "Gemini 3.1 Pro (Low)").
+ * The provider must resolve an incoming SLUG *or* LABEL to a valid label before
+ * invoking the CLI, using the live `agy models` label list.
+ *
+ * The label loader is INJECTED (a fake `loadModelLabels`) so:
+ *   - no real `agy` process is spawned,
+ *   - resolution is deterministic,
+ *   - the caching contract (load-once) is assertable via the loader call count.
+ *
+ * The CLI adapter (`invokeAntigravityCli`) is mocked to assert the `model` that
+ * reaches the CLI is the LABEL, not the slug.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ProviderMessage } from "../../../shared/types.js";
+
+// ─── Mock the CLI adapter (no real `agy` spawned) ────────────────────────────
+const invokeAntigravityCli = vi.fn();
+vi.mock("../../../server/gateway/providers/antigravity-cli.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../server/gateway/providers/antigravity-cli.js")
+  >("../../../server/gateway/providers/antigravity-cli.js");
+  return {
+    ...actual,
+    invokeAntigravityCli: (...args: unknown[]) => invokeAntigravityCli(...args),
+  };
+});
+
+import { AntigravityProvider } from "../../../server/gateway/providers/antigravity.js";
+
+const USER_MESSAGES: ProviderMessage[] = [{ role: "user", content: "What is 2+2?" }];
+
+/** The 8 roster labels exactly as `agy models` would report them. */
+const ROSTER_LABELS: readonly string[] = [
+  "Gemini 3.1 Pro (High)",
+  "Gemini 3.1 Pro (Low)",
+  "Gemini 3.5 Flash (High)",
+  "Gemini 3.5 Flash (Medium)",
+  "Gemini 3.5 Flash (Low)",
+  "GPT-OSS 120B (Medium)",
+  "Claude Sonnet 4.6 (Thinking)",
+  "Claude Opus 4.6 (Thinking)",
+];
+
+/** slug -> expected label, mirroring slugifyModelLabel(label) === slug. */
+const SLUG_TO_LABEL: ReadonlyArray<readonly [string, string]> = [
+  ["gemini-3-1-pro-high", "Gemini 3.1 Pro (High)"],
+  ["gemini-3-1-pro-low", "Gemini 3.1 Pro (Low)"],
+  ["gemini-3-5-flash-high", "Gemini 3.5 Flash (High)"],
+  ["gemini-3-5-flash-medium", "Gemini 3.5 Flash (Medium)"],
+  ["gemini-3-5-flash-low", "Gemini 3.5 Flash (Low)"],
+  ["gpt-oss-120b-medium", "GPT-OSS 120B (Medium)"],
+  ["claude-sonnet-4-6-thinking", "Claude Sonnet 4.6 (Thinking)"],
+  ["claude-opus-4-6-thinking", "Claude Opus 4.6 (Thinking)"],
+];
+
+function makeLoader(labels: readonly string[] = ROSTER_LABELS) {
+  return vi.fn(async () => [...labels]);
+}
+
+function mockCliText(text = "ok", promptBytes = 100): void {
+  invokeAntigravityCli.mockResolvedValueOnce({ text, promptBytes });
+}
+
+function cliModelArg(callIndex = 0): string {
+  return (invokeAntigravityCli.mock.calls[callIndex][0] as { model: string }).model;
+}
+
+describe("AntigravityProvider — resolveModelLabel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves a catalog SLUG to the live agy LABEL (the core fix)", async () => {
+    const loadModelLabels = makeLoader();
+    const provider = new AntigravityProvider({ loadModelLabels });
+
+    const label = await provider.resolveModelLabel("gemini-3-1-pro-low");
+
+    expect(label).toBe("Gemini 3.1 Pro (Low)");
+  });
+
+  it("passes an exact LABEL through unchanged", async () => {
+    const loadModelLabels = makeLoader();
+    const provider = new AntigravityProvider({ loadModelLabels });
+
+    const label = await provider.resolveModelLabel("Gemini 3.5 Flash (Medium)");
+
+    expect(label).toBe("Gemini 3.5 Flash (Medium)");
+  });
+
+  it("returns the default model when the id is empty/whitespace", async () => {
+    const loadModelLabels = makeLoader();
+    const provider = new AntigravityProvider({
+      loadModelLabels,
+      defaultModel: "Gemini 3.5 Flash (Medium)",
+    });
+
+    expect(await provider.resolveModelLabel("")).toBe("Gemini 3.5 Flash (Medium)");
+    expect(await provider.resolveModelLabel("   ")).toBe("Gemini 3.5 Flash (Medium)");
+  });
+
+  it("falls back to the id as-is for an unknown model (last resort)", async () => {
+    const loadModelLabels = makeLoader();
+    const provider = new AntigravityProvider({ loadModelLabels });
+
+    const label = await provider.resolveModelLabel("totally-unknown-model");
+
+    expect(label).toBe("totally-unknown-model");
+  });
+
+  it("falls back gracefully (no throw) when the label list cannot be loaded", async () => {
+    const loadModelLabels = vi.fn(async () => {
+      throw new Error("agy models failed: not logged in");
+    });
+    const provider = new AntigravityProvider({ loadModelLabels });
+
+    // A slug cannot be mapped without the list, so it falls back to the id as-is.
+    await expect(provider.resolveModelLabel("gemini-3-1-pro-low")).resolves.toBe(
+      "gemini-3-1-pro-low",
+    );
+  });
+
+  it("uses the default model on load failure when the id is empty", async () => {
+    const loadModelLabels = vi.fn(async () => {
+      throw new Error("agy models failed");
+    });
+    const provider = new AntigravityProvider({
+      loadModelLabels,
+      defaultModel: "Gemini 3.5 Flash (Medium)",
+    });
+
+    await expect(provider.resolveModelLabel("")).resolves.toBe("Gemini 3.5 Flash (Medium)");
+  });
+
+  it("round-trips every roster slug -> label", async () => {
+    const loadModelLabels = makeLoader();
+    const provider = new AntigravityProvider({ loadModelLabels });
+
+    for (const [slug, expectedLabel] of SLUG_TO_LABEL) {
+      expect(await provider.resolveModelLabel(slug)).toBe(expectedLabel);
+    }
+  });
+});
+
+describe("AntigravityProvider — caching the label list", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads the label list at most once across N resolves", async () => {
+    const loadModelLabels = makeLoader();
+    const provider = new AntigravityProvider({ loadModelLabels });
+
+    await provider.resolveModelLabel("gemini-3-1-pro-low");
+    await provider.resolveModelLabel("gemini-3-5-flash-high");
+    await provider.resolveModelLabel("Gemini 3.1 Pro (High)");
+
+    expect(loadModelLabels).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries the loader after a failed load (does not cache failure forever)", async () => {
+    const loadModelLabels = vi
+      .fn<[], Promise<string[]>>()
+      .mockRejectedValueOnce(new Error("transient agy failure"))
+      .mockResolvedValueOnce([...ROSTER_LABELS]);
+    const provider = new AntigravityProvider({ loadModelLabels });
+
+    // First resolve: load fails -> graceful fallback to id-as-is.
+    expect(await provider.resolveModelLabel("gemini-3-1-pro-low")).toBe("gemini-3-1-pro-low");
+    // Second resolve: loader retried, succeeds -> slug now maps to label.
+    expect(await provider.resolveModelLabel("gemini-3-1-pro-low")).toBe("Gemini 3.1 Pro (Low)");
+    expect(loadModelLabels).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("AntigravityProvider — complete() sends the LABEL to the CLI", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes the resolved LABEL (not the slug) to invokeAntigravityCli", async () => {
+    const loadModelLabels = makeLoader();
+    const provider = new AntigravityProvider({ loadModelLabels });
+    mockCliText("4", 40);
+
+    const result = await provider.complete("gemini-3-1-pro-low", USER_MESSAGES);
+
+    expect(cliModelArg()).toBe("Gemini 3.1 Pro (Low)");
+    expect(result.content).toBe("4");
+    expect(result.finishReason).toBe("stop");
+  });
+
+  it("only loads the label list once across multiple complete() calls", async () => {
+    const loadModelLabels = makeLoader();
+    const provider = new AntigravityProvider({ loadModelLabels });
+    mockCliText("a");
+    mockCliText("b");
+
+    await provider.complete("gemini-3-1-pro-low", USER_MESSAGES);
+    await provider.complete("gemini-3-5-flash-high", USER_MESSAGES);
+
+    expect(loadModelLabels).toHaveBeenCalledTimes(1);
+    expect(cliModelArg(0)).toBe("Gemini 3.1 Pro (Low)");
+    expect(cliModelArg(1)).toBe("Gemini 3.5 Flash (High)");
+  });
+
+  it("still sends a usable model when the label list fails to load", async () => {
+    const loadModelLabels = vi.fn(async () => {
+      throw new Error("agy models failed");
+    });
+    const provider = new AntigravityProvider({
+      loadModelLabels,
+      defaultModel: "Gemini 3.5 Flash (Medium)",
+    });
+    mockCliText("ok");
+
+    await provider.complete("", USER_MESSAGES);
+
+    expect(cliModelArg()).toBe("Gemini 3.5 Flash (Medium)");
+  });
+});


### PR DESCRIPTION
**Why all Gemini show `error` on /stats and all Claude `success`.**

`agy --model=<X>` needs the human LABEL (`"Gemini 3.1 Pro (Low)"`, per `agy models`), but callers pass the catalog SLUG (`"gemini-3-1-pro-low"`). `resolveModel` returned the slug verbatim → agy didn't recognize it, dropped into its agentic mode, and under `--print` returned **empty stdout** → `AntigravityCliError` → `status=error`. Claude was unaffected (its CLI ids opus/sonnet/haiku are valid as-is).

**Proven live:** same prompt — `--model="Gemini 3.1 Pro (Low)"` → clean JSON verdict; `--model="gemini-3-1-pro-low"` → agentic/empty.

**Impact (bigger than /stats cosmetics):** every antigravity path was silently degraded — consensus **voters fail-closed** to REQUEST_CHANGES (not real opinions) and the **debate gemini critic degraded to Opus-only** every time. No real multi-model deliberation had occurred.

**Fix:** `AntigravityProvider.resolveModelLabel` maps an incoming id (slug OR label) → a valid agy label (exact-label → `slugifyModelLabel(label)===id` → default/id-as-is). Labels lazy-loaded once from `agy models` + cached (single in-flight promise; failed load retries after CLI login); never throws (graceful fallback). CLI adapter contract unchanged.

12 new tests (8 roster models slug→label round-trip, cache load-once, retry-after-failure, `complete()` sends the LABEL); tsc clean; unit **4767**.