### PR TITLE
feat(task-groups): planning verdict panel + pipeline handoff & insights

### DIFF
--- a/client/src/components/layout/MainLayout.tsx
+++ b/client/src/components/layout/MainLayout.tsx
@@ -49,7 +49,17 @@ const ROLE_BADGE: Record<UserRole, { label: string; className: string }> = {
 export default function MainLayout({ children }: MainLayoutProps) {
   const [location, navigate] = useLocation();
   const { data: pendingQuestions } = usePendingQuestions();
-  const pendingCount = Array.isArray(pendingQuestions) ? pendingQuestions.length : 0;
+  const pendingList = Array.isArray(pendingQuestions)
+    ? (pendingQuestions as Array<{ runId?: string; pipelineName?: string | null }>)
+    : [];
+  const pendingCount = pendingList.length;
+  // Group pending questions by the pipeline they belong to, so the sidebar can
+  // show WHICH pipeline(s) are waiting — not just a bare count.
+  const pendingByPipeline = pendingList.reduce<Record<string, number>>((acc, q) => {
+    const key = q.pipelineName || "Unknown pipeline";
+    acc[key] = (acc[key] ?? 0) + 1;
+    return acc;
+  }, {});
   const { user, logout } = useAuth();
 
   // Detect if we're inside a workspace so we can show the connections sub-item
@@ -196,9 +206,14 @@ export default function MainLayout({ children }: MainLayoutProps) {
                   {pendingCount} pending question{pendingCount !== 1 ? "s" : ""}
                 </span>
               </div>
-              <p className="text-[10px] text-muted-foreground mt-1">
-                Agents are waiting for your input
-              </p>
+              <ul className="mt-1 space-y-0.5">
+                {Object.entries(pendingByPipeline).map(([name, count]) => (
+                  <li key={name} className="flex items-center justify-between gap-2 text-[10px] text-muted-foreground">
+                    <span className="truncate">{name}</span>
+                    <span className="shrink-0 tabular-nums font-medium text-amber-600">{count}</span>
+                  </li>
+                ))}
+              </ul>
             </div>
           )}
         </div>

--- a/client/src/components/task-groups/verdict-panel.tsx
+++ b/client/src/components/task-groups/verdict-panel.tsx
@@ -1,0 +1,292 @@
+/**
+ * VerdictPanel — the structured "planning verdict" surface shown BELOW the last
+ * agent on a finished task group's detail page.
+ *
+ * A debate/synthesis task group ends with a judge task whose `output` carries a
+ * structured artifact: { verdict, pros[], cons[], action_points[] }. This panel
+ * finds that execution in the latest iteration and renders it as a real UI block
+ * (verdict callout + pros/cons + an Action Points TABLE) instead of raw JSON.
+ *
+ * It also closes the loop: the action points can be HANDED OFF to a pipeline
+ * (e.g. Full SDLC Pipeline) — one pipeline_run task per action point — which is
+ * the "planning → execution" transition. Handing off is optional (the user
+ * decides whether to send them on).
+ *
+ * SECURITY: all model-authored text is rendered as INERT React text.
+ */
+import { useMemo, useState } from "react";
+import { useLocation } from "wouter";
+import { useIterationDetail } from "@/hooks/use-task-iterations";
+import { usePipelines, apiRequest } from "@/hooks/use-pipeline";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { useToast } from "@/hooks/use-toast";
+import { Gavel, Send, ThumbsUp, ThumbsDown, Loader2 } from "lucide-react";
+import type { IterationExecution } from "@/lib/task-iterations";
+
+interface ActionPoint {
+  title: string;
+  priority?: string;
+  effort?: string;
+  rationale?: string;
+  tradeoff?: string;
+}
+
+interface VerdictOutput {
+  verdict?: string;
+  pros: string[];
+  cons: string[];
+  action_points: ActionPoint[];
+}
+
+function asStringArray(v: unknown): string[] {
+  return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+}
+
+/**
+ * Find the judge/synthesis execution that carries the structured verdict.
+ * Prefer one with action_points; fall back to any with verdict/pros/cons.
+ */
+function extractVerdict(
+  executions: IterationExecution[],
+): { data: VerdictOutput; source: string } | null {
+  let fallback: { data: VerdictOutput; source: string } | null = null;
+  for (const e of executions) {
+    const o = e.output;
+    if (!o || typeof o !== "object" || Array.isArray(o)) continue;
+    const obj = o as Record<string, unknown>;
+    const aps = Array.isArray(obj.action_points)
+      ? (obj.action_points as unknown[]).filter(
+          (a): a is ActionPoint =>
+            !!a && typeof a === "object" && typeof (a as ActionPoint).title === "string",
+        )
+      : [];
+    const hasVerdict = typeof obj.verdict === "string";
+    const hasProsCons = Array.isArray(obj.pros) || Array.isArray(obj.cons);
+    if (aps.length === 0 && !hasVerdict && !hasProsCons) continue;
+
+    const data: VerdictOutput = {
+      verdict: typeof obj.verdict === "string" ? obj.verdict : undefined,
+      pros: asStringArray(obj.pros),
+      cons: asStringArray(obj.cons),
+      action_points: aps,
+    };
+    const candidate = { data, source: e.taskName ?? "" };
+    if (aps.length > 0) return candidate; // the judge — take it
+    fallback = fallback ?? candidate;
+  }
+  return fallback;
+}
+
+const PRIORITY_COLOR: Record<string, string> = {
+  P0: "bg-red-600 text-white",
+  P1: "bg-orange-500 text-white",
+  P2: "bg-yellow-500 text-black",
+  P3: "bg-slate-500 text-white",
+};
+
+export function VerdictPanel({
+  groupId,
+  iterationNumber,
+  groupName,
+}: {
+  groupId: string;
+  iterationNumber: number;
+  groupName: string;
+}) {
+  const detail = useIterationDetail(groupId, iterationNumber);
+  const pipelinesQuery = usePipelines();
+  const { toast } = useToast();
+  const [, navigate] = useLocation();
+  const [pipelineId, setPipelineId] = useState<string>("");
+  const [sending, setSending] = useState(false);
+
+  const result = useMemo(
+    () => (detail.data ? extractVerdict(detail.data.executions) : null),
+    [detail.data],
+  );
+
+  const pipelines = (pipelinesQuery.data ?? []) as Array<{ id: string; name: string }>;
+  const effectivePipelineId =
+    pipelineId ||
+    pipelines.find((p) => /full sdlc/i.test(p.name))?.id ||
+    pipelines[0]?.id ||
+    "";
+
+  if (!result) return null;
+  const { data, source } = result;
+  const actionPoints = data.action_points;
+
+  async function sendToPipeline() {
+    if (!effectivePipelineId || actionPoints.length === 0) return;
+    setSending(true);
+    try {
+      const pipeline = pipelines.find((p) => p.id === effectivePipelineId);
+      const payload = {
+        name: `Handoff: ${groupName} → ${pipeline?.name ?? "Pipeline"}`.slice(0, 200),
+        description:
+          `Action points из вердикта планирования переданы на исполнение в ${pipeline?.name ?? "pipeline"}.`.slice(
+            0,
+            5000,
+          ),
+        input: `Передача action points планирования (${groupName}) на исполнение.`.slice(0, 50000),
+        tasks: actionPoints.map((ap, i) => ({
+          name: `[${ap.priority ?? "-"}] ${ap.title}`.slice(0, 200),
+          description:
+            [ap.rationale, ap.tradeoff ? `Трейд-офф: ${ap.tradeoff}` : ""]
+              .filter(Boolean)
+              .join(" ")
+              .slice(0, 5000) || ap.title.slice(0, 5000),
+          executionMode: "pipeline_run" as const,
+          pipelineId: effectivePipelineId,
+          sortOrder: i,
+          input: {
+            feature: ap.title,
+            rationale: ap.rationale ?? "",
+            tradeoff: ap.tradeoff ?? "",
+            priority: ap.priority ?? "",
+            effort: ap.effort ?? "",
+            source: groupName,
+          },
+        })),
+      };
+      const created = (await apiRequest("POST", "/api/task-groups", payload)) as { id: string };
+      toast({
+        title: "Передано на исполнение",
+        description: `${actionPoints.length} action points → ${pipeline?.name}. Откройте группу и нажмите Run.`,
+      });
+      navigate(`/task-groups/${created.id}`);
+    } catch (err) {
+      toast({
+        variant: "destructive",
+        title: "Не удалось передать",
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <Card className="border-primary/40">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Gavel className="h-4 w-4 text-primary" />
+          Вердикт планирования
+          {source && (
+            <span className="text-xs font-normal text-muted-foreground">— {source}</span>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {data.verdict && (
+          <div className="rounded-md border-l-4 border-primary bg-muted/50 p-3 text-sm leading-relaxed">
+            {data.verdict}
+          </div>
+        )}
+
+        {(data.pros.length > 0 || data.cons.length > 0) && (
+          <div className="grid gap-4 sm:grid-cols-2">
+            {data.pros.length > 0 && (
+              <div>
+                <h4 className="mb-2 flex items-center gap-1.5 text-sm font-semibold text-green-600 dark:text-green-400">
+                  <ThumbsUp className="h-4 w-4" /> Плюсы
+                </h4>
+                <ul className="space-y-1 text-sm text-muted-foreground">
+                  {data.pros.map((p, i) => (
+                    <li key={i} className="flex gap-2">
+                      <span className="text-green-500">+</span>
+                      <span>{p}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {data.cons.length > 0 && (
+              <div>
+                <h4 className="mb-2 flex items-center gap-1.5 text-sm font-semibold text-red-600 dark:text-red-400">
+                  <ThumbsDown className="h-4 w-4" /> Минусы
+                </h4>
+                <ul className="space-y-1 text-sm text-muted-foreground">
+                  {data.cons.map((c, i) => (
+                    <li key={i} className="flex gap-2">
+                      <span className="text-red-500">−</span>
+                      <span>{c}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+
+        {actionPoints.length > 0 && (
+          <div>
+            <h4 className="mb-2 text-sm font-semibold">Action Points</h4>
+            <div className="overflow-x-auto rounded-md border">
+              <table className="w-full text-sm">
+                <thead className="bg-muted/50 text-xs uppercase text-muted-foreground">
+                  <tr>
+                    <th className="px-3 py-2 text-left font-medium">#</th>
+                    <th className="px-3 py-2 text-left font-medium">Действие</th>
+                    <th className="px-3 py-2 text-left font-medium">Приоритет</th>
+                    <th className="px-3 py-2 text-left font-medium">Усилие</th>
+                    <th className="px-3 py-2 text-left font-medium">Обоснование</th>
+                    <th className="px-3 py-2 text-left font-medium">Трейд-офф</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {actionPoints.map((ap, i) => (
+                    <tr key={i} className="align-top">
+                      <td className="px-3 py-2 text-muted-foreground tabular-nums">{i + 1}</td>
+                      <td className="px-3 py-2 font-medium">{ap.title}</td>
+                      <td className="px-3 py-2">
+                        {ap.priority && (
+                          <Badge className={PRIORITY_COLOR[ap.priority] ?? "bg-muted"}>
+                            {ap.priority}
+                          </Badge>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 tabular-nums">{ap.effort ?? "—"}</td>
+                      <td className="px-3 py-2 text-muted-foreground">{ap.rationale ?? "—"}</td>
+                      <td className="px-3 py-2 text-muted-foreground">{ap.tradeoff ?? "—"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {actionPoints.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2 border-t pt-4">
+            <span className="text-sm text-muted-foreground">
+              Фаза планирования завершена. Передать action points на исполнение:
+            </span>
+            <select
+              className="rounded-md border bg-background px-2 py-1.5 text-sm"
+              value={effectivePipelineId}
+              onChange={(e) => setPipelineId(e.target.value)}
+              aria-label="Pipeline"
+            >
+              {pipelines.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+            <Button size="sm" onClick={sendToPipeline} disabled={sending || !effectivePipelineId}>
+              {sending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="mr-2 h-4 w-4" />
+              )}
+              Передать в пайплайн
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/hooks/use-pipeline.ts
+++ b/client/src/hooks/use-pipeline.ts
@@ -185,6 +185,15 @@ export function usePendingQuestions() {
   });
 }
 
+/** Per-pipeline run-status counts (succeeded/failed/running/queued) for the list. */
+export function usePipelineRunStats() {
+  return useQuery({
+    queryKey: ["/api/pipeline-run-stats"],
+    queryFn: () => apiRequest("GET", "/api/pipeline-run-stats"),
+    refetchInterval: 5000,
+  });
+}
+
 export function useAnswerQuestion() {
   const qc = useQueryClient();
   return useMutation({

--- a/client/src/pages/PipelineList.tsx
+++ b/client/src/pages/PipelineList.tsx
@@ -3,7 +3,7 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Plus, GitMerge, ChevronRight, Loader2 } from "lucide-react";
-import { usePipelines, useCreatePipeline, useDeletePipeline } from "@/hooks/use-pipeline";
+import { usePipelines, useCreatePipeline, useDeletePipeline, usePipelineRunStats } from "@/hooks/use-pipeline";
 import { DEFAULT_PIPELINE_STAGES } from "@shared/constants";
 import type { PipelineStageConfig } from "@shared/types";
 
@@ -18,10 +18,15 @@ interface Pipeline {
 export default function PipelineList() {
   const [, navigate] = useLocation();
   const { data: pipelines, isLoading } = usePipelines();
+  const { data: runStats } = usePipelineRunStats();
   const createPipeline = useCreatePipeline();
   const deletePipeline = useDeletePipeline();
 
   const pipelineList: Pipeline[] = Array.isArray(pipelines) ? pipelines : [];
+  const stats = (runStats ?? {}) as Record<
+    string,
+    { succeeded: number; failed: number; running: number; queued: number; total: number }
+  >;
 
   const handleCreate = () => {
     createPipeline.mutate(
@@ -109,13 +114,39 @@ export default function PipelineList() {
                           {pipeline.description}
                         </p>
                       )}
-                      <div className="flex items-center gap-2 mt-2">
+                      <div className="flex items-center flex-wrap gap-2 mt-2">
                         <Badge variant="outline" className="text-[10px] h-4 px-1.5">
                           {enabledStages}/{totalStages} stages active
                         </Badge>
                         <span className="text-[10px] text-muted-foreground font-mono">
                           {pipeline.id.slice(0, 8)}
                         </span>
+                        {(() => {
+                          const s = stats[pipeline.id];
+                          if (!s || s.total === 0) {
+                            return (
+                              <span className="text-[10px] text-muted-foreground">no runs</span>
+                            );
+                          }
+                          const chip = (n: number, cls: string, label: string) =>
+                            n > 0 ? (
+                              <span
+                                className={`inline-flex items-center gap-1 rounded px-1.5 h-4 text-[10px] font-medium ${cls}`}
+                                title={`${n} ${label}`}
+                              >
+                                <span className="h-1.5 w-1.5 rounded-full bg-current opacity-80" />
+                                {n}
+                              </span>
+                            ) : null;
+                          return (
+                            <span className="inline-flex items-center gap-1.5">
+                              {chip(s.succeeded, "bg-green-500/15 text-green-600 dark:text-green-400", "succeeded")}
+                              {chip(s.failed, "bg-red-500/15 text-red-600 dark:text-red-400", "failed")}
+                              {chip(s.running, "bg-blue-500/15 text-blue-600 dark:text-blue-400", "running")}
+                              {chip(s.queued, "bg-amber-500/15 text-amber-600 dark:text-amber-400", "queued")}
+                            </span>
+                          );
+                        })()}
                       </div>
                     </div>
                   </div>

--- a/client/src/pages/TaskGroup.tsx
+++ b/client/src/pages/TaskGroup.tsx
@@ -44,6 +44,7 @@ import {
   IterationsPanel,
   IterationDetailView,
 } from "@/components/task-groups/iterations-panel";
+import { VerdictPanel } from "@/components/task-groups/verdict-panel";
 import { useToast } from "@/hooks/use-toast";
 import { useTaskGroupEvents } from "@/hooks/use-task-events";
 import { useActiveModels } from "@/hooks/use-pipeline";
@@ -785,6 +786,18 @@ export default function TaskGroupPage() {
             )}
           </div>
         </div>
+      )}
+
+      {/* Structured planning verdict (verdict + pros/cons + action points table)
+          rendered BELOW the agents once a judge/synthesis task has produced it.
+          Self-hides when the latest iteration carries no structured output.
+          Its action points can be handed off to a pipeline (planning→execution). */}
+      {!editing && shownIteration !== null && (
+        <VerdictPanel
+          groupId={id}
+          iterationNumber={shownIteration}
+          groupName={group.name}
+        />
       )}
       </div>
     </div>

--- a/client/src/pages/TaskGroupList.tsx
+++ b/client/src/pages/TaskGroupList.tsx
@@ -32,7 +32,10 @@ export default function TaskGroupList() {
   }>;
 
   return (
-    <div className="p-6 max-w-5xl mx-auto space-y-6">
+    // MainLayout's <main> clips overflow, so this page owns its own vertical
+    // scroll — otherwise a long list of task groups gets cut off at the fold.
+    <div className="h-full overflow-y-auto">
+      <div className="p-6 max-w-5xl mx-auto space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold">Task Groups</h1>
@@ -96,6 +99,7 @@ export default function TaskGroupList() {
           ))}
         </div>
       )}
+      </div>
     </div>
   );
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -462,7 +462,53 @@ export async function registerRoutes(
   // Global pending questions endpoint (protected by /api/questions middleware above)
   app.get("/api/questions/pending", async (_req, res) => {
     const pending = await storage.getPendingQuestions();
-    res.json(pending);
+    if (pending.length === 0) {
+      res.json(pending);
+      return;
+    }
+    // Enrich each question with the pipeline it belongs to (question → run →
+    // pipeline) so the UI can say WHICH pipeline is waiting, not just a count.
+    const [runs, pipelines] = await Promise.all([
+      storage.getPipelineRuns(),
+      storage.getPipelines(),
+    ]);
+    const runToPipeline = new Map(runs.map((r) => [r.id, r.pipelineId]));
+    const pipelineName = new Map(pipelines.map((p) => [p.id, p.name]));
+    const enriched = pending.map((q) => {
+      const pid = q.runId ? runToPipeline.get(q.runId) : undefined;
+      return {
+        ...q,
+        pipelineId: pid ?? null,
+        pipelineName: pid ? pipelineName.get(pid) ?? null : null,
+      };
+    });
+    res.json(enriched);
+  });
+
+  // Per-pipeline run-status counts for the Pipelines list (succeeded / failed /
+  // running / queued), so each pipeline card can show its run health at a glance.
+  app.get("/api/pipeline-run-stats", async (_req, res) => {
+    const runs = await storage.getPipelineRuns();
+    const stats: Record<
+      string,
+      { succeeded: number; failed: number; running: number; queued: number; total: number }
+    > = {};
+    for (const r of runs) {
+      const s = (stats[r.pipelineId] ??= {
+        succeeded: 0,
+        failed: 0,
+        running: 0,
+        queued: 0,
+        total: 0,
+      });
+      s.total++;
+      if (r.status === "completed") s.succeeded++;
+      else if (r.status === "failed") s.failed++;
+      else if (r.status === "running") s.running++;
+      else if (r.status === "pending" || r.status === "paused") s.queued++;
+      // "cancelled" counts only toward total.
+    }
+    res.json(stats);
   });
 
   // Stats summary endpoint (protected by /api/stats middleware above)


### PR DESCRIPTION
## Summary
Surfaces a finished task group's planning verdict and closes the planning→execution loop, plus pipeline observability on the Pipelines list.

- **VerdictPanel** — on a completed group, renders the judge's structured output below the agents: verdict callout, pros/cons, and an **Action Points table**. Action points can be handed off to a pipeline (e.g. Full SDLC) directly from the page.
- **Pipeline run-stats** — new `GET /api/pipeline-run-stats`; the Pipelines list shows colour-coded run counts per pipeline (succeeded / failed / running / queued).
- **Pending-question attribution** — `GET /api/questions/pending` enriched with `pipelineName`; the sidebar badge now shows *which* pipeline is waiting.
- **Fix** — restore vertical scroll on the task-groups list page.

## Notes
- `tsc --noEmit` clean. Server endpoints verified live.
- Excludes unrelated local churn (`package-lock.json`, `.env.example`).