### PR TITLE
feat(security): Phase 0e — versioned ciphertext + rekey, then require ENCRYPTION_KEY

### DIFF
--- a/scripts/rekey-v2.ts
+++ b/scripts/rekey-v2.ts
@@ -1,0 +1,387 @@
+#!/usr/bin/env tsx
+/**
+ * rekey-v2.ts — ADR-001 PR-0e data migration script
+ *
+ * Re-encrypts every AES-256-GCM ciphertext stored by server/crypto.ts to the
+ * new v2: format, which uses a per-value random salt.  The script is idempotent:
+ * values already prefixed `v2:` are skipped.
+ *
+ * USAGE
+ * ─────
+ *   # Dry-run (prints what would change, writes nothing):
+ *   DATABASE_URL=... ENCRYPTION_KEY=... npx tsx scripts/rekey-v2.ts --dry-run
+ *
+ *   # Live run (re-encrypts all non-v2: rows):
+ *   DATABASE_URL=... ENCRYPTION_KEY=... npx tsx scripts/rekey-v2.ts
+ *
+ *   # Verification gate — confirm ALL rows carry v2: before fallback removal:
+ *   DATABASE_URL=... ENCRYPTION_KEY=... npx tsx scripts/rekey-v2.ts --verify
+ *
+ * DEPLOY SEQUENCE (per ADR-001 §4 PR-0e)
+ * ────────────────────────────────────────
+ *   1. Deploy Commit 1 (versioned ciphertext + dual-key rekey).
+ *   2. Run this script with --dry-run first to audit scope.
+ *   3. Run without flags to rekey all rows in EACH environment (dev → staging → prod).
+ *   4. Run with --verify in EACH environment.  All rows must report 0 non-v2: rows.
+ *   5. ONLY THEN deploy Commit 2 (fallback removal + mandatory ENCRYPTION_KEY).
+ *
+ * COLUMNS COVERED
+ * ───────────────
+ *   provider_keys.api_key_encrypted
+ *   git_skill_sources.encrypted_pat
+ *   argocd_config.token_enc
+ *   workspace_connections.secrets_encrypted
+ *   tracker_connections.api_token        (will be encrypted after PR-0d merges)
+ *   remote_agents.auth_token_enc         (will be encrypted after PR-0d merges)
+ *
+ * TRIGGER-CRYPTO NOTE
+ * ───────────────────
+ *   server/services/trigger-crypto.ts uses a SEPARATE key (TRIGGER_SECRET_KEY)
+ *   and a different ciphertext format (no static salt, direct 32-byte hex key).
+ *   That column (triggers.secretEncrypted) is NOT touched here — migrate it
+ *   separately if/when trigger-crypto gains a versioned format.
+ */
+
+import { Pool } from "pg";
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "crypto";
+
+// ─── Helpers (inline — no server imports to keep script standalone) ───────────
+
+const ALGORITHM = "aes-256-gcm";
+const KEY_LEN = 32;
+const LEGACY_SALT = "multiqlti-provider-keys-v1";
+const V2_SALT_LEN = 32;
+const V2_PREFIX = "v2:";
+const DEV_FALLBACK_KEY = "dev-default-insecure-key-change-me!";
+
+function deriveKey(secret: string, salt: string): Buffer {
+  return scryptSync(secret, salt, KEY_LEN);
+}
+
+/** Is this value already in the v2: format? */
+function isV2(value: string): boolean {
+  return value.startsWith(V2_PREFIX);
+}
+
+/**
+ * Attempt to decrypt a legacy (unprefixed) ciphertext with the given key and
+ * the static legacy salt.  Throws on GCM auth-tag failure.
+ */
+function tryDecryptLegacy(hex: string, secret: string): string {
+  const buf = Buffer.from(hex, "hex");
+  if (buf.length < 12 + 16) throw new Error("Too short to be valid ciphertext");
+  const iv = buf.subarray(0, 12);
+  const authTag = buf.subarray(12, 28);
+  const payload = buf.subarray(28);
+  const key = deriveKey(secret, LEGACY_SALT);
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
+}
+
+/**
+ * Encrypt plaintext in the v2: format with a fresh random salt per call.
+ * Wire format: "v2:" + hex(salt[32] | iv[12] | authTag[16] | ciphertext)
+ */
+function encryptV2(plaintext: string, secret: string): string {
+  const salt = randomBytes(V2_SALT_LEN);
+  const key = deriveKey(secret, salt.toString("hex"));
+  const iv = randomBytes(12);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return V2_PREFIX + Buffer.concat([salt, iv, authTag, encrypted]).toString("hex");
+}
+
+/**
+ * Decrypt a value in either v2: or legacy format.
+ * Returns the plaintext, or throws if it cannot be decrypted with any known key.
+ */
+function decryptAny(value: string, currentKey: string): string {
+  if (value.startsWith(V2_PREFIX)) {
+    // Already v2: — decrypt with current key and embedded salt
+    const hex = value.slice(V2_PREFIX.length);
+    const buf = Buffer.from(hex, "hex");
+    const V2_HEADER_LEN = V2_SALT_LEN + 12 + 16;
+    if (buf.length < V2_HEADER_LEN) throw new Error("v2: ciphertext too short");
+    const salt = buf.subarray(0, V2_SALT_LEN);
+    const iv = buf.subarray(V2_SALT_LEN, V2_SALT_LEN + 12);
+    const authTag = buf.subarray(V2_SALT_LEN + 12, V2_HEADER_LEN);
+    const payload = buf.subarray(V2_HEADER_LEN);
+    const key = deriveKey(currentKey, salt.toString("hex"));
+    const decipher = createDecipheriv(ALGORITHM, key, iv);
+    decipher.setAuthTag(authTag);
+    return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
+  }
+
+  // Legacy format — try current key first, then the dev fallback
+  try {
+    return tryDecryptLegacy(value, currentKey);
+  } catch {
+    // Current key failed; try the known insecure fallback
+  }
+  return tryDecryptLegacy(value, DEV_FALLBACK_KEY);
+}
+
+// ─── Column descriptors ────────────────────────────────────────────────────────
+
+interface Column {
+  /** Human-readable label for log output */
+  label: string;
+  /** SQL to fetch rows: must return { id, value } */
+  selectSql: string;
+  /** SQL to update a single row's encrypted column */
+  updateSql: string;
+  /** Whether this column may be NULL (nullable columns are skipped when NULL) */
+  nullable: boolean;
+}
+
+const COLUMNS: Column[] = [
+  {
+    label: "provider_keys.api_key_encrypted",
+    selectSql: "SELECT id::text, api_key_encrypted AS value FROM provider_keys WHERE api_key_encrypted IS NOT NULL",
+    updateSql: "UPDATE provider_keys SET api_key_encrypted = $1 WHERE id::text = $2",
+    nullable: false,
+  },
+  {
+    label: "git_skill_sources.encrypted_pat",
+    selectSql: "SELECT id::text, encrypted_pat AS value FROM git_skill_sources WHERE encrypted_pat IS NOT NULL",
+    updateSql: "UPDATE git_skill_sources SET encrypted_pat = $1 WHERE id::text = $2",
+    nullable: true,
+  },
+  {
+    label: "argocd_config.token_enc",
+    selectSql: "SELECT id::text, token_enc AS value FROM argocd_config WHERE token_enc IS NOT NULL",
+    updateSql: "UPDATE argocd_config SET token_enc = $1 WHERE id::text = $2",
+    nullable: true,
+  },
+  {
+    label: "workspace_connections.secrets_encrypted",
+    selectSql: "SELECT id::text, secrets_encrypted AS value FROM workspace_connections WHERE secrets_encrypted IS NOT NULL",
+    updateSql: "UPDATE workspace_connections SET secrets_encrypted = $1 WHERE id::text = $2",
+    nullable: true,
+  },
+  {
+    label: "tracker_connections.api_token",
+    selectSql: "SELECT id::text, api_token AS value FROM tracker_connections WHERE api_token IS NOT NULL",
+    updateSql: "UPDATE tracker_connections SET api_token = $1 WHERE id::text = $2",
+    nullable: true,
+  },
+  {
+    label: "remote_agents.auth_token_enc",
+    selectSql: "SELECT id::text, auth_token_enc AS value FROM remote_agents WHERE auth_token_enc IS NOT NULL",
+    updateSql: "UPDATE remote_agents SET auth_token_enc = $1 WHERE id::text = $2",
+    nullable: true,
+  },
+];
+
+// ─── Modes ─────────────────────────────────────────────────────────────────────
+
+type Mode = "live" | "dry-run" | "verify";
+
+interface Stats {
+  label: string;
+  total: number;
+  alreadyV2: number;
+  rekeyed: number;
+  errors: number;
+  nonV2Remaining: number;
+}
+
+async function processColumn(
+  pool: Pool,
+  col: Column,
+  currentKey: string,
+  mode: Mode,
+): Promise<Stats> {
+  const stats: Stats = {
+    label: col.label,
+    total: 0,
+    alreadyV2: 0,
+    rekeyed: 0,
+    errors: 0,
+    nonV2Remaining: 0,
+  };
+
+  let rows: Array<{ id: string; value: string }>;
+  try {
+    const result = await pool.query<{ id: string; value: string }>(col.selectSql);
+    rows = result.rows;
+  } catch (err) {
+    // Table may not exist yet (e.g. tracker_connections.api_token pre-PR-0d)
+    console.warn(`  [skip] ${col.label}: table/column not found (${(err as Error).message})`);
+    return stats;
+  }
+
+  stats.total = rows.length;
+
+  for (const row of rows) {
+    const { id, value } = row;
+
+    if (!value) continue;
+
+    if (isV2(value)) {
+      stats.alreadyV2++;
+      continue;
+    }
+
+    // Non-v2: value
+    stats.nonV2Remaining++;
+
+    if (mode === "verify") continue; // just counting
+
+    // Try to decrypt with current key, then fallback
+    let plaintext: string;
+    try {
+      plaintext = decryptAny(value, currentKey);
+    } catch (err) {
+      console.error(
+        `  [error] ${col.label} id=${id}: could not decrypt — ` +
+        `${(err as Error).message}`,
+      );
+      stats.errors++;
+      continue;
+    }
+
+    if (mode === "dry-run") {
+      console.log(`  [would rekey] ${col.label} id=${id}`);
+      continue;
+    }
+
+    // live: re-encrypt as v2:
+    const rekeyed = encryptV2(plaintext, currentKey);
+    try {
+      await pool.query(col.updateSql, [rekeyed, id]);
+      stats.rekeyed++;
+      console.log(`  [rekeyed] ${col.label} id=${id}`);
+    } catch (err) {
+      console.error(`  [error] ${col.label} id=${id}: update failed — ${(err as Error).message}`);
+      stats.errors++;
+    }
+  }
+
+  return stats;
+}
+
+// ─── Main ──────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const isDryRun = args.includes("--dry-run");
+  const isVerify = args.includes("--verify");
+  const isHelp = args.includes("--help") || args.includes("-h");
+
+  if (isHelp) {
+    console.log(`
+rekey-v2.ts — ADR-001 PR-0e rekey migration script
+
+Usage:
+  DATABASE_URL=... ENCRYPTION_KEY=... npx tsx scripts/rekey-v2.ts [options]
+
+Options:
+  --dry-run   Show what would be rekeyed without writing any changes.
+  --verify    Check that ALL rows carry v2:. Exit 1 if any non-v2: rows remain.
+  --help      Show this help message.
+
+Environment:
+  DATABASE_URL    PostgreSQL connection string (required).
+  ENCRYPTION_KEY  (or MULTI_ENCRYPTION_KEY) The app's encryption key (required).
+
+Columns covered:
+  provider_keys.api_key_encrypted
+  git_skill_sources.encrypted_pat
+  argocd_config.token_enc
+  workspace_connections.secrets_encrypted
+  tracker_connections.api_token          (after PR-0d)
+  remote_agents.auth_token_enc           (after PR-0d)
+
+Columns NOT covered (separate key/format):
+  triggers.secret_encrypted              (TRIGGER_SECRET_KEY — migrate separately)
+`);
+    process.exit(0);
+  }
+
+  // --- Validate env ---
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) {
+    console.error("Error: DATABASE_URL is not set.");
+    process.exit(1);
+  }
+
+  const currentKey = process.env.ENCRYPTION_KEY ?? process.env.MULTI_ENCRYPTION_KEY;
+  if (!currentKey || currentKey.length < 32) {
+    console.error(
+      "Error: ENCRYPTION_KEY (or MULTI_ENCRYPTION_KEY) is not set or is shorter than 32 chars.",
+    );
+    process.exit(1);
+  }
+
+  const mode: Mode = isVerify ? "verify" : isDryRun ? "dry-run" : "live";
+  console.log(`\n=== rekey-v2.ts [mode: ${mode}] ===\n`);
+
+  if (mode === "live") {
+    console.log(
+      "WARNING: This will re-encrypt existing rows in the database.\n" +
+      "         Make sure a database backup exists before proceeding.\n",
+    );
+  }
+
+  const pool = new Pool({ connectionString: dbUrl });
+
+  const allStats: Stats[] = [];
+  let totalErrors = 0;
+  let totalNonV2 = 0;
+
+  for (const col of COLUMNS) {
+    console.log(`Processing: ${col.label}`);
+    const stats = await processColumn(pool, col, currentKey, mode);
+    allStats.push(stats);
+    totalErrors += stats.errors;
+    totalNonV2 += stats.nonV2Remaining;
+    console.log(
+      `  total=${stats.total} already_v2=${stats.alreadyV2} ` +
+      (mode === "live" ? `rekeyed=${stats.rekeyed} ` : "") +
+      (mode === "dry-run" ? `would_rekey=${stats.nonV2Remaining} ` : "") +
+      (mode === "verify" ? `non_v2=${stats.nonV2Remaining} ` : "") +
+      `errors=${stats.errors}`,
+    );
+  }
+
+  await pool.end();
+
+  console.log("\n=== Summary ===");
+  if (mode === "verify") {
+    if (totalNonV2 > 0) {
+      console.error(
+        `\nFAIL: ${totalNonV2} row(s) are NOT in v2: format across the covered columns.` +
+        "\n      Run the live rekey before deploying the fallback-removal commit.",
+      );
+      process.exit(1);
+    }
+    if (totalErrors > 0) {
+      console.error(`\nFAIL: ${totalErrors} error(s) encountered during verification.`);
+      process.exit(1);
+    }
+    console.log("\nPASS: All covered rows are in v2: format. Safe to deploy fallback removal.");
+    process.exit(0);
+  }
+
+  if (totalErrors > 0) {
+    console.error(`\n${totalErrors} error(s) encountered. Review the output above.`);
+    process.exit(1);
+  }
+
+  if (mode === "dry-run") {
+    const wouldRekey = allStats.reduce((acc, s) => acc + s.nonV2Remaining, 0);
+    console.log(`\nDry-run complete. Would rekey ${wouldRekey} row(s). No changes written.`);
+  } else {
+    const total = allStats.reduce((acc, s) => acc + s.rekeyed, 0);
+    console.log(`\nRekey complete. ${total} row(s) re-encrypted to v2: format.`);
+  }
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Unexpected error:", err);
+  process.exit(1);
+});

--- a/server/crypto.ts
+++ b/server/crypto.ts
@@ -3,47 +3,216 @@ import { configLoader } from "./config/loader";
 
 const ALGORITHM = "aes-256-gcm";
 const KEY_LEN = 32;
-const SALT = "multiqlti-provider-keys-v1"; // static salt; key is config-derived
 
-function deriveKey(secret: string): Buffer {
-  return scryptSync(secret, SALT, KEY_LEN);
+/**
+ * Legacy static salt used for all ciphertext produced before v2:.
+ * Kept here ONLY to decrypt existing (pre-rekey) rows — never used for new
+ * encryptions. The v2: format embeds a per-value random salt instead.
+ */
+const LEGACY_SALT = "multiqlti-provider-keys-v1";
+
+/**
+ * V2 salt length in bytes. Each v2: ciphertext embeds a fresh 32-byte random
+ * salt so key-derivation is independent per value.
+ */
+const V2_SALT_LEN = 32;
+
+/**
+ * The old insecure dev-fallback key.
+ *
+ * Used ONLY inside `decryptLegacy()` to detect rows that were written with the
+ * fallback instead of a real key. This lets the rekey migration script find and
+ * re-encrypt those rows. The application NEVER produces new ciphertext with this
+ * key — `encrypt()` calls `getSecret()` which throws if ENCRYPTION_KEY is unset.
+ *
+ * After the rekey migration confirms zero non-v2: rows in every environment,
+ * this constant and the fallback branch in decryptLegacy() will be removed in a
+ * separate deploy (see PR-0e Commit 2 — "Remove fallback").
+ */
+const DEV_FALLBACK_KEY = "dev-default-insecure-key-change-me!";
+
+function deriveKey(secret: string, salt: string): Buffer {
+  return scryptSync(secret, salt, KEY_LEN);
 }
 
+/**
+ * Returns the configured encryption secret.
+ *
+ * Throws if ENCRYPTION_KEY / MULTI_ENCRYPTION_KEY is not set.
+ * There is NO insecure dev-fallback — a missing key is a hard failure.
+ * To run tests, set ENCRYPTION_KEY (any 32+-char string) or mock configLoader.
+ */
 function getSecret(): string {
   const { key } = configLoader.get().encryption;
   if (!key) {
-    console.warn(
-      "[crypto] encryption.key is not set — using insecure dev default. " +
-      "Set ENCRYPTION_KEY (or MULTI_ENCRYPTION_KEY) in production.",
+    throw new Error(
+      "[crypto] ENCRYPTION_KEY (or MULTI_ENCRYPTION_KEY) is not configured. " +
+      "Set it to a random string of at least 32 characters. " +
+      "This value must be the SAME across all server instances sharing a database.",
     );
-    return "dev-default-insecure-key-change-me!";
   }
   return key;
 }
 
-/**
- * Encrypts plaintext with AES-256-GCM.
- * Returns a hex string: iv(24) + authTag(32) + ciphertext.
- */
-export function encrypt(plaintext: string): string {
-  const key = deriveKey(getSecret());
+// ─── V2 format ────────────────────────────────────────────────────────────────
+//
+// Wire format (binary, then hex-encoded):
+//   salt    (32 bytes) — random per-value, embedded in the ciphertext
+//   iv      (12 bytes) — AES-GCM nonce
+//   authTag (16 bytes) — GCM authentication tag
+//   payload (n  bytes) — encrypted plaintext
+//
+// Stored as: "v2:" + Buffer.concat([salt, iv, authTag, payload]).toString("hex")
+//
+// Benefits over the legacy format:
+//   - Per-value random salt: each ciphertext uses an independently derived key.
+//   - Version prefix: format is self-describing; migration scripts can detect
+//     which rows need rekeying vs. which are already current.
+
+const V2_PREFIX = "v2:";
+const V2_HEADER_LEN = V2_SALT_LEN + 12 + 16; // salt + iv + authTag (bytes)
+
+function encryptV2(plaintext: string, secret: string): string {
+  const salt = randomBytes(V2_SALT_LEN);
+  const key = deriveKey(secret, salt.toString("hex"));
   const iv = randomBytes(12);
   const cipher = createCipheriv(ALGORITHM, key, iv);
   const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
   const authTag = cipher.getAuthTag();
-  return Buffer.concat([iv, authTag, encrypted]).toString("hex");
+  return V2_PREFIX + Buffer.concat([salt, iv, authTag, encrypted]).toString("hex");
+}
+
+function decryptV2(prefixedHex: string, secret: string): string {
+  const hex = prefixedHex.slice(V2_PREFIX.length);
+  const buf = Buffer.from(hex, "hex");
+  if (buf.length < V2_HEADER_LEN) {
+    throw new Error("[crypto] v2: ciphertext is too short to be valid");
+  }
+  const salt = buf.subarray(0, V2_SALT_LEN);
+  const iv = buf.subarray(V2_SALT_LEN, V2_SALT_LEN + 12);
+  const authTag = buf.subarray(V2_SALT_LEN + 12, V2_HEADER_LEN);
+  const payload = buf.subarray(V2_HEADER_LEN);
+  const key = deriveKey(secret, salt.toString("hex"));
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
+}
+
+// ─── Legacy format ─────────────────────────────────────────────────────────────
+//
+// Wire format (binary, then hex-encoded, NO prefix):
+//   iv      (12 bytes)
+//   authTag (16 bytes)
+//   payload (n  bytes)
+//
+// Key derived with: scryptSync(secret, LEGACY_SALT, KEY_LEN)
+
+const LEGACY_HEADER_LEN = 12 + 16;
+
+function decryptLegacy(hex: string): string {
+  const buf = Buffer.from(hex, "hex");
+  if (buf.length < LEGACY_HEADER_LEN) {
+    throw new Error("[crypto] legacy ciphertext is too short to be valid");
+  }
+  const iv = buf.subarray(0, 12);
+  const authTag = buf.subarray(12, 28);
+  const payload = buf.subarray(28);
+
+  // Try the real (configured) key first.
+  const currentSecret = getSecret();
+  try {
+    const key = deriveKey(currentSecret, LEGACY_SALT);
+    const decipher = createDecipheriv(ALGORITHM, key, iv);
+    decipher.setAuthTag(authTag);
+    return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
+  } catch {
+    // GCM auth-tag failure means this value was NOT encrypted with the current
+    // key.  Try the dev-fallback key so the rekey migration can detect and
+    // re-encrypt these rows.
+    //
+    // NOTE: This fallback branch will be removed in Commit 2 of PR-0e AFTER the
+    // rekey migration script has confirmed zero non-v2: rows in every environment.
+  }
+
+  try {
+    const fallbackKey = deriveKey(DEV_FALLBACK_KEY, LEGACY_SALT);
+    const decipher = createDecipheriv(ALGORITHM, fallbackKey, iv);
+    decipher.setAuthTag(authTag);
+    return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
+  } catch {
+    throw new Error(
+      "[crypto] failed to decrypt legacy ciphertext with both the current key and the dev fallback. " +
+      "The ciphertext may be corrupt, or encrypted with an unknown key.",
+    );
+  }
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Encrypts plaintext with AES-256-GCM.
+ *
+ * Returns a `v2:` prefixed hex string.  The embedded random salt ensures each
+ * call produces independently derived key material even when the same secret is
+ * reused.
+ *
+ * Wire format: `"v2:" + hex(salt[32] | iv[12] | authTag[16] | ciphertext)`
+ */
+export function encrypt(plaintext: string): string {
+  return encryptV2(plaintext, getSecret());
 }
 
 /**
- * Decrypts a hex string produced by encrypt().
+ * Decrypts a string produced by `encrypt()` (v2: format) or any legacy value
+ * produced by the previous format (no prefix).
+ *
+ * Dispatch:
+ *   - Starts with `v2:` → decryptV2 with the current key.
+ *   - No prefix (legacy) → decryptLegacy: tries current key first, then the
+ *     dev-fallback key so the rekey migration can detect affected rows.
+ *
+ * After the rekey migration + `--verify` passes in every environment, Commit 2
+ * of PR-0e removes the legacy branch and the fallback key entirely.
  */
 export function decrypt(ciphertext: string): string {
-  const key = deriveKey(getSecret());
-  const buf = Buffer.from(ciphertext, "hex");
+  if (ciphertext.startsWith(V2_PREFIX)) {
+    return decryptV2(ciphertext, getSecret());
+  }
+  return decryptLegacy(ciphertext);
+}
+
+/**
+ * Returns true if the value is already in the v2: format (i.e. produced by
+ * this version of encrypt() or already rekeyed by the migration script).
+ */
+export function isV2(value: string): boolean {
+  return value.startsWith(V2_PREFIX);
+}
+
+/**
+ * Exposed for the rekey migration script ONLY.  Do not call from application
+ * code.
+ *
+ * Attempts to decrypt a legacy (non-v2:) ciphertext using a known secret and
+ * the static legacy salt.  Throws on auth-tag failure.  The caller (rekey
+ * script) is expected to catch the error and try alternative keys.
+ */
+export function decryptLegacyWithKey(hex: string, secret: string): string {
+  const buf = Buffer.from(hex, "hex");
+  if (buf.length < LEGACY_HEADER_LEN) {
+    throw new Error("[crypto] legacy ciphertext is too short to be valid");
+  }
   const iv = buf.subarray(0, 12);
   const authTag = buf.subarray(12, 28);
-  const encrypted = buf.subarray(28);
+  const payload = buf.subarray(28);
+  const key = deriveKey(secret, LEGACY_SALT);
   const decipher = createDecipheriv(ALGORITHM, key, iv);
   decipher.setAuthTag(authTag);
-  return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString("utf8");
+  return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
 }
+
+/**
+ * The dev fallback key — exported for the rekey script so it can try to
+ * decrypt values that were written without a real ENCRYPTION_KEY.
+ */
+export const DEV_FALLBACK_KEY_EXPORT = DEV_FALLBACK_KEY;

--- a/server/crypto.ts
+++ b/server/crypto.ts
@@ -1,35 +1,20 @@
 import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "crypto";
 import { configLoader } from "./config/loader";
 
+// ─── DO NOT DEPLOY THIS FILE UNTIL ──────────────────────────────────────────
+// 1. The rekey migration script (scripts/rekey-v2.ts) has been run in EVERY
+//    environment (dev → staging → prod).
+// 2. `npx tsx scripts/rekey-v2.ts --verify` exits 0 (zero non-v2: rows) in
+//    EVERY environment.
+// Only after both checks pass is it safe to deploy this commit, which removes
+// the insecure dev-fallback key and the legacy-format fallback branch.
+// ─────────────────────────────────────────────────────────────────────────────
+
 const ALGORITHM = "aes-256-gcm";
 const KEY_LEN = 32;
-
-/**
- * Legacy static salt used for all ciphertext produced before v2:.
- * Kept here ONLY to decrypt existing (pre-rekey) rows — never used for new
- * encryptions. The v2: format embeds a per-value random salt instead.
- */
-const LEGACY_SALT = "multiqlti-provider-keys-v1";
-
-/**
- * V2 salt length in bytes. Each v2: ciphertext embeds a fresh 32-byte random
- * salt so key-derivation is independent per value.
- */
 const V2_SALT_LEN = 32;
-
-/**
- * The old insecure dev-fallback key.
- *
- * Used ONLY inside `decryptLegacy()` to detect rows that were written with the
- * fallback instead of a real key. This lets the rekey migration script find and
- * re-encrypt those rows. The application NEVER produces new ciphertext with this
- * key — `encrypt()` calls `getSecret()` which throws if ENCRYPTION_KEY is unset.
- *
- * After the rekey migration confirms zero non-v2: rows in every environment,
- * this constant and the fallback branch in decryptLegacy() will be removed in a
- * separate deploy (see PR-0e Commit 2 — "Remove fallback").
- */
-const DEV_FALLBACK_KEY = "dev-default-insecure-key-change-me!";
+const V2_PREFIX = "v2:";
+const V2_HEADER_LEN = V2_SALT_LEN + 12 + 16; // salt + iv + authTag (bytes)
 
 function deriveKey(secret: string, salt: string): Buffer {
   return scryptSync(secret, salt, KEY_LEN);
@@ -39,8 +24,8 @@ function deriveKey(secret: string, salt: string): Buffer {
  * Returns the configured encryption secret.
  *
  * Throws if ENCRYPTION_KEY / MULTI_ENCRYPTION_KEY is not set.
- * There is NO insecure dev-fallback — a missing key is a hard failure.
- * To run tests, set ENCRYPTION_KEY (any 32+-char string) or mock configLoader.
+ * There is NO fallback — a missing key is a hard startup failure.
+ * In tests, mock configLoader or set ENCRYPTION_KEY to any 32+-char string.
  */
 function getSecret(): string {
   const { key } = configLoader.get().encryption;
@@ -63,14 +48,6 @@ function getSecret(): string {
 //   payload (n  bytes) — encrypted plaintext
 //
 // Stored as: "v2:" + Buffer.concat([salt, iv, authTag, payload]).toString("hex")
-//
-// Benefits over the legacy format:
-//   - Per-value random salt: each ciphertext uses an independently derived key.
-//   - Version prefix: format is self-describing; migration scripts can detect
-//     which rows need rekeying vs. which are already current.
-
-const V2_PREFIX = "v2:";
-const V2_HEADER_LEN = V2_SALT_LEN + 12 + 16; // salt + iv + authTag (bytes)
 
 function encryptV2(plaintext: string, secret: string): string {
   const salt = randomBytes(V2_SALT_LEN);
@@ -98,55 +75,6 @@ function decryptV2(prefixedHex: string, secret: string): string {
   return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
 }
 
-// ─── Legacy format ─────────────────────────────────────────────────────────────
-//
-// Wire format (binary, then hex-encoded, NO prefix):
-//   iv      (12 bytes)
-//   authTag (16 bytes)
-//   payload (n  bytes)
-//
-// Key derived with: scryptSync(secret, LEGACY_SALT, KEY_LEN)
-
-const LEGACY_HEADER_LEN = 12 + 16;
-
-function decryptLegacy(hex: string): string {
-  const buf = Buffer.from(hex, "hex");
-  if (buf.length < LEGACY_HEADER_LEN) {
-    throw new Error("[crypto] legacy ciphertext is too short to be valid");
-  }
-  const iv = buf.subarray(0, 12);
-  const authTag = buf.subarray(12, 28);
-  const payload = buf.subarray(28);
-
-  // Try the real (configured) key first.
-  const currentSecret = getSecret();
-  try {
-    const key = deriveKey(currentSecret, LEGACY_SALT);
-    const decipher = createDecipheriv(ALGORITHM, key, iv);
-    decipher.setAuthTag(authTag);
-    return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
-  } catch {
-    // GCM auth-tag failure means this value was NOT encrypted with the current
-    // key.  Try the dev-fallback key so the rekey migration can detect and
-    // re-encrypt these rows.
-    //
-    // NOTE: This fallback branch will be removed in Commit 2 of PR-0e AFTER the
-    // rekey migration script has confirmed zero non-v2: rows in every environment.
-  }
-
-  try {
-    const fallbackKey = deriveKey(DEV_FALLBACK_KEY, LEGACY_SALT);
-    const decipher = createDecipheriv(ALGORITHM, fallbackKey, iv);
-    decipher.setAuthTag(authTag);
-    return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
-  } catch {
-    throw new Error(
-      "[crypto] failed to decrypt legacy ciphertext with both the current key and the dev fallback. " +
-      "The ciphertext may be corrupt, or encrypted with an unknown key.",
-    );
-  }
-}
-
 // ─── Public API ───────────────────────────────────────────────────────────────
 
 /**
@@ -163,56 +91,31 @@ export function encrypt(plaintext: string): string {
 }
 
 /**
- * Decrypts a string produced by `encrypt()` (v2: format) or any legacy value
- * produced by the previous format (no prefix).
+ * Decrypts a string produced by `encrypt()`.
  *
- * Dispatch:
- *   - Starts with `v2:` → decryptV2 with the current key.
- *   - No prefix (legacy) → decryptLegacy: tries current key first, then the
- *     dev-fallback key so the rekey migration can detect affected rows.
+ * Only accepts `v2:` prefixed values.  Legacy unprefixed values are no longer
+ * supported — they must have been migrated by `scripts/rekey-v2.ts` before
+ * this commit was deployed.
  *
- * After the rekey migration + `--verify` passes in every environment, Commit 2
- * of PR-0e removes the legacy branch and the fallback key entirely.
+ * If a legacy value is encountered here it means the rekey migration was not
+ * completed before deploying this commit.  The error message is explicit about
+ * the remediation: roll back this commit and run the rekey migration.
  */
 export function decrypt(ciphertext: string): string {
   if (ciphertext.startsWith(V2_PREFIX)) {
     return decryptV2(ciphertext, getSecret());
   }
-  return decryptLegacy(ciphertext);
+  throw new Error(
+    "[crypto] encountered a legacy (non-v2:) ciphertext after fallback removal. " +
+    "This means the rekey migration was not completed before deploying this commit. " +
+    "Roll back this deploy, run `npx tsx scripts/rekey-v2.ts` until --verify passes " +
+    "in every environment, then re-deploy.",
+  );
 }
 
 /**
- * Returns true if the value is already in the v2: format (i.e. produced by
- * this version of encrypt() or already rekeyed by the migration script).
+ * Returns true if the value is already in the v2: format.
  */
 export function isV2(value: string): boolean {
   return value.startsWith(V2_PREFIX);
 }
-
-/**
- * Exposed for the rekey migration script ONLY.  Do not call from application
- * code.
- *
- * Attempts to decrypt a legacy (non-v2:) ciphertext using a known secret and
- * the static legacy salt.  Throws on auth-tag failure.  The caller (rekey
- * script) is expected to catch the error and try alternative keys.
- */
-export function decryptLegacyWithKey(hex: string, secret: string): string {
-  const buf = Buffer.from(hex, "hex");
-  if (buf.length < LEGACY_HEADER_LEN) {
-    throw new Error("[crypto] legacy ciphertext is too short to be valid");
-  }
-  const iv = buf.subarray(0, 12);
-  const authTag = buf.subarray(12, 28);
-  const payload = buf.subarray(28);
-  const key = deriveKey(secret, LEGACY_SALT);
-  const decipher = createDecipheriv(ALGORITHM, key, iv);
-  decipher.setAuthTag(authTag);
-  return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
-}
-
-/**
- * The dev fallback key — exported for the rekey script so it can try to
- * decrypt values that were written without a real ENCRYPTION_KEY.
- */
-export const DEV_FALLBACK_KEY_EXPORT = DEV_FALLBACK_KEY;

--- a/tests/unit/crypto.test.ts
+++ b/tests/unit/crypto.test.ts
@@ -1,29 +1,32 @@
 /**
- * Unit tests for server/crypto.ts (PR-0e — versioned ciphertext + dual-key rekey)
+ * Unit tests for server/crypto.ts (PR-0e Commit 2 — fallback removed)
  *
- * These tests verify:
+ * This is the Commit 2 version of the test file.  It covers the post-migration
+ * state where:
+ *   - All DB rows are in v2: format (rekey migration has been verified).
+ *   - Legacy (unprefixed) ciphertext is no longer supported — decrypt() throws.
+ *   - The dev-fallback key and decryptLegacyWithKey() have been removed.
+ *
+ * For the Commit 1 tests (dual-key detection, legacy fallback, migration helpers)
+ * see the git history at the Commit 1 SHA.
+ *
+ * Tests:
  *   1. encrypt() produces a `v2:` prefixed string
  *   2. decrypt() round-trips a v2: value correctly
- *   3. decrypt() can still decrypt legacy (unprefixed) values encrypted with the
- *      current key (backward compat — existing rows that were encrypted pre-PR-0e)
- *   4. decrypt() falls back to the dev-fallback key for legacy values (migration
- *      detection — lets the rekey script find and re-encrypt those rows)
- *   5. encrypt() / decrypt() throw when ENCRYPTION_KEY is not configured
- *   6. The rekey migration path is idempotent (v2: values are re-readable)
- *   7. isV2() correctly identifies format
- *   8. decryptLegacyWithKey() is accessible for the rekey script
+ *   3. decrypt() throws for legacy (non-v2:) values (post-migration guard)
+ *   4. encrypt() / decrypt() throw when ENCRYPTION_KEY is not configured
+ *   5. isV2() correctly identifies format
+ *   6. Rekey idempotency (v2: values re-read and re-encrypt cleanly)
  *
  * The configLoader is mocked so these tests work without a running server or
- * any real ENCRYPTION_KEY env var.  To test the "throws when missing" path,
- * the mock returns undefined for the key.
+ * any real ENCRYPTION_KEY env var.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ─── Mock configLoader BEFORE importing crypto ────────────────────────────────
 
 const TEST_KEY_32 = "test-key-32-chars-exactly-paddedX"; // 33 chars, valid (min 32)
-const ALT_KEY_32 = "alternate-key-32-chars-padded-XXX"; // 33 chars
 
 let mockEncryptionKey: string | undefined = TEST_KEY_32;
 
@@ -37,31 +40,7 @@ vi.mock("../../server/config/loader.js", () => ({
 
 // ─── Import AFTER mocks ───────────────────────────────────────────────────────
 
-import {
-  encrypt,
-  decrypt,
-  isV2,
-  decryptLegacyWithKey,
-  DEV_FALLBACK_KEY_EXPORT,
-} from "../../server/crypto.js";
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-/**
- * Produce a legacy-format ciphertext using the internal crypto primitives.
- * This simulates what was stored by the OLD crypto.ts (pre-PR-0e).
- */
-function makeLegacyCiphertext(plaintext: string, secret: string): string {
-  const { createCipheriv, randomBytes, scryptSync } = require("crypto");
-  const SALT = "multiqlti-provider-keys-v1";
-  const KEY_LEN = 32;
-  const key = scryptSync(secret, SALT, KEY_LEN);
-  const iv = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", key, iv);
-  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
-  const authTag = cipher.getAuthTag();
-  return Buffer.concat([iv, authTag, encrypted]).toString("hex");
-}
+import { encrypt, decrypt, isV2 } from "../../server/crypto.js";
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
@@ -116,29 +95,25 @@ describe("decrypt() — v2: round-trip", () => {
   });
 });
 
-describe("decrypt() — legacy backward compatibility", () => {
+describe("decrypt() — legacy guard (post-migration)", () => {
   beforeEach(() => {
     mockEncryptionKey = TEST_KEY_32;
   });
 
-  it("decrypts a legacy (unprefixed) value encrypted with the CURRENT key", () => {
-    const plaintext = "legacy secret value";
-    const legacy = makeLegacyCiphertext(plaintext, TEST_KEY_32);
-    expect(legacy).not.toMatch(/^v2:/);
-    expect(decrypt(legacy)).toBe(plaintext);
+  it("throws for unprefixed (legacy) ciphertext with a helpful error message", () => {
+    // Simulate encountering a row that was NOT migrated before this commit was deployed
+    const fakeHex = Buffer.alloc(60, 0xab).toString("hex"); // not v2: prefixed
+    expect(() => decrypt(fakeHex)).toThrow(/rekey migration/i);
   });
 
-  it("decrypts a legacy value encrypted with the DEV FALLBACK key (migration detection)", () => {
-    // Simulates a prod row written before ENCRYPTION_KEY was configured
-    const plaintext = "value written with fallback key";
-    const legacy = makeLegacyCiphertext(plaintext, DEV_FALLBACK_KEY_EXPORT);
-    expect(decrypt(legacy)).toBe(plaintext);
-  });
-
-  it("throws when a legacy value cannot be decrypted with either key", () => {
-    // Random noise that isn't valid GCM ciphertext for any known key
-    const garbage = Buffer.alloc(60, 0xab).toString("hex");
-    expect(() => decrypt(garbage)).toThrow();
+  it("throws with a rollback instruction when legacy value is encountered", () => {
+    const fakeHex = Buffer.alloc(60, 0xab).toString("hex");
+    const error = (() => {
+      try { decrypt(fakeHex); return null; }
+      catch (e) { return e as Error; }
+    })();
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/rekey-v2\.ts/);
   });
 });
 
@@ -156,63 +131,35 @@ describe("isV2()", () => {
   });
 });
 
-describe("decryptLegacyWithKey() — rekey script helper", () => {
-  beforeEach(() => {
-    mockEncryptionKey = TEST_KEY_32;
-  });
-
-  it("decrypts a legacy value with the correct key", () => {
-    const plaintext = "plaintext for rekey";
-    const legacy = makeLegacyCiphertext(plaintext, TEST_KEY_32);
-    expect(decryptLegacyWithKey(legacy, TEST_KEY_32)).toBe(plaintext);
-  });
-
-  it("throws when given the wrong key", () => {
-    const plaintext = "plaintext for rekey";
-    const legacy = makeLegacyCiphertext(plaintext, TEST_KEY_32);
-    expect(() => decryptLegacyWithKey(legacy, ALT_KEY_32)).toThrow();
-  });
-
-  it("decrypts a fallback-key legacy value with the fallback key", () => {
-    const plaintext = "written with fallback";
-    const legacy = makeLegacyCiphertext(plaintext, DEV_FALLBACK_KEY_EXPORT);
-    expect(decryptLegacyWithKey(legacy, DEV_FALLBACK_KEY_EXPORT)).toBe(plaintext);
-  });
-});
-
 describe("rekey idempotency", () => {
   beforeEach(() => {
     mockEncryptionKey = TEST_KEY_32;
   });
 
-  it("a v2: value is unchanged when re-read after a simulated rekey", () => {
+  it("a v2: value is unchanged when re-read after a rekey pass", () => {
     const plaintext = "idempotent secret";
 
     // Step 1: encrypt (as rekey script would produce)
     const v2Ciphertext = encrypt(plaintext);
     expect(isV2(v2Ciphertext)).toBe(true);
 
-    // Step 2: decrypt the v2: value (simulates a second rekey pass — should be a no-op)
+    // Step 2: decrypt the v2: value (simulates a second rekey pass — a no-op)
     const recovered = decrypt(v2Ciphertext);
     expect(recovered).toBe(plaintext);
 
-    // Step 3: re-encrypting again produces a DIFFERENT ciphertext (new random
-    // salt) but decrypts to the same plaintext (idempotent from the data perspective)
+    // Step 3: re-encrypting again produces a different ciphertext (new random
+    // salt) but decrypts to the same plaintext (idempotent from data perspective)
     const v2Again = encrypt(recovered);
     expect(v2Again).not.toBe(v2Ciphertext); // different random salt
     expect(decrypt(v2Again)).toBe(plaintext);
   });
 
-  it("a legacy value that has been rekeyed is no longer treated as legacy", () => {
-    const plaintext = "pre-migration secret";
-    const legacy = makeLegacyCiphertext(plaintext, TEST_KEY_32);
-    expect(isV2(legacy)).toBe(false);
-
-    // Simulate what the rekey script does: decrypt legacy → re-encrypt as v2:
-    const recovered = decryptLegacyWithKey(legacy, TEST_KEY_32);
-    const rekeyed = encrypt(recovered);
-
-    expect(isV2(rekeyed)).toBe(true);
-    expect(decrypt(rekeyed)).toBe(plaintext);
+  it("each encrypt() call uses a distinct salt (independent key derivation per value)", () => {
+    const plaintext = "check salt independence";
+    const results = Array.from({ length: 5 }, () => encrypt(plaintext));
+    const unique = new Set(results);
+    expect(unique.size).toBe(5); // all different (random salts)
+    // but all decrypt to the same plaintext
+    results.forEach((ct) => expect(decrypt(ct)).toBe(plaintext));
   });
 });

--- a/tests/unit/crypto.test.ts
+++ b/tests/unit/crypto.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for server/crypto.ts (PR-0e — versioned ciphertext + dual-key rekey)
+ *
+ * These tests verify:
+ *   1. encrypt() produces a `v2:` prefixed string
+ *   2. decrypt() round-trips a v2: value correctly
+ *   3. decrypt() can still decrypt legacy (unprefixed) values encrypted with the
+ *      current key (backward compat — existing rows that were encrypted pre-PR-0e)
+ *   4. decrypt() falls back to the dev-fallback key for legacy values (migration
+ *      detection — lets the rekey script find and re-encrypt those rows)
+ *   5. encrypt() / decrypt() throw when ENCRYPTION_KEY is not configured
+ *   6. The rekey migration path is idempotent (v2: values are re-readable)
+ *   7. isV2() correctly identifies format
+ *   8. decryptLegacyWithKey() is accessible for the rekey script
+ *
+ * The configLoader is mocked so these tests work without a running server or
+ * any real ENCRYPTION_KEY env var.  To test the "throws when missing" path,
+ * the mock returns undefined for the key.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ─── Mock configLoader BEFORE importing crypto ────────────────────────────────
+
+const TEST_KEY_32 = "test-key-32-chars-exactly-paddedX"; // 33 chars, valid (min 32)
+const ALT_KEY_32 = "alternate-key-32-chars-padded-XXX"; // 33 chars
+
+let mockEncryptionKey: string | undefined = TEST_KEY_32;
+
+vi.mock("../../server/config/loader.js", () => ({
+  configLoader: {
+    get: () => ({
+      encryption: { key: mockEncryptionKey },
+    }),
+  },
+}));
+
+// ─── Import AFTER mocks ───────────────────────────────────────────────────────
+
+import {
+  encrypt,
+  decrypt,
+  isV2,
+  decryptLegacyWithKey,
+  DEV_FALLBACK_KEY_EXPORT,
+} from "../../server/crypto.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Produce a legacy-format ciphertext using the internal crypto primitives.
+ * This simulates what was stored by the OLD crypto.ts (pre-PR-0e).
+ */
+function makeLegacyCiphertext(plaintext: string, secret: string): string {
+  const { createCipheriv, randomBytes, scryptSync } = require("crypto");
+  const SALT = "multiqlti-provider-keys-v1";
+  const KEY_LEN = 32;
+  const key = scryptSync(secret, SALT, KEY_LEN);
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return Buffer.concat([iv, authTag, encrypted]).toString("hex");
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("encrypt()", () => {
+  beforeEach(() => {
+    mockEncryptionKey = TEST_KEY_32;
+  });
+
+  it("produces a v2: prefixed string", () => {
+    const result = encrypt("hello world");
+    expect(result).toMatch(/^v2:/);
+  });
+
+  it("produces different ciphertexts for the same plaintext (random salt per call)", () => {
+    const a = encrypt("same plaintext");
+    const b = encrypt("same plaintext");
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/^v2:/);
+    expect(b).toMatch(/^v2:/);
+  });
+
+  it("throws when ENCRYPTION_KEY is not configured", () => {
+    mockEncryptionKey = undefined;
+    expect(() => encrypt("anything")).toThrow(/ENCRYPTION_KEY/);
+  });
+});
+
+describe("decrypt() — v2: round-trip", () => {
+  beforeEach(() => {
+    mockEncryptionKey = TEST_KEY_32;
+  });
+
+  it("decrypts a value produced by encrypt()", () => {
+    const plaintext = "super secret api key";
+    const ciphertext = encrypt(plaintext);
+    expect(decrypt(ciphertext)).toBe(plaintext);
+  });
+
+  it("handles unicode and long values", () => {
+    const plaintext = "日本語テスト — with emoji 🔐 — " + "x".repeat(500);
+    expect(decrypt(encrypt(plaintext))).toBe(plaintext);
+  });
+
+  it("throws on a corrupted v2: payload", () => {
+    expect(() => decrypt("v2:deadbeef")).toThrow();
+  });
+
+  it("throws when ENCRYPTION_KEY is not configured", () => {
+    const ciphertext = encrypt("something");
+    mockEncryptionKey = undefined;
+    expect(() => decrypt(ciphertext)).toThrow(/ENCRYPTION_KEY/);
+  });
+});
+
+describe("decrypt() — legacy backward compatibility", () => {
+  beforeEach(() => {
+    mockEncryptionKey = TEST_KEY_32;
+  });
+
+  it("decrypts a legacy (unprefixed) value encrypted with the CURRENT key", () => {
+    const plaintext = "legacy secret value";
+    const legacy = makeLegacyCiphertext(plaintext, TEST_KEY_32);
+    expect(legacy).not.toMatch(/^v2:/);
+    expect(decrypt(legacy)).toBe(plaintext);
+  });
+
+  it("decrypts a legacy value encrypted with the DEV FALLBACK key (migration detection)", () => {
+    // Simulates a prod row written before ENCRYPTION_KEY was configured
+    const plaintext = "value written with fallback key";
+    const legacy = makeLegacyCiphertext(plaintext, DEV_FALLBACK_KEY_EXPORT);
+    expect(decrypt(legacy)).toBe(plaintext);
+  });
+
+  it("throws when a legacy value cannot be decrypted with either key", () => {
+    // Random noise that isn't valid GCM ciphertext for any known key
+    const garbage = Buffer.alloc(60, 0xab).toString("hex");
+    expect(() => decrypt(garbage)).toThrow();
+  });
+});
+
+describe("isV2()", () => {
+  it("returns true for v2: prefixed values", () => {
+    expect(isV2("v2:abcdef")).toBe(true);
+  });
+
+  it("returns false for legacy (unprefixed) values", () => {
+    expect(isV2("abcdef1234")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isV2("")).toBe(false);
+  });
+});
+
+describe("decryptLegacyWithKey() — rekey script helper", () => {
+  beforeEach(() => {
+    mockEncryptionKey = TEST_KEY_32;
+  });
+
+  it("decrypts a legacy value with the correct key", () => {
+    const plaintext = "plaintext for rekey";
+    const legacy = makeLegacyCiphertext(plaintext, TEST_KEY_32);
+    expect(decryptLegacyWithKey(legacy, TEST_KEY_32)).toBe(plaintext);
+  });
+
+  it("throws when given the wrong key", () => {
+    const plaintext = "plaintext for rekey";
+    const legacy = makeLegacyCiphertext(plaintext, TEST_KEY_32);
+    expect(() => decryptLegacyWithKey(legacy, ALT_KEY_32)).toThrow();
+  });
+
+  it("decrypts a fallback-key legacy value with the fallback key", () => {
+    const plaintext = "written with fallback";
+    const legacy = makeLegacyCiphertext(plaintext, DEV_FALLBACK_KEY_EXPORT);
+    expect(decryptLegacyWithKey(legacy, DEV_FALLBACK_KEY_EXPORT)).toBe(plaintext);
+  });
+});
+
+describe("rekey idempotency", () => {
+  beforeEach(() => {
+    mockEncryptionKey = TEST_KEY_32;
+  });
+
+  it("a v2: value is unchanged when re-read after a simulated rekey", () => {
+    const plaintext = "idempotent secret";
+
+    // Step 1: encrypt (as rekey script would produce)
+    const v2Ciphertext = encrypt(plaintext);
+    expect(isV2(v2Ciphertext)).toBe(true);
+
+    // Step 2: decrypt the v2: value (simulates a second rekey pass — should be a no-op)
+    const recovered = decrypt(v2Ciphertext);
+    expect(recovered).toBe(plaintext);
+
+    // Step 3: re-encrypting again produces a DIFFERENT ciphertext (new random
+    // salt) but decrypts to the same plaintext (idempotent from the data perspective)
+    const v2Again = encrypt(recovered);
+    expect(v2Again).not.toBe(v2Ciphertext); // different random salt
+    expect(decrypt(v2Again)).toBe(plaintext);
+  });
+
+  it("a legacy value that has been rekeyed is no longer treated as legacy", () => {
+    const plaintext = "pre-migration secret";
+    const legacy = makeLegacyCiphertext(plaintext, TEST_KEY_32);
+    expect(isV2(legacy)).toBe(false);
+
+    // Simulate what the rekey script does: decrypt legacy → re-encrypt as v2:
+    const recovered = decryptLegacyWithKey(legacy, TEST_KEY_32);
+    const rekeyed = encrypt(recovered);
+
+    expect(isV2(rekeyed)).toBe(true);
+    expect(decrypt(rekeyed)).toBe(plaintext);
+  });
+});


### PR DESCRIPTION
## Summary

ADR-001 PR-0e: adds `v2:` ciphertext versioning, a dual-key rekey migration script, and a post-migration fallback-removal commit. Fixes the P0 security issue where a missing `ENCRYPTION_KEY` silently used a public dev default (`dev-default-insecure-key-change-me!` + static salt = zero security for any row written without a real key).

Closes / relates to ADR-001 (PR #394).

---

## Two-commit, two-deploy structure

This PR contains **two commits that must be deployed separately**.

### Commit 1 — `feat(security): versioned ciphertext v2: + dual-key rekey migration`
Safe to deploy at any time. Rolling forward does not break existing rows.

What it does:
- `encrypt()` now prefixes output with `v2:` and embeds a **32-byte random salt** per value, so each ciphertext uses independently derived key material.
- `decrypt()` dispatches on prefix: `v2:` → current key + embedded salt; bare (legacy) → tries current key (static salt) then the hardcoded dev fallback, so the rekey script can detect and re-encrypt rows written without a real key.
- `getSecret()` **throws** if `ENCRYPTION_KEY` / `MULTI_ENCRYPTION_KEY` is unset. No more silent dev fallback for new writes.
- New script `scripts/rekey-v2.ts` with `--dry-run`, live, and `--verify` modes.

### Commit 2 — `fix(security): remove insecure dev fallback, require ENCRYPTION_KEY`
**DO NOT deploy until the rekey migration + `--verify` passes in every environment.**

What it does:
- Removes `decryptLegacy` fallback branch, `DEV_FALLBACK_KEY`, `LEGACY_SALT`, `decryptLegacyWithKey`, and `DEV_FALLBACK_KEY_EXPORT`.
- `decrypt()` now throws immediately on any non-`v2:` value with an actionable error message pointing to `rekey-v2.ts`.
- Updated tests to match post-migration API.

---

## v2: ciphertext format

```
"v2:" + hex(salt[32] | iv[12] | authTag[16] | ciphertext[n])
```

- `salt` — 32 random bytes, unique per value. Key is derived as `scrypt(secret, salt.hex(), 32)`.
- `iv` — 12-byte AES-GCM nonce.
- `authTag` — 16-byte GCM auth tag.
- Total overhead vs legacy: +32 bytes (salt) + `"v2:"` prefix.

Legacy format (backward-compat, Commit 1 only): `hex(iv[12] | authTag[16] | ciphertext[n])`, key derived from static `LEGACY_SALT`.

---

## Rekey migration deploy sequence (per ADR-001 §4)

```
1. Deploy Commit 1.
2. For each environment (dev → staging → prod):
   a. DATABASE_URL=... ENCRYPTION_KEY=... npx tsx scripts/rekey-v2.ts --dry-run
   b. DATABASE_URL=... ENCRYPTION_KEY=... npx tsx scripts/rekey-v2.ts
   c. DATABASE_URL=... ENCRYPTION_KEY=... npx tsx scripts/rekey-v2.ts --verify
      # must exit 0 — zero non-v2: rows — before proceeding
3. ONLY after step 2c passes in ALL environments: deploy Commit 2.
```

The script is idempotent: already-`v2:`-prefixed rows are skipped. Re-running is safe.

---

## Encrypted columns covered

| Column | Table | Notes |
|--------|-------|-------|
| `api_key_encrypted` | `provider_keys` | LLM provider API keys |
| `encrypted_pat` | `git_skill_sources` | GitHub/GitLab PATs |
| `token_enc` | `argocd_config` | ArgoCD bearer token |
| `secrets_encrypted` | `workspace_connections` | JSON blob of workspace secrets |
| `api_token` | `tracker_connections` | Jira/Linear tokens (will be encrypted after PR-0d) |
| `auth_token_enc` | `remote_agents` | Remote agent bearer tokens (will be encrypted after PR-0d) |

---

## trigger-crypto.ts decision

`server/services/trigger-crypto.ts` uses a **separate key** (`TRIGGER_SECRET_KEY`) with a different ciphertext format: no static salt, raw 32-byte hex key, no insecure fallback, already throws on missing key. It was not touched in this PR. `triggers.secret_encrypted` rows are **out of scope** for `rekey-v2.ts` — migrate them separately if/when trigger-crypto gains a versioned format.

---

## Static salt decision

The legacy `LEGACY_SALT = "multiqlti-provider-keys-v1"` is kept in Commit 1 solely for backward-compatible decryption of existing rows. The `v2:` format replaces it with per-value random salts. Combined with the now-mandatory `ENCRYPTION_KEY`, this means:

- Any existing row encrypted with a real (non-fallback) key is still readable post-Commit-1 deploy.
- After rekey migration, all rows use independent key derivation. The static salt code path becomes unreachable and is removed in Commit 2.
- Risk of static salt for pre-migration rows: low if `ENCRYPTION_KEY` was set (attacker still needs the key to brute-force); P0 if the dev fallback was used (public key + static salt = zero security → rekey immediately).

---

## Test results

| Metric | Before | After Commit 1 | After Commit 2 |
|--------|--------|----------------|----------------|
| Test files | 326 | 327 | 327 |
| Tests pass | 5840 | 5858 | 5854 |
| Tests skip | 6 | 6 | 6 |
| tsc | exit 0 | exit 0 | exit 0 |

New test file `tests/unit/crypto.test.ts`:
- Commit 1 (18 tests): v2: round-trip, legacy backward compat, dev-fallback detection, missing-key throw, isV2, decryptLegacyWithKey, idempotency.
- Commit 2 (14 tests): v2: round-trip, missing-key throw, isV2, idempotency, legacy-guard error.

---

## Rollback

- Commit 1 rollback: revert the commit; existing rows still decrypt correctly with the old `decrypt()`.
- Commit 2 rollback: revert to Commit 1 (restores legacy support); any legacy row encountered post-Commit-2 deploy means the rekey was incomplete.