### PR TITLE
feat: ADR-001 PR-0a — fail-closed project scoping + system context helpers

### DIFF
--- a/server/context.ts
+++ b/server/context.ts
@@ -4,14 +4,119 @@ export interface RequestContext {
   projectId?: string;
   userId?: string;
   role?: string;
+  /** Set to true for legitimately cross-project background work via runAsSystem(). */
+  system?: boolean;
 }
 
 export const requestContext = new AsyncLocalStorage<RequestContext>();
 
+/**
+ * Returns the current project ID from the ALS context.
+ *
+ * Throws in three situations (fail-closed):
+ *   1. No ALS context at all — background/startup caller must use runAsProject()
+ *      or runAsSystem() to establish context before calling storage methods.
+ *   2. System context (system === true) — getProjectId() is structurally forbidden
+ *      in system context so that system code cannot silently read project-scoped
+ *      secret data. Use unscopedSystemQuery() for legitimate cross-project reads.
+ *   3. ALS context exists but has no projectId — requireProject middleware (PR-0b)
+ *      has not been wired, or the background caller should use runAsProject().
+ */
 export function getProjectId(): string {
   const ctx = requestContext.getStore();
-  if (!ctx || !ctx.projectId) {
-    throw new Error("No project context available for this request");
+  if (!ctx) {
+    throw new Error(
+      "No request context — this path runs outside a request handler. " +
+        "Wrap background/startup callers in runAsProject(projectId, fn) or runAsSystem(reason, fn).",
+    );
+  }
+  if (ctx.system) {
+    throw new Error(
+      "System context cannot call getProjectId() — system code must never read " +
+        "project-scoped data via withProject(). " +
+        "Use unscopedSystemQuery(label, fn) for legitimate cross-project reads.",
+    );
+  }
+  if (!ctx.projectId) {
+    throw new Error(
+      "No projectId in context — ensure the x-project-id header is sent and " +
+        "requireProject middleware is wired (PR-0b), " +
+        "or use runAsProject(projectId, fn) for background callers.",
+    );
   }
   return ctx.projectId;
+}
+
+/**
+ * Runs fn inside a project-scoped ALS context.
+ *
+ * Use for background jobs that own a single projectId — e.g., pipeline
+ * execution triggered for a specific project, or a trigger that fires
+ * once per-project.
+ *
+ * @example
+ *   await runAsProject(pipeline.projectId, async () => {
+ *     await storage.updatePipelineRun(runId, { status: "running" });
+ *   });
+ */
+export function runAsProject<T>(projectId: string, fn: () => Promise<T>): Promise<T> {
+  return requestContext.run({ projectId, userId: "system", role: "owner" }, fn);
+}
+
+/**
+ * Runs fn inside a system-scoped ALS context for legitimately cross-project
+ * background work.
+ *
+ * HARD RULES enforced by this contract:
+ *   (a) Every entry writes a structured audit log record (who/why/when).
+ *   (b) getProjectId() THROWS inside system context — use unscopedSystemQuery()
+ *       for cross-project DB reads; use runAsProject() for single-project reads.
+ *   (c) System context is forbidden from calling issueLease() or reading secret
+ *       material — the credential broker enforces this structurally (PR-1b).
+ *
+ * Naming convention: functions that call runAsSystem should be named getAllXxx
+ * or have an "Unscoped" suffix so cross-project reads are greppable in review.
+ *
+ * @example
+ *   await runAsSystem("cron-scheduler-bootstrap", async () => {
+ *     const triggers = await storage.getAllEnabledTriggersByType("schedule");
+ *     ...
+ *   });
+ */
+export function runAsSystem<T>(reason: string, fn: () => Promise<T>): Promise<T> {
+  // Audit record: every system-context entry is logged with a mandatory reason.
+  // Replace with your structured logger if one is wired to this module.
+  console.info(
+    JSON.stringify({ scope: "system-access", reason, at: new Date().toISOString() }),
+  );
+  return requestContext.run({ system: true, userId: "system", role: "system" }, fn);
+}
+
+/**
+ * Asserts that the current ALS context is a system context (system === true)
+ * and runs the provided query. This is the ONLY sanctioned bypass for
+ * project-scoped query filtering — it is explicit, greppable, and audited
+ * by the surrounding runAsSystem() call.
+ *
+ * Cross-project storage methods MUST use this wrapper and follow the getAll*
+ * naming convention so they are easy to find in security reviews.
+ *
+ * @throws if called outside a runAsSystem() context.
+ *
+ * @example
+ *   async getAllEnabledTriggersByType(type: string) {
+ *     return unscopedSystemQuery("getAllEnabledTriggersByType", () =>
+ *       db.select().from(triggers).where(eq(triggers.type, type))
+ *     );
+ *   }
+ */
+export async function unscopedSystemQuery<T>(label: string, q: () => Promise<T>): Promise<T> {
+  const ctx = requestContext.getStore();
+  if (!ctx?.system) {
+    throw new Error(
+      `unscopedSystemQuery("${label}") called outside system context — ` +
+        "wrap the call site in runAsSystem(reason, fn) first.",
+    );
+  }
+  return q();
 }

--- a/server/db.ts
+++ b/server/db.ts
@@ -22,43 +22,113 @@ pool.on("error", (err: Error) => {
 
 export const db = drizzle(pool, { schema });
 
-import { getProjectId } from "./context";
+import { requestContext } from "./context";
 import { SQL, and, eq } from "drizzle-orm";
 
 /**
  * Helper to wrap any Drizzle query condition with the current project ID filter.
+ *
+ * FAIL-CLOSED: throws rather than silently bypassing isolation when no project
+ * context is present. Callers outside a request handler MUST be wrapped in
+ * runAsProject(projectId, fn) or runAsSystem(reason, fn).
+ *
+ * System context (runAsSystem) is allowed to call withProject for SELECT queries
+ * but the project filter is NOT applied — the query runs cross-project.  The
+ * audit trail is provided by the surrounding runAsSystem() call. System context
+ * callers must NOT use withProject to access secret material (enforced at the
+ * broker layer in PR-1b).
+ *
  * Usage: db.select().from(table).where(withProject(table, eq(table.id, id)))
  */
 export function withProject(table: any, condition?: SQL | undefined): SQL {
-  try {
-    const projectId = getProjectId();
-    const projectFilter = eq(table.projectId, projectId);
-    return condition ? and(projectFilter, condition)! : projectFilter;
-  } catch (e) {
-    // Fallback if executed outside of a project context (e.g., background cron jobs)
-    // In strict mode, you might want to throw here instead.
+  const ctx = requestContext.getStore();
+
+  if (!ctx) {
+    throw new Error(
+      "withProject: no request context — this path runs outside a request handler. " +
+        "Wrap background/startup callers in runAsProject(projectId, fn) or runAsSystem(reason, fn). " +
+        "See server/context.ts and ADR-001 §3.1(c)/(d).",
+    );
+  }
+
+  if (ctx.system) {
+    // System context: the runAsSystem() audit trail covers this cross-project read.
+    // Do NOT apply a project filter — system code reads across all projects by design.
+    // System context is structurally prohibited from accessing secret material (PR-1b).
     if (!condition) {
-      throw new Error("withProject requires a condition when outside project context");
+      throw new Error(
+        "withProject: system context SELECT requires a WHERE condition — " +
+          "pass a filter expression or use unscopedSystemQuery(label, fn) explicitly.",
+      );
     }
     return condition;
   }
+
+  if (!ctx.projectId) {
+    throw new Error(
+      "withProject: no projectId in context — ensure the x-project-id header is sent " +
+        "and requireProject middleware is wired (PR-0b), " +
+        "or use runAsProject(projectId, fn) for background callers.",
+    );
+  }
+
+  // Sanity-check: table must have a projectId column. Tables that don't have it
+  // yet (e.g. provider_keys, argocd_config, triggers pre-PR-0c) will be caught
+  // here at development/test time rather than silently bypassing isolation.
+  if (table.projectId === undefined) {
+    throw new Error(
+      'withProject: table has no "projectId" column — ' +
+        "add the column in PR-0c before enabling project scoping on this table.",
+    );
+  }
+
+  const projectFilter = eq(table.projectId, ctx.projectId);
+  return condition ? and(projectFilter, condition)! : projectFilter;
 }
 
 /**
  * Helper to inject the current project ID into data for insert operations.
+ *
+ * FAIL-CLOSED: throws when no context is present.
+ *
+ * In system context (runAsSystem) sets projectId to null, creating globally
+ * visible rows (e.g. seeded default models, built-in skills, pipeline templates).
+ * This matches the pre-existing schema design where nullable projectId means
+ * "shared across all projects".
+ *
  * Usage: db.insert(table).values(withProjectInsert(table, data))
  */
 export function withProjectInsert<T>(table: any, data: T): T {
-  try {
-    const projectId = getProjectId();
-    
-    if (Array.isArray(data)) {
-      return data.map(item => ({ ...item, projectId })) as unknown as T;
-    }
-    return { ...data, projectId } as unknown as T;
-  } catch (e) {
-    return data;
+  const ctx = requestContext.getStore();
+
+  if (!ctx) {
+    throw new Error(
+      "withProjectInsert: no request context — wrap background/startup inserts in " +
+        "runAsProject(projectId, fn) or runAsSystem(reason, fn). " +
+        "See server/context.ts and ADR-001 §3.1(c)/(d).",
+    );
   }
+
+  if (ctx.system) {
+    // System context: insert with projectId=null (globally shared / unscoped data).
+    // Use for system-level seeding that creates resources shared across all projects.
+    if (Array.isArray(data)) {
+      return data.map((item) => ({ ...item, projectId: null })) as unknown as T;
+    }
+    return { ...data, projectId: null } as unknown as T;
+  }
+
+  if (!ctx.projectId) {
+    throw new Error(
+      "withProjectInsert: no projectId in context — ensure requireProject middleware " +
+        "is wired (PR-0b) or use runAsProject(projectId, fn) for background inserts.",
+    );
+  }
+
+  if (Array.isArray(data)) {
+    return data.map((item) => ({ ...item, projectId: ctx.projectId! })) as unknown as T;
+  }
+  return { ...data, projectId: ctx.projectId } as unknown as T;
 }
 
 /**

--- a/server/remote-agents/remote-agent-manager.ts
+++ b/server/remote-agents/remote-agent-manager.ts
@@ -1,5 +1,6 @@
 import { eq } from "drizzle-orm";
 import { db } from "../db";
+import { runAsSystem } from "../context";
 import { remoteAgents, a2aTasks } from "@shared/schema";
 import { A2AClient } from "./a2a-client";
 import { AgentDiscoveryService } from "./agent-discovery";
@@ -49,7 +50,9 @@ export class RemoteAgentManager {
 
   /** Load all agents from DB and auto-connect those flagged for it. */
   async initialize(): Promise<void> {
-    const agents = await this.listAgents();
+    // listAgents() is a cross-project query (remote agents span all projects).
+    // runAsSystem establishes the required ALS context and provides an audit trail.
+    const agents = await runAsSystem("remote-agent-manager-init", () => this.listAgents());
     for (const agent of agents) {
       if (agent.autoConnect && agent.enabled) {
         await this.connectAgent(agent.id).catch(() => {
@@ -267,7 +270,8 @@ export class RemoteAgentManager {
 
   private startHeartbeat(intervalMs: number): void {
     this.heartbeatInterval = setInterval(async () => {
-      const agents = await this.listAgents();
+      // listAgents() reads across all projects; runAsSystem provides context + audit.
+      const agents = await runAsSystem("remote-agent-heartbeat", () => this.listAgents());
       for (const agent of agents) {
         if (!agent.enabled) continue;
         const health = await this.discovery.healthCheck(agent);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -95,6 +95,7 @@ import { ConflictResolutionService } from "./federation/conflict-resolution";
 import { MemoryFederationService } from "./federation/memory-federation";
 import { PipelineSyncService } from "./federation/pipeline-sync";
 import { getFederationManager } from "./federation/manager-state";
+import { runAsSystem } from "./context";
 
 export async function registerRoutes(
   httpServer: Server,
@@ -311,15 +312,21 @@ export async function registerRoutes(
   try {
     triggerService = new TriggerService(storage);
 
+    // fireTrigger is called from background contexts (cron, file watcher, GitHub events)
+    // where no project ALS context is established. runAsSystem audits the access and
+    // allows withProject to operate cross-project (no project filter applied in system
+    // context). getPipeline validates the pipeline still exists; updateTrigger records
+    // the last-fired timestamp. Both operate cross-project in system context.
     const fireTrigger = async (trigger: import("@shared/schema").TriggerRow, payload: unknown): Promise<void> => {
-      // Fire the trigger by starting a pipeline run
-      const pipeline = await storage.getPipeline(trigger.pipelineId);
-      if (!pipeline) {
-        log(`[triggers] Pipeline not found for trigger ${trigger.id}`, "triggers");
-        return;
-      }
-      await storage.updateTrigger(trigger.id, { lastTriggeredAt: new Date() });
-      log(`[triggers] Fired trigger ${trigger.id} for pipeline ${pipeline.id}`, "triggers");
+      await runAsSystem("fire-trigger", async () => {
+        const pipeline = await storage.getPipeline(trigger.pipelineId);
+        if (!pipeline) {
+          log(`[triggers] Pipeline not found for trigger ${trigger.id}`, "triggers");
+          return;
+        }
+        await storage.updateTrigger(trigger.id, { lastTriggeredAt: new Date() });
+        log(`[triggers] Fired trigger ${trigger.id} for pipeline ${pipeline.id}`, "triggers");
+      });
     };
 
     // VETO-1 fix: pass storage as third argument so routes can look up pipeline ownership
@@ -327,8 +334,11 @@ export async function registerRoutes(
     registerWebhookRoutes(app, storage, triggerService, fireTrigger);
     webhookRoutesRegistered = true;
 
+    // Use getAllEnabledTriggersByType (cross-project, system-context) wrapped in
+    // runAsSystem so the scheduler can load triggers across ALL projects at bootstrap.
     cronScheduler = new CronScheduler({
-      getEnabledTriggersByType: (type) => storage.getEnabledTriggersByType(type),
+      getEnabledTriggersByType: (type) =>
+        runAsSystem("cron-scheduler-bootstrap", () => storage.getAllEnabledTriggersByType(type)),
       fireTrigger,
     });
     await cronScheduler.bootstrap();
@@ -337,7 +347,8 @@ export async function registerRoutes(
     await knowledgeRefreshScheduler.start();
 
     fileWatcherService = new FileWatcherService({
-      getEnabledTriggersByType: (type) => storage.getEnabledTriggersByType(type),
+      getEnabledTriggersByType: (type) =>
+        runAsSystem("file-watcher-bootstrap", () => storage.getAllEnabledTriggersByType(type)),
       fireTrigger,
     });
     await fileWatcherService.bootstrap();
@@ -422,29 +433,37 @@ export async function registerRoutes(
   // Phase 6.10 — ArgoCD auto-connect from env vars (if configured)
   await autoConnectArgoCdFromEnv();
 
-  // Seed built-in skills (idempotent — checks each by ID)
-  for (const skill of BUILTIN_SKILLS) {
-    const existing = await storage.getSkill(skill.id as string);
-    if (!existing) {
-      await storage.createSkill(skill);
+  // Seed built-in skills (idempotent — checks each by ID).
+  // Runs in system context: built-in skills have null projectId (globally shared).
+  await runAsSystem("startup-seed-builtin-skills", async () => {
+    for (const skill of BUILTIN_SKILLS) {
+      const existing = await storage.getSkill(skill.id as string);
+      if (!existing) {
+        await storage.createSkill(skill);
+      }
     }
-  }
+  });
 
-  // Seed default models
-  const existingModels = await storage.getModels();
-  if (existingModels.length === 0) {
-    for (const model of DEFAULT_MODELS) {
-      await storage.createModel(model);
+  // Seed default models. getModels() is an unscoped global select; createModel()
+  // uses withProjectInsert which sets projectId=null in system context (global row).
+  await runAsSystem("startup-seed-default-models", async () => {
+    const existingModels = await storage.getModels();
+    if (existingModels.length === 0) {
+      for (const model of DEFAULT_MODELS) {
+        await storage.createModel(model);
+      }
+      log(`Seeded ${DEFAULT_MODELS.length} default models`);
     }
-    log(`Seeded ${DEFAULT_MODELS.length} default models`);
-  }
+  });
 
   // Reconcile the DB model catalog to the LIVE discovered models so every
   // DB-catalog consumer (Workspace, pipeline, manager, dashboard, settings)
   // only sees the real subscription-CLI models. Best-effort, never blocks boot.
   try {
-    const recon = await reconcileModelCatalog(storage, gateway);
-    log(`Reconciled model catalog: ${recon.upserted} upserted, ${recon.deactivated} deactivated`);
+    await runAsSystem("startup-reconcile-model-catalog", async () => {
+      const recon = await reconcileModelCatalog(storage, gateway);
+      log(`Reconciled model catalog: ${recon.upserted} upserted, ${recon.deactivated} deactivated`);
+    });
   } catch (e) {
     log(`Model catalog reconcile skipped: ${(e as Error).message}`);
   }
@@ -452,12 +471,14 @@ export async function registerRoutes(
   // Best-effort: re-point any EXISTING pipeline stage that still references a now
   // inactive/dead model slug onto a working default. Never throws / never blocks boot.
   try {
-    const stageRecon = await reconcileExistingPipelineStages(storage);
-    if (stageRecon.stagesRepointed > 0) {
-      log(
-        `Re-pointed dead pipeline stages: ${stageRecon.stagesRepointed} stages across ${stageRecon.pipelinesUpdated} pipelines`,
-      );
-    }
+    await runAsSystem("startup-reconcile-pipeline-stages", async () => {
+      const stageRecon = await reconcileExistingPipelineStages(storage);
+      if (stageRecon.stagesRepointed > 0) {
+        log(
+          `Re-pointed dead pipeline stages: ${stageRecon.stagesRepointed} stages across ${stageRecon.pipelinesUpdated} pipelines`,
+        );
+      }
+    });
   } catch (e) {
     log(`Pipeline stage reconcile skipped: ${(e as Error).message}`);
   }
@@ -466,28 +487,33 @@ export async function registerRoutes(
   // KB_SEED_EXAMPLE=true). Idempotent; projection is best-effort.
   if (process.env.KB_SEED_EXAMPLE === "true") {
     try {
-      const seed = await seedExampleTerraformCards(storage, { resolveAdminUserId: resolveFirstAdminUserId });
-      log(
-        `Seeded example Terraform cards: ${seed.created} created, ${seed.alreadyPresent} already present ` +
-          `(workspace ${seed.workspaceId}; projection ${seed.projectionSkipped ? "skipped" : "ok"})`,
-      );
+      await runAsSystem("startup-seed-kb-example", async () => {
+        const seed = await seedExampleTerraformCards(storage, { resolveAdminUserId: resolveFirstAdminUserId });
+        log(
+          `Seeded example Terraform cards: ${seed.created} created, ${seed.alreadyPresent} already present ` +
+            `(workspace ${seed.workspaceId}; projection ${seed.projectionSkipped ? "skipped" : "ok"})`,
+        );
+      });
     } catch (e) {
       log(`Knowledge example seed skipped: ${(e as Error).message}`);
     }
   }
 
-  // Seed default pipeline template
-  const existingPipelines = await storage.getPipelines();
-  if (existingPipelines.length === 0) {
-    await storage.createPipeline({
-      name: "Full SDLC Pipeline",
-      description:
-        "Complete software development lifecycle: Planning → Architecture → Development → Testing → Code Review → Deployment → Monitoring",
-      stages: DEFAULT_PIPELINE_STAGES,
-      isTemplate: true,
-    });
-    log("Seeded default SDLC pipeline template");
-  }
+  // Seed default pipeline template. getPipelines() is an unscoped global select;
+  // createPipeline() uses withProjectInsert which sets projectId=null in system context.
+  await runAsSystem("startup-seed-default-pipeline", async () => {
+    const existingPipelines = await storage.getPipelines();
+    if (existingPipelines.length === 0) {
+      await storage.createPipeline({
+        name: "Full SDLC Pipeline",
+        description:
+          "Complete software development lifecycle: Planning → Architecture → Development → Testing → Code Review → Deployment → Monitoring",
+        stages: DEFAULT_PIPELINE_STAGES,
+        isTemplate: true,
+      });
+      log("Seeded default SDLC pipeline template");
+    }
+  });
 
   // Global pending questions endpoint (protected by /api/questions middleware above)
   app.get("/api/questions/pending", async (_req, res) => {

--- a/server/routes/webhooks.ts
+++ b/server/routes/webhooks.ts
@@ -15,6 +15,7 @@ import {
   startRateLimitCleanup,
 } from "../services/webhook-handler.js";
 import { handleGitHubEvent } from "../services/github-event-handler.js";
+import { runAsSystem } from "../context.js";
 
 function correlationId(): string {
   return randomUUID().slice(0, 8);
@@ -55,7 +56,13 @@ export function registerWebhookRoutes(
         req.headers as Record<string, string | string[] | undefined>,
         req.body as unknown,
         {
-          getEnabledTriggersByType: (type) => storage.getEnabledTriggersByType(type),
+          // getEnabledTriggersByType must run cross-project (no ALS context on github-events).
+          // runAsSystem establishes a system context; getAllEnabledTriggersByType bypasses
+          // the project filter so all matching triggers across all projects are returned.
+          getEnabledTriggersByType: (type) =>
+            runAsSystem("github-event-trigger-lookup", () =>
+              storage.getAllEnabledTriggersByType(type),
+            ),
           getSecret: (id) => triggerService.getSecret(id),
           fireTrigger,
         },

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -1,6 +1,7 @@
 import { eq, desc, and, or, ilike, lt, ne, gte, lte, asc, isNull, inArray, sql as drizzleSql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { db, withProject, withProjectInsert } from "./db";
+import { unscopedSystemQuery } from "./context";
 import type { IStorage, PracticeCardFilters, MorningBriefFilters, NewsItemFilters, LlmRequestFilters, LlmRequestStats, LlmStatsByModel, LlmStatsByProvider, LlmStatsByTeam, LlmTimelinePoint, RunHistoryQuery, PipelineRunHistoryRow, TaskGroupHistoryRow } from "./storage";
 import {
   TASK_GROUP_V2_MAX_LIMIT,
@@ -1405,6 +1406,20 @@ export class PgStorage implements IStorage {
       .select()
       .from(triggers)
       .where(withProject(triggers, and(eq(triggers.enabled, true), eq(triggers.type, type as TriggerRow["type"]))));
+  }
+
+  /**
+   * Cross-project query: returns ALL enabled triggers of this type across every
+   * project. Intended for background/system callers (CronScheduler, FileWatcher,
+   * GitHub event handler). MUST be called within runAsSystem(). See ADR-001 §3.1(d).
+   */
+  async getAllEnabledTriggersByType(type: string): Promise<TriggerRow[]> {
+    return unscopedSystemQuery("getAllEnabledTriggersByType", () =>
+      db
+        .select()
+        .from(triggers)
+        .where(and(eq(triggers.enabled, true), eq(triggers.type, type as TriggerRow["type"]))),
+    );
   }
 
   async createTrigger(

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -440,6 +440,9 @@ export interface IStorage {
   getTriggers(pipelineId: string): Promise<TriggerRow[]>;
   getTrigger(id: string): Promise<TriggerRow | undefined>;
   getEnabledTriggersByType(type: string): Promise<TriggerRow[]>;
+  /** Cross-project query for system/background use: returns ALL enabled triggers of this type
+   *  across every project. Must be called within runAsSystem(). See ADR-001 §3.1(d). */
+  getAllEnabledTriggersByType(type: string): Promise<TriggerRow[]>;
   createTrigger(data: Omit<TriggerRow, 'id' | 'createdAt' | 'updatedAt' | 'lastTriggeredAt'> & { secretEncrypted?: string | null }): Promise<TriggerRow>;
   updateTrigger(id: string, updates: Partial<TriggerRow>): Promise<TriggerRow>;
   deleteTrigger(id: string): Promise<void>;
@@ -2156,6 +2159,12 @@ export class MemStorage implements IStorage {
   }
 
   async getEnabledTriggersByType(type: string): Promise<TriggerRow[]> {
+    return Array.from(this.triggersMap.values()).filter((t) => t.enabled && t.type === type);
+  }
+
+  // Cross-project: in MemStorage there is no project isolation, so this is
+  // identical to getEnabledTriggersByType. Both return all matching triggers.
+  async getAllEnabledTriggersByType(type: string): Promise<TriggerRow[]> {
     return Array.from(this.triggersMap.values()).filter((t) => t.enabled && t.type === type);
   }
 

--- a/server/ws/manager.ts
+++ b/server/ws/manager.ts
@@ -3,6 +3,7 @@ import type { Server, IncomingMessage } from "http";
 import type { WsEvent, User } from "@shared/types";
 import type { IStorage } from "../storage";
 import { authService } from "../auth/service";
+import { runAsSystem } from "../context";
 import { isVisible } from "../routes/authorize-run.js";
 
 function extractTokenFromRequest(req: IncomingMessage): string | null {
@@ -97,21 +98,28 @@ export class WsManager {
   ): Promise<boolean> {
     if (!user?.id || !this.storage) return false;
 
-    // 1) Pipeline-family path (unchanged, checked first).
-    const run = await this.storage.getPipelineRun(runId);
-    if (run) {
-      if (!isVisible(run.triggeredBy, user)) return false;
+    // WS connections survive the HTTP upgrade but the ALS context does not
+    // propagate through the socket event loop. Wrap storage lookups in
+    // runAsSystem so they have context; no project filter is applied in system
+    // context, which is correct here — we're looking up a run by ID without
+    // knowing its project yet (that's the whole point of the ownership check).
+    return runAsSystem("ws-authorize-and-subscribe", async () => {
+      // 1) Pipeline-family path (unchanged, checked first).
+      const run = await this.storage!.getPipelineRun(runId);
+      if (run) {
+        if (!isVisible(run.triggeredBy, user)) return false;
+        this.subscribe(ws, runId);
+        return true;
+      }
+
+      // 2) Task-group fallback (H3) — gate on task_groups.createdBy.
+      const group = await this.storage!.getTaskGroup(runId);
+      if (!group) return false; // unknown in both spaces → fail closed.
+      if (!isVisible(group.createdBy, user)) return false;
+
       this.subscribe(ws, runId);
       return true;
-    }
-
-    // 2) Task-group fallback (H3) — gate on task_groups.createdBy.
-    const group = await this.storage.getTaskGroup(runId);
-    if (!group) return false; // unknown in both spaces → fail closed.
-    if (!isVisible(group.createdBy, user)) return false;
-
-    this.subscribe(ws, runId);
-    return true;
+    });
   }
 
   subscribe(ws: WebSocket, runId: string): void {


### PR DESCRIPTION
## Summary

This is the keystone PR of ADR-001 (per-project secrets isolation). It converts `withProject`/`withProjectInsert` from fail-open (silent catch/fallback) to **fail-closed** (hard throw when no AsyncLocalStorage context exists), and adds the explicit system-context primitives that all background/startup code must use instead.

## What Changed

### `server/context.ts` — new helpers
- `RequestContext.system?: boolean` — marks cross-project background contexts
- `runAsProject<T>(projectId, fn)` — establishes per-project ALS context for background jobs
- `runAsSystem<T>(reason, fn)` — establishes cross-project context with structured audit log (`{ scope: "system-access", reason, at }`)
- `unscopedSystemQuery<T>(label, fn)` — asserts system context, then runs a raw DB query that bypasses `withProject`; explicit + greppable

### `server/db.ts` — fail-closed
| State | `withProject` behavior | `withProjectInsert` behavior |
|-------|----------------------|------------------------------|
| No ALS context | **THROWS** | **THROWS** |
| System context | Returns bare condition (no project filter; audited by `runAsSystem`) | Sets `projectId: null` (globally shared row) |
| Project context, table missing `projectId` | **THROWS** | n/a |
| Project context, table has `projectId` | `eq(table.projectId, ctx.projectId) AND condition` | `{ ...data, projectId: ctx.projectId }` |

### `server/storage.ts` / `server/storage-pg.ts`
- `IStorage.getAllEnabledTriggersByType(type)` — cross-project variant for background schedulers. MemStorage delegates to existing impl. PgStorage uses `unscopedSystemQuery` to assert system context before the DB call.

## Call-Site Audit

All background/startup entry points have been converted:

| Call site | File | Fix applied |
|-----------|------|-------------|
| Startup skill seeding | `routes.ts:~426` | `runAsSystem("startup-seed-builtin-skills", …)` |
| Startup model seeding | `routes.ts:~434` | `runAsSystem("startup-seed-default-models", …)` |
| `reconcileModelCatalog` | `routes.ts:~446` | `runAsSystem("startup-reconcile-model-catalog", …)` |
| `reconcileExistingPipelineStages` | `routes.ts:~455` | `runAsSystem("startup-reconcile-pipeline-stages", …)` |
| KB example seed | `routes.ts:~466` | `runAsSystem("startup-seed-kb-example", …)` |
| Startup pipeline template seed | `routes.ts:~480` | `runAsSystem("startup-seed-default-pipeline", …)` |
| `fireTrigger` | `routes.ts:~315` | `runAsSystem("fire-trigger", …)` |
| `CronScheduler` deps | `routes.ts:~331` | `runAsSystem("cron-scheduler-bootstrap", () => storage.getAllEnabledTriggersByType(…))` |
| `FileWatcherService` deps | `routes.ts:~340` | `runAsSystem("file-watcher-bootstrap", () => storage.getAllEnabledTriggersByType(…))` |
| GitHub event trigger lookup | `routes/webhooks.ts:~58` | `runAsSystem("github-event-trigger-lookup", …)` + `getAllEnabledTriggersByType` |
| `RemoteAgentManager.initialize()` | `remote-agent-manager.ts:~52` | `runAsSystem("remote-agent-manager-init", …)` |
| `RemoteAgentManager` heartbeat | `remote-agent-manager.ts:~269` | `runAsSystem("remote-agent-heartbeat", …)` |
| `WsManager.authorizeAndSubscribe` | `ws/manager.ts:~93` | `runAsSystem("ws-authorize-and-subscribe", …)` |

## Known Gaps (deferred to later PRs)

- **[R3-SEC-10 / PR-0c]** `mcpToolCalls` has no `projectId` column — `withProject(mcpToolCalls, …)` will throw "table has no projectId column" until PR-0c adds the column.
- **[PR-0b]** HTTP endpoints that use project-scoped storage will throw "no projectId in context" until PR-0b wires `requireProject` middleware that stamps the ALS context from the `x-project-id` header. Unit tests pass because they use `MemStorage` which doesn't call `withProject`.

## Verification

```
npx tsc --noEmit   # exit 0
npx vitest run --exclude '**/config-sync/**'   # 326 files, 5840 pass, 6 skipped
```

The 3 config-sync test files excluded above time out in the baseline too (CLI process spawn issue; pre-existing, unrelated to this PR).

## Rollout Note

This PR is safe to merge independently but has a deployment dependency:
- If deployed with PgStorage (not MemStorage), HTTP requests that hit project-scoped storage **will throw** until PR-0b (`requireProject` middleware) is deployed in the same release.
- Safe path: batch PR-0a + PR-0b into a single deploy, or deploy to a staging env first to confirm the middleware wire-up.
- Background services (cron, file-watcher, webhooks, WS, remote-agent) are **fully wired** and safe to deploy alone.

## Not in Scope

- `requireProject` middleware (PR-0b)
- `projectId` column additions (PR-0c)
- Crypto/token changes (PR-0d / PR-0e)
- `authTokenEnc` encryption in `remote-agent-manager.ts`