### PR TITLE
feat(security): Phase 0 — per-project secrets isolation (adversarial-review-fixed)

### DIFF
--- a/migrations/0027_phase0c_projectid_secret_tables.sql
+++ b/migrations/0027_phase0c_projectid_secret_tables.sql
@@ -1,0 +1,209 @@
+-- migration: 0027_phase0c_projectid_secret_tables
+-- ADR-001 Phase 0c — per-project scoping for the remaining secret/config tables.
+--
+-- Tables modified:
+--   provider_keys     — add project_id; swap unique(provider) → unique(project_id, provider)
+--   argocd_config     — add project_id; convert id from fixed-DEFAULT-1 to serial; one row/project
+--   triggers          — add project_id (denormalized from pipelines.project_id via JOIN backfill)
+--   mcp_tool_calls    — add project_id (resolves PR-0a column-not-found gap; backfill from pipeline_runs)
+--
+-- Migration sequence per ADR-001 §5 (backfill-safe pattern):
+--   1. Create sentinel "default" project (operator must reassign later — see note below)
+--   2. Add columns as NULLABLE (safe while legacy rows have no project_id)
+--   3. Backfill all existing rows
+--   4. Set NOT NULL
+--   5. provider_keys: drop old unique(provider) constraint; add unique(project_id, provider)
+--   6. argocd_config: convert id column from fixed DEFAULT 1 to an auto-incrementing sequence
+--
+-- OPERATOR NOTE (sentinel project):
+--   Existing provider_keys and argocd_config rows are assigned to the synthetic
+--   "default" project (id = '__default__'). This keeps the DB constraint valid but
+--   does NOT imply they are correctly scoped to a real user project.
+--
+--   Before enabling hard project isolation (PR-0a fail-closed + PR-0b requireProject),
+--   an operator MUST:
+--     1. Run: SELECT provider FROM provider_keys WHERE project_id = '__default__';
+--     2. Reassign each row to the correct project via UPDATE provider_keys SET project_id = ...
+--     3. Repeat for argocd_config.
+--     4. Acknowledge the inventory by deleting or renaming the sentinel project row.
+--
+--   Failing to reassign will silently expose the default-project credentials to whichever
+--   project context first calls the route (depending on requireProject enforcement).
+--
+-- Idempotent: every step uses IF NOT EXISTS / IF EXISTS / DO NOTHING guards.
+
+-- ─── Step 1: Create sentinel "default" project ─────────────────────────────
+-- Requires at least one user to exist (ownerId FK). We pick the first user by
+-- created_at. If no users exist (fresh DB), the backfill is a no-op anyway.
+
+DO $$
+DECLARE
+  v_owner_id TEXT;
+BEGIN
+  SELECT id INTO v_owner_id FROM users ORDER BY created_at ASC LIMIT 1;
+  IF v_owner_id IS NOT NULL THEN
+    INSERT INTO projects (id, name, description, owner_id, created_at, updated_at)
+    VALUES (
+      '__default__',
+      'Default Project (legacy credentials — operator must reassign)',
+      'Synthetic sentinel project created by migration 0027. Holds global credentials '
+        'that existed before per-project scoping. Operator must reassign rows to real '
+        'projects and remove this entry.',
+      v_owner_id,
+      NOW(),
+      NOW()
+    )
+    ON CONFLICT (id) DO NOTHING;
+  END IF;
+END $$;
+
+-- ─── provider_keys ─────────────────────────────────────────────────────────
+
+-- 2a. Add project_id as nullable
+ALTER TABLE provider_keys
+  ADD COLUMN IF NOT EXISTS project_id TEXT REFERENCES projects(id) ON DELETE CASCADE;
+
+-- 3a. Backfill existing rows with sentinel project
+UPDATE provider_keys
+SET project_id = '__default__'
+WHERE project_id IS NULL;
+
+-- 4a. Set NOT NULL
+ALTER TABLE provider_keys
+  ALTER COLUMN project_id SET NOT NULL;
+
+-- 5a. Drop old single-column unique constraint and add composite one
+--     The old constraint name is provider_keys_provider_unique (Drizzle default).
+ALTER TABLE provider_keys
+  DROP CONSTRAINT IF EXISTS provider_keys_provider_unique;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'provider_keys_project_provider_unique'
+      AND conrelid = 'provider_keys'::regclass
+  ) THEN
+    ALTER TABLE provider_keys
+      ADD CONSTRAINT provider_keys_project_provider_unique
+      UNIQUE (project_id, provider);
+  END IF;
+END $$;
+
+-- ─── argocd_config ─────────────────────────────────────────────────────────
+
+-- 2b. Add project_id as nullable
+ALTER TABLE argocd_config
+  ADD COLUMN IF NOT EXISTS project_id TEXT REFERENCES projects(id) ON DELETE CASCADE;
+
+-- 3b. Backfill existing rows (typically only the singleton id=1 row)
+UPDATE argocd_config
+SET project_id = '__default__'
+WHERE project_id IS NULL;
+
+-- 4b. Set NOT NULL
+ALTER TABLE argocd_config
+  ALTER COLUMN project_id SET NOT NULL;
+
+-- 5b. Add unique(project_id) — one ArgoCD config per project
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'argocd_config_project_unique'
+      AND conrelid = 'argocd_config'::regclass
+  ) THEN
+    ALTER TABLE argocd_config
+      ADD CONSTRAINT argocd_config_project_unique
+      UNIQUE (project_id);
+  END IF;
+END $$;
+
+-- 6b. Convert id from fixed DEFAULT 1 to an auto-incrementing sequence.
+--     This replaces the singleton pattern with a proper surrogate key.
+DO $$
+BEGIN
+  -- Only run if the sequence doesn't exist yet (idempotent)
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_sequences
+    WHERE schemaname = current_schema()
+      AND sequencename = 'argocd_config_id_seq'
+  ) THEN
+    CREATE SEQUENCE argocd_config_id_seq;
+    -- Start the sequence AFTER the current max id (existing row id=1 stays untouched)
+    PERFORM setval('argocd_config_id_seq',
+      COALESCE((SELECT MAX(id) FROM argocd_config), 0) + 1, false);
+    -- Drop the static DEFAULT 1 and attach the sequence
+    ALTER TABLE argocd_config ALTER COLUMN id DROP DEFAULT;
+    ALTER TABLE argocd_config ALTER COLUMN id SET DEFAULT nextval('argocd_config_id_seq');
+    ALTER SEQUENCE argocd_config_id_seq OWNED BY argocd_config.id;
+  END IF;
+END $$;
+
+-- ─── triggers ──────────────────────────────────────────────────────────────
+
+-- 2c. Add project_id as nullable
+ALTER TABLE triggers
+  ADD COLUMN IF NOT EXISTS project_id TEXT REFERENCES projects(id) ON DELETE CASCADE;
+
+-- 3c. Backfill from pipelines.project_id (denormalized — ADR-001 §3.1(e))
+UPDATE triggers t
+SET project_id = p.project_id
+FROM pipelines p
+WHERE t.pipeline_id = p.id
+  AND t.project_id IS NULL
+  AND p.project_id IS NOT NULL;
+
+-- Any triggers whose pipeline has no project_id yet fall back to sentinel
+UPDATE triggers
+SET project_id = '__default__'
+WHERE project_id IS NULL;
+
+-- 4c. Set NOT NULL
+ALTER TABLE triggers
+  ALTER COLUMN project_id SET NOT NULL;
+
+-- Index for project-scoped trigger queries (withProject filter)
+CREATE INDEX IF NOT EXISTS triggers_project_id_idx ON triggers(project_id);
+
+-- ─── mcp_tool_calls ────────────────────────────────────────────────────────
+
+-- 2d. Add project_id as nullable
+ALTER TABLE mcp_tool_calls
+  ADD COLUMN IF NOT EXISTS project_id TEXT REFERENCES projects(id) ON DELETE CASCADE;
+
+-- 3d. Backfill from pipeline_runs.project_id (via pipeline_run_id FK)
+UPDATE mcp_tool_calls mc
+SET project_id = pr.project_id
+FROM pipeline_runs pr
+WHERE mc.pipeline_run_id = pr.id
+  AND mc.project_id IS NULL
+  AND pr.project_id IS NOT NULL;
+
+-- Rows without a pipeline_run_id (or whose run has no project_id) use sentinel
+UPDATE mcp_tool_calls
+SET project_id = '__default__'
+WHERE project_id IS NULL;
+
+-- 4d. Set NOT NULL
+ALTER TABLE mcp_tool_calls
+  ALTER COLUMN project_id SET NOT NULL;
+
+-- Index for project-scoped tool-call queries (withProject filter)
+CREATE INDEX IF NOT EXISTS mcp_tool_calls_project_id_idx ON mcp_tool_calls(project_id);
+
+-- ─── Rollback (for reference — not auto-applied) ───────────────────────────
+--
+--   ALTER TABLE mcp_tool_calls DROP COLUMN IF EXISTS project_id;
+--   ALTER TABLE triggers DROP COLUMN IF EXISTS project_id;
+--
+--   ALTER TABLE argocd_config DROP CONSTRAINT IF EXISTS argocd_config_project_unique;
+--   ALTER TABLE argocd_config DROP COLUMN IF EXISTS project_id;
+--   ALTER TABLE argocd_config ALTER COLUMN id SET DEFAULT 1;
+--   DROP SEQUENCE IF EXISTS argocd_config_id_seq;
+--
+--   ALTER TABLE provider_keys DROP CONSTRAINT IF EXISTS provider_keys_project_provider_unique;
+--   ALTER TABLE provider_keys DROP COLUMN IF EXISTS project_id;
+--   ALTER TABLE provider_keys ADD CONSTRAINT provider_keys_provider_unique UNIQUE (provider);
+--
+--   DELETE FROM projects WHERE id = '__default__';

--- a/migrations/0027_phase0c_projectid_secret_tables.sql
+++ b/migrations/0027_phase0c_projectid_secret_tables.sql
@@ -7,55 +7,79 @@
 --   triggers          — add project_id (denormalized from pipelines.project_id via JOIN backfill)
 --   mcp_tool_calls    — add project_id (resolves PR-0a column-not-found gap; backfill from pipeline_runs)
 --
+-- HOW TO APPLY (push-based deploy) — MANDATORY ORDERING:
+--   1. Run this file FIRST (handles add-nullable → backfill → SET NOT NULL):
+--        psql "$DATABASE_URL" -f migrations/0027_phase0c_projectid_secret_tables.sql
+--   2. Then run: psql "$DATABASE_URL" -f migrations/0028_phase0d_clean_argocd_env.sql
+--   3. THEN run `npm run db:push` (drizzle-kit push) to sync schema.ts.
+--      schema.ts declares .notNull() on the four projectId columns; since the DB
+--      already has NOT NULL after step 1, push is a no-op for those constraints.
+--   Running db:push BEFORE step 1 fails on populated tables (no backfill yet).
+--
 -- Migration sequence per ADR-001 §5 (backfill-safe pattern):
---   1. Create sentinel "default" project (operator must reassign later — see note below)
+--   1. Create __system__ user (permanent owner) + __default__ sentinel project
 --   2. Add columns as NULLABLE (safe while legacy rows have no project_id)
 --   3. Backfill all existing rows
 --   4. Set NOT NULL
---   5. provider_keys: drop old unique(provider) constraint; add unique(project_id, provider)
---   6. argocd_config: convert id column from fixed DEFAULT 1 to an auto-incrementing sequence
+--   5. provider_keys: drop old unique(provider); add unique(project_id, provider)
+--   6. argocd_config: convert id from fixed DEFAULT 1 to an auto-incrementing sequence
 --
--- OPERATOR NOTE (sentinel project):
---   Existing provider_keys and argocd_config rows are assigned to the synthetic
---   "default" project (id = '__default__'). This keeps the DB constraint valid but
---   does NOT imply they are correctly scoped to a real user project.
+-- R3-HIGH SENTINEL CASCADE FIX:
+--   The __default__ project is owned by the __system__ user — a permanent internal
+--   user row that is NEVER deleted.  The original design tied ownership to the first
+--   real user (ORDER BY created_at); a GDPR/user-purge of that user would cascade-
+--   delete the sentinel project and all legacy provider_keys / argocd_config rows.
+--   With __system__ as owner, user deletions cannot reach the sentinel project.
+--   The __system__ user has is_active=FALSE so it CANNOT authenticate.
+--   Operators MUST NOT delete the __system__ user row.
 --
---   Before enabling hard project isolation (PR-0a fail-closed + PR-0b requireProject),
+-- OPERATOR NOTE (sentinel project reassignment):
+--   Existing provider_keys and argocd_config rows are assigned to '__default__'.
+--   Before enabling hard project isolation (PR-0a fail-closed + PR-0b requireProject)
 --   an operator MUST:
---     1. Run: SELECT provider FROM provider_keys WHERE project_id = '__default__';
---     2. Reassign each row to the correct project via UPDATE provider_keys SET project_id = ...
+--     1. SELECT provider FROM provider_keys WHERE project_id = '__default__';
+--     2. Reassign each row: UPDATE provider_keys SET project_id = '<real-id>' WHERE ...
 --     3. Repeat for argocd_config.
---     4. Acknowledge the inventory by deleting or renaming the sentinel project row.
---
---   Failing to reassign will silently expose the default-project credentials to whichever
---   project context first calls the route (depending on requireProject enforcement).
+--     4. Acknowledge by deleting or renaming the __default__ project row.
 --
 -- Idempotent: every step uses IF NOT EXISTS / IF EXISTS / DO NOTHING guards.
+-- Transactional: entire file runs in BEGIN/COMMIT — partial failure rolls back all.
 
--- ─── Step 1: Create sentinel "default" project ─────────────────────────────
--- Requires at least one user to exist (ownerId FK). We pick the first user by
--- created_at. If no users exist (fresh DB), the backfill is a no-op anyway.
+BEGIN;
+
+-- ─── Step 1: Create __system__ user + sentinel __default__ project ──────────
+--
+-- __system__ is permanent. GDPR/user-purge operations MUST NOT delete it.
+-- is_active=FALSE prevents login. Epoch timestamp makes it clearly synthetic.
 
 DO $$
-DECLARE
-  v_owner_id TEXT;
 BEGIN
-  SELECT id INTO v_owner_id FROM users ORDER BY created_at ASC LIMIT 1;
-  IF v_owner_id IS NOT NULL THEN
-    INSERT INTO projects (id, name, description, owner_id, created_at, updated_at)
+  IF NOT EXISTS (SELECT 1 FROM users WHERE id = '__system__') THEN
+    INSERT INTO users (id, email, name, is_active, role, created_at, updated_at)
     VALUES (
-      '__default__',
-      'Default Project (legacy credentials — operator must reassign)',
-      'Synthetic sentinel project created by migration 0027. Holds global credentials '
-        'that existed before per-project scoping. Operator must reassign rows to real '
-        'projects and remove this entry.',
-      v_owner_id,
-      NOW(),
-      NOW()
-    )
-    ON CONFLICT (id) DO NOTHING;
+      '__system__',
+      'system@internal.multiqlti',
+      'System',
+      FALSE,
+      'user',
+      TIMESTAMPTZ '1970-01-01 00:00:00+00',
+      TIMESTAMPTZ '1970-01-01 00:00:00+00'
+    );
   END IF;
 END $$;
+
+INSERT INTO projects (id, name, description, owner_id, created_at, updated_at)
+VALUES (
+  '__default__',
+  'Default Project (legacy credentials — operator must reassign)',
+  'Synthetic sentinel project created by migration 0027. Holds global credentials '
+    'that existed before per-project scoping. Operator must reassign rows to real '
+    'projects and remove this entry. Owner is __system__ (permanent; never delete).',
+  '__system__',
+  NOW(),
+  NOW()
+)
+ON CONFLICT (id) DO NOTHING;
 
 -- ─── provider_keys ─────────────────────────────────────────────────────────
 
@@ -72,7 +96,7 @@ WHERE project_id IS NULL;
 ALTER TABLE provider_keys
   ALTER COLUMN project_id SET NOT NULL;
 
--- 5a. Drop old single-column unique constraint and add composite one
+-- 5a. Drop old single-column unique constraint; add composite constraint.
 --     The old constraint name is provider_keys_provider_unique (Drizzle default).
 ALTER TABLE provider_keys
   DROP CONSTRAINT IF EXISTS provider_keys_provider_unique;
@@ -120,20 +144,16 @@ BEGIN
 END $$;
 
 -- 6b. Convert id from fixed DEFAULT 1 to an auto-incrementing sequence.
---     This replaces the singleton pattern with a proper surrogate key.
 DO $$
 BEGIN
-  -- Only run if the sequence doesn't exist yet (idempotent)
   IF NOT EXISTS (
     SELECT 1 FROM pg_sequences
     WHERE schemaname = current_schema()
       AND sequencename = 'argocd_config_id_seq'
   ) THEN
     CREATE SEQUENCE argocd_config_id_seq;
-    -- Start the sequence AFTER the current max id (existing row id=1 stays untouched)
     PERFORM setval('argocd_config_id_seq',
       COALESCE((SELECT MAX(id) FROM argocd_config), 0) + 1, false);
-    -- Drop the static DEFAULT 1 and attach the sequence
     ALTER TABLE argocd_config ALTER COLUMN id DROP DEFAULT;
     ALTER TABLE argocd_config ALTER COLUMN id SET DEFAULT nextval('argocd_config_id_seq');
     ALTER SEQUENCE argocd_config_id_seq OWNED BY argocd_config.id;
@@ -154,7 +174,7 @@ WHERE t.pipeline_id = p.id
   AND t.project_id IS NULL
   AND p.project_id IS NOT NULL;
 
--- Any triggers whose pipeline has no project_id yet fall back to sentinel
+-- Triggers whose pipeline has no project_id fall back to sentinel
 UPDATE triggers
 SET project_id = '__default__'
 WHERE project_id IS NULL;
@@ -163,7 +183,6 @@ WHERE project_id IS NULL;
 ALTER TABLE triggers
   ALTER COLUMN project_id SET NOT NULL;
 
--- Index for project-scoped trigger queries (withProject filter)
 CREATE INDEX IF NOT EXISTS triggers_project_id_idx ON triggers(project_id);
 
 -- ─── mcp_tool_calls ────────────────────────────────────────────────────────
@@ -180,7 +199,7 @@ WHERE mc.pipeline_run_id = pr.id
   AND mc.project_id IS NULL
   AND pr.project_id IS NOT NULL;
 
--- Rows without a pipeline_run_id (or whose run has no project_id) use sentinel
+-- Rows without a pipeline_run_id or with no project_id on the run use sentinel
 UPDATE mcp_tool_calls
 SET project_id = '__default__'
 WHERE project_id IS NULL;
@@ -189,21 +208,22 @@ WHERE project_id IS NULL;
 ALTER TABLE mcp_tool_calls
   ALTER COLUMN project_id SET NOT NULL;
 
--- Index for project-scoped tool-call queries (withProject filter)
 CREATE INDEX IF NOT EXISTS mcp_tool_calls_project_id_idx ON mcp_tool_calls(project_id);
+
+COMMIT;
 
 -- ─── Rollback (for reference — not auto-applied) ───────────────────────────
 --
+--   BEGIN;
 --   ALTER TABLE mcp_tool_calls DROP COLUMN IF EXISTS project_id;
 --   ALTER TABLE triggers DROP COLUMN IF EXISTS project_id;
---
 --   ALTER TABLE argocd_config DROP CONSTRAINT IF EXISTS argocd_config_project_unique;
 --   ALTER TABLE argocd_config DROP COLUMN IF EXISTS project_id;
 --   ALTER TABLE argocd_config ALTER COLUMN id SET DEFAULT 1;
 --   DROP SEQUENCE IF EXISTS argocd_config_id_seq;
---
 --   ALTER TABLE provider_keys DROP CONSTRAINT IF EXISTS provider_keys_project_provider_unique;
 --   ALTER TABLE provider_keys DROP COLUMN IF EXISTS project_id;
 --   ALTER TABLE provider_keys ADD CONSTRAINT provider_keys_provider_unique UNIQUE (provider);
---
 --   DELETE FROM projects WHERE id = '__default__';
+--   DELETE FROM users WHERE id = '__system__';
+--   COMMIT;

--- a/migrations/0027_phase0d_clean_argocd_env.sql
+++ b/migrations/0027_phase0d_clean_argocd_env.sql
@@ -1,0 +1,40 @@
+-- Phase 0d: Remove plaintext ARGOCD_TOKEN from mcp_servers.env JSONB.
+--
+-- Background: server/routes/argocd-settings.ts previously wrote the decrypted
+-- ArgoCD token directly into the `env` JSONB column of the argocd MCP server
+-- row.  This was a plaintext secret leak; the column is now left without the
+-- token (the encrypted copy lives in argocd_config.token_enc).
+--
+-- This migration is idempotent: the `-` operator is a no-op when the key is
+-- absent.  It is safe to run multiple times.
+--
+-- Run before restarting the application with the Phase-0d code:
+--   psql "$DATABASE_URL" -f migrations/0027_phase0d_clean_argocd_env.sql
+--   -- or --
+--   npx drizzle-kit migrate  (if this file is applied via drizzle migrate)
+--
+-- After running, verify with:
+--   SELECT id, env FROM mcp_servers WHERE env ? 'ARGOCD_TOKEN';
+--   -- should return 0 rows
+
+UPDATE mcp_servers
+SET    env = env - 'ARGOCD_TOKEN'
+WHERE  env ? 'ARGOCD_TOKEN';
+
+-- Belt-and-suspenders: also strip any other secret-shaped keys that should
+-- never reside in this column (TOKEN, SECRET, KEY, PASSWORD, CREDENTIAL).
+-- These patterns match top-level JSONB keys only.
+UPDATE mcp_servers
+SET    env = (
+  SELECT jsonb_object_agg(k, v)
+  FROM   jsonb_each(env) AS kv(k, v)
+  WHERE  k !~* 'TOKEN|SECRET|PASSWORD|CREDENTIAL'
+    AND  k !~* '^API_KEY$|_API_KEY$|^APIKEY$'
+)
+WHERE  env IS NOT NULL
+  AND  EXISTS (
+    SELECT 1
+    FROM   jsonb_object_keys(env) k
+    WHERE  k ~* 'TOKEN|SECRET|PASSWORD|CREDENTIAL'
+       OR  k ~* '^API_KEY$|_API_KEY$|^APIKEY$'
+  );

--- a/migrations/0028_phase0d_clean_argocd_env.sql
+++ b/migrations/0028_phase0d_clean_argocd_env.sql
@@ -1,0 +1,52 @@
+-- migration: 0028_phase0d_clean_argocd_env
+-- (Renamed from 0027_phase0d to 0028_phase0d to avoid collision with 0027_phase0c.
+--  Run AFTER 0027_phase0c_projectid_secret_tables.sql.)
+--
+-- Phase 0d: Remove plaintext ARGOCD_TOKEN from mcp_servers.env JSONB.
+--
+-- Background: server/routes/argocd-settings.ts previously wrote the decrypted
+-- ArgoCD token directly into the `env` JSONB column of the argocd MCP server
+-- row.  This was a plaintext secret leak; the column is now left without the
+-- token (the encrypted copy lives in argocd_config.token_enc).
+--
+-- This migration is idempotent: the `-` operator is a no-op when the key is
+-- absent.  It is safe to run multiple times.
+--
+-- Run before restarting the application with the Phase-0d code:
+--   psql "$DATABASE_URL" -f migrations/0028_phase0d_clean_argocd_env.sql
+--
+-- After running, verify with:
+--   SELECT id, env FROM mcp_servers WHERE env ? 'ARGOCD_TOKEN';
+--   -- should return 0 rows
+--
+-- R3-MED fix: COALESCE around jsonb_object_agg prevents setting env=NULL when
+-- all top-level keys match the secret-shaped pattern.  Without COALESCE, a row
+-- whose env contained ONLY secret keys would have env set to SQL NULL rather
+-- than an empty JSON object.
+
+-- Step 1: Quick targeted removal of ARGOCD_TOKEN specifically (idempotent).
+UPDATE mcp_servers
+SET    env = env - 'ARGOCD_TOKEN'
+WHERE  env ? 'ARGOCD_TOKEN';
+
+-- Step 2: Belt-and-suspenders sweep — strip any remaining secret-shaped top-level
+-- keys (TOKEN, SECRET, KEY, PASSWORD, CREDENTIAL patterns).
+-- COALESCE ensures that if ALL keys are stripped, env is set to '{}' rather than
+-- SQL NULL (which would lose the column value for future updates).
+UPDATE mcp_servers
+SET    env = COALESCE(
+         (
+           SELECT jsonb_object_agg(k, v)
+           FROM   jsonb_each(env) AS kv(k, v)
+           WHERE  k !~* 'TOKEN|SECRET|PASSWORD|CREDENTIAL'
+             AND  k !~* '^API_KEY$|_API_KEY$|^APIKEY$'
+         ),
+         '{}'::jsonb
+       )
+WHERE  env IS NOT NULL
+  AND  EXISTS (
+         SELECT 1
+         FROM   jsonb_object_keys(env) k
+         WHERE  k ~* 'TOKEN|SECRET|PASSWORD|CREDENTIAL'
+            OR  k ~* '^API_KEY$|_API_KEY$|^APIKEY$'
+       );

--- a/scripts/encrypt-existing-secrets.ts
+++ b/scripts/encrypt-existing-secrets.ts
@@ -1,0 +1,169 @@
+/**
+ * Phase 0d — one-time data migration: encrypt plaintext credential fields.
+ *
+ * Affected tables:
+ *   tracker_connections.api_token       — was stored as plaintext; now AES-256-GCM
+ *   remote_agents.auth_token_enc        — was stored as plaintext despite the _enc name
+ *
+ * The ARGOCD_TOKEN cleanup in mcp_servers.env is handled by the companion SQL
+ * migration: migrations/0027_phase0d_clean_argocd_env.sql
+ *
+ * Usage:
+ *   DATABASE_URL=<url> ENCRYPTION_KEY=<key> npx tsx scripts/encrypt-existing-secrets.ts
+ *
+ * Safety:
+ *   - Idempotent: rows that are already valid AES-256-GCM ciphertexts are skipped.
+ *   - Dry-run mode: set DRY_RUN=true to preview without writing.
+ *   - MUST be run with the NEW code deployed (i.e. after this PR merges) so that
+ *     the ENCRYPTION_KEY in the environment is the same key the app will use to
+ *     decrypt.
+ *   - Run ONCE per environment, before restarting the application with the new
+ *     code; if the application starts with the new code before this script runs,
+ *     new rows will be encrypted correctly but old rows will cause decrypt errors
+ *     until this script completes.
+ *
+ * Operational note: after running this script, ROTATE the affected tokens
+ * (Jira API tokens, remote agent bearer tokens) — encryption is not a substitute
+ * for rotation of credentials that were previously stored in plaintext.
+ */
+
+import { drizzle } from "drizzle-orm/node-postgres";
+import pg from "pg";
+import { trackerConnections, remoteAgents } from "../shared/schema.js";
+import { encrypt, decrypt } from "../server/crypto.js";
+import { eq } from "drizzle-orm";
+
+const DRY_RUN = process.env["DRY_RUN"] === "true";
+
+if (!process.env["DATABASE_URL"]) {
+  console.error("DATABASE_URL is required");
+  process.exit(1);
+}
+
+const pool = new pg.Pool({ connectionString: process.env["DATABASE_URL"] });
+const db = drizzle(pool);
+
+/**
+ * Returns true if the value looks like an AES-256-GCM ciphertext produced
+ * by server/crypto.ts:encrypt().
+ *
+ * Format: hex(iv[12] + authTag[16] + ciphertext[N]) — minimum 56 hex chars.
+ * We attempt an actual decrypt as the authoritative check; this heuristic is
+ * just used for logging clarity.
+ */
+function isAlreadyEncrypted(value: string): boolean {
+  // Minimum: 12-byte IV + 16-byte authTag = 28 bytes = 56 hex chars
+  if (value.length < 56) return false;
+  if (!/^[0-9a-f]+$/i.test(value)) return false;
+  try {
+    decrypt(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function encryptTrackerTokens(): Promise<void> {
+  console.log("\n=== tracker_connections.api_token ===");
+
+  const rows = await db
+    .select({ id: trackerConnections.id, apiToken: trackerConnections.apiToken })
+    .from(trackerConnections);
+
+  let skipped = 0;
+  let updated = 0;
+  let nullRows = 0;
+
+  for (const row of rows) {
+    if (!row.apiToken) {
+      nullRows++;
+      continue;
+    }
+
+    if (isAlreadyEncrypted(row.apiToken)) {
+      console.log(`  [SKIP] ${row.id} — already encrypted`);
+      skipped++;
+      continue;
+    }
+
+    const ciphertext = encrypt(row.apiToken);
+    console.log(`  [${DRY_RUN ? "DRY" : "ENC"}] ${row.id} — encrypting api_token (${row.apiToken.slice(0, 4)}...)`);
+
+    if (!DRY_RUN) {
+      await db
+        .update(trackerConnections)
+        .set({ apiToken: ciphertext })
+        .where(eq(trackerConnections.id, row.id));
+    }
+    updated++;
+  }
+
+  console.log(
+    `  Done: ${updated} encrypted, ${skipped} already-encrypted, ${nullRows} null (no-op).`,
+  );
+}
+
+async function encryptRemoteAgentTokens(): Promise<void> {
+  console.log("\n=== remote_agents.auth_token_enc ===");
+
+  const rows = await db
+    .select({ id: remoteAgents.id, authTokenEnc: remoteAgents.authTokenEnc })
+    .from(remoteAgents);
+
+  let skipped = 0;
+  let updated = 0;
+  let nullRows = 0;
+
+  for (const row of rows) {
+    if (!row.authTokenEnc) {
+      nullRows++;
+      continue;
+    }
+
+    if (isAlreadyEncrypted(row.authTokenEnc)) {
+      console.log(`  [SKIP] ${row.id} — already encrypted`);
+      skipped++;
+      continue;
+    }
+
+    const ciphertext = encrypt(row.authTokenEnc);
+    console.log(`  [${DRY_RUN ? "DRY" : "ENC"}] ${row.id} — encrypting auth_token_enc (${row.authTokenEnc.slice(0, 4)}...)`);
+
+    if (!DRY_RUN) {
+      await db
+        .update(remoteAgents)
+        .set({ authTokenEnc: ciphertext })
+        .where(eq(remoteAgents.id, row.id));
+    }
+    updated++;
+  }
+
+  console.log(
+    `  Done: ${updated} encrypted, ${skipped} already-encrypted, ${nullRows} null (no-op).`,
+  );
+}
+
+async function main(): Promise<void> {
+  if (DRY_RUN) {
+    console.log("DRY_RUN=true — no writes will be made.");
+  }
+
+  try {
+    await encryptTrackerTokens();
+    await encryptRemoteAgentTokens();
+    console.log("\nMigration complete.");
+    console.log(
+      "\nREMINDER: rotate the affected credentials (Jira API tokens, remote-agent bearer tokens).",
+    );
+    console.log(
+      "Also apply: migrations/0027_phase0d_clean_argocd_env.sql (removes ARGOCD_TOKEN from mcp_servers.env).",
+    );
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});

--- a/scripts/encrypt-existing-secrets.ts
+++ b/scripts/encrypt-existing-secrets.ts
@@ -6,13 +6,15 @@
  *   remote_agents.auth_token_enc        — was stored as plaintext despite the _enc name
  *
  * The ARGOCD_TOKEN cleanup in mcp_servers.env is handled by the companion SQL
- * migration: migrations/0027_phase0d_clean_argocd_env.sql
+ * migration: migrations/0028_phase0d_clean_argocd_env.sql
  *
  * Usage:
  *   DATABASE_URL=<url> ENCRYPTION_KEY=<key> npx tsx scripts/encrypt-existing-secrets.ts
  *
  * Safety:
- *   - Idempotent: rows that are already valid AES-256-GCM ciphertexts are skipped.
+ *   - Idempotent: rows already encrypted (v2: prefix OR legacy hex format) are skipped.
+ *     A v2:-prefixed value (produced by scripts/rekey-v2.ts) is detected FIRST,
+ *     preventing double-encryption on a second run (R2-H1 fix).
  *   - Dry-run mode: set DRY_RUN=true to preview without writing.
  *   - MUST be run with the NEW code deployed (i.e. after this PR merges) so that
  *     the ENCRYPTION_KEY in the environment is the same key the app will use to
@@ -30,7 +32,7 @@
 import { drizzle } from "drizzle-orm/node-postgres";
 import pg from "pg";
 import { trackerConnections, remoteAgents } from "../shared/schema.js";
-import { encrypt, decrypt } from "../server/crypto.js";
+import { encrypt, decrypt, isV2 } from "../server/crypto.js";
 import { eq } from "drizzle-orm";
 
 const DRY_RUN = process.env["DRY_RUN"] === "true";
@@ -44,15 +46,23 @@ const pool = new pg.Pool({ connectionString: process.env["DATABASE_URL"] });
 const db = drizzle(pool);
 
 /**
- * Returns true if the value looks like an AES-256-GCM ciphertext produced
- * by server/crypto.ts:encrypt().
+ * Returns true if the value is already encrypted and should be skipped.
  *
- * Format: hex(iv[12] + authTag[16] + ciphertext[N]) — minimum 56 hex chars.
- * We attempt an actual decrypt as the authoritative check; this heuristic is
- * just used for logging clarity.
+ * R2-H1 fix: checks the v2: prefix FIRST. Without this guard a second run
+ * double-encrypts rows already migrated by scripts/rekey-v2.ts, causing
+ * permanent corruption (the v2: prefix fails the hex regex, so `isAlreadyEncrypted`
+ * returned false and `encrypt()` was called again on an already-encrypted value).
+ *
+ * Detection order:
+ *   1. v2: prefix → already in new format → skip immediately
+ *   2. Legacy hex check (≥56 all-hex chars) + decrypt attempt → legacy encrypted → skip
+ *   3. Anything else → plaintext → proceed to encrypt
  */
 function isAlreadyEncrypted(value: string): boolean {
-  // Minimum: 12-byte IV + 16-byte authTag = 28 bytes = 56 hex chars
+  // R2-H1: v2: prefix = already migrated. Skip to prevent double-encrypt.
+  if (isV2(value)) return true;
+
+  // Legacy format: hex(iv[12] + authTag[16] + ciphertext) — minimum 56 hex chars.
   if (value.length < 56) return false;
   if (!/^[0-9a-f]+$/i.test(value)) return false;
   try {
@@ -156,7 +166,7 @@ async function main(): Promise<void> {
       "\nREMINDER: rotate the affected credentials (Jira API tokens, remote-agent bearer tokens).",
     );
     console.log(
-      "Also apply: migrations/0027_phase0d_clean_argocd_env.sql (removes ARGOCD_TOKEN from mcp_servers.env).",
+      "Also apply: migrations/0028_phase0d_clean_argocd_env.sql (removes ARGOCD_TOKEN from mcp_servers.env).",
     );
   } finally {
     await pool.end();

--- a/scripts/reassign-default-project-credentials.ts
+++ b/scripts/reassign-default-project-credentials.ts
@@ -1,0 +1,138 @@
+/**
+ * ADR-001 PR-0c — Operator credential-reassignment helper.
+ *
+ * PURPOSE
+ * -------
+ * Migration 0027_phase0c_projectid_secret_tables.sql assigned all pre-existing
+ * provider_keys and argocd_config rows to the sentinel project '__default__'.
+ * This is a safe placeholder — it does NOT scope those credentials to any real
+ * user project, and the sentinel project should never be exposed to end-users.
+ *
+ * Operators MUST reassign these rows to the correct projects before enabling
+ * hard project isolation (PR-0a fail-closed + PR-0b requireProject wiring).
+ * Until they do, the credentials remain accessible only through the sentinel
+ * context (which only exists in the DB — no HTTP route carries this project id).
+ *
+ * USAGE
+ * -----
+ *   DATABASE_URL=postgresql://... npx tsx scripts/reassign-default-project-credentials.ts
+ *
+ * The script is READ-ONLY by default. Pass --apply to perform the reassignment
+ * interactively (requires editing the TARGET_PROJECT_ID constant below first).
+ *
+ * STEPS FOR OPERATORS
+ * -------------------
+ * 1. List all real projects:
+ *      SELECT id, name FROM projects WHERE id != '__default__';
+ *
+ * 2. For each provider_key row in __default__, decide which project owns it:
+ *      SELECT id, provider, created_at FROM provider_keys WHERE project_id = '__default__';
+ *      UPDATE provider_keys SET project_id = '<real-project-id>' WHERE id = '<row-id>';
+ *
+ * 3. For the argocd_config row(s) in __default__:
+ *      SELECT id, server_url, enabled FROM argocd_config WHERE project_id = '__default__';
+ *      UPDATE argocd_config SET project_id = '<real-project-id>' WHERE id = <row-id>;
+ *
+ * 4. Once all rows are reassigned, you may delete the sentinel project:
+ *      DELETE FROM projects WHERE id = '__default__';
+ *    (or rename it to make it obvious it's been processed)
+ *
+ * 5. Document the reassignment in your change log for SOC-2 / audit purposes.
+ */
+
+import { Pool } from "pg";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+async function main(): Promise<void> {
+  const applyMode = process.argv.includes("--apply");
+
+  console.log("=== ADR-001 PR-0c: Default-project credential inventory ===\n");
+
+  if (!process.env.DATABASE_URL) {
+    console.error("ERROR: DATABASE_URL is not set.");
+    process.exit(1);
+  }
+
+  const client = await pool.connect();
+
+  try {
+    // ── Provider keys in sentinel project ────────────────────────────────────
+    const providerKeyRows = await client.query<{
+      id: string;
+      provider: string;
+      created_at: Date;
+    }>(
+      "SELECT id, provider, created_at FROM provider_keys WHERE project_id = '__default__' ORDER BY provider",
+    );
+
+    console.log(`provider_keys assigned to __default__: ${providerKeyRows.rowCount ?? 0}`);
+    if (providerKeyRows.rows.length > 0) {
+      for (const row of providerKeyRows.rows) {
+        console.log(`  • id=${row.id}  provider=${row.provider}  created_at=${row.created_at.toISOString()}`);
+      }
+    } else {
+      console.log("  (none — all provider keys have been reassigned ✓)");
+    }
+
+    // ── ArgoCD config rows in sentinel project ────────────────────────────────
+    const argoCdRows = await client.query<{
+      id: number;
+      server_url: string | null;
+      enabled: boolean;
+    }>(
+      "SELECT id, server_url, enabled FROM argocd_config WHERE project_id = '__default__' ORDER BY id",
+    );
+
+    console.log(`\nargocd_config assigned to __default__: ${argoCdRows.rowCount ?? 0}`);
+    if (argoCdRows.rows.length > 0) {
+      for (const row of argoCdRows.rows) {
+        console.log(
+          `  • id=${row.id}  server_url=${row.server_url ?? "(null)"}  enabled=${row.enabled}`,
+        );
+      }
+    } else {
+      console.log("  (none — all argocd configs have been reassigned ✓)");
+    }
+
+    // ── Real projects (for reference) ─────────────────────────────────────────
+    const projectRows = await client.query<{ id: string; name: string }>(
+      "SELECT id, name FROM projects WHERE id != '__default__' ORDER BY name",
+    );
+
+    console.log(`\nAvailable real projects (${projectRows.rowCount ?? 0}):`);
+    for (const row of projectRows.rows) {
+      console.log(`  • id=${row.id}  name=${row.name}`);
+    }
+
+    if (applyMode) {
+      console.log("\n--apply mode is not automated. Edit this script to add UPDATE statements.");
+      console.log("Example:");
+      console.log(
+        "  await client.query(\"UPDATE provider_keys SET project_id = '<id>' WHERE id = '<row-id>'\");",
+      );
+    } else {
+      console.log(
+        "\nRun with --apply to update rows (you must edit the script with the correct target project ids).",
+      );
+    }
+
+    const allClear =
+      (providerKeyRows.rowCount ?? 0) === 0 && (argoCdRows.rowCount ?? 0) === 0;
+    if (allClear) {
+      console.log("\n✓ All credentials have been reassigned. Safe to remove the __default__ project.");
+    } else {
+      console.log(
+        "\n⚠  Action required: reassign the rows above before enabling hard project isolation (PR-0a+0b).",
+      );
+    }
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("Script failed:", err);
+  process.exit(1);
+});

--- a/scripts/rekey-v2.ts
+++ b/scripts/rekey-v2.ts
@@ -1,0 +1,387 @@
+#!/usr/bin/env tsx
+/**
+ * rekey-v2.ts — ADR-001 PR-0e data migration script
+ *
+ * Re-encrypts every AES-256-GCM ciphertext stored by server/crypto.ts to the
+ * new v2: format, which uses a per-value random salt.  The script is idempotent:
+ * values already prefixed `v2:` are skipped.
+ *
+ * USAGE
+ * ─────
+ *   # Dry-run (prints what would change, writes nothing):
+ *   DATABASE_URL=... ENCRYPTION_KEY=... npx tsx scripts/rekey-v2.ts --dry-run
+ *
+ *   # Live run (re-encrypts all non-v2: rows):
+ *   DATABASE_URL=... ENCRYPTION_KEY=... npx tsx scripts/rekey-v2.ts
+ *
+ *   # Verification gate — confirm ALL rows carry v2: before fallback removal:
+ *   DATABASE_URL=... ENCRYPTION_KEY=... npx tsx scripts/rekey-v2.ts --verify
+ *
+ * DEPLOY SEQUENCE (per ADR-001 §4 PR-0e)
+ * ────────────────────────────────────────
+ *   1. Deploy Commit 1 (versioned ciphertext + dual-key rekey).
+ *   2. Run this script with --dry-run first to audit scope.
+ *   3. Run without flags to rekey all rows in EACH environment (dev → staging → prod).
+ *   4. Run with --verify in EACH environment.  All rows must report 0 non-v2: rows.
+ *   5. ONLY THEN deploy Commit 2 (fallback removal + mandatory ENCRYPTION_KEY).
+ *
+ * COLUMNS COVERED
+ * ───────────────
+ *   provider_keys.api_key_encrypted
+ *   git_skill_sources.encrypted_pat
+ *   argocd_config.token_enc
+ *   workspace_connections.secrets_encrypted
+ *   tracker_connections.api_token        (will be encrypted after PR-0d merges)
+ *   remote_agents.auth_token_enc         (will be encrypted after PR-0d merges)
+ *
+ * TRIGGER-CRYPTO NOTE
+ * ───────────────────
+ *   server/services/trigger-crypto.ts uses a SEPARATE key (TRIGGER_SECRET_KEY)
+ *   and a different ciphertext format (no static salt, direct 32-byte hex key).
+ *   That column (triggers.secretEncrypted) is NOT touched here — migrate it
+ *   separately if/when trigger-crypto gains a versioned format.
+ */
+
+import { Pool } from "pg";
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "crypto";
+
+// ─── Helpers (inline — no server imports to keep script standalone) ───────────
+
+const ALGORITHM = "aes-256-gcm";
+const KEY_LEN = 32;
+const LEGACY_SALT = "multiqlti-provider-keys-v1";
+const V2_SALT_LEN = 32;
+const V2_PREFIX = "v2:";
+const DEV_FALLBACK_KEY = "dev-default-insecure-key-change-me!";
+
+function deriveKey(secret: string, salt: string): Buffer {
+  return scryptSync(secret, salt, KEY_LEN);
+}
+
+/** Is this value already in the v2: format? */
+function isV2(value: string): boolean {
+  return value.startsWith(V2_PREFIX);
+}
+
+/**
+ * Attempt to decrypt a legacy (unprefixed) ciphertext with the given key and
+ * the static legacy salt.  Throws on GCM auth-tag failure.
+ */
+function tryDecryptLegacy(hex: string, secret: string): string {
+  const buf = Buffer.from(hex, "hex");
+  if (buf.length < 12 + 16) throw new Error("Too short to be valid ciphertext");
+  const iv = buf.subarray(0, 12);
+  const authTag = buf.subarray(12, 28);
+  const payload = buf.subarray(28);
+  const key = deriveKey(secret, LEGACY_SALT);
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
+}
+
+/**
+ * Encrypt plaintext in the v2: format with a fresh random salt per call.
+ * Wire format: "v2:" + hex(salt[32] | iv[12] | authTag[16] | ciphertext)
+ */
+function encryptV2(plaintext: string, secret: string): string {
+  const salt = randomBytes(V2_SALT_LEN);
+  const key = deriveKey(secret, salt.toString("hex"));
+  const iv = randomBytes(12);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return V2_PREFIX + Buffer.concat([salt, iv, authTag, encrypted]).toString("hex");
+}
+
+/**
+ * Decrypt a value in either v2: or legacy format.
+ * Returns the plaintext, or throws if it cannot be decrypted with any known key.
+ */
+function decryptAny(value: string, currentKey: string): string {
+  if (value.startsWith(V2_PREFIX)) {
+    // Already v2: — decrypt with current key and embedded salt
+    const hex = value.slice(V2_PREFIX.length);
+    const buf = Buffer.from(hex, "hex");
+    const V2_HEADER_LEN = V2_SALT_LEN + 12 + 16;
+    if (buf.length < V2_HEADER_LEN) throw new Error("v2: ciphertext too short");
+    const salt = buf.subarray(0, V2_SALT_LEN);
+    const iv = buf.subarray(V2_SALT_LEN, V2_SALT_LEN + 12);
+    const authTag = buf.subarray(V2_SALT_LEN + 12, V2_HEADER_LEN);
+    const payload = buf.subarray(V2_HEADER_LEN);
+    const key = deriveKey(currentKey, salt.toString("hex"));
+    const decipher = createDecipheriv(ALGORITHM, key, iv);
+    decipher.setAuthTag(authTag);
+    return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
+  }
+
+  // Legacy format — try current key first, then the dev fallback
+  try {
+    return tryDecryptLegacy(value, currentKey);
+  } catch {
+    // Current key failed; try the known insecure fallback
+  }
+  return tryDecryptLegacy(value, DEV_FALLBACK_KEY);
+}
+
+// ─── Column descriptors ────────────────────────────────────────────────────────
+
+interface Column {
+  /** Human-readable label for log output */
+  label: string;
+  /** SQL to fetch rows: must return { id, value } */
+  selectSql: string;
+  /** SQL to update a single row's encrypted column */
+  updateSql: string;
+  /** Whether this column may be NULL (nullable columns are skipped when NULL) */
+  nullable: boolean;
+}
+
+const COLUMNS: Column[] = [
+  {
+    label: "provider_keys.api_key_encrypted",
+    selectSql: "SELECT id::text, api_key_encrypted AS value FROM provider_keys WHERE api_key_encrypted IS NOT NULL",
+    updateSql: "UPDATE provider_keys SET api_key_encrypted = $1 WHERE id::text = $2",
+    nullable: false,
+  },
+  {
+    label: "git_skill_sources.encrypted_pat",
+    selectSql: "SELECT id::text, encrypted_pat AS value FROM git_skill_sources WHERE encrypted_pat IS NOT NULL",
+    updateSql: "UPDATE git_skill_sources SET encrypted_pat = $1 WHERE id::text = $2",
+    nullable: true,
+  },
+  {
+    label: "argocd_config.token_enc",
+    selectSql: "SELECT id::text, token_enc AS value FROM argocd_config WHERE token_enc IS NOT NULL",
+    updateSql: "UPDATE argocd_config SET token_enc = $1 WHERE id::text = $2",
+    nullable: true,
+  },
+  {
+    label: "workspace_connections.secrets_encrypted",
+    selectSql: "SELECT id::text, secrets_encrypted AS value FROM workspace_connections WHERE secrets_encrypted IS NOT NULL",
+    updateSql: "UPDATE workspace_connections SET secrets_encrypted = $1 WHERE id::text = $2",
+    nullable: true,
+  },
+  {
+    label: "tracker_connections.api_token",
+    selectSql: "SELECT id::text, api_token AS value FROM tracker_connections WHERE api_token IS NOT NULL",
+    updateSql: "UPDATE tracker_connections SET api_token = $1 WHERE id::text = $2",
+    nullable: true,
+  },
+  {
+    label: "remote_agents.auth_token_enc",
+    selectSql: "SELECT id::text, auth_token_enc AS value FROM remote_agents WHERE auth_token_enc IS NOT NULL",
+    updateSql: "UPDATE remote_agents SET auth_token_enc = $1 WHERE id::text = $2",
+    nullable: true,
+  },
+];
+
+// ─── Modes ─────────────────────────────────────────────────────────────────────
+
+type Mode = "live" | "dry-run" | "verify";
+
+interface Stats {
+  label: string;
+  total: number;
+  alreadyV2: number;
+  rekeyed: number;
+  errors: number;
+  nonV2Remaining: number;
+}
+
+async function processColumn(
+  pool: Pool,
+  col: Column,
+  currentKey: string,
+  mode: Mode,
+): Promise<Stats> {
+  const stats: Stats = {
+    label: col.label,
+    total: 0,
+    alreadyV2: 0,
+    rekeyed: 0,
+    errors: 0,
+    nonV2Remaining: 0,
+  };
+
+  let rows: Array<{ id: string; value: string }>;
+  try {
+    const result = await pool.query<{ id: string; value: string }>(col.selectSql);
+    rows = result.rows;
+  } catch (err) {
+    // Table may not exist yet (e.g. tracker_connections.api_token pre-PR-0d)
+    console.warn(`  [skip] ${col.label}: table/column not found (${(err as Error).message})`);
+    return stats;
+  }
+
+  stats.total = rows.length;
+
+  for (const row of rows) {
+    const { id, value } = row;
+
+    if (!value) continue;
+
+    if (isV2(value)) {
+      stats.alreadyV2++;
+      continue;
+    }
+
+    // Non-v2: value
+    stats.nonV2Remaining++;
+
+    if (mode === "verify") continue; // just counting
+
+    // Try to decrypt with current key, then fallback
+    let plaintext: string;
+    try {
+      plaintext = decryptAny(value, currentKey);
+    } catch (err) {
+      console.error(
+        `  [error] ${col.label} id=${id}: could not decrypt — ` +
+        `${(err as Error).message}`,
+      );
+      stats.errors++;
+      continue;
+    }
+
+    if (mode === "dry-run") {
+      console.log(`  [would rekey] ${col.label} id=${id}`);
+      continue;
+    }
+
+    // live: re-encrypt as v2:
+    const rekeyed = encryptV2(plaintext, currentKey);
+    try {
+      await pool.query(col.updateSql, [rekeyed, id]);
+      stats.rekeyed++;
+      console.log(`  [rekeyed] ${col.label} id=${id}`);
+    } catch (err) {
+      console.error(`  [error] ${col.label} id=${id}: update failed — ${(err as Error).message}`);
+      stats.errors++;
+    }
+  }
+
+  return stats;
+}
+
+// ─── Main ──────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const isDryRun = args.includes("--dry-run");
+  const isVerify = args.includes("--verify");
+  const isHelp = args.includes("--help") || args.includes("-h");
+
+  if (isHelp) {
+    console.log(`
+rekey-v2.ts — ADR-001 PR-0e rekey migration script
+
+Usage:
+  DATABASE_URL=... ENCRYPTION_KEY=... npx tsx scripts/rekey-v2.ts [options]
+
+Options:
+  --dry-run   Show what would be rekeyed without writing any changes.
+  --verify    Check that ALL rows carry v2:. Exit 1 if any non-v2: rows remain.
+  --help      Show this help message.
+
+Environment:
+  DATABASE_URL    PostgreSQL connection string (required).
+  ENCRYPTION_KEY  (or MULTI_ENCRYPTION_KEY) The app's encryption key (required).
+
+Columns covered:
+  provider_keys.api_key_encrypted
+  git_skill_sources.encrypted_pat
+  argocd_config.token_enc
+  workspace_connections.secrets_encrypted
+  tracker_connections.api_token          (after PR-0d)
+  remote_agents.auth_token_enc           (after PR-0d)
+
+Columns NOT covered (separate key/format):
+  triggers.secret_encrypted              (TRIGGER_SECRET_KEY — migrate separately)
+`);
+    process.exit(0);
+  }
+
+  // --- Validate env ---
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) {
+    console.error("Error: DATABASE_URL is not set.");
+    process.exit(1);
+  }
+
+  const currentKey = process.env.ENCRYPTION_KEY ?? process.env.MULTI_ENCRYPTION_KEY;
+  if (!currentKey || currentKey.length < 32) {
+    console.error(
+      "Error: ENCRYPTION_KEY (or MULTI_ENCRYPTION_KEY) is not set or is shorter than 32 chars.",
+    );
+    process.exit(1);
+  }
+
+  const mode: Mode = isVerify ? "verify" : isDryRun ? "dry-run" : "live";
+  console.log(`\n=== rekey-v2.ts [mode: ${mode}] ===\n`);
+
+  if (mode === "live") {
+    console.log(
+      "WARNING: This will re-encrypt existing rows in the database.\n" +
+      "         Make sure a database backup exists before proceeding.\n",
+    );
+  }
+
+  const pool = new Pool({ connectionString: dbUrl });
+
+  const allStats: Stats[] = [];
+  let totalErrors = 0;
+  let totalNonV2 = 0;
+
+  for (const col of COLUMNS) {
+    console.log(`Processing: ${col.label}`);
+    const stats = await processColumn(pool, col, currentKey, mode);
+    allStats.push(stats);
+    totalErrors += stats.errors;
+    totalNonV2 += stats.nonV2Remaining;
+    console.log(
+      `  total=${stats.total} already_v2=${stats.alreadyV2} ` +
+      (mode === "live" ? `rekeyed=${stats.rekeyed} ` : "") +
+      (mode === "dry-run" ? `would_rekey=${stats.nonV2Remaining} ` : "") +
+      (mode === "verify" ? `non_v2=${stats.nonV2Remaining} ` : "") +
+      `errors=${stats.errors}`,
+    );
+  }
+
+  await pool.end();
+
+  console.log("\n=== Summary ===");
+  if (mode === "verify") {
+    if (totalNonV2 > 0) {
+      console.error(
+        `\nFAIL: ${totalNonV2} row(s) are NOT in v2: format across the covered columns.` +
+        "\n      Run the live rekey before deploying the fallback-removal commit.",
+      );
+      process.exit(1);
+    }
+    if (totalErrors > 0) {
+      console.error(`\nFAIL: ${totalErrors} error(s) encountered during verification.`);
+      process.exit(1);
+    }
+    console.log("\nPASS: All covered rows are in v2: format. Safe to deploy fallback removal.");
+    process.exit(0);
+  }
+
+  if (totalErrors > 0) {
+    console.error(`\n${totalErrors} error(s) encountered. Review the output above.`);
+    process.exit(1);
+  }
+
+  if (mode === "dry-run") {
+    const wouldRekey = allStats.reduce((acc, s) => acc + s.nonV2Remaining, 0);
+    console.log(`\nDry-run complete. Would rekey ${wouldRekey} row(s). No changes written.`);
+  } else {
+    const total = allStats.reduce((acc, s) => acc + s.rekeyed, 0);
+    console.log(`\nRekey complete. ${total} row(s) re-encrypted to v2: format.`);
+  }
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("Unexpected error:", err);
+  process.exit(1);
+});

--- a/server/config-sync/appliers/trigger-applier.ts
+++ b/server/config-sync/appliers/trigger-applier.ts
@@ -59,7 +59,7 @@ export async function applyTriggers(
           // createTrigger requires the full TriggerRow minus id/timestamps,
           // plus optional secretEncrypted.  We pass null for secretEncrypted
           // since the YAML never carries secret material.
-          const createData: Omit<TriggerRow, "id" | "createdAt" | "updatedAt" | "lastTriggeredAt"> & { secretEncrypted?: string | null } = {
+          const createData: Omit<TriggerRow, "id" | "projectId" | "createdAt" | "updatedAt" | "lastTriggeredAt"> & { secretEncrypted?: string | null } = {
             pipelineId: pipeline.id,
             type: triggerType as TriggerRow["type"],
             config: entity.config as TriggerRow["config"],

--- a/server/context.ts
+++ b/server/context.ts
@@ -4,14 +4,119 @@ export interface RequestContext {
   projectId?: string;
   userId?: string;
   role?: string;
+  /** Set to true for legitimately cross-project background work via runAsSystem(). */
+  system?: boolean;
 }
 
 export const requestContext = new AsyncLocalStorage<RequestContext>();
 
+/**
+ * Returns the current project ID from the ALS context.
+ *
+ * Throws in three situations (fail-closed):
+ *   1. No ALS context at all — background/startup caller must use runAsProject()
+ *      or runAsSystem() to establish context before calling storage methods.
+ *   2. System context (system === true) — getProjectId() is structurally forbidden
+ *      in system context so that system code cannot silently read project-scoped
+ *      secret data. Use unscopedSystemQuery() for legitimate cross-project reads.
+ *   3. ALS context exists but has no projectId — requireProject middleware (PR-0b)
+ *      has not been wired, or the background caller should use runAsProject().
+ */
 export function getProjectId(): string {
   const ctx = requestContext.getStore();
-  if (!ctx || !ctx.projectId) {
-    throw new Error("No project context available for this request");
+  if (!ctx) {
+    throw new Error(
+      "No request context — this path runs outside a request handler. " +
+        "Wrap background/startup callers in runAsProject(projectId, fn) or runAsSystem(reason, fn).",
+    );
+  }
+  if (ctx.system) {
+    throw new Error(
+      "System context cannot call getProjectId() — system code must never read " +
+        "project-scoped data via withProject(). " +
+        "Use unscopedSystemQuery(label, fn) for legitimate cross-project reads.",
+    );
+  }
+  if (!ctx.projectId) {
+    throw new Error(
+      "No projectId in context — ensure the x-project-id header is sent and " +
+        "requireProject middleware is wired (PR-0b), " +
+        "or use runAsProject(projectId, fn) for background callers.",
+    );
   }
   return ctx.projectId;
+}
+
+/**
+ * Runs fn inside a project-scoped ALS context.
+ *
+ * Use for background jobs that own a single projectId — e.g., pipeline
+ * execution triggered for a specific project, or a trigger that fires
+ * once per-project.
+ *
+ * @example
+ *   await runAsProject(pipeline.projectId, async () => {
+ *     await storage.updatePipelineRun(runId, { status: "running" });
+ *   });
+ */
+export function runAsProject<T>(projectId: string, fn: () => Promise<T>): Promise<T> {
+  return requestContext.run({ projectId, userId: "system", role: "owner" }, fn);
+}
+
+/**
+ * Runs fn inside a system-scoped ALS context for legitimately cross-project
+ * background work.
+ *
+ * HARD RULES enforced by this contract:
+ *   (a) Every entry writes a structured audit log record (who/why/when).
+ *   (b) getProjectId() THROWS inside system context — use unscopedSystemQuery()
+ *       for cross-project DB reads; use runAsProject() for single-project reads.
+ *   (c) System context is forbidden from calling issueLease() or reading secret
+ *       material — the credential broker enforces this structurally (PR-1b).
+ *
+ * Naming convention: functions that call runAsSystem should be named getAllXxx
+ * or have an "Unscoped" suffix so cross-project reads are greppable in review.
+ *
+ * @example
+ *   await runAsSystem("cron-scheduler-bootstrap", async () => {
+ *     const triggers = await storage.getAllEnabledTriggersByType("schedule");
+ *     ...
+ *   });
+ */
+export function runAsSystem<T>(reason: string, fn: () => Promise<T>): Promise<T> {
+  // Audit record: every system-context entry is logged with a mandatory reason.
+  // Replace with your structured logger if one is wired to this module.
+  console.info(
+    JSON.stringify({ scope: "system-access", reason, at: new Date().toISOString() }),
+  );
+  return requestContext.run({ system: true, userId: "system", role: "system" }, fn);
+}
+
+/**
+ * Asserts that the current ALS context is a system context (system === true)
+ * and runs the provided query. This is the ONLY sanctioned bypass for
+ * project-scoped query filtering — it is explicit, greppable, and audited
+ * by the surrounding runAsSystem() call.
+ *
+ * Cross-project storage methods MUST use this wrapper and follow the getAll*
+ * naming convention so they are easy to find in security reviews.
+ *
+ * @throws if called outside a runAsSystem() context.
+ *
+ * @example
+ *   async getAllEnabledTriggersByType(type: string) {
+ *     return unscopedSystemQuery("getAllEnabledTriggersByType", () =>
+ *       db.select().from(triggers).where(eq(triggers.type, type))
+ *     );
+ *   }
+ */
+export async function unscopedSystemQuery<T>(label: string, q: () => Promise<T>): Promise<T> {
+  const ctx = requestContext.getStore();
+  if (!ctx?.system) {
+    throw new Error(
+      `unscopedSystemQuery("${label}") called outside system context — ` +
+        "wrap the call site in runAsSystem(reason, fn) first.",
+    );
+  }
+  return q();
 }

--- a/server/crypto.ts
+++ b/server/crypto.ts
@@ -3,47 +3,216 @@ import { configLoader } from "./config/loader";
 
 const ALGORITHM = "aes-256-gcm";
 const KEY_LEN = 32;
-const SALT = "multiqlti-provider-keys-v1"; // static salt; key is config-derived
 
-function deriveKey(secret: string): Buffer {
-  return scryptSync(secret, SALT, KEY_LEN);
+/**
+ * Legacy static salt used for all ciphertext produced before v2:.
+ * Kept here ONLY to decrypt existing (pre-rekey) rows — never used for new
+ * encryptions. The v2: format embeds a per-value random salt instead.
+ */
+const LEGACY_SALT = "multiqlti-provider-keys-v1";
+
+/**
+ * V2 salt length in bytes. Each v2: ciphertext embeds a fresh 32-byte random
+ * salt so key-derivation is independent per value.
+ */
+const V2_SALT_LEN = 32;
+
+/**
+ * The old insecure dev-fallback key.
+ *
+ * Used ONLY inside `decryptLegacy()` to detect rows that were written with the
+ * fallback instead of a real key. This lets the rekey migration script find and
+ * re-encrypt those rows. The application NEVER produces new ciphertext with this
+ * key — `encrypt()` calls `getSecret()` which throws if ENCRYPTION_KEY is unset.
+ *
+ * After the rekey migration confirms zero non-v2: rows in every environment,
+ * this constant and the fallback branch in decryptLegacy() will be removed in a
+ * separate deploy (see PR-0e Commit 2 — "Remove fallback").
+ */
+const DEV_FALLBACK_KEY = "dev-default-insecure-key-change-me!";
+
+function deriveKey(secret: string, salt: string): Buffer {
+  return scryptSync(secret, salt, KEY_LEN);
 }
 
+/**
+ * Returns the configured encryption secret.
+ *
+ * Throws if ENCRYPTION_KEY / MULTI_ENCRYPTION_KEY is not set.
+ * There is NO insecure dev-fallback — a missing key is a hard failure.
+ * To run tests, set ENCRYPTION_KEY (any 32+-char string) or mock configLoader.
+ */
 function getSecret(): string {
   const { key } = configLoader.get().encryption;
   if (!key) {
-    console.warn(
-      "[crypto] encryption.key is not set — using insecure dev default. " +
-      "Set ENCRYPTION_KEY (or MULTI_ENCRYPTION_KEY) in production.",
+    throw new Error(
+      "[crypto] ENCRYPTION_KEY (or MULTI_ENCRYPTION_KEY) is not configured. " +
+      "Set it to a random string of at least 32 characters. " +
+      "This value must be the SAME across all server instances sharing a database.",
     );
-    return "dev-default-insecure-key-change-me!";
   }
   return key;
 }
 
-/**
- * Encrypts plaintext with AES-256-GCM.
- * Returns a hex string: iv(24) + authTag(32) + ciphertext.
- */
-export function encrypt(plaintext: string): string {
-  const key = deriveKey(getSecret());
+// ─── V2 format ────────────────────────────────────────────────────────────────
+//
+// Wire format (binary, then hex-encoded):
+//   salt    (32 bytes) — random per-value, embedded in the ciphertext
+//   iv      (12 bytes) — AES-GCM nonce
+//   authTag (16 bytes) — GCM authentication tag
+//   payload (n  bytes) — encrypted plaintext
+//
+// Stored as: "v2:" + Buffer.concat([salt, iv, authTag, payload]).toString("hex")
+//
+// Benefits over the legacy format:
+//   - Per-value random salt: each ciphertext uses an independently derived key.
+//   - Version prefix: format is self-describing; migration scripts can detect
+//     which rows need rekeying vs. which are already current.
+
+const V2_PREFIX = "v2:";
+const V2_HEADER_LEN = V2_SALT_LEN + 12 + 16; // salt + iv + authTag (bytes)
+
+function encryptV2(plaintext: string, secret: string): string {
+  const salt = randomBytes(V2_SALT_LEN);
+  const key = deriveKey(secret, salt.toString("hex"));
   const iv = randomBytes(12);
   const cipher = createCipheriv(ALGORITHM, key, iv);
   const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
   const authTag = cipher.getAuthTag();
-  return Buffer.concat([iv, authTag, encrypted]).toString("hex");
+  return V2_PREFIX + Buffer.concat([salt, iv, authTag, encrypted]).toString("hex");
+}
+
+function decryptV2(prefixedHex: string, secret: string): string {
+  const hex = prefixedHex.slice(V2_PREFIX.length);
+  const buf = Buffer.from(hex, "hex");
+  if (buf.length < V2_HEADER_LEN) {
+    throw new Error("[crypto] v2: ciphertext is too short to be valid");
+  }
+  const salt = buf.subarray(0, V2_SALT_LEN);
+  const iv = buf.subarray(V2_SALT_LEN, V2_SALT_LEN + 12);
+  const authTag = buf.subarray(V2_SALT_LEN + 12, V2_HEADER_LEN);
+  const payload = buf.subarray(V2_HEADER_LEN);
+  const key = deriveKey(secret, salt.toString("hex"));
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
+}
+
+// ─── Legacy format ─────────────────────────────────────────────────────────────
+//
+// Wire format (binary, then hex-encoded, NO prefix):
+//   iv      (12 bytes)
+//   authTag (16 bytes)
+//   payload (n  bytes)
+//
+// Key derived with: scryptSync(secret, LEGACY_SALT, KEY_LEN)
+
+const LEGACY_HEADER_LEN = 12 + 16;
+
+function decryptLegacy(hex: string): string {
+  const buf = Buffer.from(hex, "hex");
+  if (buf.length < LEGACY_HEADER_LEN) {
+    throw new Error("[crypto] legacy ciphertext is too short to be valid");
+  }
+  const iv = buf.subarray(0, 12);
+  const authTag = buf.subarray(12, 28);
+  const payload = buf.subarray(28);
+
+  // Try the real (configured) key first.
+  const currentSecret = getSecret();
+  try {
+    const key = deriveKey(currentSecret, LEGACY_SALT);
+    const decipher = createDecipheriv(ALGORITHM, key, iv);
+    decipher.setAuthTag(authTag);
+    return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
+  } catch {
+    // GCM auth-tag failure means this value was NOT encrypted with the current
+    // key.  Try the dev-fallback key so the rekey migration can detect and
+    // re-encrypt these rows.
+    //
+    // NOTE: This fallback branch will be removed in Commit 2 of PR-0e AFTER the
+    // rekey migration script has confirmed zero non-v2: rows in every environment.
+  }
+
+  try {
+    const fallbackKey = deriveKey(DEV_FALLBACK_KEY, LEGACY_SALT);
+    const decipher = createDecipheriv(ALGORITHM, fallbackKey, iv);
+    decipher.setAuthTag(authTag);
+    return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
+  } catch {
+    throw new Error(
+      "[crypto] failed to decrypt legacy ciphertext with both the current key and the dev fallback. " +
+      "The ciphertext may be corrupt, or encrypted with an unknown key.",
+    );
+  }
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Encrypts plaintext with AES-256-GCM.
+ *
+ * Returns a `v2:` prefixed hex string.  The embedded random salt ensures each
+ * call produces independently derived key material even when the same secret is
+ * reused.
+ *
+ * Wire format: `"v2:" + hex(salt[32] | iv[12] | authTag[16] | ciphertext)`
+ */
+export function encrypt(plaintext: string): string {
+  return encryptV2(plaintext, getSecret());
 }
 
 /**
- * Decrypts a hex string produced by encrypt().
+ * Decrypts a string produced by `encrypt()` (v2: format) or any legacy value
+ * produced by the previous format (no prefix).
+ *
+ * Dispatch:
+ *   - Starts with `v2:` → decryptV2 with the current key.
+ *   - No prefix (legacy) → decryptLegacy: tries current key first, then the
+ *     dev-fallback key so the rekey migration can detect affected rows.
+ *
+ * After the rekey migration + `--verify` passes in every environment, Commit 2
+ * of PR-0e removes the legacy branch and the fallback key entirely.
  */
 export function decrypt(ciphertext: string): string {
-  const key = deriveKey(getSecret());
-  const buf = Buffer.from(ciphertext, "hex");
+  if (ciphertext.startsWith(V2_PREFIX)) {
+    return decryptV2(ciphertext, getSecret());
+  }
+  return decryptLegacy(ciphertext);
+}
+
+/**
+ * Returns true if the value is already in the v2: format (i.e. produced by
+ * this version of encrypt() or already rekeyed by the migration script).
+ */
+export function isV2(value: string): boolean {
+  return value.startsWith(V2_PREFIX);
+}
+
+/**
+ * Exposed for the rekey migration script ONLY.  Do not call from application
+ * code.
+ *
+ * Attempts to decrypt a legacy (non-v2:) ciphertext using a known secret and
+ * the static legacy salt.  Throws on auth-tag failure.  The caller (rekey
+ * script) is expected to catch the error and try alternative keys.
+ */
+export function decryptLegacyWithKey(hex: string, secret: string): string {
+  const buf = Buffer.from(hex, "hex");
+  if (buf.length < LEGACY_HEADER_LEN) {
+    throw new Error("[crypto] legacy ciphertext is too short to be valid");
+  }
   const iv = buf.subarray(0, 12);
   const authTag = buf.subarray(12, 28);
-  const encrypted = buf.subarray(28);
+  const payload = buf.subarray(28);
+  const key = deriveKey(secret, LEGACY_SALT);
   const decipher = createDecipheriv(ALGORITHM, key, iv);
   decipher.setAuthTag(authTag);
-  return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString("utf8");
+  return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
 }
+
+/**
+ * The dev fallback key — exported for the rekey script so it can try to
+ * decrypt values that were written without a real ENCRYPTION_KEY.
+ */
+export const DEV_FALLBACK_KEY_EXPORT = DEV_FALLBACK_KEY;

--- a/server/crypto.ts
+++ b/server/crypto.ts
@@ -1,35 +1,20 @@
 import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "crypto";
 import { configLoader } from "./config/loader";
 
+// ─── DO NOT DEPLOY THIS FILE UNTIL ──────────────────────────────────────────
+// 1. The rekey migration script (scripts/rekey-v2.ts) has been run in EVERY
+//    environment (dev → staging → prod).
+// 2. `npx tsx scripts/rekey-v2.ts --verify` exits 0 (zero non-v2: rows) in
+//    EVERY environment.
+// Only after both checks pass is it safe to deploy this commit, which removes
+// the insecure dev-fallback key and the legacy-format fallback branch.
+// ─────────────────────────────────────────────────────────────────────────────
+
 const ALGORITHM = "aes-256-gcm";
 const KEY_LEN = 32;
-
-/**
- * Legacy static salt used for all ciphertext produced before v2:.
- * Kept here ONLY to decrypt existing (pre-rekey) rows — never used for new
- * encryptions. The v2: format embeds a per-value random salt instead.
- */
-const LEGACY_SALT = "multiqlti-provider-keys-v1";
-
-/**
- * V2 salt length in bytes. Each v2: ciphertext embeds a fresh 32-byte random
- * salt so key-derivation is independent per value.
- */
 const V2_SALT_LEN = 32;
-
-/**
- * The old insecure dev-fallback key.
- *
- * Used ONLY inside `decryptLegacy()` to detect rows that were written with the
- * fallback instead of a real key. This lets the rekey migration script find and
- * re-encrypt those rows. The application NEVER produces new ciphertext with this
- * key — `encrypt()` calls `getSecret()` which throws if ENCRYPTION_KEY is unset.
- *
- * After the rekey migration confirms zero non-v2: rows in every environment,
- * this constant and the fallback branch in decryptLegacy() will be removed in a
- * separate deploy (see PR-0e Commit 2 — "Remove fallback").
- */
-const DEV_FALLBACK_KEY = "dev-default-insecure-key-change-me!";
+const V2_PREFIX = "v2:";
+const V2_HEADER_LEN = V2_SALT_LEN + 12 + 16; // salt + iv + authTag (bytes)
 
 function deriveKey(secret: string, salt: string): Buffer {
   return scryptSync(secret, salt, KEY_LEN);
@@ -39,8 +24,8 @@ function deriveKey(secret: string, salt: string): Buffer {
  * Returns the configured encryption secret.
  *
  * Throws if ENCRYPTION_KEY / MULTI_ENCRYPTION_KEY is not set.
- * There is NO insecure dev-fallback — a missing key is a hard failure.
- * To run tests, set ENCRYPTION_KEY (any 32+-char string) or mock configLoader.
+ * There is NO fallback — a missing key is a hard startup failure.
+ * In tests, mock configLoader or set ENCRYPTION_KEY to any 32+-char string.
  */
 function getSecret(): string {
   const { key } = configLoader.get().encryption;
@@ -63,14 +48,6 @@ function getSecret(): string {
 //   payload (n  bytes) — encrypted plaintext
 //
 // Stored as: "v2:" + Buffer.concat([salt, iv, authTag, payload]).toString("hex")
-//
-// Benefits over the legacy format:
-//   - Per-value random salt: each ciphertext uses an independently derived key.
-//   - Version prefix: format is self-describing; migration scripts can detect
-//     which rows need rekeying vs. which are already current.
-
-const V2_PREFIX = "v2:";
-const V2_HEADER_LEN = V2_SALT_LEN + 12 + 16; // salt + iv + authTag (bytes)
 
 function encryptV2(plaintext: string, secret: string): string {
   const salt = randomBytes(V2_SALT_LEN);
@@ -98,55 +75,6 @@ function decryptV2(prefixedHex: string, secret: string): string {
   return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
 }
 
-// ─── Legacy format ─────────────────────────────────────────────────────────────
-//
-// Wire format (binary, then hex-encoded, NO prefix):
-//   iv      (12 bytes)
-//   authTag (16 bytes)
-//   payload (n  bytes)
-//
-// Key derived with: scryptSync(secret, LEGACY_SALT, KEY_LEN)
-
-const LEGACY_HEADER_LEN = 12 + 16;
-
-function decryptLegacy(hex: string): string {
-  const buf = Buffer.from(hex, "hex");
-  if (buf.length < LEGACY_HEADER_LEN) {
-    throw new Error("[crypto] legacy ciphertext is too short to be valid");
-  }
-  const iv = buf.subarray(0, 12);
-  const authTag = buf.subarray(12, 28);
-  const payload = buf.subarray(28);
-
-  // Try the real (configured) key first.
-  const currentSecret = getSecret();
-  try {
-    const key = deriveKey(currentSecret, LEGACY_SALT);
-    const decipher = createDecipheriv(ALGORITHM, key, iv);
-    decipher.setAuthTag(authTag);
-    return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
-  } catch {
-    // GCM auth-tag failure means this value was NOT encrypted with the current
-    // key.  Try the dev-fallback key so the rekey migration can detect and
-    // re-encrypt these rows.
-    //
-    // NOTE: This fallback branch will be removed in Commit 2 of PR-0e AFTER the
-    // rekey migration script has confirmed zero non-v2: rows in every environment.
-  }
-
-  try {
-    const fallbackKey = deriveKey(DEV_FALLBACK_KEY, LEGACY_SALT);
-    const decipher = createDecipheriv(ALGORITHM, fallbackKey, iv);
-    decipher.setAuthTag(authTag);
-    return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
-  } catch {
-    throw new Error(
-      "[crypto] failed to decrypt legacy ciphertext with both the current key and the dev fallback. " +
-      "The ciphertext may be corrupt, or encrypted with an unknown key.",
-    );
-  }
-}
-
 // ─── Public API ───────────────────────────────────────────────────────────────
 
 /**
@@ -163,56 +91,31 @@ export function encrypt(plaintext: string): string {
 }
 
 /**
- * Decrypts a string produced by `encrypt()` (v2: format) or any legacy value
- * produced by the previous format (no prefix).
+ * Decrypts a string produced by `encrypt()`.
  *
- * Dispatch:
- *   - Starts with `v2:` → decryptV2 with the current key.
- *   - No prefix (legacy) → decryptLegacy: tries current key first, then the
- *     dev-fallback key so the rekey migration can detect affected rows.
+ * Only accepts `v2:` prefixed values.  Legacy unprefixed values are no longer
+ * supported — they must have been migrated by `scripts/rekey-v2.ts` before
+ * this commit was deployed.
  *
- * After the rekey migration + `--verify` passes in every environment, Commit 2
- * of PR-0e removes the legacy branch and the fallback key entirely.
+ * If a legacy value is encountered here it means the rekey migration was not
+ * completed before deploying this commit.  The error message is explicit about
+ * the remediation: roll back this commit and run the rekey migration.
  */
 export function decrypt(ciphertext: string): string {
   if (ciphertext.startsWith(V2_PREFIX)) {
     return decryptV2(ciphertext, getSecret());
   }
-  return decryptLegacy(ciphertext);
+  throw new Error(
+    "[crypto] encountered a legacy (non-v2:) ciphertext after fallback removal. " +
+    "This means the rekey migration was not completed before deploying this commit. " +
+    "Roll back this deploy, run `npx tsx scripts/rekey-v2.ts` until --verify passes " +
+    "in every environment, then re-deploy.",
+  );
 }
 
 /**
- * Returns true if the value is already in the v2: format (i.e. produced by
- * this version of encrypt() or already rekeyed by the migration script).
+ * Returns true if the value is already in the v2: format.
  */
 export function isV2(value: string): boolean {
   return value.startsWith(V2_PREFIX);
 }
-
-/**
- * Exposed for the rekey migration script ONLY.  Do not call from application
- * code.
- *
- * Attempts to decrypt a legacy (non-v2:) ciphertext using a known secret and
- * the static legacy salt.  Throws on auth-tag failure.  The caller (rekey
- * script) is expected to catch the error and try alternative keys.
- */
-export function decryptLegacyWithKey(hex: string, secret: string): string {
-  const buf = Buffer.from(hex, "hex");
-  if (buf.length < LEGACY_HEADER_LEN) {
-    throw new Error("[crypto] legacy ciphertext is too short to be valid");
-  }
-  const iv = buf.subarray(0, 12);
-  const authTag = buf.subarray(12, 28);
-  const payload = buf.subarray(28);
-  const key = deriveKey(secret, LEGACY_SALT);
-  const decipher = createDecipheriv(ALGORITHM, key, iv);
-  decipher.setAuthTag(authTag);
-  return Buffer.concat([decipher.update(payload), decipher.final()]).toString("utf8");
-}
-
-/**
- * The dev fallback key — exported for the rekey script so it can try to
- * decrypt values that were written without a real ENCRYPTION_KEY.
- */
-export const DEV_FALLBACK_KEY_EXPORT = DEV_FALLBACK_KEY;

--- a/server/db.ts
+++ b/server/db.ts
@@ -98,7 +98,7 @@ export function withProject(table: any, condition?: SQL | undefined): SQL {
  *
  * Usage: db.insert(table).values(withProjectInsert(table, data))
  */
-export function withProjectInsert<T>(table: any, data: T): T {
+export function withProjectInsert<T>(table: any, data: T): T & { projectId: string | null } {
   const ctx = requestContext.getStore();
 
   if (!ctx) {
@@ -113,9 +113,9 @@ export function withProjectInsert<T>(table: any, data: T): T {
     // System context: insert with projectId=null (globally shared / unscoped data).
     // Use for system-level seeding that creates resources shared across all projects.
     if (Array.isArray(data)) {
-      return data.map((item) => ({ ...item, projectId: null })) as unknown as T;
+      return data.map((item) => ({ ...item, projectId: null })) as unknown as T & { projectId: string | null };
     }
-    return { ...data, projectId: null } as unknown as T;
+    return { ...data, projectId: null } as unknown as T & { projectId: string | null };
   }
 
   if (!ctx.projectId) {
@@ -126,9 +126,9 @@ export function withProjectInsert<T>(table: any, data: T): T {
   }
 
   if (Array.isArray(data)) {
-    return data.map((item) => ({ ...item, projectId: ctx.projectId! })) as unknown as T;
+    return data.map((item) => ({ ...item, projectId: ctx.projectId! })) as unknown as T & { projectId: string | null };
   }
-  return { ...data, projectId: ctx.projectId } as unknown as T;
+  return { ...data, projectId: ctx.projectId } as unknown as T & { projectId: string | null };
 }
 
 /**

--- a/server/db.ts
+++ b/server/db.ts
@@ -22,43 +22,113 @@ pool.on("error", (err: Error) => {
 
 export const db = drizzle(pool, { schema });
 
-import { getProjectId } from "./context";
+import { requestContext } from "./context";
 import { SQL, and, eq } from "drizzle-orm";
 
 /**
  * Helper to wrap any Drizzle query condition with the current project ID filter.
+ *
+ * FAIL-CLOSED: throws rather than silently bypassing isolation when no project
+ * context is present. Callers outside a request handler MUST be wrapped in
+ * runAsProject(projectId, fn) or runAsSystem(reason, fn).
+ *
+ * System context (runAsSystem) is allowed to call withProject for SELECT queries
+ * but the project filter is NOT applied — the query runs cross-project.  The
+ * audit trail is provided by the surrounding runAsSystem() call. System context
+ * callers must NOT use withProject to access secret material (enforced at the
+ * broker layer in PR-1b).
+ *
  * Usage: db.select().from(table).where(withProject(table, eq(table.id, id)))
  */
 export function withProject(table: any, condition?: SQL | undefined): SQL {
-  try {
-    const projectId = getProjectId();
-    const projectFilter = eq(table.projectId, projectId);
-    return condition ? and(projectFilter, condition)! : projectFilter;
-  } catch (e) {
-    // Fallback if executed outside of a project context (e.g., background cron jobs)
-    // In strict mode, you might want to throw here instead.
+  const ctx = requestContext.getStore();
+
+  if (!ctx) {
+    throw new Error(
+      "withProject: no request context — this path runs outside a request handler. " +
+        "Wrap background/startup callers in runAsProject(projectId, fn) or runAsSystem(reason, fn). " +
+        "See server/context.ts and ADR-001 §3.1(c)/(d).",
+    );
+  }
+
+  if (ctx.system) {
+    // System context: the runAsSystem() audit trail covers this cross-project read.
+    // Do NOT apply a project filter — system code reads across all projects by design.
+    // System context is structurally prohibited from accessing secret material (PR-1b).
     if (!condition) {
-      throw new Error("withProject requires a condition when outside project context");
+      throw new Error(
+        "withProject: system context SELECT requires a WHERE condition — " +
+          "pass a filter expression or use unscopedSystemQuery(label, fn) explicitly.",
+      );
     }
     return condition;
   }
+
+  if (!ctx.projectId) {
+    throw new Error(
+      "withProject: no projectId in context — ensure the x-project-id header is sent " +
+        "and requireProject middleware is wired (PR-0b), " +
+        "or use runAsProject(projectId, fn) for background callers.",
+    );
+  }
+
+  // Sanity-check: table must have a projectId column. Tables that don't have it
+  // yet (e.g. provider_keys, argocd_config, triggers pre-PR-0c) will be caught
+  // here at development/test time rather than silently bypassing isolation.
+  if (table.projectId === undefined) {
+    throw new Error(
+      'withProject: table has no "projectId" column — ' +
+        "add the column in PR-0c before enabling project scoping on this table.",
+    );
+  }
+
+  const projectFilter = eq(table.projectId, ctx.projectId);
+  return condition ? and(projectFilter, condition)! : projectFilter;
 }
 
 /**
  * Helper to inject the current project ID into data for insert operations.
+ *
+ * FAIL-CLOSED: throws when no context is present.
+ *
+ * In system context (runAsSystem) sets projectId to null, creating globally
+ * visible rows (e.g. seeded default models, built-in skills, pipeline templates).
+ * This matches the pre-existing schema design where nullable projectId means
+ * "shared across all projects".
+ *
  * Usage: db.insert(table).values(withProjectInsert(table, data))
  */
 export function withProjectInsert<T>(table: any, data: T): T {
-  try {
-    const projectId = getProjectId();
-    
-    if (Array.isArray(data)) {
-      return data.map(item => ({ ...item, projectId })) as unknown as T;
-    }
-    return { ...data, projectId } as unknown as T;
-  } catch (e) {
-    return data;
+  const ctx = requestContext.getStore();
+
+  if (!ctx) {
+    throw new Error(
+      "withProjectInsert: no request context — wrap background/startup inserts in " +
+        "runAsProject(projectId, fn) or runAsSystem(reason, fn). " +
+        "See server/context.ts and ADR-001 §3.1(c)/(d).",
+    );
   }
+
+  if (ctx.system) {
+    // System context: insert with projectId=null (globally shared / unscoped data).
+    // Use for system-level seeding that creates resources shared across all projects.
+    if (Array.isArray(data)) {
+      return data.map((item) => ({ ...item, projectId: null })) as unknown as T;
+    }
+    return { ...data, projectId: null } as unknown as T;
+  }
+
+  if (!ctx.projectId) {
+    throw new Error(
+      "withProjectInsert: no projectId in context — ensure requireProject middleware " +
+        "is wired (PR-0b) or use runAsProject(projectId, fn) for background inserts.",
+    );
+  }
+
+  if (Array.isArray(data)) {
+    return data.map((item) => ({ ...item, projectId: ctx.projectId! })) as unknown as T;
+  }
+  return { ...data, projectId: ctx.projectId } as unknown as T;
 }
 
 /**

--- a/server/remote-agents/remote-agent-manager.ts
+++ b/server/remote-agents/remote-agent-manager.ts
@@ -1,5 +1,6 @@
 import { eq } from "drizzle-orm";
 import { db } from "../db";
+import { runAsSystem } from "../context";
 import { remoteAgents, a2aTasks } from "@shared/schema";
 import { A2AClient } from "./a2a-client";
 import { AgentDiscoveryService } from "./agent-discovery";
@@ -49,7 +50,9 @@ export class RemoteAgentManager {
 
   /** Load all agents from DB and auto-connect those flagged for it. */
   async initialize(): Promise<void> {
-    const agents = await this.listAgents();
+    // listAgents() is a cross-project query (remote agents span all projects).
+    // runAsSystem establishes the required ALS context and provides an audit trail.
+    const agents = await runAsSystem("remote-agent-manager-init", () => this.listAgents());
     for (const agent of agents) {
       if (agent.autoConnect && agent.enabled) {
         await this.connectAgent(agent.id).catch(() => {
@@ -267,7 +270,8 @@ export class RemoteAgentManager {
 
   private startHeartbeat(intervalMs: number): void {
     this.heartbeatInterval = setInterval(async () => {
-      const agents = await this.listAgents();
+      // listAgents() reads across all projects; runAsSystem provides context + audit.
+      const agents = await runAsSystem("remote-agent-heartbeat", () => this.listAgents());
       for (const agent of agents) {
         if (!agent.enabled) continue;
         const health = await this.discovery.healthCheck(agent);

--- a/server/remote-agents/remote-agent-manager.ts
+++ b/server/remote-agents/remote-agent-manager.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import { db } from "../db";
 import { remoteAgents, a2aTasks } from "@shared/schema";
+import { encrypt, decrypt } from "../crypto";
 import { A2AClient } from "./a2a-client";
 import { AgentDiscoveryService } from "./agent-discovery";
 import type {
@@ -94,7 +95,8 @@ export class RemoteAgentManager {
         cluster: input.cluster ?? null,
         namespace: input.namespace ?? null,
         labels: input.labels ?? null,
-        authTokenEnc: input.authTokenEnc ?? null,
+        // Encrypt the bearer token before persisting (PR-0d: encrypt plaintext authTokenEnc).
+        authTokenEnc: input.authTokenEnc ? encrypt(input.authTokenEnc) : null,
         enabled: input.enabled ?? true,
         autoConnect: input.autoConnect ?? false,
         status: agentCard ? "online" : "offline",
@@ -298,7 +300,9 @@ export class RemoteAgentManager {
       cluster: row.cluster,
       namespace: row.namespace,
       labels: row.labels as Record<string, string> | null,
-      authTokenEnc: row.authTokenEnc,
+      // Decrypt at the DB boundary so all callers receive the plaintext token.
+      // The DB column stores AES-256-GCM ciphertext; the config field holds plaintext.
+      authTokenEnc: row.authTokenEnc ? decrypt(row.authTokenEnc) : null,
       enabled: row.enabled,
       autoConnect: row.autoConnect,
       status: row.status as RemoteAgentConfig["status"],

--- a/server/remote-agents/remote-agent-manager.ts
+++ b/server/remote-agents/remote-agent-manager.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
-import { db } from "../db";
-import { runAsSystem } from "../context";
+import { db, withProject, withProjectInsert } from "../db";
+import { runAsSystem, unscopedSystemQuery } from "../context";
 import { remoteAgents, a2aTasks } from "@shared/schema";
 import { encrypt, decrypt } from "../crypto";
 import { A2AClient } from "./a2a-client";
@@ -51,16 +51,20 @@ export class RemoteAgentManager {
 
   /** Load all agents from DB and auto-connect those flagged for it. */
   async initialize(): Promise<void> {
-    // listAgents() is a cross-project query (remote agents span all projects).
-    // runAsSystem establishes the required ALS context and provides an audit trail.
-    const agents = await runAsSystem("remote-agent-manager-init", () => this.listAgents());
-    for (const agent of agents) {
-      if (agent.autoConnect && agent.enabled) {
-        await this.connectAgent(agent.id).catch(() => {
-          // Agent may be unreachable at startup -- continue with others
-        });
+    // Wrap the entire init (getAllAgents + auto-connect loop) in runAsSystem so
+    // that getAllAgents' unscopedSystemQuery assertion passes, and all subsequent
+    // manager calls (getAgent, connectAgent) run in system context where
+    // withProject strips the project filter and returns the id-only condition.
+    await runAsSystem("remote-agent-manager-init", async () => {
+      const agents = await this.getAllAgents();
+      for (const agent of agents) {
+        if (agent.autoConnect && agent.enabled) {
+          await this.connectAgent(agent.id).catch(() => {
+            // Agent may be unreachable at startup -- continue with others
+          });
+        }
       }
-    }
+    });
     this.startHeartbeat(60_000);
   }
 
@@ -88,23 +92,27 @@ export class RemoteAgentManager {
       // Agent may be offline -- register anyway with status offline
     }
 
+    // H-5: withProjectInsert stamps projectId from the current ALS context
+    // (the POST route runs under requireProject, so context is always present).
     const [created] = await db
       .insert(remoteAgents)
-      .values({
-        name: input.name,
-        environment: input.environment,
-        transport: input.transport,
-        endpoint: input.endpoint,
-        cluster: input.cluster ?? null,
-        namespace: input.namespace ?? null,
-        labels: input.labels ?? null,
-        // Encrypt the bearer token before persisting (PR-0d: encrypt plaintext authTokenEnc).
-        authTokenEnc: input.authTokenEnc ? encrypt(input.authTokenEnc) : null,
-        enabled: input.enabled ?? true,
-        autoConnect: input.autoConnect ?? false,
-        status: agentCard ? "online" : "offline",
-        agentCard: agentCard as unknown as Record<string, unknown> | null,
-      })
+      .values(
+        withProjectInsert(remoteAgents, {
+          name: input.name,
+          environment: input.environment,
+          transport: input.transport,
+          endpoint: input.endpoint,
+          cluster: input.cluster ?? null,
+          namespace: input.namespace ?? null,
+          labels: input.labels ?? null,
+          // Encrypt the bearer token before persisting (PR-0d: encrypt plaintext authTokenEnc).
+          authTokenEnc: input.authTokenEnc ? encrypt(input.authTokenEnc) : null,
+          enabled: input.enabled ?? true,
+          autoConnect: input.autoConnect ?? false,
+          status: agentCard ? "online" : "offline",
+          agentCard: agentCard as unknown as Record<string, unknown> | null,
+        }),
+      )
       .returning();
 
     return this.rowToConfig(created);
@@ -112,7 +120,11 @@ export class RemoteAgentManager {
 
   async unregisterAgent(agentId: string): Promise<void> {
     this.clients.delete(agentId);
-    await db.delete(remoteAgents).where(eq(remoteAgents.id, agentId));
+    // H-4: scope the DELETE to the current project so project A cannot delete
+    // project B's agent by guessing an ID.
+    await db
+      .delete(remoteAgents)
+      .where(withProject(remoteAgents, eq(remoteAgents.id, agentId)));
   }
 
   // ── Connection ─────────────────────────────────────────────────────
@@ -132,6 +144,9 @@ export class RemoteAgentManager {
 
     this.clients.set(agentId, client);
 
+    // H-4: scope the UPDATE so this cannot modify a cross-project agent.
+    // In system context (startup/heartbeat) withProject strips the project filter
+    // and applies only the id condition — correct for system-level operations.
     await db
       .update(remoteAgents)
       .set({
@@ -142,15 +157,16 @@ export class RemoteAgentManager {
           (health.agentCard as unknown as Record<string, unknown>) ?? null,
         updatedAt: new Date(),
       })
-      .where(eq(remoteAgents.id, agentId));
+      .where(withProject(remoteAgents, eq(remoteAgents.id, agentId)));
   }
 
   async disconnectAgent(agentId: string): Promise<void> {
     this.clients.delete(agentId);
+    // H-4: scope the UPDATE to the current project.
     await db
       .update(remoteAgents)
       .set({ status: "offline" as const, updatedAt: new Date() })
-      .where(eq(remoteAgents.id, agentId));
+      .where(withProject(remoteAgents, eq(remoteAgents.id, agentId)));
   }
 
   // ── Routing ────────────────────────────────────────────────────────
@@ -196,17 +212,20 @@ export class RemoteAgentManager {
     const client = this.clients.get(agentId);
     if (!client) throw new Error(`Agent ${agentId} not connected`);
 
-    // Persist task before sending
+    // H-6: withProjectInsert stamps projectId on the task row from ALS context
+    // (dispatch routes run under requireProject).
     const [task] = await db
       .insert(a2aTasks)
-      .values({
-        agentId,
-        runId: options?.runId ?? null,
-        stageExecutionId: options?.stageExecutionId ?? null,
-        skill: options?.skill ?? null,
-        input: message as unknown as Record<string, unknown>,
-        status: "submitted",
-      })
+      .values(
+        withProjectInsert(a2aTasks, {
+          agentId,
+          runId: options?.runId ?? null,
+          stageExecutionId: options?.stageExecutionId ?? null,
+          skill: options?.skill ?? null,
+          input: message as unknown as Record<string, unknown>,
+          status: "submitted",
+        }),
+      )
       .returning();
 
     const start = Date.now();
@@ -248,19 +267,49 @@ export class RemoteAgentManager {
 
   // ── Query ──────────────────────────────────────────────────────────
 
+  /**
+   * List agents scoped to the current project (per-project HTTP routes).
+   *
+   * MUST be called in a per-project request context (requireProject sets it).
+   * withProject(remoteAgents) injects WHERE projectId = ? from the ALS context.
+   * In system context this would throw (no bare withProject without condition) —
+   * use getAllAgents() instead for background/heartbeat callers.
+   */
   async listAgents(): Promise<RemoteAgentConfig[]> {
     const rows = await db
       .select()
       .from(remoteAgents)
+      .where(withProject(remoteAgents))
       .orderBy(remoteAgents.name);
     return rows.map((r) => this.rowToConfig(r));
   }
 
+  /**
+   * List ALL agents across all projects — for system/background callers only.
+   *
+   * MUST be called inside runAsSystem(reason, fn) — unscopedSystemQuery enforces
+   * this structurally. Mirrors the getAllEnabledTriggersByType pattern.
+   */
+  private async getAllAgents(): Promise<RemoteAgentConfig[]> {
+    const rows = await unscopedSystemQuery("agent-heartbeat-list", () =>
+      db.select().from(remoteAgents).orderBy(remoteAgents.name),
+    );
+    return rows.map((r) => this.rowToConfig(r));
+  }
+
+  /**
+   * Get a single agent by ID, scoped to the current project.
+   *
+   * H-4: withProject adds AND projectId = ? so cross-project ID guessing
+   * returns null (→ 404 in routes) instead of leaking another project's config.
+   * In system context withProject strips the project filter, returning only
+   * the id condition — correct for startup/heartbeat callers.
+   */
   async getAgent(agentId: string): Promise<RemoteAgentConfig | null> {
     const [row] = await db
       .select()
       .from(remoteAgents)
-      .where(eq(remoteAgents.id, agentId));
+      .where(withProject(remoteAgents, eq(remoteAgents.id, agentId)));
     return row ? this.rowToConfig(row) : null;
   }
 
@@ -272,21 +321,25 @@ export class RemoteAgentManager {
 
   private startHeartbeat(intervalMs: number): void {
     this.heartbeatInterval = setInterval(async () => {
-      // listAgents() reads across all projects; runAsSystem provides context + audit.
-      const agents = await runAsSystem("remote-agent-heartbeat", () => this.listAgents());
-      for (const agent of agents) {
-        if (!agent.enabled) continue;
-        const health = await this.discovery.healthCheck(agent);
-        await db
-          .update(remoteAgents)
-          .set({
-            status: health.status,
-            lastHeartbeatAt: new Date(),
-            healthError: health.error ?? null,
-            updatedAt: new Date(),
-          })
-          .where(eq(remoteAgents.id, agent.id));
-      }
+      // Wrap the entire heartbeat body in runAsSystem so that getAllAgents()
+      // (which asserts system context via unscopedSystemQuery) and any DB
+      // writes all execute under the same audit-trail context.
+      await runAsSystem("remote-agent-heartbeat", async () => {
+        const agents = await this.getAllAgents();
+        for (const agent of agents) {
+          if (!agent.enabled) continue;
+          const health = await this.discovery.healthCheck(agent);
+          await db
+            .update(remoteAgents)
+            .set({
+              status: health.status,
+              lastHeartbeatAt: new Date(),
+              healthError: health.error ?? null,
+              updatedAt: new Date(),
+            })
+            .where(eq(remoteAgents.id, agent.id));
+        }
+      });
     }, intervalMs);
   }
 
@@ -304,8 +357,9 @@ export class RemoteAgentManager {
       cluster: row.cluster,
       namespace: row.namespace,
       labels: row.labels as Record<string, string> | null,
-      // Decrypt at the DB boundary so all callers receive the plaintext token.
-      // The DB column stores AES-256-GCM ciphertext; the config field holds plaintext.
+      // Decrypt at the DB boundary so internal callers (connectAgent) receive the
+      // plaintext token. HTTP responses MUST strip this via toPublicAgent() in the
+      // route layer (H-3 fix in routes/remote-agents.ts).
       authTokenEnc: row.authTokenEnc ? decrypt(row.authTokenEnc) : null,
       enabled: row.enabled,
       autoConnect: row.autoConnect,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -46,6 +46,7 @@ import { FileWatcherService } from "./services/file-watcher";
 import { stopRateLimitCleanup } from "./services/webhook-handler";
 import { BUILTIN_SKILLS } from "./skills/builtin";
 import { requireAuth } from "./auth/middleware";
+import { requireProject } from "./middleware/project";
 import { tracer } from "./tracing/tracer";
 import { DEFAULT_MODELS, DEFAULT_PIPELINE_STAGES } from "@shared/constants";
 import { log } from "./index";
@@ -121,44 +122,71 @@ export async function registerRoutes(
   const projectRoutes = (await import("./routes/projects")).default;
   app.use("/api/projects", projectRoutes);
 
-  // Register protected route groups — all require authentication
-  app.use("/api/pipelines", requireAuth);
-  app.use("/api/runs", requireAuth);
-  app.use("/api/activity", requireAuth);
-  app.use("/api/models", requireAuth);
-  app.use("/api/gateway", requireAuth);
-  app.use("/api/settings", requireAuth);
-  app.use("/api/workspaces", requireAuth);
-  app.use("/api/chat", requireAuth);
-  app.use("/api/questions", requireAuth);
-  app.use("/api/stats", requireAuth);
-  app.use("/api/strategies", requireAuth);
-  app.use("/api/privacy", requireAuth);
-  app.use("/api/memory", requireAuth);
-  app.use("/api/memories", requireAuth);
-  app.use("/api/lessons", requireAuth);
-  app.use("/api/tools", requireAuth);
-  app.use("/api/mcp", requireAuth);
-  app.use("/api/providers", requireAuth);
+  // Register protected route groups — all require authentication.
+  //
+  // Project-scoped routes (requireAuth + requireProject):
+  //   requireProject reads x-project-id, validates owner/member, sets ALS context.
+  //   Keep /api/projects, auth, health, /api/teams, /api/sandbox, /api/federation public
+  //   (i.e. requireAuth only or no auth) because they must work without a project context.
+  //
+  // UNCERTAIN routes that were scoped conservatively (per ADR-001 §3.1b "when unsure, scope it"):
+  //   /api/models    — models have optional projectId; global catalog seeded without project
+  //   /api/gateway   — uses project-specific provider keys after PR-0c
+  //   /api/lessons   — workspace-scoped (workspaceId), not directly project-scoped
+  //   /api/traces    — indirectly scoped via runId → pipelineRuns.projectId
+  //   /api/lmstudio  — local server config; import creates project-scoped models
+  //   /api/skill-market — external registry; install creates project-scoped skills
+
+  // ── Project-scoped (requireAuth + requireProject) ──────────────────────────
+  app.use("/api/pipelines", requireAuth, requireProject);
+  app.use("/api/runs", requireAuth, requireProject);
+  app.use("/api/activity", requireAuth, requireProject);
+  app.use("/api/models", requireAuth, requireProject);         // UNCERTAIN — see note above
+  app.use("/api/gateway", requireAuth, requireProject);        // UNCERTAIN — see note above
+  app.use("/api/settings", requireAuth, requireProject);
+  app.use("/api/workspaces", requireAuth, requireProject);
+  app.use("/api/chat", requireAuth, requireProject);
+  app.use("/api/questions", requireAuth, requireProject);
+  app.use("/api/stats", requireAuth, requireProject);
+  app.use("/api/strategies", requireAuth, requireProject);
+  app.use("/api/privacy", requireAuth, requireProject);
+  app.use("/api/memory", requireAuth, requireProject);
+  app.use("/api/memories", requireAuth, requireProject);
+  app.use("/api/lessons", requireAuth, requireProject);        // UNCERTAIN — see note above
+  app.use("/api/tools", requireAuth, requireProject);
+  app.use("/api/mcp", requireAuth, requireProject);
+  app.use("/api/providers", requireAuth, requireProject);
+  app.use("/api/maintenance", requireAuth, requireProject);
+  app.use("/api/specialization-profiles", requireAuth, requireProject);
+  app.use("/api/skills", requireAuth, requireProject);
+  app.use("/api/guardrails", requireAuth, requireProject);
+  app.use("/api/triggers", requireAuth, requireProject);
+  app.use("/api/traces", requireAuth, requireProject);         // UNCERTAIN — see note above
+  app.use("/api/task-groups", requireAuth, requireProject);
+  app.use("/api/consilium-loops", requireAuth, requireProject);
+  app.use("/api/task-templates", requireAuth, requireProject);
+  app.use("/api/library", requireAuth, requireProject);
+  app.use("/api/lmstudio", requireAuth, requireProject);       // UNCERTAIN — see note above
+  app.use("/api/skill-teams", requireAuth, requireProject);
+  app.use("/api/tracker-connections", requireAuth, requireProject);
+  app.use("/api/remote-agents", requireAuth, requireProject);
+  app.use("/api/skill-market", requireAuth, requireProject);   // UNCERTAIN — see note above
+  // /api/workspaces/:id/knowledge is already covered by /api/workspaces above;
+  // keep this explicit mount for clarity and so the middleware fires even if the
+  // /api/workspaces mount is ever narrowed.
+  app.use("/api/workspaces/:id/knowledge", requireAuth, requireProject);
+
+  // ── Auth-only (requireAuth, no requireProject) ─────────────────────────────
+  // /api/teams — returns global SDLC team constants, not project data
   app.use("/api/teams", requireAuth);
+  // /api/sandbox — Docker execution utility, no project-specific data
   app.use("/api/sandbox", requireAuth);
-  app.use("/api/maintenance", requireAuth);
-  app.use("/api/specialization-profiles", requireAuth);
-  app.use("/api/skills", requireAuth);
-  app.use("/api/guardrails", requireAuth);
-  app.use("/api/triggers", requireAuth);
-  app.use("/api/traces", requireAuth);
-  app.use("/api/task-groups", requireAuth);
-  app.use("/api/consilium-loops", requireAuth);
-  app.use("/api/task-templates", requireAuth);
-  app.use("/api/library", requireAuth);
-  app.use("/api/lmstudio", requireAuth);
-  app.use("/api/skill-teams", requireAuth);
-  app.use("/api/tracker-connections", requireAuth);
-  app.use("/api/remote-agents", requireAuth);
-  app.use("/api/skill-market", requireAuth);
+  // /api/federation — cross-instance infrastructure, inherently cross-project
   app.use("/api/federation", requireAuth);
-  app.use("/api/workspaces/:id/knowledge", requireAuth);
+
+  // /api/pipeline-run-stats — was entirely unprotected (bug); add both guards now.
+  // This inline endpoint reads pipeline runs (project-scoped data).
+  app.use("/api/pipeline-run-stats", requireAuth, requireProject);
 
   // Register route implementations
   registerModelRoutes(app, storage);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -95,6 +95,7 @@ import { ConflictResolutionService } from "./federation/conflict-resolution";
 import { MemoryFederationService } from "./federation/memory-federation";
 import { PipelineSyncService } from "./federation/pipeline-sync";
 import { getFederationManager } from "./federation/manager-state";
+import { runAsSystem } from "./context";
 
 export async function registerRoutes(
   httpServer: Server,
@@ -311,15 +312,21 @@ export async function registerRoutes(
   try {
     triggerService = new TriggerService(storage);
 
+    // fireTrigger is called from background contexts (cron, file watcher, GitHub events)
+    // where no project ALS context is established. runAsSystem audits the access and
+    // allows withProject to operate cross-project (no project filter applied in system
+    // context). getPipeline validates the pipeline still exists; updateTrigger records
+    // the last-fired timestamp. Both operate cross-project in system context.
     const fireTrigger = async (trigger: import("@shared/schema").TriggerRow, payload: unknown): Promise<void> => {
-      // Fire the trigger by starting a pipeline run
-      const pipeline = await storage.getPipeline(trigger.pipelineId);
-      if (!pipeline) {
-        log(`[triggers] Pipeline not found for trigger ${trigger.id}`, "triggers");
-        return;
-      }
-      await storage.updateTrigger(trigger.id, { lastTriggeredAt: new Date() });
-      log(`[triggers] Fired trigger ${trigger.id} for pipeline ${pipeline.id}`, "triggers");
+      await runAsSystem("fire-trigger", async () => {
+        const pipeline = await storage.getPipeline(trigger.pipelineId);
+        if (!pipeline) {
+          log(`[triggers] Pipeline not found for trigger ${trigger.id}`, "triggers");
+          return;
+        }
+        await storage.updateTrigger(trigger.id, { lastTriggeredAt: new Date() });
+        log(`[triggers] Fired trigger ${trigger.id} for pipeline ${pipeline.id}`, "triggers");
+      });
     };
 
     // VETO-1 fix: pass storage as third argument so routes can look up pipeline ownership
@@ -327,8 +334,11 @@ export async function registerRoutes(
     registerWebhookRoutes(app, storage, triggerService, fireTrigger);
     webhookRoutesRegistered = true;
 
+    // Use getAllEnabledTriggersByType (cross-project, system-context) wrapped in
+    // runAsSystem so the scheduler can load triggers across ALL projects at bootstrap.
     cronScheduler = new CronScheduler({
-      getEnabledTriggersByType: (type) => storage.getEnabledTriggersByType(type),
+      getEnabledTriggersByType: (type) =>
+        runAsSystem("cron-scheduler-bootstrap", () => storage.getAllEnabledTriggersByType(type)),
       fireTrigger,
     });
     await cronScheduler.bootstrap();
@@ -337,7 +347,8 @@ export async function registerRoutes(
     await knowledgeRefreshScheduler.start();
 
     fileWatcherService = new FileWatcherService({
-      getEnabledTriggersByType: (type) => storage.getEnabledTriggersByType(type),
+      getEnabledTriggersByType: (type) =>
+        runAsSystem("file-watcher-bootstrap", () => storage.getAllEnabledTriggersByType(type)),
       fireTrigger,
     });
     await fileWatcherService.bootstrap();
@@ -422,29 +433,37 @@ export async function registerRoutes(
   // Phase 6.10 — ArgoCD auto-connect from env vars (if configured)
   await autoConnectArgoCdFromEnv();
 
-  // Seed built-in skills (idempotent — checks each by ID)
-  for (const skill of BUILTIN_SKILLS) {
-    const existing = await storage.getSkill(skill.id as string);
-    if (!existing) {
-      await storage.createSkill(skill);
+  // Seed built-in skills (idempotent — checks each by ID).
+  // Runs in system context: built-in skills have null projectId (globally shared).
+  await runAsSystem("startup-seed-builtin-skills", async () => {
+    for (const skill of BUILTIN_SKILLS) {
+      const existing = await storage.getSkill(skill.id as string);
+      if (!existing) {
+        await storage.createSkill(skill);
+      }
     }
-  }
+  });
 
-  // Seed default models
-  const existingModels = await storage.getModels();
-  if (existingModels.length === 0) {
-    for (const model of DEFAULT_MODELS) {
-      await storage.createModel(model);
+  // Seed default models. getModels() is an unscoped global select; createModel()
+  // uses withProjectInsert which sets projectId=null in system context (global row).
+  await runAsSystem("startup-seed-default-models", async () => {
+    const existingModels = await storage.getModels();
+    if (existingModels.length === 0) {
+      for (const model of DEFAULT_MODELS) {
+        await storage.createModel(model);
+      }
+      log(`Seeded ${DEFAULT_MODELS.length} default models`);
     }
-    log(`Seeded ${DEFAULT_MODELS.length} default models`);
-  }
+  });
 
   // Reconcile the DB model catalog to the LIVE discovered models so every
   // DB-catalog consumer (Workspace, pipeline, manager, dashboard, settings)
   // only sees the real subscription-CLI models. Best-effort, never blocks boot.
   try {
-    const recon = await reconcileModelCatalog(storage, gateway);
-    log(`Reconciled model catalog: ${recon.upserted} upserted, ${recon.deactivated} deactivated`);
+    await runAsSystem("startup-reconcile-model-catalog", async () => {
+      const recon = await reconcileModelCatalog(storage, gateway);
+      log(`Reconciled model catalog: ${recon.upserted} upserted, ${recon.deactivated} deactivated`);
+    });
   } catch (e) {
     log(`Model catalog reconcile skipped: ${(e as Error).message}`);
   }
@@ -452,12 +471,14 @@ export async function registerRoutes(
   // Best-effort: re-point any EXISTING pipeline stage that still references a now
   // inactive/dead model slug onto a working default. Never throws / never blocks boot.
   try {
-    const stageRecon = await reconcileExistingPipelineStages(storage);
-    if (stageRecon.stagesRepointed > 0) {
-      log(
-        `Re-pointed dead pipeline stages: ${stageRecon.stagesRepointed} stages across ${stageRecon.pipelinesUpdated} pipelines`,
-      );
-    }
+    await runAsSystem("startup-reconcile-pipeline-stages", async () => {
+      const stageRecon = await reconcileExistingPipelineStages(storage);
+      if (stageRecon.stagesRepointed > 0) {
+        log(
+          `Re-pointed dead pipeline stages: ${stageRecon.stagesRepointed} stages across ${stageRecon.pipelinesUpdated} pipelines`,
+        );
+      }
+    });
   } catch (e) {
     log(`Pipeline stage reconcile skipped: ${(e as Error).message}`);
   }
@@ -466,28 +487,33 @@ export async function registerRoutes(
   // KB_SEED_EXAMPLE=true). Idempotent; projection is best-effort.
   if (process.env.KB_SEED_EXAMPLE === "true") {
     try {
-      const seed = await seedExampleTerraformCards(storage, { resolveAdminUserId: resolveFirstAdminUserId });
-      log(
-        `Seeded example Terraform cards: ${seed.created} created, ${seed.alreadyPresent} already present ` +
-          `(workspace ${seed.workspaceId}; projection ${seed.projectionSkipped ? "skipped" : "ok"})`,
-      );
+      await runAsSystem("startup-seed-kb-example", async () => {
+        const seed = await seedExampleTerraformCards(storage, { resolveAdminUserId: resolveFirstAdminUserId });
+        log(
+          `Seeded example Terraform cards: ${seed.created} created, ${seed.alreadyPresent} already present ` +
+            `(workspace ${seed.workspaceId}; projection ${seed.projectionSkipped ? "skipped" : "ok"})`,
+        );
+      });
     } catch (e) {
       log(`Knowledge example seed skipped: ${(e as Error).message}`);
     }
   }
 
-  // Seed default pipeline template
-  const existingPipelines = await storage.getPipelines();
-  if (existingPipelines.length === 0) {
-    await storage.createPipeline({
-      name: "Full SDLC Pipeline",
-      description:
-        "Complete software development lifecycle: Planning → Architecture → Development → Testing → Code Review → Deployment → Monitoring",
-      stages: DEFAULT_PIPELINE_STAGES,
-      isTemplate: true,
-    });
-    log("Seeded default SDLC pipeline template");
-  }
+  // Seed default pipeline template. getPipelines() is an unscoped global select;
+  // createPipeline() uses withProjectInsert which sets projectId=null in system context.
+  await runAsSystem("startup-seed-default-pipeline", async () => {
+    const existingPipelines = await storage.getPipelines();
+    if (existingPipelines.length === 0) {
+      await storage.createPipeline({
+        name: "Full SDLC Pipeline",
+        description:
+          "Complete software development lifecycle: Planning → Architecture → Development → Testing → Code Review → Deployment → Monitoring",
+        stages: DEFAULT_PIPELINE_STAGES,
+        isTemplate: true,
+      });
+      log("Seeded default SDLC pipeline template");
+    }
+  });
 
   // Global pending questions endpoint (protected by /api/questions middleware above)
   app.get("/api/questions/pending", async (_req, res) => {

--- a/server/routes/argocd-settings.ts
+++ b/server/routes/argocd-settings.ts
@@ -15,7 +15,7 @@
 import { Router } from "express";
 import { z } from "zod";
 import type { IStorage } from "../storage";
-import { encrypt, decrypt } from "../crypto";
+import { encrypt } from "../crypto";
 import { mcpClientManager } from "../tools/mcp-client";
 import { argoCdService } from "../services/argocd-service";
 import type { ArgoCdConfigRow } from "@shared/schema";
@@ -144,25 +144,32 @@ export function registerArgoCdSettingsRoutes(router: Router, storage: IStorage):
         return res.status(400).json({ error: "token is required for the initial ArgoCD configuration" });
       }
 
-      // Upsert mcp_servers row for ArgoCD
-      const decryptedToken = decrypt(tokenEnc);
+      // Upsert mcp_servers row for ArgoCD.
+      //
+      // PR-0d: We intentionally do NOT write the decrypted ARGOCD_TOKEN into
+      // mcp_servers.env.  For SSE transport the env field is not passed to the
+      // SSEClientTransport layer (see server/tools/mcp-client.ts connect()), so
+      // storing the plaintext token there is both unnecessary and a plaintext leak
+      // in the DB.
+      //
+      // TODO(PR-1): inject ARGOCD_TOKEN at MCP spawn time via the credential
+      // broker seam (CredentialProvider.issueLease → spawnBuiltinServer secrets
+      // arg) instead of persisting it to mcp_servers.env at all.
       let mcpServerId: number | null = existingRow?.mcpServerId ?? null;
 
       if (mcpServerId !== null) {
-        // Update existing MCP server row
+        // Update existing MCP server row (URL + flags only; token stays in argocd_config.token_enc)
         await storage.updateMcpServer(mcpServerId, {
           url: serverUrl,
-          env: { ARGOCD_TOKEN: decryptedToken },
           enabled,
           autoConnect: enabled,
         } as Partial<import("@shared/types").McpServerConfig>);
       } else {
-        // Create new MCP server row
+        // Create new MCP server row without env (token lives in argocd_config.token_enc)
         const inserted = await storage.createMcpServer({
           name: "argocd",
           transport: "sse",
           url: serverUrl,
-          env: { ARGOCD_TOKEN: decryptedToken },
           enabled,
           autoConnect: enabled,
           toolCount: 0,

--- a/server/routes/argocd-settings.ts
+++ b/server/routes/argocd-settings.ts
@@ -172,7 +172,6 @@ export function registerArgoCdSettingsRoutes(router: Router, storage: IStorage):
 
       // Upsert argocd_config row
       await storage.saveArgoCdConfig({
-        id: 1,
         serverUrl,
         tokenEnc,
         verifySsl,
@@ -207,7 +206,6 @@ export function registerArgoCdSettingsRoutes(router: Router, storage: IStorage):
 
       // Update health status
       await storage.saveArgoCdConfig({
-        id: 1,
         healthStatus,
         healthError,
         lastHealthCheckAt: new Date(),

--- a/server/routes/remote-agents.ts
+++ b/server/routes/remote-agents.ts
@@ -20,6 +20,7 @@ import { z } from "zod";
 import { eq } from "drizzle-orm";
 import { db } from "../db";
 import { remoteAgents } from "@shared/schema";
+import { encrypt } from "../crypto";
 import type { RemoteAgentManager } from "../remote-agents/remote-agent-manager";
 
 // ─── Validation schemas ───────────────────────────────────────────────────────
@@ -191,7 +192,8 @@ export function registerRemoteAgentRoutes(
       if (data.namespace !== undefined) updateSet.namespace = data.namespace;
       if (data.labels !== undefined) updateSet.labels = data.labels;
       if (data.authTokenEnc !== undefined)
-        updateSet.authTokenEnc = data.authTokenEnc;
+        // Encrypt the bearer token before writing to DB (PR-0d: encrypt plaintext authTokenEnc).
+        updateSet.authTokenEnc = data.authTokenEnc ? encrypt(data.authTokenEnc) : null;
       if (data.enabled !== undefined) updateSet.enabled = data.enabled;
       if (data.autoConnect !== undefined)
         updateSet.autoConnect = data.autoConnect;

--- a/server/routes/remote-agents.ts
+++ b/server/routes/remote-agents.ts
@@ -18,10 +18,11 @@
 import type { Router } from "express";
 import { z } from "zod";
 import { eq } from "drizzle-orm";
-import { db } from "../db";
+import { db, withProject } from "../db";
 import { remoteAgents } from "@shared/schema";
 import { encrypt } from "../crypto";
 import type { RemoteAgentManager } from "../remote-agents/remote-agent-manager";
+import type { RemoteAgentConfig } from "@shared/types";
 
 // ─── Validation schemas ───────────────────────────────────────────────────────
 
@@ -58,6 +59,25 @@ const DispatchSchema = z.object({
   skill: z.string().optional(),
 });
 
+// ─── DTO helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * H-3 fix: strips the decrypted authTokenEnc from HTTP responses and replaces
+ * it with a boolean hasAuthToken so callers know whether a token is configured
+ * without receiving the plaintext credential.
+ *
+ * Internal callers (connectAgent, discovery) continue to receive the plaintext
+ * via rowToConfig() — only the HTTP response boundary is sanitised here.
+ */
+type PublicAgentConfig = Omit<RemoteAgentConfig, "authTokenEnc"> & {
+  hasAuthToken: boolean;
+};
+
+function toPublicAgent(agent: RemoteAgentConfig): PublicAgentConfig {
+  const { authTokenEnc, ...rest } = agent;
+  return { ...rest, hasAuthToken: authTokenEnc != null };
+}
+
 // ─── Route registration ───────────────────────────────────────────────────────
 
 export function registerRemoteAgentRoutes(
@@ -77,7 +97,8 @@ export function registerRemoteAgentRoutes(
     }
     try {
       const agents = await manager!.listAgents();
-      return res.json(agents);
+      // H-3: strip plaintext authTokenEnc from all list responses.
+      return res.json(agents.map(toPublicAgent));
     } catch (e) {
       return res.status(500).json({ error: (e as Error).message });
     }
@@ -103,7 +124,8 @@ export function registerRemoteAgentRoutes(
     }
     try {
       const agent = await manager!.registerAgent(parse.data);
-      return res.status(201).json(agent);
+      // H-3: strip plaintext authTokenEnc — caller just sent it, no need to echo it back.
+      return res.status(201).json(toPublicAgent(agent));
     } catch (e) {
       return res.status(500).json({ error: (e as Error).message });
     }
@@ -146,11 +168,13 @@ export function registerRemoteAgentRoutes(
         .json({ error: "Remote agent subsystem is not available" });
     }
     try {
+      // H-4: getAgent() uses withProject — returns null for cross-project agents.
       const agent = await manager!.getAgent(req.params.id);
       if (!agent) {
         return res.status(404).json({ error: "Agent not found" });
       }
-      return res.json(agent);
+      // H-3: strip plaintext authTokenEnc.
+      return res.json(toPublicAgent(agent));
     } catch (e) {
       return res.status(500).json({ error: (e as Error).message });
     }
@@ -175,6 +199,7 @@ export function registerRemoteAgentRoutes(
       });
     }
     try {
+      // H-4: getAgent() is project-scoped; cross-project IDs return null → 404.
       const existing = await manager!.getAgent(req.params.id);
       if (!existing) {
         return res.status(404).json({ error: "Agent not found" });
@@ -198,13 +223,17 @@ export function registerRemoteAgentRoutes(
       if (data.autoConnect !== undefined)
         updateSet.autoConnect = data.autoConnect;
 
+      // H-4: scope the UPDATE to the current project so a cross-project actor
+      // cannot modify another project's agent by supplying its ID.
       await db
         .update(remoteAgents)
         .set(updateSet)
-        .where(eq(remoteAgents.id, req.params.id));
+        .where(withProject(remoteAgents, eq(remoteAgents.id, req.params.id)));
 
+      // H-4: getAgent() is project-scoped here too.
       const updated = await manager!.getAgent(req.params.id);
-      return res.json(updated);
+      // H-3: strip plaintext authTokenEnc from update response.
+      return res.json(updated ? toPublicAgent(updated) : null);
     } catch (e) {
       return res.status(500).json({ error: (e as Error).message });
     }
@@ -219,6 +248,7 @@ export function registerRemoteAgentRoutes(
         .json({ error: "Remote agent subsystem is not available" });
     }
     try {
+      // H-4: unregisterAgent() uses withProject — safe for cross-project IDs.
       await manager!.unregisterAgent(req.params.id);
       return res.status(204).end();
     } catch (e) {
@@ -235,6 +265,7 @@ export function registerRemoteAgentRoutes(
         .json({ error: "Remote agent subsystem is not available" });
     }
     try {
+      // H-4: getAgent() is project-scoped — cross-project IDs return null → 404.
       const agent = await manager!.getAgent(req.params.id);
       if (!agent) {
         return res.status(404).json({ error: "Agent not found" });
@@ -257,6 +288,7 @@ export function registerRemoteAgentRoutes(
         .json({ error: "Remote agent subsystem is not available" });
     }
     try {
+      // H-4: getAgent() is project-scoped — cross-project IDs return null → 404.
       const agent = await manager!.getAgent(req.params.id);
       if (!agent) {
         return res.status(404).json({ error: "Agent not found" });
@@ -283,6 +315,7 @@ export function registerRemoteAgentRoutes(
         .json({ error: "Remote agent subsystem is not available" });
     }
     try {
+      // H-4: getAgent() is project-scoped — cross-project IDs return null → 404.
       const agent = await manager!.getAgent(req.params.id);
       if (!agent) {
         return res.status(404).json({ error: "Agent not found" });
@@ -325,6 +358,7 @@ export function registerRemoteAgentRoutes(
       });
     }
     try {
+      // H-4: getAgent() is project-scoped — cross-project IDs return null → 404.
       const agent = await manager!.getAgent(req.params.id);
       if (!agent) {
         return res.status(404).json({ error: "Agent not found" });

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -7,6 +7,7 @@ import { resolve } from "path";
 import { db, withProject, withProjectInsert } from "../db";
 import { providerKeys } from "@shared/schema";
 import { encrypt, decrypt } from "../crypto";
+import { unscopedSystemQuery } from "../context";
 import type { Gateway } from "../gateway/index";
 import { configLoader } from "../config/loader";
 import type { VersionsResponse } from "@shared/types";
@@ -119,10 +120,16 @@ async function probePostgresVersion(): Promise<string | null> {
 }
 
 export function registerSettingsRoutes(router: Router, gateway: Gateway) {
-  /** GET /api/settings/providers — list providers with config status */
+  /**
+   * GET /api/settings/providers — list providers with config status.
+   *
+   * M-7 fix: the query was previously unscoped (`db.select().from(providerKeys)`)
+   * behind requireProject, returning metadata from ALL projects. Added
+   * `.where(withProject(providerKeys))` to scope it to the current project.
+   */
   router.get("/api/settings/providers", async (_req, res) => {
     try {
-      const rows = await db.select().from(providerKeys);
+      const rows = await db.select().from(providerKeys).where(withProject(providerKeys));
       const dbMap = new Map(rows.map((r) => [r.provider, r]));
 
       const result = CLOUD_PROVIDERS.map((provider) => {
@@ -239,10 +246,25 @@ export function registerSettingsRoutes(router: Router, gateway: Gateway) {
   });
 }
 
-/** Load DB-stored keys and return a map of provider → decrypted key. */
+/**
+ * Load DB-stored keys and return a map of provider → decrypted key.
+ *
+ * M-8 fix: the query was unscoped and decrypted ALL projects' keys. It is now
+ * guarded by unscopedSystemQuery, which throws if called outside a runAsSystem()
+ * context. Callers MUST use:
+ *
+ *   await runAsSystem("startup-load-provider-keys", () => loadProviderKeysFromDb())
+ *
+ * Per-project gateway key resolution will move to the Phase-1 credential broker;
+ * this function is a transitional helper for startup-time gateway seeding only.
+ */
 export async function loadProviderKeysFromDb(): Promise<Map<string, string>> {
   try {
-    const rows = await db.select().from(providerKeys);
+    // unscopedSystemQuery throws if not called inside runAsSystem() — this ensures
+    // callers always establish an explicit audit context before reading all-project keys.
+    const rows = await unscopedSystemQuery("gateway-load-provider-keys", () =>
+      db.select().from(providerKeys),
+    );
     const map = new Map<string, string>();
     for (const row of rows) {
       try {

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -4,7 +4,7 @@ import { eq } from "drizzle-orm";
 import { spawnSync } from "child_process";
 import { readFileSync } from "fs";
 import { resolve } from "path";
-import { db } from "../db";
+import { db, withProject, withProjectInsert } from "../db";
 import { providerKeys } from "@shared/schema";
 import { encrypt, decrypt } from "../crypto";
 import type { Gateway } from "../gateway/index";
@@ -164,11 +164,14 @@ export function registerSettingsRoutes(router: Router, gateway: Gateway) {
       const encrypted = encrypt(result.data.key);
       const now = new Date();
 
+      // ADR-001 PR-0c: inject projectId from ALS context via withProjectInsert.
+      // Conflict target is composite (projectId, provider) since the unique
+      // constraint on provider alone was dropped in the PR-0c migration.
       await db
         .insert(providerKeys)
-        .values({ provider, apiKeyEncrypted: encrypted, updatedAt: now })
+        .values(withProjectInsert(providerKeys, { provider, apiKeyEncrypted: encrypted, updatedAt: now }))
         .onConflictDoUpdate({
-          target: providerKeys.provider,
+          target: [providerKeys.projectId, providerKeys.provider],
           set: { apiKeyEncrypted: encrypted, updatedAt: now },
         });
 
@@ -189,7 +192,7 @@ export function registerSettingsRoutes(router: Router, gateway: Gateway) {
     }
 
     try {
-      await db.delete(providerKeys).where(eq(providerKeys.provider, provider));
+      await db.delete(providerKeys).where(withProject(providerKeys, eq(providerKeys.provider, provider)));
       // Reload gateway — if config key is set it will still work, otherwise provider is gone
       await gateway.reloadProvider(provider as CloudProvider, null);
       res.json({ ok: true, provider });

--- a/server/routes/tracker.ts
+++ b/server/routes/tracker.ts
@@ -39,6 +39,18 @@ const SubmitWorkSchema = z.object({
   trackerBaseUrl: z.string().url().max(2000).optional(),
 });
 
+// ─── DTO helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * H-3 (tracker): strip the apiToken from list responses so the plaintext
+ * credential is never returned over the wire. Callers receive hasApiToken
+ * to know whether a token is configured without seeing its value.
+ */
+function toPublicTrackerConnection(conn: Record<string, unknown>): Record<string, unknown> {
+  const { apiToken, ...rest } = conn;
+  return { ...rest, hasApiToken: apiToken != null };
+}
+
 // ─── Route Registration ─────────────────────────────────────────────────────
 
 export function registerTrackerRoutes(
@@ -64,10 +76,14 @@ export function registerTrackerRoutes(
   );
 
   // List tracker connections for a task group
+  // H-3: redact apiToken — callers only need to know whether a token is configured.
   router.get("/api/tracker-connections/:groupId", async (req, res) => {
     try {
       const conns = await storage.getTrackerConnectionsByGroup(req.params.groupId);
-      res.json(conns);
+      const safe = (conns as unknown as Array<Record<string, unknown>>).map(
+        toPublicTrackerConnection,
+      );
+      res.json(safe);
     } catch (err) {
       res.status(500).json({ error: String(err) });
     }

--- a/server/routes/webhooks.ts
+++ b/server/routes/webhooks.ts
@@ -31,11 +31,14 @@ export function registerWebhookRoutes(
   startRateLimitCleanup();
 
   // POST /api/webhooks/:triggerId — generic webhook receiver
+  // PUBLIC endpoint: no requireProject, no x-project-id header.
+  // C-1: getTrigger and getSecret must run inside runAsSystem so withProject
+  // (fail-closed) does not throw "no request context" on every incoming webhook.
   app.post("/api/webhooks/:triggerId", async (req, res) => {
     try {
       await handleWebhookRequest(req, res, {
-        getTrigger: (id) => storage.getTrigger(id),
-        getSecret: (id) => triggerService.getSecret(id),
+        getTrigger: (id) => runAsSystem("webhook-get-trigger", () => storage.getTrigger(id)),
+        getSecret:  (id) => runAsSystem("webhook-get-secret",  () => triggerService.getSecret(id)),
         fireTrigger,
       });
     } catch (e) {
@@ -49,6 +52,8 @@ export function registerWebhookRoutes(
   });
 
   // POST /api/github-events — GitHub webhook event router
+  // PUBLIC endpoint: no requireProject, no x-project-id header.
+  // C-2: getSecret must run inside runAsSystem (same reason as C-1).
   app.post("/api/github-events", async (req, res) => {
     try {
       const result = await handleGitHubEvent(
@@ -63,7 +68,8 @@ export function registerWebhookRoutes(
             runAsSystem("github-event-trigger-lookup", () =>
               storage.getAllEnabledTriggersByType(type),
             ),
-          getSecret: (id) => triggerService.getSecret(id),
+          getSecret: (id) =>
+            runAsSystem("github-event-get-secret", () => triggerService.getSecret(id)),
           fireTrigger,
         },
       );

--- a/server/routes/webhooks.ts
+++ b/server/routes/webhooks.ts
@@ -15,6 +15,7 @@ import {
   startRateLimitCleanup,
 } from "../services/webhook-handler.js";
 import { handleGitHubEvent } from "../services/github-event-handler.js";
+import { runAsSystem } from "../context.js";
 
 function correlationId(): string {
   return randomUUID().slice(0, 8);
@@ -55,7 +56,13 @@ export function registerWebhookRoutes(
         req.headers as Record<string, string | string[] | undefined>,
         req.body as unknown,
         {
-          getEnabledTriggersByType: (type) => storage.getEnabledTriggersByType(type),
+          // getEnabledTriggersByType must run cross-project (no ALS context on github-events).
+          // runAsSystem establishes a system context; getAllEnabledTriggersByType bypasses
+          // the project filter so all matching triggers across all projects are returned.
+          getEnabledTriggersByType: (type) =>
+            runAsSystem("github-event-trigger-lookup", () =>
+              storage.getAllEnabledTriggersByType(type),
+            ),
           getSecret: (id) => triggerService.getSecret(id),
           fireTrigger,
         },

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -1,6 +1,7 @@
 import { eq, desc, and, or, ilike, lt, ne, gte, lte, asc, isNull, inArray, sql as drizzleSql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { db, withProject, withProjectInsert } from "./db";
+import { unscopedSystemQuery } from "./context";
 import type { IStorage, PracticeCardFilters, MorningBriefFilters, NewsItemFilters, LlmRequestFilters, LlmRequestStats, LlmStatsByModel, LlmStatsByProvider, LlmStatsByTeam, LlmTimelinePoint, RunHistoryQuery, PipelineRunHistoryRow, TaskGroupHistoryRow } from "./storage";
 import {
   TASK_GROUP_V2_MAX_LIMIT,
@@ -1405,6 +1406,20 @@ export class PgStorage implements IStorage {
       .select()
       .from(triggers)
       .where(withProject(triggers, and(eq(triggers.enabled, true), eq(triggers.type, type as TriggerRow["type"]))));
+  }
+
+  /**
+   * Cross-project query: returns ALL enabled triggers of this type across every
+   * project. Intended for background/system callers (CronScheduler, FileWatcher,
+   * GitHub event handler). MUST be called within runAsSystem(). See ADR-001 §3.1(d).
+   */
+  async getAllEnabledTriggersByType(type: string): Promise<TriggerRow[]> {
+    return unscopedSystemQuery("getAllEnabledTriggersByType", () =>
+      db
+        .select()
+        .from(triggers)
+        .where(and(eq(triggers.enabled, true), eq(triggers.type, type as TriggerRow["type"]))),
+    );
   }
 
   async createTrigger(

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -1588,22 +1588,37 @@ export class PgStorage implements IStorage {
 
   // ─── Tracker Connections (Issue Tracker Integration) ────────────────────────
 
+  /** Decrypt the api_token column for a tracker connection row. Null-safe. */
+  private decryptTrackerToken(row: typeof trackerConnections.$inferSelect): TrackerConnectionRow {
+    return {
+      ...row,
+      apiToken: row.apiToken ? decrypt(row.apiToken) : null,
+    };
+  }
+
   async getTrackerConnectionsByGroup(taskGroupId: string): Promise<TrackerConnectionRow[]> {
-    return db.select().from(trackerConnections)
+    const rows = await db.select().from(trackerConnections)
       .where(withProject(trackerConnections, eq(trackerConnections.taskGroupId, taskGroupId)));
+    return rows.map((r) => this.decryptTrackerToken(r));
   }
 
   async getTrackerConnection(id: string): Promise<TrackerConnectionRow | undefined> {
     const [row] = await db.select().from(trackerConnections)
       .where(withProject(trackerConnections, eq(trackerConnections.id, id)));
-    return row;
+    return row ? this.decryptTrackerToken(row) : undefined;
   }
 
   async createTrackerConnection(data: InsertTrackerConnection): Promise<TrackerConnectionRow> {
+    // Encrypt the token before persisting; decrypt on the way out so callers always
+    // receive plaintext regardless of storage layer.
+    const encryptedData = {
+      ...data,
+      apiToken: data.apiToken ? encrypt(data.apiToken) : (data.apiToken ?? null),
+    };
     const [row] = await db.insert(trackerConnections)
-      .values(withProjectInsert(trackerConnections, data as typeof trackerConnections.$inferInsert))
+      .values(withProjectInsert(trackerConnections, encryptedData as typeof trackerConnections.$inferInsert))
       .returning();
-    return row;
+    return this.decryptTrackerToken(row);
   }
 
   async deleteTrackerConnection(id: string): Promise<void> {

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -1408,7 +1408,7 @@ export class PgStorage implements IStorage {
   }
 
   async createTrigger(
-    data: Omit<TriggerRow, "id" | "createdAt" | "updatedAt" | "lastTriggeredAt"> & { secretEncrypted?: string | null },
+    data: Omit<TriggerRow, "id" | "projectId" | "createdAt" | "updatedAt" | "lastTriggeredAt"> & { secretEncrypted?: string | null },
   ): Promise<TriggerRow> {
     const [row] = await db
       .insert(triggers)
@@ -1657,18 +1657,22 @@ export class PgStorage implements IStorage {
 
 
   // ─── ArgoCD Config ────────────────────────────────────────────────────────
+  // ADR-001 PR-0c [R3-SEC-5]: converted from id=1 singleton to per-project rows.
+  // All three functions use withProject(argoCdConfig) for project-scoped access.
+  // They will throw without a project context (same as all other scoped tables);
+  // this is intentional — enforce as soon as requireProject is wired (PR-0b).
 
   async getArgoCdConfig(): Promise<ArgoCdConfigRow | null> {
-    const [row] = await db.select().from(argoCdConfig).where(eq(argoCdConfig.id, 1));
+    const [row] = await db.select().from(argoCdConfig).where(withProject(argoCdConfig));
     return row ?? null;
   }
 
-  async saveArgoCdConfig(config: Partial<InsertArgoCdConfig> & { id?: number }): Promise<ArgoCdConfigRow> {
+  async saveArgoCdConfig(config: Partial<InsertArgoCdConfig>): Promise<ArgoCdConfigRow> {
     const now = new Date();
     const existing = await this.getArgoCdConfig();
 
     if (existing) {
-      // Update existing row
+      // Update existing row for the current project
       const updates: Record<string, unknown> = { updatedAt: now };
       if (config.serverUrl !== undefined) updates.serverUrl = config.serverUrl;
       if (config.tokenEnc !== undefined) updates.tokenEnc = config.tokenEnc;
@@ -1682,15 +1686,14 @@ export class PgStorage implements IStorage {
       const [row] = await db
         .update(argoCdConfig)
         .set(updates)
-        .where(eq(argoCdConfig.id, 1))
+        .where(withProject(argoCdConfig, eq(argoCdConfig.id, existing.id)))
         .returning();
       return row;
     } else {
-      // Insert new row
+      // Insert new row; withProjectInsert injects projectId from ALS context
       const [row] = await db
         .insert(argoCdConfig)
-        .values({
-          id: config.id ?? 1,
+        .values(withProjectInsert(argoCdConfig, {
           serverUrl: config.serverUrl ?? null,
           tokenEnc: config.tokenEnc ?? null,
           verifySsl: config.verifySsl ?? true,
@@ -1699,14 +1702,14 @@ export class PgStorage implements IStorage {
           healthStatus: ((config as Record<string, unknown>).healthStatus as string) ?? "unknown",
           healthError: ((config as Record<string, unknown>).healthError as string) ?? null,
           updatedAt: now,
-        } as typeof argoCdConfig.$inferInsert)
+        } as typeof argoCdConfig.$inferInsert))
         .returning();
       return row;
     }
   }
 
   async deleteArgoCdConfig(): Promise<void> {
-    await db.delete(argoCdConfig).where(eq(argoCdConfig.id, 1));
+    await db.delete(argoCdConfig).where(withProject(argoCdConfig));
   }
 
   // ─── Workspaces ───────────────────────────────────────────────────────────

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -440,7 +440,7 @@ export interface IStorage {
   getTriggers(pipelineId: string): Promise<TriggerRow[]>;
   getTrigger(id: string): Promise<TriggerRow | undefined>;
   getEnabledTriggersByType(type: string): Promise<TriggerRow[]>;
-  createTrigger(data: Omit<TriggerRow, 'id' | 'createdAt' | 'updatedAt' | 'lastTriggeredAt'> & { secretEncrypted?: string | null }): Promise<TriggerRow>;
+  createTrigger(data: Omit<TriggerRow, 'id' | 'projectId' | 'createdAt' | 'updatedAt' | 'lastTriggeredAt'> & { secretEncrypted?: string | null }): Promise<TriggerRow>;
   updateTrigger(id: string, updates: Partial<TriggerRow>): Promise<TriggerRow>;
   deleteTrigger(id: string): Promise<void>;
 
@@ -612,7 +612,7 @@ export interface IStorage {
 
   // ArgoCD Config
   getArgoCdConfig(): Promise<ArgoCdConfigRow | null>;
-  saveArgoCdConfig(config: Partial<InsertArgoCdConfig> & { id?: number }): Promise<ArgoCdConfigRow>;
+  saveArgoCdConfig(config: Partial<InsertArgoCdConfig>): Promise<ArgoCdConfigRow>;
   deleteArgoCdConfig(): Promise<void>;
 
   // Workspaces
@@ -2160,12 +2160,13 @@ export class MemStorage implements IStorage {
   }
 
   async createTrigger(
-    data: Omit<TriggerRow, 'id' | 'createdAt' | 'updatedAt' | 'lastTriggeredAt'> & { secretEncrypted?: string | null },
+    data: Omit<TriggerRow, 'id' | 'projectId' | 'createdAt' | 'updatedAt' | 'lastTriggeredAt'> & { secretEncrypted?: string | null },
   ): Promise<TriggerRow> {
     const id = randomUUID();
     const now = new Date();
     const row: TriggerRow = {
       id,
+      projectId: null, // MemStorage has no project context; projectId is null in-memory
       pipelineId: data.pipelineId,
       type: data.type as TriggerRow["type"],
       config: (data.config ?? {}) as TriggerRow["config"],
@@ -2523,7 +2524,7 @@ export class MemStorage implements IStorage {
     return this.argoCdConfigRow;
   }
 
-  async saveArgoCdConfig(config: Partial<InsertArgoCdConfig> & { id?: number }): Promise<ArgoCdConfigRow> {
+  async saveArgoCdConfig(config: Partial<InsertArgoCdConfig>): Promise<ArgoCdConfigRow> {
     const now = new Date();
     if (this.argoCdConfigRow) {
       // Update existing
@@ -2533,9 +2534,10 @@ export class MemStorage implements IStorage {
         updatedAt: now,
       } as ArgoCdConfigRow;
     } else {
-      // Create new
+      // Create new; id is a serial auto-inc (no longer singleton id=1)
       this.argoCdConfigRow = {
-        id: config.id ?? 1,
+        id: 1, // MemStorage uses a single in-memory row; id is irrelevant here
+        projectId: null, // MemStorage has no project context
         serverUrl: config.serverUrl ?? null,
         tokenEnc: config.tokenEnc ?? null,
         verifySsl: config.verifySsl ?? true,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -440,6 +440,9 @@ export interface IStorage {
   getTriggers(pipelineId: string): Promise<TriggerRow[]>;
   getTrigger(id: string): Promise<TriggerRow | undefined>;
   getEnabledTriggersByType(type: string): Promise<TriggerRow[]>;
+  /** Cross-project query for system/background use: returns ALL enabled triggers of this type
+   *  across every project. Must be called within runAsSystem(). See ADR-001 §3.1(d). */
+  getAllEnabledTriggersByType(type: string): Promise<TriggerRow[]>;
   createTrigger(data: Omit<TriggerRow, 'id' | 'createdAt' | 'updatedAt' | 'lastTriggeredAt'> & { secretEncrypted?: string | null }): Promise<TriggerRow>;
   updateTrigger(id: string, updates: Partial<TriggerRow>): Promise<TriggerRow>;
   deleteTrigger(id: string): Promise<void>;
@@ -2156,6 +2159,12 @@ export class MemStorage implements IStorage {
   }
 
   async getEnabledTriggersByType(type: string): Promise<TriggerRow[]> {
+    return Array.from(this.triggersMap.values()).filter((t) => t.enabled && t.type === type);
+  }
+
+  // Cross-project: in MemStorage there is no project isolation, so this is
+  // identical to getEnabledTriggersByType. Both return all matching triggers.
+  async getAllEnabledTriggersByType(type: string): Promise<TriggerRow[]> {
     return Array.from(this.triggersMap.values()).filter((t) => t.enabled && t.type === type);
   }
 

--- a/server/ws/manager.ts
+++ b/server/ws/manager.ts
@@ -3,6 +3,7 @@ import type { Server, IncomingMessage } from "http";
 import type { WsEvent, User } from "@shared/types";
 import type { IStorage } from "../storage";
 import { authService } from "../auth/service";
+import { runAsSystem } from "../context";
 import { isVisible } from "../routes/authorize-run.js";
 
 function extractTokenFromRequest(req: IncomingMessage): string | null {
@@ -97,21 +98,28 @@ export class WsManager {
   ): Promise<boolean> {
     if (!user?.id || !this.storage) return false;
 
-    // 1) Pipeline-family path (unchanged, checked first).
-    const run = await this.storage.getPipelineRun(runId);
-    if (run) {
-      if (!isVisible(run.triggeredBy, user)) return false;
+    // WS connections survive the HTTP upgrade but the ALS context does not
+    // propagate through the socket event loop. Wrap storage lookups in
+    // runAsSystem so they have context; no project filter is applied in system
+    // context, which is correct here — we're looking up a run by ID without
+    // knowing its project yet (that's the whole point of the ownership check).
+    return runAsSystem("ws-authorize-and-subscribe", async () => {
+      // 1) Pipeline-family path (unchanged, checked first).
+      const run = await this.storage!.getPipelineRun(runId);
+      if (run) {
+        if (!isVisible(run.triggeredBy, user)) return false;
+        this.subscribe(ws, runId);
+        return true;
+      }
+
+      // 2) Task-group fallback (H3) — gate on task_groups.createdBy.
+      const group = await this.storage!.getTaskGroup(runId);
+      if (!group) return false; // unknown in both spaces → fail closed.
+      if (!isVisible(group.createdBy, user)) return false;
+
       this.subscribe(ws, runId);
       return true;
-    }
-
-    // 2) Task-group fallback (H3) — gate on task_groups.createdBy.
-    const group = await this.storage.getTaskGroup(runId);
-    if (!group) return false; // unknown in both spaces → fail closed.
-    if (!isVisible(group.createdBy, user)) return false;
-
-    this.subscribe(ws, runId);
-    return true;
+    });
   }
 
   subscribe(ws: WebSocket, runId: string): void {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -293,15 +293,27 @@ export type ChatMessage = typeof chatMessages.$inferSelect;
 
 // ─── Provider Keys ──────────────────────────────────
 
-export const providerKeys = pgTable("provider_keys", {
-  id: varchar("id")
-    .primaryKey()
-    .default(sql`gen_random_uuid()`),
-  provider: text("provider").notNull().unique(),
-  apiKeyEncrypted: text("api_key_encrypted").notNull(),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at").defaultNow(),
-});
+export const providerKeys = pgTable(
+  "provider_keys",
+  {
+    id: varchar("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    // Per-project scoping: ADR-001 PR-0c
+    projectId: text("project_id").references(() => projects.id, { onDelete: "cascade" }),
+    provider: text("provider").notNull(),
+    apiKeyEncrypted: text("api_key_encrypted").notNull(),
+    createdAt: timestamp("created_at").defaultNow(),
+    updatedAt: timestamp("updated_at").defaultNow(),
+  },
+  (table) => ({
+    // Composite unique replaces the old global unique(provider): ADR-001 §5
+    projectProviderUniq: unique("provider_keys_project_provider_unique").on(
+      table.projectId,
+      table.provider,
+    ),
+  }),
+);
 
 export type ProviderKey = typeof providerKeys.$inferSelect;
 
@@ -431,19 +443,30 @@ export type McpServerRow = typeof mcpServers.$inferSelect;
 export const ARGOCD_HEALTH_STATUS = ['connected', 'error', 'unknown'] as const;
 export type ArgoCdHealthStatus = typeof ARGOCD_HEALTH_STATUS[number];
 
-export const argoCdConfig = pgTable('argocd_config', {
-  id: integer('id').primaryKey().default(1),
-  serverUrl: text('server_url'),
-  tokenEnc: text('token_enc'),
-  verifySsl: boolean('verify_ssl').notNull().default(true),
-  enabled: boolean('enabled').notNull().default(false),
-  mcpServerId: integer('mcp_server_id').references(() => mcpServers.id, { onDelete: 'set null' }),
-  lastHealthCheckAt: timestamp('last_health_check_at'),
-  healthStatus: text('health_status').notNull().default('unknown').$type<ArgoCdHealthStatus>(),
-  healthError: text('health_error'),
-  createdAt: timestamp('created_at').notNull().defaultNow(),
-  updatedAt: timestamp('updated_at').notNull().defaultNow(),
-});
+export const argoCdConfig = pgTable(
+  'argocd_config',
+  {
+    // Changed from integer().default(1) singleton to serial (auto-inc) + per-project unique:
+    // ADR-001 PR-0c converts the id=1 singleton to per-project rows.
+    id: serial('id').primaryKey(),
+    // Per-project scoping: one row per project — ADR-001 §3.1(e) [R3-SEC-5]
+    projectId: text('project_id').references(() => projects.id, { onDelete: 'cascade' }),
+    serverUrl: text('server_url'),
+    tokenEnc: text('token_enc'),
+    verifySsl: boolean('verify_ssl').notNull().default(true),
+    enabled: boolean('enabled').notNull().default(false),
+    mcpServerId: integer('mcp_server_id').references(() => mcpServers.id, { onDelete: 'set null' }),
+    lastHealthCheckAt: timestamp('last_health_check_at'),
+    healthStatus: text('health_status').notNull().default('unknown').$type<ArgoCdHealthStatus>(),
+    healthError: text('health_error'),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+  },
+  (table) => ({
+    // One ArgoCD config per project (replaces the id=1 singleton): ADR-001 §5
+    projectUniq: unique('argocd_config_project_unique').on(table.projectId),
+  }),
+);
 
 export const insertArgoCdConfigSchema = createInsertSchema(argoCdConfig).omit({
   id: true,
@@ -725,6 +748,8 @@ export const triggers = pgTable(
     id: varchar("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    // Denormalized from pipelines.projectId for direct query scoping: ADR-001 PR-0c §3.1(e)
+    projectId: text("project_id").references(() => projects.id, { onDelete: "cascade" }),
     pipelineId: varchar("pipeline_id")
       .notNull()
       .references(() => pipelines.id, { onDelete: "cascade" }),
@@ -739,11 +764,13 @@ export const triggers = pgTable(
   (table) => ({
     pipelineIdIdx: index("triggers_pipeline_id_idx").on(table.pipelineId),
     enabledTypeIdx: index("triggers_enabled_type_idx").on(table.enabled, table.type),
+    projectIdIdx: index("triggers_project_id_idx").on(table.projectId),
   }),
 );
 
 export const insertTriggerSchema = createInsertSchema(triggers).omit({
   id: true,
+  projectId: true,
   createdAt: true,
   updatedAt: true,
   lastTriggeredAt: true,
@@ -1768,6 +1795,10 @@ export const mcpToolCalls = pgTable(
     id: varchar("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    // Per-project scoping: ADR-001 PR-0c — resolves the column-not-found gap
+    // that would cause fail-closed withProject(mcpToolCalls) to throw. Backfilled
+    // from pipeline_runs.project_id via JOIN on pipeline_run_id.
+    projectId: text("project_id").references(() => projects.id, { onDelete: "cascade" }),
     /** Nullable — tool calls may occur outside a pipeline run context. */
     pipelineRunId: varchar("pipeline_run_id"),
     /** DAG stage ID within the run, if applicable. */
@@ -1794,11 +1825,13 @@ export const mcpToolCalls = pgTable(
       table.connectionId,
       table.startedAt,
     ),
+    projectIdIdx: index("mcp_tool_calls_project_id_idx").on(table.projectId),
   }),
 );
 
 export const insertMcpToolCallSchema = createInsertSchema(mcpToolCalls).omit({
   id: true,
+  projectId: true,
   startedAt: true,
 });
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -300,7 +300,10 @@ export const providerKeys = pgTable(
       .primaryKey()
       .default(sql`gen_random_uuid()`),
     // Per-project scoping: ADR-001 PR-0c
-    projectId: text("project_id").references(() => projects.id, { onDelete: "cascade" }),
+    // ADR-001 PR-0c R3-HIGH: .notNull() ensures drizzle-kit push preserves the NOT NULL
+    // DB constraint. .$type<string|null> keeps TS nullable for withProjectInsert callers
+    // (which inject projectId at runtime) and MemStorage (uses null in-memory mock).
+    projectId: text("project_id").references(() => projects.id, { onDelete: "cascade" }).notNull().$type<string | null>(),
     provider: text("provider").notNull(),
     apiKeyEncrypted: text("api_key_encrypted").notNull(),
     createdAt: timestamp("created_at").defaultNow(),
@@ -450,7 +453,8 @@ export const argoCdConfig = pgTable(
     // ADR-001 PR-0c converts the id=1 singleton to per-project rows.
     id: serial('id').primaryKey(),
     // Per-project scoping: one row per project — ADR-001 §3.1(e) [R3-SEC-5]
-    projectId: text('project_id').references(() => projects.id, { onDelete: 'cascade' }),
+    // ADR-001 PR-0c R3-HIGH: see providerKeys.projectId comment above.
+    projectId: text('project_id').references(() => projects.id, { onDelete: 'cascade' }).notNull().$type<string | null>(),
     serverUrl: text('server_url'),
     tokenEnc: text('token_enc'),
     verifySsl: boolean('verify_ssl').notNull().default(true),
@@ -749,7 +753,8 @@ export const triggers = pgTable(
       .primaryKey()
       .default(sql`gen_random_uuid()`),
     // Denormalized from pipelines.projectId for direct query scoping: ADR-001 PR-0c §3.1(e)
-    projectId: text("project_id").references(() => projects.id, { onDelete: "cascade" }),
+    // ADR-001 PR-0c R3-HIGH: see providerKeys.projectId comment above.
+    projectId: text("project_id").references(() => projects.id, { onDelete: "cascade" }).notNull().$type<string | null>(),
     pipelineId: varchar("pipeline_id")
       .notNull()
       .references(() => pipelines.id, { onDelete: "cascade" }),
@@ -1798,7 +1803,8 @@ export const mcpToolCalls = pgTable(
     // Per-project scoping: ADR-001 PR-0c — resolves the column-not-found gap
     // that would cause fail-closed withProject(mcpToolCalls) to throw. Backfilled
     // from pipeline_runs.project_id via JOIN on pipeline_run_id.
-    projectId: text("project_id").references(() => projects.id, { onDelete: "cascade" }),
+    // ADR-001 PR-0c R3-HIGH: see providerKeys.projectId comment above.
+    projectId: text("project_id").references(() => projects.id, { onDelete: "cascade" }).notNull().$type<string | null>(),
     /** Nullable — tool calls may occur outside a pipeline run context. */
     pipelineRunId: varchar("pipeline_run_id"),
     /** DAG stage ID within the run, if applicable. */

--- a/tests/integration/cross-project-http-isolation.test.ts
+++ b/tests/integration/cross-project-http-isolation.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Cross-project HTTP isolation tests (ADR-001 PR-0f, item 4)
+ *
+ * Proves that the `requireProject` middleware correctly enforces project
+ * membership at the HTTP boundary:
+ *
+ *   1. Missing x-project-id → 400 (not duplicated from require-project-middleware.test.ts;
+ *      included here only as a sanity anchor for the test app setup).
+ *   2. Project does not exist → 404.
+ *   3. User is a member of project A but NOT of project B → 403 on project B.
+ *   4. User IS a member (non-owner) of project A → 200, context set to project A.
+ *   5. User IS the owner of project A → 200, context set to project A.
+ *   6. Successful request sets ALS context to the x-project-id value — downstream
+ *      handlers can only see that project's ID (data-isolation proof at context level).
+ *   7. After a 403 on project B, a subsequent valid request for project A succeeds
+ *      and sets context to project A — 403 does NOT corrupt or bleed state.
+ *
+ * Strategy: build a minimal express app mirroring the requireAuth → requireProject
+ * chain.  The db module is mocked so the tests are DB-free; `projects` and
+ * `project_members` table queries return controlled payloads.  The real
+ * requestContext (ALS) and requireProject logic are exercised.
+ *
+ * NOTE: the 400-without-header matrix for every scoped route is already in
+ * tests/integration/require-project-middleware.test.ts.  This file focuses on
+ * the 403 membership case and the data-isolation (context-value) proof.
+ */
+
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import request from "supertest";
+import express from "express";
+import type { Express, Request, Response, NextFunction } from "express";
+import type { User } from "../../shared/types.js";
+
+// ─── Mutable store controlled by tests ────────────────────────────────────────
+//
+// vi.hoisted() ensures these values are available inside the vi.mock() factory
+// (both are hoisted above the module graph).  Tests mutate .value between calls.
+
+const STORE = vi.hoisted(() => ({
+  projectsRows: [] as unknown[],
+  membersRows: [] as unknown[],
+}));
+
+// ─── Mock the db module so requireProject makes no real DB calls ──────────────
+//
+// requireProject calls:
+//   db.select().from(projects).where(…).limit(1)   → determines if project exists + ownerId
+//   db.select().from(projectMembers).where(…).limit(1) → determines if user is a member
+//
+// We route the mock responses by table name (drizzle's BaseName symbol).
+
+vi.mock("../../server/db.js", () => {
+  const TABLE_NAME = Symbol.for("drizzle:BaseName");
+
+  return {
+    db: {
+      select: () => ({
+        from: (table: unknown) => ({
+          where: () => ({
+            limit: () => {
+              const name = (table as Record<symbol, string>)[TABLE_NAME];
+              if (name === "projects") return Promise.resolve(STORE.projectsRows);
+              if (name === "project_members") return Promise.resolve(STORE.membersRows);
+              return Promise.resolve([]);
+            },
+          }),
+        }),
+      }),
+    },
+    pool: { on: () => {} },
+    // withProject / withProjectInsert are not called by requireProject itself —
+    // they are route-handler concerns.  Expose no-op stubs.
+    withProject: (_t: unknown, cond?: unknown) => cond ?? {},
+    withProjectInsert: (_t: unknown, data: unknown) => data,
+    runMigrations: async () => {},
+  };
+});
+
+// ─── Synthetic users ──────────────────────────────────────────────────────────
+
+const USER_A: User = {
+  id: "user-a",
+  email: "a@example.com",
+  name: "User A",
+  isActive: true,
+  role: "user",
+  lastLoginAt: null,
+  createdAt: new Date(0),
+};
+
+// PROJECT_A is owned by USER_A.  USER_A has NO membership in PROJECT_B.
+const PROJECT_A = { id: "proj-a", name: "Project A", ownerId: "user-a", createdAt: new Date(0), updatedAt: new Date(0) };
+const PROJECT_B = { id: "proj-b", name: "Project B", ownerId: "user-b", createdAt: new Date(0), updatedAt: new Date(0) };
+
+/** Injects USER_A as the authenticated user on every request. */
+function injectUserA(req: Request, _res: Response, next: NextFunction) {
+  req.user = USER_A;
+  next();
+}
+
+/** A stub handler that returns the project context it sees — isolation proof. */
+async function contextEchoHandler(req: Request, res: Response) {
+  // Import context here to avoid module-graph issues at test-app build time.
+  const { getProjectId } = await import("../../server/context.js");
+  try {
+    const projectId = getProjectId();
+    res.json({ ok: true, projectId });
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+}
+
+// ─── Build the test express app ───────────────────────────────────────────────
+
+let app: Express;
+
+beforeAll(async () => {
+  const { requireProject } = await import("../../server/middleware/project.js");
+
+  app = express();
+  app.use(express.json());
+  app.use(injectUserA);
+
+  // Mount a scoped router that mirrors the requireAuth → requireProject chain.
+  // The context-echo handler returns the projectId from ALS for isolation verification.
+  const router = express.Router();
+  router.use(requireProject as express.RequestHandler);
+  router.get("/data", contextEchoHandler as express.RequestHandler);
+  app.use("/api/pipelines", router);
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("HTTP middleware — 400 on missing x-project-id (sanity check)", () => {
+  it("scoped route returns 400 when x-project-id header is absent", async () => {
+    const res = await request(app).get("/api/pipelines/data");
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: expect.stringContaining("x-project-id") });
+  });
+});
+
+describe("HTTP middleware — 404 when project does not exist", () => {
+  it("x-project-id refers to a non-existent project → 404", async () => {
+    STORE.projectsRows = []; // empty: project not found
+    STORE.membersRows = [];
+
+    const res = await request(app)
+      .get("/api/pipelines/data")
+      .set("x-project-id", "proj-nonexistent");
+
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({ error: expect.stringContaining("Project not found") });
+  });
+});
+
+describe("HTTP middleware — 403 cross-project membership check", () => {
+  it("user-A (member of proj-a, NOT proj-b) gets 403 when sending x-project-id: proj-b", async () => {
+    // Project B exists, but USER_A is not a member (not an owner either).
+    STORE.projectsRows = [PROJECT_B];
+    STORE.membersRows = []; // USER_A has no membership in proj-b
+
+    const res = await request(app)
+      .get("/api/pipelines/data")
+      .set("x-project-id", "proj-b");
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ error: expect.stringContaining("Access denied") });
+  });
+
+  it("403 response does not leak any of project B's data in the body", async () => {
+    STORE.projectsRows = [PROJECT_B];
+    STORE.membersRows = [];
+
+    const res = await request(app)
+      .get("/api/pipelines/data")
+      .set("x-project-id", "proj-b");
+
+    expect(res.status).toBe(403);
+    // The body must not contain project-B data
+    const body = JSON.stringify(res.body);
+    expect(body).not.toContain("proj-b data");
+    expect(body).not.toContain("proj-b secret");
+  });
+});
+
+describe("HTTP middleware — 200 with valid membership, context set correctly", () => {
+  it("user-A as owner of proj-a gets 200 and ALS context is set to proj-a", async () => {
+    // USER_A owns PROJECT_A → owner branch in requireProject fires.
+    STORE.projectsRows = [PROJECT_A];
+    STORE.membersRows = []; // ownership check succeeds before member check
+
+    const res = await request(app)
+      .get("/api/pipelines/data")
+      .set("x-project-id", "proj-a");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, projectId: "proj-a" });
+  });
+
+  it("user-A as a non-owner member of proj-a gets 200 and ALS context is set to proj-a", async () => {
+    // USER_A is not the owner but is a member (e.g. another user owns the project).
+    const otherUserProject = { ...PROJECT_A, ownerId: "user-c" };
+    STORE.projectsRows = [otherUserProject];
+    STORE.membersRows = [{ projectId: "proj-a", userId: "user-a", role: "editor" }];
+
+    const res = await request(app)
+      .get("/api/pipelines/data")
+      .set("x-project-id", "proj-a");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, projectId: "proj-a" });
+  });
+
+  it("ALS context value matches exactly the x-project-id sent in the header", async () => {
+    STORE.projectsRows = [PROJECT_A];
+    STORE.membersRows = [];
+
+    const res = await request(app)
+      .get("/api/pipelines/data")
+      .set("x-project-id", "proj-a");
+
+    // The handler reads getProjectId() from ALS — must equal the header value.
+    expect(res.body.projectId).toBe("proj-a");
+  });
+});
+
+describe("HTTP middleware — 403 does not corrupt subsequent successful requests", () => {
+  it("after a 403 on proj-b, a valid request for proj-a succeeds with correct context", async () => {
+    // First request: 403 on proj-b
+    STORE.projectsRows = [PROJECT_B];
+    STORE.membersRows = [];
+    const failRes = await request(app)
+      .get("/api/pipelines/data")
+      .set("x-project-id", "proj-b");
+    expect(failRes.status).toBe(403);
+
+    // Second request: 200 on proj-a — context must be proj-a, not contaminated.
+    STORE.projectsRows = [PROJECT_A];
+    STORE.membersRows = [];
+    const successRes = await request(app)
+      .get("/api/pipelines/data")
+      .set("x-project-id", "proj-a");
+    expect(successRes.status).toBe(200);
+    expect(successRes.body.projectId).toBe("proj-a");
+  });
+});

--- a/tests/integration/remote-agents-isolation.test.ts
+++ b/tests/integration/remote-agents-isolation.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Remote Agents isolation tests (ADR-001 fix-isolation: H-3 / H-4)
+ *
+ * H-3: GET /api/remote-agents (list), GET /api/remote-agents/:id, and
+ *      POST /api/remote-agents (create) must NOT return the plaintext authTokenEnc
+ *      field.  Instead the response contains `hasAuthToken: boolean`.
+ *
+ * H-4: A user in project A must receive 404 (not the agent) when requesting
+ *      project B's agent by ID.  The manager's getAgent() uses
+ *      withProject(remoteAgents, eq(remoteAgents.id, id)) so cross-project IDs
+ *      yield no row → null → 404.
+ *
+ * Test strategy:
+ *  H-3 — uses the existing mock-manager harness from remote-agents-api.test.ts;
+ *         verifies response shape after toPublicAgent() is applied in routes.
+ *  H-4 — uses a context-aware mock manager whose getAgent() / listAgents()
+ *         look up the ALS project context (mimicking withProject behaviour).
+ *         The requireProject middleware is mounted on the router; the db module
+ *         is mocked so requireProject makes no real DB calls.
+ */
+
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import request from "supertest";
+import express from "express";
+import type { Express, Request, Response, NextFunction } from "express";
+import type { RemoteAgentManager } from "../../server/remote-agents/remote-agent-manager.js";
+import type { RemoteAgentConfig, A2AMessage } from "../../shared/types.js";
+import type { Router } from "express";
+import type { User } from "../../shared/types.js";
+
+// ─── Mutable store for requireProject DB mock ─────────────────────────────────
+
+const DB_STORE = vi.hoisted(() => ({
+  projectsRows: [] as unknown[],
+  membersRows: [] as unknown[],
+}));
+
+// Mock db module so requireProject works without a real database.
+vi.mock("../../server/db.js", () => {
+  const TABLE_NAME = Symbol.for("drizzle:BaseName");
+  return {
+    db: {
+      select: () => ({
+        from: (table: unknown) => ({
+          where: () => ({
+            limit: () => {
+              const name = (table as Record<symbol, string>)[TABLE_NAME];
+              if (name === "projects") return Promise.resolve(DB_STORE.projectsRows);
+              if (name === "project_members") return Promise.resolve(DB_STORE.membersRows);
+              return Promise.resolve([]);
+            },
+          }),
+          // for listAgents / getAgent calls that go through withProject
+          orderBy: () => Promise.resolve([]),
+        }),
+      }),
+      update: () => ({ set: () => ({ where: () => Promise.resolve() }) }),
+      insert: () => ({ values: () => ({ returning: () => Promise.resolve([]) }) }),
+      delete: () => ({ where: () => Promise.resolve() }),
+    },
+    pool: { on: () => {} },
+    withProject: (_t: unknown, cond?: unknown) => cond ?? Symbol("no-cond"),
+    withProjectInsert: (_t: unknown, data: unknown) => data,
+    runMigrations: async () => {},
+  };
+});
+
+// ─── Shared mock agent factory (same as remote-agents-api.test.ts) ────────────
+
+const NOW = new Date("2026-03-23T12:00:00Z");
+
+function makeAgent(overrides: Partial<RemoteAgentConfig> = {}): RemoteAgentConfig {
+  return {
+    id: "agent-1",
+    name: "k8s-agent",
+    environment: "kubernetes",
+    transport: "a2a-http",
+    endpoint: "https://agent.example.com",
+    cluster: null,
+    namespace: null,
+    labels: null,
+    authTokenEnc: null,
+    enabled: true,
+    autoConnect: false,
+    status: "online",
+    lastHeartbeatAt: NOW,
+    healthError: null,
+    agentCard: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+// ─── H-3: Token redaction tests ───────────────────────────────────────────────
+//
+// Uses a simple mock manager (no project context required) — these tests focus
+// on the response DTO shape, not on project isolation.
+
+function createTokenMockManager(): RemoteAgentManager {
+  const agents = new Map<string, RemoteAgentConfig>();
+
+  return {
+    initialize: async () => {},
+    shutdown: async () => {},
+
+    listAgents: async () => Array.from(agents.values()),
+
+    getAgent: async (id: string) => agents.get(id) ?? null,
+
+    registerAgent: async (input: Record<string, unknown>) => {
+      const id = `agent-${Date.now()}`;
+      const agent = makeAgent({
+        id,
+        name: input.name as string,
+        environment: input.environment as RemoteAgentConfig["environment"],
+        endpoint: input.endpoint as string,
+        // Store the raw token value (simulating what rowToConfig returns after decrypt)
+        authTokenEnc: (input.authTokenEnc as string | undefined) ?? null,
+      });
+      agents.set(id, agent);
+      return agent;
+    },
+
+    unregisterAgent: async (id: string) => { agents.delete(id); },
+    connectAgent: async () => {},
+    disconnectAgent: async () => {},
+    getConnectionStatus: () => false,
+    resolveAgent: async () => null,
+    dispatchTask: async () => ({ taskId: "t1", status: "completed", durationMs: 1 }),
+  } as unknown as RemoteAgentManager;
+}
+
+describe("H-3: auth token is NOT exposed in remote-agent HTTP responses", () => {
+  let app: Express;
+
+  beforeAll(async () => {
+    const { registerRemoteAgentRoutes } = await import("../../server/routes/remote-agents.js");
+    app = express();
+    app.use(express.json());
+    registerRemoteAgentRoutes(app as unknown as Router, createTokenMockManager());
+  });
+
+  it("POST /api/remote-agents with authTokenEnc: response has hasAuthToken=true, no plaintext authTokenEnc", async () => {
+    const res = await request(app)
+      .post("/api/remote-agents")
+      .send({
+        name: "secured-agent",
+        environment: "kubernetes",
+        endpoint: "https://secured.example.com",
+        authTokenEnc: "super-secret-bearer-token",
+      });
+
+    expect(res.status).toBe(201);
+    // Must NOT return the plaintext token
+    expect(res.body).not.toHaveProperty("authTokenEnc");
+    // Must signal that a token is configured
+    expect(res.body).toHaveProperty("hasAuthToken", true);
+  });
+
+  it("POST /api/remote-agents without authTokenEnc: response has hasAuthToken=false", async () => {
+    const res = await request(app)
+      .post("/api/remote-agents")
+      .send({
+        name: "open-agent",
+        environment: "linux",
+        endpoint: "https://open.example.com",
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body).not.toHaveProperty("authTokenEnc");
+    expect(res.body).toHaveProperty("hasAuthToken", false);
+  });
+
+  it("GET /api/remote-agents: list response does not expose authTokenEnc for any agent", async () => {
+    // Create one agent with a token
+    await request(app)
+      .post("/api/remote-agents")
+      .send({
+        name: "list-token-agent",
+        environment: "docker",
+        endpoint: "https://list-token.example.com",
+        authTokenEnc: "token-in-list",
+      });
+
+    const res = await request(app).get("/api/remote-agents");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+
+    for (const agent of res.body as Record<string, unknown>[]) {
+      // None of the agents should expose a raw token
+      expect(agent).not.toHaveProperty("authTokenEnc");
+      expect(agent).toHaveProperty("hasAuthToken");
+      expect(typeof agent.hasAuthToken).toBe("boolean");
+    }
+
+    // The token agent should have hasAuthToken=true
+    const tokenAgent = (res.body as Array<{ name: string; hasAuthToken: boolean }>).find(
+      (a) => a.name === "list-token-agent",
+    );
+    expect(tokenAgent).toBeDefined();
+    expect(tokenAgent!.hasAuthToken).toBe(true);
+  });
+
+  it("GET /api/remote-agents/:id: detail response does not expose authTokenEnc", async () => {
+    const createRes = await request(app)
+      .post("/api/remote-agents")
+      .send({
+        name: "id-token-agent",
+        environment: "cloud",
+        endpoint: "https://id-token.example.com",
+        authTokenEnc: "id-level-secret",
+      });
+    const id = createRes.body.id;
+
+    const res = await request(app).get(`/api/remote-agents/${id}`);
+    expect(res.status).toBe(200);
+    expect(res.body).not.toHaveProperty("authTokenEnc");
+    expect(res.body).toHaveProperty("hasAuthToken", true);
+  });
+});
+
+// ─── H-4: Project isolation tests ─────────────────────────────────────────────
+//
+// Uses a context-aware mock manager that reads the ALS project context (set by
+// requireProject middleware) to decide which "project store" to use — exactly
+// what the real getAgent()/listAgents() do after the withProject fix.
+
+const TEST_USER: User = {
+  id: "user-test",
+  email: "test@example.com",
+  name: "Test User",
+  isActive: true,
+  role: "user",
+  lastLoginAt: null,
+  createdAt: new Date(0),
+};
+
+const PROJECT_A = {
+  id: "proj-a",
+  name: "Project A",
+  ownerId: "user-test",
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+};
+
+const PROJECT_B = {
+  id: "proj-b",
+  name: "Project B",
+  ownerId: "user-test",
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+};
+
+// Agent registered in project A only
+const AGENT_IN_A = makeAgent({ id: "agent-proj-a", name: "proj-a-agent" });
+
+function createIsolationManager(): RemoteAgentManager {
+  // Each "project" has its own agent store
+  const storeA = new Map<string, RemoteAgentConfig>([["agent-proj-a", AGENT_IN_A]]);
+  const storeB = new Map<string, RemoteAgentConfig>(); // no agents in project B
+
+  async function currentStore(): Promise<Map<string, RemoteAgentConfig>> {
+    const { requestContext } = await import("../../server/context.js");
+    const ctx = requestContext.getStore();
+    if (ctx?.projectId === "proj-a") return storeA;
+    if (ctx?.projectId === "proj-b") return storeB;
+    return new Map();
+  }
+
+  return {
+    initialize: async () => {},
+    shutdown: async () => {},
+    listAgents: async () => Array.from((await currentStore()).values()),
+    getAgent: async (id: string) => (await currentStore()).get(id) ?? null,
+    registerAgent: async () => AGENT_IN_A,
+    unregisterAgent: async () => {},
+    connectAgent: async () => {},
+    disconnectAgent: async () => {},
+    getConnectionStatus: () => false,
+    resolveAgent: async () => null,
+    dispatchTask: async () => ({ taskId: "t", status: "completed", durationMs: 1 }),
+  } as unknown as RemoteAgentManager;
+}
+
+/** Inject TEST_USER as the authenticated user on every request. */
+function injectTestUser(req: Request, _res: Response, next: NextFunction) {
+  req.user = TEST_USER;
+  next();
+}
+
+describe("H-4: project isolation — project-B user cannot access project-A agent", () => {
+  let app: Express;
+
+  beforeAll(async () => {
+    const { requireProject } = await import("../../server/middleware/project.js");
+    const { registerRemoteAgentRoutes } = await import("../../server/routes/remote-agents.js");
+
+    app = express();
+    app.use(express.json());
+    app.use(injectTestUser);
+
+    // Mount the routes behind requireProject so each request runs in project ALS context.
+    const router = express.Router();
+    router.use(requireProject as express.RequestHandler);
+    registerRemoteAgentRoutes(router as unknown as Router, createIsolationManager());
+    app.use(router);
+  });
+
+  it("project-A user can GET their own agent", async () => {
+    DB_STORE.projectsRows = [PROJECT_A];
+    DB_STORE.membersRows = [];
+
+    const res = await request(app)
+      .get("/api/remote-agents/agent-proj-a")
+      .set("x-project-id", "proj-a");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("id", "agent-proj-a");
+  });
+
+  it("project-B user gets 404 (not the agent) when requesting project-A agent ID", async () => {
+    // Project B exists and user owns it — so requireProject succeeds for proj-b.
+    // The isolation must come from the project-scoped getAgent() returning null.
+    DB_STORE.projectsRows = [PROJECT_B];
+    DB_STORE.membersRows = [];
+
+    const res = await request(app)
+      .get("/api/remote-agents/agent-proj-a")   // agent lives in proj-a
+      .set("x-project-id", "proj-b");           // but request is for proj-b
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty("error", "Agent not found");
+  });
+
+  it("project-B user gets empty list (not project-A agents) from GET /api/remote-agents", async () => {
+    DB_STORE.projectsRows = [PROJECT_B];
+    DB_STORE.membersRows = [];
+
+    const res = await request(app)
+      .get("/api/remote-agents")
+      .set("x-project-id", "proj-b");
+
+    expect(res.status).toBe(200);
+    // Project B has no agents — the list must be empty, not leaking proj-a's agents
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toHaveLength(0);
+  });
+
+  it("project-A user sees their agent in the list", async () => {
+    DB_STORE.projectsRows = [PROJECT_A];
+    DB_STORE.membersRows = [];
+
+    const res = await request(app)
+      .get("/api/remote-agents")
+      .set("x-project-id", "proj-a");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0]).toHaveProperty("id", "agent-proj-a");
+  });
+
+  it("project-B user gets 404 for connect attempt on project-A agent ID", async () => {
+    DB_STORE.projectsRows = [PROJECT_B];
+    DB_STORE.membersRows = [];
+
+    const res = await request(app)
+      .post("/api/remote-agents/agent-proj-a/connect")
+      .set("x-project-id", "proj-b");
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty("error", "Agent not found");
+  });
+
+  it("project-B user gets 404 for dispatch attempt on project-A agent ID", async () => {
+    DB_STORE.projectsRows = [PROJECT_B];
+    DB_STORE.membersRows = [];
+
+    const res = await request(app)
+      .post("/api/remote-agents/agent-proj-a/dispatch")
+      .set("x-project-id", "proj-b")
+      .send({
+        message: { role: "user", parts: [{ type: "text", text: "hello" }] },
+      });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty("error", "Agent not found");
+  });
+});

--- a/tests/integration/require-project-middleware.test.ts
+++ b/tests/integration/require-project-middleware.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Route-coverage test: requireProject middleware wiring (ADR-001 PR-0b).
+ *
+ * Verifies that every project-scoped router in routes.ts returns 400 when
+ * `x-project-id` is absent but the user is authenticated, and that genuinely
+ * public/cross-project routers (/api/projects, /api/auth, /api/health,
+ * /api/teams, /api/sandbox, /api/federation) do NOT fail with 400.
+ *
+ * Strategy: build a minimal express app that mirrors the middleware chain from
+ * routes.ts (requireAuth → requireProject → stub handler) but replaces every
+ * route implementation with a single GET "ping" so the test remains DB-free.
+ *
+ * The 400 response fires inside requireProject at line 12:
+ *   if (!projectId) { res.status(400).json({ error: "x-project-id header is required" }); return; }
+ * which runs BEFORE any DB call, so no database mock is needed for this
+ * "header absent" test path.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import request from "supertest";
+import express from "express";
+import type { Express, Request, Response, NextFunction } from "express";
+import type { User } from "../../shared/types.js";
+
+// ─── Synthetic authenticated user (no real JWT / DB) ─────────────────────────
+
+const TEST_USER: User = {
+  id: "test-user-id",
+  email: "test@example.com",
+  name: "Test User",
+  isActive: true,
+  role: "admin",
+  lastLoginAt: null,
+  createdAt: new Date(0),
+};
+
+/** Simulates requireAuth by unconditionally setting req.user. */
+function injectUser(req: Request, _res: Response, next: NextFunction) {
+  req.user = TEST_USER;
+  next();
+}
+
+/** Simple stub handler — any project-scoped GET that makes it past middleware. */
+function pingHandler(_req: Request, res: Response) {
+  res.json({ ok: true });
+}
+
+// ─── Test app ─────────────────────────────────────────────────────────────────
+
+let app: Express;
+
+beforeAll(async () => {
+  const { requireProject } = await import("../../server/middleware/project.js");
+
+  app = express();
+  app.use(express.json());
+
+  // Inject user on every request so requireAuth would pass.
+  app.use(injectUser);
+
+  // ── Project-scoped routes (requireProject applied) ──────────────────────────
+  // Mirror the middleware chain from routes.ts exactly.  Each stub GET is just
+  // enough to verify that requireProject fires before the handler.
+  const SCOPED: string[] = [
+    "/api/pipelines",
+    "/api/runs",
+    "/api/activity",
+    "/api/models",
+    "/api/gateway",
+    "/api/settings",
+    "/api/workspaces",
+    "/api/chat",
+    "/api/questions",
+    "/api/stats",
+    "/api/strategies",
+    "/api/privacy",
+    "/api/memory",
+    "/api/memories",
+    "/api/lessons",
+    "/api/tools",
+    "/api/mcp",
+    "/api/providers",
+    "/api/maintenance",
+    "/api/specialization-profiles",
+    "/api/skills",
+    "/api/guardrails",
+    "/api/triggers",
+    "/api/traces",
+    "/api/task-groups",
+    "/api/consilium-loops",
+    "/api/task-templates",
+    "/api/library",
+    "/api/lmstudio",
+    "/api/skill-teams",
+    "/api/tracker-connections",
+    "/api/remote-agents",
+    "/api/skill-market",
+    "/api/workspaces/:id/knowledge",
+    "/api/pipeline-run-stats",
+  ];
+
+  for (const prefix of SCOPED) {
+    app.use(prefix, requireProject);
+    app.get(prefix, pingHandler);
+    // Stub a sub-path too so tests hitting e.g. /api/pipelines/foo also work.
+    app.get(`${prefix}/ping`, pingHandler);
+  }
+
+  // ── Public / auth-only routes (NO requireProject) ──────────────────────────
+  // These should respond normally even without x-project-id.
+  const PUBLIC: string[] = [
+    "/api/projects",
+    "/api/auth",
+    "/api/health",
+    "/api/teams",
+    "/api/sandbox",
+    "/api/federation",
+  ];
+
+  for (const prefix of PUBLIC) {
+    app.get(prefix, pingHandler);
+    app.get(`${prefix}/ping`, pingHandler);
+  }
+});
+
+// ─── Test: scoped routes return 400 without x-project-id ─────────────────────
+
+describe("Project-scoped routers — return 400 when x-project-id is absent", () => {
+  const SCOPED_SAMPLES = [
+    "/api/pipelines",
+    "/api/runs",
+    "/api/activity",
+    "/api/models",
+    "/api/gateway",
+    "/api/settings",
+    "/api/workspaces",
+    "/api/chat",
+    "/api/questions",
+    "/api/stats",
+    "/api/strategies",
+    "/api/privacy",
+    "/api/memory",
+    "/api/memories",
+    "/api/lessons",
+    "/api/tools",
+    "/api/mcp",
+    "/api/providers",
+    "/api/maintenance",
+    "/api/specialization-profiles",
+    "/api/skills",
+    "/api/guardrails",
+    "/api/triggers",
+    "/api/traces",
+    "/api/task-groups",
+    "/api/consilium-loops",
+    "/api/task-templates",
+    "/api/library",
+    "/api/lmstudio",
+    "/api/skill-teams",
+    "/api/tracker-connections",
+    "/api/remote-agents",
+    "/api/skill-market",
+    "/api/pipeline-run-stats",
+  ];
+
+  for (const route of SCOPED_SAMPLES) {
+    it(`GET ${route} → 400 (missing x-project-id, user is authed)`, async () => {
+      const res = await request(app).get(route);
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({ error: expect.stringContaining("x-project-id") });
+    });
+  }
+
+  // Also test a sub-resource path to ensure middleware fires at any depth.
+  it("GET /api/pipelines/some-id → 400 (middleware fires on sub-paths)", async () => {
+    const res = await request(app).get("/api/pipelines/some-id");
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: expect.stringContaining("x-project-id") });
+  });
+
+  it("GET /api/workspaces/:id/knowledge → 400 (explicit nested mount is scoped)", async () => {
+    const res = await request(app).get("/api/workspaces/ws-123/knowledge");
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: expect.stringContaining("x-project-id") });
+  });
+});
+
+// ─── Test: public routers do NOT return 400 for missing x-project-id ─────────
+
+describe("Public / auth-only routers — do NOT enforce x-project-id", () => {
+  const PUBLIC_ROUTES = [
+    "/api/projects",
+    "/api/teams",
+    "/api/sandbox",
+    "/api/federation",
+    "/api/health",
+    "/api/auth",
+  ];
+
+  for (const route of PUBLIC_ROUTES) {
+    it(`GET ${route} → NOT 400 (no x-project-id enforcement)`, async () => {
+      const res = await request(app).get(route);
+      // Must not be blocked by requireProject — allow 200 or any other status
+      // but 400 with the specific project header error message is a failure.
+      if (res.status === 400) {
+        expect(res.body).not.toMatchObject({ error: expect.stringContaining("x-project-id") });
+      } else {
+        expect(res.status).not.toBe(400);
+      }
+    });
+  }
+});
+
+// ─── Test: scoped route responds 200 when x-project-id header IS provided ────
+// (middleware passes the header check; DB validation is not exercised here since
+// the stub handler responds before any storage call.)
+// NOTE: requireProject makes a DB call to validate the project — in a real
+// integration test with a DB that would succeed.  Here we skip the full DB path
+// and only confirm the early-exit 400 on missing header vs the stub 200 path
+// is not reachable without a valid project context (DB mock omitted by design).
+it("scoped route — 401 when user is NOT authenticated (requireProject also checks req.user)", async () => {
+  // Build a separate app WITHOUT the user injection to simulate no-auth.
+  const { requireProject } = await import("../../server/middleware/project.js");
+  const noAuthApp = express();
+  noAuthApp.use(express.json());
+  noAuthApp.use("/api/pipelines", requireProject);
+  noAuthApp.get("/api/pipelines", pingHandler);
+
+  // Send the project header but no user — should get 401 from requireProject.
+  const res = await request(noAuthApp)
+    .get("/api/pipelines")
+    .set("x-project-id", "proj-xyz");
+  expect(res.status).toBe(401);
+});

--- a/tests/integration/webhook-public-endpoint.test.ts
+++ b/tests/integration/webhook-public-endpoint.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Webhook public-endpoint isolation tests (ADR-001 fix-isolation: C-1 / C-2)
+ *
+ * Verifies that the two public webhook endpoints do NOT throw "no request
+ * context" (i.e. do NOT 500) when invoked with no x-project-id header.
+ *
+ * Root cause (before fix): getTrigger / getSecret called storage methods that
+ * internally called withProject(), which throws fail-closed when there is no
+ * ALS context.  Fix: wrap each callback in runAsSystem() so the system context
+ * is established before the callback executes.
+ *
+ * Test strategy:
+ *  - Mock the webhook-handler / github-event-handler to call the dep callbacks
+ *    directly (so we exercise the runAsSystem wrapping, not the full handler logic).
+ *  - Provide a "context-asserting" mock storage whose getTrigger / getSecret
+ *    throw if called with NO ALS context — simulating the production fail-closed
+ *    behaviour.  With the fix, runAsSystem establishes system context and the
+ *    mock does NOT throw.
+ *  - Assert the route returns 200, not 500.
+ */
+
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import request from "supertest";
+import express from "express";
+import type { Express } from "express";
+
+// ─── Simulate the fail-closed context assertion ───────────────────────────────
+//
+// The real withProject() throws "no request context" when called with no ALS
+// store.  We replicate that guard inside the mock storage callbacks so the test
+// catches regressions (a missing runAsSystem wrap would still cause 500).
+
+vi.mock("../../server/services/webhook-handler.js", () => ({
+  /**
+   * Minimal stand-in for handleWebhookRequest: calls getTrigger and getSecret
+   * and returns 200 — enough to exercise the runAsSystem context wrapping.
+   */
+  handleWebhookRequest: async (
+    _req: unknown,
+    res: { json: (v: unknown) => unknown },
+    deps: {
+      getTrigger: (id: string) => Promise<unknown>;
+      getSecret: (id: string) => Promise<unknown>;
+    },
+  ) => {
+    await deps.getTrigger("trigger-abc");
+    await deps.getSecret("trigger-abc");
+    res.json({ ok: true });
+  },
+  startRateLimitCleanup: () => {},
+}));
+
+vi.mock("../../server/services/github-event-handler.js", () => ({
+  /**
+   * Minimal stand-in for handleGitHubEvent: calls getSecret and returns a
+   * successful result — enough to exercise the runAsSystem wrapping.
+   */
+  handleGitHubEvent: async (
+    _rawBody: unknown,
+    _headers: unknown,
+    _body: unknown,
+    deps: {
+      getEnabledTriggersByType: (type: string) => Promise<unknown>;
+      getSecret: (id: string) => Promise<unknown>;
+      fireTrigger: unknown;
+    },
+  ) => {
+    await deps.getEnabledTriggersByType("push");
+    await deps.getSecret("trigger-abc");
+    return { fired: ["trigger-abc"], errors: [] };
+  },
+}));
+
+// ─── Context-asserting mock storage / trigger service ────────────────────────
+//
+// Each method checks whether there is an ALS context before proceeding.
+// Without the runAsSystem fix, getTrigger / getSecret are called with no
+// context and these throw — exactly what withProject() does in production.
+
+async function requireContext(label: string): Promise<void> {
+  const { requestContext } = await import("../../server/context.js");
+  const ctx = requestContext.getStore();
+  if (!ctx) {
+    throw new Error(
+      `[test] No ALS context in ${label} — withProject would throw in production`,
+    );
+  }
+}
+
+const mockStorage = {
+  getTrigger: async (id: string) => {
+    await requireContext(`getTrigger(${id})`);
+    return { id, enabled: true, type: "webhook", projectId: "any-project" };
+  },
+  getAllEnabledTriggersByType: async (_type: string) => {
+    await requireContext("getAllEnabledTriggersByType");
+    return [];
+  },
+};
+
+const mockTriggerService = {
+  getSecret: async (id: string) => {
+    await requireContext(`getSecret(${id})`);
+    return null; // no HMAC secret configured
+  },
+};
+
+const mockFireTrigger = async () => {};
+
+// ─── Test app setup ───────────────────────────────────────────────────────────
+
+let app: Express;
+
+beforeAll(async () => {
+  const { registerWebhookRoutes } = await import("../../server/routes/webhooks.js");
+  app = express();
+  app.use(express.json());
+  registerWebhookRoutes(
+    app,
+    mockStorage as never,
+    mockTriggerService as never,
+    mockFireTrigger,
+  );
+});
+
+// ─── C-1 tests ────────────────────────────────────────────────────────────────
+
+describe("C-1: POST /api/webhooks/:triggerId — no x-project-id, no 500", () => {
+  it("returns 200 (not 500 due to missing ALS context) with no x-project-id header", async () => {
+    const res = await request(app)
+      .post("/api/webhooks/trigger-abc")
+      .send({ event: "test" });
+
+    // Key assertion: must NOT be 500 (which would indicate a missing runAsSystem wrap)
+    expect(res.status).not.toBe(500);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("ok", true);
+  });
+
+  it("succeeds for multiple concurrent calls without context bleed", async () => {
+    const [r1, r2] = await Promise.all([
+      request(app).post("/api/webhooks/trigger-1").send({}),
+      request(app).post("/api/webhooks/trigger-2").send({}),
+    ]);
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+  });
+});
+
+// ─── C-2 tests ────────────────────────────────────────────────────────────────
+
+describe("C-2: POST /api/github-events — no x-project-id, getSecret in runAsSystem", () => {
+  it("returns 200 (not 500) with no x-project-id header", async () => {
+    const res = await request(app)
+      .post("/api/github-events")
+      .set("x-github-event", "push")
+      .send({ action: "push" });
+
+    expect(res.status).not.toBe(500);
+    expect(res.status).toBe(200);
+    // VETO-3: response only returns aggregate count, not trigger IDs
+    expect(res.body).toHaveProperty("fired");
+    expect(typeof res.body.fired).toBe("number");
+  });
+
+  it("does not leak trigger IDs or error details to the caller", async () => {
+    const res = await request(app)
+      .post("/api/github-events")
+      .set("x-github-event", "push")
+      .send({});
+
+    expect(res.body).not.toHaveProperty("errors");
+    expect(res.body).not.toHaveProperty("triggerId");
+    // Only the fired count is returned
+    expect(Object.keys(res.body)).toEqual(["fired"]);
+  });
+});

--- a/tests/unit/crypto.test.ts
+++ b/tests/unit/crypto.test.ts
@@ -1,29 +1,32 @@
 /**
- * Unit tests for server/crypto.ts (PR-0e — versioned ciphertext + dual-key rekey)
+ * Unit tests for server/crypto.ts (PR-0e Commit 2 — fallback removed)
  *
- * These tests verify:
+ * This is the Commit 2 version of the test file.  It covers the post-migration
+ * state where:
+ *   - All DB rows are in v2: format (rekey migration has been verified).
+ *   - Legacy (unprefixed) ciphertext is no longer supported — decrypt() throws.
+ *   - The dev-fallback key and decryptLegacyWithKey() have been removed.
+ *
+ * For the Commit 1 tests (dual-key detection, legacy fallback, migration helpers)
+ * see the git history at the Commit 1 SHA.
+ *
+ * Tests:
  *   1. encrypt() produces a `v2:` prefixed string
  *   2. decrypt() round-trips a v2: value correctly
- *   3. decrypt() can still decrypt legacy (unprefixed) values encrypted with the
- *      current key (backward compat — existing rows that were encrypted pre-PR-0e)
- *   4. decrypt() falls back to the dev-fallback key for legacy values (migration
- *      detection — lets the rekey script find and re-encrypt those rows)
- *   5. encrypt() / decrypt() throw when ENCRYPTION_KEY is not configured
- *   6. The rekey migration path is idempotent (v2: values are re-readable)
- *   7. isV2() correctly identifies format
- *   8. decryptLegacyWithKey() is accessible for the rekey script
+ *   3. decrypt() throws for legacy (non-v2:) values (post-migration guard)
+ *   4. encrypt() / decrypt() throw when ENCRYPTION_KEY is not configured
+ *   5. isV2() correctly identifies format
+ *   6. Rekey idempotency (v2: values re-read and re-encrypt cleanly)
  *
  * The configLoader is mocked so these tests work without a running server or
- * any real ENCRYPTION_KEY env var.  To test the "throws when missing" path,
- * the mock returns undefined for the key.
+ * any real ENCRYPTION_KEY env var.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ─── Mock configLoader BEFORE importing crypto ────────────────────────────────
 
 const TEST_KEY_32 = "test-key-32-chars-exactly-paddedX"; // 33 chars, valid (min 32)
-const ALT_KEY_32 = "alternate-key-32-chars-padded-XXX"; // 33 chars
 
 let mockEncryptionKey: string | undefined = TEST_KEY_32;
 
@@ -37,31 +40,7 @@ vi.mock("../../server/config/loader.js", () => ({
 
 // ─── Import AFTER mocks ───────────────────────────────────────────────────────
 
-import {
-  encrypt,
-  decrypt,
-  isV2,
-  decryptLegacyWithKey,
-  DEV_FALLBACK_KEY_EXPORT,
-} from "../../server/crypto.js";
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-/**
- * Produce a legacy-format ciphertext using the internal crypto primitives.
- * This simulates what was stored by the OLD crypto.ts (pre-PR-0e).
- */
-function makeLegacyCiphertext(plaintext: string, secret: string): string {
-  const { createCipheriv, randomBytes, scryptSync } = require("crypto");
-  const SALT = "multiqlti-provider-keys-v1";
-  const KEY_LEN = 32;
-  const key = scryptSync(secret, SALT, KEY_LEN);
-  const iv = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", key, iv);
-  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
-  const authTag = cipher.getAuthTag();
-  return Buffer.concat([iv, authTag, encrypted]).toString("hex");
-}
+import { encrypt, decrypt, isV2 } from "../../server/crypto.js";
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
@@ -116,29 +95,25 @@ describe("decrypt() — v2: round-trip", () => {
   });
 });
 
-describe("decrypt() — legacy backward compatibility", () => {
+describe("decrypt() — legacy guard (post-migration)", () => {
   beforeEach(() => {
     mockEncryptionKey = TEST_KEY_32;
   });
 
-  it("decrypts a legacy (unprefixed) value encrypted with the CURRENT key", () => {
-    const plaintext = "legacy secret value";
-    const legacy = makeLegacyCiphertext(plaintext, TEST_KEY_32);
-    expect(legacy).not.toMatch(/^v2:/);
-    expect(decrypt(legacy)).toBe(plaintext);
+  it("throws for unprefixed (legacy) ciphertext with a helpful error message", () => {
+    // Simulate encountering a row that was NOT migrated before this commit was deployed
+    const fakeHex = Buffer.alloc(60, 0xab).toString("hex"); // not v2: prefixed
+    expect(() => decrypt(fakeHex)).toThrow(/rekey migration/i);
   });
 
-  it("decrypts a legacy value encrypted with the DEV FALLBACK key (migration detection)", () => {
-    // Simulates a prod row written before ENCRYPTION_KEY was configured
-    const plaintext = "value written with fallback key";
-    const legacy = makeLegacyCiphertext(plaintext, DEV_FALLBACK_KEY_EXPORT);
-    expect(decrypt(legacy)).toBe(plaintext);
-  });
-
-  it("throws when a legacy value cannot be decrypted with either key", () => {
-    // Random noise that isn't valid GCM ciphertext for any known key
-    const garbage = Buffer.alloc(60, 0xab).toString("hex");
-    expect(() => decrypt(garbage)).toThrow();
+  it("throws with a rollback instruction when legacy value is encountered", () => {
+    const fakeHex = Buffer.alloc(60, 0xab).toString("hex");
+    const error = (() => {
+      try { decrypt(fakeHex); return null; }
+      catch (e) { return e as Error; }
+    })();
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/rekey-v2\.ts/);
   });
 });
 
@@ -156,63 +131,35 @@ describe("isV2()", () => {
   });
 });
 
-describe("decryptLegacyWithKey() — rekey script helper", () => {
-  beforeEach(() => {
-    mockEncryptionKey = TEST_KEY_32;
-  });
-
-  it("decrypts a legacy value with the correct key", () => {
-    const plaintext = "plaintext for rekey";
-    const legacy = makeLegacyCiphertext(plaintext, TEST_KEY_32);
-    expect(decryptLegacyWithKey(legacy, TEST_KEY_32)).toBe(plaintext);
-  });
-
-  it("throws when given the wrong key", () => {
-    const plaintext = "plaintext for rekey";
-    const legacy = makeLegacyCiphertext(plaintext, TEST_KEY_32);
-    expect(() => decryptLegacyWithKey(legacy, ALT_KEY_32)).toThrow();
-  });
-
-  it("decrypts a fallback-key legacy value with the fallback key", () => {
-    const plaintext = "written with fallback";
-    const legacy = makeLegacyCiphertext(plaintext, DEV_FALLBACK_KEY_EXPORT);
-    expect(decryptLegacyWithKey(legacy, DEV_FALLBACK_KEY_EXPORT)).toBe(plaintext);
-  });
-});
-
 describe("rekey idempotency", () => {
   beforeEach(() => {
     mockEncryptionKey = TEST_KEY_32;
   });
 
-  it("a v2: value is unchanged when re-read after a simulated rekey", () => {
+  it("a v2: value is unchanged when re-read after a rekey pass", () => {
     const plaintext = "idempotent secret";
 
     // Step 1: encrypt (as rekey script would produce)
     const v2Ciphertext = encrypt(plaintext);
     expect(isV2(v2Ciphertext)).toBe(true);
 
-    // Step 2: decrypt the v2: value (simulates a second rekey pass — should be a no-op)
+    // Step 2: decrypt the v2: value (simulates a second rekey pass — a no-op)
     const recovered = decrypt(v2Ciphertext);
     expect(recovered).toBe(plaintext);
 
-    // Step 3: re-encrypting again produces a DIFFERENT ciphertext (new random
-    // salt) but decrypts to the same plaintext (idempotent from the data perspective)
+    // Step 3: re-encrypting again produces a different ciphertext (new random
+    // salt) but decrypts to the same plaintext (idempotent from data perspective)
     const v2Again = encrypt(recovered);
     expect(v2Again).not.toBe(v2Ciphertext); // different random salt
     expect(decrypt(v2Again)).toBe(plaintext);
   });
 
-  it("a legacy value that has been rekeyed is no longer treated as legacy", () => {
-    const plaintext = "pre-migration secret";
-    const legacy = makeLegacyCiphertext(plaintext, TEST_KEY_32);
-    expect(isV2(legacy)).toBe(false);
-
-    // Simulate what the rekey script does: decrypt legacy → re-encrypt as v2:
-    const recovered = decryptLegacyWithKey(legacy, TEST_KEY_32);
-    const rekeyed = encrypt(recovered);
-
-    expect(isV2(rekeyed)).toBe(true);
-    expect(decrypt(rekeyed)).toBe(plaintext);
+  it("each encrypt() call uses a distinct salt (independent key derivation per value)", () => {
+    const plaintext = "check salt independence";
+    const results = Array.from({ length: 5 }, () => encrypt(plaintext));
+    const unique = new Set(results);
+    expect(unique.size).toBe(5); // all different (random salts)
+    // but all decrypt to the same plaintext
+    results.forEach((ct) => expect(decrypt(ct)).toBe(plaintext));
   });
 });

--- a/tests/unit/crypto.test.ts
+++ b/tests/unit/crypto.test.ts
@@ -17,6 +17,7 @@
  *   4. encrypt() / decrypt() throw when ENCRYPTION_KEY is not configured
  *   5. isV2() correctly identifies format
  *   6. Rekey idempotency (v2: values re-read and re-encrypt cleanly)
+ *   7. Tamper-resistance: GCM auth-tag rejects payload bit-flip (R2-L1 fix)
  *
  * The configLoader is mocked so these tests work without a running server or
  * any real ENCRYPTION_KEY env var.
@@ -84,7 +85,9 @@ describe("decrypt() — v2: round-trip", () => {
     expect(decrypt(encrypt(plaintext))).toBe(plaintext);
   });
 
-  it("throws on a corrupted v2: payload", () => {
+  it("throws on a corrupted v2: payload (length guard path)", () => {
+    // "v2:deadbeef" is too short to be a valid ciphertext — hits the length guard
+    // before GCM auth-tag verification. See the tamper test for the GCM path.
     expect(() => decrypt("v2:deadbeef")).toThrow();
   });
 
@@ -92,6 +95,58 @@ describe("decrypt() — v2: round-trip", () => {
     const ciphertext = encrypt("something");
     mockEncryptionKey = undefined;
     expect(() => decrypt(ciphertext)).toThrow(/ENCRYPTION_KEY/);
+  });
+});
+
+describe("decrypt() — tamper resistance (R2-L1)", () => {
+  beforeEach(() => {
+    mockEncryptionKey = TEST_KEY_32;
+  });
+
+  /**
+   * R2-L1 fix: verifies GCM auth-tag rejection on ciphertext payload tampering.
+   *
+   * v2: wire format after the "v2:" prefix (hex-encoded binary):
+   *   salt    [32 bytes = 64 hex chars]
+   *   iv      [12 bytes = 24 hex chars]
+   *   authTag [16 bytes = 32 hex chars]
+   *   payload [N  bytes = 2N hex chars]  ← flip one char HERE
+   *
+   * Header = 32+12+16 = 60 bytes = 120 hex chars.
+   * Payload starts at hex index 120 (relative to start of the hex string).
+   *
+   * Flipping a hex char in the payload corrupts one nibble of the encrypted
+   * bytes. AES-256-GCM's auth tag covers the entire payload, so any change
+   * causes decipher.final() to throw — NOT the length guard.
+   *
+   * This test differs from "v2:deadbeef" (which hits the length guard) because
+   * the tampered value has the SAME length as a valid ciphertext.
+   */
+  it("throws (GCM auth-tag rejection, not length guard) when one payload nibble is flipped", () => {
+    const plaintext = "tamper-detection-test";
+    const ciphertext = encrypt(plaintext);
+
+    const V2_PREFIX = "v2:";
+    const hex = ciphertext.slice(V2_PREFIX.length);
+
+    // Header = salt(64) + iv(24) + authTag(32) = 120 hex chars.
+    const HEADER_HEX_LEN = 120;
+
+    // Sanity check: must have payload bytes to flip.
+    expect(hex.length).toBeGreaterThan(HEADER_HEX_LEN);
+
+    // Flip the first hex char of the payload (XOR nibble by 1 for guaranteed change).
+    const originalNibble = parseInt(hex[HEADER_HEX_LEN], 16);
+    const flippedNibble = (originalNibble ^ 0x01).toString(16);
+    const tampered =
+      V2_PREFIX +
+      hex.slice(0, HEADER_HEX_LEN) +
+      flippedNibble +
+      hex.slice(HEADER_HEX_LEN + 1);
+
+    // Same length as original — this is the GCM auth-tag path, not length guard.
+    expect(tampered.length).toBe(ciphertext.length);
+    expect(() => decrypt(tampered)).toThrow();
   });
 });
 

--- a/tests/unit/crypto.test.ts
+++ b/tests/unit/crypto.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for server/crypto.ts (PR-0e — versioned ciphertext + dual-key rekey)
+ *
+ * These tests verify:
+ *   1. encrypt() produces a `v2:` prefixed string
+ *   2. decrypt() round-trips a v2: value correctly
+ *   3. decrypt() can still decrypt legacy (unprefixed) values encrypted with the
+ *      current key (backward compat — existing rows that were encrypted pre-PR-0e)
+ *   4. decrypt() falls back to the dev-fallback key for legacy values (migration
+ *      detection — lets the rekey script find and re-encrypt those rows)
+ *   5. encrypt() / decrypt() throw when ENCRYPTION_KEY is not configured
+ *   6. The rekey migration path is idempotent (v2: values are re-readable)
+ *   7. isV2() correctly identifies format
+ *   8. decryptLegacyWithKey() is accessible for the rekey script
+ *
+ * The configLoader is mocked so these tests work without a running server or
+ * any real ENCRYPTION_KEY env var.  To test the "throws when missing" path,
+ * the mock returns undefined for the key.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ─── Mock configLoader BEFORE importing crypto ────────────────────────────────
+
+const TEST_KEY_32 = "test-key-32-chars-exactly-paddedX"; // 33 chars, valid (min 32)
+const ALT_KEY_32 = "alternate-key-32-chars-padded-XXX"; // 33 chars
+
+let mockEncryptionKey: string | undefined = TEST_KEY_32;
+
+vi.mock("../../server/config/loader.js", () => ({
+  configLoader: {
+    get: () => ({
+      encryption: { key: mockEncryptionKey },
+    }),
+  },
+}));
+
+// ─── Import AFTER mocks ───────────────────────────────────────────────────────
+
+import {
+  encrypt,
+  decrypt,
+  isV2,
+  decryptLegacyWithKey,
+  DEV_FALLBACK_KEY_EXPORT,
+} from "../../server/crypto.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Produce a legacy-format ciphertext using the internal crypto primitives.
+ * This simulates what was stored by the OLD crypto.ts (pre-PR-0e).
+ */
+function makeLegacyCiphertext(plaintext: string, secret: string): string {
+  const { createCipheriv, randomBytes, scryptSync } = require("crypto");
+  const SALT = "multiqlti-provider-keys-v1";
+  const KEY_LEN = 32;
+  const key = scryptSync(secret, SALT, KEY_LEN);
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return Buffer.concat([iv, authTag, encrypted]).toString("hex");
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("encrypt()", () => {
+  beforeEach(() => {
+    mockEncryptionKey = TEST_KEY_32;
+  });
+
+  it("produces a v2: prefixed string", () => {
+    const result = encrypt("hello world");
+    expect(result).toMatch(/^v2:/);
+  });
+
+  it("produces different ciphertexts for the same plaintext (random salt per call)", () => {
+    const a = encrypt("same plaintext");
+    const b = encrypt("same plaintext");
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/^v2:/);
+    expect(b).toMatch(/^v2:/);
+  });
+
+  it("throws when ENCRYPTION_KEY is not configured", () => {
+    mockEncryptionKey = undefined;
+    expect(() => encrypt("anything")).toThrow(/ENCRYPTION_KEY/);
+  });
+});
+
+describe("decrypt() — v2: round-trip", () => {
+  beforeEach(() => {
+    mockEncryptionKey = TEST_KEY_32;
+  });
+
+  it("decrypts a value produced by encrypt()", () => {
+    const plaintext = "super secret api key";
+    const ciphertext = encrypt(plaintext);
+    expect(decrypt(ciphertext)).toBe(plaintext);
+  });
+
+  it("handles unicode and long values", () => {
+    const plaintext = "日本語テスト — with emoji 🔐 — " + "x".repeat(500);
+    expect(decrypt(encrypt(plaintext))).toBe(plaintext);
+  });
+
+  it("throws on a corrupted v2: payload", () => {
+    expect(() => decrypt("v2:deadbeef")).toThrow();
+  });
+
+  it("throws when ENCRYPTION_KEY is not configured", () => {
+    const ciphertext = encrypt("something");
+    mockEncryptionKey = undefined;
+    expect(() => decrypt(ciphertext)).toThrow(/ENCRYPTION_KEY/);
+  });
+});
+
+describe("decrypt() — legacy backward compatibility", () => {
+  beforeEach(() => {
+    mockEncryptionKey = TEST_KEY_32;
+  });
+
+  it("decrypts a legacy (unprefixed) value encrypted with the CURRENT key", () => {
+    const plaintext = "legacy secret value";
+    const legacy = makeLegacyCiphertext(plaintext, TEST_KEY_32);
+    expect(legacy).not.toMatch(/^v2:/);
+    expect(decrypt(legacy)).toBe(plaintext);
+  });
+
+  it("decrypts a legacy value encrypted with the DEV FALLBACK key (migration detection)", () => {
+    // Simulates a prod row written before ENCRYPTION_KEY was configured
+    const plaintext = "value written with fallback key";
+    const legacy = makeLegacyCiphertext(plaintext, DEV_FALLBACK_KEY_EXPORT);
+    expect(decrypt(legacy)).toBe(plaintext);
+  });
+
+  it("throws when a legacy value cannot be decrypted with either key", () => {
+    // Random noise that isn't valid GCM ciphertext for any known key
+    const garbage = Buffer.alloc(60, 0xab).toString("hex");
+    expect(() => decrypt(garbage)).toThrow();
+  });
+});
+
+describe("isV2()", () => {
+  it("returns true for v2: prefixed values", () => {
+    expect(isV2("v2:abcdef")).toBe(true);
+  });
+
+  it("returns false for legacy (unprefixed) values", () => {
+    expect(isV2("abcdef1234")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isV2("")).toBe(false);
+  });
+});
+
+describe("decryptLegacyWithKey() — rekey script helper", () => {
+  beforeEach(() => {
+    mockEncryptionKey = TEST_KEY_32;
+  });
+
+  it("decrypts a legacy value with the correct key", () => {
+    const plaintext = "plaintext for rekey";
+    const legacy = makeLegacyCiphertext(plaintext, TEST_KEY_32);
+    expect(decryptLegacyWithKey(legacy, TEST_KEY_32)).toBe(plaintext);
+  });
+
+  it("throws when given the wrong key", () => {
+    const plaintext = "plaintext for rekey";
+    const legacy = makeLegacyCiphertext(plaintext, TEST_KEY_32);
+    expect(() => decryptLegacyWithKey(legacy, ALT_KEY_32)).toThrow();
+  });
+
+  it("decrypts a fallback-key legacy value with the fallback key", () => {
+    const plaintext = "written with fallback";
+    const legacy = makeLegacyCiphertext(plaintext, DEV_FALLBACK_KEY_EXPORT);
+    expect(decryptLegacyWithKey(legacy, DEV_FALLBACK_KEY_EXPORT)).toBe(plaintext);
+  });
+});
+
+describe("rekey idempotency", () => {
+  beforeEach(() => {
+    mockEncryptionKey = TEST_KEY_32;
+  });
+
+  it("a v2: value is unchanged when re-read after a simulated rekey", () => {
+    const plaintext = "idempotent secret";
+
+    // Step 1: encrypt (as rekey script would produce)
+    const v2Ciphertext = encrypt(plaintext);
+    expect(isV2(v2Ciphertext)).toBe(true);
+
+    // Step 2: decrypt the v2: value (simulates a second rekey pass — should be a no-op)
+    const recovered = decrypt(v2Ciphertext);
+    expect(recovered).toBe(plaintext);
+
+    // Step 3: re-encrypting again produces a DIFFERENT ciphertext (new random
+    // salt) but decrypts to the same plaintext (idempotent from the data perspective)
+    const v2Again = encrypt(recovered);
+    expect(v2Again).not.toBe(v2Ciphertext); // different random salt
+    expect(decrypt(v2Again)).toBe(plaintext);
+  });
+
+  it("a legacy value that has been rekeyed is no longer treated as legacy", () => {
+    const plaintext = "pre-migration secret";
+    const legacy = makeLegacyCiphertext(plaintext, TEST_KEY_32);
+    expect(isV2(legacy)).toBe(false);
+
+    // Simulate what the rekey script does: decrypt legacy → re-encrypt as v2:
+    const recovered = decryptLegacyWithKey(legacy, TEST_KEY_32);
+    const rekeyed = encrypt(recovered);
+
+    expect(isV2(rekeyed)).toBe(true);
+    expect(decrypt(rekeyed)).toBe(plaintext);
+  });
+});

--- a/tests/unit/remote-agent-manager.test.ts
+++ b/tests/unit/remote-agent-manager.test.ts
@@ -12,9 +12,14 @@ const mockDb = {
 
 vi.mock("../../server/db", () => ({
   db: mockDb,
+  // H-5/H-6/H-4 fix: pass through so the manager can call them without error.
+  // Project-scoping behaviour is tested separately in remote-agents-isolation.test.ts.
+  withProject: (_t: unknown, cond?: unknown) => cond ?? {},
+  withProjectInsert: (_t: unknown, data: unknown) => data,
 }));
 
-// Build a chainable query-builder mock that mimics drizzle's API
+// Build a chainable query-builder mock that mimics drizzle's API.
+// Handles .values().returning(), .set().where(), and .where().orderBy() chains.
 function createQueryChain(opts: {
   onReturning?: () => Record<string, unknown>[];
   onExecute?: () => Record<string, unknown>[];
@@ -39,6 +44,17 @@ function createQueryChain(opts: {
     return opts.onReturning?.() ?? [];
   });
   return chain;
+}
+
+/**
+ * Helper for select mocks that need to support .where().orderBy() chaining.
+ * Used for listAgents() and resolveAgent() which now call withProject() first.
+ */
+function chainableSelect(rows: unknown[]) {
+  const self: Record<string, unknown> = {};
+  self.where = vi.fn().mockReturnValue(self);
+  self.orderBy = vi.fn().mockReturnValue(rows);
+  return self;
 }
 
 // ─── Mock A2AClient ─────────────────────────────────────────────────────────
@@ -271,6 +287,7 @@ describe("RemoteAgentManager", () => {
   describe("resolveAgent", () => {
     it("resolves by explicit agentId", async () => {
       const row = makeAgentRow({ id: "agent-x" });
+      // getAgent() calls .select().from().where() — use createQueryChain
       const selectChain = createQueryChain({ onExecute: () => [row] });
       mockDb.select.mockReturnValue({
         from: vi.fn().mockReturnValue(selectChain),
@@ -295,10 +312,9 @@ describe("RemoteAgentManager", () => {
         labels: { role: "coder" },
         enabled: true,
       });
+      // listAgents() calls .select().from().where().orderBy() — use chainableSelect
       mockDb.select.mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          orderBy: vi.fn().mockReturnValue([row1, row2]),
-        }),
+        from: vi.fn().mockReturnValue(chainableSelect([row1, row2])),
       });
 
       const mgr = await getManager();
@@ -312,9 +328,7 @@ describe("RemoteAgentManager", () => {
 
     it("returns null when no agent matches selector", async () => {
       mockDb.select.mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          orderBy: vi.fn().mockReturnValue([]),
-        }),
+        from: vi.fn().mockReturnValue(chainableSelect([])),
       });
 
       const mgr = await getManager();
@@ -328,9 +342,7 @@ describe("RemoteAgentManager", () => {
     it("falls back to any online agent when no selector given", async () => {
       const row = makeAgentRow({ id: "fallback", status: "online" });
       mockDb.select.mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          orderBy: vi.fn().mockReturnValue([row]),
-        }),
+        from: vi.fn().mockReturnValue(chainableSelect([row])),
       });
 
       const mgr = await getManager();
@@ -452,14 +464,14 @@ describe("RemoteAgentManager", () => {
         enabled: true,
       });
 
-      // listAgents call
+      // getAllAgents() (cross-project) calls .select().from().orderBy() — no .where()
       mockDb.select.mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           orderBy: vi.fn().mockReturnValue([row1, row2]),
         }),
       });
 
-      // connectAgent -> getAgent call
+      // connectAgent -> getAgent() calls .select().from().where() — use createQueryChain
       const agentSelectChain = createQueryChain({
         onExecute: () => [row1],
       });
@@ -508,10 +520,9 @@ describe("RemoteAgentManager", () => {
   describe("listAgents", () => {
     it("returns mapped agent configs from DB rows", async () => {
       const row = makeAgentRow({ id: "list-1", name: "alpha" });
+      // listAgents() now calls .select().from().where().orderBy() — use chainableSelect
       mockDb.select.mockReturnValue({
-        from: vi.fn().mockReturnValue({
-          orderBy: vi.fn().mockReturnValue([row]),
-        }),
+        from: vi.fn().mockReturnValue(chainableSelect([row])),
       });
 
       const mgr = await getManager();

--- a/tests/unit/scoping/db-layer-isolation.test.ts
+++ b/tests/unit/scoping/db-layer-isolation.test.ts
@@ -1,0 +1,328 @@
+/**
+ * DB-layer project scoping — unit tests (ADR-001 PR-0f, items 1-3)
+ *
+ * Proves the isolation contract of `withProject`, `withProjectInsert`,
+ * `runAsProject`, `runAsSystem`, `getProjectId`, and `unscopedSystemQuery`
+ * WITHOUT hitting a real database.  The helpers build Drizzle SQL fragments
+ * and manage ALS context; no query is ever executed here.
+ *
+ * SQL verification uses PgDialect.sqlToQuery() to serialise the Drizzle SQL
+ * expressions returned by `withProject`, confirming the exact project_id
+ * value embedded in the generated WHERE clause.  Two different project
+ * contexts produce two different SQL params — the structural proof that
+ * project A's queries cannot match project B's rows.
+ *
+ * Coverage:
+ *  Group 1 — Fail-closed: no context → throws
+ *  Group 2 — Project context: correct projectId in SQL + in insert data
+ *  Group 3 — Context isolation: nested and concurrent contexts
+ *  Group 4 — System context: getProjectId throws; withProject guards; unscopedSystemQuery
+ *  Group 5 — SQL proof across the three Phase-0c secret tables
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { eq } from "drizzle-orm";
+
+// ─── Mock configLoader before any server module is imported ──────────────────
+// server/db.ts creates a Pool at module load; without this mock configLoader.get()
+// may throw if required env vars are absent in CI.
+
+vi.mock("../../../server/config/loader.js", () => ({
+  configLoader: {
+    get: () => ({
+      database: { url: undefined },
+      server: { nodeEnv: "test", port: 3000 },
+      auth: { jwtSecret: "test-secret-minimum-32-chars-xx", bcryptRounds: 4, sessionTtlDays: 1 },
+      encryption: { key: undefined },
+      providers: {},
+      features: {
+        sandbox: { enabled: false },
+        privacy: { enabled: false },
+        maintenance: { enabled: false, cronSchedule: "" },
+      },
+    }),
+  },
+}));
+
+// ─── Import AFTER mocks ───────────────────────────────────────────────────────
+
+import { withProject, withProjectInsert } from "../../../server/db.js";
+import {
+  runAsProject,
+  runAsSystem,
+  getProjectId,
+  unscopedSystemQuery,
+} from "../../../server/context.js";
+import {
+  providerKeys,
+  argoCdConfig,
+  triggers,
+} from "../../../shared/schema.js";
+import { pgTable, text } from "drizzle-orm/pg-core";
+
+// ─── Helper: serialise a Drizzle SQL fragment to { sql, params } ─────────────
+
+const dialect = new PgDialect();
+
+function toQuery(sql: import("drizzle-orm").SQL): { sql: string; params: unknown[] } {
+  const q = dialect.sqlToQuery(sql);
+  return { sql: q.sql, params: q.params };
+}
+
+// ─── Group 1: Fail-closed — no ALS context → throws ─────────────────────────
+
+describe("Fail-closed: withProject/withProjectInsert throw with no ALS context", () => {
+  it("withProject(providerKeys) throws without a context", () => {
+    expect(() => withProject(providerKeys)).toThrow(
+      /no request context/i,
+    );
+  });
+
+  it("withProject(argoCdConfig) throws without a context", () => {
+    expect(() => withProject(argoCdConfig)).toThrow(
+      /no request context/i,
+    );
+  });
+
+  it("withProject(triggers) throws without a context", () => {
+    expect(() => withProject(triggers)).toThrow(
+      /no request context/i,
+    );
+  });
+
+  it("withProjectInsert(providerKeys, data) throws without a context", () => {
+    expect(() =>
+      withProjectInsert(providerKeys, { provider: "anthropic", apiKeyEncrypted: "enc" }),
+    ).toThrow(/no request context/i);
+  });
+
+  it("getProjectId() throws without a context", () => {
+    expect(() => getProjectId()).toThrow(/no request context/i);
+  });
+});
+
+// ─── Group 2: Project context — correct projectId in SQL and insert data ─────
+
+describe("Project context: withProject generates SQL filtered to the current project", () => {
+  it("under runAsProject('proj-a'), getProjectId() returns 'proj-a'", async () => {
+    const result = await runAsProject("proj-a", async () => getProjectId());
+    expect(result).toBe("proj-a");
+  });
+
+  it("under runAsProject('proj-a'), withProject(providerKeys) embeds project_id='proj-a' in SQL", async () => {
+    const { sql, params } = await runAsProject("proj-a", async () =>
+      toQuery(withProject(providerKeys)),
+    );
+    expect(sql).toMatch(/project_id/);
+    expect(params).toContain("proj-a");
+  });
+
+  it("under runAsProject('proj-b'), withProject(providerKeys) embeds project_id='proj-b' — different from proj-a", async () => {
+    const qA = await runAsProject("proj-a", async () => toQuery(withProject(providerKeys)));
+    const qB = await runAsProject("proj-b", async () => toQuery(withProject(providerKeys)));
+
+    // Both SQL strings are identical in structure, but the params differ.
+    expect(qA.sql).toBe(qB.sql); // same column reference
+    expect(qA.params[0]).toBe("proj-a");
+    expect(qB.params[0]).toBe("proj-b");
+    // The core isolation proof: proj-a param cannot match proj-b rows.
+    expect(qA.params[0]).not.toBe(qB.params[0]);
+  });
+
+  it("withProject(triggers, condition) ANDs the project filter with the given condition", async () => {
+    const condition = eq(triggers.enabled, true);
+    const { sql, params } = await runAsProject("proj-x", async () =>
+      toQuery(withProject(triggers, condition)),
+    );
+    // Both the project_id filter AND the additional condition must appear.
+    expect(sql).toMatch(/project_id/);
+    expect(params).toContain("proj-x");
+    // The enabled=true param should also be present (ANDed condition).
+    expect(params).toContain(true);
+  });
+
+  it("under runAsProject('proj-a'), withProjectInsert stamps projectId='proj-a'", async () => {
+    const result = await runAsProject("proj-a", async () =>
+      withProjectInsert(providerKeys, { provider: "anthropic", apiKeyEncrypted: "enc" }),
+    );
+    expect((result as Record<string, unknown>).projectId).toBe("proj-a");
+  });
+
+  it("under runAsProject('proj-b'), withProjectInsert stamps projectId='proj-b'", async () => {
+    const result = await runAsProject("proj-b", async () =>
+      withProjectInsert(providerKeys, { provider: "openai", apiKeyEncrypted: "enc2" }),
+    );
+    expect((result as Record<string, unknown>).projectId).toBe("proj-b");
+  });
+
+  it("withProjectInsert stamping is specific to the context — proj-a vs proj-b differ", async () => {
+    const rA = await runAsProject("proj-a", async () =>
+      withProjectInsert(providerKeys, { provider: "anthropic", apiKeyEncrypted: "x" }),
+    );
+    const rB = await runAsProject("proj-b", async () =>
+      withProjectInsert(providerKeys, { provider: "anthropic", apiKeyEncrypted: "x" }),
+    );
+    expect((rA as Record<string, unknown>).projectId).toBe("proj-a");
+    expect((rB as Record<string, unknown>).projectId).toBe("proj-b");
+  });
+});
+
+// ─── Group 3: Context isolation — nested and concurrent contexts ─────────────
+
+describe("Context isolation: nested and concurrent runAsProject calls", () => {
+  it("inner runAsProject shadows outer; outer resumes correctly after inner completes", async () => {
+    const results: string[] = [];
+
+    await runAsProject("outer-proj", async () => {
+      results.push(getProjectId()); // "outer-proj"
+
+      await runAsProject("inner-proj", async () => {
+        results.push(getProjectId()); // "inner-proj"
+      });
+
+      results.push(getProjectId()); // back to "outer-proj"
+    });
+
+    expect(results).toEqual(["outer-proj", "inner-proj", "outer-proj"]);
+  });
+
+  it("concurrent runAsProject calls each see their own projectId (no ALS bleed)", async () => {
+    // Start two concurrent contexts and collect what each sees.
+    const collected: Record<string, string[]> = { a: [], b: [] };
+
+    await Promise.all([
+      runAsProject("concurrent-a", async () => {
+        // Yield so the two tasks interleave, then read context.
+        await Promise.resolve();
+        collected["a"].push(getProjectId());
+        await Promise.resolve();
+        collected["a"].push(getProjectId());
+      }),
+      runAsProject("concurrent-b", async () => {
+        await Promise.resolve();
+        collected["b"].push(getProjectId());
+        await Promise.resolve();
+        collected["b"].push(getProjectId());
+      }),
+    ]);
+
+    expect(collected["a"]).toEqual(["concurrent-a", "concurrent-a"]);
+    expect(collected["b"]).toEqual(["concurrent-b", "concurrent-b"]);
+  });
+});
+
+// ─── Group 4: System context ──────────────────────────────────────────────────
+
+describe("System context: getProjectId throws; withProject guards", () => {
+  it("under runAsSystem, getProjectId() throws (structural barrier against project-scoped reads)", async () => {
+    await runAsSystem("test-audit-reason", async () => {
+      expect(() => getProjectId()).toThrow(/system context/i);
+    });
+  });
+
+  it("under runAsSystem, withProject(providerKeys) with NO condition throws", async () => {
+    // System context cannot read all project rows silently through withProject.
+    await runAsSystem("test-no-condition", async () => {
+      expect(() => withProject(providerKeys)).toThrow(/system context.*WHERE condition/i);
+    });
+  });
+
+  it("under runAsSystem, withProject(argoCdConfig) with NO condition throws", async () => {
+    // argoCdConfig.getArgoCdConfig() uses withProject(argoCdConfig) — so calling it
+    // in system context throws, proving system code cannot read per-project ArgoCD secrets.
+    await runAsSystem("test-argocd-guard", async () => {
+      expect(() => withProject(argoCdConfig)).toThrow(/system context.*WHERE condition/i);
+    });
+  });
+
+  it("under runAsSystem, withProject(table, condition) returns condition WITHOUT project filter", async () => {
+    // When a condition is explicitly provided, system context is permitted to make
+    // a cross-project read (audited by runAsSystem's reason).  The returned SQL must
+    // NOT contain a project_id filter — it is a cross-project query by design.
+    const condition = eq(triggers.enabled, true);
+
+    const { sql, params } = await runAsSystem("test-cross-project-read", async () =>
+      toQuery(withProject(triggers, condition)),
+    );
+
+    // The condition itself is returned as-is — no project_id filter injected.
+    expect(sql).not.toMatch(/project_id/);
+    // Only the condition's own params are present (enabled = true).
+    expect(params).toContain(true);
+    // Notably: no "proj-xxx" string in params, confirming no project filter was added.
+    expect(params.some((p) => typeof p === "string" && p.startsWith("proj"))).toBe(false);
+  });
+
+  it("under runAsSystem, withProjectInsert stamps projectId=null (globally shared row)", async () => {
+    const result = await runAsSystem("test-global-insert", async () =>
+      withProjectInsert(providerKeys, { provider: "builtin", apiKeyEncrypted: "x" }),
+    );
+    expect((result as Record<string, unknown>).projectId).toBeNull();
+  });
+
+  it("unscopedSystemQuery throws when called OUTSIDE a runAsSystem context", async () => {
+    await expect(
+      unscopedSystemQuery("test-label", async () => "should not run"),
+    ).rejects.toThrow(/outside system context/i);
+  });
+
+  it("unscopedSystemQuery throws when called inside runAsProject (not system context)", async () => {
+    await runAsProject("proj-a", async () => {
+      await expect(
+        unscopedSystemQuery("test-label", async () => "should not run"),
+      ).rejects.toThrow(/outside system context/i);
+    });
+  });
+
+  it("unscopedSystemQuery runs the query inside runAsSystem", async () => {
+    const value = await runAsSystem("test-unscoped-query", async () =>
+      unscopedSystemQuery("test-label", async () => "cross-project-result"),
+    );
+    expect(value).toBe("cross-project-result");
+  });
+});
+
+// ─── Group 5: SQL proof across the three Phase-0c secret tables ─────────────
+
+describe("SQL proof: all three Phase-0c secret tables carry the project filter", () => {
+  const PROJECT_ID = "proj-phase0c";
+
+  it("providerKeys: withProject generates SQL filtering on provider_keys.project_id", async () => {
+    const { sql, params } = await runAsProject(PROJECT_ID, async () =>
+      toQuery(withProject(providerKeys)),
+    );
+    expect(sql).toMatch(/"provider_keys"\."project_id"/);
+    expect(params[0]).toBe(PROJECT_ID);
+  });
+
+  it("argoCdConfig: withProject generates SQL filtering on argocd_config.project_id", async () => {
+    const { sql, params } = await runAsProject(PROJECT_ID, async () =>
+      toQuery(withProject(argoCdConfig)),
+    );
+    expect(sql).toMatch(/"argocd_config"\."project_id"/);
+    expect(params[0]).toBe(PROJECT_ID);
+  });
+
+  it("triggers: withProject generates SQL filtering on triggers.project_id", async () => {
+    const condition = eq(triggers.pipelineId, "pipe-1");
+    const { sql, params } = await runAsProject(PROJECT_ID, async () =>
+      toQuery(withProject(triggers, condition)),
+    );
+    expect(sql).toMatch(/"triggers"\."project_id"/);
+    expect(params).toContain(PROJECT_ID);
+  });
+
+  it("withProject on a table WITHOUT projectId column throws — prevents accidental unscoped access", async () => {
+    // A table that was not yet migrated (no projectId column) must be rejected
+    // at development/test time, not silently bypass isolation.
+    const unmigratedTable = pgTable("legacy_table", {
+      id: text("id").primaryKey(),
+    });
+
+    // Verify the column guard fires when the table lacks projectId.
+    await expect(
+      runAsProject("proj-guard", async () => withProject(unmigratedTable as any)),
+    ).rejects.toThrow(/no "projectId" column/);
+  });
+});


### PR DESCRIPTION
Consolidated, review-corrected **Phase 0** of ADR-001 (#394): closes the live cross-project isolation gaps + dosed-credential foundation. Contains 0a–0f plus all fixes from an independent 4-axis adversarial code review.

## Review found real bugs (now fixed)
- **Outages (R1 C-1/C-2):** webhook + github-event handlers called fail-closed `withProject` with no context → 500. Wrapped in `runAsSystem`.
- **Token exfiltration (R1 H-3 / R2 H-2):** `GET /api/remote-agents` returned decrypted bearer tokens for ALL projects. Now per-project scoped + tokens redacted (`hasAuthToken`).
- **Cross-project R/W (R1 H-4/H-5/H-6):** remote-agents get/update/delete/dispatch + registerAgent/dispatchTask were unscoped. Now `withProject`/`withProjectInsert`; heartbeat uses explicit `unscopedSystemQuery`.
- **Metadata leak (R1 M-7/M-8):** `GET /api/settings/providers` + gateway key load were unscoped. Fixed.
- **Data corruption (R2 H-1):** `encrypt-existing-secrets` double-encrypted `v2:` rows on re-run. Added `isV2` guard.
- **Migrations (R3):** `schema.ts` `projectId` now `NOT NULL` (push-based DDL is source of truth); sentinel project owned by a permanent `__system__` user (kills a GDPR cascade that wiped legacy secrets); transaction wrapper + `COALESCE`; `0027`→`0028` renumber.
- **Type fix:** `withProjectInsert` return type now includes `projectId` — which exposed two more unscoped insert sites (provider-keys upsert, createTrigger), now fixed.

## Verification
`tsc` exit 0. All affected test files pass in isolation (73/73); added tests for C-1/C-2/H-3/H-4 + crypto tamper. Full parallel suite shows 6 cross-file **flaky** failures that pass deterministically in isolation (pre-existing test-isolation issue — see follow-up).

## Deploy sequence
`psql -f 0027_phase0c` → `psql -f 0028_phase0d` → `db:push` → `encrypt-existing-secrets` → `rekey-v2 --verify` → rotate tokens → env-by-env promotion.

Supersedes #395–#400 for merging (kept open for granular review). Depends on ADR-001 #394, ADR-002 #402.