### PR TITLE
fix: task-group tasks run on a real model, not the mock stub

### DIFF
--- a/client/src/components/task-groups/task-form-logic.ts
+++ b/client/src/components/task-groups/task-form-logic.ts
@@ -13,12 +13,24 @@ import type { TaskGroupStatus } from "@shared/types";
 
 export type ExecutionMode = "direct_llm" | "pipeline_run";
 
+/**
+ * Sentinel for "no explicit model" in the per-task model picker. Empty string
+ * (Radix Select cannot use "" as an item value) would be ambiguous, so the
+ * unset state is carried as `null` on the draft and rendered as the
+ * DEFAULT_MODEL_OPTION item. On submit, a `null` modelSlug is omitted from the
+ * payload so the SERVER applies its real default (pipeline.taskGroups.defaultModel)
+ * — it must NEVER coerce to "mock".
+ */
+export const DEFAULT_MODEL_OPTION = "__default__";
+
 export interface TaskDraft {
   id: string;
   name: string;
   description: string;
   executionMode: ExecutionMode;
   dependsOn: string[];
+  /** Pinned model slug, or null to use the server's real default. */
+  modelSlug: string | null;
 }
 
 export interface GroupDraft {
@@ -40,6 +52,7 @@ export function emptyTask(): TaskDraft {
     description: "",
     executionMode: "direct_llm",
     dependsOn: [],
+    modelSlug: null,
   };
 }
 
@@ -71,6 +84,15 @@ export function toggleDependency(task: TaskDraft, depId: string): TaskDraft {
     ? task.dependsOn.filter((d) => d !== depId)
     : [...task.dependsOn, depId];
   return { ...task, dependsOn: next };
+}
+
+/**
+ * Set a task's pinned model slug, immutably. The DEFAULT_MODEL_OPTION sentinel
+ * (or any falsy value) clears the pin back to `null` so the server default wins.
+ */
+export function setTaskModel(task: TaskDraft, slug: string): TaskDraft {
+  const next = !slug || slug === DEFAULT_MODEL_OPTION ? null : slug;
+  return { ...task, modelSlug: next };
 }
 
 /** Replace one task in the list by id, immutably. */

--- a/client/src/components/task-groups/task-form.tsx
+++ b/client/src/components/task-groups/task-form.tsx
@@ -23,6 +23,8 @@ import { Badge } from "@/components/ui/badge";
 import { Trash2 } from "lucide-react";
 import {
   toggleDependency,
+  setTaskModel,
+  DEFAULT_MODEL_OPTION,
   type TaskDraft,
   type SiblingOption,
   type ExecutionMode,
@@ -34,6 +36,8 @@ export {
   isGroupEditable,
   isGroupRelabelOnly,
   toggleDependency,
+  setTaskModel,
+  DEFAULT_MODEL_OPTION,
   updateTaskInList,
   removeTaskFromList,
   addTaskToList,
@@ -50,6 +54,12 @@ export type {
   TaskGroupStatus,
 } from "./task-form-logic";
 
+/** A selectable model for the per-task model picker. */
+export interface ModelOption {
+  slug: string;
+  name: string;
+}
+
 // ─── TaskRow (presentational) ────────────────────────────────────────────────
 
 interface TaskRowProps {
@@ -57,6 +67,8 @@ interface TaskRowProps {
   index: number;
   /** Sibling options for the dependsOn picker (chip = name, toggles id). */
   siblings: readonly SiblingOption[];
+  /** Active models for the per-task model picker (slug → label). */
+  models: readonly ModelOption[];
   onChange: (updated: TaskDraft) => void;
   onRemove: () => void;
   /** When true the row is read-only (no inputs, no remove). */
@@ -67,6 +79,7 @@ export function TaskRow({
   task,
   index,
   siblings,
+  models,
   onChange,
   onRemove,
   disabled = false,
@@ -121,6 +134,31 @@ export function TaskRow({
             </Select>
           </div>
         </div>
+
+        {task.executionMode === "direct_llm" && (
+          <div className="space-y-1">
+            <Label htmlFor={`task-model-${task.id}`}>Model</Label>
+            <Select
+              value={task.modelSlug ?? DEFAULT_MODEL_OPTION}
+              disabled={disabled}
+              onValueChange={(v) => onChange(setTaskModel(task, v))}
+            >
+              <SelectTrigger id={`task-model-${task.id}`} aria-label="Model">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={DEFAULT_MODEL_OPTION}>
+                  Default (server picks an active model)
+                </SelectItem>
+                {models.map((m) => (
+                  <SelectItem key={m.slug} value={m.slug}>
+                    {m.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
 
         <div className="space-y-1">
           <Label htmlFor={`task-desc-${task.id}`}>Description *</Label>

--- a/client/src/pages/CreateTaskGroup.tsx
+++ b/client/src/pages/CreateTaskGroup.tsx
@@ -23,6 +23,7 @@ import {
   type TaskDraft,
   type GroupDraft,
   type SiblingOption,
+  type ModelOption,
 } from "@/components/task-groups/task-form";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -308,7 +309,10 @@ function SubmitWorkForm() {
 export default function CreateTaskGroup() {
   const [, navigate] = useLocation();
   const createMutation = useCreateTaskGroup();
+  const modelsQuery = useActiveModels();
   const [viewMode, setViewMode] = useState<ViewMode>("manual");
+
+  const models = (modelsQuery.data ?? []) as ModelOption[];
 
   const [group, setGroup] = useState<GroupDraft>({
     name: "",
@@ -357,6 +361,9 @@ export default function CreateTaskGroup() {
           executionMode: t.executionMode,
           dependsOn: t.dependsOn,
           sortOrder: i,
+          // Omit modelSlug when unset so the SERVER applies its real default
+          // (pipeline.taskGroups.defaultModel) — never coerce to "mock".
+          ...(t.modelSlug ? { modelSlug: t.modelSlug } : {}),
         })),
       });
       const created = result as { id: string };
@@ -496,6 +503,7 @@ export default function CreateTaskGroup() {
                     task={task}
                     index={index}
                     siblings={siblings}
+                    models={models}
                     onChange={(updated) => updateTask(task.id, updated)}
                     onRemove={() => removeTask(task.id)}
                   />

--- a/client/src/pages/TaskGroup.tsx
+++ b/client/src/pages/TaskGroup.tsx
@@ -31,6 +31,7 @@ import {
   editErrorMessage,
 } from "@/hooks/use-task-groups";
 import { useTaskGroupEvents } from "@/hooks/use-task-events";
+import { useActiveModels } from "@/hooks/use-pipeline";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -67,6 +68,7 @@ import {
   type GroupDraft,
   type SiblingOption,
   type ExecutionMode,
+  type ModelOption,
 } from "@/components/task-groups/task-form";
 import {
   buildTimeline,
@@ -198,6 +200,8 @@ function EditForm({ groupId, group, fullEdit, onDone }: EditFormProps) {
   const updateTask = useUpdateTask(groupId);
   const addTask = useAddTask(groupId);
   const deleteTask = useDeleteTask(groupId);
+  const modelsQuery = useActiveModels();
+  const models = (modelsQuery.data ?? []) as ModelOption[];
 
   const [draft, setDraft] = useState<GroupDraft>({
     name: group.name,
@@ -215,6 +219,7 @@ function EditForm({ groupId, group, fullEdit, onDone }: EditFormProps) {
         description: t.description,
         executionMode: asExecutionMode(t.executionMode),
         dependsOn: t.dependsOn ?? [],
+        modelSlug: t.modelSlug ?? null,
       })),
   );
   // Track which task ids existed on the server so we PATCH vs POST correctly.
@@ -278,6 +283,8 @@ function EditForm({ groupId, group, fullEdit, onDone }: EditFormProps) {
             // final graph (cycle / dangling → 400).
             dependsOn: t.dependsOn,
             sortOrder: i,
+            // null clears any pin so the server applies its real default (never "mock").
+            modelSlug: t.modelSlug,
           };
           if (serverTaskIds.has(t.id)) {
             await updateTask.mutateAsync({ taskId: t.id, ...payload });
@@ -392,6 +399,7 @@ function EditForm({ groupId, group, fullEdit, onDone }: EditFormProps) {
                   task={task}
                   index={index}
                   siblings={siblings}
+                  models={models}
                   onChange={(updated) => changeTask(task.id, updated)}
                   onRemove={() => removeTask(task.id)}
                   disabled={anyPending}

--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -1,5 +1,16 @@
 import { z } from "zod";
 
+/**
+ * Default model slug for direct_llm task-group tasks created WITHOUT an explicit
+ * model. Must be a REAL, active subscription-CLI slug — NEVER "mock". A "mock"
+ * default makes task groups "complete" instantly with canned garbage at cost 0
+ * (fix/task-group-real-model-execution); kept in sync with the pipeline defaults
+ * re-pointed off the disabled local models in PR #363 (claude-sonnet). Used as
+ * the zod default for `pipeline.taskGroups.defaultModel` below so the orchestrator
+ * resolves a working model when a task has no `modelSlug`.
+ */
+export const DEFAULT_TASK_MODEL = "claude-sonnet";
+
 export const ConfigSchema = z.object({
   server: z.object({
     port: z.number().int().min(1).max(65535).default(5000),
@@ -261,6 +272,18 @@ export const ConfigSchema = z.object({
       overallTimeoutMs: z.coerce.number().int().min(10_000).max(3_600_000).default(1_800_000),
       /** Per-voter / per-turn timeout. 1s..10min (90s default). */
       voterTimeoutMs: z.coerce.number().int().min(1_000).max(600_000).default(90_000),
+    }).default({}),
+    /**
+     * Task-group (multi-task) execution. `defaultModel` is the slug applied to a
+     * `direct_llm` task created WITHOUT an explicit `modelSlug`. It MUST resolve
+     * to a real, active model — NEVER "mock" — otherwise the group "completes"
+     * instantly with the MockProvider canned stub at cost 0
+     * (fix/task-group-real-model-execution). Defaults to the same working
+     * subscription CLI the pipeline defaults use (PR #363).
+     */
+    taskGroups: z.object({
+      /** Real default model for model-less direct_llm tasks. NEVER "mock". */
+      defaultModel: z.string().min(1).default(DEFAULT_TASK_MODEL),
     }).default({}),
   }).default({}),
 });

--- a/server/services/task-orchestrator.ts
+++ b/server/services/task-orchestrator.ts
@@ -5,6 +5,8 @@ import type { Gateway } from "../gateway/index";
 import type { TaskGroupRow, TaskRow, InsertTaskGroup, InsertTask } from "@shared/schema";
 import type { WsEvent, TaskResult } from "@shared/types";
 import type { TaskTracer } from "./task-tracer";
+import { configLoader } from "../config/loader.js";
+import { DEFAULT_TASK_MODEL } from "../config/schema.js";
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -300,7 +302,12 @@ export class TaskOrchestrator {
     const traceCtx = this.activeGroupTraces.get(group.id);
     const taskSpanId = traceCtx?.taskSpanIds.get(task.id) ?? "";
     let llmSpanId = "";
-    const modelSlug = task.modelSlug ?? "mock";
+    // A model-less direct_llm task MUST resolve to a REAL model — NEVER "mock"
+    // (a "mock" default makes the group "complete" instantly with canned garbage
+    // at cost 0; fix/task-group-real-model-execution). The default comes from the
+    // pipeline.taskGroups.defaultModel config knob (DEFAULT_TASK_MODEL fallback).
+    const configuredDefault = configLoader.get().pipeline.taskGroups.defaultModel;
+    const modelSlug = task.modelSlug ?? configuredDefault ?? DEFAULT_TASK_MODEL;
 
     if (this.tracer && traceCtx && taskSpanId) {
       try {

--- a/tests/unit/task-form.test.ts
+++ b/tests/unit/task-form.test.ts
@@ -15,6 +15,8 @@ import {
   isGroupEditable,
   isGroupRelabelOnly,
   toggleDependency,
+  setTaskModel,
+  DEFAULT_MODEL_OPTION,
   addTaskToList,
   removeTaskFromList,
   updateTaskInList,
@@ -40,6 +42,7 @@ function task(overrides: Partial<TaskDraft> = {}): TaskDraft {
     description: overrides.description ?? "Do a thing",
     executionMode: overrides.executionMode ?? "direct_llm",
     dependsOn: overrides.dependsOn ?? [],
+    modelSlug: overrides.modelSlug ?? null,
   };
 }
 
@@ -93,6 +96,72 @@ describe("toggleDependency", () => {
     const t = task({ dependsOn: ["a", "b"] });
     expect(toggleDependency(t, "a").dependsOn).toEqual(["b"]);
     expect(toggleDependency(t, "c").dependsOn).toEqual(["a", "b", "c"]);
+  });
+});
+
+// ─── per-task model (setTaskModel + emptyTask default + reducer preservation) ───
+
+describe("emptyTask", () => {
+  it("starts with no pinned model (null → server default, never mock)", () => {
+    expect(emptyTask().modelSlug).toBeNull();
+  });
+});
+
+describe("setTaskModel", () => {
+  it("pins an explicit slug immutably", () => {
+    const t = task({ modelSlug: null });
+    const next = setTaskModel(t, "claude-sonnet");
+    expect(next.modelSlug).toBe("claude-sonnet");
+    expect(t.modelSlug).toBeNull(); // original untouched
+  });
+
+  it("clears the pin back to null on the DEFAULT_MODEL_OPTION sentinel", () => {
+    const t = task({ modelSlug: "claude-opus" });
+    expect(setTaskModel(t, DEFAULT_MODEL_OPTION).modelSlug).toBeNull();
+  });
+
+  it("treats an empty slug as 'unset' (null, never coerced to mock)", () => {
+    const t = task({ modelSlug: "claude-haiku" });
+    expect(setTaskModel(t, "").modelSlug).toBeNull();
+  });
+
+  it("preserves all other task fields", () => {
+    const t = task({ id: "x", name: "N", dependsOn: ["d1"] });
+    const next = setTaskModel(t, "claude-sonnet");
+    expect(next.id).toBe("x");
+    expect(next.name).toBe("N");
+    expect(next.dependsOn).toEqual(["d1"]);
+  });
+});
+
+describe("reducers preserve modelSlug", () => {
+  it("addTaskToList keeps existing pins and adds an unpinned task", () => {
+    const list = [task({ id: "a", modelSlug: "claude-opus" })];
+    const next = addTaskToList(list);
+    expect(next[0].modelSlug).toBe("claude-opus");
+    expect(next[1].modelSlug).toBeNull();
+  });
+
+  it("updateTaskInList carries the updated task's pinned model", () => {
+    const list = [task({ id: "a", modelSlug: null }), task({ id: "b" })];
+    const next = updateTaskInList(list, "a", setTaskModel(list[0], "claude-sonnet"));
+    expect(next[0].modelSlug).toBe("claude-sonnet");
+    expect(next[1].modelSlug).toBeNull();
+  });
+
+  it("toggleDependency does not disturb the pinned model", () => {
+    const t = task({ modelSlug: "claude-sonnet", dependsOn: [] });
+    expect(toggleDependency(t, "d1").modelSlug).toBe("claude-sonnet");
+  });
+
+  it("removeTaskFromList preserves surviving siblings' pins", () => {
+    const list = [
+      task({ id: "a", modelSlug: "claude-opus" }),
+      task({ id: "b", modelSlug: "claude-haiku", dependsOn: ["a"] }),
+    ];
+    const next = removeTaskFromList(list, "a");
+    expect(next).toHaveLength(1);
+    expect(next[0].modelSlug).toBe("claude-haiku");
   });
 });
 

--- a/tests/unit/task-orchestrator-default-model.test.ts
+++ b/tests/unit/task-orchestrator-default-model.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for TaskOrchestrator direct_llm model resolution
+ * (fix/task-group-real-model-execution).
+ *
+ * Regression guard for the bug where a `direct_llm` task created WITHOUT a
+ * `modelSlug` defaulted to "mock" (server/services/task-orchestrator.ts:303
+ * `task.modelSlug ?? "mock"`), so the group "completed" instantly with the
+ * MockProvider canned stub at cost 0. The default is now the configured real
+ * model (pipeline.taskGroups.defaultModel → DEFAULT_TASK_MODEL = "claude-sonnet").
+ *
+ * Strategy: seed a group via the orchestrator's own createTaskGroup, then drive
+ * a real startGroup() over MemStorage with a SPY gateway. The slug the
+ * orchestrator hands to gateway.complete() is the assertion target:
+ *   - no modelSlug      → the configured default (NOT "mock"),
+ *   - explicit slug     → that slug verbatim,
+ *   - explicit "mock"   → "mock" (deterministic opt-in, no real CLI).
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { MemStorage } from "../../server/storage.js";
+import { TaskOrchestrator } from "../../server/services/task-orchestrator.js";
+import { DEFAULT_TASK_MODEL } from "../../server/config/schema.js";
+import type { WsManager } from "../../server/ws/manager.js";
+import type { PipelineController } from "../../server/controller/pipeline-controller.js";
+import type { Gateway } from "../../server/gateway/index.js";
+import type { GatewayRequest, GatewayResponse } from "../../shared/types.js";
+
+interface SpyGateway {
+  gateway: Gateway;
+  calls: GatewayRequest[];
+}
+
+/** A gateway double whose complete() records the request and returns valid JSON. */
+function makeSpyGateway(): SpyGateway {
+  const calls: GatewayRequest[] = [];
+  const gateway = {
+    async complete(request: GatewayRequest): Promise<GatewayResponse> {
+      calls.push(request);
+      return {
+        content: JSON.stringify({
+          summary: "real model summary",
+          output: { ok: true },
+          decisions: ["did the thing"],
+        }),
+        tokensUsed: 42,
+        modelSlug: request.modelSlug,
+        finishReason: "stop",
+      };
+    },
+  } as unknown as Gateway;
+  return { gateway, calls };
+}
+
+function makeOrchestrator(gateway: Gateway): { orchestrator: TaskOrchestrator; storage: MemStorage } {
+  const storage = new MemStorage();
+  const wsManager = { broadcastToRun: () => {} } as unknown as WsManager;
+  const pipelineController = {} as unknown as PipelineController;
+  const orchestrator = new TaskOrchestrator(storage, wsManager, pipelineController, gateway);
+  return { orchestrator, storage };
+}
+
+describe("TaskOrchestrator direct_llm model resolution", () => {
+  let spy: SpyGateway;
+
+  beforeEach(() => {
+    spy = makeSpyGateway();
+  });
+
+  it("resolves a model-less direct_llm task to the configured real default (NOT mock)", async () => {
+    const { orchestrator } = makeOrchestrator(spy.gateway);
+
+    // modelSlug intentionally omitted → must NOT fall back to "mock".
+    const { group } = await orchestrator.createTaskGroup({
+      name: "G",
+      description: "d",
+      input: "do work",
+      tasks: [{ name: "T1", description: "summarise", executionMode: "direct_llm" }],
+    });
+
+    await orchestrator.startGroup(group.id);
+
+    expect(spy.calls).toHaveLength(1);
+    expect(spy.calls[0].modelSlug).not.toBe("mock");
+    expect(spy.calls[0].modelSlug).toBe(DEFAULT_TASK_MODEL);
+  });
+
+  it("uses an explicit modelSlug verbatim", async () => {
+    const { orchestrator } = makeOrchestrator(spy.gateway);
+
+    const { group } = await orchestrator.createTaskGroup({
+      name: "G",
+      description: "d",
+      input: "do work",
+      tasks: [
+        {
+          name: "T1",
+          description: "summarise",
+          executionMode: "direct_llm",
+          modelSlug: "claude-haiku",
+        },
+      ],
+    });
+
+    await orchestrator.startGroup(group.id);
+
+    expect(spy.calls).toHaveLength(1);
+    expect(spy.calls[0].modelSlug).toBe("claude-haiku");
+  });
+
+  it("honours an explicit mock pin (deterministic opt-in, no real CLI)", async () => {
+    const { orchestrator } = makeOrchestrator(spy.gateway);
+
+    const { group } = await orchestrator.createTaskGroup({
+      name: "G",
+      description: "d",
+      input: "do work",
+      tasks: [
+        {
+          name: "T1",
+          description: "summarise",
+          executionMode: "direct_llm",
+          modelSlug: "mock",
+        },
+      ],
+    });
+
+    await orchestrator.startGroup(group.id);
+
+    expect(spy.calls).toHaveLength(1);
+    expect(spy.calls[0].modelSlug).toBe("mock");
+  });
+
+  it("persists the task summary from the real gateway response (not the canned stub)", async () => {
+    const { orchestrator, storage } = makeOrchestrator(spy.gateway);
+
+    const { group, tasks } = await orchestrator.createTaskGroup({
+      name: "G",
+      description: "d",
+      input: "do work",
+      tasks: [{ name: "T1", description: "summarise", executionMode: "direct_llm" }],
+    });
+
+    await orchestrator.startGroup(group.id);
+
+    const persisted = await storage.getTask(tasks[0].id);
+    expect(persisted?.summary).toBe("real model summary");
+    expect(persisted?.status).toBe("completed");
+  });
+});


### PR DESCRIPTION
A Task Group **completed in 0.08s** with every task summary = `"Generated 3 core files…"` (the MockProvider canned stub, cost 0) — nothing real executed. Cause: `task-orchestrator.executeDirectLlm` did `task.modelSlug ?? "mock"`, and the create form had **no model field**, so model-less tasks always hit MockProvider. (Same class as #363.)

- Orchestrator default → real model: `task.modelSlug ?? config pipeline.taskGroups.defaultModel ?? DEFAULT_TASK_MODEL ("claude-sonnet")`. Never "mock". Config knob (zod, default claude-sonnet).
- **Per-task Model picker** in the shared task-form (Create + edit), fed by active claude/antigravity models; "Default (server picks)" → unset → orchestrator default; `modelSlug` sent on create + edit.
- New test: model-less `direct_llm` task resolves to the real default (slug to `gateway.complete` ≠ "mock"); explicit slug honoured; explicit "mock" still works for determinism.

tsc clean; unit **4874**; task-groups integration 53. The iterations + task-library **v2** is a separate follow-up (chosen sequencing: mock-fix first).