### PR TITLE
feat: edit task groups + execution history + Live Activity history

### DIFF
--- a/client/src/components/task-groups/task-form-logic.ts
+++ b/client/src/components/task-groups/task-form-logic.ts
@@ -1,0 +1,159 @@
+/**
+ * Pure task-group form logic — NO React/JSX/UI imports — so it is importable in
+ * the node-env vitest projects without jsdom (mirrors lib/activity.ts). The
+ * presentational TaskRow lives in task-form.tsx and re-exports everything here.
+ *
+ * dependsOn semantics differ by surface:
+ *  - CREATE: tasks have no server ids yet, so dependsOn is keyed by task NAME.
+ *  - EDIT: tasks exist on the server, so dependsOn is keyed by task ID.
+ * Either way `dependsOn` holds the same key as the surface's `task.id`, so the
+ * reducers below work for both.
+ */
+import type { TaskGroupStatus } from "@shared/types";
+
+export type ExecutionMode = "direct_llm" | "pipeline_run";
+
+export interface TaskDraft {
+  id: string;
+  name: string;
+  description: string;
+  executionMode: ExecutionMode;
+  dependsOn: string[];
+}
+
+export interface GroupDraft {
+  name: string;
+  description: string;
+  input: string;
+}
+
+/** A sibling option for the dependsOn picker: chip shows `name`, toggles `id`. */
+export interface SiblingOption {
+  id: string;
+  name: string;
+}
+
+export function emptyTask(): TaskDraft {
+  return {
+    id: crypto.randomUUID(),
+    name: "",
+    description: "",
+    executionMode: "direct_llm",
+    dependsOn: [],
+  };
+}
+
+/**
+ * Mirror of the server gating (the server is authoritative; the FE only avoids
+ * showing controls that would 409):
+ *  - `pending` → full edit (group name/description/input + tasks).
+ *  - terminal  → relabel only (group name/description).
+ *  - otherwise (running / ready / blocked) → read-only.
+ */
+export function isGroupEditable(status: string): boolean {
+  return status === "pending";
+}
+
+const TERMINAL_STATUSES: ReadonlySet<string> = new Set([
+  "completed",
+  "failed",
+  "cancelled",
+]);
+
+/** Terminal groups allow ONLY name/description relabel (no input, no tasks). */
+export function isGroupRelabelOnly(status: string): boolean {
+  return TERMINAL_STATUSES.has(status);
+}
+
+/** Toggle a dependency id on a task, immutably. */
+export function toggleDependency(task: TaskDraft, depId: string): TaskDraft {
+  const next = task.dependsOn.includes(depId)
+    ? task.dependsOn.filter((d) => d !== depId)
+    : [...task.dependsOn, depId];
+  return { ...task, dependsOn: next };
+}
+
+/** Replace one task in the list by id, immutably. */
+export function updateTaskInList(
+  tasks: readonly TaskDraft[],
+  id: string,
+  updated: TaskDraft,
+): TaskDraft[] {
+  return tasks.map((t) => (t.id === id ? updated : t));
+}
+
+/**
+ * Remove a task by id and strip its id from every sibling's dependsOn (mirrors
+ * the server, which strips the removed id from siblings on DELETE). Works for
+ * both id-spaces because dependsOn always holds the same key as `task.id`.
+ */
+export function removeTaskFromList(
+  tasks: readonly TaskDraft[],
+  id: string,
+): TaskDraft[] {
+  return tasks
+    .filter((t) => t.id !== id)
+    .map((t) => ({ ...t, dependsOn: t.dependsOn.filter((d) => d !== id) }));
+}
+
+/** Append a fresh empty task, immutably. */
+export function addTaskToList(tasks: readonly TaskDraft[]): TaskDraft[] {
+  return [...tasks, emptyTask()];
+}
+
+// ─── Validation ────────────────────────────────────────────────────────────────
+
+export interface ValidationErrors {
+  name?: string;
+  description?: string;
+  input?: string;
+  tasks?: string;
+  taskErrors?: Record<string, { name?: string; description?: string }>;
+}
+
+export interface ValidateOptions {
+  /** Skip the `input` requirement (terminal relabel mode has no input field). */
+  requireInput?: boolean;
+  /** Skip task validation (relabel-only mode does not edit tasks). */
+  requireTasks?: boolean;
+}
+
+export function validate(
+  group: GroupDraft,
+  tasks: readonly TaskDraft[],
+  options: ValidateOptions = { requireInput: true, requireTasks: true },
+): ValidationErrors {
+  const { requireInput = true, requireTasks = true } = options;
+  const errors: ValidationErrors = {};
+
+  if (!group.name.trim()) errors.name = "Name is required.";
+  if (!group.description.trim()) errors.description = "Description is required.";
+  if (requireInput && !group.input.trim()) errors.input = "Input is required.";
+
+  if (requireTasks) {
+    if (tasks.length === 0) errors.tasks = "Add at least one task.";
+
+    const taskErrors: Record<string, { name?: string; description?: string }> = {};
+    tasks.forEach((t) => {
+      const te: { name?: string; description?: string } = {};
+      if (!t.name.trim()) te.name = "Task name is required.";
+      if (!t.description.trim()) te.description = "Task description is required.";
+      if (Object.keys(te).length > 0) taskErrors[t.id] = te;
+    });
+    if (Object.keys(taskErrors).length > 0) errors.taskErrors = taskErrors;
+  }
+
+  return errors;
+}
+
+export function hasErrors(errors: ValidationErrors): boolean {
+  return (
+    !!errors.name ||
+    !!errors.description ||
+    !!errors.input ||
+    !!errors.tasks ||
+    (errors.taskErrors != null && Object.keys(errors.taskErrors).length > 0)
+  );
+}
+
+export type { TaskGroupStatus };

--- a/client/src/components/task-groups/task-form.tsx
+++ b/client/src/components/task-groups/task-form.tsx
@@ -1,0 +1,174 @@
+/**
+ * Shared task-group form pieces, used by BOTH CreateTaskGroup.tsx (create) and
+ * TaskGroup.tsx (edit mode). The PURE logic lives in ./task-form-logic (no React
+ * imports, node-testable without jsdom); this file owns the presentational
+ * TaskRow and re-exports the logic so callers have a single import surface.
+ *
+ * SECURITY: all task/group text is user-authored and rendered as INERT React
+ * text (value/children) — never via dangerouslySetInnerHTML.
+ */
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { Trash2 } from "lucide-react";
+import {
+  toggleDependency,
+  type TaskDraft,
+  type SiblingOption,
+  type ExecutionMode,
+} from "./task-form-logic";
+
+// Re-export the pure logic so existing import sites keep using "@/components/task-groups/task-form".
+export {
+  emptyTask,
+  isGroupEditable,
+  isGroupRelabelOnly,
+  toggleDependency,
+  updateTaskInList,
+  removeTaskFromList,
+  addTaskToList,
+  validate,
+  hasErrors,
+} from "./task-form-logic";
+export type {
+  ExecutionMode,
+  TaskDraft,
+  GroupDraft,
+  SiblingOption,
+  ValidationErrors,
+  ValidateOptions,
+  TaskGroupStatus,
+} from "./task-form-logic";
+
+// ─── TaskRow (presentational) ────────────────────────────────────────────────
+
+interface TaskRowProps {
+  task: TaskDraft;
+  index: number;
+  /** Sibling options for the dependsOn picker (chip = name, toggles id). */
+  siblings: readonly SiblingOption[];
+  onChange: (updated: TaskDraft) => void;
+  onRemove: () => void;
+  /** When true the row is read-only (no inputs, no remove). */
+  disabled?: boolean;
+}
+
+export function TaskRow({
+  task,
+  index,
+  siblings,
+  onChange,
+  onRemove,
+  disabled = false,
+}: TaskRowProps) {
+  return (
+    <Card className="relative">
+      <CardHeader className="pb-2 flex flex-row items-center justify-between">
+        <CardTitle className="text-sm font-medium text-muted-foreground">
+          Task {index + 1}
+        </CardTitle>
+        {!disabled && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-muted-foreground hover:text-red-500"
+            onClick={onRemove}
+            aria-label={`Remove task ${index + 1}`}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div className="space-y-1">
+            <Label htmlFor={`task-name-${task.id}`}>Name *</Label>
+            <Input
+              id={`task-name-${task.id}`}
+              placeholder="e.g. Summarise input"
+              value={task.name}
+              disabled={disabled}
+              onChange={(e) => onChange({ ...task, name: e.target.value })}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={`task-mode-${task.id}`}>Execution mode *</Label>
+            <Select
+              value={task.executionMode}
+              disabled={disabled}
+              onValueChange={(v) =>
+                onChange({ ...task, executionMode: v as ExecutionMode })
+              }
+            >
+              <SelectTrigger id={`task-mode-${task.id}`}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="direct_llm">Direct LLM</SelectItem>
+                <SelectItem value="pipeline_run">Pipeline run</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor={`task-desc-${task.id}`}>Description *</Label>
+          <Textarea
+            id={`task-desc-${task.id}`}
+            placeholder="What should this task do?"
+            rows={2}
+            value={task.description}
+            disabled={disabled}
+            onChange={(e) => onChange({ ...task, description: e.target.value })}
+          />
+        </div>
+
+        {siblings.length > 0 && (
+          <div className="space-y-1">
+            <Label>Depends on</Label>
+            <div
+              className="flex flex-wrap gap-2"
+              role="group"
+              aria-label="Dependencies"
+            >
+              {siblings.map((sibling) => {
+                const active = task.dependsOn.includes(sibling.id);
+                return (
+                  <button
+                    key={sibling.id}
+                    type="button"
+                    disabled={disabled}
+                    aria-pressed={active}
+                    onClick={() => onChange(toggleDependency(task, sibling.id))}
+                    className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <Badge
+                      className={
+                        active
+                          ? "bg-primary text-primary-foreground cursor-pointer"
+                          : "bg-muted text-muted-foreground cursor-pointer hover:bg-muted/70"
+                      }
+                    >
+                      {sibling.name || "(unnamed)"}
+                    </Badge>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/components/task-groups/timeline.ts
+++ b/client/src/components/task-groups/timeline.ts
@@ -1,0 +1,133 @@
+/**
+ * Pure helper that turns a task group's tasks into a read-only execution
+ * timeline for the TaskGroup page. Timeline-oriented and metadata-only: it
+ * surfaces statuses, durations, model/team and the start/end timestamps — never
+ * summary or error text (those stay behind the owner-gated detail in the page,
+ * which already comes from the owner-scoped GET :id).
+ *
+ * Unit-tested without a DOM renderer (the repo has no jsdom; see
+ * tests/unit/task-form.test.ts which also covers buildTimeline).
+ */
+
+/** Minimal task shape the timeline needs (subset of the GET :id task rows). */
+export interface TimelineTaskInput {
+  id: string;
+  name: string;
+  status: string;
+  executionMode?: string | null;
+  modelSlug?: string | null;
+  teamId?: string | null;
+  sortOrder?: number | null;
+  startedAt?: string | null;
+  completedAt?: string | null;
+}
+
+/** One row of the rendered timeline. */
+export interface TimelineEntry {
+  id: string;
+  name: string;
+  status: string;
+  executionMode: string | null;
+  modelSlug: string | null;
+  teamId: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  /** Wall-clock duration in ms when both timestamps are present, else null. */
+  durationMs: number | null;
+  /** True iff the task has actually started (has a startedAt). */
+  hasRun: boolean;
+}
+
+const TERMINAL: ReadonlySet<string> = new Set([
+  "completed",
+  "failed",
+  "cancelled",
+]);
+
+/** Parse an ISO timestamp to epoch ms, or null when absent/unparseable. */
+function toEpoch(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * Compute the duration of a task in ms. Uses startedAt→completedAt when both
+ * exist; returns null otherwise (a running task with no completedAt has no
+ * fixed duration, and the page renders "running"/"—" instead).
+ */
+export function taskDurationMs(task: TimelineTaskInput): number | null {
+  const start = toEpoch(task.startedAt);
+  const end = toEpoch(task.completedAt);
+  if (start === null || end === null) return null;
+  const delta = end - start;
+  return delta >= 0 ? delta : null;
+}
+
+/**
+ * Build the chronological timeline. Ordering rule:
+ *  1. Tasks that have started are ordered by startedAt ascending.
+ *  2. Tasks that have NOT started come after, ordered by sortOrder ascending
+ *     (their authored order), so a pending group still shows a stable timeline.
+ * The sort is stable for ties. Never mutates the input array.
+ */
+export function buildTimeline(
+  tasks: readonly TimelineTaskInput[],
+): TimelineEntry[] {
+  const entries = tasks.map((t) => {
+    const startedAt = t.startedAt ?? null;
+    return {
+      id: t.id,
+      name: t.name,
+      status: t.status,
+      executionMode: t.executionMode ?? null,
+      modelSlug: t.modelSlug ?? null,
+      teamId: t.teamId ?? null,
+      startedAt,
+      completedAt: t.completedAt ?? null,
+      durationMs: taskDurationMs(t),
+      hasRun: startedAt !== null,
+      _start: toEpoch(startedAt),
+      _sort: typeof t.sortOrder === "number" ? t.sortOrder : 0,
+    };
+  });
+
+  entries.sort((a, b) => {
+    // started tasks first, ordered by start time
+    if (a._start !== null && b._start !== null) return a._start - b._start;
+    if (a._start !== null) return -1;
+    if (b._start !== null) return 1;
+    // neither started → authored order
+    return a._sort - b._sort;
+  });
+
+  return entries.map(({ _start, _sort, ...entry }) => entry);
+}
+
+/** Whether every task in the timeline has reached a terminal state. */
+export function isTimelineComplete(entries: readonly TimelineEntry[]): boolean {
+  return entries.length > 0 && entries.every((e) => TERMINAL.has(e.status));
+}
+
+/** Total wall-clock span (earliest start → latest end) in ms, or null. */
+export function timelineSpanMs(
+  entries: readonly TimelineEntry[],
+): number | null {
+  const starts = entries
+    .map((e) => toEpoch(e.startedAt))
+    .filter((n): n is number => n !== null);
+  const ends = entries
+    .map((e) => toEpoch(e.completedAt))
+    .filter((n): n is number => n !== null);
+  if (starts.length === 0 || ends.length === 0) return null;
+  const span = Math.max(...ends) - Math.min(...starts);
+  return span >= 0 ? span : null;
+}
+
+/** Human-friendly duration label. Mirrors TaskGroupTrace.formatDuration. */
+export function formatDuration(ms: number | null): string {
+  if (ms === null || ms === 0) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${(ms / 60_000).toFixed(1)}m`;
+}

--- a/client/src/hooks/use-activity.ts
+++ b/client/src/hooks/use-activity.ts
@@ -19,16 +19,23 @@
  * The merge/grouping/subscription logic is pure (see @/lib/activity) and unit
  * tested; this hook is the thin React/WS wiring.
  */
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
 import { wsClient } from "@/lib/websocket";
-import type { WsEvent } from "@shared/types";
+import type { WsEvent, ActivityMode } from "@shared/types";
 import {
   mergeWsEvent,
   snapshotRunIds,
+  appendHistoryPage,
+  buildHistoryQuery,
+  emptyHistoryState,
+  hasMoreHistory,
   type ActivitySnapshot,
   type LiveActivityRun,
+  type ActivityHistoryPage,
+  type ActivityHistoryRow,
+  type HistoryState,
 } from "@/lib/activity";
 
 /** Snapshot poll interval (fallback refresh; also reconciles WS drift). */
@@ -114,5 +121,83 @@ export function useActivity(): UseActivityResult {
     isLoading: query.isLoading,
     error: query.error,
     isConnected,
+  };
+}
+
+// ─── Activity History (terminal runs, keyset-paginated) ────────────────────────
+/**
+ * useActivityHistory — manual keyset pagination over GET /api/activity/history.
+ *
+ * The snapshot lens (useActivity) shows what's running NOW; this shows past
+ * (terminal) runs across all modes. We page by cursor: the first request carries
+ * no cursor (newest page), and "Load more" re-queries with the previous page's
+ * nextCursor. Each fetched page is folded onto the accumulated list by the pure
+ * appendHistoryPage reducer (de-duped by mode:runId). The page rendering reuses
+ * the SAME row shape as the live tab (mode group, currentUnit, status badge,
+ * owner column for admins).
+ *
+ * The fetch/merge logic is pure (see @/lib/activity); this hook is the thin wiring.
+ */
+/** Default page size; the server clamps to ≤100 and buildHistoryQuery mirrors it. */
+export const ACTIVITY_HISTORY_PAGE_SIZE = 25;
+
+export interface UseActivityHistoryResult {
+  items: ActivityHistoryRow[];
+  isAdmin: boolean;
+  hasMore: boolean;
+  isLoading: boolean;
+  isFetchingMore: boolean;
+  error: unknown;
+  loadMore: () => void;
+}
+
+export function useActivityHistory(
+  mode: ActivityMode | null = null,
+): UseActivityHistoryResult {
+  // The cursor currently being requested. `null` = first/newest page.
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [state, setState] = useState<HistoryState>(emptyHistoryState);
+
+  const queryString = useMemo(
+    () =>
+      buildHistoryQuery({
+        limit: ACTIVITY_HISTORY_PAGE_SIZE,
+        cursor,
+        mode,
+      }),
+    [cursor, mode],
+  );
+
+  const query = useQuery<ActivityHistoryPage>({
+    // The mode is part of the key so switching mode refetches a fresh first page.
+    queryKey: ["/api/activity/history", mode, cursor],
+    queryFn: async () => {
+      const page = (await apiRequest(
+        "GET",
+        `/api/activity/history${queryString}`,
+      ).then((r) => r.json())) as ActivityHistoryPage;
+      // Fold synchronously so items/cursor stay consistent with this page.
+      setState((prev) => appendHistoryPage(prev, page, cursor === null));
+      return page;
+    },
+    // Each (mode,cursor) pair is fetched exactly once; pages are immutable.
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+  });
+
+  const loadMore = useCallback(() => {
+    if (state.nextCursor) setCursor(state.nextCursor);
+  }, [state.nextCursor]);
+
+  const isFirstPagePending = query.isLoading && cursor === null;
+
+  return {
+    items: state.items,
+    isAdmin: state.isAdmin,
+    hasMore: hasMoreHistory(state),
+    isLoading: isFirstPagePending,
+    isFetchingMore: query.isFetching && cursor !== null,
+    error: query.error,
+    loadMore,
   };
 }

--- a/client/src/hooks/use-task-groups.ts
+++ b/client/src/hooks/use-task-groups.ts
@@ -1,6 +1,80 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "./use-pipeline";
 
+// ─── Status-aware error ───────────────────────────────────────────────────────
+// The edit routes return 409 (non-pending / running) and 400 (cycle / dangling
+// dependency). The shared apiRequest() collapses everything to Error(message),
+// which loses the status the edit UI needs to phrase the inline message. This
+// small request keeps the HTTP status on a typed error so callers can branch.
+
+export class TaskGroupApiError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "TaskGroupApiError";
+    this.status = status;
+  }
+}
+
+function authHeaders(hasBody: boolean): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (hasBody) headers["Content-Type"] = "application/json";
+  const token = localStorage.getItem("auth_token");
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  return headers;
+}
+
+/** Like apiRequest, but throws a TaskGroupApiError carrying the HTTP status. */
+async function editRequest(
+  method: string,
+  url: string,
+  body?: unknown,
+): Promise<unknown> {
+  const res = await fetch(url, {
+    method,
+    headers: authHeaders(body !== undefined),
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+    credentials: "include",
+  });
+  if (!res.ok) {
+    const parsed = (await res
+      .json()
+      .catch(() => ({ message: res.statusText }))) as {
+      message?: string;
+      error?: string;
+    };
+    throw new TaskGroupApiError(
+      res.status,
+      parsed.message ?? parsed.error ?? res.statusText,
+    );
+  }
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+/**
+ * Translate an edit error into the inline message the UI shows. 409 = the group
+ * left the editable window (running, or input-after-terminal); 400 = the graph
+ * is invalid (cycle / dangling / self dependency). Anything else surfaces the
+ * server message verbatim.
+ */
+export function editErrorMessage(error: unknown): string {
+  if (error instanceof TaskGroupApiError) {
+    if (error.status === 409) {
+      return error.message || "Can't edit a running or completed group.";
+    }
+    if (error.status === 400) {
+      return (
+        error.message ||
+        "Invalid task graph (dependency cycle or dangling reference)."
+      );
+    }
+    return error.message;
+  }
+  if (error instanceof Error) return error.message;
+  return "Something went wrong.";
+}
+
 // ─── Queries ────────────────────────────────────────────────────────────────
 
 export function useTaskGroups() {
@@ -84,6 +158,85 @@ export function useRetryTask() {
     mutationFn: ({ groupId, taskId }: { groupId: string; taskId: string }) =>
       apiRequest("POST", `/api/task-groups/${groupId}/tasks/${taskId}/retry`),
     onSuccess: (_data, { groupId }) => {
+      qc.invalidateQueries({ queryKey: ["/api/task-groups", groupId] });
+    },
+  });
+}
+
+// ─── Edit mutations (status-aware; invalidate the group query) ─────────────────
+
+/** PATCH the group's own fields. `input` is rejected (409) once terminal. */
+export interface UpdateTaskGroupInput {
+  name?: string;
+  description?: string;
+  input?: string;
+}
+
+export function useUpdateTaskGroup(id: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: UpdateTaskGroupInput) =>
+      editRequest("PATCH", `/api/task-groups/${id}`, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["/api/task-groups", id] });
+      qc.invalidateQueries({ queryKey: ["/api/task-groups"] });
+    },
+  });
+}
+
+/** PATCH a single task. dependsOn is keyed by task id. 409 non-pending, 400 cycle. */
+export interface UpdateTaskInput {
+  name?: string;
+  description?: string;
+  executionMode?: "pipeline_run" | "direct_llm";
+  dependsOn?: string[];
+  modelSlug?: string | null;
+  teamId?: string | null;
+  pipelineId?: string | null;
+  sortOrder?: number;
+}
+
+export function useUpdateTask(groupId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ taskId, ...data }: { taskId: string } & UpdateTaskInput) =>
+      editRequest("PATCH", `/api/task-groups/${groupId}/tasks/${taskId}`, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["/api/task-groups", groupId] });
+    },
+  });
+}
+
+/** POST a new task to a pending group. */
+export interface AddTaskInput {
+  name: string;
+  description: string;
+  executionMode?: "pipeline_run" | "direct_llm";
+  dependsOn?: string[];
+  modelSlug?: string | null;
+  teamId?: string | null;
+  pipelineId?: string | null;
+  sortOrder?: number;
+}
+
+export function useAddTask(groupId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: AddTaskInput) =>
+      editRequest("POST", `/api/task-groups/${groupId}/tasks`, data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["/api/task-groups", groupId] });
+    },
+  });
+}
+
+/** DELETE a task; the server strips its id from siblings' dependsOn. */
+export function useDeleteTask(groupId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (taskId: string) =>
+      editRequest("DELETE", `/api/task-groups/${groupId}/tasks/${taskId}`),
+    onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["/api/task-groups", groupId] });
     },
   });

--- a/client/src/lib/activity.ts
+++ b/client/src/lib/activity.ts
@@ -1,13 +1,15 @@
 /**
  * Pure helpers + UI-facing types for the read-only "Live Activity" debugging
- * lens (GET /api/activity + the live WS deltas).
+ * lens (GET /api/activity + the live WS deltas) AND the Activity History tab
+ * (GET /api/activity/history, keyset-paginated).
  *
  * Mirrors the lib/orchestrator.ts / lib/news.ts model: the page + hook are thin,
  * and the logic that actually matters — the multi-run merge-by-runId reducer
  * that folds live WS deltas onto the polled snapshot, the mode grouping, the
- * runId set for ownership-scoped subscription, and the small display helpers —
- * lives here as pure functions that are unit-tested without a DOM renderer (the
- * repo has no jsdom; see tests/unit/orchestrator-ui.test.ts).
+ * runId set for ownership-scoped subscription, the history page concatenation,
+ * and the small display helpers — lives here as pure functions that are
+ * unit-tested without a DOM renderer (the repo has no jsdom; see
+ * tests/unit/orchestrator-ui.test.ts).
  *
  * SECURITY: every field surfaced through the Activity lens is metadata only and
  * ENUM/system-derived (mode, status, agent/team id, model slug, ids). The
@@ -18,10 +20,18 @@ import type {
   ActivityRun,
   ActivitySnapshot,
   ActivityMode,
+  ActivityHistoryRow,
+  ActivityHistoryPage,
   WsEvent,
 } from "@shared/types";
 
-export type { ActivityRun, ActivitySnapshot, ActivityMode };
+export type {
+  ActivityRun,
+  ActivitySnapshot,
+  ActivityMode,
+  ActivityHistoryRow,
+  ActivityHistoryPage,
+};
 
 /** The fixed display order of the mode groups on the page. */
 export const ACTIVITY_MODE_ORDER: readonly ActivityMode[] = [
@@ -29,6 +39,7 @@ export const ACTIVITY_MODE_ORDER: readonly ActivityMode[] = [
   "manager",
   "orchestrator",
   "consensus",
+  "task_group",
 ] as const;
 
 /** Human label for each mode group. */
@@ -37,6 +48,7 @@ export const ACTIVITY_MODE_LABELS: Record<ActivityMode, string> = {
   manager: "Manager loops",
   orchestrator: "Orchestrator runs",
   consensus: "Consensus runs",
+  task_group: "Task groups",
 };
 
 /** A mode group with its rows, ready to render. */
@@ -56,6 +68,27 @@ export function groupByMode(runs: readonly ActivityRun[]): ActivityGroup[] {
     label: ACTIVITY_MODE_LABELS[mode],
     runs: runs.filter((r) => r.mode === mode),
   })).filter((g) => g.runs.length > 0);
+}
+
+/** A history mode group with its rows, ready to render. */
+export interface ActivityHistoryGroup {
+  mode: ActivityMode;
+  label: string;
+  rows: ActivityHistoryRow[];
+}
+
+/**
+ * Group history rows by mode in the same fixed order. Empty modes are omitted.
+ * Rows within a mode keep their server order (newest-first keyset order).
+ */
+export function groupHistoryByMode(
+  rows: readonly ActivityHistoryRow[],
+): ActivityHistoryGroup[] {
+  return ACTIVITY_MODE_ORDER.map((mode) => ({
+    mode,
+    label: ACTIVITY_MODE_LABELS[mode],
+    rows: rows.filter((r) => r.mode === mode),
+  })).filter((g) => g.rows.length > 0);
 }
 
 /**
@@ -91,9 +124,22 @@ export interface LiveActivityRun extends ActivityRun {
   lastDeltaAt?: number;
 }
 
+/** The WS event types that keep a row feeling live between snapshot refetches. */
+const LIVE_EVENT_TYPES: ReadonlySet<WsEvent["type"]> = new Set<WsEvent["type"]>([
+  "stage:progress",
+  "manager:decision",
+  "orchestrator:step",
+  // task_group deltas: the orchestrator broadcasts these with runId = groupId.
+  "task:started",
+  "task:completed",
+  "task:failed",
+  "taskgroup:started",
+  "taskgroup:progress",
+]);
+
 /**
  * Immutably merge a single live WS event onto the current rows, keyed by
- * `event.runId`. Only the three additive live signals are merged:
+ * `event.runId`. The additive live signals merged are:
  *
  *  - `stage:progress`     → refreshes currentUnit.modelSlug, marks "running",
  *                           bumps the live `lastDeltaAt` pulse.
@@ -101,6 +147,10 @@ export interface LiveActivityRun extends ActivityRun {
  *                           marks "running", bumps the pulse.
  *  - `orchestrator:step`  → updates currentUnit.label/agent/modelSlug/status from
  *                           the step metadata, bumps the pulse.
+ *  - `task:started`/`task:completed`/`task:failed`/`taskgroup:started`/
+ *    `taskgroup:progress` (mode `task_group`, runId = groupId) → updates the
+ *    current task label/agent (team)/model/status, bumps the pulse. The snapshot
+ *    remains the source of truth for which group is active.
  *
  * Events for a runId NOT present in the snapshot are ignored (we only know about
  * — and only subscribe to — runs the snapshot returned). Events without a runId,
@@ -120,11 +170,7 @@ export function mergeWsEvent(
 ): LiveActivityRun[] {
   const runId = event.runId;
   if (!runId) return runs as LiveActivityRun[];
-  if (
-    event.type !== "stage:progress" &&
-    event.type !== "manager:decision" &&
-    event.type !== "orchestrator:step"
-  ) {
+  if (!LIVE_EVENT_TYPES.has(event.type)) {
     return runs as LiveActivityRun[];
   }
 
@@ -163,6 +209,18 @@ function applyDelta(
     };
   }
 
+  // task_group deltas (runId = groupId). The current "unit" is the task in
+  // motion; we surface its enum-derived name/team/model/status as metadata.
+  if (
+    event.type === "task:started" ||
+    event.type === "task:completed" ||
+    event.type === "task:failed" ||
+    event.type === "taskgroup:started" ||
+    event.type === "taskgroup:progress"
+  ) {
+    return applyTaskGroupDelta(row, event, payload, now);
+  }
+
   // stage:progress / manager:decision: keep the snapshot-derived label, refresh
   // the model + mark running. manager:decision also re-attributes the agent when
   // the payload carries a teamId.
@@ -179,6 +237,53 @@ function applyDelta(
         event.type === "manager:decision" && teamId ? teamId : baseUnit.agent,
       modelSlug: modelSlug ?? baseUnit.modelSlug,
       status: "running",
+    },
+    lastDeltaAt: now,
+  };
+}
+
+/**
+ * Fold a task-group WS delta onto the row's currentUnit. Metadata only:
+ * task name (label), team (agent), model slug, and an enum-derived status. Per-
+ * event-type status so a completed/failed task pulses with the right colour;
+ * taskgroup:* envelope events keep the prior unit but still pulse "live".
+ */
+function applyTaskGroupDelta(
+  row: LiveActivityRun,
+  event: WsEvent,
+  payload: Record<string, unknown>,
+  now: number,
+): LiveActivityRun {
+  const prevUnit = row.currentUnit;
+  const base = prevUnit ?? {
+    label: row.title,
+    agent: "task",
+    modelSlug: null,
+    status: "running",
+  };
+
+  // Envelope events carry no per-task fields → keep the unit, just pulse.
+  if (event.type === "taskgroup:started" || event.type === "taskgroup:progress") {
+    return { ...row, currentUnit: { ...base }, lastDeltaAt: now };
+  }
+
+  const name = payloadString(payload, "name");
+  const teamId = payloadString(payload, "teamId");
+  const modelSlug = payloadString(payload, "modelSlug");
+  const status =
+    event.type === "task:completed"
+      ? "completed"
+      : event.type === "task:failed"
+        ? "failed"
+        : "running";
+
+  return {
+    ...row,
+    currentUnit: {
+      label: name ?? base.label,
+      agent: teamId ?? base.agent,
+      modelSlug: modelSlug ?? base.modelSlug,
+      status,
     },
     lastDeltaAt: now,
   };
@@ -210,4 +315,79 @@ export function isLiveNow(
 /** Display a model slug, or an em-dash placeholder when unknown. */
 export function displayModel(modelSlug: string | null | undefined): string {
   return modelSlug && modelSlug.length > 0 ? modelSlug : "—";
+}
+
+// ─── Activity History (keyset pagination) ──────────────────────────────────────
+
+/** Accumulated history state the hook/page consume. */
+export interface HistoryState {
+  items: ActivityHistoryRow[];
+  nextCursor: string | null;
+  isAdmin: boolean;
+}
+
+/** Empty starting state before the first page lands. */
+export function emptyHistoryState(): HistoryState {
+  return { items: [], nextCursor: null, isAdmin: false };
+}
+
+/** Stable de-dupe key for a history row (runId is groupId for task_group). */
+export function historyRowKey(row: ActivityHistoryRow): string {
+  return `${row.mode}:${row.runId}`;
+}
+
+/**
+ * Fold one fetched page onto the accumulated history state. The first page
+ * (cursor === null in the request) REPLACES the list; subsequent pages APPEND.
+ * De-dupes by `${mode}:${runId}` so a row that straddles a keyset boundary (or a
+ * re-fetched first page) is never shown twice. Never mutates its inputs.
+ *
+ * `isFirstPage` mirrors "the request carried no cursor": true on initial load /
+ * refresh, false when paging with a nextCursor.
+ */
+export function appendHistoryPage(
+  prev: HistoryState,
+  page: ActivityHistoryPage,
+  isFirstPage: boolean,
+): HistoryState {
+  const baseItems = isFirstPage ? [] : prev.items;
+  const seen = new Set(baseItems.map(historyRowKey));
+  const merged = baseItems.slice();
+  for (const row of page.items) {
+    const key = historyRowKey(row);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(row);
+  }
+  return {
+    items: merged,
+    nextCursor: page.nextCursor,
+    isAdmin: page.isAdmin,
+  };
+}
+
+/** Whether there is another page to load. */
+export function hasMoreHistory(state: HistoryState): boolean {
+  return state.nextCursor !== null;
+}
+
+/**
+ * Build the `GET /api/activity/history` query string from page params. `limit`
+ * is clamped to the server's ≤100 ceiling defensively; `cursor`/`mode` are only
+ * appended when present. Returns the leading "?" or "" when empty.
+ */
+export function buildHistoryQuery(params: {
+  limit?: number;
+  cursor?: string | null;
+  mode?: ActivityMode | null;
+}): string {
+  const search = new URLSearchParams();
+  if (typeof params.limit === "number" && Number.isFinite(params.limit)) {
+    const clamped = Math.max(1, Math.min(100, Math.floor(params.limit)));
+    search.set("limit", String(clamped));
+  }
+  if (params.cursor) search.set("cursor", params.cursor);
+  if (params.mode) search.set("mode", params.mode);
+  const qs = search.toString();
+  return qs ? `?${qs}` : "";
 }

--- a/client/src/pages/Activity.tsx
+++ b/client/src/pages/Activity.tsx
@@ -1,32 +1,35 @@
 /**
- * Activity — a read-only "Live Activity" debugging lens at /activity.
+ * Activity — a read-only debugging lens at /activity with two tabs:
  *
- * Shows what's running RIGHT NOW across the four run modes (pipeline / manager /
- * orchestrator / consensus): for each active run, the current unit's label, the
- * agent/role, the model, and a status badge, with a live pulse when WS deltas
- * are flowing. The owner column is shown only to admins.
+ *  - "Live": what's running RIGHT NOW across the five run modes (pipeline /
+ *    manager / orchestrator / consensus / task_group). Seeds from the polled
+ *    GET /api/activity snapshot and merges additive live WS deltas onto the rows.
+ *  - "History": past (terminal) runs across all modes, from
+ *    GET /api/activity/history (keyset-paginated, "Load more" via nextCursor).
  *
- * Data flow: useActivity() seeds from the polled GET /api/activity snapshot and
- * merges the additive live WS deltas (stage:progress / manager:decision /
- * orchestrator:step) onto the rows. Consensus emits no WS events, so its rows
- * are refresh-only — covered by the 5s refetch.
+ * Both tabs render the SAME row shape (mode group, title, current/last unit
+ * label·agent·model, status badge, started/completed, owner column for admins).
  *
  * SECURITY: every string rendered here is run metadata only (mode, status,
- * agent/team id, model slug, ids) and is rendered as INERT React text. There is
- * no HTML sink and no transcript/prompt/task text (the backend strips those).
+ * agent/role id, model slug, ids, FIXED mode-label titles) and is rendered as
+ * INERT React text. There is no HTML sink and no transcript/prompt/task text
+ * (the backend strips those and builds the history rows by allowlist).
  */
 import type { ReactNode } from "react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Activity as ActivityIcon, WifiOff, AlertTriangle, Loader2 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-import { useActivity } from "@/hooks/use-activity";
+import { useActivity, useActivityHistory } from "@/hooks/use-activity";
 import {
   groupByMode,
+  groupHistoryByMode,
   displayModel,
   isLiveNow,
   type ActivityGroup,
+  type ActivityHistoryGroup,
+  type ActivityHistoryRow,
   type LiveActivityRun,
 } from "@/lib/activity";
 
@@ -57,6 +60,13 @@ function StatusPill({ status }: { status: string }) {
       {status}
     </Badge>
   );
+}
+
+/** Local time, or an em-dash placeholder. */
+function displayTime(iso: string | null): string {
+  if (!iso) return "—";
+  const ms = Date.parse(iso);
+  return Number.isFinite(ms) ? new Date(ms).toLocaleString() : "—";
 }
 
 // ─── States (loading / empty / error / disconnected) ──────────────────────────────
@@ -94,7 +104,7 @@ function errorMessage(err: unknown): string {
   return "Could not load activity.";
 }
 
-// ─── Run row ──────────────────────────────────────────────────────────────────────
+// ─── Live run row ───────────────────────────────────────────────────────────────
 
 interface RunRowProps {
   run: LiveActivityRun;
@@ -145,7 +155,49 @@ function RunRow({ run, isAdmin, now }: RunRowProps) {
   );
 }
 
-function GroupTable({
+// ─── History row (same column shape, timestamps instead of a live pulse) ──────────
+
+function HistoryRow({ row, isAdmin }: { row: ActivityHistoryRow; isAdmin: boolean }) {
+  const unit = row.currentUnit;
+  const unitStatus = unit?.status ?? row.status;
+  return (
+    <tr className="border-t border-border align-top">
+      <td className="px-3 py-2">
+        <span className="flex flex-col">
+          <span className="text-sm font-medium leading-tight">{row.title}</span>
+          <span className="font-mono text-[10px] text-muted-foreground">{row.runId}</span>
+        </span>
+      </td>
+      <td className="px-3 py-2 text-sm">{unit ? unit.label : "—"}</td>
+      <td className="px-3 py-2 text-sm">{unit ? unit.agent : "—"}</td>
+      <td className="px-3 py-2">
+        <span className="font-mono text-xs text-muted-foreground">
+          {displayModel(unit?.modelSlug)}
+        </span>
+      </td>
+      <td className="px-3 py-2">
+        <StatusPill status={unitStatus} />
+      </td>
+      <td className="px-3 py-2">
+        <span className="text-xs text-muted-foreground">{displayTime(row.startedAt)}</span>
+      </td>
+      <td className="px-3 py-2">
+        <span className="text-xs text-muted-foreground">{displayTime(row.completedAt)}</span>
+      </td>
+      {isAdmin && (
+        <td className="px-3 py-2">
+          <span className="font-mono text-xs text-muted-foreground">
+            {row.ownerId ?? "—"}
+          </span>
+        </td>
+      )}
+    </tr>
+  );
+}
+
+// ─── Mode-group tables ────────────────────────────────────────────────────────────
+
+function LiveGroupTable({
   group,
   isAdmin,
   now,
@@ -183,7 +235,7 @@ function GroupTable({
             </thead>
             <tbody>
               {group.runs.map((run) => (
-                <RunRow key={run.runId} run={run} isAdmin={isAdmin} now={now} />
+                <RunRow key={run.runId} run={run as LiveActivityRun} isAdmin={isAdmin} now={now} />
               ))}
             </tbody>
           </table>
@@ -193,75 +245,259 @@ function GroupTable({
   );
 }
 
+function HistoryGroupTable({
+  group,
+  isAdmin,
+}: {
+  group: ActivityHistoryGroup;
+  isAdmin: boolean;
+}) {
+  const headingId = `history-group-${group.mode}`;
+  return (
+    <Card aria-labelledby={headingId}>
+      <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0 py-4">
+        <CardTitle id={headingId} className="text-sm">
+          {group.label}
+        </CardTitle>
+        <Badge variant="secondary" className="tabular-nums">
+          {group.rows.length}
+        </Badge>
+      </CardHeader>
+      <CardContent className="px-0 pb-2">
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse text-left">
+            <caption className="sr-only">{`Past ${group.label.toLowerCase()}`}</caption>
+            <thead>
+              <tr className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                <th scope="col" className="px-3 pb-2 font-medium">Run</th>
+                <th scope="col" className="px-3 pb-2 font-medium">Last unit</th>
+                <th scope="col" className="px-3 pb-2 font-medium">Agent</th>
+                <th scope="col" className="px-3 pb-2 font-medium">Model</th>
+                <th scope="col" className="px-3 pb-2 font-medium">Status</th>
+                <th scope="col" className="px-3 pb-2 font-medium">Started</th>
+                <th scope="col" className="px-3 pb-2 font-medium">Completed</th>
+                {isAdmin && (
+                  <th scope="col" className="px-3 pb-2 font-medium">Owner</th>
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {group.rows.map((row) => (
+                <HistoryRow
+                  key={`${row.mode}:${row.runId}`}
+                  row={row}
+                  isAdmin={isAdmin}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Tabs ───────────────────────────────────────────────────────────────────────
+
+type TabKey = "live" | "history";
+
+const TABS: ReadonlyArray<{ key: TabKey; label: string }> = [
+  { key: "live", label: "Live" },
+  { key: "history", label: "History" },
+];
+
+function TabBar({
+  active,
+  onSelect,
+}: {
+  active: TabKey;
+  onSelect: (key: TabKey) => void;
+}) {
+  return (
+    <div role="tablist" aria-label="Activity view" className="flex gap-1 border-b border-border">
+      {TABS.map((tab) => {
+        const selected = tab.key === active;
+        return (
+          <button
+            key={tab.key}
+            type="button"
+            role="tab"
+            id={`activity-tab-${tab.key}`}
+            aria-selected={selected}
+            aria-controls={`activity-panel-${tab.key}`}
+            tabIndex={selected ? 0 : -1}
+            onClick={() => onSelect(tab.key)}
+            className={cn(
+              "-mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              selected
+                ? "border-foreground text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Live panel ───────────────────────────────────────────────────────────────────
+
+function LivePanel() {
+  const { runs, isAdmin, truncated, isLoading, error, isConnected } = useActivity();
+  // A single render-time clock for the live pulse so every row agrees.
+  const now = Date.now();
+  const groups = useMemo(() => groupByMode(runs), [runs]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-muted-foreground">
+        Read-only view of currently active runs. Refreshes every 5s and merges
+        live updates. Metadata only — no transcripts.
+      </p>
+
+      {!isConnected && (
+        <span
+          className="inline-flex w-fit items-center gap-1.5 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-xs font-medium text-amber-600"
+          role="status"
+        >
+          <WifiOff className="h-3.5 w-3.5" aria-hidden />
+          Live updates disconnected — polling
+        </span>
+      )}
+
+      {truncated && (
+        <div
+          className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-600"
+          role="status"
+        >
+          <AlertTriangle className="h-3.5 w-3.5 shrink-0" aria-hidden />
+          The list was capped. Some active runs are not shown.
+        </div>
+      )}
+
+      {isLoading ? (
+        <CenteredState
+          icon={<Loader2 className="h-5 w-5 motion-safe:animate-spin" />}
+          title="Loading activity…"
+        />
+      ) : error ? (
+        <CenteredState
+          tone="destructive"
+          icon={<AlertTriangle className="h-5 w-5" />}
+          title="Could not load activity"
+          description={errorMessage(error)}
+        />
+      ) : groups.length === 0 ? (
+        <CenteredState
+          icon={<ActivityIcon className="h-5 w-5" />}
+          title="No active runs"
+          description="Nothing is running right now. This view updates automatically when a run starts."
+        />
+      ) : (
+        <div className="flex flex-col gap-4">
+          {groups.map((group) => (
+            <LiveGroupTable key={group.mode} group={group} isAdmin={isAdmin} now={now} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── History panel ──────────────────────────────────────────────────────────────
+
+function HistoryPanel() {
+  const { items, isAdmin, hasMore, isLoading, isFetchingMore, error, loadMore } =
+    useActivityHistory();
+  const groups = useMemo(() => groupHistoryByMode(items), [items]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-muted-foreground">
+        Read-only history of past runs across all modes. Metadata only — no
+        transcripts.
+      </p>
+
+      {isLoading ? (
+        <CenteredState
+          icon={<Loader2 className="h-5 w-5 motion-safe:animate-spin" />}
+          title="Loading history…"
+        />
+      ) : error ? (
+        <CenteredState
+          tone="destructive"
+          icon={<AlertTriangle className="h-5 w-5" />}
+          title="Could not load history"
+          description={errorMessage(error)}
+        />
+      ) : groups.length === 0 ? (
+        <CenteredState
+          icon={<ActivityIcon className="h-5 w-5" />}
+          title="No past runs"
+          description="Completed, failed, and cancelled runs will appear here."
+        />
+      ) : (
+        <>
+          <div className="flex flex-col gap-4">
+            {groups.map((group) => (
+              <HistoryGroupTable key={group.mode} group={group} isAdmin={isAdmin} />
+            ))}
+          </div>
+          {hasMore && (
+            <div className="flex justify-center">
+              <button
+                type="button"
+                onClick={loadMore}
+                disabled={isFetchingMore}
+                className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+              >
+                {isFetchingMore && (
+                  <Loader2 className="h-3.5 w-3.5 motion-safe:animate-spin" aria-hidden />
+                )}
+                {isFetchingMore ? "Loading…" : "Load more"}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
 // ─── Page ────────────────────────────────────────────────────────────────────────
 
 export default function Activity() {
-  const { runs, isAdmin, truncated, isLoading, error, isConnected } = useActivity();
-
-  // A single render-time clock for the live pulse so every row agrees. The 5s
-  // refetch + WS events drive re-renders, which is frequent enough for a 10s
-  // pulse window.
-  const now = Date.now();
-  const groups = useMemo(() => groupByMode(runs), [runs]);
+  const [tab, setTab] = useState<TabKey>("live");
 
   return (
     <div className="flex h-full flex-col">
       <header className="flex items-center gap-3 border-b border-border px-6 py-4">
         <ActivityIcon className="h-5 w-5 text-muted-foreground" aria-hidden />
-        <h1 className="text-lg font-semibold tracking-tight">Live Activity</h1>
-        {!isConnected && (
-          <span
-            className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-xs font-medium text-amber-600"
-            role="status"
-          >
-            <WifiOff className="h-3.5 w-3.5" aria-hidden />
-            Live updates disconnected — polling
-          </span>
-        )}
+        <h1 className="text-lg font-semibold tracking-tight">Activity</h1>
       </header>
 
       <div className="flex-1 overflow-auto p-6">
         <div className="mx-auto flex max-w-4xl flex-col gap-4">
-          <p className="text-sm text-muted-foreground">
-            Read-only view of currently active runs. Refreshes every 5s and merges
-            live updates. Metadata only — no transcripts.
-          </p>
+          <TabBar active={tab} onSelect={setTab} />
 
-          {truncated && (
-            <div
-              className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-600"
-              role="status"
-            >
-              <AlertTriangle className="h-3.5 w-3.5 shrink-0" aria-hidden />
-              The list was capped. Some active runs are not shown.
-            </div>
-          )}
-
-          {isLoading ? (
-            <CenteredState
-              icon={<Loader2 className="h-5 w-5 motion-safe:animate-spin" />}
-              title="Loading activity…"
-            />
-          ) : error ? (
-            <CenteredState
-              tone="destructive"
-              icon={<AlertTriangle className="h-5 w-5" />}
-              title="Could not load activity"
-              description={errorMessage(error)}
-            />
-          ) : groups.length === 0 ? (
-            <CenteredState
-              icon={<ActivityIcon className="h-5 w-5" />}
-              title="No active runs"
-              description="Nothing is running right now. This view updates automatically when a run starts."
-            />
-          ) : (
-            <div className="flex flex-col gap-4">
-              {groups.map((group) => (
-                <GroupTable key={group.mode} group={group} isAdmin={isAdmin} now={now} />
-              ))}
-            </div>
-          )}
+          <div
+            role="tabpanel"
+            id="activity-panel-live"
+            aria-labelledby="activity-tab-live"
+            hidden={tab !== "live"}
+          >
+            {tab === "live" && <LivePanel />}
+          </div>
+          <div
+            role="tabpanel"
+            id="activity-panel-history"
+            aria-labelledby="activity-tab-history"
+            hidden={tab !== "history"}
+          >
+            {tab === "history" && <HistoryPanel />}
+          </div>
         </div>
       </div>
     </div>

--- a/client/src/pages/CreateTaskGroup.tsx
+++ b/client/src/pages/CreateTaskGroup.tsx
@@ -10,27 +10,24 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
-import { ArrowLeft, Plus, Trash2, Wand2, ExternalLink } from "lucide-react";
+import { ArrowLeft, Plus, Wand2, ExternalLink } from "lucide-react";
 import { Link } from "wouter";
+import {
+  TaskRow,
+  emptyTask,
+  validate,
+  hasErrors,
+  addTaskToList,
+  removeTaskFromList,
+  updateTaskInList,
+  type TaskDraft,
+  type GroupDraft,
+  type SiblingOption,
+} from "@/components/task-groups/task-form";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
-type ExecutionMode = "direct_llm" | "pipeline_run";
 type ViewMode = "manual" | "submit-work";
-
-interface TaskDraft {
-  id: string;
-  name: string;
-  description: string;
-  executionMode: ExecutionMode;
-  dependsOn: string[];
-}
-
-interface GroupDraft {
-  name: string;
-  description: string;
-  input: string;
-}
 
 interface SplitTaskPreview {
   name: string;
@@ -38,166 +35,6 @@ interface SplitTaskPreview {
   conditionsOfDone: string[];
   tests: string[];
   dependsOn?: string[];
-}
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function emptyTask(): TaskDraft {
-  return {
-    id: crypto.randomUUID(),
-    name: "",
-    description: "",
-    executionMode: "direct_llm",
-    dependsOn: [],
-  };
-}
-
-// ─── Sub-component: single task row ──────────────────────────────────────────
-
-interface TaskRowProps {
-  task: TaskDraft;
-  index: number;
-  siblingNames: string[];
-  onChange: (updated: TaskDraft) => void;
-  onRemove: () => void;
-}
-
-function TaskRow({ task, index, siblingNames, onChange, onRemove }: TaskRowProps) {
-  function toggleDep(name: string) {
-    const next = task.dependsOn.includes(name)
-      ? task.dependsOn.filter((d) => d !== name)
-      : [...task.dependsOn, name];
-    onChange({ ...task, dependsOn: next });
-  }
-
-  return (
-    <Card className="relative">
-      <CardHeader className="pb-2 flex flex-row items-center justify-between">
-        <CardTitle className="text-sm font-medium text-muted-foreground">
-          Task {index + 1}
-        </CardTitle>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7 text-muted-foreground hover:text-red-500"
-          onClick={onRemove}
-        >
-          <Trash2 className="h-4 w-4" />
-        </Button>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <div className="space-y-1">
-            <Label htmlFor={`task-name-${task.id}`}>Name *</Label>
-            <Input
-              id={`task-name-${task.id}`}
-              placeholder="e.g. Summarise input"
-              value={task.name}
-              onChange={(e) => onChange({ ...task, name: e.target.value })}
-            />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor={`task-mode-${task.id}`}>Execution mode *</Label>
-            <Select
-              value={task.executionMode}
-              onValueChange={(v) =>
-                onChange({ ...task, executionMode: v as ExecutionMode })
-              }
-            >
-              <SelectTrigger id={`task-mode-${task.id}`}>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="direct_llm">Direct LLM</SelectItem>
-                <SelectItem value="pipeline_run">Pipeline run</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-        </div>
-
-        <div className="space-y-1">
-          <Label htmlFor={`task-desc-${task.id}`}>Description *</Label>
-          <Textarea
-            id={`task-desc-${task.id}`}
-            placeholder="What should this task do?"
-            rows={2}
-            value={task.description}
-            onChange={(e) => onChange({ ...task, description: e.target.value })}
-          />
-        </div>
-
-        {siblingNames.length > 0 && (
-          <div className="space-y-1">
-            <Label>Depends on</Label>
-            <div className="flex flex-wrap gap-2">
-              {siblingNames.map((name) => {
-                const active = task.dependsOn.includes(name);
-                return (
-                  <button
-                    key={name}
-                    type="button"
-                    onClick={() => toggleDep(name)}
-                    className="focus:outline-none"
-                  >
-                    <Badge
-                      className={
-                        active
-                          ? "bg-primary text-primary-foreground cursor-pointer"
-                          : "bg-muted text-muted-foreground cursor-pointer hover:bg-muted/70"
-                      }
-                    >
-                      {name}
-                    </Badge>
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
-
-// ─── Validation ───────────────────────────────────────────────────────────────
-
-interface ValidationErrors {
-  name?: string;
-  description?: string;
-  input?: string;
-  tasks?: string;
-  taskErrors?: Record<string, { name?: string; description?: string }>;
-}
-
-function validate(group: GroupDraft, tasks: TaskDraft[]): ValidationErrors {
-  const errors: ValidationErrors = {};
-
-  if (!group.name.trim()) errors.name = "Name is required.";
-  if (!group.description.trim()) errors.description = "Description is required.";
-  if (!group.input.trim()) errors.input = "Input is required.";
-  if (tasks.length === 0) errors.tasks = "Add at least one task.";
-
-  const taskErrors: Record<string, { name?: string; description?: string }> = {};
-  tasks.forEach((t) => {
-    const te: { name?: string; description?: string } = {};
-    if (!t.name.trim()) te.name = "Task name is required.";
-    if (!t.description.trim()) te.description = "Task description is required.";
-    if (Object.keys(te).length > 0) taskErrors[t.id] = te;
-  });
-  if (Object.keys(taskErrors).length > 0) errors.taskErrors = taskErrors;
-
-  return errors;
-}
-
-function hasErrors(errors: ValidationErrors): boolean {
-  return (
-    !!errors.name ||
-    !!errors.description ||
-    !!errors.input ||
-    !!errors.tasks ||
-    (errors.taskErrors != null && Object.keys(errors.taskErrors).length > 0)
-  );
 }
 
 // ─── Submit Work sub-component ────────────────────────────────────────────────
@@ -485,17 +322,21 @@ export default function CreateTaskGroup() {
   const errors = validate(group, tasks);
 
   function updateTask(id: string, updated: TaskDraft) {
-    setTasks((prev) => prev.map((t) => (t.id === id ? updated : t)));
+    setTasks((prev) => updateTaskInList(prev, id, updated));
   }
 
   function removeTask(id: string) {
+    // In CREATE mode dependsOn is keyed by NAME, so re-key the removed task's
+    // name out of siblings (the shared reducer strips by the same key it removes).
     setTasks((prev) => {
-      const remaining = prev.filter((t) => t.id !== id);
       const removedName = prev.find((t) => t.id === id)?.name ?? "";
-      return remaining.map((t) => ({
-        ...t,
-        dependsOn: t.dependsOn.filter((d) => d !== removedName),
-      }));
+      const remaining = removeTaskFromList(prev, id);
+      return removedName
+        ? remaining.map((t) => ({
+            ...t,
+            dependsOn: t.dependsOn.filter((d) => d !== removedName),
+          }))
+        : remaining;
     });
   }
 
@@ -629,7 +470,7 @@ export default function CreateTaskGroup() {
                 type="button"
                 variant="outline"
                 size="sm"
-                onClick={() => setTasks((prev) => [...prev, emptyTask()])}
+                onClick={() => setTasks((prev) => addTaskToList(prev))}
               >
                 <Plus className="h-4 w-4 mr-2" />
                 Add task
@@ -641,9 +482,11 @@ export default function CreateTaskGroup() {
             )}
 
             {tasks.map((task, index) => {
-              const siblingNames = tasks
+              // CREATE mode: dependsOn is keyed by NAME, so the sibling id is the
+              // sibling's name (chip shows the same name). Only named siblings.
+              const siblings: SiblingOption[] = tasks
                 .filter((t) => t.id !== task.id && t.name.trim() !== "")
-                .map((t) => t.name.trim());
+                .map((t) => ({ id: t.name.trim(), name: t.name.trim() }));
 
               const taskErr = errors.taskErrors?.[task.id];
 
@@ -652,7 +495,7 @@ export default function CreateTaskGroup() {
                   <TaskRow
                     task={task}
                     index={index}
-                    siblingNames={siblingNames}
+                    siblings={siblings}
                     onChange={(updated) => updateTask(task.id, updated)}
                     onRemove={() => removeTask(task.id)}
                   />

--- a/client/src/pages/TaskGroup.tsx
+++ b/client/src/pages/TaskGroup.tsx
@@ -1,12 +1,79 @@
+/**
+ * Task Group detail page.
+ *
+ * Three surfaces share this page:
+ *  - the read-only run view (tasks + live activity stream + progress) — the
+ *    default;
+ *  - an EDIT mode (status-driven, mirrors the server which is authoritative):
+ *      pending  → full edit (group name/description/input + add/remove/edit
+ *                 tasks + dependsOn-by-id);
+ *      terminal → relabel only (group name/description);
+ *      running  → no edit controls (read-only).
+ *    Edit errors surface inline: 409 = "Can't edit a running/completed group",
+ *    400 = "Dependency cycle / dangling reference";
+ *  - a read-only TIMELINE panel (buildTimeline) showing each task's
+ *    status + startedAt→completedAt duration + model/team in chronological order.
+ *    Summary/error stay behind the owner-gated detail (GET :id is owner-scoped).
+ *
+ * SECURITY: all group/task text is user-authored and rendered as INERT React
+ * text — never via dangerouslySetInnerHTML.
+ */
 import { useRoute } from "wouter";
-import { useTaskGroup, useStartTaskGroup, useCancelTaskGroup, useRetryTask } from "@/hooks/use-task-groups";
+import {
+  useTaskGroup,
+  useStartTaskGroup,
+  useCancelTaskGroup,
+  useRetryTask,
+  useUpdateTaskGroup,
+  useUpdateTask,
+  useAddTask,
+  useDeleteTask,
+  editErrorMessage,
+} from "@/hooks/use-task-groups";
 import { useTaskGroupEvents } from "@/hooks/use-task-events";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
-import { Play, XCircle, RotateCcw, ArrowLeft, CheckCircle2, Clock, Loader2, AlertCircle, Ban, Activity } from "lucide-react";
+import {
+  Play,
+  XCircle,
+  RotateCcw,
+  ArrowLeft,
+  CheckCircle2,
+  Clock,
+  Loader2,
+  AlertCircle,
+  Ban,
+  Activity,
+  Pencil,
+  Plus,
+  Save,
+} from "lucide-react";
 import { Link } from "wouter";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  TaskRow,
+  isGroupEditable,
+  isGroupRelabelOnly,
+  addTaskToList,
+  removeTaskFromList,
+  updateTaskInList,
+  validate,
+  hasErrors,
+  type TaskDraft,
+  type GroupDraft,
+  type SiblingOption,
+  type ExecutionMode,
+} from "@/components/task-groups/task-form";
+import {
+  buildTimeline,
+  formatDuration,
+  timelineSpanMs,
+  type TimelineEntry,
+} from "@/components/task-groups/timeline";
 
 // ─── Status badges ──────────────────────────────────────────────────────────
 
@@ -30,6 +97,342 @@ function StatusBadge({ status }: { status: string }) {
   );
 }
 
+// ─── Server task shape (from GET /api/task-groups/:id) ────────────────────────
+
+interface ServerTask {
+  id: string;
+  name: string;
+  description: string;
+  status: string;
+  executionMode: string;
+  modelSlug: string | null;
+  teamId?: string | null;
+  summary: string | null;
+  errorMessage: string | null;
+  dependsOn: string[];
+  sortOrder?: number | null;
+  startedAt?: string | null;
+  completedAt?: string | null;
+}
+
+interface ServerGroup {
+  id: string;
+  name: string;
+  description: string;
+  status: string;
+  input: string;
+  output: unknown;
+  createdAt: string;
+  tasks: ServerTask[];
+}
+
+function asExecutionMode(value: string): ExecutionMode {
+  return value === "pipeline_run" ? "pipeline_run" : "direct_llm";
+}
+
+// ─── Timeline panel (read-only) ───────────────────────────────────────────────
+
+function TimelinePanel({ entries }: { entries: readonly TimelineEntry[] }) {
+  const span = timelineSpanMs(entries);
+  return (
+    <Card aria-labelledby="timeline-heading">
+      <CardHeader className="py-3 flex flex-row items-center justify-between space-y-0">
+        <CardTitle id="timeline-heading" className="text-sm font-semibold">
+          Timeline
+        </CardTitle>
+        {span !== null && (
+          <span className="text-xs text-muted-foreground tabular-nums">
+            total {formatDuration(span)}
+          </span>
+        )}
+      </CardHeader>
+      <CardContent className="px-0 pb-2">
+        {entries.length === 0 ? (
+          <p className="px-4 py-6 text-center text-xs text-muted-foreground">
+            No tasks to show yet.
+          </p>
+        ) : (
+          <ol className="divide-y divide-border">
+            {entries.map((e) => (
+              <li key={e.id} className="flex items-start gap-3 px-4 py-2">
+                <span className="mt-0.5 shrink-0">
+                  <StatusBadge status={e.status} />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium">{e.name}</p>
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+                    {e.executionMode && <span>{e.executionMode}</span>}
+                    {e.modelSlug && <span className="font-mono">{e.modelSlug}</span>}
+                    {e.teamId && <span>team: {e.teamId}</span>}
+                    {e.hasRun && e.startedAt && (
+                      <span title={e.startedAt}>
+                        started {new Date(e.startedAt).toLocaleTimeString()}
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                  {formatDuration(e.durationMs)}
+                </span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Edit form ────────────────────────────────────────────────────────────────
+
+interface EditFormProps {
+  groupId: string;
+  group: ServerGroup;
+  /** Full edit (pending) vs relabel-only (terminal). */
+  fullEdit: boolean;
+  onDone: () => void;
+}
+
+function EditForm({ groupId, group, fullEdit, onDone }: EditFormProps) {
+  const updateGroup = useUpdateTaskGroup(groupId);
+  const updateTask = useUpdateTask(groupId);
+  const addTask = useAddTask(groupId);
+  const deleteTask = useDeleteTask(groupId);
+
+  const [draft, setDraft] = useState<GroupDraft>({
+    name: group.name,
+    description: group.description,
+    input: group.input,
+  });
+  // Edit-mode tasks: dependsOn is keyed by task ID.
+  const [tasks, setTasks] = useState<TaskDraft[]>(() =>
+    group.tasks
+      .slice()
+      .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
+      .map((t) => ({
+        id: t.id,
+        name: t.name,
+        description: t.description,
+        executionMode: asExecutionMode(t.executionMode),
+        dependsOn: t.dependsOn ?? [],
+      })),
+  );
+  // Track which task ids existed on the server so we PATCH vs POST correctly.
+  const serverTaskIds = useMemo(
+    () => new Set(group.tasks.map((t) => t.id)),
+    [group.tasks],
+  );
+
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const errors = validate(draft, tasks, {
+    requireInput: fullEdit,
+    requireTasks: fullEdit,
+  });
+
+  const anyPending =
+    updateGroup.isPending ||
+    updateTask.isPending ||
+    addTask.isPending ||
+    deleteTask.isPending;
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitted(true);
+    if (hasErrors(errors)) return;
+    setError(null);
+
+    try {
+      // 1. Group fields. input is only sent in full (pending) edit.
+      await updateGroup.mutateAsync(
+        fullEdit
+          ? {
+              name: draft.name.trim(),
+              description: draft.description.trim(),
+              input: draft.input.trim(),
+            }
+          : {
+              name: draft.name.trim(),
+              description: draft.description.trim(),
+            },
+      );
+
+      if (fullEdit) {
+        // 2. Deletions: server tasks no longer present in the draft.
+        const draftIds = new Set(tasks.map((t) => t.id));
+        for (const t of group.tasks) {
+          if (!draftIds.has(t.id)) {
+            await deleteTask.mutateAsync(t.id);
+          }
+        }
+
+        // 3. Upserts in order (sortOrder = index).
+        for (let i = 0; i < tasks.length; i++) {
+          const t = tasks[i];
+          const payload = {
+            name: t.name.trim(),
+            description: t.description.trim(),
+            executionMode: t.executionMode,
+            // dependsOn already references task ids; the server validates the
+            // final graph (cycle / dangling → 400).
+            dependsOn: t.dependsOn,
+            sortOrder: i,
+          };
+          if (serverTaskIds.has(t.id)) {
+            await updateTask.mutateAsync({ taskId: t.id, ...payload });
+          } else {
+            await addTask.mutateAsync(payload);
+          }
+        }
+      }
+
+      onDone();
+    } catch (err) {
+      setError(editErrorMessage(err));
+    }
+  }
+
+  function changeTask(id: string, updated: TaskDraft) {
+    setTasks((prev) => updateTaskInList(prev, id, updated));
+  }
+
+  function removeTask(id: string) {
+    // dependsOn is keyed by id here, so the shared reducer strips it cleanly.
+    setTasks((prev) => removeTaskFromList(prev, id));
+  }
+
+  return (
+    <form onSubmit={handleSave} noValidate className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">
+            {fullEdit ? "Edit group" : "Rename group"}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="edit-name">Name *</Label>
+            <Input
+              id="edit-name"
+              value={draft.name}
+              onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+            />
+            {submitted && errors.name && (
+              <p className="text-xs text-red-500">{errors.name}</p>
+            )}
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="edit-description">Description *</Label>
+            <Textarea
+              id="edit-description"
+              rows={2}
+              value={draft.description}
+              onChange={(e) =>
+                setDraft({ ...draft, description: e.target.value })
+              }
+            />
+            {submitted && errors.description && (
+              <p className="text-xs text-red-500">{errors.description}</p>
+            )}
+          </div>
+          {fullEdit && (
+            <div className="space-y-1">
+              <Label htmlFor="edit-input">Input *</Label>
+              <Textarea
+                id="edit-input"
+                rows={4}
+                value={draft.input}
+                onChange={(e) => setDraft({ ...draft, input: e.target.value })}
+              />
+              {submitted && errors.input && (
+                <p className="text-xs text-red-500">{errors.input}</p>
+              )}
+            </div>
+          )}
+          {!fullEdit && (
+            <p className="text-xs text-muted-foreground">
+              This group has finished, so only its name and description can be
+              changed. Tasks and input are locked.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {fullEdit && (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-base font-semibold">Tasks</h2>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setTasks((prev) => addTaskToList(prev))}
+            >
+              <Plus className="h-4 w-4 mr-2" />
+              Add task
+            </Button>
+          </div>
+
+          {submitted && errors.tasks && (
+            <p className="text-xs text-red-500">{errors.tasks}</p>
+          )}
+
+          {tasks.map((task, index) => {
+            // EDIT mode: dependsOn keyed by task ID. Sibling option id = task id,
+            // chip shows the (possibly edited) sibling name.
+            const siblings: SiblingOption[] = tasks
+              .filter((t) => t.id !== task.id)
+              .map((t) => ({ id: t.id, name: t.name.trim() }));
+            const taskErr = errors.taskErrors?.[task.id];
+
+            return (
+              <div key={task.id} className="space-y-1">
+                <TaskRow
+                  task={task}
+                  index={index}
+                  siblings={siblings}
+                  onChange={(updated) => changeTask(task.id, updated)}
+                  onRemove={() => removeTask(task.id)}
+                  disabled={anyPending}
+                />
+                {submitted && taskErr && (
+                  <div className="px-1 space-y-0.5">
+                    {taskErr.name && (
+                      <p className="text-xs text-red-500">{taskErr.name}</p>
+                    )}
+                    {taskErr.description && (
+                      <p className="text-xs text-red-500">
+                        {taskErr.description}
+                      </p>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {error && (
+        <p role="alert" className="text-sm text-red-500">
+          {error}
+        </p>
+      )}
+
+      <div className="flex justify-end gap-3">
+        <Button type="button" variant="outline" onClick={onDone} disabled={anyPending}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={anyPending}>
+          <Save className="h-4 w-4 mr-2" />
+          {anyPending ? "Saving..." : "Save changes"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
 // ─── Task Group Detail Page ─────────────────────────────────────────────────
 
 export default function TaskGroupPage() {
@@ -42,6 +445,7 @@ export default function TaskGroupPage() {
   const cancelMutation = useCancelTaskGroup();
   const retryMutation = useRetryTask();
   const activityEndRef = useRef<HTMLDivElement>(null);
+  const [editing, setEditing] = useState(false);
 
   // Auto-scroll activity stream
   useEffect(() => {
@@ -52,26 +456,7 @@ export default function TaskGroupPage() {
     return <div className="p-6 text-muted-foreground">Loading...</div>;
   }
 
-  const group = data as {
-    id: string;
-    name: string;
-    description: string;
-    status: string;
-    input: string;
-    output: unknown;
-    createdAt: string;
-    tasks: Array<{
-      id: string;
-      name: string;
-      description: string;
-      status: string;
-      executionMode: string;
-      modelSlug: string | null;
-      summary: string | null;
-      errorMessage: string | null;
-      dependsOn: string[];
-    }>;
-  };
+  const group = data as ServerGroup;
 
   // Merge WS events into task statuses for real-time display
   const taskNameMap = new Map(group.tasks.map((t) => [t.id, t.name]));
@@ -85,9 +470,15 @@ export default function TaskGroupPage() {
     };
   });
 
-  const effectiveStatus = events.groupStatus !== "pending" ? events.groupStatus : group.status;
+  const effectiveStatus =
+    events.groupStatus !== "pending" ? events.groupStatus : group.status;
   const canStart = effectiveStatus === "pending";
   const canCancel = effectiveStatus === "running";
+  const fullEdit = isGroupEditable(effectiveStatus);
+  const relabelOnly = isGroupRelabelOnly(effectiveStatus);
+  const canEdit = fullEdit || relabelOnly;
+
+  const timeline = buildTimeline(group.tasks);
 
   return (
     <div className="p-6 max-w-6xl mx-auto space-y-6">
@@ -106,19 +497,25 @@ export default function TaskGroupPage() {
           <p className="text-sm text-muted-foreground mt-1">{group.description}</p>
         </div>
         <div className="flex gap-2">
-          {canStart && (
+          {!editing && canEdit && (
+            <Button variant="outline" onClick={() => setEditing(true)}>
+              <Pencil className="h-4 w-4 mr-2" />
+              Edit
+            </Button>
+          )}
+          {!editing && canStart && (
             <Button onClick={() => startMutation.mutate(id)} disabled={startMutation.isPending}>
               <Play className="h-4 w-4 mr-2" />
               Start
             </Button>
           )}
-          {canCancel && (
+          {!editing && canCancel && (
             <Button variant="destructive" onClick={() => cancelMutation.mutate(id)} disabled={cancelMutation.isPending}>
               <XCircle className="h-4 w-4 mr-2" />
               Cancel
             </Button>
           )}
-          {effectiveStatus !== "pending" && (
+          {!editing && effectiveStatus !== "pending" && (
             <Link href={`/task-groups/${id}/trace`}>
               <Button variant="outline">
                 <Activity className="h-4 w-4 mr-2" />
@@ -129,119 +526,130 @@ export default function TaskGroupPage() {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Tasks panel */}
-        <div className="lg:col-span-2 space-y-3">
-          <h2 className="text-lg font-semibold">Tasks</h2>
-          {mergedTasks.map((t) => (
-            <Card key={t.id} className={t.status === "running" ? "border-blue-500/50" : ""}>
-              <CardHeader className="py-3 pb-1">
-                <div className="flex items-center justify-between">
-                  <CardTitle className="text-sm font-medium">{t.name}</CardTitle>
-                  <div className="flex items-center gap-2">
-                    <StatusBadge status={t.status} />
-                    {t.status === "failed" && (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 text-xs"
-                        onClick={() => retryMutation.mutate({ groupId: id, taskId: t.id })}
-                        disabled={retryMutation.isPending}
-                      >
-                        <RotateCcw className="h-3 w-3 mr-1" />
-                        Retry
-                      </Button>
+      {editing ? (
+        <EditForm
+          groupId={id}
+          group={group}
+          fullEdit={fullEdit}
+          onDone={() => setEditing(false)}
+        />
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          {/* Tasks panel */}
+          <div className="lg:col-span-2 space-y-3">
+            <h2 className="text-lg font-semibold">Tasks</h2>
+            {mergedTasks.map((t) => (
+              <Card key={t.id} className={t.status === "running" ? "border-blue-500/50" : ""}>
+                <CardHeader className="py-3 pb-1">
+                  <div className="flex items-center justify-between">
+                    <CardTitle className="text-sm font-medium">{t.name}</CardTitle>
+                    <div className="flex items-center gap-2">
+                      <StatusBadge status={t.status} />
+                      {t.status === "failed" && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 text-xs"
+                          onClick={() => retryMutation.mutate({ groupId: id, taskId: t.id })}
+                          disabled={retryMutation.isPending}
+                        >
+                          <RotateCcw className="h-3 w-3 mr-1" />
+                          Retry
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent className="py-2 space-y-1">
+                  <p className="text-xs text-muted-foreground">{t.description}</p>
+                  <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                    <span>{t.executionMode}</span>
+                    {t.modelSlug && <span>{t.modelSlug}</span>}
+                    {t.dependsOn.length > 0 && (
+                      <span>
+                        depends on: {t.dependsOn.map((d) => taskNameMap.get(d) ?? d.slice(0, 8)).join(", ")}
+                      </span>
                     )}
                   </div>
-                </div>
-              </CardHeader>
-              <CardContent className="py-2 space-y-1">
-                <p className="text-xs text-muted-foreground">{t.description}</p>
-                <div className="flex items-center gap-3 text-xs text-muted-foreground">
-                  <span>{t.executionMode}</span>
-                  {t.modelSlug && <span>{t.modelSlug}</span>}
-                  {t.dependsOn.length > 0 && (
-                    <span>
-                      depends on: {t.dependsOn.map((d) => taskNameMap.get(d) ?? d.slice(0, 8)).join(", ")}
-                    </span>
-                  )}
-                </div>
-                {t.summary && (
-                  <div className="mt-2 p-2 bg-green-50 dark:bg-green-950 rounded text-xs text-green-800 dark:text-green-200">
-                    {t.summary}
-                  </div>
-                )}
-                {t.error && (
-                  <div className="mt-2 p-2 bg-red-50 dark:bg-red-950 rounded text-xs text-red-800 dark:text-red-200">
-                    {t.error}
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-
-        {/* Activity stream */}
-        <div className="space-y-3">
-          <h2 className="text-lg font-semibold">Activity</h2>
-          <Card>
-            <CardContent className="p-0">
-              <div className="max-h-[600px] overflow-y-auto p-3 space-y-2 font-mono text-xs">
-                {events.activity.length === 0 ? (
-                  <p className="text-muted-foreground text-center py-8">
-                    {effectiveStatus === "pending" ? "Start the group to see activity" : "No activity yet"}
-                  </p>
-                ) : (
-                  events.activity.map((entry, i) => (
-                    <div key={i} className="flex gap-2">
-                      <span className="text-muted-foreground shrink-0">
-                        {new Date(entry.timestamp).toLocaleTimeString()}
-                      </span>
-                      <span
-                        className={
-                          entry.type.includes("failed") ? "text-red-500" :
-                          entry.type.includes("completed") ? "text-green-500" :
-                          entry.type.includes("started") ? "text-blue-500" :
-                          "text-foreground"
-                        }
-                      >
-                        {entry.message}
-                      </span>
+                  {t.summary && (
+                    <div className="mt-2 p-2 bg-green-50 dark:bg-green-950 rounded text-xs text-green-800 dark:text-green-200">
+                      {t.summary}
                     </div>
-                  ))
-                )}
-                <div ref={activityEndRef} />
-              </div>
-            </CardContent>
-          </Card>
+                  )}
+                  {t.error && (
+                    <div className="mt-2 p-2 bg-red-50 dark:bg-red-950 rounded text-xs text-red-800 dark:text-red-200">
+                      {t.error}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            ))}
+          </div>
 
-          {/* Progress summary */}
-          {effectiveStatus === "running" && (
+          {/* Right column: Timeline + Activity stream */}
+          <div className="space-y-3">
+            <TimelinePanel entries={timeline} />
+
+            <h2 className="text-lg font-semibold">Activity</h2>
             <Card>
-              <CardContent className="py-3">
-                <div className="text-sm space-y-1">
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Completed</span>
-                    <span className="font-medium">{events.completedCount}/{events.totalCount || group.tasks.length}</span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Running</span>
-                    <span className="font-medium">{events.runningCount}</span>
-                  </div>
-                  <div className="w-full bg-muted rounded-full h-2 mt-2">
-                    <div
-                      className="bg-green-500 h-2 rounded-full transition-all"
-                      style={{
-                        width: `${((events.completedCount / (events.totalCount || group.tasks.length)) * 100) || 0}%`,
-                      }}
-                    />
-                  </div>
+              <CardContent className="p-0">
+                <div className="max-h-[600px] overflow-y-auto p-3 space-y-2 font-mono text-xs">
+                  {events.activity.length === 0 ? (
+                    <p className="text-muted-foreground text-center py-8">
+                      {effectiveStatus === "pending" ? "Start the group to see activity" : "No activity yet"}
+                    </p>
+                  ) : (
+                    events.activity.map((entry, i) => (
+                      <div key={i} className="flex gap-2">
+                        <span className="text-muted-foreground shrink-0">
+                          {new Date(entry.timestamp).toLocaleTimeString()}
+                        </span>
+                        <span
+                          className={
+                            entry.type.includes("failed") ? "text-red-500" :
+                            entry.type.includes("completed") ? "text-green-500" :
+                            entry.type.includes("started") ? "text-blue-500" :
+                            "text-foreground"
+                          }
+                        >
+                          {entry.message}
+                        </span>
+                      </div>
+                    ))
+                  )}
+                  <div ref={activityEndRef} />
                 </div>
               </CardContent>
             </Card>
-          )}
+
+            {/* Progress summary */}
+            {effectiveStatus === "running" && (
+              <Card>
+                <CardContent className="py-3">
+                  <div className="text-sm space-y-1">
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Completed</span>
+                      <span className="font-medium">{events.completedCount}/{events.totalCount || group.tasks.length}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Running</span>
+                      <span className="font-medium">{events.runningCount}</span>
+                    </div>
+                    <div className="w-full bg-muted rounded-full h-2 mt-2">
+                      <div
+                        className="bg-green-500 h-2 rounded-full transition-all"
+                        style={{
+                          width: `${((events.completedCount / (events.totalCount || group.tasks.length)) * 100) || 0}%`,
+                        }}
+                      />
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/docs/design/task-groups-edit-history.md
+++ b/docs/design/task-groups-edit-history.md
@@ -1,0 +1,270 @@
+# Task Groups — Edit, History & Live-Activity History — Design
+
+**Status**: Proposed
+**Author**: solution-architect (DESIGN phase)
+**Date**: 2026-06-16
+**Branch**: `feature/task-groups-edit-and-history`
+**Builds on**: `docs/design/live-run-activity-ui.md` (the already-shipped `/activity` lens).
+
+> DESIGN ONLY. No implementation code in this change beyond this document. Every symbol/path below was verified against the current tree.
+
+---
+
+## 0. TL;DR for the Lead
+
+Three features over the Task-Group + Live-Activity surfaces:
+
+- **(A) Edit a Task Group** — group fields (name/description/input) + per-task fields, add/remove task, change `dependsOn`. New `PATCH`/`POST`/`DELETE` endpoints. **Editing is allowed only while `status === "pending"`** (not yet started). Once started, a group is a historical record (`running`/`completed`/`failed`/`cancelled`) and is **immutable except its `name`/`description` as a label**.
+- **(B) Task-Group history** — interpreted (see §2) as **the execution timeline of THIS one-shot group**: its task lifecycle + the `task_traces` spans, surfaced as a panel on `TaskGroup.tsx`. **Plus** task-groups should *appear in the Live-Activity history* (feature C) and, while running, in the *live* `/activity` snapshot. No new per-run table.
+- **(C) Live-Activity run history** — a **History tab** on `/activity` listing PAST runs (completed/failed/cancelled) across ALL modes **including task-groups**, DB-backed, owner/admin-scoped, metadata-only, paginated. New `GET /api/activity/history`.
+
+**Two pre-existing security/correctness findings surfaced during grounding (flagged to Lead, §7):**
+
+1. **IDOR on every task-group route.** `server/routes/task-groups.ts` is behind `requireAuth` (routes.ts:144) but **none of its handlers check ownership** (`task_groups.createdBy`). Any authenticated user can read/start/cancel/delete/retry/(soon edit) **any** group. This must be closed as part of (A) — the new mutations cannot ship un-gated, and the existing reads/mutations should be gated in the same pass (consistent with the `authorize-run.ts` + consensus IDOR work).
+2. **Task-group live WS is currently dead.** `WsManager.authorizeAndSubscribe` (ws/manager.ts:86) resolves ownership via `storage.getPipelineRun(runId)` and **fails closed when no row** (`if (!run) return false`). Task-group events are broadcast on `broadcastToRun(groupId, …)` where `groupId` is a `task_groups.id`, which has **no `pipeline_runs` row** → the subscribe is **rejected**, so `TaskGroup.tsx`'s "Activity" stream never receives live events today (it survives only on the 3s `useTaskGroup` poll). Feature (B)'s live timeline depends on fixing this. Design in §4.3.
+
+---
+
+## 1. Verified data model (corrections + confirmations)
+
+All confirmed against `shared/schema.ts`, `server/routes/task-groups.ts`, `server/services/task-orchestrator.ts`, `server/storage.ts`.
+
+| Fact | Verified |
+|------|----------|
+| `task_groups` (schema.ts:1085) — one-shot lifecycle `pending → running → completed/failed/cancelled` (`TASK_GROUP_STATUSES`, :1082); fields `input`, `output` (jsonb), `traceId`, `startedAt`, `completedAt`, `createdBy` (FK `users.id`, `onDelete: set null`). | ✅ exactly as briefed |
+| **No per-run table.** A group is created, **started once** (`POST :id/start` → `orchestrator.startGroup`, which throws if `status !== "pending"`, task-orchestrator.ts:122), runs, settles. It is never re-run into multiple "runs". | ✅ confirmed |
+| `tasks` (schema.ts:1117) — per-group, FK `group_id` **cascade** (:1125); `status` (`TASK_STATUSES` incl. `blocked`/`ready`, :1111), `executionMode` (`direct_llm`\|`pipeline_run`, :1114), `dependsOn jsonb string[]` (:1130, stores **task IDs**, resolved from names at create — task-orchestrator.ts:91-98), `sortOrder`, `output`, `summary`, `errorMessage`, etc. | ✅ |
+| `task_traces` (schema.ts:1232) — FK `group_id` cascade, `traceId` unique, `spans jsonb`, `totalDurationMs/Tokens/CostUsd`. One trace row **per group**. Visualized by `client/src/pages/TaskGroupTrace.tsx` via `use-task-trace.ts`. | ✅ |
+| Routes (`task-groups.ts`): `GET /api/task-groups`, `GET :id`, `POST` (create, `validateBody(CreateTaskGroupSchema)`), `POST :id/start`, `POST :id/cancel`, `DELETE :id`, `POST :id/tasks/:taskId/retry`. **No PATCH/PUT.** | ✅ |
+| **AuthZ gap**: handlers read `req.user?.id` only to stamp `createdBy` on create (task-groups.ts:75). **No owner check on any read or mutation.** `req.user.role`/admin never consulted. Errors use `res.json({ error: String(err) })` — leaks internals, not the `ApiResponse` envelope. | ✅ (IDOR — §7.1) |
+| `IStorage` task methods (storage.ts:376-393): `getTaskGroups`, `getTaskGroup`, `createTaskGroup`, `updateTaskGroup(id, Partial<TaskGroupRow>)`, `deleteTaskGroup`, `getTasksByGroup`, `getTask`, `createTask`, `updateTask(id, Partial<TaskRow>)`, `getReadyTasks`, `getBlockedTasks`, `getTaskTrace`. **There is NO `deleteTask(id)`.** | ✅ (one new storage method needed — §3.1) |
+| `TaskOrchestrator` has **no `activeRuns`/AbortController registry** like the controllers. It has a private `activeGroupTraces: Map<groupId, …>` (task-orchestrator.ts:40) populated only between `startGroup` and group settle. No public `getActiveGroupIds()` accessor. | ✅ (relevant to §4.3 live snapshot) |
+| Task-group WS events (`taskgroup:started/progress/completed/failed`, `task:created/ready/started/completed/failed`) already exist in the `WsEventType` union (types.ts:495-504) and are broadcast via `wsManager.broadcastToRun(groupId, …)` with `runId = groupId` (task-orchestrator.ts:600). | ✅ |
+
+**Correction vs. the brief's note that routes may not be owner-gated:** confirmed — they are **authenticated but not owner-gated at all**. There is no partial gating to extend; ownership must be added from scratch, keyed on `task_groups.createdBy` (NOT `pipeline_runs.triggeredBy`, since groups have no pipeline_runs row).
+
+---
+
+## 2. Feature (B) interpretation — STATED EXPLICITLY
+
+> The brief flags the ambiguity ("в activity task-groups нужна история"). I read it two ways and **design for both**, because they are complementary and cheap together:
+
+**Primary reading — "a Task Group's history is its own execution timeline."** Because a group is **one-shot** (no multiple runs), its "history" is the single execution it had: the **task lifecycle** (each task's status transitions, started/completed timestamps, summary/error) **plus** the **trace** (`task_traces` spans: durations, tokens, cost). This already half-exists: `TaskGroup.tsx` has a live "Activity" event log and a "Trace" button → `TaskGroupTrace.tsx`. The gap is that (a) the timeline is **ephemeral** (WS-only, lost on reload — and currently dead, §0.2) and (b) there is no consolidated, reload-survivable per-group timeline panel.
+→ **Design: a "History / Timeline" panel on `TaskGroup.tsx`** built from durable data (the task rows' timestamps/status + the trace), with the live WS stream layered on top when the group is running. (§4.2)
+
+**Secondary reading — "task-groups should appear in /activity, with a history entry."** This is reasonable and we honour it via **feature (C)**: task-groups become a first-class **mode** in the Activity *History* tab (past groups) and, while running, in the *live* Activity snapshot (§4.3). So "history in activity" = the group shows up in the Activity History list like any other run.
+
+Both are delivered. Neither requires a new per-run table (§5).
+
+---
+
+## 3. Feature (A) — Edit a Task Group
+
+### 3.1 The "editable only while pending" rule (the core invariant)
+
+A group's `status` defines whether it is a **draft** (mutable) or a **historical record** (immutable):
+
+| Group status | Group name/description | Group `input` | Tasks (fields / add / remove / dependsOn) |
+|---|---|---|---|
+| `pending` | ✅ editable | ✅ editable | ✅ fully editable |
+| `running` | ❌ (409) | ❌ (409) | ❌ (409) |
+| `completed` / `failed` / `cancelled` | ⚠️ **name/description only** (relabel a record) | ❌ (409) | ❌ (409) |
+
+Rationale: once `startGroup` flips `status` to `running` (task-orchestrator.ts:124) and seeds task statuses/trace, mutating tasks or `input` mid/post-run corrupts the execution record and the dependency graph the orchestrator already resolved. `input` is the immutable objective the run was launched with. Only the human-facing **label** (`name`/`description`) may be corrected on a finished group. Enforced server-side; the UI mirrors it (read-only fields + disabled actions) but the server is authoritative.
+
+This mirrors the existing guard in `startGroup` (`if (group.status !== "pending") throw …`, task-orchestrator.ts:122) — we generalise the same "pending = mutable" notion to edits.
+
+### 3.2 Endpoints (all owner-gated, see §6)
+
+A shared helper `authorizeTaskGroup(req, res, storage, groupId)` (new, sibling of `authorize-run.ts`, but keyed on `task_groups.createdBy`) gates every route below: `401` unauth → `404` missing → `403` non-owner (admin bypass; **ownerless `createdBy == null` denied to non-admins**, matching the strict `authorize-run` posture). On success returns `{ ownerId }`. **This same helper is retro-fitted onto the existing GET/start/cancel/delete/retry routes to close §7.1.**
+
+```
+PATCH  /api/task-groups/:id
+```
+Body (all optional; at least one required): `{ name?, description?, input? }`.
+- Validation: `name` 1–200, `description` 1–5000, `input` 1–50000 (reuse the bounds from `CreateTaskGroupSchema`, task-groups.ts:9-12), via `validateBody`.
+- **Guard:** if `input` present and `status !== "pending"` → **409** `{ error: "Cannot edit input after the group has started" }`. If `name`/`description` only, allowed in any status. Running → 409 for any field.
+- Maps to `storage.updateTaskGroup(id, patch)`. Returns the updated `{ ...group, tasks }` (same shape as `GET :id`) in the `ApiResponse` envelope.
+
+```
+PATCH  /api/task-groups/:id/tasks/:taskId
+```
+Body (optional): `{ name?, description?, executionMode?, dependsOn?, pipelineId?, modelSlug?, teamId?, input?, sortOrder? }`.
+- **Guard:** group `status` must be `pending` → else **409**. Task must belong to the group (`task.groupId === id`, else 404 — prevents cross-group taskId tampering).
+- `dependsOn` is an array of **task IDs within this group**; validate every id exists in the group's tasks and **reject self-reference and cycles** (pure DAG check, §3.3). Reuse `CreateTaskGroupSchema`'s per-task field bounds.
+- Maps to `storage.updateTask(taskId, patch)`. While `pending`, also **recompute initial status** (`ready` if `dependsOn` empty, else `blocked`) so the draft stays consistent (mirrors create-time logic, task-orchestrator.ts:98).
+
+```
+POST   /api/task-groups/:id/tasks
+```
+Body: a single task object (same per-task schema as create). **Guard:** group `pending` → else 409.
+- `dependsOn` references resolved/validated against existing group tasks (by **ID**; the FE supplies ids it already knows). New task gets `sortOrder` = max+1 by default. Maps to `storage.createTask({ groupId: id, … })`. Returns the created task.
+
+```
+DELETE /api/task-groups/:id/tasks/:taskId
+```
+**Guard:** group `pending` → else 409. Task must belong to the group.
+- **Requires a new `IStorage.deleteTask(id: string): Promise<void>`** (none exists — §1). Implement on `MemStorage` + `PgStorage` (additive interface method).
+- **Referential cleanup:** after delete, **strip the removed task's id from every sibling's `dependsOn`** (the create/remove UI already does this client-side — CreateTaskGroup.tsx:491-499; the server must do it durably). Do it in the orchestrator/service layer (a small `removeTask(groupId, taskId)` that deletes + fixes siblings + re-derives their `ready`/`blocked` status), not raw in the route, to keep the route thin and the logic unit-testable. Returns `204`.
+
+> **Edit orchestration lives in `TaskOrchestrator`** (or a thin `TaskGroupEditor` collaborator), not the route handler — the route validates + authorizes + delegates. This keeps it consistent with how create/start/cancel already delegate to the orchestrator, and gives a single TDD'd unit for the dependsOn-rewrite + status-recompute rules.
+
+### 3.3 DAG / dependsOn integrity (pure, reused)
+
+`dependsOn` edits and task removal can introduce **cycles** or **dangling refs**. Add a pure helper `validateTaskGraph(tasks: {id, dependsOn}[]): { ok: true } | { ok: false; reason }` (new `server/services/task-graph.ts`, unit-tested with a table): rejects (a) a dep id not in the group, (b) self-dependency, (c) any cycle (DFS/Kahn). Called by `PATCH task`, `POST task`, `DELETE task` before persisting. (The orchestrator's runtime unblock logic already assumes a DAG — task-orchestrator.ts:463-466 — so this just enforces the invariant the runtime already relies on.)
+
+### 3.4 Frontend — edit mode on `TaskGroup.tsx`
+
+- **Reuse, don't rebuild the form.** Extract `TaskRow`, `emptyTask`, `validate`, `hasErrors`, and the `TaskDraft`/`GroupDraft` types from `CreateTaskGroup.tsx` (lines 21-201) into a shared `client/src/components/task-groups/task-form.tsx` (+ `task-form-types.ts`). `CreateTaskGroup.tsx` imports them (behaviour-preserving refactor); the edit mode reuses the identical pieces. This is a pure DRY move — the create form already has every control edit needs (name/desc/input, add task, remove task with dependsOn cleanup, dependsOn toggle badges).
+- **Edit affordance:** an "Edit" button on `TaskGroup.tsx` header, shown only when `effectiveStatus === "pending"` (full edit) OR always-but-limited-to-name/description when terminal. Toggles the detail view into an editable form seeded from `data` (the group + tasks). On save, fire the PATCH/POST/DELETE mutations (new hooks in `use-task-groups.ts`: `useUpdateTaskGroup`, `useUpdateTask`, `useAddTask`, `useDeleteTask`) then invalidate `["/api/task-groups", id]`.
+- **dependsOn in edit uses IDs.** The create form toggles deps by **name** (CreateTaskGroup.tsx:130-156) because tasks have no ids yet. In edit, tasks have real ids; the shared `TaskRow` must accept `siblings: {id, name}[]` and toggle by id, mapping to names only for display. (Small generalisation of the shared component; covered by tests.)
+- a11y: edit toggle is a real `<button>`; form fields keep their `<Label htmlFor>` wiring already present; disabled/read-only states announced.
+
+---
+
+## 4. Feature (B) — Task-Group history / timeline
+
+### 4.1 No new data — read what exists
+
+Durable per-group timeline is reconstructable from rows we already have:
+- **Per-task lifecycle:** `tasks` rows carry `status`, `startedAt`, `completedAt`, `summary`, `errorMessage`, `sortOrder` — already returned by `GET :id`. That is the ordered task timeline.
+- **Trace:** `task_traces` (spans + durations + tokens + cost) via the existing trace path that `TaskGroupTrace.tsx` already consumes (`use-task-trace.ts`). No change needed.
+- **Group-level:** `task_groups.startedAt`/`completedAt`/`status`/`output`.
+
+So **(B) needs no new endpoint** for the durable view — it composes existing reads.
+
+### 4.2 Frontend — a "Timeline" panel on `TaskGroup.tsx`
+
+- Add a **Timeline** panel/section (or a small tab toggle: "Tasks" | "Timeline") to `TaskGroup.tsx` that renders a durable, reload-surviving chronology built from the task rows' `startedAt`/`completedAt`/`status` + the group's `startedAt`/`completedAt`. Each entry: task name, status badge (reuse the page's existing `StatusBadge`, TaskGroup.tsx:23), start/end, duration, summary/error. Sorted by `startedAt` (fallback `sortOrder`).
+- **Layer the live stream on top:** keep the existing WS "Activity" log (`use-task-events.ts`) for the running case — once §4.3 fixes the subscribe, it works live; until/independently, the durable timeline from rows is always correct on reload (the poll keeps it fresh, `useTaskGroup` refetchInterval 3s).
+- **Link, don't duplicate, the trace:** the existing "Trace" button → `TaskGroupTrace.tsx` stays the deep span view. The Timeline panel is the lightweight per-task chronology; it can show trace totals (duration/tokens/cost) inline from `task_traces` and link out for the full span tree.
+- This is FE-only (composition of existing hooks/data) plus the small WS fix in §4.3.
+
+### 4.3 Should task-groups join the LIVE `/activity` snapshot? — Yes, and the prerequisite WS fix
+
+The current `/activity` snapshot (activity.ts) unions `PipelineController.getActiveRunIds()` ∪ `ConsensusController.getActiveRunIds()`. Task-groups are **not** represented because (a) `TaskOrchestrator` exposes no active-id accessor, and (b) a group is keyed by `task_groups.id`, not `pipeline_runs.id`, so the per-run ownership gate in both the route and the WS layer doesn't apply to it.
+
+**Decision: add task-groups as a fifth Activity mode (`"task_group"`), for BOTH the live snapshot and the history tab.** Concretely:
+
+- **Active-id accessor (small):** add `getActiveGroupIds(): string[]` to `TaskOrchestrator`, backed by the existing `activeGroupTraces` map keys (already the set of in-flight groups). Sibling of the controllers' `getActiveRunIds()`.
+- **Ownership for groups is `task_groups.createdBy`**, not `pipeline_runs.triggeredBy`. So `/api/activity` must branch: for group ids, load `getTaskGroup(id)` and gate on `createdBy`; for the existing modes, keep the `pipeline_runs.triggeredBy` gate. Build a metadata-only `ActivityRun` with `mode: "task_group"`, `currentUnit` = the running/last task (label `Task N`, agent = `executionMode`, model = `task.modelSlug`, status = task status), `title: "Task group"` (NEVER `group.name` if names can carry user text — use a fixed label or the group's short id; see §6 note on `title`).
+- **WS live deltas for groups (the §0.2 fix):** the WS subscribe gate (ws/manager.ts:86) must learn that a `runId` can be a **task-group id**. Add a fallback: if `getPipelineRun(runId)` is null, try `getTaskGroup(runId)` and gate on `createdBy`. This (i) fixes the currently-dead `TaskGroup.tsx` live stream and (ii) lets the Activity page subscribe to group ids it got from the (owner-scoped) snapshot. Then extend the client `mergeWsEvent` (lib/activity.ts:115) to fold `taskgroup:*` / `task:*` events onto a `task_group` row (additive; mirrors the existing `orchestrator:step` handling).
+
+> **Scope guard:** the WS-gate fallback is a **small, security-relevant** change to a shared hardening path. It is its own task (§8, T3.1) with its own tests (group owner can subscribe; non-owner denied; unknown id denied; admin bypass; existing pipeline behaviour unchanged). If the Lead wants to minimise blast radius, the **live** task-group Activity row (and the `TaskGroup.tsx` live-stream fix) can ship **after** the rest; the durable Timeline (§4.2) and the **History tab** (§5) do NOT depend on it (they are DB-backed/poll-backed).
+
+---
+
+## 5. Feature (C) — Live-Activity History tab
+
+### 5.1 Endpoint
+
+```
+GET /api/activity/history?limit=&cursor=&mode=
+```
+- **DB-backed** (NOT the in-memory registries — history is by definition not active). Returns PAST runs (terminal statuses) across all modes **including task-groups**, newest first.
+- **Auth/scoping:** `requireAuth` (already on `/api/activity`, routes.ts:120). Per row: non-admin sees only their own (pipeline-family via `pipeline_runs.triggeredBy`; task-groups via `task_groups.createdBy`); admin sees all + `ownerId`. Reuse the `authorizeRun` ownership *predicate* logic (don't re-implement the 401/404/403 flow — history filters a list, it doesn't authorize a single run; factor the boolean `isVisible(ownerId, user)` out of `authorize-run.ts` so both share it).
+- **Metadata-only:** `mode`, `title` (fixed label), `runStatus`, `startedAt`, `completedAt`, optional `current`/last-unit summary (enum-derived agent/model), `ownerId` (admin only), `workspaceId`. **NO `output`, no `decisionText`, no transcripts, no `summary`/`errorMessage` free-text, no task `input`.** (The per-group durable detail with summaries lives behind the owner-gated `GET :id` on the group page, §4.2 — not in the cross-user history list.)
+- **Pagination (mandatory, no unbounded query):** `limit` default 25, **hard max 100** (clamp server-side). Keyset/cursor pagination ordered by `(completedAt desc, id desc)` — cursor encodes the last `(completedAt, id)`. Response: `{ items: ActivityHistoryRow[], nextCursor: string | null, isAdmin }`.
+
+### 5.2 Storage — the one real query addition
+
+No table changes, but the cross-mode "terminal runs, owner-scoped, paginated" read needs storage helpers (current storage has only `getPipelineRuns(pipelineId?)` — unfiltered, unpaginated, storage.ts:213). Add **paginated, status-filtered, owner-filtered** finders:
+- `listPipelineRunHistory({ ownerId?, limit, cursor })` over `pipeline_runs` where `status IN (completed, failed, cancelled, rejected)` (covers pipeline/manager/orchestrator/consensus since all FK pipeline_runs). Mode is then classified per-row as today (`getConsensusRun`/`getOrchestratorRun`/manager-iterations/else pipeline — reuse the exact classification in activity.ts `buildActivityRun`, extracted into a shared `classifyRun` so live + history agree).
+- `listTaskGroupHistory({ ownerId?, limit, cursor })` over `task_groups` where `status IN (completed, failed, cancelled)`.
+- The route **merges** the two keyset streams by `completedAt` and applies the global `limit`/`cursor`. (Two ordered sources merged is fine at this scale; document the merge-cursor encoding. If the Lead prefers, v1 can paginate the two lists independently behind a `mode` filter and merge only the "All" view client-side — call this out as an open question, §7.4.)
+- Indexes: `pipeline_runs(status, started_at)` and `task_groups(status, created_at)` may be warranted if these tables grow; flag as a follow-up (the tables are modest today).
+
+### 5.3 Frontend — History tab on `Activity.tsx`
+
+- Convert the `/activity` page header into a **tabbed** view: **"Live"** (the existing snapshot view, unchanged) | **"History"** (new). Reuse the `@/components/ui` tabs (compound `Tabs` pattern) — keep the tab in **URL state** (e.g. `?tab=history`) so it's shareable/back-button friendly (per web patterns: URL as state).
+- **Reuse the row rendering.** The History table reuses the same column model + `StatusPill` from `Activity.tsx` (lines 38-145). `RunRow`/`StatusPill`/`GroupTable` already live in the page; factor the row + status pill into small shared components so both tabs use them. History adds a **Completed** column and drops the live pulse.
+- **Pagination UI:** "Load more" (cursor) — no infinite unbounded fetch; a `useActivityHistory` hook does `useInfiniteQuery` (TanStack) keyed by `["/api/activity/history", mode]`, passing `nextCursor`. Empty/loading/error states reuse `CenteredState` (Activity.tsx:64).
+- Task-groups appear as a fifth group/section (`mode: "task_group"`, label e.g. "Task groups"). Extend `ACTIVITY_MODE_ORDER`/`ACTIVITY_MODE_LABELS` (lib/activity.ts:27-40) and the `ActivityMode` union (types.ts:3095) to include `"task_group"`.
+- Each history row for a task-group **links to** `/task-groups/:id` (its detail/Timeline). Pipeline-family rows can link to their existing run views.
+
+---
+
+## 6. Security (consolidated)
+
+| Concern | Decision |
+|---|---|
+| **Edit endpoints owner-gating** | New `authorizeTaskGroup` (keyed `task_groups.createdBy`): 401→404→403, admin bypass, **ownerless denied to non-admins**. Applied to ALL task-group routes (incl. retro-fitting the existing un-gated GET/start/cancel/delete/retry — closes §7.1). |
+| **Editable-only-when-pending** | Server-authoritative 409 when mutating tasks/`input` on a non-`pending` group; only `name`/`description` editable post-terminal. UI mirrors but does not enforce. |
+| **dependsOn integrity** | Pure `validateTaskGraph` rejects dangling refs, self-deps, cycles before persist (§3.3). taskId tampering blocked (task must belong to the path's group → else 404). |
+| **History endpoint scoping** | Per-row owner filter (pipeline-family: `triggeredBy`; groups: `createdBy`); admin sees all + `ownerId`. Shared `isVisible` predicate with `authorize-run.ts`. |
+| **Metadata-only (history + live)** | NO output/decisionText/transcripts/free-text summary/task input in any cross-user Activity payload. Only ids, enum-derived agent/model/phase, status, timestamps, workspaceId, mode. The live `activity.ts` already enforces this; the history endpoint follows the same rule. `title` for task-groups uses a **fixed label or short id**, not `group.name` (names are user free-text and could leak across the admin view) — OR scrub via `scrubAndTruncate` if a name is shown; **recommend the fixed-label/short-id approach** to avoid any leak vector. |
+| **Pagination cap** | `limit` clamped to max 100 server-side; keyset cursor; never an unbounded `SELECT *`. |
+| **WS subscribe (task-group fallback)** | The new `getTaskGroup` fallback in `authorizeAndSubscribe` is itself owner-gated (`createdBy`), fails closed on unknown id — does NOT widen the existing posture, it extends the same ownership rule to a second id space. |
+| **Error envelope** | New routes return generic errors via the `ApiResponse` envelope (no `String(err)` leakage); the existing `String(err)` task-group handlers should be tightened in the same pass. |
+
+---
+
+## 7. Risks & Open Questions (for the Lead)
+
+1. **(BLOCKER to ship-A) Pre-existing IDOR on all task-group routes (§0.1).** New edit mutations cannot ship without owner-gating, and shipping them gated while leaving GET/start/cancel/delete un-gated is inconsistent and still-exploitable. **Recommend: close the whole route file's gating in this change** (T1.1). Confirm.
+2. **(Affects B-live + the TaskGroup live stream) Task-group WS is dead today (§0.2).** The WS subscribe gate fails closed for `task_groups.id`. **Recommend: add the `getTaskGroup`/`createdBy` fallback** (T3.1) — it both fixes the existing broken `TaskGroup.tsx` stream and enables live task-group rows in `/activity`. Acceptable to land **after** the DB-backed History + durable Timeline (which don't depend on it). Confirm sequencing.
+3. **Post-terminal editability of name/description.** I allow relabelling `name`/`description` on finished groups (everything else 409). Alternative: lock everything once started (simpler, stricter). Confirm which.
+4. **History pagination across two sources.** Merging two keyset streams (`pipeline_runs` + `task_groups`) by `completedAt` under one global cursor is the clean "All" view but adds cursor complexity. Simpler v1: paginate per `mode` and only merge the "All" tab client-side from the first page of each. Confirm appetite (recommend the merged keyset; fall back to per-mode if time-boxed).
+5. **`deleteTask` storage method (§1).** Removing a task in edit mode needs a new hard-delete `IStorage.deleteTask` (none exists; group cascade only fires on group delete). Additive to `MemStorage` + `PgStorage`. Confirm acceptable (it is the only storage-surface addition; **no schema/migration**).
+6. **"Task group" as a fifth Activity mode.** Extends the `ActivityMode` union + the page's mode grouping. Confirm task-groups should sit in the **same** `/activity` surface (recommended — one observability lens) vs. only on their own pages.
+7. **Concurrency/perf of History.** Keyset + `limit ≤ 100` bounds it; classification does O(rows) `get*` lookups per page (same pattern as live `buildActivityRun`). If `pipeline_runs`/`task_groups` grow large, add the status/time indexes (§5.2). Lead to set expected history volume.
+
+---
+
+## 8. Task Breakdown (ordered, file-owned, small units)
+
+> Standards on every code task: TDD ≥80% new modules, no `any` (narrow `unknown`), reuse-first, a11y, owner/admin scoping, metadata-only history, edit-guard, pagination cap. Server on host (`make dev`), never Docker. Feature branch + PR, no AI mentions.
+
+### Phase 0 — Shared contract + storage primitives (BE; blocks most)
+- **T0.1 (BE)** — Extend `ActivityMode` to include `"task_group"`; add `ActivityHistoryRow` + `ActivityHistoryPage` types to `shared/types.ts`. *Owns:* `shared/types.ts`.
+- **T0.2 (BE)** — Add `IStorage.deleteTask(id)` + implement on `MemStorage` (`server/storage.ts`) and `PgStorage` (`server/storage-pg.ts`). *Owns:* those three. **TDD:** delete removes the row; group cascade unaffected.
+- **T0.3 (BE)** — Add `listPipelineRunHistory` + `listTaskGroupHistory` (status-filtered, owner-optional, keyset-paginated) to `IStorage` + both impls. *Owns:* `storage.ts`, `storage-pg.ts`. **TDD:** terminal-only; owner filter; cursor ordering; limit clamp.
+
+### Phase 1 — Edit (A) backend (Security-first)
+- **T1.1 (Security/BE)** — `server/routes/authorize-task-group.ts` (`authorizeTaskGroup` keyed on `createdBy`; reuse the `isVisible` predicate extracted from `authorize-run.ts`). Retrofit it onto the existing GET/start/cancel/delete/retry handlers in `server/routes/task-groups.ts` (closes §7.1). *Owns:* new file + `task-groups.ts` (gating lines + error-envelope tightening). **TDD:** 401/404/403/owner/admin/ownerless on each verb.
+- **T1.2 (BE)** — Pure `server/services/task-graph.ts` (`validateTaskGraph`: dangling/self/cycle). *Owns:* new file. **TDD:** table over valid DAGs, self-dep, 2- and 3-node cycles, dangling id.
+- **T1.3 (BE)** — Edit orchestration in `TaskOrchestrator` (or `TaskGroupEditor`): `updateGroup`, `updateTask`, `addTask`, `removeTask` (delete + strip siblings' `dependsOn` + re-derive ready/blocked), all enforcing the pending-only rule + `validateTaskGraph`. *Owns:* `server/services/task-orchestrator.ts` (+ maybe a small new collaborator). **TDD:** pending-only 409 paths; dependsOn rewrite on remove; status recompute; cross-group taskId rejected.
+- **T1.4 (BE)** — Routes: `PATCH /api/task-groups/:id`, `PATCH …/tasks/:taskId`, `POST …/tasks`, `DELETE …/tasks/:taskId` in `task-groups.ts`, each `authorizeTaskGroup` → `validateBody` → delegate to T1.3, `ApiResponse` envelope, 409 on guard. *Owns:* `task-groups.ts`. **TDD (integration):** happy edit on pending; 409 on running/completed (input + tasks); name/desc allowed post-terminal; owner-scoping; no cross-group leak.
+
+### Phase 2 — Activity History (C) backend
+- **T2.1 (BE)** — Extract `classifyRun` (mode + current-unit builder) from `activity.ts` `buildActivityRun` into a shared module so live + history agree; add a `task_group` classifier. *Owns:* `server/routes/activity.ts` (+ small shared helper). **TDD:** each mode incl. task_group classified.
+- **T2.2 (BE)** — `GET /api/activity/history` in `server/routes/activity.ts` (or a sibling `activity-history.ts`): merge the two history finders, owner/admin filter via `isVisible`, metadata-only, `limit ≤ 100`, keyset cursor; register under the existing `/api/activity` requireAuth prefix. *Owns:* the route file + one line in `routes.ts` if a new file. **TDD (integration):** 401; non-admin sees only own (both id-spaces); admin sees all + ownerId; terminal-only; **no output/transcript/free-text field present** (explicit assertion); cursor paginates; limit clamps.
+
+### Phase 3 — WS task-group enablement (Security; can trail)
+- **T3.1 (Security/BE)** — `authorizeAndSubscribe` fallback: null `pipeline_runs` → try `getTaskGroup`, gate on `createdBy`, fail closed. *Owns:* `server/ws/manager.ts`. **TDD:** group owner subscribes; non-owner denied; unknown id denied; admin bypass; existing pipeline path unchanged.
+- **T3.2 (BE)** — Add `getActiveGroupIds()` to `TaskOrchestrator`; include task-group ids (gated on `createdBy`) in the LIVE `/api/activity` snapshot as `mode: "task_group"`. *Owns:* `task-orchestrator.ts`, `activity.ts`. **TDD:** active group appears for owner only; metadata-only.
+
+### Phase 4 — Frontend
+- **T4.1 (FE)** — Extract the create-form pieces (`TaskRow`, `emptyTask`, `validate`, `hasErrors`, `TaskDraft`/`GroupDraft`) into `client/src/components/task-groups/task-form.tsx` (+ types); generalise `TaskRow` to toggle `dependsOn` by **id** with name display; rewire `CreateTaskGroup.tsx` to import them (behaviour-preserving). *Owns:* new files + `CreateTaskGroup.tsx`. **TDD/visual:** create flow unchanged.
+- **T4.2 (FE)** — Edit mode on `client/src/pages/TaskGroup.tsx` (Edit button gated by status; reuse shared form; full edit when `pending`, name/desc-only when terminal) + new mutation hooks in `client/src/hooks/use-task-groups.ts` (`useUpdateTaskGroup`/`useUpdateTask`/`useAddTask`/`useDeleteTask`). *Owns:* `TaskGroup.tsx`, `use-task-groups.ts`.
+- **T4.3 (FE)** — Timeline panel on `TaskGroup.tsx` (durable per-task chronology from rows + trace totals; reuse `StatusBadge`; link to existing Trace). *Owns:* `TaskGroup.tsx` (+ a small `TaskGroupTimeline` component). Extend `mergeWsEvent` (lib/activity.ts) + `use-task-events` consumption only if T3 landed.
+- **T4.4 (FE)** — History tab on `client/src/pages/Activity.tsx`: tabbed Live|History (URL state), `useActivityHistory` infinite-query hook, reuse row/StatusPill, task_group section, "Load more", link group rows to `/task-groups/:id`. Extend `ACTIVITY_MODE_ORDER`/`LABELS` (lib/activity.ts). *Owns:* `Activity.tsx`, new hook, `lib/activity.ts`.
+
+### Phase 5 — QA
+- **T5.1 (QA/E2E)** — Playwright: (A) create a pending group → edit name + add/remove task + change dependsOn → save → reflected; start it → edit blocked (409 surfaced). (B) finished group shows Timeline + Trace; reload preserves timeline. (C) `/activity` History tab lists a completed group + a completed pipeline run; second user doesn't see another's; admin sees both + owner. *Owns:* `tests/e2e/task-groups-edit-history.spec.ts`.
+- **T5.2 (QA)** — ≥80% coverage on new modules (`authorize-task-group`, `task-graph`, edit orchestration, history finders, history route, the FE hooks/shared form); a11y pass on edit mode + History tab (keyboard, labels, reduced-motion, contrast).
+
+**Ordering:** T0.* → Phase 1 (T1.1 first — security) → Phase 2 → Phase 4 FE in parallel after its BE dep lands → Phase 3 (may trail; only the live task-group row + TaskGroup live stream depend on it) → Phase 5. The durable Timeline (T4.3) and History (T2.2/T4.4) do NOT block on Phase 3.
+
+---
+
+## 9. Reuse Inventory (no reinvention)
+
+| Need | Reused symbol / file |
+|------|----------------------|
+| Group ownership | `task_groups.createdBy` (schema.ts:1095) — NOT `pipeline_runs.triggeredBy` |
+| Pipeline-family ownership (history) | `pipeline_runs.triggeredBy` (schema.ts:152) |
+| AuthZ predicate | `isVisible` extracted from `server/routes/authorize-run.ts` |
+| Pending-only precedent | `startGroup` guard (task-orchestrator.ts:122) |
+| Validation middleware + bounds | `validateBody` (`server/middleware/validate.ts:13`) + `CreateTaskGroupSchema` bounds (task-groups.ts:9-29) |
+| Run classification (live=history parity) | `buildActivityRun` → extracted `classifyRun` (`server/routes/activity.ts:150`) |
+| Active-id accessor pattern | `PipelineController.getActiveRunIds` / `ConsensusController.getActiveRunIds` |
+| Trace view | `TaskGroupTrace.tsx` + `use-task-trace.ts` (unchanged) |
+| Create-form controls | `TaskRow`/`emptyTask`/`validate`/`TaskDraft` (`CreateTaskGroup.tsx:21-201`) → shared module |
+| Task-group mutation hooks | `use-task-groups.ts` (extend with edit hooks) |
+| Live WS event log | `use-task-events.ts` (`taskgroup:*`/`task:*` already mapped) |
+| Activity row + status pill | `RunRow`/`StatusPill`/`GroupTable` (`Activity.tsx:38-194`) |
+| Activity merge + grouping | `mergeWsEvent`/`groupByMode`/`ACTIVITY_MODE_*` (`lib/activity.ts`) |
+| WS subscribe ownership gate | `WsManager.authorizeAndSubscribe` (`ws/manager.ts:86`) — extend with group fallback |
+| Pagination | TanStack `useInfiniteQuery`; keyset cursor (no offset) |
+| API envelope | `ApiResponse<T>` (project patterns) |

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -156,20 +156,6 @@ export async function registerRoutes(
   registerPipelineRoutes(app, storage, gateway);
   registerOrchestratorRoutes(app, storage, controller);
   registerConsensusRoutes(app, storage, consensusController);
-  // Live Activity observability lens (read-only, owner/admin-scoped, metadata-only).
-  // Model slugs mirror buildOrchestratorAgent + the consensus controller wiring.
-  registerActivityRoutes(app, storage, {
-    pipelineController: controller,
-    consensusController,
-    orchestratorModels: {
-      planModelSlug: process.env.ORCHESTRATOR_PLAN_MODEL ?? "claude-opus",
-      synthesizeModelSlug: process.env.ORCHESTRATOR_PLAN_MODEL ?? "claude-opus",
-      proposerModelSlug: process.env.ORCHESTRATOR_PLAN_MODEL ?? "claude-opus",
-      criticModelSlug: process.env.ORCHESTRATOR_CRITIC_MODEL ?? "gemini-flash",
-      judgeModelSlug: process.env.ORCHESTRATOR_PLAN_MODEL ?? "claude-opus",
-    },
-    consensusClaudeModelSlug: process.env.CONSENSUS_CLAUDE_MODEL ?? "claude-opus",
-  });
   registerRunRoutes(app, storage, controller);
   registerChatRoutes(app, storage, gateway, wsManager);
   registerGatewayRoutes(app, gateway);
@@ -255,6 +241,24 @@ export async function registerRoutes(
   const taskOrchestrator = new TaskOrchestrator(storage, wsManager, controller, gateway);
   taskOrchestrator.setTracer(taskTracer);
   registerTaskGroupRoutes(app, storage, taskOrchestrator);
+
+  // Live Activity observability lens (read-only, owner/admin-scoped, metadata-only).
+  // Registered AFTER the task orchestrator so task-groups can join the live snapshot
+  // (and the History tab) as the fifth mode. Model slugs mirror buildOrchestratorAgent
+  // + the consensus controller wiring.
+  registerActivityRoutes(app, storage, {
+    pipelineController: controller,
+    consensusController,
+    taskOrchestrator,
+    orchestratorModels: {
+      planModelSlug: process.env.ORCHESTRATOR_PLAN_MODEL ?? "claude-opus",
+      synthesizeModelSlug: process.env.ORCHESTRATOR_PLAN_MODEL ?? "claude-opus",
+      proposerModelSlug: process.env.ORCHESTRATOR_PLAN_MODEL ?? "claude-opus",
+      criticModelSlug: process.env.ORCHESTRATOR_CRITIC_MODEL ?? "gemini-flash",
+      judgeModelSlug: process.env.ORCHESTRATOR_PLAN_MODEL ?? "claude-opus",
+    },
+    consensusClaudeModelSlug: process.env.CONSENSUS_CLAUDE_MODEL ?? "claude-opus",
+  });
   registerSkillTeamRoutes(app, storage);
   registerGitSkillSourceRoutes(app);
   registerTaskTraceRoutes(app, storage);

--- a/server/routes/activity.ts
+++ b/server/routes/activity.ts
@@ -1,35 +1,45 @@
 /**
- * GET /api/activity — the read-only "Live Activity" observability lens.
+ * /api/activity — the read-only "Live Activity" observability lens + its History
+ * tab.
  *
- * Returns an owner/admin-scoped snapshot of the runs that are active RIGHT NOW
- * across all four modes (pipeline / manager / orchestrator / consensus). The
- * authoritative live truth is the in-memory activeRuns registries of the two
- * controllers — NOT a DB status query (which lags the controllers).
+ * GET /api/activity            — owner/admin-scoped snapshot of runs active NOW
+ *                                across all FIVE modes (pipeline / manager /
+ *                                orchestrator / consensus / task_group).
+ * GET /api/activity/history    — DB-backed list of PAST (terminal) runs across
+ *                                all modes, owner/admin-scoped, METADATA-ONLY,
+ *                                keyset-paginated (H1/H4).
  *
- * Scoping (shared authorizeRun rule, applied per run):
+ * Scoping (shared isVisible rule, applied per run):
  *   - 401 if unauthenticated;
- *   - a non-admin sees ONLY runs whose pipeline_runs.triggeredBy === their id;
- *   - an admin sees ALL active runs and each row carries `ownerId`;
- *   - ownerless (triggeredBy == null) runs are HIDDEN from non-admins.
+ *   - a non-admin sees ONLY runs they own (pipeline-family via
+ *     pipeline_runs.triggeredBy; task-groups via task_groups.createdBy);
+ *   - an admin sees ALL runs and each row carries `ownerId`;
+ *   - ownerless runs are HIDDEN from non-admins.
  *
- * Security — METADATA ONLY. Every row carries only: run id, mode, an
- * enum-derived label/agent/phase, a model slug, a status, a timestamp, and the
- * workspace id. NO transcript, prompt, task text, decision text, step output,
- * or reasoning ever enters this payload. `title` is a non-sensitive mode/name
- * label, never the user's free-text input.
+ * Security — METADATA ONLY. Every row carries only: id, mode, an enum-derived
+ * label/agent/phase, a model slug, a status, timestamps, and the workspace id.
+ * NO transcript, prompt, task text, decision text, step output, summary,
+ * errorMessage, or reasoning ever enters this payload. The history row is built
+ * by an explicit ALLOWLIST, never by spreading a DB row. `title` is a FIXED mode
+ * label, never the user's free-text name.
  *
  * Mounted under the `/api/activity` requireAuth prefix in server/routes.ts.
  */
+import { z } from "zod";
 import type { Router, Request, Response } from "express";
-import type { IStorage } from "../storage";
+import type { IStorage, RunHistoryQuery } from "../storage";
 import type { PipelineController } from "../controller/pipeline-controller";
 import type { ConsensusController } from "../consensus/consensus-controller";
+import type { TaskOrchestrator } from "../services/task-orchestrator";
 import type {
   ActivityMode,
   ActivityRun,
   ActivityUnit,
   ActivitySnapshot,
+  ActivityHistoryRow,
+  ActivityHistoryPage,
 } from "@shared/types";
+import { isVisible } from "./authorize-run.js";
 import {
   orchestratorStepModel,
   managerTeamModel,
@@ -39,14 +49,31 @@ import {
 /** Hard cap on returned rows; we log (never silently drop) when we truncate. */
 const MAX_ACTIVITY_ROWS = 200;
 
+/** History pagination bounds (H4). */
+const HISTORY_DEFAULT_LIMIT = 25;
+const HISTORY_MAX_LIMIT = 100;
+
+/** FIXED mode labels — never the user's free-text name. */
+const MODE_TITLES: Record<ActivityMode, string> = {
+  pipeline: "Pipeline run",
+  manager: "Manager run",
+  orchestrator: "Orchestrator run",
+  consensus: "Consensus run",
+  task_group: "Task group",
+};
+
 export interface ActivityRouteDeps {
   pipelineController: Pick<PipelineController, "getActiveRunIds">;
   consensusController: Pick<ConsensusController, "getActiveRunIds">;
+  /** Optional — the task orchestrator's in-flight group ids (live task_group rows). */
+  taskOrchestrator?: Pick<TaskOrchestrator, "getActiveGroupIds">;
   /** Fixed orchestrator model slugs (matches buildOrchestratorAgent). */
   orchestratorModels: ActivityOrchestratorModels;
   /** Claude slug the consensus engine pins for blind/adjudication. */
   consensusClaudeModelSlug: string;
 }
+
+// ─── Current-unit builders (metadata only) ────────────────────────────────────
 
 /** Build the current-unit summary for a CONSENSUS run (metadata only). */
 async function consensusUnit(
@@ -61,16 +88,10 @@ async function consensusUnit(
   if (!latest) {
     return { unit: { label: "Round 0", agent: "consensus", modelSlug: null, status }, status };
   }
-  // review phase = the voter roster; blind/adjudication = Claude.
   const modelSlug = latest.phase === "review" ? null : claudeModelSlug;
   const agent = latest.phase === "review" ? "voters" : latest.phase;
   return {
-    unit: {
-      label: `Round ${latest.round} · ${latest.phase}`,
-      agent,
-      modelSlug,
-      status,
-    },
+    unit: { label: `Round ${latest.round} · ${latest.phase}`, agent, modelSlug, status },
     status,
   };
 }
@@ -84,7 +105,6 @@ async function orchestratorUnit(
   const run = await storage.getOrchestratorRun(runId);
   const steps = await storage.getOrchestratorSteps(runId);
   const status = run?.status ?? "executing";
-  // Current step = the running one, else the last completed/known step.
   const running = steps.find((s) => s.status === "running");
   const current = running ?? (steps.length > 0 ? steps[steps.length - 1] : undefined);
   if (!current) return { unit: null, status };
@@ -129,8 +149,7 @@ async function pipelineUnit(
 ): Promise<{ unit: ActivityUnit | null; status: string }> {
   const stages = await storage.getStageExecutions(runId);
   const running = stages.find((s) => s.status === "running");
-  const current =
-    running ?? stages.find((s) => s.stageIndex === currentStageIndex) ?? undefined;
+  const current = running ?? stages.find((s) => s.stageIndex === currentStageIndex) ?? undefined;
   if (!current) return { unit: null, status: runStatus };
   return {
     unit: {
@@ -143,10 +162,77 @@ async function pipelineUnit(
   };
 }
 
+/** Build the current-unit summary for a TASK GROUP (running/last task). */
+async function taskGroupUnit(
+  storage: IStorage,
+  groupId: string,
+  groupStatus: string,
+): Promise<{ unit: ActivityUnit | null; status: string }> {
+  const tasks = await storage.getTasksByGroup(groupId);
+  if (tasks.length === 0) return { unit: null, status: groupStatus };
+  const running = tasks.find((t) => t.status === "running");
+  const current = running ?? tasks[tasks.length - 1];
+  // Agent = the executionMode (enum), model = the task's model slug. NO task text.
+  return {
+    unit: {
+      label: `Task ${current.sortOrder + 1}`,
+      agent: current.executionMode,
+      modelSlug: current.modelSlug ?? null,
+      status: current.status,
+    },
+    status: groupStatus,
+  };
+}
+
+// ─── Classification (live + history share this) ───────────────────────────────
+
+interface ClassifiedRun {
+  mode: ActivityMode;
+  title: string;
+  unitResult: { unit: ActivityUnit | null; status: string };
+}
+
 /**
- * Classify a run by mode and build its metadata-only Activity row. Returns null
- * when the run can't be classified (e.g. the row vanished mid-request).
+ * Classify a pipeline_runs-keyed run by mode and build its metadata-only
+ * current-unit. Shared by the live snapshot and the history endpoint so the two
+ * agree. Returns null when the parent pipeline_runs row is gone.
  */
+async function classifyPipelineFamily(
+  storage: IStorage,
+  deps: Pick<ActivityRouteDeps, "consensusClaudeModelSlug" | "orchestratorModels">,
+  runId: string,
+): Promise<ClassifiedRun | null> {
+  const run = await storage.getPipelineRun(runId);
+  if (!run) return null;
+
+  const consensus = await storage.getConsensusRun(runId);
+  if (consensus) {
+    return {
+      mode: "consensus",
+      title: MODE_TITLES.consensus,
+      unitResult: await consensusUnit(storage, runId, deps.consensusClaudeModelSlug),
+    };
+  }
+  const orchestrator = await storage.getOrchestratorRun(runId);
+  if (orchestrator) {
+    return {
+      mode: "orchestrator",
+      title: MODE_TITLES.orchestrator,
+      unitResult: await orchestratorUnit(storage, runId, deps.orchestratorModels),
+    };
+  }
+  const managerResult = await managerUnit(storage, runId, run.status);
+  if (managerResult) {
+    return { mode: "manager", title: MODE_TITLES.manager, unitResult: managerResult };
+  }
+  return {
+    mode: "pipeline",
+    title: MODE_TITLES.pipeline,
+    unitResult: await pipelineUnit(storage, runId, run.currentStageIndex, run.status),
+  };
+}
+
+/** Build a metadata-only live ActivityRun for a pipeline-family run. */
 async function buildActivityRun(
   storage: IStorage,
   deps: ActivityRouteDeps,
@@ -154,108 +240,274 @@ async function buildActivityRun(
   ownerId: string | null,
   isAdmin: boolean,
 ): Promise<ActivityRun | null> {
+  const classified = await classifyPipelineFamily(storage, deps, runId);
+  if (!classified) return null;
   const run = await storage.getPipelineRun(runId);
   if (!run) return null;
 
-  let mode: ActivityMode;
-  let title: string;
-  let unitResult: { unit: ActivityUnit | null; status: string };
-
-  const consensus = await storage.getConsensusRun(runId);
-  if (consensus) {
-    mode = "consensus";
-    title = "Consensus run";
-    unitResult = await consensusUnit(storage, runId, deps.consensusClaudeModelSlug);
-  } else {
-    const orchestrator = await storage.getOrchestratorRun(runId);
-    if (orchestrator) {
-      mode = "orchestrator";
-      title = "Orchestrator run";
-      unitResult = await orchestratorUnit(storage, runId, deps.orchestratorModels);
-    } else {
-      const managerResult = await managerUnit(storage, runId, run.status);
-      if (managerResult) {
-        mode = "manager";
-        title = "Manager run";
-        unitResult = managerResult;
-      } else {
-        mode = "pipeline";
-        title = "Pipeline run";
-        unitResult = await pipelineUnit(
-          storage,
-          runId,
-          run.currentStageIndex,
-          run.status,
-        );
-      }
-    }
-  }
-
   const row: ActivityRun = {
     runId,
-    mode,
-    title,
-    status: unitResult.status,
+    mode: classified.mode,
+    title: classified.title,
+    status: classified.unitResult.status,
     workspaceId: run.workspaceId ?? null,
-    currentUnit: unitResult.unit,
+    currentUnit: classified.unitResult.unit,
     startedAt: run.startedAt ? run.startedAt.toISOString() : null,
   };
-  // Owner attribution is admin-only.
   if (isAdmin) row.ownerId = ownerId;
   return row;
 }
+
+/** Build a metadata-only live ActivityRun for a task group. */
+async function buildTaskGroupRun(
+  storage: IStorage,
+  groupId: string,
+  ownerId: string | null,
+  isAdmin: boolean,
+): Promise<ActivityRun | null> {
+  const group = await storage.getTaskGroup(groupId);
+  if (!group) return null;
+  const unitResult = await taskGroupUnit(storage, groupId, group.status);
+  const row: ActivityRun = {
+    runId: groupId,
+    mode: "task_group",
+    title: MODE_TITLES.task_group,
+    status: group.status,
+    workspaceId: null,
+    currentUnit: unitResult.unit,
+    startedAt: group.startedAt ? group.startedAt.toISOString() : null,
+  };
+  if (isAdmin) row.ownerId = ownerId;
+  return row;
+}
+
+// ─── History cursor (opaque base64 keyset, Zod-validated) ──────────────────────
+
+const CursorSchema = z.object({
+  completedAt: z.string().datetime(),
+  id: z.string().min(1).max(200),
+});
+type Cursor = z.infer<typeof CursorSchema>;
+
+function encodeCursor(c: Cursor): string {
+  return Buffer.from(JSON.stringify(c), "utf8").toString("base64url");
+}
+
+/** Parse an opaque cursor; returns null on any malformed/invalid input. */
+function decodeCursor(raw: string): Cursor | null {
+  try {
+    const json = Buffer.from(raw, "base64url").toString("utf8");
+    const parsed = CursorSchema.safeParse(JSON.parse(json));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+const HistoryQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(HISTORY_MAX_LIMIT).optional(),
+  cursor: z.string().min(1).max(2000).optional(),
+  mode: z.enum(["pipeline", "manager", "orchestrator", "consensus", "task_group"]).optional(),
+});
+
+/** A merged history candidate keyed on the global (completedAt, id) ordering. */
+interface HistoryCandidate {
+  id: string;
+  completedAt: Date | null;
+  isTaskGroup: boolean;
+}
+
+/** Sort two candidates by (completedAt desc, id desc). null completedAt sorts last. */
+function cmpCandidates(a: HistoryCandidate, b: HistoryCandidate): number {
+  const ta = a.completedAt ? a.completedAt.getTime() : -Infinity;
+  const tb = b.completedAt ? b.completedAt.getTime() : -Infinity;
+  if (ta !== tb) return tb - ta;
+  return b.id.localeCompare(a.id);
+}
+
+// ─── Route registration ────────────────────────────────────────────────────
 
 export function registerActivityRoutes(
   router: Router,
   storage: IStorage,
   deps: ActivityRouteDeps,
 ): void {
+  // ── Live snapshot ──────────────────────────────────────────────────────────
   router.get("/api/activity", async (req: Request, res: Response) => {
-    if (!req.user?.id) {
-      return res.status(401).json({ error: "Authentication required" });
-    }
-    const userId = req.user.id;
+    if (!req.user?.id) return res.status(401).json({ error: "Authentication required" });
     const isAdmin = req.user.role === "admin";
 
     try {
-      // Union the two registries (pipeline+manager+orchestrator ∪ consensus).
-      const candidateIds = [
+      const pipelineFamilyIds = [
         ...deps.pipelineController.getActiveRunIds(),
         ...deps.consensusController.getActiveRunIds(),
       ];
-      const uniqueIds = [...new Set(candidateIds)];
+      const groupIds = deps.taskOrchestrator?.getActiveGroupIds() ?? [];
+      const uniquePipeline = [...new Set(pipelineFamilyIds)];
+      const uniqueGroups = [...new Set(groupIds)];
 
       const rows: ActivityRun[] = [];
       let truncated = false;
 
-      for (const runId of uniqueIds) {
+      // Pipeline-family rows — owner gate via pipeline_runs.triggeredBy.
+      for (const runId of uniquePipeline) {
         const run = await storage.getPipelineRun(runId);
-        if (!run) continue; // registry/DB raced — skip.
-
-        // Single ownership gate for ALL modes via pipeline_runs.triggeredBy.
-        const isOwner = run.triggeredBy != null && run.triggeredBy === userId;
-        if (!isAdmin && !isOwner) continue; // hides others' + ownerless from non-admins.
-
+        if (!run) continue;
+        if (!isVisible(run.triggeredBy, req.user)) continue;
         if (rows.length >= MAX_ACTIVITY_ROWS) {
           truncated = true;
           break;
         }
-
         const row = await buildActivityRun(storage, deps, runId, run.triggeredBy, isAdmin);
         if (row) rows.push(row);
       }
 
+      // Task-group rows — owner gate via task_groups.createdBy.
+      if (!truncated) {
+        for (const groupId of uniqueGroups) {
+          const group = await storage.getTaskGroup(groupId);
+          if (!group) continue;
+          if (!isVisible(group.createdBy, req.user)) continue;
+          if (rows.length >= MAX_ACTIVITY_ROWS) {
+            truncated = true;
+            break;
+          }
+          const row = await buildTaskGroupRun(storage, groupId, group.createdBy, isAdmin);
+          if (row) rows.push(row);
+        }
+      }
+
       if (truncated) {
         console.warn(
-          `[activity] row cap hit: ${uniqueIds.length} candidate active runs > ${MAX_ACTIVITY_ROWS} cap; response truncated`,
+          `[activity] row cap hit: candidate active runs > ${MAX_ACTIVITY_ROWS} cap; response truncated`,
         );
       }
 
       const snapshot: ActivitySnapshot = { runs: rows, isAdmin, truncated };
       return res.json(snapshot);
     } catch {
-      // Generic — never leak internal detail.
       return res.status(500).json({ error: "Failed to load activity" });
     }
   });
+
+  // ── History tab (terminal runs, DB-backed, metadata-only, keyset) ────────────
+  router.get("/api/activity/history", async (req: Request, res: Response) => {
+    if (!req.user?.id) return res.status(401).json({ error: "Authentication required" });
+    const isAdmin = req.user.role === "admin";
+    const ownerId = isAdmin ? undefined : req.user.id; // SQL owner filter for non-admins.
+
+    const parsedQuery = HistoryQuerySchema.safeParse(req.query);
+    if (!parsedQuery.success) {
+      return res.status(400).json({ error: "Invalid query parameters" });
+    }
+    const { mode } = parsedQuery.data;
+    const limit = Math.min(parsedQuery.data.limit ?? HISTORY_DEFAULT_LIMIT, HISTORY_MAX_LIMIT);
+
+    let cursor: Cursor | undefined;
+    if (parsedQuery.data.cursor) {
+      const decoded = decodeCursor(parsedQuery.data.cursor);
+      if (!decoded) return res.status(400).json({ error: "Invalid cursor" });
+      cursor = decoded;
+    }
+
+    try {
+      const baseQuery: RunHistoryQuery = {
+        ownerId,
+        limit,
+        cursor: cursor ? { completedAt: cursor.completedAt, id: cursor.id } : undefined,
+      };
+
+      const wantPipeline = mode !== "task_group";
+      const wantGroups = mode === undefined || mode === "task_group";
+
+      // Over-fetch `limit` from each source; merge by the global keyset ordering.
+      const pipelineRows = wantPipeline ? await storage.listPipelineRunHistory(baseQuery) : [];
+      const groupRows = wantGroups ? await storage.listTaskGroupHistory(baseQuery) : [];
+
+      const candidates: HistoryCandidate[] = [
+        ...pipelineRows.map((r) => ({ id: r.id, completedAt: r.completedAt, isTaskGroup: false })),
+        ...groupRows.map((r) => ({ id: r.id, completedAt: r.completedAt, isTaskGroup: true })),
+      ];
+      candidates.sort(cmpCandidates);
+      const page = candidates.slice(0, limit);
+
+      const items: ActivityHistoryRow[] = [];
+      for (const cand of page) {
+        const row = cand.isTaskGroup
+          ? await buildTaskGroupHistoryRow(storage, cand.id, isAdmin)
+          : await buildPipelineHistoryRow(storage, deps, cand.id, isAdmin);
+        if (row) {
+          // Mode filter (defense in depth — already partitioned by source).
+          if (mode && row.mode !== mode) continue;
+          items.push(row);
+        }
+      }
+
+      const last = page[page.length - 1];
+      const nextCursor =
+        page.length === limit && last
+          ? encodeCursor({
+              completedAt: (last.completedAt ?? new Date(0)).toISOString(),
+              id: last.id,
+            })
+          : null;
+
+      const payload: ActivityHistoryPage = { items, nextCursor, isAdmin };
+      return res.json(payload);
+    } catch {
+      return res.status(500).json({ error: "Failed to load activity history" });
+    }
+  });
+}
+
+// ─── History row builders (ALLOWLIST — never spread a DB row) ───────────────────
+
+async function buildPipelineHistoryRow(
+  storage: IStorage,
+  deps: Pick<ActivityRouteDeps, "consensusClaudeModelSlug" | "orchestratorModels">,
+  runId: string,
+  isAdmin: boolean,
+): Promise<ActivityHistoryRow | null> {
+  const run = await storage.getPipelineRun(runId);
+  if (!run) return null;
+  const classified = await classifyPipelineFamily(storage, deps, runId);
+  if (!classified) return null;
+
+  // Explicit allowlist — only enum/id/timestamp fields; NO output/input/summary.
+  const row: ActivityHistoryRow = {
+    runId,
+    mode: classified.mode,
+    title: classified.title,
+    status: run.status,
+    startedAt: run.startedAt ? run.startedAt.toISOString() : null,
+    completedAt: run.completedAt ? run.completedAt.toISOString() : null,
+    currentUnit: classified.unitResult.unit,
+    workspaceId: run.workspaceId ?? null,
+  };
+  if (isAdmin) row.ownerId = run.triggeredBy ?? null;
+  return row;
+}
+
+async function buildTaskGroupHistoryRow(
+  storage: IStorage,
+  groupId: string,
+  isAdmin: boolean,
+): Promise<ActivityHistoryRow | null> {
+  const group = await storage.getTaskGroup(groupId);
+  if (!group) return null;
+  const unitResult = await taskGroupUnit(storage, groupId, group.status);
+
+  // Explicit allowlist — FIXED title (NEVER group.name), no output/summary/input.
+  const row: ActivityHistoryRow = {
+    runId: groupId,
+    mode: "task_group",
+    title: MODE_TITLES.task_group,
+    status: group.status,
+    startedAt: group.startedAt ? group.startedAt.toISOString() : null,
+    completedAt: group.completedAt ? group.completedAt.toISOString() : null,
+    currentUnit: unitResult.unit,
+    workspaceId: null,
+  };
+  if (isAdmin) row.ownerId = group.createdBy ?? null;
+  return row;
 }

--- a/server/routes/authorize-run.ts
+++ b/server/routes/authorize-run.ts
@@ -13,10 +13,35 @@
  * On success returns { ownerId }; on failure it writes the status + a generic
  * body to `res` and returns null (the caller must early-return).
  *
- * Callers: routes/orchestrator.ts, routes/consensus.ts, routes/activity.ts.
+ * Callers: routes/orchestrator.ts, routes/consensus.ts, routes/activity.ts,
+ * routes/authorize-task-group.ts (via isVisible), ws/manager.ts (via isVisible).
  */
 import type { Request, Response } from "express";
 import type { IStorage } from "../storage";
+
+/** Minimal user shape the visibility predicate needs (id + role). */
+export interface VisibilityUser {
+  id?: string;
+  role?: string;
+}
+
+/**
+ * The single ownership-visibility predicate shared by every owner-scoped read in
+ * the codebase (authorizeRun, authorizeTaskGroup, the activity history filter,
+ * and the WS subscribe gate). A row is visible iff the caller is an admin OR the
+ * caller owns it. Ownerless rows (ownerId == null) are visible ONLY to admins —
+ * the STRICT posture (transcripts/activity/groups are never world-readable).
+ *
+ * Fail-closed: a caller with no id is never granted visibility.
+ */
+export function isVisible(
+  ownerId: string | null | undefined,
+  user: VisibilityUser | undefined,
+): boolean {
+  if (!user?.id) return false;
+  if (user.role === "admin") return true;
+  return ownerId != null && ownerId === user.id;
+}
 
 export interface AuthorizeRunOptions {
   /**
@@ -53,10 +78,8 @@ export async function authorizeRun(
     return null;
   }
 
-  const isAdmin = req.user.role === "admin";
-  const isOwner = run.triggeredBy != null && run.triggeredBy === req.user.id;
-  // Deny when ownerless (stricter than manager) unless admin.
-  if (!isAdmin && !isOwner) {
+  // Reuse the shared predicate; 403 when not visible (owner mismatch / ownerless / non-admin).
+  if (!isVisible(run.triggeredBy, req.user)) {
     res.status(403).json({ error: "Forbidden" });
     return null;
   }

--- a/server/routes/authorize-task-group.ts
+++ b/server/routes/authorize-task-group.ts
@@ -1,0 +1,55 @@
+/**
+ * Owner-or-admin authorization for a TASK GROUP, keyed on `task_groups.createdBy`
+ * (NOT `pipeline_runs.triggeredBy` — task groups have no pipeline_runs row).
+ *
+ * Mirrors routes/authorize-run.ts exactly:
+ *   - ordering 401 unauth → 404 missing → 403 non-owner;
+ *   - admin bypass;
+ *   - STRICT: ownerless groups (createdBy == null) are DENIED to non-admins.
+ *
+ * On success returns { group, ownerId }; on failure it writes the status + a
+ * generic body to `res` and returns null (the caller must early-return).
+ *
+ * Closes the pre-existing IDOR on every task-group route (C1): the routes were
+ * behind requireAuth but performed NO ownership check.
+ *
+ * Caller: server/routes/task-groups.ts (every per-id route + the 4 edit routes).
+ */
+import type { Request, Response } from "express";
+import type { IStorage } from "../storage";
+import type { TaskGroupRow } from "@shared/schema";
+import { isVisible } from "./authorize-run.js";
+
+export interface AuthorizedTaskGroup {
+  /** The group row (already loaded — callers reuse it to avoid a second read). */
+  group: TaskGroupRow;
+  /** The group owner id (task_groups.createdBy); null for ownerless groups (admin-only). */
+  ownerId: string | null;
+}
+
+export async function authorizeTaskGroup(
+  req: Request,
+  res: Response,
+  storage: IStorage,
+  groupId: string,
+): Promise<AuthorizedTaskGroup | null> {
+  // 401 first — unauth takes precedence over existence.
+  if (!req.user?.id) {
+    res.status(401).json({ error: "Authentication required" });
+    return null;
+  }
+
+  const group = await storage.getTaskGroup(groupId);
+  if (!group) {
+    res.status(404).json({ error: "Task group not found" });
+    return null;
+  }
+
+  // Reuse the shared predicate; 403 when not visible (owner mismatch / ownerless / non-admin).
+  if (!isVisible(group.createdBy, req.user)) {
+    res.status(403).json({ error: "Forbidden" });
+    return null;
+  }
+
+  return { group, ownerId: group.createdBy };
+}

--- a/server/routes/task-groups.ts
+++ b/server/routes/task-groups.ts
@@ -1,32 +1,79 @@
 import { Router } from "express";
 import { z } from "zod";
+import type { Request, Response } from "express";
 import type { IStorage } from "../storage";
 import type { TaskOrchestrator } from "../services/task-orchestrator";
 import { validateBody } from "../middleware/validate.js";
+import { authorizeTaskGroup } from "./authorize-task-group.js";
+import { isVisible } from "./authorize-run.js";
+import {
+  TaskGroupEditor,
+  TaskGroupEditError,
+} from "../services/task-group-editor.js";
 
 // ─── Validation Schemas ─────────────────────────────────────────────────────
+
+const TaskFieldsSchema = z.object({
+  name: z.string().min(1).max(200),
+  description: z.string().min(1).max(5000),
+  executionMode: z.enum(["pipeline_run", "direct_llm"]).optional(),
+  dependsOn: z.array(z.string().max(200)).max(50).optional(),
+  pipelineId: z.string().max(100).optional(),
+  modelSlug: z.string().max(100).optional(),
+  teamId: z.string().max(100).optional(),
+  input: z.record(z.unknown()).optional(),
+  sortOrder: z.number().int().min(0).max(1000).optional(),
+});
 
 const CreateTaskGroupSchema = z.object({
   name: z.string().min(1).max(200),
   description: z.string().min(1).max(5000),
   input: z.string().min(1).max(50000),
-  tasks: z
-    .array(
-      z.object({
-        name: z.string().min(1).max(200),
-        description: z.string().min(1).max(5000),
-        executionMode: z.enum(["pipeline_run", "direct_llm"]).optional(),
-        dependsOn: z.array(z.string().max(200)).max(50).optional(),
-        pipelineId: z.string().max(100).optional(),
-        modelSlug: z.string().max(100).optional(),
-        teamId: z.string().max(100).optional(),
-        input: z.record(z.unknown()).optional(),
-        sortOrder: z.number().int().min(0).max(1000).optional(),
-      }),
-    )
-    .min(1)
-    .max(100),
+  tasks: z.array(TaskFieldsSchema).min(1).max(100),
 });
+
+/** PATCH group — all optional, at least one required. */
+const UpdateTaskGroupSchema = z
+  .object({
+    name: z.string().min(1).max(200).optional(),
+    description: z.string().min(1).max(5000).optional(),
+    input: z.string().min(1).max(50000).optional(),
+  })
+  .refine((b) => b.name !== undefined || b.description !== undefined || b.input !== undefined, {
+    message: "At least one of name, description, input is required",
+  });
+
+/** PATCH task — all optional, at least one required. */
+const UpdateTaskSchema = z
+  .object({
+    name: z.string().min(1).max(200).optional(),
+    description: z.string().min(1).max(5000).optional(),
+    executionMode: z.enum(["pipeline_run", "direct_llm"]).optional(),
+    dependsOn: z.array(z.string().max(200)).max(50).optional(),
+    pipelineId: z.string().max(100).optional(),
+    modelSlug: z.string().max(100).optional(),
+    teamId: z.string().max(100).optional(),
+    input: z.record(z.unknown()).optional(),
+    sortOrder: z.number().int().min(0).max(1000).optional(),
+  })
+  .refine((b) => Object.keys(b).length > 0, { message: "At least one field is required" });
+
+/** POST new task — same per-task field bounds as create. */
+const AddTaskSchema = TaskFieldsSchema;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Map a thrown error to a generic client response (M1: never leak String(err)).
+ * Edit-layer errors carry their HTTP status; everything else is a generic 500.
+ */
+function sendError(res: Response, err: unknown, fallbackMessage: string): void {
+  if (err instanceof TaskGroupEditError) {
+    res.status(err.status).json({ error: err.message });
+    return;
+  }
+  res.status(500).json({ error: fallbackMessage });
+}
 
 // ─── Route Registration ─────────────────────────────────────────────────────
 
@@ -35,96 +82,181 @@ export function registerTaskGroupRoutes(
   storage: IStorage,
   orchestrator: TaskOrchestrator,
 ) {
-  // List all task groups
-  router.get("/api/task-groups", async (_req, res) => {
+  const editor = new TaskGroupEditor(storage);
+
+  // List task groups — owner-scoped (C1). Non-admins see only their own; admins
+  // see all + an ownerId on each row.
+  router.get("/api/task-groups", async (req: Request, res: Response) => {
+    if (!req.user?.id) return res.status(401).json({ error: "Authentication required" });
+    const isAdmin = req.user.role === "admin";
     try {
       const groups = await storage.getTaskGroups();
-      // Attach task counts
+      const visible = groups.filter((g) => isVisible(g.createdBy, req.user));
       const result = await Promise.all(
-        groups.map(async (g) => {
+        visible.map(async (g) => {
           const tasks = await storage.getTasksByGroup(g.id);
-          return {
+          const row: Record<string, unknown> = {
             ...g,
             taskCount: tasks.length,
             completedCount: tasks.filter((t) => t.status === "completed").length,
           };
+          // Owner attribution is admin-only; hide createdBy from non-admins.
+          if (!isAdmin) delete row.createdBy;
+          return row;
         }),
       );
       res.json(result);
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
+    } catch {
+      res.status(500).json({ error: "Failed to load task groups" });
     }
   });
 
-  // Get single task group with all tasks
-  router.get("/api/task-groups/:id", async (req, res) => {
+  // Get single task group with all tasks (C1 gated).
+  router.get("/api/task-groups/:id", async (req: Request, res: Response) => {
+    const auth = await authorizeTaskGroup(req, res, storage, String(req.params.id));
+    if (!auth) return;
     try {
-      const group = await storage.getTaskGroup(req.params.id);
-      if (!group) return res.status(404).json({ error: "Task group not found" });
-      const tasks = await storage.getTasksByGroup(group.id);
-      res.json({ ...group, tasks });
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
+      const tasks = await storage.getTasksByGroup(auth.group.id);
+      res.json({ ...auth.group, tasks });
+    } catch {
+      res.status(500).json({ error: "Failed to load task group" });
     }
   });
 
-  // Create task group with tasks
-  router.post("/api/task-groups", validateBody(CreateTaskGroupSchema), async (req, res) => {
+  // Create task group with tasks (stamps createdBy from the session).
+  router.post("/api/task-groups", validateBody(CreateTaskGroupSchema), async (req: Request, res: Response) => {
+    if (!req.user?.id) return res.status(401).json({ error: "Authentication required" });
     try {
       const body = req.body as z.infer<typeof CreateTaskGroupSchema>;
-      const userId = (req as unknown as { user?: { id: string } }).user?.id;
-      const result = await orchestrator.createTaskGroup({
-        ...body,
-        createdBy: userId,
-      });
+      const result = await orchestrator.createTaskGroup({ ...body, createdBy: req.user.id });
       res.status(201).json({ ...result.group, tasks: result.tasks });
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
+    } catch {
+      res.status(500).json({ error: "Failed to create task group" });
     }
   });
 
-  // Start task group execution
-  router.post("/api/task-groups/:id/start", async (req, res) => {
+  // Start task group execution (C1 gated).
+  router.post("/api/task-groups/:id/start", async (req: Request, res: Response) => {
+    const auth = await authorizeTaskGroup(req, res, storage, String(req.params.id));
+    if (!auth) return;
     try {
-      await orchestrator.startGroup(req.params.id);
-      const group = await storage.getTaskGroup(req.params.id);
+      await orchestrator.startGroup(String(req.params.id));
+      const group = await storage.getTaskGroup(String(req.params.id));
       res.json(group);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      // startGroup throws on non-pending — surface as a 400 with its safe message.
+      const message = err instanceof Error ? err.message : "Failed to start task group";
       res.status(400).json({ error: message });
     }
   });
 
-  // Cancel task group
-  router.post("/api/task-groups/:id/cancel", async (req, res) => {
+  // Cancel task group (C1 gated).
+  router.post("/api/task-groups/:id/cancel", async (req: Request, res: Response) => {
+    const auth = await authorizeTaskGroup(req, res, storage, String(req.params.id));
+    if (!auth) return;
     try {
-      await orchestrator.cancelGroup(req.params.id);
-      const group = await storage.getTaskGroup(req.params.id);
+      await orchestrator.cancelGroup(String(req.params.id));
+      const group = await storage.getTaskGroup(String(req.params.id));
       res.json(group);
-    } catch (err) {
-      res.status(500).json({ error: String(err) });
+    } catch {
+      res.status(500).json({ error: "Failed to cancel task group" });
     }
   });
 
-  // Delete task group
-  router.delete("/api/task-groups/:id", async (req, res) => {
+  // Delete task group (C1 gated).
+  router.delete("/api/task-groups/:id", async (req: Request, res: Response) => {
+    const auth = await authorizeTaskGroup(req, res, storage, String(req.params.id));
+    if (!auth) return;
     try {
-      await storage.deleteTaskGroup(req.params.id);
+      await storage.deleteTaskGroup(String(req.params.id));
+      res.status(204).end();
+    } catch {
+      res.status(500).json({ error: "Failed to delete task group" });
+    }
+  });
+
+  // Retry a failed task (C1 + C2: authorize the group AND assert task ∈ group).
+  router.post("/api/task-groups/:id/tasks/:taskId/retry", async (req: Request, res: Response) => {
+    const auth = await authorizeTaskGroup(req, res, storage, String(req.params.id));
+    if (!auth) return;
+    try {
+      // C2/M3: the task must belong to this group, else 404 (cross-group tamper).
+      const task = await storage.getTask(String(req.params.taskId));
+      if (!task || task.groupId !== String(req.params.id)) {
+        return res.status(404).json({ error: "Task not found" });
+      }
+      await orchestrator.retryTask(String(req.params.taskId));
+      const updated = await storage.getTask(String(req.params.taskId));
+      res.json(updated);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to retry task";
+      res.status(400).json({ error: message });
+    }
+  });
+
+  // ─── Edit endpoints (A) — all C1 gated + pending-guarded in the editor ──────
+
+  // PATCH group (name/description/input).
+  router.patch(
+    "/api/task-groups/:id",
+    validateBody(UpdateTaskGroupSchema),
+    async (req: Request, res: Response) => {
+      const auth = await authorizeTaskGroup(req, res, storage, String(req.params.id));
+      if (!auth) return;
+      try {
+        const patch = req.body as z.infer<typeof UpdateTaskGroupSchema>;
+        const group = await editor.updateGroup(String(req.params.id), patch);
+        const tasks = await storage.getTasksByGroup(group.id);
+        res.json({ ...group, tasks });
+      } catch (err) {
+        sendError(res, err, "Failed to update task group");
+      }
+    },
+  );
+
+  // PATCH a task.
+  router.patch(
+    "/api/task-groups/:id/tasks/:taskId",
+    validateBody(UpdateTaskSchema),
+    async (req: Request, res: Response) => {
+      const auth = await authorizeTaskGroup(req, res, storage, String(req.params.id));
+      if (!auth) return;
+      try {
+        const patch = req.body as z.infer<typeof UpdateTaskSchema>;
+        const task = await editor.updateTask(String(req.params.id), String(req.params.taskId), patch);
+        res.json(task);
+      } catch (err) {
+        sendError(res, err, "Failed to update task");
+      }
+    },
+  );
+
+  // POST a new task into a group.
+  router.post(
+    "/api/task-groups/:id/tasks",
+    validateBody(AddTaskSchema),
+    async (req: Request, res: Response) => {
+      const auth = await authorizeTaskGroup(req, res, storage, String(req.params.id));
+      if (!auth) return;
+      try {
+        const body = req.body as z.infer<typeof AddTaskSchema>;
+        const task = await editor.addTask(String(req.params.id), body);
+        res.status(201).json(task);
+      } catch (err) {
+        sendError(res, err, "Failed to add task");
+      }
+    },
+  );
+
+  // DELETE a task from a group.
+  router.delete("/api/task-groups/:id/tasks/:taskId", async (req: Request, res: Response) => {
+    const auth = await authorizeTaskGroup(req, res, storage, String(req.params.id));
+    if (!auth) return;
+    try {
+      await editor.removeTask(String(req.params.id), String(req.params.taskId));
       res.status(204).end();
     } catch (err) {
-      res.status(500).json({ error: String(err) });
-    }
-  });
-
-  // Retry a failed task
-  router.post("/api/task-groups/:id/tasks/:taskId/retry", async (req, res) => {
-    try {
-      await orchestrator.retryTask(req.params.taskId);
-      const task = await storage.getTask(req.params.taskId);
-      res.json(task);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      res.status(400).json({ error: message });
+      sendError(res, err, "Failed to delete task");
     }
   });
 }

--- a/server/routes/task-traces.ts
+++ b/server/routes/task-traces.ts
@@ -1,5 +1,6 @@
 import type { Express } from "express";
 import type { IStorage } from "../storage";
+import { authorizeTaskGroup } from "./authorize-task-group.js";
 
 // ─── Route Registration ─────────────────────────────────────────────────────
 
@@ -11,6 +12,13 @@ export function registerTaskTraceRoutes(app: Express, storage: IStorage): void {
       if (!groupId) {
         return res.status(400).json({ error: "Missing group id" });
       }
+
+      // Owner-or-admin gate (same IDOR class closed on the other task-group
+      // routes): the trace exposes the span tree, durations, token/cost, and
+      // error strings — must not be readable cross-tenant. authorizeTaskGroup
+      // writes 401/404/403 + returns null on failure.
+      const auth = await authorizeTaskGroup(req, res, storage, groupId);
+      if (!auth) return;
 
       const trace = await storage.getTaskTrace(groupId);
       if (!trace) {

--- a/server/services/task-graph.ts
+++ b/server/services/task-graph.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure DAG validation for task-group dependency graphs.
+ *
+ * `dependsOn` stores task IDs within the same group. Edits (PATCH task, POST
+ * task, DELETE task) can introduce dangling refs, self-deps, or cycles — the
+ * orchestrator's runtime unblock logic assumes a valid DAG, so this enforces the
+ * invariant the runtime already relies on, BEFORE any persist.
+ *
+ * Stateless and storage-free so it is trivially unit-testable.
+ *
+ * Callers: server/routes/task-groups.ts (PATCH/POST/DELETE task handlers).
+ */
+
+export interface TaskGraphNode {
+  id: string;
+  dependsOn: string[];
+}
+
+export type TaskGraphResult = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Validate that `tasks` form a valid DAG:
+ *   - every dependsOn id must reference a task in the set (no dangling refs);
+ *   - no task may depend on itself;
+ *   - no cycles.
+ * Returns `{ ok: true }` for any valid DAG (including the empty graph), else
+ * `{ ok: false, reason }` with a non-sensitive, id-only reason.
+ */
+export function validateTaskGraph(tasks: ReadonlyArray<TaskGraphNode>): TaskGraphResult {
+  const ids = new Set(tasks.map((t) => t.id));
+
+  // Dangling + self-dep checks first (cheap, precise).
+  for (const t of tasks) {
+    for (const dep of t.dependsOn) {
+      if (dep === t.id) {
+        return { ok: false, reason: `Task ${t.id} cannot depend on itself` };
+      }
+      if (!ids.has(dep)) {
+        return { ok: false, reason: `Task ${t.id} depends on unknown task ${dep}` };
+      }
+    }
+  }
+
+  // Cycle detection via iterative DFS with white/grey/black coloring.
+  const adjacency = new Map<string, string[]>();
+  for (const t of tasks) adjacency.set(t.id, t.dependsOn);
+
+  const WHITE = 0;
+  const GREY = 1;
+  const BLACK = 2;
+  const color = new Map<string, number>();
+  for (const id of ids) color.set(id, WHITE);
+
+  const stack: Array<{ id: string; iter: Iterator<string> }> = [];
+
+  for (const start of ids) {
+    if (color.get(start) !== WHITE) continue;
+    color.set(start, GREY);
+    stack.push({ id: start, iter: (adjacency.get(start) ?? [])[Symbol.iterator]() });
+
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1];
+      const next = frame.iter.next();
+      if (next.done) {
+        color.set(frame.id, BLACK);
+        stack.pop();
+        continue;
+      }
+      const dep = next.value;
+      const depColor = color.get(dep) ?? WHITE;
+      if (depColor === GREY) {
+        return { ok: false, reason: `Dependency cycle detected involving task ${dep}` };
+      }
+      if (depColor === WHITE) {
+        color.set(dep, GREY);
+        stack.push({ id: dep, iter: (adjacency.get(dep) ?? [])[Symbol.iterator]() });
+      }
+    }
+  }
+
+  return { ok: true };
+}

--- a/server/services/task-group-editor.ts
+++ b/server/services/task-group-editor.ts
@@ -1,0 +1,232 @@
+/**
+ * Task-group edit orchestration (thin collaborator over IStorage).
+ *
+ * Encapsulates the "editable only while pending" invariant + the dependsOn
+ * rewrite / status-recompute rules so the route handlers stay thin (authorize →
+ * validateBody → delegate). Mirrors how create/start/cancel delegate to the
+ * orchestrator.
+ *
+ * Edit matrix (H2):
+ *   pending   → name/description/input + tasks (add/remove/patch) all editable;
+ *   running   → every edit 409 (mutating mid-run corrupts the execution record);
+ *   terminal  → only name/description relabel; input + tasks 409.
+ *
+ * TOCTOU: each method RE-READS the group immediately before persisting and
+ * re-checks `status === "pending"` (for task/input edits). The route authorizes
+ * then delegates synchronously, so this re-read is the persist-time guard
+ * against a concurrent `startGroup` flipping the status between auth and write.
+ *
+ * Errors are thrown as `TaskGroupEditError` carrying an HTTP status so the route
+ * maps them generically (404 missing / 409 not-pending / 400 invalid graph).
+ *
+ * Caller: server/routes/task-groups.ts (PATCH/POST/DELETE task + PATCH group).
+ */
+import type { IStorage } from "../storage";
+import type { TaskGroupRow, TaskRow, InsertTask } from "@shared/schema";
+import { validateTaskGraph } from "./task-graph.js";
+
+/** An edit-layer error that maps to a specific HTTP status in the route. */
+export class TaskGroupEditError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "TaskGroupEditError";
+  }
+}
+
+export interface GroupPatch {
+  name?: string;
+  description?: string;
+  input?: string;
+}
+
+export interface TaskPatch {
+  name?: string;
+  description?: string;
+  executionMode?: "pipeline_run" | "direct_llm";
+  dependsOn?: string[];
+  pipelineId?: string;
+  modelSlug?: string;
+  teamId?: string;
+  input?: Record<string, unknown>;
+  sortOrder?: number;
+}
+
+export interface NewTaskInput {
+  name: string;
+  description: string;
+  executionMode?: "pipeline_run" | "direct_llm";
+  dependsOn?: string[];
+  pipelineId?: string;
+  modelSlug?: string;
+  teamId?: string;
+  input?: Record<string, unknown>;
+  sortOrder?: number;
+}
+
+export class TaskGroupEditor {
+  constructor(private storage: IStorage) {}
+
+  /** Load the group fresh or throw 404 (persist-time existence check). */
+  private async requireGroup(groupId: string): Promise<TaskGroupRow> {
+    const group = await this.storage.getTaskGroup(groupId);
+    if (!group) throw new TaskGroupEditError(404, "Task group not found");
+    return group;
+  }
+
+  /** Load a task that MUST belong to `groupId`, else 404 (cross-group guard, M3). */
+  private async requireTaskInGroup(groupId: string, taskId: string): Promise<TaskRow> {
+    const task = await this.storage.getTask(taskId);
+    if (!task || task.groupId !== groupId) {
+      throw new TaskGroupEditError(404, "Task not found");
+    }
+    return task;
+  }
+
+  /**
+   * PATCH group fields. `input` requires `pending`; `name`/`description` allowed
+   * post-terminal (relabel) but blocked while `running`.
+   */
+  async updateGroup(groupId: string, patch: GroupPatch): Promise<TaskGroupRow> {
+    const group = await this.requireGroup(groupId);
+    const wantsInput = patch.input !== undefined;
+
+    if (group.status === "running") {
+      throw new TaskGroupEditError(409, "Cannot edit a running task group");
+    }
+    if (group.status !== "pending" && wantsInput) {
+      throw new TaskGroupEditError(409, "Cannot edit input after the group has started");
+    }
+
+    const updates: Partial<TaskGroupRow> = {};
+    if (patch.name !== undefined) updates.name = patch.name;
+    if (patch.description !== undefined) updates.description = patch.description;
+    if (wantsInput) updates.input = patch.input;
+
+    return this.storage.updateTaskGroup(groupId, updates);
+  }
+
+  /** PATCH a single task — pending-only, DAG-validated, status recomputed. */
+  async updateTask(groupId: string, taskId: string, patch: TaskPatch): Promise<TaskRow> {
+    const group = await this.requireGroup(groupId);
+    await this.requireTaskInGroup(groupId, taskId);
+    this.assertPending(group);
+
+    const updates: Partial<TaskRow> = {};
+    if (patch.name !== undefined) updates.name = patch.name;
+    if (patch.description !== undefined) updates.description = patch.description;
+    if (patch.executionMode !== undefined) updates.executionMode = patch.executionMode;
+    if (patch.pipelineId !== undefined) updates.pipelineId = patch.pipelineId;
+    if (patch.modelSlug !== undefined) updates.modelSlug = patch.modelSlug;
+    if (patch.teamId !== undefined) updates.teamId = patch.teamId;
+    if (patch.input !== undefined) updates.input = patch.input;
+    if (patch.sortOrder !== undefined) updates.sortOrder = patch.sortOrder;
+
+    if (patch.dependsOn !== undefined) {
+      const dependsOn = [...patch.dependsOn];
+      // Validate the resulting graph (siblings unchanged, this task's deps swapped).
+      await this.assertValidGraph(groupId, taskId, dependsOn);
+      updates.dependsOn = dependsOn;
+      updates.status = dependsOn.length === 0 ? "ready" : "blocked";
+    }
+
+    return this.storage.updateTask(taskId, updates);
+  }
+
+  /** POST a new task — pending-only, DAG-validated, sortOrder = max+1 default. */
+  async addTask(groupId: string, input: NewTaskInput): Promise<TaskRow> {
+    const group = await this.requireGroup(groupId);
+    this.assertPending(group);
+
+    const dependsOn = [...(input.dependsOn ?? [])];
+    const siblings = await this.storage.getTasksByGroup(groupId);
+
+    // Validate the candidate graph (siblings + the new node) before persisting.
+    // The new task has no id yet → a sentinel that cannot collide with a UUID.
+    const candidate = [
+      ...siblings.map((s) => ({ id: s.id, dependsOn: s.dependsOn as string[] })),
+      { id: "__new__", dependsOn },
+    ];
+    const result = validateTaskGraph(candidate);
+    if (!result.ok) throw new TaskGroupEditError(400, result.reason);
+
+    const maxSort = siblings.reduce((m, s) => Math.max(m, s.sortOrder), -1);
+    const status = dependsOn.length === 0 ? "ready" : "blocked";
+
+    return this.storage.createTask({
+      groupId,
+      name: input.name,
+      description: input.description,
+      executionMode: input.executionMode ?? "direct_llm",
+      dependsOn,
+      pipelineId: input.pipelineId ?? null,
+      modelSlug: input.modelSlug ?? null,
+      teamId: input.teamId ?? null,
+      input: input.input ?? {},
+      sortOrder: input.sortOrder ?? maxSort + 1,
+      status,
+    } as InsertTask);
+  }
+
+  /**
+   * DELETE a task — pending-only. Strips the removed id from every sibling's
+   * dependsOn, re-validates the remaining graph, and recomputes sibling status.
+   */
+  async removeTask(groupId: string, taskId: string): Promise<void> {
+    const group = await this.requireGroup(groupId);
+    await this.requireTaskInGroup(groupId, taskId);
+    this.assertPending(group);
+
+    await this.storage.deleteTask(taskId);
+
+    const remaining = await this.storage.getTasksByGroup(groupId);
+    // Re-validate the remaining graph (with the removed id stripped) before fixing siblings.
+    const stripped = remaining.map((s) => ({
+      id: s.id,
+      dependsOn: (s.dependsOn as string[]).filter((d) => d !== taskId),
+    }));
+    const result = validateTaskGraph(stripped);
+    if (!result.ok) throw new TaskGroupEditError(400, result.reason);
+
+    // Rewrite siblings whose deps referenced the removed task, recomputing status.
+    for (const s of remaining) {
+      const deps = s.dependsOn as string[];
+      if (!deps.includes(taskId)) continue;
+      const nextDeps = deps.filter((d) => d !== taskId);
+      const updates: Partial<TaskRow> = { dependsOn: nextDeps };
+      // Only recompute draft statuses (blocked/ready) — never resurrect terminal ones.
+      if (s.status === "blocked" || s.status === "ready") {
+        updates.status = nextDeps.length === 0 ? "ready" : "blocked";
+      }
+      await this.storage.updateTask(s.id, updates);
+    }
+  }
+
+  // ─── internals ────────────────────────────────────────────────────────────
+
+  private assertPending(group: TaskGroupRow): void {
+    if (group.status !== "pending") {
+      throw new TaskGroupEditError(409, "Task group can only be edited while pending");
+    }
+  }
+
+  /**
+   * Build the candidate graph for an in-place task patch (this task's deps
+   * swapped, siblings untouched) and validate it.
+   */
+  private async assertValidGraph(
+    groupId: string,
+    taskId: string,
+    nextDeps: string[],
+  ): Promise<void> {
+    const tasks = await this.storage.getTasksByGroup(groupId);
+    const candidate = tasks.map((t) => ({
+      id: t.id,
+      dependsOn: t.id === taskId ? nextDeps : (t.dependsOn as string[]),
+    }));
+    const result = validateTaskGraph(candidate);
+    if (!result.ok) throw new TaskGroupEditError(400, result.reason);
+  }
+}

--- a/server/services/task-orchestrator.ts
+++ b/server/services/task-orchestrator.ts
@@ -52,6 +52,15 @@ export class TaskOrchestrator {
   }
 
   /**
+   * The ids of the task groups currently in flight (between startGroup and group
+   * settle). Backed by the activeGroupTraces map keys. Sibling of the
+   * controllers' getActiveRunIds(); used by the live /api/activity snapshot.
+   */
+  getActiveGroupIds(): string[] {
+    return [...this.activeGroupTraces.keys()];
+  }
+
+  /**
    * Create a task group with tasks. Resolves task name references in
    * dependsOn to IDs and computes initial statuses (ready / blocked).
    */

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -1,7 +1,7 @@
 import { eq, desc, and, or, ilike, lt, ne, gte, lte, asc, isNull, inArray, sql as drizzleSql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { db } from "./db";
-import type { IStorage, PracticeCardFilters, MorningBriefFilters, NewsItemFilters, LlmRequestFilters, LlmRequestStats, LlmStatsByModel, LlmStatsByProvider, LlmStatsByTeam, LlmTimelinePoint } from "./storage";
+import type { IStorage, PracticeCardFilters, MorningBriefFilters, NewsItemFilters, LlmRequestFilters, LlmRequestStats, LlmStatsByModel, LlmStatsByProvider, LlmStatsByTeam, LlmTimelinePoint, RunHistoryQuery, PipelineRunHistoryRow, TaskGroupHistoryRow } from "./storage";
 import type { Memory, InsertMemory, MemoryScope, MemoryType, McpServerConfig } from "@shared/types";
 import {
   users, models, pipelines, pipelineRuns,
@@ -233,6 +233,45 @@ export class PgStorage implements IStorage {
         .orderBy(desc(pipelineRuns.createdAt));
     }
     return db.select().from(pipelineRuns).orderBy(desc(pipelineRuns.createdAt));
+  }
+
+  async listPipelineRunHistory(query: RunHistoryQuery): Promise<PipelineRunHistoryRow[]> {
+    const conditions: SQL[] = [
+      inArray(pipelineRuns.status, ["completed", "failed", "cancelled", "rejected"]),
+    ];
+    if (query.ownerId != null) conditions.push(eq(pipelineRuns.triggeredBy, query.ownerId));
+    if (query.cursor) {
+      const c = new Date(query.cursor.completedAt);
+      conditions.push(
+        or(
+          lt(pipelineRuns.completedAt, c),
+          and(eq(pipelineRuns.completedAt, c), lt(pipelineRuns.id, query.cursor.id)),
+        )!,
+      );
+    }
+    const rows = await db
+      .select({
+        id: pipelineRuns.id,
+        status: pipelineRuns.status,
+        workspaceId: pipelineRuns.workspaceId,
+        triggeredBy: pipelineRuns.triggeredBy,
+        startedAt: pipelineRuns.startedAt,
+        completedAt: pipelineRuns.completedAt,
+        currentStageIndex: pipelineRuns.currentStageIndex,
+      })
+      .from(pipelineRuns)
+      .where(and(...conditions))
+      .orderBy(desc(pipelineRuns.completedAt), desc(pipelineRuns.id))
+      .limit(query.limit);
+    return rows.map((r) => ({
+      id: r.id,
+      status: r.status,
+      workspaceId: r.workspaceId ?? null,
+      triggeredBy: r.triggeredBy ?? null,
+      startedAt: r.startedAt ?? null,
+      completedAt: r.completedAt ?? null,
+      currentStageIndex: r.currentStageIndex ?? 0,
+    }));
   }
 
   async getPipelineRun(id: string): Promise<PipelineRun | undefined> {
@@ -1350,6 +1389,45 @@ export class PgStorage implements IStorage {
     return db.select().from(tasks)
       .where(and(eq(tasks.groupId, groupId), eq(tasks.status, "blocked")))
       .orderBy(asc(tasks.sortOrder));
+  }
+
+  async deleteTask(id: string): Promise<void> {
+    await db.delete(tasks).where(eq(tasks.id, id));
+  }
+
+  async listTaskGroupHistory(query: RunHistoryQuery): Promise<TaskGroupHistoryRow[]> {
+    const conditions: SQL[] = [
+      inArray(taskGroups.status, ["completed", "failed", "cancelled"]),
+    ];
+    if (query.ownerId != null) conditions.push(eq(taskGroups.createdBy, query.ownerId));
+    if (query.cursor) {
+      const c = new Date(query.cursor.completedAt);
+      conditions.push(
+        or(
+          lt(taskGroups.completedAt, c),
+          and(eq(taskGroups.completedAt, c), lt(taskGroups.id, query.cursor.id)),
+        )!,
+      );
+    }
+    const rows = await db
+      .select({
+        id: taskGroups.id,
+        status: taskGroups.status,
+        createdBy: taskGroups.createdBy,
+        startedAt: taskGroups.startedAt,
+        completedAt: taskGroups.completedAt,
+      })
+      .from(taskGroups)
+      .where(and(...conditions))
+      .orderBy(desc(taskGroups.completedAt), desc(taskGroups.id))
+      .limit(query.limit);
+    return rows.map((r) => ({
+      id: r.id,
+      status: r.status,
+      createdBy: r.createdBy ?? null,
+      startedAt: r.startedAt ?? null,
+      completedAt: r.completedAt ?? null,
+    }));
   }
 
   // ─── Task Traces (End-to-End Request Observability) ──────────────────────────

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -185,6 +185,67 @@ export interface PracticeCardFilters {
   offset?: number;
 }
 
+/**
+ * In-memory keyset pagination over `(completedAt desc, id desc)` for the history
+ * finders. A null completedAt sorts LAST (treated as -Infinity). The cursor is
+ * exclusive: only rows strictly older than (cursor.completedAt, cursor.id) are
+ * returned. Returns at most `query.limit` rows.
+ */
+function keysetPage<T extends { id: string; completedAt: Date | null }>(
+  rows: T[],
+  query: RunHistoryQuery,
+): T[] {
+  const ts = (d: Date | null): number => (d ? d.getTime() : -Infinity);
+  const sorted = [...rows].sort((a, b) => {
+    const ta = ts(a.completedAt);
+    const tb = ts(b.completedAt);
+    if (ta !== tb) return tb - ta; // completedAt desc
+    return b.id.localeCompare(a.id); // id desc
+  });
+  let filtered = sorted;
+  if (query.cursor) {
+    const cTs = new Date(query.cursor.completedAt).getTime();
+    const cId = query.cursor.id;
+    filtered = sorted.filter((r) => {
+      const rt = ts(r.completedAt);
+      if (rt < cTs) return true;
+      if (rt > cTs) return false;
+      return r.id.localeCompare(cId) < 0; // same ts, strictly smaller id
+    });
+  }
+  return filtered.slice(0, query.limit);
+}
+
+/** Keyset-paginated history finder options (terminal-status runs only). */
+export interface RunHistoryQuery {
+  /** When set, restrict to runs owned by this user (non-admin scoping). Admins omit it. */
+  ownerId?: string;
+  /** Max rows to return (the caller clamps to <=100). */
+  limit: number;
+  /** Keyset cursor: only rows strictly older than (completedAt, id) are returned. */
+  cursor?: { completedAt: string; id: string };
+}
+
+/** One row of pipeline-family run history (terminal). Metadata is classified by the route. */
+export interface PipelineRunHistoryRow {
+  id: string;
+  status: string;
+  workspaceId: string | null;
+  triggeredBy: string | null;
+  startedAt: Date | null;
+  completedAt: Date | null;
+  currentStageIndex: number;
+}
+
+/** One row of task-group history (terminal). */
+export interface TaskGroupHistoryRow {
+  id: string;
+  status: string;
+  createdBy: string | null;
+  startedAt: Date | null;
+  completedAt: Date | null;
+}
+
 export interface IStorage {
   // Users (legacy scaffold — auth handled by AuthService)
   getUser(id: string): Promise<UserRow | undefined>;
@@ -211,6 +272,8 @@ export interface IStorage {
 
   // Pipeline Runs
   getPipelineRuns(pipelineId?: string): Promise<PipelineRun[]>;
+  /** Terminal-status pipeline-family runs, owner-filtered, keyset-paginated (completedAt desc, id desc). */
+  listPipelineRunHistory(query: RunHistoryQuery): Promise<PipelineRunHistoryRow[]>;
   getPipelineRun(id: string): Promise<PipelineRun | undefined>;
   createPipelineRun(run: InsertPipelineRun): Promise<PipelineRun>;
   updatePipelineRun(id: string, updates: Partial<PipelineRun>): Promise<PipelineRun>;
@@ -384,6 +447,10 @@ export interface IStorage {
   getTask(id: string): Promise<TaskRow | undefined>;
   createTask(data: InsertTask): Promise<TaskRow>;
   updateTask(id: string, updates: Partial<TaskRow>): Promise<TaskRow>;
+  /** Hard-delete a single task by id (used by task-group edit). */
+  deleteTask(id: string): Promise<void>;
+  /** Terminal-status task groups, owner-filtered, keyset-paginated (completedAt desc, id desc). */
+  listTaskGroupHistory(query: RunHistoryQuery): Promise<TaskGroupHistoryRow[]>;
   getReadyTasks(groupId: string): Promise<TaskRow[]>;
   getBlockedTasks(groupId: string): Promise<TaskRow[]>;
 
@@ -667,6 +734,23 @@ export class MemStorage implements IStorage {
     const all = Array.from(this.runs.values());
     if (pipelineId) return all.filter((r) => r.pipelineId === pipelineId);
     return all;
+  }
+
+  async listPipelineRunHistory(query: RunHistoryQuery): Promise<PipelineRunHistoryRow[]> {
+    const terminal = new Set(["completed", "failed", "cancelled", "rejected"]);
+    const rows = Array.from(this.runs.values())
+      .filter((r) => terminal.has(r.status))
+      .filter((r) => (query.ownerId == null ? true : r.triggeredBy === query.ownerId))
+      .map((r) => ({
+        id: r.id,
+        status: r.status,
+        workspaceId: r.workspaceId ?? null,
+        triggeredBy: r.triggeredBy ?? null,
+        startedAt: r.startedAt ?? null,
+        completedAt: r.completedAt ?? null,
+        currentStageIndex: r.currentStageIndex ?? 0,
+      }));
+    return keysetPage(rows, query);
   }
 
   async getPipelineRun(id: string): Promise<PipelineRun | undefined> {
@@ -1944,6 +2028,25 @@ export class MemStorage implements IStorage {
     return Array.from(this.tasksMap.values())
       .filter((t) => t.groupId === groupId && t.status === "blocked")
       .sort((a, b) => a.sortOrder - b.sortOrder);
+  }
+
+  async deleteTask(id: string): Promise<void> {
+    this.tasksMap.delete(id);
+  }
+
+  async listTaskGroupHistory(query: RunHistoryQuery): Promise<TaskGroupHistoryRow[]> {
+    const terminal = new Set(["completed", "failed", "cancelled"]);
+    const rows = Array.from(this.taskGroupsMap.values())
+      .filter((g) => terminal.has(g.status))
+      .filter((g) => (query.ownerId == null ? true : g.createdBy === query.ownerId))
+      .map((g) => ({
+        id: g.id,
+        status: g.status,
+        createdBy: g.createdBy ?? null,
+        startedAt: g.startedAt ?? null,
+        completedAt: g.completedAt ?? null,
+      }));
+    return keysetPage(rows, query);
   }
 
   // ─── Task Traces (End-to-End Request Observability) ──────────────────────────

--- a/server/ws/manager.ts
+++ b/server/ws/manager.ts
@@ -3,6 +3,7 @@ import type { Server, IncomingMessage } from "http";
 import type { WsEvent, User } from "@shared/types";
 import type { IStorage } from "../storage";
 import { authService } from "../auth/service";
+import { isVisible } from "../routes/authorize-run.js";
 
 function extractTokenFromRequest(req: IncomingMessage): string | null {
   const url = req.url ?? "";
@@ -77,11 +78,17 @@ export class WsManager {
   }
 
   /**
-   * Ownership-gated subscribe (the only path the live socket uses). Resolves the
-   * run via pipeline_runs.triggeredBy — the single ownership source for ALL run
-   * modes — and registers the socket only when the user is the owner or an
-   * admin. Ownerless runs are denied to non-admins. Returns whether it
-   * subscribed. Fails closed when storage/user are unavailable.
+   * Ownership-gated subscribe (the only path the live socket uses). A `runId`
+   * may name TWO id-spaces:
+   *   1. pipeline_runs.id   — owner via pipeline_runs.triggeredBy (pipeline /
+   *      manager / orchestrator / consensus). Checked FIRST (unchanged path).
+   *   2. task_groups.id     — owner via task_groups.createdBy (H3 fallback).
+   *      Task-group events broadcast on broadcastToRun(groupId,…) which has no
+   *      pipeline_runs row, so without this fallback the subscribe was rejected
+   *      (the TaskGroup live stream was dead).
+   *
+   * Ownerless rows are denied to non-admins (the strict isVisible posture);
+   * unknown ids in BOTH spaces fail closed. Returns whether it subscribed.
    */
   async authorizeAndSubscribe(
     ws: WebSocket,
@@ -90,12 +97,18 @@ export class WsManager {
   ): Promise<boolean> {
     if (!user?.id || !this.storage) return false;
 
+    // 1) Pipeline-family path (unchanged, checked first).
     const run = await this.storage.getPipelineRun(runId);
-    if (!run) return false;
+    if (run) {
+      if (!isVisible(run.triggeredBy, user)) return false;
+      this.subscribe(ws, runId);
+      return true;
+    }
 
-    const isAdmin = user.role === "admin";
-    const isOwner = run.triggeredBy != null && run.triggeredBy === user.id;
-    if (!isAdmin && !isOwner) return false;
+    // 2) Task-group fallback (H3) — gate on task_groups.createdBy.
+    const group = await this.storage.getTaskGroup(runId);
+    if (!group) return false; // unknown in both spaces → fail closed.
+    if (!isVisible(group.createdBy, user)) return false;
 
     this.subscribe(ws, runId);
     return true;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -3092,7 +3092,7 @@ export type ConsensusRoundPhase = "blind" | "review" | "adjudication";
 // id, an enum-derived label, or a model slug.
 
 /** Which run mode an active run belongs to. */
-export type ActivityMode = "pipeline" | "manager" | "orchestrator" | "consensus";
+export type ActivityMode = "pipeline" | "manager" | "orchestrator" | "consensus" | "task_group";
 
 /** The current unit of work inside a run (stage / iteration / step / round). */
 export interface ActivityUnit {
@@ -3135,4 +3135,34 @@ export interface OrchestratorStepEventPayload {
   type: OrchestratorStepType;
   status: OrchestratorStepStatus;
   modelSlug: string | null;
+}
+
+// ─── Activity History (terminal runs, DB-backed, metadata-only) ──────────────
+// METADATA-ONLY: built by an explicit allowlist, NEVER by spreading a DB row.
+// NO output / input / summary / errorMessage / decisionText / transcript.
+
+/** One past (terminal) run as seen through the Activity History tab. */
+export interface ActivityHistoryRow {
+  /** runId for pipeline-family modes; groupId for task_group mode. */
+  runId: string;
+  mode: ActivityMode;
+  /** FIXED mode label — NEVER the user's group/run name (no free-text leak). */
+  title: string;
+  status: RunStatus | string;
+  startedAt: string | null;
+  completedAt: string | null;
+  /** Enum-derived last/current unit summary, or null. Metadata only. */
+  currentUnit: ActivityUnit | null;
+  workspaceId: string | null;
+  /** Owner id — present for admins only (attribution). */
+  ownerId?: string | null;
+}
+
+/** The /api/activity/history response payload (keyset-paginated). */
+export interface ActivityHistoryPage {
+  items: ActivityHistoryRow[];
+  /** Opaque base64 keyset cursor for the next page, or null at the end. */
+  nextCursor: string | null;
+  /** Whether the caller is admin (FE shows the owner column). */
+  isAdmin: boolean;
 }

--- a/tests/helpers/test-task-group-app.ts
+++ b/tests/helpers/test-task-group-app.ts
@@ -1,0 +1,87 @@
+/**
+ * Test app factory for the /api/task-groups routes over MemStorage + a real
+ * TaskOrchestrator with inert collaborators (no CLI/network/real DB/WS server).
+ *
+ * Mirrors test-consensus-app: an injectable authenticated user (id/role), a
+ * header to force the unauth path, and the ability to seed groups owned by other
+ * users so the owner/admin/ownerless authz paths are exercised. The orchestrator
+ * is constructed with no-op WS + pipeline-controller + gateway doubles because
+ * the route tests never drive real task execution — they exercise authz, edit
+ * guards, and the edit orchestration.
+ */
+import express from "express";
+import type { Router } from "express";
+import { MemStorage } from "../../server/storage.js";
+import { TaskOrchestrator } from "../../server/services/task-orchestrator.js";
+import { registerTaskGroupRoutes } from "../../server/routes/task-groups.js";
+import type { WsManager } from "../../server/ws/manager.js";
+import type { PipelineController } from "../../server/controller/pipeline-controller.js";
+import type { Gateway } from "../../server/gateway/index.js";
+import type { User, UserRole } from "../../shared/types.js";
+
+export interface TaskGroupTestAppOptions {
+  role?: UserRole;
+  userId?: string;
+  /** When true, the user session carries no id (drives the 401 path). */
+  noUserId?: boolean;
+}
+
+export interface TaskGroupTestApp {
+  app: express.Express;
+  storage: MemStorage;
+  orchestrator: TaskOrchestrator;
+  userId: string;
+}
+
+/** No-op WS manager — broadcasts go nowhere in the route tests. */
+function makeWsManager(): WsManager {
+  return { broadcastToRun: () => {} } as unknown as WsManager;
+}
+
+/** Inert pipeline controller — never invoked by the authz/edit route tests. */
+function makePipelineController(): PipelineController {
+  return {} as unknown as PipelineController;
+}
+
+/** Inert gateway — never invoked by the authz/edit route tests. */
+function makeGateway(): Gateway {
+  return {} as unknown as Gateway;
+}
+
+export function createTaskGroupTestApp(opts: TaskGroupTestAppOptions = {}): TaskGroupTestApp {
+  const role: UserRole = opts.role ?? "user";
+  const userId = opts.userId ?? "test-user-id";
+
+  const storage = new MemStorage();
+  const orchestrator = new TaskOrchestrator(
+    storage,
+    makeWsManager(),
+    makePipelineController(),
+    makeGateway(),
+  );
+
+  const user: User = {
+    id: opts.noUserId ? (undefined as unknown as string) : userId,
+    email: "tg@example.com",
+    name: "Task Group User",
+    isActive: true,
+    role,
+    lastLoginAt: null,
+    createdAt: new Date(0),
+  };
+
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (req.headers["x-test-unauth"] === "1") {
+      req.user = undefined as never;
+    } else {
+      req.user = user;
+    }
+    next();
+  });
+
+  registerTaskGroupRoutes(app as unknown as Router, storage, orchestrator);
+
+  return { app, storage, orchestrator, userId };
+}

--- a/tests/integration/activity/history.test.ts
+++ b/tests/integration/activity/history.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Integration tests for GET /api/activity/history — the DB-backed History tab.
+ *
+ * Covers (H1/H4): 401 unauth; owner sees only their own across BOTH id-spaces
+ * (pipeline_runs.triggeredBy + task_groups.createdBy); admin sees all + ownerId;
+ * terminal-status only (running/pending excluded); METADATA-ONLY exact-key
+ * allowlist + a banned-string scan (no input/output/summary/transcript leak,
+ * fixed title not the group name); keyset pagination across the merged streams;
+ * limit clamp to 100; malformed cursor → 400.
+ *
+ * supertest over MemStorage. No CLI / network / real DB.
+ */
+import { describe, it, expect } from "vitest";
+import request from "supertest";
+import express from "express";
+import type { Router } from "express";
+import { MemStorage } from "../../../server/storage.js";
+import { registerActivityRoutes } from "../../../server/routes/activity.js";
+import type { ActivityRouteDeps } from "../../../server/routes/activity.js";
+import type { User, UserRole } from "../../../shared/types.js";
+import type { InsertTaskGroup, InsertTask } from "@shared/schema";
+
+const ORCH_MODELS = {
+  planModelSlug: "claude-opus",
+  synthesizeModelSlug: "claude-opus",
+  proposerModelSlug: "claude-opus",
+  criticModelSlug: "gemini-flash",
+  judgeModelSlug: "claude-opus",
+};
+
+function buildApp(storage: MemStorage, opts: { userId?: string; role?: UserRole; noUser?: boolean } = {}) {
+  const deps: ActivityRouteDeps = {
+    pipelineController: { getActiveRunIds: () => [] },
+    consensusController: { getActiveRunIds: () => [] },
+    taskOrchestrator: { getActiveGroupIds: () => [] },
+    orchestratorModels: ORCH_MODELS,
+    consensusClaudeModelSlug: "claude-opus",
+  };
+  const user: User = {
+    id: opts.noUser ? (undefined as unknown as string) : opts.userId ?? "owner",
+    email: "a@x.com",
+    name: "A",
+    isActive: true,
+    role: opts.role ?? "user",
+    lastLoginAt: null,
+    createdAt: new Date(0),
+  };
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (opts.noUser) req.user = undefined as never;
+    else req.user = user;
+    next();
+  });
+  registerActivityRoutes(app as unknown as Router, storage, deps);
+  return app;
+}
+
+async function seedPipelineRun(
+  storage: MemStorage,
+  triggeredBy: string | null,
+  status: string,
+  completedAt: Date | null,
+) {
+  return storage.createPipelineRun({
+    pipelineId: "p1",
+    status,
+    input: "SECRET PIPELINE INPUT do not leak",
+    output: { secret: "PIPELINE OUTPUT must not leak" },
+    currentStageIndex: 0,
+    startedAt: completedAt ? new Date(completedAt.getTime() - 1000) : new Date(),
+    completedAt,
+    triggeredBy,
+    dagMode: false,
+  });
+}
+
+async function seedTaskGroup(
+  storage: MemStorage,
+  createdBy: string | null,
+  status: string,
+  completedAt: Date | null,
+) {
+  const group = await storage.createTaskGroup({
+    name: "SUPER SECRET GROUP NAME",
+    description: "secret description leak test",
+    input: "SECRET GROUP INPUT leak test",
+    status,
+    createdBy,
+    startedAt: completedAt ? new Date(completedAt.getTime() - 1000) : new Date(),
+    completedAt,
+  } as InsertTaskGroup);
+  await storage.createTask({
+    groupId: group.id,
+    name: "secret task name leak",
+    description: "secret task desc leak",
+    executionMode: "direct_llm",
+    dependsOn: [],
+    input: { secret: "task input leak" },
+    summary: "SECRET TASK SUMMARY leak",
+    status: "completed",
+    sortOrder: 0,
+    modelSlug: "claude-sonnet",
+  } as InsertTask);
+  return group;
+}
+
+describe("GET /api/activity/history — auth + scoping", () => {
+  it("401 when unauthenticated", async () => {
+    const storage = new MemStorage();
+    const res = await request(buildApp(storage, { noUser: true })).get("/api/activity/history");
+    expect(res.status).toBe(401);
+  });
+
+  it("non-admin sees only their own across both id-spaces", async () => {
+    const storage = new MemStorage();
+    await seedPipelineRun(storage, "me", "completed", new Date("2026-01-01T00:00:00Z"));
+    await seedPipelineRun(storage, "other", "completed", new Date("2026-01-02T00:00:00Z"));
+    await seedTaskGroup(storage, "me", "completed", new Date("2026-01-03T00:00:00Z"));
+    await seedTaskGroup(storage, "other", "failed", new Date("2026-01-04T00:00:00Z"));
+
+    const res = await request(buildApp(storage, { userId: "me" })).get("/api/activity/history");
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(2);
+    expect(res.body.isAdmin).toBe(false);
+    // No ownerId for non-admins.
+    for (const item of res.body.items) expect(item.ownerId).toBeUndefined();
+  });
+
+  it("admin sees all + ownerId attribution", async () => {
+    const storage = new MemStorage();
+    await seedPipelineRun(storage, "me", "completed", new Date("2026-01-01T00:00:00Z"));
+    await seedTaskGroup(storage, "other", "completed", new Date("2026-01-03T00:00:00Z"));
+    const res = await request(buildApp(storage, { userId: "boss", role: "admin" })).get(
+      "/api/activity/history",
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(2);
+    expect(res.body.isAdmin).toBe(true);
+    expect(res.body.items.some((i: { ownerId?: string }) => i.ownerId === "other")).toBe(true);
+  });
+});
+
+describe("GET /api/activity/history — terminal-only", () => {
+  it("excludes running and pending runs/groups", async () => {
+    const storage = new MemStorage();
+    await seedPipelineRun(storage, "me", "running", null);
+    await seedPipelineRun(storage, "me", "completed", new Date("2026-01-01T00:00:00Z"));
+    await seedTaskGroup(storage, "me", "pending", null);
+    await seedTaskGroup(storage, "me", "cancelled", new Date("2026-01-02T00:00:00Z"));
+
+    const res = await request(buildApp(storage, { userId: "me" })).get("/api/activity/history");
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(2);
+    const statuses = res.body.items.map((i: { status: string }) => i.status).sort();
+    expect(statuses).toEqual(["cancelled", "completed"]);
+  });
+});
+
+describe("GET /api/activity/history — metadata-only allowlist", () => {
+  it("exposes only the allowlisted keys and no banned strings", async () => {
+    const storage = new MemStorage();
+    await seedPipelineRun(storage, "me", "completed", new Date("2026-01-01T00:00:00Z"));
+    await seedTaskGroup(storage, "me", "completed", new Date("2026-01-02T00:00:00Z"));
+
+    const res = await request(buildApp(storage, { userId: "boss", role: "admin" })).get(
+      "/api/activity/history",
+    );
+    expect(res.status).toBe(200);
+
+    const allowedKeys = new Set([
+      "runId",
+      "mode",
+      "title",
+      "status",
+      "startedAt",
+      "completedAt",
+      "currentUnit",
+      "workspaceId",
+      "ownerId",
+    ]);
+    const allowedUnitKeys = new Set(["label", "agent", "modelSlug", "status"]);
+    for (const item of res.body.items) {
+      for (const key of Object.keys(item)) expect(allowedKeys.has(key)).toBe(true);
+      if (item.currentUnit) {
+        for (const key of Object.keys(item.currentUnit)) {
+          expect(allowedUnitKeys.has(key)).toBe(true);
+        }
+      }
+    }
+
+    // Banned-string scan over the entire serialized payload.
+    const serialized = JSON.stringify(res.body);
+    const banned = [
+      "SECRET PIPELINE INPUT",
+      "PIPELINE OUTPUT",
+      "SUPER SECRET GROUP NAME",
+      "secret description",
+      "SECRET GROUP INPUT",
+      "secret task name",
+      "SECRET TASK SUMMARY",
+      "task input leak",
+    ];
+    for (const b of banned) expect(serialized).not.toContain(b);
+
+    // Title is the FIXED label, never the group name.
+    const group = res.body.items.find((i: { mode: string }) => i.mode === "task_group");
+    expect(group.title).toBe("Task group");
+  });
+});
+
+describe("GET /api/activity/history — pagination", () => {
+  it("paginates by keyset cursor without overlap", async () => {
+    const storage = new MemStorage();
+    for (let i = 0; i < 5; i++) {
+      await seedPipelineRun(
+        storage,
+        "me",
+        "completed",
+        new Date(`2026-01-0${i + 1}T00:00:00Z`),
+      );
+    }
+    const app = buildApp(storage, { userId: "me" });
+
+    const first = await request(app).get("/api/activity/history?limit=2");
+    expect(first.status).toBe(200);
+    expect(first.body.items).toHaveLength(2);
+    expect(first.body.nextCursor).toBeTruthy();
+
+    const second = await request(app).get(
+      `/api/activity/history?limit=2&cursor=${encodeURIComponent(first.body.nextCursor)}`,
+    );
+    expect(second.body.items).toHaveLength(2);
+
+    const firstIds = new Set(first.body.items.map((i: { runId: string }) => i.runId));
+    for (const item of second.body.items) {
+      expect(firstIds.has(item.runId)).toBe(false);
+    }
+    // Newest first.
+    expect(first.body.items[0].completedAt > first.body.items[1].completedAt).toBe(true);
+  });
+
+  it("rejects limit above the 100 bound with 400 (no unbounded query)", async () => {
+    const storage = new MemStorage();
+    await seedPipelineRun(storage, "me", "completed", new Date("2026-01-01T00:00:00Z"));
+    const res = await request(buildApp(storage, { userId: "me" })).get(
+      "/api/activity/history?limit=99999",
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts limit=100 exactly", async () => {
+    const storage = new MemStorage();
+    await seedPipelineRun(storage, "me", "completed", new Date("2026-01-01T00:00:00Z"));
+    const res = await request(buildApp(storage, { userId: "me" })).get(
+      "/api/activity/history?limit=100",
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects a malformed cursor with 400", async () => {
+    const storage = new MemStorage();
+    const res = await request(buildApp(storage, { userId: "me" })).get(
+      "/api/activity/history?cursor=not-a-valid-cursor",
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("filters by mode=task_group", async () => {
+    const storage = new MemStorage();
+    await seedPipelineRun(storage, "me", "completed", new Date("2026-01-01T00:00:00Z"));
+    await seedTaskGroup(storage, "me", "completed", new Date("2026-01-02T00:00:00Z"));
+    const res = await request(buildApp(storage, { userId: "me" })).get(
+      "/api/activity/history?mode=task_group",
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].mode).toBe("task_group");
+  });
+});

--- a/tests/integration/activity/live-task-group.test.ts
+++ b/tests/integration/activity/live-task-group.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Integration tests for task-groups as the FIFTH live Activity mode.
+ *
+ * GET /api/activity unions the controllers' active run ids with the task
+ * orchestrator's getActiveGroupIds(). A live group row is owner-scoped via
+ * task_groups.createdBy, metadata-only, with a FIXED title (never the group
+ * name) and a currentUnit derived from the running/last task.
+ *
+ * supertest over MemStorage. No CLI / network / real DB.
+ */
+import { describe, it, expect } from "vitest";
+import request from "supertest";
+import express from "express";
+import type { Router } from "express";
+import { MemStorage } from "../../../server/storage.js";
+import { registerActivityRoutes } from "../../../server/routes/activity.js";
+import type { ActivityRouteDeps } from "../../../server/routes/activity.js";
+import type { User, UserRole } from "../../../shared/types.js";
+import type { InsertTaskGroup, InsertTask } from "@shared/schema";
+
+const ORCH_MODELS = {
+  planModelSlug: "claude-opus",
+  synthesizeModelSlug: "claude-opus",
+  proposerModelSlug: "claude-opus",
+  criticModelSlug: "gemini-flash",
+  judgeModelSlug: "claude-opus",
+};
+
+function buildApp(
+  storage: MemStorage,
+  opts: { userId?: string; role?: UserRole; activeGroupIds?: string[] } = {},
+) {
+  const deps: ActivityRouteDeps = {
+    pipelineController: { getActiveRunIds: () => [] },
+    consensusController: { getActiveRunIds: () => [] },
+    taskOrchestrator: { getActiveGroupIds: () => opts.activeGroupIds ?? [] },
+    orchestratorModels: ORCH_MODELS,
+    consensusClaudeModelSlug: "claude-opus",
+  };
+  const user: User = {
+    id: opts.userId ?? "owner",
+    email: "a@x.com",
+    name: "A",
+    isActive: true,
+    role: opts.role ?? "user",
+    lastLoginAt: null,
+    createdAt: new Date(0),
+  };
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.user = user;
+    next();
+  });
+  registerActivityRoutes(app as unknown as Router, storage, deps);
+  return app;
+}
+
+async function seedRunningGroup(storage: MemStorage, createdBy: string | null) {
+  const group = await storage.createTaskGroup({
+    name: "SECRET LIVE GROUP NAME",
+    description: "secret live desc",
+    input: "secret live input",
+    status: "running",
+    createdBy,
+    startedAt: new Date(),
+  } as InsertTaskGroup);
+  await storage.createTask({
+    groupId: group.id,
+    name: "secret live task name",
+    description: "secret live task desc",
+    executionMode: "pipeline_run",
+    dependsOn: [],
+    input: { secret: "live task input" },
+    status: "running",
+    sortOrder: 0,
+    modelSlug: "claude-sonnet",
+  } as InsertTask);
+  return group;
+}
+
+describe("GET /api/activity — task_group as the fifth live mode", () => {
+  it("shows the owner's running group with metadata-only fields", async () => {
+    const storage = new MemStorage();
+    const group = await seedRunningGroup(storage, "owner");
+    const res = await request(
+      buildApp(storage, { userId: "owner", activeGroupIds: [group.id] }),
+    ).get("/api/activity");
+
+    expect(res.status).toBe(200);
+    expect(res.body.runs).toHaveLength(1);
+    const row = res.body.runs[0];
+    expect(row.mode).toBe("task_group");
+    expect(row.title).toBe("Task group");
+    expect(row.runId).toBe(group.id);
+    expect(row.currentUnit.agent).toBe("pipeline_run"); // executionMode, not text
+    expect(row.currentUnit.modelSlug).toBe("claude-sonnet");
+
+    // No banned strings anywhere.
+    const serialized = JSON.stringify(res.body);
+    for (const b of [
+      "SECRET LIVE GROUP NAME",
+      "secret live desc",
+      "secret live input",
+      "secret live task name",
+    ]) {
+      expect(serialized).not.toContain(b);
+    }
+  });
+
+  it("hides another user's running group from a non-admin", async () => {
+    const storage = new MemStorage();
+    const group = await seedRunningGroup(storage, "someone-else");
+    const res = await request(
+      buildApp(storage, { userId: "me", activeGroupIds: [group.id] }),
+    ).get("/api/activity");
+    expect(res.status).toBe(200);
+    expect(res.body.runs).toHaveLength(0);
+  });
+
+  it("hides an ownerless running group from a non-admin but shows it to an admin", async () => {
+    const storage = new MemStorage();
+    const group = await seedRunningGroup(storage, null);
+
+    const nonAdmin = await request(
+      buildApp(storage, { userId: "me", activeGroupIds: [group.id] }),
+    ).get("/api/activity");
+    expect(nonAdmin.body.runs).toHaveLength(0);
+
+    const adminRes = await request(
+      buildApp(storage, { userId: "boss", role: "admin", activeGroupIds: [group.id] }),
+    ).get("/api/activity");
+    expect(adminRes.body.runs).toHaveLength(1);
+    expect(adminRes.body.runs[0].ownerId).toBe(null);
+  });
+});

--- a/tests/integration/task-groups/idor-and-edit.test.ts
+++ b/tests/integration/task-groups/idor-and-edit.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Integration tests for the /api/task-groups routes:
+ *   - C1 IDOR matrix: every per-id route × 401 / 404 / 403-non-owner / owner /
+ *     admin / ownerless(createdBy==null deny non-admin) + the list-own filter.
+ *   - C2/M3: cross-group taskId → 404 on every task-scoped route.
+ *   - H2 edit guard: pending OK, running/terminal 409 per route; name/desc
+ *     relabel allowed post-terminal.
+ *   - M1: generic error envelope (no String(err) leak).
+ *
+ * Deterministic: MemStorage + supertest, no real CLI/network/DB.
+ */
+import { describe, it, expect } from "vitest";
+import request from "supertest";
+import { createTaskGroupTestApp } from "../../helpers/test-task-group-app.js";
+import type { MemStorage } from "../../../server/storage.js";
+import type { InsertTaskGroup, InsertTask, TaskGroupStatus } from "@shared/schema";
+
+async function seedGroup(
+  storage: MemStorage,
+  createdBy: string | null,
+  status: TaskGroupStatus = "pending",
+) {
+  return storage.createTaskGroup({
+    name: "G",
+    description: "D",
+    input: "obj",
+    status,
+    createdBy,
+  } as InsertTaskGroup);
+}
+
+async function seedTask(storage: MemStorage, groupId: string, name = "t") {
+  return storage.createTask({
+    groupId,
+    name,
+    description: "d",
+    executionMode: "direct_llm",
+    dependsOn: [],
+    input: {},
+    status: "ready",
+    sortOrder: 0,
+  } as InsertTask);
+}
+
+// ─── C1: per-id route IDOR matrix ──────────────────────────────────────────────
+
+describe("task-groups IDOR — GET /api/task-groups/:id", () => {
+  it("401 when unauthenticated", async () => {
+    const { app, storage } = createTaskGroupTestApp();
+    const g = await seedGroup(storage, "test-user-id");
+    const res = await request(app).get(`/api/task-groups/${g.id}`).set("x-test-unauth", "1");
+    expect(res.status).toBe(401);
+  });
+
+  it("404 when the group does not exist", async () => {
+    const { app } = createTaskGroupTestApp();
+    const res = await request(app).get("/api/task-groups/ghost");
+    expect(res.status).toBe(404);
+  });
+
+  it("403 when the caller is not the owner", async () => {
+    const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+    const g = await seedGroup(storage, "someone-else");
+    const res = await request(app).get(`/api/task-groups/${g.id}`);
+    expect(res.status).toBe(403);
+  });
+
+  it("200 for the owner", async () => {
+    const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+    const g = await seedGroup(storage, "me");
+    const res = await request(app).get(`/api/task-groups/${g.id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(g.id);
+  });
+
+  it("200 for an admin viewing another user's group", async () => {
+    const { app, storage } = createTaskGroupTestApp({ userId: "boss", role: "admin" });
+    const g = await seedGroup(storage, "someone-else");
+    const res = await request(app).get(`/api/task-groups/${g.id}`);
+    expect(res.status).toBe(200);
+  });
+
+  it("403 on an ownerless group for a non-admin", async () => {
+    const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+    const g = await seedGroup(storage, null);
+    const res = await request(app).get(`/api/task-groups/${g.id}`);
+    expect(res.status).toBe(403);
+  });
+
+  it("200 on an ownerless group for an admin", async () => {
+    const { app, storage } = createTaskGroupTestApp({ userId: "boss", role: "admin" });
+    const g = await seedGroup(storage, null);
+    const res = await request(app).get(`/api/task-groups/${g.id}`);
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("task-groups IDOR — mutating per-id routes are all gated", () => {
+  const routes: Array<{ method: "post" | "delete"; path: (id: string) => string }> = [
+    { method: "post", path: (id) => `/api/task-groups/${id}/start` },
+    { method: "post", path: (id) => `/api/task-groups/${id}/cancel` },
+    { method: "delete", path: (id) => `/api/task-groups/${id}` },
+  ];
+
+  for (const r of routes) {
+    it(`${r.method.toUpperCase()} ${r.path(":id")} → 403 for a non-owner`, async () => {
+      const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+      const g = await seedGroup(storage, "someone-else");
+      const res = await request(app)[r.method](r.path(g.id));
+      expect(res.status).toBe(403);
+    });
+
+    it(`${r.method.toUpperCase()} ${r.path(":id")} → 401 unauth`, async () => {
+      const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+      const g = await seedGroup(storage, "me");
+      const res = await request(app)[r.method](r.path(g.id)).set("x-test-unauth", "1");
+      expect(res.status).toBe(401);
+    });
+
+    it(`${r.method.toUpperCase()} ${r.path(":id")} → 404 missing`, async () => {
+      const { app } = createTaskGroupTestApp({ userId: "me" });
+      const res = await request(app)[r.method](r.path("ghost"));
+      expect(res.status).toBe(404);
+    });
+  }
+});
+
+// ─── C1: list-own filter ──────────────────────────────────────────────────────
+
+describe("GET /api/task-groups list — owner-scoped (C1)", () => {
+  it("non-admin sees only their own groups and createdBy is hidden", async () => {
+    const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+    await seedGroup(storage, "me");
+    await seedGroup(storage, "someone-else");
+    await seedGroup(storage, null);
+    const res = await request(app).get("/api/task-groups");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].createdBy).toBeUndefined();
+  });
+
+  it("admin sees all groups with createdBy attribution", async () => {
+    const { app, storage } = createTaskGroupTestApp({ userId: "boss", role: "admin" });
+    await seedGroup(storage, "me");
+    await seedGroup(storage, "someone-else");
+    await seedGroup(storage, null);
+    const res = await request(app).get("/api/task-groups");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(3);
+    expect(res.body.some((g: { createdBy?: string }) => g.createdBy === "me")).toBe(true);
+  });
+
+  it("401 unauth on list", async () => {
+    const { app } = createTaskGroupTestApp();
+    const res = await request(app).get("/api/task-groups").set("x-test-unauth", "1");
+    expect(res.status).toBe(401);
+  });
+});
+
+// ─── C2 / M3: cross-group taskId → 404 ─────────────────────────────────────────
+
+describe("task-scoped routes assert task ∈ group (C2/M3)", () => {
+  it("retry: a taskId from a DIFFERENT group → 404", async () => {
+    const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+    const g1 = await seedGroup(storage, "me");
+    const g2 = await seedGroup(storage, "me");
+    const t = await seedTask(storage, g2.id);
+    const res = await request(app).post(`/api/task-groups/${g1.id}/tasks/${t.id}/retry`);
+    expect(res.status).toBe(404);
+  });
+
+  it("PATCH task: a taskId from a DIFFERENT group → 404", async () => {
+    const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+    const g1 = await seedGroup(storage, "me");
+    const g2 = await seedGroup(storage, "me");
+    const t = await seedTask(storage, g2.id);
+    const res = await request(app)
+      .patch(`/api/task-groups/${g1.id}/tasks/${t.id}`)
+      .send({ name: "x" });
+    expect(res.status).toBe(404);
+  });
+
+  it("DELETE task: a taskId from a DIFFERENT group → 404", async () => {
+    const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+    const g1 = await seedGroup(storage, "me");
+    const g2 = await seedGroup(storage, "me");
+    const t = await seedTask(storage, g2.id);
+    const res = await request(app).delete(`/api/task-groups/${g1.id}/tasks/${t.id}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("retry: group is still owner-gated (non-owner → 403, not 404)", async () => {
+    const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+    const g = await seedGroup(storage, "someone-else");
+    const t = await seedTask(storage, g.id);
+    const res = await request(app).post(`/api/task-groups/${g.id}/tasks/${t.id}/retry`);
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─── H2: edit guards ────────────────────────────────────────────────────────
+
+describe("edit guard — PATCH group", () => {
+  it("200 editing name/description/input on a pending group", async () => {
+    const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+    const g = await seedGroup(storage, "me", "pending");
+    const res = await request(app)
+      .patch(`/api/task-groups/${g.id}`)
+      .send({ name: "N", description: "DD", input: "new" });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe("N");
+    expect(res.body.tasks).toBeDefined();
+  });
+
+  it("409 editing input on a completed group, but name/desc relabel OK", async () => {
+    const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+    const g = await seedGroup(storage, "me", "completed");
+    const blocked = await request(app).patch(`/api/task-groups/${g.id}`).send({ input: "x" });
+    expect(blocked.status).toBe(409);
+    const relabel = await request(app).patch(`/api/task-groups/${g.id}`).send({ name: "relabel" });
+    expect(relabel.status).toBe(200);
+    expect(relabel.body.name).toBe("relabel");
+  });
+
+  it("409 editing anything on a running group", async () => {
+    const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+    const g = await seedGroup(storage, "me", "running");
+    const res = await request(app).patch(`/api/task-groups/${g.id}`).send({ name: "x" });
+    expect(res.status).toBe(409);
+  });
+
+  it("400 when no field is supplied", async () => {
+    const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+    const g = await seedGroup(storage, "me", "pending");
+    const res = await request(app).patch(`/api/task-groups/${g.id}`).send({});
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("edit guard — task routes 409 on non-pending", () => {
+  for (const status of ["running", "completed"] as const) {
+    it(`PATCH task → 409 when group is ${status}`, async () => {
+      const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+      const g = await seedGroup(storage, "me", status);
+      const t = await seedTask(storage, g.id);
+      const res = await request(app)
+        .patch(`/api/task-groups/${g.id}/tasks/${t.id}`)
+        .send({ name: "x" });
+      expect(res.status).toBe(409);
+    });
+
+    it(`POST task → 409 when group is ${status}`, async () => {
+      const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+      const g = await seedGroup(storage, "me", status);
+      const res = await request(app)
+        .post(`/api/task-groups/${g.id}/tasks`)
+        .send({ name: "c", description: "d" });
+      expect(res.status).toBe(409);
+    });
+
+    it(`DELETE task → 409 when group is ${status}`, async () => {
+      const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+      const g = await seedGroup(storage, "me", status);
+      const t = await seedTask(storage, g.id);
+      const res = await request(app).delete(`/api/task-groups/${g.id}/tasks/${t.id}`);
+      expect(res.status).toBe(409);
+    });
+  }
+});
+
+describe("edit happy paths on pending groups", () => {
+  it("POST task adds and DELETE task removes, cleaning sibling deps", async () => {
+    const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+    const g = await seedGroup(storage, "me", "pending");
+    const a = await seedTask(storage, g.id, "a");
+
+    const add = await request(app)
+      .post(`/api/task-groups/${g.id}/tasks`)
+      .send({ name: "b", description: "d", dependsOn: [a.id] });
+    expect(add.status).toBe(201);
+    expect(add.body.status).toBe("blocked");
+
+    const del = await request(app).delete(`/api/task-groups/${g.id}/tasks/${a.id}`);
+    expect(del.status).toBe(204);
+
+    const remaining = await storage.getTasksByGroup(g.id);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].dependsOn).toEqual([]);
+    expect(remaining[0].status).toBe("ready");
+  });
+
+  it("PATCH task rejects a cycle with 400", async () => {
+    const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+    const g = await seedGroup(storage, "me", "pending");
+    const a = await seedTask(storage, g.id, "a");
+    const b = await storage.createTask({
+      groupId: g.id,
+      name: "b",
+      description: "d",
+      executionMode: "direct_llm",
+      dependsOn: [a.id],
+      input: {},
+      status: "blocked",
+      sortOrder: 1,
+    } as InsertTask);
+    const res = await request(app)
+      .patch(`/api/task-groups/${g.id}/tasks/${a.id}`)
+      .send({ dependsOn: [b.id] });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── M1: error envelope never leaks internals ──────────────────────────────────
+
+describe("M1 — generic error envelope", () => {
+  it("409 body is a plain { error } string, not a stack/internal dump", async () => {
+    const { app, storage } = createTaskGroupTestApp({ userId: "me" });
+    const g = await seedGroup(storage, "me", "running");
+    const res = await request(app).patch(`/api/task-groups/${g.id}`).send({ name: "x" });
+    expect(res.status).toBe(409);
+    expect(typeof res.body.error).toBe("string");
+    expect(res.body.error).not.toMatch(/at \w|Error:|\/server\//);
+  });
+});

--- a/tests/unit/activity-ui.test.ts
+++ b/tests/unit/activity-ui.test.ts
@@ -11,14 +11,26 @@ import { describe, it, expect } from "vitest";
 import {
   mergeWsEvent,
   groupByMode,
+  groupHistoryByMode,
   snapshotRunIds,
   isLiveNow,
   displayModel,
+  appendHistoryPage,
+  emptyHistoryState,
+  hasMoreHistory,
+  historyRowKey,
+  buildHistoryQuery,
   ACTIVITY_MODE_ORDER,
   LIVE_PULSE_WINDOW_MS,
   type LiveActivityRun,
 } from "@/lib/activity";
-import type { ActivityRun, ActivityMode, WsEvent } from "@shared/types";
+import type {
+  ActivityRun,
+  ActivityMode,
+  WsEvent,
+  ActivityHistoryRow,
+  ActivityHistoryPage,
+} from "@shared/types";
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -184,8 +196,14 @@ describe("groupByMode", () => {
     expect(groupByMode([])).toEqual([]);
   });
 
-  it("covers all four contract modes in ACTIVITY_MODE_ORDER", () => {
-    const modes: ActivityMode[] = ["pipeline", "manager", "orchestrator", "consensus"];
+  it("covers all five contract modes in ACTIVITY_MODE_ORDER", () => {
+    const modes: ActivityMode[] = [
+      "pipeline",
+      "manager",
+      "orchestrator",
+      "consensus",
+      "task_group",
+    ];
     expect([...ACTIVITY_MODE_ORDER].sort()).toEqual([...modes].sort());
   });
 });
@@ -246,5 +264,206 @@ describe("ownerId attribution (admin-only column data)", () => {
   it("is absent/undefined on non-admin rows", () => {
     const row = makeRun({ runId: "a" });
     expect(row.ownerId).toBeUndefined();
+  });
+});
+
+// ─── task_group: live merge + grouping ──────────────────────────────────────────
+// A task_group active row appears in BOTH the snapshot grouping AND folds its
+// own WS deltas (runId = groupId). These cover the task_group branch added to
+// mergeWsEvent / groupByMode.
+
+describe("mergeWsEvent — task_group deltas (runId = groupId)", () => {
+  it("task:started updates the unit name/team/model and marks running", () => {
+    const rows = [makeRun({ runId: "g1", mode: "task_group" })];
+    const next = mergeWsEvent(
+      rows,
+      ev("task:started", "g1", { name: "Summarise", teamId: "research", modelSlug: "gpt-x" }),
+      NOW,
+    );
+    expect(next[0].currentUnit).toEqual({
+      label: "Summarise",
+      agent: "research",
+      modelSlug: "gpt-x",
+      status: "running",
+    });
+    expect(next[0].lastDeltaAt).toBe(NOW);
+  });
+
+  it("task:completed / task:failed set the matching unit status", () => {
+    const rows = [makeRun({ runId: "g1", mode: "task_group" })];
+    const done = mergeWsEvent(rows, ev("task:completed", "g1", { name: "A" }), NOW);
+    expect(done[0].currentUnit?.status).toBe("completed");
+    const failed = mergeWsEvent(rows, ev("task:failed", "g1", { name: "A" }), NOW);
+    expect(failed[0].currentUnit?.status).toBe("failed");
+  });
+
+  it("taskgroup:progress keeps the prior unit but still pulses live", () => {
+    const rows = [makeRun({ runId: "g1", mode: "task_group" })];
+    const next = mergeWsEvent(rows, ev("taskgroup:progress", "g1", { completed: 2, running: 1 }), NOW);
+    expect(next[0].currentUnit).toEqual(rows[0].currentUnit);
+    expect(next[0].lastDeltaAt).toBe(NOW);
+    expect(isLiveNow(next[0], NOW)).toBe(true);
+  });
+
+  it("ignores a task_group delta for an unknown groupId", () => {
+    const rows = [makeRun({ runId: "g1", mode: "task_group" })];
+    expect(mergeWsEvent(rows, ev("task:started", "ghost", { name: "X" }), NOW)).toBe(rows);
+  });
+
+  it("does not mutate the input on a task_group delta", () => {
+    const rows = [makeRun({ runId: "g1", mode: "task_group" })];
+    const before = JSON.stringify(rows);
+    mergeWsEvent(rows, ev("task:started", "g1", { name: "Y" }), NOW);
+    expect(JSON.stringify(rows)).toBe(before);
+  });
+});
+
+describe("groupByMode — task_group", () => {
+  it("places task_group rows in their own group, after consensus", () => {
+    const rows = [
+      makeRun({ runId: "g1", mode: "task_group" }),
+      makeRun({ runId: "p1", mode: "pipeline" }),
+    ];
+    const groups = groupByMode(rows);
+    expect(groups.map((g) => g.mode)).toEqual(["pipeline", "task_group"]);
+    expect(groups[1].label).toBe("Task groups");
+  });
+});
+
+// ─── Activity History: cursor / merge helpers ───────────────────────────────────
+
+function historyRow(overrides: Partial<ActivityHistoryRow> = {}): ActivityHistoryRow {
+  return {
+    runId: overrides.runId ?? "r1",
+    mode: overrides.mode ?? "pipeline",
+    title: overrides.title ?? "Pipeline run",
+    status: overrides.status ?? "completed",
+    startedAt: overrides.startedAt ?? "2026-06-16T10:00:00.000Z",
+    completedAt: overrides.completedAt ?? "2026-06-16T10:01:00.000Z",
+    currentUnit: overrides.currentUnit ?? null,
+    workspaceId: overrides.workspaceId ?? null,
+    ...(overrides.ownerId !== undefined ? { ownerId: overrides.ownerId } : {}),
+  };
+}
+
+function page(
+  items: ActivityHistoryRow[],
+  nextCursor: string | null,
+  isAdmin = false,
+): ActivityHistoryPage {
+  return { items, nextCursor, isAdmin };
+}
+
+describe("appendHistoryPage", () => {
+  it("first page (isFirstPage=true) REPLACES the list and sets cursor/admin", () => {
+    const prev = { items: [historyRow({ runId: "stale" })], nextCursor: "c0", isAdmin: false };
+    const next = appendHistoryPage(prev, page([historyRow({ runId: "r1" })], "c1", true), true);
+    expect(next.items.map((r) => r.runId)).toEqual(["r1"]);
+    expect(next.nextCursor).toBe("c1");
+    expect(next.isAdmin).toBe(true);
+  });
+
+  it("subsequent page APPENDS onto the accumulated items", () => {
+    const first = appendHistoryPage(
+      emptyHistoryState(),
+      page([historyRow({ runId: "r1" })], "c1"),
+      true,
+    );
+    const second = appendHistoryPage(
+      first,
+      page([historyRow({ runId: "r2" })], null),
+      false,
+    );
+    expect(second.items.map((r) => r.runId)).toEqual(["r1", "r2"]);
+    expect(second.nextCursor).toBeNull();
+  });
+
+  it("de-dupes by mode:runId across a keyset boundary", () => {
+    const first = appendHistoryPage(
+      emptyHistoryState(),
+      page([historyRow({ runId: "r1" }), historyRow({ runId: "r2" })], "c1"),
+      true,
+    );
+    // r2 reappears at the boundary of the next page → must not duplicate.
+    const second = appendHistoryPage(
+      first,
+      page([historyRow({ runId: "r2" }), historyRow({ runId: "r3" })], null),
+      false,
+    );
+    expect(second.items.map((r) => r.runId)).toEqual(["r1", "r2", "r3"]);
+  });
+
+  it("keys de-dupe by mode too: same runId in two modes is kept", () => {
+    const next = appendHistoryPage(
+      emptyHistoryState(),
+      page(
+        [
+          historyRow({ runId: "x", mode: "pipeline" }),
+          historyRow({ runId: "x", mode: "task_group" }),
+        ],
+        null,
+      ),
+      true,
+    );
+    expect(next.items).toHaveLength(2);
+  });
+
+  it("does not mutate the prev state", () => {
+    const prev = appendHistoryPage(emptyHistoryState(), page([historyRow({ runId: "r1" })], "c1"), true);
+    const before = JSON.stringify(prev);
+    appendHistoryPage(prev, page([historyRow({ runId: "r2" })], null), false);
+    expect(JSON.stringify(prev)).toBe(before);
+  });
+});
+
+describe("historyRowKey", () => {
+  it("combines mode and runId (groupId for task_group)", () => {
+    expect(historyRowKey(historyRow({ mode: "task_group", runId: "g1" }))).toBe("task_group:g1");
+  });
+});
+
+describe("hasMoreHistory", () => {
+  it("is true when a cursor remains, false at the end", () => {
+    expect(hasMoreHistory({ items: [], nextCursor: "c1", isAdmin: false })).toBe(true);
+    expect(hasMoreHistory({ items: [], nextCursor: null, isAdmin: false })).toBe(false);
+  });
+});
+
+describe("buildHistoryQuery", () => {
+  it("clamps limit to the ≤100 server ceiling and emits cursor/mode", () => {
+    expect(buildHistoryQuery({ limit: 250, cursor: "abc", mode: "task_group" })).toBe(
+      "?limit=100&cursor=abc&mode=task_group",
+    );
+  });
+
+  it("floors a positive limit and never goes below 1", () => {
+    expect(buildHistoryQuery({ limit: 0 })).toBe("?limit=1");
+  });
+
+  it("omits cursor/mode when absent and url-encodes the cursor", () => {
+    expect(buildHistoryQuery({ limit: 25, cursor: null, mode: null })).toBe("?limit=25");
+    expect(buildHistoryQuery({ limit: 25, cursor: "a b/c=" })).toContain("cursor=a+b%2Fc%3D");
+  });
+
+  it("is empty when no params are given", () => {
+    expect(buildHistoryQuery({})).toBe("");
+  });
+});
+
+describe("groupHistoryByMode", () => {
+  it("groups in the fixed mode order and omits empty modes", () => {
+    const rows = [
+      historyRow({ runId: "g1", mode: "task_group" }),
+      historyRow({ runId: "p1", mode: "pipeline" }),
+      historyRow({ runId: "p2", mode: "pipeline" }),
+    ];
+    const groups = groupHistoryByMode(rows);
+    expect(groups.map((g) => g.mode)).toEqual(["pipeline", "task_group"]);
+    expect(groups[0].rows).toHaveLength(2);
+    expect(groups[1].rows).toHaveLength(1);
+  });
+
+  it("returns [] for no rows (drives the empty state)", () => {
+    expect(groupHistoryByMode([])).toEqual([]);
   });
 });

--- a/tests/unit/services/task-graph.test.ts
+++ b/tests/unit/services/task-graph.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for server/services/task-graph.ts — pure DAG validation used by the
+ * task-group edit routes. Reject self-dependency, cycles, and dangling refs; OK
+ * for any valid DAG (including the empty graph).
+ */
+import { describe, it, expect } from "vitest";
+import { validateTaskGraph } from "../../../server/services/task-graph.js";
+
+describe("validateTaskGraph", () => {
+  it("accepts the empty graph", () => {
+    expect(validateTaskGraph([])).toEqual({ ok: true });
+  });
+
+  it("accepts a single task with no deps", () => {
+    expect(validateTaskGraph([{ id: "a", dependsOn: [] }])).toEqual({ ok: true });
+  });
+
+  it("accepts a valid linear DAG a -> b -> c", () => {
+    const tasks = [
+      { id: "a", dependsOn: [] },
+      { id: "b", dependsOn: ["a"] },
+      { id: "c", dependsOn: ["b"] },
+    ];
+    expect(validateTaskGraph(tasks)).toEqual({ ok: true });
+  });
+
+  it("accepts a diamond DAG (a -> b, a -> c, b&c -> d)", () => {
+    const tasks = [
+      { id: "a", dependsOn: [] },
+      { id: "b", dependsOn: ["a"] },
+      { id: "c", dependsOn: ["a"] },
+      { id: "d", dependsOn: ["b", "c"] },
+    ];
+    expect(validateTaskGraph(tasks)).toEqual({ ok: true });
+  });
+
+  it("rejects a self-dependency", () => {
+    const res = validateTaskGraph([{ id: "a", dependsOn: ["a"] }]);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/self/i);
+  });
+
+  it("rejects a dangling dependency (dep id not in the group)", () => {
+    const res = validateTaskGraph([{ id: "a", dependsOn: ["ghost"] }]);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/unknown|dangling|not.*exist/i);
+  });
+
+  it("rejects a 2-node cycle (a -> b -> a)", () => {
+    const tasks = [
+      { id: "a", dependsOn: ["b"] },
+      { id: "b", dependsOn: ["a"] },
+    ];
+    const res = validateTaskGraph(tasks);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/cycle/i);
+  });
+
+  it("rejects a 3-node cycle (a -> b -> c -> a)", () => {
+    const tasks = [
+      { id: "a", dependsOn: ["c"] },
+      { id: "b", dependsOn: ["a"] },
+      { id: "c", dependsOn: ["b"] },
+    ];
+    const res = validateTaskGraph(tasks);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/cycle/i);
+  });
+
+  it("accepts duplicate dep ids that still form a DAG", () => {
+    const tasks = [
+      { id: "a", dependsOn: [] },
+      { id: "b", dependsOn: ["a", "a"] },
+    ];
+    expect(validateTaskGraph(tasks)).toEqual({ ok: true });
+  });
+});

--- a/tests/unit/services/task-group-editor.test.ts
+++ b/tests/unit/services/task-group-editor.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for server/services/task-group-editor.ts — the pending-only edit
+ * orchestration (group fields, per-task fields, add/remove, dependsOn rewrite +
+ * status recompute), DAG-validated and TOCTOU-guarded against a concurrent start.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { MemStorage } from "../../../server/storage.js";
+import {
+  TaskGroupEditor,
+  TaskGroupEditError,
+} from "../../../server/services/task-group-editor.js";
+import type { InsertTaskGroup, InsertTask, TaskStatus } from "@shared/schema";
+
+async function seedGroup(
+  storage: MemStorage,
+  status: InsertTaskGroup["status"] = "pending",
+) {
+  const group = await storage.createTaskGroup({
+    name: "G",
+    description: "D",
+    input: "obj",
+    status,
+    createdBy: "owner",
+  } as InsertTaskGroup);
+  return group;
+}
+
+async function seedTask(
+  storage: MemStorage,
+  groupId: string,
+  name: string,
+  opts: { dependsOn?: string[]; status?: TaskStatus; sortOrder?: number } = {},
+) {
+  return storage.createTask({
+    groupId,
+    name,
+    description: "d",
+    executionMode: "direct_llm",
+    dependsOn: opts.dependsOn ?? [],
+    input: {},
+    status: opts.status ?? "ready",
+    sortOrder: opts.sortOrder ?? 0,
+  } as InsertTask);
+}
+
+describe("TaskGroupEditor.updateGroup", () => {
+  let storage: MemStorage;
+  let editor: TaskGroupEditor;
+  beforeEach(() => {
+    storage = new MemStorage();
+    editor = new TaskGroupEditor(storage);
+  });
+
+  it("updates name/description/input on a pending group", async () => {
+    const g = await seedGroup(storage, "pending");
+    const updated = await editor.updateGroup(g.id, { name: "N", description: "DD", input: "new" });
+    expect(updated.name).toBe("N");
+    expect(updated.description).toBe("DD");
+    expect(updated.input).toBe("new");
+  });
+
+  it("allows name/description relabel on a completed group", async () => {
+    const g = await seedGroup(storage, "completed");
+    const updated = await editor.updateGroup(g.id, { name: "relabel" });
+    expect(updated.name).toBe("relabel");
+  });
+
+  it("409s when editing input on a completed group", async () => {
+    const g = await seedGroup(storage, "completed");
+    await expect(editor.updateGroup(g.id, { input: "nope" })).rejects.toMatchObject({
+      status: 409,
+    });
+  });
+
+  it("409s for ANY field when the group is running", async () => {
+    const g = await seedGroup(storage, "running");
+    await expect(editor.updateGroup(g.id, { name: "x" })).rejects.toMatchObject({ status: 409 });
+  });
+
+  it("404s for a missing group", async () => {
+    await expect(editor.updateGroup("ghost", { name: "x" })).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe("TaskGroupEditor.updateTask", () => {
+  let storage: MemStorage;
+  let editor: TaskGroupEditor;
+  beforeEach(() => {
+    storage = new MemStorage();
+    editor = new TaskGroupEditor(storage);
+  });
+
+  it("updates a task's dependsOn and recomputes status to blocked", async () => {
+    const g = await seedGroup(storage);
+    const a = await seedTask(storage, g.id, "a", { status: "ready" });
+    const b = await seedTask(storage, g.id, "b", { status: "ready" });
+    const updated = await editor.updateTask(g.id, b.id, { dependsOn: [a.id] });
+    expect(updated.dependsOn).toEqual([a.id]);
+    expect(updated.status).toBe("blocked");
+  });
+
+  it("recomputes status to ready when dependsOn cleared", async () => {
+    const g = await seedGroup(storage);
+    const a = await seedTask(storage, g.id, "a");
+    const b = await seedTask(storage, g.id, "b", { dependsOn: [a.id], status: "blocked" });
+    const updated = await editor.updateTask(g.id, b.id, { dependsOn: [] });
+    expect(updated.status).toBe("ready");
+  });
+
+  it("409s when the group is not pending", async () => {
+    const g = await seedGroup(storage, "running");
+    const a = await seedTask(storage, g.id, "a");
+    await expect(editor.updateTask(g.id, a.id, { name: "x" })).rejects.toMatchObject({
+      status: 409,
+    });
+  });
+
+  it("404s when the task belongs to a different group (cross-group tamper)", async () => {
+    const g1 = await seedGroup(storage);
+    const g2 = await seedGroup(storage);
+    const t = await seedTask(storage, g2.id, "a");
+    await expect(editor.updateTask(g1.id, t.id, { name: "x" })).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  it("400s when an edit introduces a cycle", async () => {
+    const g = await seedGroup(storage);
+    const a = await seedTask(storage, g.id, "a");
+    const b = await seedTask(storage, g.id, "b", { dependsOn: [a.id], status: "blocked" });
+    // make a depend on b → cycle
+    await expect(editor.updateTask(g.id, a.id, { dependsOn: [b.id] })).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+
+  it("400s when dependsOn references a task outside the group", async () => {
+    const g = await seedGroup(storage);
+    const a = await seedTask(storage, g.id, "a");
+    await expect(editor.updateTask(g.id, a.id, { dependsOn: ["ghost"] })).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+});
+
+describe("TaskGroupEditor.addTask", () => {
+  let storage: MemStorage;
+  let editor: TaskGroupEditor;
+  beforeEach(() => {
+    storage = new MemStorage();
+    editor = new TaskGroupEditor(storage);
+  });
+
+  it("adds a ready task with sortOrder = max+1", async () => {
+    const g = await seedGroup(storage);
+    await seedTask(storage, g.id, "a", { sortOrder: 0 });
+    await seedTask(storage, g.id, "b", { sortOrder: 1 });
+    const created = await editor.addTask(g.id, { name: "c", description: "d" });
+    expect(created.sortOrder).toBe(2);
+    expect(created.status).toBe("ready");
+  });
+
+  it("adds a blocked task when it has deps", async () => {
+    const g = await seedGroup(storage);
+    const a = await seedTask(storage, g.id, "a");
+    const created = await editor.addTask(g.id, { name: "c", description: "d", dependsOn: [a.id] });
+    expect(created.status).toBe("blocked");
+  });
+
+  it("409s when the group is not pending", async () => {
+    const g = await seedGroup(storage, "completed");
+    await expect(editor.addTask(g.id, { name: "c", description: "d" })).rejects.toMatchObject({
+      status: 409,
+    });
+  });
+
+  it("400s when the new task depends on an unknown id", async () => {
+    const g = await seedGroup(storage);
+    await expect(
+      editor.addTask(g.id, { name: "c", description: "d", dependsOn: ["ghost"] }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});
+
+describe("TaskGroupEditor.removeTask", () => {
+  let storage: MemStorage;
+  let editor: TaskGroupEditor;
+  beforeEach(() => {
+    storage = new MemStorage();
+    editor = new TaskGroupEditor(storage);
+  });
+
+  it("deletes the task and strips its id from siblings' dependsOn, recomputing status", async () => {
+    const g = await seedGroup(storage);
+    const a = await seedTask(storage, g.id, "a");
+    const b = await seedTask(storage, g.id, "b", { dependsOn: [a.id], status: "blocked" });
+
+    await editor.removeTask(g.id, a.id);
+
+    const remaining = await storage.getTasksByGroup(g.id);
+    expect(remaining.map((t) => t.id)).toEqual([b.id]);
+    expect(remaining[0].dependsOn).toEqual([]);
+    // b had only a as a dep → now unblocked → ready
+    expect(remaining[0].status).toBe("ready");
+  });
+
+  it("keeps a sibling blocked when it still has remaining deps", async () => {
+    const g = await seedGroup(storage);
+    const a = await seedTask(storage, g.id, "a");
+    const b = await seedTask(storage, g.id, "b");
+    const c = await seedTask(storage, g.id, "c", { dependsOn: [a.id, b.id], status: "blocked" });
+
+    await editor.removeTask(g.id, a.id);
+
+    const cRow = (await storage.getTasksByGroup(g.id)).find((t) => t.id === c.id)!;
+    expect(cRow.dependsOn).toEqual([b.id]);
+    expect(cRow.status).toBe("blocked");
+  });
+
+  it("409s when the group is not pending", async () => {
+    const g = await seedGroup(storage, "running");
+    const a = await seedTask(storage, g.id, "a");
+    await expect(editor.removeTask(g.id, a.id)).rejects.toMatchObject({ status: 409 });
+  });
+
+  it("404s when the task is not in the group", async () => {
+    const g1 = await seedGroup(storage);
+    const g2 = await seedGroup(storage);
+    const t = await seedTask(storage, g2.id, "a");
+    await expect(editor.removeTask(g1.id, t.id)).rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe("TaskGroupEditError", () => {
+  it("carries an http status code", () => {
+    const e = new TaskGroupEditError(409, "conflict");
+    expect(e.status).toBe(409);
+    expect(e.message).toBe("conflict");
+    expect(e).toBeInstanceOf(Error);
+  });
+});

--- a/tests/unit/skills-ui.test.ts
+++ b/tests/unit/skills-ui.test.ts
@@ -282,11 +282,19 @@ describe("SkillEditor component — team dropdown (PR #171)", () => {
 
 describe("CreateTaskGroup page (PR #167)", () => {
   const source = readSource("client/src/pages/CreateTaskGroup.tsx");
+  // The shared task-form bits were extracted into a reusable module (used by
+  // BOTH CreateTaskGroup and the TaskGroup edit mode). emptyTask/validate/the
+  // dependsOn toggle now live in task-form-logic; the TaskRow + execution-mode
+  // options live in task-form.tsx. CreateTaskGroup imports + uses them.
+  const formLogic = readSource("client/src/components/task-groups/task-form-logic.ts");
+  const formRow = readSource("client/src/components/task-groups/task-form.tsx");
 
-  it("has emptyTask helper that creates a task draft with default values", () => {
-    expect(source).toContain("function emptyTask");
-    expect(source).toContain("executionMode");
-    expect(source).toContain("dependsOn");
+  it("imports the shared emptyTask helper (extracted to task-form-logic)", () => {
+    expect(source).toContain("emptyTask");
+    expect(source).toContain("@/components/task-groups/task-form");
+    expect(formLogic).toContain("function emptyTask");
+    expect(formLogic).toContain("executionMode");
+    expect(formLogic).toContain("dependsOn");
   });
 
   it("supports both manual and submit-work view modes", () => {
@@ -304,14 +312,14 @@ describe("CreateTaskGroup page (PR #167)", () => {
     expect(source).toContain("trackerUrl");
   });
 
-  it("supports both pipeline_run and direct_llm execution modes", () => {
-    expect(source).toContain('"pipeline_run"');
-    expect(source).toContain('"direct_llm"');
+  it("supports both pipeline_run and direct_llm execution modes (shared TaskRow)", () => {
+    expect(formRow).toContain('"pipeline_run"');
+    expect(formRow).toContain('"direct_llm"');
   });
 
-  it("has task dependency management (toggleDep)", () => {
-    expect(source).toContain("toggleDep");
-    expect(source).toContain("dependsOn");
+  it("has task dependency management (shared toggleDependency)", () => {
+    expect(formLogic).toContain("toggleDependency");
+    expect(formLogic).toContain("dependsOn");
   });
 
   it("navigates back on success", () => {

--- a/tests/unit/storage-history.test.ts
+++ b/tests/unit/storage-history.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for the MemStorage history finders + deleteTask (Phase 0).
+ *   - deleteTask removes a single task without disturbing siblings;
+ *   - listPipelineRunHistory / listTaskGroupHistory return terminal-status rows
+ *     only, owner-filtered when ownerId is set, ordered (completedAt desc, id
+ *     desc), bounded by limit, and keyset-paged via the cursor.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { MemStorage } from "../../server/storage.js";
+import type { InsertTaskGroup, InsertTask } from "@shared/schema";
+
+let storage: MemStorage;
+beforeEach(() => {
+  storage = new MemStorage();
+});
+
+async function pipeRun(triggeredBy: string | null, status: string, completedAt: Date | null) {
+  return storage.createPipelineRun({
+    pipelineId: "p",
+    status,
+    input: "x",
+    currentStageIndex: 0,
+    startedAt: new Date(0),
+    completedAt,
+    triggeredBy,
+    dagMode: false,
+  });
+}
+
+async function group(createdBy: string | null, status: string, completedAt: Date | null) {
+  return storage.createTaskGroup({
+    name: "g",
+    description: "d",
+    input: "i",
+    status,
+    createdBy,
+    completedAt,
+  } as InsertTaskGroup);
+}
+
+describe("MemStorage.deleteTask", () => {
+  it("removes one task and leaves siblings intact", async () => {
+    const g = await group("u", "pending", null);
+    const a = await storage.createTask({
+      groupId: g.id,
+      name: "a",
+      description: "d",
+      executionMode: "direct_llm",
+      dependsOn: [],
+      input: {},
+      status: "ready",
+      sortOrder: 0,
+    } as InsertTask);
+    const b = await storage.createTask({
+      groupId: g.id,
+      name: "b",
+      description: "d",
+      executionMode: "direct_llm",
+      dependsOn: [],
+      input: {},
+      status: "ready",
+      sortOrder: 1,
+    } as InsertTask);
+
+    await storage.deleteTask(a.id);
+    const remaining = await storage.getTasksByGroup(g.id);
+    expect(remaining.map((t) => t.id)).toEqual([b.id]);
+  });
+});
+
+describe("MemStorage.listPipelineRunHistory", () => {
+  it("returns terminal-status rows only", async () => {
+    await pipeRun("u", "running", null);
+    await pipeRun("u", "pending", null);
+    await pipeRun("u", "completed", new Date("2026-01-01T00:00:00Z"));
+    await pipeRun("u", "failed", new Date("2026-01-02T00:00:00Z"));
+    await pipeRun("u", "rejected", new Date("2026-01-03T00:00:00Z"));
+
+    const rows = await storage.listPipelineRunHistory({ limit: 100 });
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.status).sort()).toEqual(["completed", "failed", "rejected"]);
+  });
+
+  it("filters by ownerId when set", async () => {
+    await pipeRun("me", "completed", new Date("2026-01-01T00:00:00Z"));
+    await pipeRun("other", "completed", new Date("2026-01-02T00:00:00Z"));
+    const mine = await storage.listPipelineRunHistory({ ownerId: "me", limit: 100 });
+    expect(mine).toHaveLength(1);
+    expect(mine[0].triggeredBy).toBe("me");
+  });
+
+  it("orders by completedAt desc then id desc and bounds by limit", async () => {
+    await pipeRun("u", "completed", new Date("2026-01-01T00:00:00Z"));
+    await pipeRun("u", "completed", new Date("2026-01-03T00:00:00Z"));
+    await pipeRun("u", "completed", new Date("2026-01-02T00:00:00Z"));
+    const rows = await storage.listPipelineRunHistory({ limit: 2 });
+    expect(rows).toHaveLength(2);
+    expect(rows[0].completedAt!.getTime()).toBeGreaterThan(rows[1].completedAt!.getTime());
+  });
+
+  it("paginates with the keyset cursor (no overlap, no gap)", async () => {
+    for (let i = 1; i <= 4; i++) {
+      await pipeRun("u", "completed", new Date(`2026-01-0${i}T00:00:00Z`));
+    }
+    const first = await storage.listPipelineRunHistory({ limit: 2 });
+    const last = first[first.length - 1];
+    const second = await storage.listPipelineRunHistory({
+      limit: 2,
+      cursor: { completedAt: last.completedAt!.toISOString(), id: last.id },
+    });
+    const firstIds = new Set(first.map((r) => r.id));
+    for (const r of second) expect(firstIds.has(r.id)).toBe(false);
+    expect(first.length + second.length).toBe(4);
+  });
+});
+
+describe("MemStorage.listTaskGroupHistory", () => {
+  it("returns terminal-status groups only, owner-filtered", async () => {
+    await group("me", "pending", null);
+    await group("me", "running", null);
+    await group("me", "completed", new Date("2026-01-01T00:00:00Z"));
+    await group("other", "cancelled", new Date("2026-01-02T00:00:00Z"));
+
+    const all = await storage.listTaskGroupHistory({ limit: 100 });
+    expect(all).toHaveLength(2);
+
+    const mine = await storage.listTaskGroupHistory({ ownerId: "me", limit: 100 });
+    expect(mine).toHaveLength(1);
+    expect(mine[0].createdBy).toBe("me");
+  });
+});

--- a/tests/unit/task-form.test.ts
+++ b/tests/unit/task-form.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Unit tests for the shared task-group form logic (frontend) + the timeline
+ * helper. Like activity-ui.test.ts / orchestrator-ui.test.ts, these exercise the
+ * PURE helpers behind CreateTaskGroup + TaskGroup edit mode without a DOM
+ * renderer (the repo has no jsdom) — they import from task-form-logic (no React)
+ * and timeline (no React):
+ *   - the status gating (isGroupEditable / isGroupRelabelOnly),
+ *   - the task add/remove/dependsOn-by-id reducers,
+ *   - validate() with the requireInput/requireTasks options,
+ *   - buildTimeline() ordering + durations.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  emptyTask,
+  isGroupEditable,
+  isGroupRelabelOnly,
+  toggleDependency,
+  addTaskToList,
+  removeTaskFromList,
+  updateTaskInList,
+  validate,
+  hasErrors,
+  type TaskDraft,
+} from "@/components/task-groups/task-form-logic";
+import {
+  buildTimeline,
+  taskDurationMs,
+  isTimelineComplete,
+  timelineSpanMs,
+  formatDuration,
+  type TimelineTaskInput,
+} from "@/components/task-groups/timeline";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function task(overrides: Partial<TaskDraft> = {}): TaskDraft {
+  return {
+    id: overrides.id ?? "t1",
+    name: overrides.name ?? "Task",
+    description: overrides.description ?? "Do a thing",
+    executionMode: overrides.executionMode ?? "direct_llm",
+    dependsOn: overrides.dependsOn ?? [],
+  };
+}
+
+// ─── isGroupEditable / isGroupRelabelOnly (the gating) ──────────────────────────
+
+describe("isGroupEditable", () => {
+  it("allows full edit ONLY when pending", () => {
+    expect(isGroupEditable("pending")).toBe(true);
+  });
+
+  it("blocks full edit for running and terminal states", () => {
+    for (const s of ["running", "ready", "blocked", "completed", "failed", "cancelled"]) {
+      expect(isGroupEditable(s)).toBe(false);
+    }
+  });
+});
+
+describe("isGroupRelabelOnly", () => {
+  it("is true for the three terminal states", () => {
+    expect(isGroupRelabelOnly("completed")).toBe(true);
+    expect(isGroupRelabelOnly("failed")).toBe(true);
+    expect(isGroupRelabelOnly("cancelled")).toBe(true);
+  });
+
+  it("is false for pending / running / intermediate", () => {
+    for (const s of ["pending", "running", "ready", "blocked"]) {
+      expect(isGroupRelabelOnly(s)).toBe(false);
+    }
+  });
+
+  it("pending is editable but NOT relabel-only; running is neither", () => {
+    expect(isGroupEditable("pending") && !isGroupRelabelOnly("pending")).toBe(true);
+    expect(!isGroupEditable("running") && !isGroupRelabelOnly("running")).toBe(true);
+  });
+});
+
+// ─── toggleDependency (dependsOn by id) ─────────────────────────────────────────
+
+describe("toggleDependency", () => {
+  it("adds an id when absent and removes it when present (immutably)", () => {
+    const t = task({ dependsOn: [] });
+    const added = toggleDependency(t, "dep-1");
+    expect(added.dependsOn).toEqual(["dep-1"]);
+    expect(t.dependsOn).toEqual([]); // original untouched
+
+    const removed = toggleDependency(added, "dep-1");
+    expect(removed.dependsOn).toEqual([]);
+  });
+
+  it("keeps other deps when toggling one", () => {
+    const t = task({ dependsOn: ["a", "b"] });
+    expect(toggleDependency(t, "a").dependsOn).toEqual(["b"]);
+    expect(toggleDependency(t, "c").dependsOn).toEqual(["a", "b", "c"]);
+  });
+});
+
+// ─── add / update / remove reducers ─────────────────────────────────────────────
+
+describe("addTaskToList", () => {
+  it("appends a fresh empty task without mutating the input", () => {
+    const list = [task({ id: "a" })];
+    const next = addTaskToList(list);
+    expect(next).toHaveLength(2);
+    expect(list).toHaveLength(1);
+    expect(next[1].name).toBe("");
+    expect(next[1].dependsOn).toEqual([]);
+  });
+});
+
+describe("updateTaskInList", () => {
+  it("replaces the matching task by id only", () => {
+    const list = [task({ id: "a", name: "A" }), task({ id: "b", name: "B" })];
+    const next = updateTaskInList(list, "b", { ...list[1], name: "B2" });
+    expect(next[0]).toBe(list[0]); // untouched ref
+    expect(next[1].name).toBe("B2");
+  });
+});
+
+describe("removeTaskFromList — strips the removed id from siblings' dependsOn", () => {
+  it("removes the task AND its id from every sibling (mirrors the server)", () => {
+    const list = [
+      task({ id: "a" }),
+      task({ id: "b", dependsOn: ["a"] }),
+      task({ id: "c", dependsOn: ["a", "b"] }),
+    ];
+    const next = removeTaskFromList(list, "a");
+    expect(next.map((t) => t.id)).toEqual(["b", "c"]);
+    expect(next[0].dependsOn).toEqual([]); // 'a' stripped from b
+    expect(next[1].dependsOn).toEqual(["b"]); // 'a' stripped from c, 'b' kept
+  });
+
+  it("does not mutate the input list or its tasks", () => {
+    const list = [task({ id: "a" }), task({ id: "b", dependsOn: ["a"] })];
+    const before = JSON.stringify(list);
+    removeTaskFromList(list, "a");
+    expect(JSON.stringify(list)).toBe(before);
+  });
+
+  it("is a no-op-shaped result when the id is absent (still strips nothing)", () => {
+    const list = [task({ id: "a", dependsOn: ["x"] })];
+    const next = removeTaskFromList(list, "missing");
+    expect(next.map((t) => t.id)).toEqual(["a"]);
+    expect(next[0].dependsOn).toEqual(["x"]);
+  });
+});
+
+// ─── validate + hasErrors ───────────────────────────────────────────────────────
+
+describe("validate", () => {
+  const goodGroup = { name: "G", description: "D", input: "I" };
+
+  it("passes a complete pending group (input + tasks required)", () => {
+    const errors = validate(goodGroup, [task()]);
+    expect(hasErrors(errors)).toBe(false);
+  });
+
+  it("flags missing group name/description/input", () => {
+    const errors = validate({ name: "", description: "", input: "" }, [task()]);
+    expect(errors.name).toBeTruthy();
+    expect(errors.description).toBeTruthy();
+    expect(errors.input).toBeTruthy();
+    expect(hasErrors(errors)).toBe(true);
+  });
+
+  it("flags an empty task list and per-task name/description", () => {
+    expect(validate(goodGroup, []).tasks).toBeTruthy();
+    const errors = validate(goodGroup, [task({ id: "z", name: "", description: "" })]);
+    expect(errors.taskErrors?.z?.name).toBeTruthy();
+    expect(errors.taskErrors?.z?.description).toBeTruthy();
+  });
+
+  it("relabel mode (requireInput/requireTasks=false) ignores input + tasks", () => {
+    // terminal relabel: only name/description matter; empty input + no tasks OK.
+    const errors = validate({ name: "G", description: "D", input: "" }, [], {
+      requireInput: false,
+      requireTasks: false,
+    });
+    expect(hasErrors(errors)).toBe(false);
+  });
+
+  it("relabel mode still flags a blank name", () => {
+    const errors = validate({ name: "", description: "D", input: "" }, [], {
+      requireInput: false,
+      requireTasks: false,
+    });
+    expect(errors.name).toBeTruthy();
+    expect(errors.input).toBeUndefined();
+    expect(errors.tasks).toBeUndefined();
+  });
+});
+
+// ─── emptyTask ──────────────────────────────────────────────────────────────────
+
+describe("emptyTask", () => {
+  it("produces a unique-id blank direct_llm task", () => {
+    const a = emptyTask();
+    const b = emptyTask();
+    expect(a.id).not.toBe(b.id);
+    expect(a.executionMode).toBe("direct_llm");
+    expect(a.dependsOn).toEqual([]);
+  });
+});
+
+// ─── buildTimeline + duration helpers ───────────────────────────────────────────
+
+function ttask(overrides: Partial<TimelineTaskInput> = {}): TimelineTaskInput {
+  return {
+    id: overrides.id ?? "t",
+    name: overrides.name ?? "Task",
+    status: overrides.status ?? "pending",
+    executionMode: overrides.executionMode,
+    modelSlug: overrides.modelSlug,
+    teamId: overrides.teamId,
+    sortOrder: overrides.sortOrder,
+    startedAt: overrides.startedAt,
+    completedAt: overrides.completedAt,
+  };
+}
+
+describe("taskDurationMs", () => {
+  it("computes start→end in ms", () => {
+    expect(
+      taskDurationMs(
+        ttask({
+          startedAt: "2026-06-16T10:00:00.000Z",
+          completedAt: "2026-06-16T10:00:05.000Z",
+        }),
+      ),
+    ).toBe(5000);
+  });
+
+  it("is null when either timestamp is missing", () => {
+    expect(taskDurationMs(ttask({ startedAt: "2026-06-16T10:00:00.000Z" }))).toBeNull();
+    expect(taskDurationMs(ttask({ completedAt: "2026-06-16T10:00:00.000Z" }))).toBeNull();
+    expect(taskDurationMs(ttask())).toBeNull();
+  });
+
+  it("is null for a negative (clock-skew) duration", () => {
+    expect(
+      taskDurationMs(
+        ttask({
+          startedAt: "2026-06-16T10:00:05.000Z",
+          completedAt: "2026-06-16T10:00:00.000Z",
+        }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("buildTimeline", () => {
+  it("orders started tasks by startedAt, then unstarted by sortOrder", () => {
+    const tasks = [
+      ttask({ id: "late", status: "completed", startedAt: "2026-06-16T10:00:10.000Z" }),
+      ttask({ id: "p2", status: "pending", sortOrder: 5 }),
+      ttask({ id: "early", status: "completed", startedAt: "2026-06-16T10:00:01.000Z" }),
+      ttask({ id: "p1", status: "pending", sortOrder: 1 }),
+    ];
+    const tl = buildTimeline(tasks);
+    expect(tl.map((e) => e.id)).toEqual(["early", "late", "p1", "p2"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const tasks = [
+      ttask({ id: "b", startedAt: "2026-06-16T10:00:02.000Z" }),
+      ttask({ id: "a", startedAt: "2026-06-16T10:00:01.000Z" }),
+    ];
+    const ids = tasks.map((t) => t.id);
+    buildTimeline(tasks);
+    expect(tasks.map((t) => t.id)).toEqual(ids);
+  });
+
+  it("carries metadata and computes per-task duration + hasRun", () => {
+    const tl = buildTimeline([
+      ttask({
+        id: "x",
+        status: "completed",
+        executionMode: "pipeline_run",
+        modelSlug: "claude-opus",
+        teamId: "frontend",
+        startedAt: "2026-06-16T10:00:00.000Z",
+        completedAt: "2026-06-16T10:00:03.000Z",
+      }),
+      ttask({ id: "y", status: "pending" }),
+    ]);
+    const x = tl.find((e) => e.id === "x")!;
+    expect(x).toMatchObject({
+      executionMode: "pipeline_run",
+      modelSlug: "claude-opus",
+      teamId: "frontend",
+      durationMs: 3000,
+      hasRun: true,
+    });
+    const y = tl.find((e) => e.id === "y")!;
+    expect(y.hasRun).toBe(false);
+    expect(y.durationMs).toBeNull();
+  });
+
+  it("returns [] for no tasks (drives the empty state)", () => {
+    expect(buildTimeline([])).toEqual([]);
+  });
+});
+
+describe("isTimelineComplete", () => {
+  it("is true only when every task is terminal", () => {
+    const done = buildTimeline([
+      ttask({ id: "a", status: "completed" }),
+      ttask({ id: "b", status: "failed" }),
+    ]);
+    expect(isTimelineComplete(done)).toBe(true);
+
+    const mixed = buildTimeline([
+      ttask({ id: "a", status: "completed" }),
+      ttask({ id: "b", status: "running" }),
+    ]);
+    expect(isTimelineComplete(mixed)).toBe(false);
+  });
+
+  it("is false for an empty timeline", () => {
+    expect(isTimelineComplete([])).toBe(false);
+  });
+});
+
+describe("timelineSpanMs", () => {
+  it("spans earliest start to latest end", () => {
+    const tl = buildTimeline([
+      ttask({
+        id: "a",
+        startedAt: "2026-06-16T10:00:00.000Z",
+        completedAt: "2026-06-16T10:00:04.000Z",
+      }),
+      ttask({
+        id: "b",
+        startedAt: "2026-06-16T10:00:02.000Z",
+        completedAt: "2026-06-16T10:00:10.000Z",
+      }),
+    ]);
+    expect(timelineSpanMs(tl)).toBe(10_000);
+  });
+
+  it("is null with no started/completed pair", () => {
+    expect(timelineSpanMs(buildTimeline([ttask({ id: "a", status: "pending" })]))).toBeNull();
+  });
+});
+
+describe("formatDuration", () => {
+  it("formats ms / s / m and the null placeholder", () => {
+    expect(formatDuration(null)).toBe("—");
+    expect(formatDuration(0)).toBe("—");
+    expect(formatDuration(250)).toBe("250ms");
+    expect(formatDuration(1500)).toBe("1.5s");
+    expect(formatDuration(90_000)).toBe("1.5m");
+  });
+});

--- a/tests/unit/ws/ws-manager.test.ts
+++ b/tests/unit/ws/ws-manager.test.ts
@@ -56,6 +56,7 @@ function makeEvent(runId: string) {
 function storageWithRun(triggeredBy: string | null): IStorage {
   return {
     getPipelineRun: vi.fn(async () => ({ id: "r", triggeredBy })),
+    getTaskGroup: vi.fn(async () => undefined),
   } as unknown as IStorage;
 }
 
@@ -259,7 +260,10 @@ describe("WsManager.authorizeAndSubscribe — ownership gate", () => {
   });
 
   it("REJECTS subscribing to a missing run", async () => {
-    const storage = { getPipelineRun: vi.fn(async () => undefined) } as unknown as IStorage;
+    const storage = {
+      getPipelineRun: vi.fn(async () => undefined),
+      getTaskGroup: vi.fn(async () => undefined),
+    } as unknown as IStorage;
     const { manager } = await createManager(storage);
     const ws = makeFakeWs();
     const ok = await manager.authorizeAndSubscribe(ws as never, owner, "missing");

--- a/tests/unit/ws/ws-task-group-subscribe.test.ts
+++ b/tests/unit/ws/ws-task-group-subscribe.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for the H3 task-group fallback in WsManager.authorizeAndSubscribe.
+ *
+ * When `getPipelineRun(runId)` misses, the gate falls back to
+ * `getTaskGroup(runId)` and applies the SAME isVisible(createdBy,user) rule:
+ *   - group owner subscribes; non-owner denied; admin bypass; ownerless denied
+ *     to non-admin; unknown id (both spaces) denied; missing user / no storage
+ *     fail closed; the pipeline path is unchanged (pipeline-first ordering).
+ *
+ * A real (non-listening) HTTP server backs the WsManager; no network I/O.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { createServer } from "http";
+import type { IStorage } from "../../../server/storage.js";
+
+async function createManager(storage?: IStorage) {
+  const { WsManager } = await import("../../../server/ws/manager.js");
+  const httpServer = createServer();
+  const manager = new WsManager(httpServer, storage);
+  return { manager };
+}
+
+function makeFakeWs(readyState = 1) {
+  return { readyState, send: vi.fn() };
+}
+
+/** Storage where the id is a task group (no pipeline run), owned by `createdBy`. */
+function groupStorage(createdBy: string | null): IStorage {
+  return {
+    getPipelineRun: vi.fn(async () => undefined),
+    getTaskGroup: vi.fn(async () => ({ id: "g", createdBy })),
+  } as unknown as IStorage;
+}
+
+/** Storage where the id IS a pipeline run (the unchanged path); getTaskGroup must NOT be hit. */
+function pipelineStorage(triggeredBy: string | null) {
+  const getTaskGroup = vi.fn(async () => undefined);
+  const storage = {
+    getPipelineRun: vi.fn(async () => ({ id: "r", triggeredBy })),
+    getTaskGroup,
+  } as unknown as IStorage;
+  return { storage, getTaskGroup };
+}
+
+const owner = { id: "owner", role: "user" } as never;
+const intruder = { id: "intruder", role: "user" } as never;
+const admin = { id: "boss", role: "admin" } as never;
+
+describe("WsManager.authorizeAndSubscribe — task-group fallback (H3)", () => {
+  it("allows the group OWNER to subscribe to a task-group id", async () => {
+    const { manager } = await createManager(groupStorage("owner"));
+    const ws = makeFakeWs();
+    const ok = await manager.authorizeAndSubscribe(ws as never, owner, "g");
+    expect(ok).toBe(true);
+    manager.broadcastToRun("g", { type: "taskgroup:started", runId: "g", payload: {}, timestamp: "t" });
+    expect(ws.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("DENIES a non-owner on a task-group id", async () => {
+    const { manager } = await createManager(groupStorage("owner"));
+    const ws = makeFakeWs();
+    expect(await manager.authorizeAndSubscribe(ws as never, intruder, "g")).toBe(false);
+  });
+
+  it("allows an ADMIN on any task-group id", async () => {
+    const { manager } = await createManager(groupStorage("owner"));
+    const ws = makeFakeWs();
+    expect(await manager.authorizeAndSubscribe(ws as never, admin, "g")).toBe(true);
+  });
+
+  it("DENIES an ownerless group (createdBy null) to a non-admin", async () => {
+    const { manager } = await createManager(groupStorage(null));
+    const ws = makeFakeWs();
+    expect(await manager.authorizeAndSubscribe(ws as never, owner, "g")).toBe(false);
+  });
+
+  it("allows an ownerless group to an admin", async () => {
+    const { manager } = await createManager(groupStorage(null));
+    const ws = makeFakeWs();
+    expect(await manager.authorizeAndSubscribe(ws as never, admin, "g")).toBe(true);
+  });
+
+  it("DENIES an id unknown in BOTH spaces (fail closed)", async () => {
+    const storage = {
+      getPipelineRun: vi.fn(async () => undefined),
+      getTaskGroup: vi.fn(async () => undefined),
+    } as unknown as IStorage;
+    const { manager } = await createManager(storage);
+    const ws = makeFakeWs();
+    expect(await manager.authorizeAndSubscribe(ws as never, owner, "ghost")).toBe(false);
+  });
+
+  it("fails closed with no user", async () => {
+    const { manager } = await createManager(groupStorage("owner"));
+    const ws = makeFakeWs();
+    expect(await manager.authorizeAndSubscribe(ws as never, undefined, "g")).toBe(false);
+  });
+
+  it("fails closed with no storage", async () => {
+    const { manager } = await createManager(undefined);
+    const ws = makeFakeWs();
+    expect(await manager.authorizeAndSubscribe(ws as never, owner, "g")).toBe(false);
+  });
+});
+
+describe("WsManager.authorizeAndSubscribe — pipeline path unchanged", () => {
+  it("a pipeline run is authorized via triggeredBy and NEVER consults getTaskGroup", async () => {
+    const { storage, getTaskGroup } = pipelineStorage("owner");
+    const { manager } = await createManager(storage);
+    const ws = makeFakeWs();
+    const ok = await manager.authorizeAndSubscribe(ws as never, owner, "r");
+    expect(ok).toBe(true);
+    expect(getTaskGroup).not.toHaveBeenCalled();
+  });
+
+  it("a pipeline run owned by another user is denied (and getTaskGroup not consulted)", async () => {
+    const { storage, getTaskGroup } = pipelineStorage("owner");
+    const { manager } = await createManager(storage);
+    const ws = makeFakeWs();
+    expect(await manager.authorizeAndSubscribe(ws as never, intruder, "r")).toBe(false);
+    expect(getTaskGroup).not.toHaveBeenCalled();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -102,6 +102,11 @@ export default defineConfig({
         "server/routes/activity-model-map.ts",
         "server/routes/authorize-run.ts",
         "server/ws/manager.ts",
+        // task-groups edit + history + live-activity history (new modules >=80%).
+        "server/routes/authorize-task-group.ts",
+        "server/routes/task-groups.ts",
+        "server/services/task-graph.ts",
+        "server/services/task-group-editor.ts",
       ],
       exclude: ["server/**/*.test.ts", "server/index.ts", "server/vite.ts"],
     },


### PR DESCRIPTION
Three UX asks + two pre-existing auth holes closed along the way.

## Edit
`PATCH /api/task-groups/:id` (name/description/input) + PATCH/POST/DELETE tasks. **Editable only while `pending`** (409 otherwise; running blocks all, terminal allows name/description relabel) — **persist-time re-check** is TOCTOU-safe vs a concurrent start. `validateTaskGraph` rejects self-dep/cycle/dangling before every persist; DELETE strips the removed id from siblings' `dependsOn` + recomputes status. FE: status-gated edit mode reusing a shared task-form module.

## History
`GET /api/activity/history` — DB-backed terminal-status past runs across all modes incl. task-groups, owner/admin-scoped (SQL WHERE), **metadata-only allowlist** (fixed title, never group name; no output/input/summary/transcript), keyset pagination (opaque Zod cursor, limit≤100). FE: **History tab** in Live Activity + per-group **Timeline** panel. Task groups now appear as a **5th Live Activity mode**.

## Security (review PASS — no veto)
- **IDOR closed on ALL task-group routes** (`authorize-task-group` keyed on `createdBy`; list own-filtered; retry asserts task∈group). `String(err)` leaks removed.
- **WsManager.subscribe** now authorizes task-group ids fail-closed — revives the previously-dead task-group live stream.
- Folded in the sibling **`/:id/trace` IDOR** (owner-gated) since the new Timeline links to it.

## Gates
- Security PASS (9 must-fixes verified). QA PASS. `tsc` clean; unit **4861**; task-group+activity integration **77**; coverage ≥80% new modules (authorize-task-group 100%, task-graph 100% lines, editor 100% lines).
- No schema change. Builds on the Live Activity feature (#371).

Follow-up (tiny): a dedicated /:id/trace authz test (the gate reuses the 100%-tested authorizeTaskGroup).