### PR TITLE
fix: scroll the New Task Group page when content overflows

### DIFF
--- a/client/src/pages/CreateTaskGroup.tsx
+++ b/client/src/pages/CreateTaskGroup.tsx
@@ -528,6 +528,7 @@ export default function CreateTaskGroup() {
   }
 
   return (
+    <div className="h-full overflow-y-auto">
     <div className="p-6 max-w-3xl mx-auto space-y-6">
       {/* Header */}
       <div className="flex items-center gap-4">
@@ -690,6 +691,7 @@ export default function CreateTaskGroup() {
           </div>
         </form>
       )}
+    </div>
     </div>
   );
 }


### PR DESCRIPTION
MainLayout's `<main>` is `overflow-hidden` and `CreateTaskGroup` had no scroll container of its own → a long group description + 3+ tasks ran off the bottom of the viewport with no way to scroll. Wrap the page body in `h-full overflow-y-auto`. tsc clean; CSS-only.