### PR TITLE
test(security): Phase 0f — cross-project isolation tests

### DIFF
--- a/tests/integration/cross-project-http-isolation.test.ts
+++ b/tests/integration/cross-project-http-isolation.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Cross-project HTTP isolation tests (ADR-001 PR-0f, item 4)
+ *
+ * Proves that the `requireProject` middleware correctly enforces project
+ * membership at the HTTP boundary:
+ *
+ *   1. Missing x-project-id → 400 (not duplicated from require-project-middleware.test.ts;
+ *      included here only as a sanity anchor for the test app setup).
+ *   2. Project does not exist → 404.
+ *   3. User is a member of project A but NOT of project B → 403 on project B.
+ *   4. User IS a member (non-owner) of project A → 200, context set to project A.
+ *   5. User IS the owner of project A → 200, context set to project A.
+ *   6. Successful request sets ALS context to the x-project-id value — downstream
+ *      handlers can only see that project's ID (data-isolation proof at context level).
+ *   7. After a 403 on project B, a subsequent valid request for project A succeeds
+ *      and sets context to project A — 403 does NOT corrupt or bleed state.
+ *
+ * Strategy: build a minimal express app mirroring the requireAuth → requireProject
+ * chain.  The db module is mocked so the tests are DB-free; `projects` and
+ * `project_members` table queries return controlled payloads.  The real
+ * requestContext (ALS) and requireProject logic are exercised.
+ *
+ * NOTE: the 400-without-header matrix for every scoped route is already in
+ * tests/integration/require-project-middleware.test.ts.  This file focuses on
+ * the 403 membership case and the data-isolation (context-value) proof.
+ */
+
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import request from "supertest";
+import express from "express";
+import type { Express, Request, Response, NextFunction } from "express";
+import type { User } from "../../shared/types.js";
+
+// ─── Mutable store controlled by tests ────────────────────────────────────────
+//
+// vi.hoisted() ensures these values are available inside the vi.mock() factory
+// (both are hoisted above the module graph).  Tests mutate .value between calls.
+
+const STORE = vi.hoisted(() => ({
+  projectsRows: [] as unknown[],
+  membersRows: [] as unknown[],
+}));
+
+// ─── Mock the db module so requireProject makes no real DB calls ──────────────
+//
+// requireProject calls:
+//   db.select().from(projects).where(…).limit(1)   → determines if project exists + ownerId
+//   db.select().from(projectMembers).where(…).limit(1) → determines if user is a member
+//
+// We route the mock responses by table name (drizzle's BaseName symbol).
+
+vi.mock("../../server/db.js", () => {
+  const TABLE_NAME = Symbol.for("drizzle:BaseName");
+
+  return {
+    db: {
+      select: () => ({
+        from: (table: unknown) => ({
+          where: () => ({
+            limit: () => {
+              const name = (table as Record<symbol, string>)[TABLE_NAME];
+              if (name === "projects") return Promise.resolve(STORE.projectsRows);
+              if (name === "project_members") return Promise.resolve(STORE.membersRows);
+              return Promise.resolve([]);
+            },
+          }),
+        }),
+      }),
+    },
+    pool: { on: () => {} },
+    // withProject / withProjectInsert are not called by requireProject itself —
+    // they are route-handler concerns.  Expose no-op stubs.
+    withProject: (_t: unknown, cond?: unknown) => cond ?? {},
+    withProjectInsert: (_t: unknown, data: unknown) => data,
+    runMigrations: async () => {},
+  };
+});
+
+// ─── Synthetic users ──────────────────────────────────────────────────────────
+
+const USER_A: User = {
+  id: "user-a",
+  email: "a@example.com",
+  name: "User A",
+  isActive: true,
+  role: "user",
+  lastLoginAt: null,
+  createdAt: new Date(0),
+};
+
+// PROJECT_A is owned by USER_A.  USER_A has NO membership in PROJECT_B.
+const PROJECT_A = { id: "proj-a", name: "Project A", ownerId: "user-a", createdAt: new Date(0), updatedAt: new Date(0) };
+const PROJECT_B = { id: "proj-b", name: "Project B", ownerId: "user-b", createdAt: new Date(0), updatedAt: new Date(0) };
+
+/** Injects USER_A as the authenticated user on every request. */
+function injectUserA(req: Request, _res: Response, next: NextFunction) {
+  req.user = USER_A;
+  next();
+}
+
+/** A stub handler that returns the project context it sees — isolation proof. */
+async function contextEchoHandler(req: Request, res: Response) {
+  // Import context here to avoid module-graph issues at test-app build time.
+  const { getProjectId } = await import("../../server/context.js");
+  try {
+    const projectId = getProjectId();
+    res.json({ ok: true, projectId });
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+}
+
+// ─── Build the test express app ───────────────────────────────────────────────
+
+let app: Express;
+
+beforeAll(async () => {
+  const { requireProject } = await import("../../server/middleware/project.js");
+
+  app = express();
+  app.use(express.json());
+  app.use(injectUserA);
+
+  // Mount a scoped router that mirrors the requireAuth → requireProject chain.
+  // The context-echo handler returns the projectId from ALS for isolation verification.
+  const router = express.Router();
+  router.use(requireProject as express.RequestHandler);
+  router.get("/data", contextEchoHandler as express.RequestHandler);
+  app.use("/api/pipelines", router);
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("HTTP middleware — 400 on missing x-project-id (sanity check)", () => {
+  it("scoped route returns 400 when x-project-id header is absent", async () => {
+    const res = await request(app).get("/api/pipelines/data");
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: expect.stringContaining("x-project-id") });
+  });
+});
+
+describe("HTTP middleware — 404 when project does not exist", () => {
+  it("x-project-id refers to a non-existent project → 404", async () => {
+    STORE.projectsRows = []; // empty: project not found
+    STORE.membersRows = [];
+
+    const res = await request(app)
+      .get("/api/pipelines/data")
+      .set("x-project-id", "proj-nonexistent");
+
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({ error: expect.stringContaining("Project not found") });
+  });
+});
+
+describe("HTTP middleware — 403 cross-project membership check", () => {
+  it("user-A (member of proj-a, NOT proj-b) gets 403 when sending x-project-id: proj-b", async () => {
+    // Project B exists, but USER_A is not a member (not an owner either).
+    STORE.projectsRows = [PROJECT_B];
+    STORE.membersRows = []; // USER_A has no membership in proj-b
+
+    const res = await request(app)
+      .get("/api/pipelines/data")
+      .set("x-project-id", "proj-b");
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ error: expect.stringContaining("Access denied") });
+  });
+
+  it("403 response does not leak any of project B's data in the body", async () => {
+    STORE.projectsRows = [PROJECT_B];
+    STORE.membersRows = [];
+
+    const res = await request(app)
+      .get("/api/pipelines/data")
+      .set("x-project-id", "proj-b");
+
+    expect(res.status).toBe(403);
+    // The body must not contain project-B data
+    const body = JSON.stringify(res.body);
+    expect(body).not.toContain("proj-b data");
+    expect(body).not.toContain("proj-b secret");
+  });
+});
+
+describe("HTTP middleware — 200 with valid membership, context set correctly", () => {
+  it("user-A as owner of proj-a gets 200 and ALS context is set to proj-a", async () => {
+    // USER_A owns PROJECT_A → owner branch in requireProject fires.
+    STORE.projectsRows = [PROJECT_A];
+    STORE.membersRows = []; // ownership check succeeds before member check
+
+    const res = await request(app)
+      .get("/api/pipelines/data")
+      .set("x-project-id", "proj-a");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, projectId: "proj-a" });
+  });
+
+  it("user-A as a non-owner member of proj-a gets 200 and ALS context is set to proj-a", async () => {
+    // USER_A is not the owner but is a member (e.g. another user owns the project).
+    const otherUserProject = { ...PROJECT_A, ownerId: "user-c" };
+    STORE.projectsRows = [otherUserProject];
+    STORE.membersRows = [{ projectId: "proj-a", userId: "user-a", role: "editor" }];
+
+    const res = await request(app)
+      .get("/api/pipelines/data")
+      .set("x-project-id", "proj-a");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, projectId: "proj-a" });
+  });
+
+  it("ALS context value matches exactly the x-project-id sent in the header", async () => {
+    STORE.projectsRows = [PROJECT_A];
+    STORE.membersRows = [];
+
+    const res = await request(app)
+      .get("/api/pipelines/data")
+      .set("x-project-id", "proj-a");
+
+    // The handler reads getProjectId() from ALS — must equal the header value.
+    expect(res.body.projectId).toBe("proj-a");
+  });
+});
+
+describe("HTTP middleware — 403 does not corrupt subsequent successful requests", () => {
+  it("after a 403 on proj-b, a valid request for proj-a succeeds with correct context", async () => {
+    // First request: 403 on proj-b
+    STORE.projectsRows = [PROJECT_B];
+    STORE.membersRows = [];
+    const failRes = await request(app)
+      .get("/api/pipelines/data")
+      .set("x-project-id", "proj-b");
+    expect(failRes.status).toBe(403);
+
+    // Second request: 200 on proj-a — context must be proj-a, not contaminated.
+    STORE.projectsRows = [PROJECT_A];
+    STORE.membersRows = [];
+    const successRes = await request(app)
+      .get("/api/pipelines/data")
+      .set("x-project-id", "proj-a");
+    expect(successRes.status).toBe(200);
+    expect(successRes.body.projectId).toBe("proj-a");
+  });
+});

--- a/tests/unit/scoping/db-layer-isolation.test.ts
+++ b/tests/unit/scoping/db-layer-isolation.test.ts
@@ -1,0 +1,328 @@
+/**
+ * DB-layer project scoping — unit tests (ADR-001 PR-0f, items 1-3)
+ *
+ * Proves the isolation contract of `withProject`, `withProjectInsert`,
+ * `runAsProject`, `runAsSystem`, `getProjectId`, and `unscopedSystemQuery`
+ * WITHOUT hitting a real database.  The helpers build Drizzle SQL fragments
+ * and manage ALS context; no query is ever executed here.
+ *
+ * SQL verification uses PgDialect.sqlToQuery() to serialise the Drizzle SQL
+ * expressions returned by `withProject`, confirming the exact project_id
+ * value embedded in the generated WHERE clause.  Two different project
+ * contexts produce two different SQL params — the structural proof that
+ * project A's queries cannot match project B's rows.
+ *
+ * Coverage:
+ *  Group 1 — Fail-closed: no context → throws
+ *  Group 2 — Project context: correct projectId in SQL + in insert data
+ *  Group 3 — Context isolation: nested and concurrent contexts
+ *  Group 4 — System context: getProjectId throws; withProject guards; unscopedSystemQuery
+ *  Group 5 — SQL proof across the three Phase-0c secret tables
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { eq } from "drizzle-orm";
+
+// ─── Mock configLoader before any server module is imported ──────────────────
+// server/db.ts creates a Pool at module load; without this mock configLoader.get()
+// may throw if required env vars are absent in CI.
+
+vi.mock("../../../server/config/loader.js", () => ({
+  configLoader: {
+    get: () => ({
+      database: { url: undefined },
+      server: { nodeEnv: "test", port: 3000 },
+      auth: { jwtSecret: "test-secret-minimum-32-chars-xx", bcryptRounds: 4, sessionTtlDays: 1 },
+      encryption: { key: undefined },
+      providers: {},
+      features: {
+        sandbox: { enabled: false },
+        privacy: { enabled: false },
+        maintenance: { enabled: false, cronSchedule: "" },
+      },
+    }),
+  },
+}));
+
+// ─── Import AFTER mocks ───────────────────────────────────────────────────────
+
+import { withProject, withProjectInsert } from "../../../server/db.js";
+import {
+  runAsProject,
+  runAsSystem,
+  getProjectId,
+  unscopedSystemQuery,
+} from "../../../server/context.js";
+import {
+  providerKeys,
+  argoCdConfig,
+  triggers,
+} from "../../../shared/schema.js";
+import { pgTable, text } from "drizzle-orm/pg-core";
+
+// ─── Helper: serialise a Drizzle SQL fragment to { sql, params } ─────────────
+
+const dialect = new PgDialect();
+
+function toQuery(sql: import("drizzle-orm").SQL): { sql: string; params: unknown[] } {
+  const q = dialect.sqlToQuery(sql);
+  return { sql: q.sql, params: q.params };
+}
+
+// ─── Group 1: Fail-closed — no ALS context → throws ─────────────────────────
+
+describe("Fail-closed: withProject/withProjectInsert throw with no ALS context", () => {
+  it("withProject(providerKeys) throws without a context", () => {
+    expect(() => withProject(providerKeys)).toThrow(
+      /no request context/i,
+    );
+  });
+
+  it("withProject(argoCdConfig) throws without a context", () => {
+    expect(() => withProject(argoCdConfig)).toThrow(
+      /no request context/i,
+    );
+  });
+
+  it("withProject(triggers) throws without a context", () => {
+    expect(() => withProject(triggers)).toThrow(
+      /no request context/i,
+    );
+  });
+
+  it("withProjectInsert(providerKeys, data) throws without a context", () => {
+    expect(() =>
+      withProjectInsert(providerKeys, { provider: "anthropic", apiKeyEncrypted: "enc" }),
+    ).toThrow(/no request context/i);
+  });
+
+  it("getProjectId() throws without a context", () => {
+    expect(() => getProjectId()).toThrow(/no request context/i);
+  });
+});
+
+// ─── Group 2: Project context — correct projectId in SQL and insert data ─────
+
+describe("Project context: withProject generates SQL filtered to the current project", () => {
+  it("under runAsProject('proj-a'), getProjectId() returns 'proj-a'", async () => {
+    const result = await runAsProject("proj-a", async () => getProjectId());
+    expect(result).toBe("proj-a");
+  });
+
+  it("under runAsProject('proj-a'), withProject(providerKeys) embeds project_id='proj-a' in SQL", async () => {
+    const { sql, params } = await runAsProject("proj-a", async () =>
+      toQuery(withProject(providerKeys)),
+    );
+    expect(sql).toMatch(/project_id/);
+    expect(params).toContain("proj-a");
+  });
+
+  it("under runAsProject('proj-b'), withProject(providerKeys) embeds project_id='proj-b' — different from proj-a", async () => {
+    const qA = await runAsProject("proj-a", async () => toQuery(withProject(providerKeys)));
+    const qB = await runAsProject("proj-b", async () => toQuery(withProject(providerKeys)));
+
+    // Both SQL strings are identical in structure, but the params differ.
+    expect(qA.sql).toBe(qB.sql); // same column reference
+    expect(qA.params[0]).toBe("proj-a");
+    expect(qB.params[0]).toBe("proj-b");
+    // The core isolation proof: proj-a param cannot match proj-b rows.
+    expect(qA.params[0]).not.toBe(qB.params[0]);
+  });
+
+  it("withProject(triggers, condition) ANDs the project filter with the given condition", async () => {
+    const condition = eq(triggers.enabled, true);
+    const { sql, params } = await runAsProject("proj-x", async () =>
+      toQuery(withProject(triggers, condition)),
+    );
+    // Both the project_id filter AND the additional condition must appear.
+    expect(sql).toMatch(/project_id/);
+    expect(params).toContain("proj-x");
+    // The enabled=true param should also be present (ANDed condition).
+    expect(params).toContain(true);
+  });
+
+  it("under runAsProject('proj-a'), withProjectInsert stamps projectId='proj-a'", async () => {
+    const result = await runAsProject("proj-a", async () =>
+      withProjectInsert(providerKeys, { provider: "anthropic", apiKeyEncrypted: "enc" }),
+    );
+    expect((result as Record<string, unknown>).projectId).toBe("proj-a");
+  });
+
+  it("under runAsProject('proj-b'), withProjectInsert stamps projectId='proj-b'", async () => {
+    const result = await runAsProject("proj-b", async () =>
+      withProjectInsert(providerKeys, { provider: "openai", apiKeyEncrypted: "enc2" }),
+    );
+    expect((result as Record<string, unknown>).projectId).toBe("proj-b");
+  });
+
+  it("withProjectInsert stamping is specific to the context — proj-a vs proj-b differ", async () => {
+    const rA = await runAsProject("proj-a", async () =>
+      withProjectInsert(providerKeys, { provider: "anthropic", apiKeyEncrypted: "x" }),
+    );
+    const rB = await runAsProject("proj-b", async () =>
+      withProjectInsert(providerKeys, { provider: "anthropic", apiKeyEncrypted: "x" }),
+    );
+    expect((rA as Record<string, unknown>).projectId).toBe("proj-a");
+    expect((rB as Record<string, unknown>).projectId).toBe("proj-b");
+  });
+});
+
+// ─── Group 3: Context isolation — nested and concurrent contexts ─────────────
+
+describe("Context isolation: nested and concurrent runAsProject calls", () => {
+  it("inner runAsProject shadows outer; outer resumes correctly after inner completes", async () => {
+    const results: string[] = [];
+
+    await runAsProject("outer-proj", async () => {
+      results.push(getProjectId()); // "outer-proj"
+
+      await runAsProject("inner-proj", async () => {
+        results.push(getProjectId()); // "inner-proj"
+      });
+
+      results.push(getProjectId()); // back to "outer-proj"
+    });
+
+    expect(results).toEqual(["outer-proj", "inner-proj", "outer-proj"]);
+  });
+
+  it("concurrent runAsProject calls each see their own projectId (no ALS bleed)", async () => {
+    // Start two concurrent contexts and collect what each sees.
+    const collected: Record<string, string[]> = { a: [], b: [] };
+
+    await Promise.all([
+      runAsProject("concurrent-a", async () => {
+        // Yield so the two tasks interleave, then read context.
+        await Promise.resolve();
+        collected["a"].push(getProjectId());
+        await Promise.resolve();
+        collected["a"].push(getProjectId());
+      }),
+      runAsProject("concurrent-b", async () => {
+        await Promise.resolve();
+        collected["b"].push(getProjectId());
+        await Promise.resolve();
+        collected["b"].push(getProjectId());
+      }),
+    ]);
+
+    expect(collected["a"]).toEqual(["concurrent-a", "concurrent-a"]);
+    expect(collected["b"]).toEqual(["concurrent-b", "concurrent-b"]);
+  });
+});
+
+// ─── Group 4: System context ──────────────────────────────────────────────────
+
+describe("System context: getProjectId throws; withProject guards", () => {
+  it("under runAsSystem, getProjectId() throws (structural barrier against project-scoped reads)", async () => {
+    await runAsSystem("test-audit-reason", async () => {
+      expect(() => getProjectId()).toThrow(/system context/i);
+    });
+  });
+
+  it("under runAsSystem, withProject(providerKeys) with NO condition throws", async () => {
+    // System context cannot read all project rows silently through withProject.
+    await runAsSystem("test-no-condition", async () => {
+      expect(() => withProject(providerKeys)).toThrow(/system context.*WHERE condition/i);
+    });
+  });
+
+  it("under runAsSystem, withProject(argoCdConfig) with NO condition throws", async () => {
+    // argoCdConfig.getArgoCdConfig() uses withProject(argoCdConfig) — so calling it
+    // in system context throws, proving system code cannot read per-project ArgoCD secrets.
+    await runAsSystem("test-argocd-guard", async () => {
+      expect(() => withProject(argoCdConfig)).toThrow(/system context.*WHERE condition/i);
+    });
+  });
+
+  it("under runAsSystem, withProject(table, condition) returns condition WITHOUT project filter", async () => {
+    // When a condition is explicitly provided, system context is permitted to make
+    // a cross-project read (audited by runAsSystem's reason).  The returned SQL must
+    // NOT contain a project_id filter — it is a cross-project query by design.
+    const condition = eq(triggers.enabled, true);
+
+    const { sql, params } = await runAsSystem("test-cross-project-read", async () =>
+      toQuery(withProject(triggers, condition)),
+    );
+
+    // The condition itself is returned as-is — no project_id filter injected.
+    expect(sql).not.toMatch(/project_id/);
+    // Only the condition's own params are present (enabled = true).
+    expect(params).toContain(true);
+    // Notably: no "proj-xxx" string in params, confirming no project filter was added.
+    expect(params.some((p) => typeof p === "string" && p.startsWith("proj"))).toBe(false);
+  });
+
+  it("under runAsSystem, withProjectInsert stamps projectId=null (globally shared row)", async () => {
+    const result = await runAsSystem("test-global-insert", async () =>
+      withProjectInsert(providerKeys, { provider: "builtin", apiKeyEncrypted: "x" }),
+    );
+    expect((result as Record<string, unknown>).projectId).toBeNull();
+  });
+
+  it("unscopedSystemQuery throws when called OUTSIDE a runAsSystem context", async () => {
+    await expect(
+      unscopedSystemQuery("test-label", async () => "should not run"),
+    ).rejects.toThrow(/outside system context/i);
+  });
+
+  it("unscopedSystemQuery throws when called inside runAsProject (not system context)", async () => {
+    await runAsProject("proj-a", async () => {
+      await expect(
+        unscopedSystemQuery("test-label", async () => "should not run"),
+      ).rejects.toThrow(/outside system context/i);
+    });
+  });
+
+  it("unscopedSystemQuery runs the query inside runAsSystem", async () => {
+    const value = await runAsSystem("test-unscoped-query", async () =>
+      unscopedSystemQuery("test-label", async () => "cross-project-result"),
+    );
+    expect(value).toBe("cross-project-result");
+  });
+});
+
+// ─── Group 5: SQL proof across the three Phase-0c secret tables ─────────────
+
+describe("SQL proof: all three Phase-0c secret tables carry the project filter", () => {
+  const PROJECT_ID = "proj-phase0c";
+
+  it("providerKeys: withProject generates SQL filtering on provider_keys.project_id", async () => {
+    const { sql, params } = await runAsProject(PROJECT_ID, async () =>
+      toQuery(withProject(providerKeys)),
+    );
+    expect(sql).toMatch(/"provider_keys"\."project_id"/);
+    expect(params[0]).toBe(PROJECT_ID);
+  });
+
+  it("argoCdConfig: withProject generates SQL filtering on argocd_config.project_id", async () => {
+    const { sql, params } = await runAsProject(PROJECT_ID, async () =>
+      toQuery(withProject(argoCdConfig)),
+    );
+    expect(sql).toMatch(/"argocd_config"\."project_id"/);
+    expect(params[0]).toBe(PROJECT_ID);
+  });
+
+  it("triggers: withProject generates SQL filtering on triggers.project_id", async () => {
+    const condition = eq(triggers.pipelineId, "pipe-1");
+    const { sql, params } = await runAsProject(PROJECT_ID, async () =>
+      toQuery(withProject(triggers, condition)),
+    );
+    expect(sql).toMatch(/"triggers"\."project_id"/);
+    expect(params).toContain(PROJECT_ID);
+  });
+
+  it("withProject on a table WITHOUT projectId column throws — prevents accidental unscoped access", async () => {
+    // A table that was not yet migrated (no projectId column) must be rejected
+    // at development/test time, not silently bypass isolation.
+    const unmigratedTable = pgTable("legacy_table", {
+      id: text("id").primaryKey(),
+    });
+
+    // Verify the column guard fires when the table lacks projectId.
+    await expect(
+      runAsProject("proj-guard", async () => withProject(unmigratedTable as any)),
+    ).rejects.toThrow(/no "projectId" column/);
+  });
+});


### PR DESCRIPTION
## Summary

Cross-project isolation tests for ADR-001 Phase 0f, running against the combined Phase-0 branch (0a+0b+0c+0d+0e merged into `feature/phase0-integration`).

References ADR-001 PR #394.

---

## What each test proves

### `tests/unit/scoping/db-layer-isolation.test.ts` — 26 tests, zero DB

**Group 1 — Fail-closed (5 tests)**
`withProject`, `withProjectInsert`, and `getProjectId` all throw with the `no request context` message when called with no ALS context. Any background path that forgets to call `runAsProject` or `runAsSystem` will fail immediately with a clear error, not silently bypass isolation.

**Group 2 — Project context SQL correctness (7 tests)**
`PgDialect.sqlToQuery()` serialises the Drizzle `SQL` fragment returned by `withProject`. Under `runAsProject("proj-a")` the params contain `"proj-a"`; under `runAsProject("proj-b")` they contain `"proj-b"`. The two param arrays differ — the structural proof that an SQL query built in project A's context cannot match project B's rows (different `project_id` value in the WHERE clause). `withProjectInsert` stamps the identical `projectId` value onto insert data.

**Group 3 — Context isolation (2 tests)**
Nested `runAsProject` calls shadow the outer context and restore it correctly on return. Concurrent `runAsProject` calls (via `Promise.all`) each see only their own `projectId` — ALS prevents cross-task bleed.

**Group 4 — System context (8 tests)**
`runAsSystem` establishes a context where `getProjectId()` throws unconditionally (structural barrier). `withProject(table)` with no condition also throws under system context — therefore storage methods like `getArgoCdConfig()` (which internally call `withProject(argoCdConfig)`) will throw if mistakenly called in system context, preventing silent cross-project reads of secret rows. `withProject(table, condition)` under system context returns the condition **without** a project_id filter (audited cross-project read, as designed). `unscopedSystemQuery` enforces system context on entry.

**Group 5 — SQL proof across Phase-0c secret tables (4 tests)**
All three tables that gained `projectId` in PR-0c — `provider_keys`, `argocd_config`, `triggers` — produce a `"<table>"."project_id" = $1` fragment via `withProject`. A table without a `projectId` column throws rather than producing an unscoped query.

---

### `tests/integration/cross-project-http-isolation.test.ts` — 8 tests, DB-free

**400 / 404 anchors (2 tests)**
Missing `x-project-id` → 400. Non-existent project → 404.

**403 cross-project membership (2 tests)**
User-A is not a member of project-B. `requireProject` returns 403 and the response body contains no project-B data.

**200 with correct ALS context (3 tests)**
Owner access and member (non-owner) access both succeed and return 200. The stub handler reads `getProjectId()` from ALS and returns it in the response — its value must equal the `x-project-id` header, proving the middleware sets up the right project context for downstream handlers.

**Context integrity after 403 (1 test)**
A 403 on project-B followed by a valid request for project-A succeeds and sets context to `proj-a`. A rejected request cannot corrupt the ALS context for subsequent requests.

---

## DB-layer harness approach

No `pglite`, no testcontainers, no `DATABASE_URL` required.

- The unit tests call `withProject` and `withProjectInsert` directly (they return Drizzle `SQL` fragments / plain objects; no query is executed). `PgDialect.sqlToQuery()` from `drizzle-orm/pg-core` serialises the fragments for assertion.
- The integration tests mock `server/db.js` via `vi.hoisted` + `vi.mock` so `requireProject`'s `db.select()` calls return controlled payloads. The real `requestContext` ALS and `requireProject` middleware logic run without modification.

**Limitation**: the unit tests prove that the WHERE clause carries the correct `project_id = $projectId` value, but do not verify that a real Postgres query would actually filter rows correctly. That verification requires a real DB (or pglite, which is not installed) and is out of scope for this PR.

---

## Results

```
tsc --noEmit: exit 0
vitest run tests/unit/scoping/db-layer-isolation.test.ts: 26/26 passed
vitest run tests/integration/cross-project-http-isolation.test.ts: 8/8 passed
vitest run --exclude '**/config-sync/**': 330 files / 5931 tests passed, 6 skipped
```

This branch sits on top of `feature/phase0-integration` (which merges 0a+0b+0c+0d+0e). The diff against the base is the two test files only.