### PR TITLE
feat: strict project (tenant) isolation — storage scoping + client transport

### DIFF
--- a/ISOLATION.md
+++ b/ISOLATION.md
@@ -1,0 +1,114 @@
+# Project (Tenant) Isolation
+
+Every project is an independent tenant. With project A selected, no data from
+project B may appear in any list, detail view, count, dropdown, or search.
+This document describes the enforcement model and the audit that produced this
+PR.
+
+## The model
+
+Three layers, all required:
+
+1. **`requireProject` middleware** (`server/middleware/project.ts`)
+   Reads the `x-project-id` header (400 if missing), validates the caller is the
+   project **owner or a member** (403 otherwise), then runs the rest of the
+   request inside an AsyncLocalStorage context (`requestContext.run({ projectId,
+   userId, role }, …)`). Mounted on every project-owned `/api/*` prefix in
+   `server/routes.ts`.
+
+2. **Scoping helpers** (`server/db.ts`) — build the `WHERE` fragment from the ALS
+   context. **Fail-closed**: they throw if there is no context in a request.
+   - `withProject(table, condition?)` — strict per-project (`project_id = ctx`).
+     Used for secret tables and detail/mutate-by-id. In **system** context it
+     requires an explicit `condition` (no blind cross-project enumeration).
+   - `withProjectList(table, condition?)` — for non-secret LIST reads. Request
+     context → per-project filter; **system** context → cross-project (audited
+     via `runAsSystem`); no context → throws.
+   - `withProjectOrGlobal(table, condition?)` — `project_id IS NULL OR =
+     project_id` ctx. For the **global catalog** pattern (see below).
+   - `withProjectInsert(table, data)` — forces `projectId = ctx.projectId` on
+     write (spread last), so a request body can never inject `projectId: null`
+     to escalate a row to global.
+
+3. **Explicit system/background scope** (`server/context.ts`)
+   Code that legitimately runs outside a request (startup seeds, cron, file
+   watcher, pollers, config-sync, federation) wraps its DB access in
+   `runAsSystem(reason, fn)` (cross-project, audited) or
+   `runAsProject(projectId, fn)` (a specific project). `unscopedSystemQuery` is
+   the explicit escape hatch. Without one of these, a scoped read throws rather
+   than silently leaking.
+
+**The isolation guarantee lives on the server.** Once a storage read is scoped,
+project B's rows cannot reach a project-A request regardless of the client. The
+client work below is about UX (no spurious 400s), not the security boundary.
+
+## What this PR changed
+
+### Storage scoping (`server/storage-pg.ts`)
+Previously-unscoped LIST/READ methods now scope through the helpers:
+
+| Method | Fix |
+|---|---|
+| `getTaskGroups`, `getSkillTeams` | `withProject` |
+| `getPipelines`, `getPipelineRuns` (both branches), `getSkills` (no-filter path), `getMcpServers`, `getSpecializationProfiles`, `getModelsWithSkillBindings` | `withProjectList` |
+| `getLlmRequestStats` / `…ByModel` / `…ByProvider` | `withProject` (was aggregating cost/usage across all projects) |
+| `getChatMessages` | unconditional `withProjectList` base (a no-`runId` call previously dumped all projects' chat) |
+| `getLoops` (consilium_loops), `getTraces` | scoped via subquery through their project-owned parents (`task_groups` / `pipeline_runs`) — these tables have **no** `project_id` column; no migration |
+| `getModels`, `getActiveModels`, `getModelBySlug` | `withProjectOrGlobal` (global catalog, see below) |
+
+Route modules that issued **raw** unscoped queries (behind `requireProject`)
+were scoped too: `routes/maintenance.ts`, `routes/privacy.ts`, `routes/library.ts`,
+and `remote-agents/remote-agent-manager.ts` (`listAgents` + an IDOR in
+`getAgent` that loaded a remote-agent config by id with no project scope).
+
+### Global-catalog exception (product decision)
+The **LLM model catalog** and the **skill marketplace registry** stay global.
+Catalog models are stored with `project_id = NULL` (the startup reconcile runs
+under `runAsSystem`) and are visible in every project via `withProjectOrGlobal`;
+project-specific models, plus all **configs, provider keys, installed skills,
+bindings, and teams**, remain strictly per-project.
+
+### System/background callers wrapped
+`config-sync` apply/export, `federation/config-sync`, the MCP self-server pipeline
+listing, and the consilium-loop poller now run their cross-project/background DB
+access inside `runAsSystem`, so the newly-scoped reads resolve instead of throwing.
+
+### Client transport (`client/src/**`)
+- `lib/projectHeaders.ts` — one canonical `buildAuthHeaders()` that always sends
+  `x-project-id` when a project is selected and **never** as an empty string;
+  plus `isPublicPath` (auth/health/projects/teams/sandbox/federation are exempt)
+  and a typed `ProjectRequiredError` guard.
+- The shared helpers (`lib/queryClient.ts`, `hooks/use-pipeline.ts`,
+  `hooks/use-task-groups.ts`) route through it; `Costs.tsx` and `GuardrailEditor.tsx`
+  fixed directly.
+- `lib/installFetchInterceptor.ts` — a one-time `window.fetch` patch (wired once in
+  `main.tsx`) that injects `x-project-id` on same-origin, non-public `/api/*`
+  requests **only if the caller didn't already set it** (idempotent, never
+  overwrites, never empty). This backstops the ~30 inline-fetch call sites without
+  editing them, so no UI action 400s with "x-project-id required".
+- Project switching stays a hard `window.location.reload()` (deliberate — it
+  wipes all query cache and cannot leak stale cross-project data).
+
+## Tests
+`tests/unit/scoping/list-methods-isolation.test.ts` extends the existing
+`db-layer-isolation` harness (serialises the Drizzle SQL via `PgDialect`, no real
+DB): it proves each newly-scoped method embeds the bound `project_id` param, that
+two project contexts produce different params, that subquery-scoped methods carry
+the filter without inventing a non-existent column, and that the catalog methods
+use the `IS NULL OR =` predicate. `npx tsc --noEmit` is clean; the full unit suite
+passes (one unrelated gateway test is a flaky timeout under parallel load — green
+in isolation).
+
+## Known follow-ups (out of scope for this PR — need migration or design)
+- **`models.slug` uniqueness** — currently globally `unique`; should be
+  `unique(projectId, slug)` so two projects can hold the same private slug, and
+  the `upsertModelBySlug` conflict path should re-assert scope. Needs a migration.
+- **MCP self-server** (`mcp-servers/multiqlti-self`) lists pipelines cross-project
+  under `runAsSystem`, scoped only by workspace token. Needs an MCP-token→project
+  mapping before it can be project-scoped.
+- **Latent throwers** — several pre-existing `withProject(traces/consilium_loops, …)`
+  detail/update methods (`getTrace`, `updateTraceSpans`, `getLoopsByOwner`,
+  `getActiveLoopByGroup`, `updateLoop`, …) reference a non-existent `project_id`
+  column and therefore **throw** (500) in request context today. This is a
+  correctness bug, **not** a leak (fail-closed). Fix by adding the column or
+  converting them to the subquery pattern used here for the list methods.

--- a/client/src/components/pipeline/GuardrailEditor.tsx
+++ b/client/src/components/pipeline/GuardrailEditor.tsx
@@ -11,6 +11,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Switch } from "@/components/ui/switch";
 import { ChevronDown, ChevronUp, Plus, Trash2, TestTube } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { buildAuthHeaders } from "@/lib/projectHeaders";
 import type { StageGuardrail, GuardrailType, GuardrailOnFail, GuardrailConfig } from "@shared/types";
 
 interface GuardrailEditorProps {
@@ -84,7 +85,7 @@ function GuardrailCard({
     try {
       const res = await fetch("/api/guardrails/test", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: buildAuthHeaders(true),
         body: JSON.stringify({ guardrail, sampleOutput: testOutput }),
       });
       const data = await res.json() as { passed: boolean; reason?: string };

--- a/client/src/hooks/use-pipeline.ts
+++ b/client/src/hooks/use-pipeline.ts
@@ -1,19 +1,17 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { wsClient } from "@/lib/websocket";
-
-function getAuthToken(): string | null {
-  return localStorage.getItem("auth_token");
-}
+import {
+  buildAuthHeaders,
+  assertProjectSelected,
+} from "@/lib/projectHeaders";
 
 export async function apiRequest(method: string, url: string, body?: unknown) {
-  const headers: Record<string, string> = {};
-  if (body) headers["Content-Type"] = "application/json";
-  const token = getAuthToken();
-  if (token) headers["Authorization"] = `Bearer ${token}`;
+  // Friendly typed error instead of a doomed 400 when no project is selected.
+  assertProjectSelected(url);
 
   const res = await fetch(url, {
     method,
-    headers,
+    headers: buildAuthHeaders(body !== undefined),
     body: body ? JSON.stringify(body) : undefined,
   });
   if (!res.ok) {
@@ -364,11 +362,11 @@ export function useRejectStage() {
 export function useExportRun() {
   return useMutation({
     mutationFn: async ({ runId, format }: { runId: string; format: "markdown" | "zip" }) => {
-      const token = getAuthToken();
-      const headers: Record<string, string> = {};
-      if (token) headers["Authorization"] = `Bearer ${token}`;
-
-      const res = await fetch(`/api/runs/${runId}/export?format=${format}`, { headers });
+      // Export is project-scoped — carry auth + x-project-id via the canonical helper.
+      assertProjectSelected(`/api/runs/${runId}/export`);
+      const res = await fetch(`/api/runs/${runId}/export?format=${format}`, {
+        headers: buildAuthHeaders(false),
+      });
       if (!res.ok) {
         const errText = await res.text().catch(() => res.statusText);
         throw new Error(errText || res.statusText);

--- a/client/src/hooks/use-task-groups.ts
+++ b/client/src/hooks/use-task-groups.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "./use-pipeline";
+import { buildAuthHeaders, assertProjectSelected } from "@/lib/projectHeaders";
 
 // ─── Status-aware error ───────────────────────────────────────────────────────
 // The edit routes return 409 (non-pending / running) and 400 (cycle / dangling
@@ -16,23 +17,17 @@ export class TaskGroupApiError extends Error {
   }
 }
 
-function authHeaders(hasBody: boolean): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (hasBody) headers["Content-Type"] = "application/json";
-  const token = localStorage.getItem("auth_token");
-  if (token) headers["Authorization"] = `Bearer ${token}`;
-  return headers;
-}
-
 /** Like apiRequest, but throws a TaskGroupApiError carrying the HTTP status. */
 async function editRequest(
   method: string,
   url: string,
   body?: unknown,
 ): Promise<unknown> {
+  // Friendly typed error instead of a doomed 400 when no project is selected.
+  assertProjectSelected(url);
   const res = await fetch(url, {
     method,
-    headers: authHeaders(body !== undefined),
+    headers: buildAuthHeaders(body !== undefined),
     body: body !== undefined ? JSON.stringify(body) : undefined,
     credentials: "include",
   });

--- a/client/src/lib/installFetchInterceptor.ts
+++ b/client/src/lib/installFetchInterceptor.ts
@@ -1,0 +1,106 @@
+/**
+ * Global `x-project-id` fetch interceptor (project-isolation safety net).
+ *
+ * The shared transport helpers (lib/queryClient.ts, hooks/use-pipeline.ts,
+ * hooks/use-task-groups.ts, pages/Costs.tsx, …) attach `x-project-id` via the
+ * canonical `buildAuthHeaders` in projectHeaders.ts. But a number of legacy hooks
+ * and pages still build their own headers inline and would 400 on project-scoped
+ * routes. Rather than edit each of them, this module monkeypatches `window.fetch`
+ * exactly once so EVERY same-origin `/api/*` request that targets a project-scoped
+ * route carries `x-project-id` — unless the caller already set it.
+ *
+ * Design constraints (intentionally conservative — this is a safety net, not a
+ * policy layer):
+ *  - Only touches SAME-ORIGIN requests whose path starts with `/api/`. Cross-origin
+ *    and non-API requests pass through untouched.
+ *  - Public / project-agnostic routes (auth, health, projects, teams, sandbox,
+ *    federation) are exempt — see PUBLIC_PATH_PREFIXES in projectHeaders.ts.
+ *  - NEVER overwrites a header the caller explicitly provided.
+ *  - NEVER sets an empty `x-project-id` — when no project is selected the request
+ *    is sent as-is, so the server returns its normal 400 (the friendly "select a
+ *    project" guard lives in the shared helpers, not here). The interceptor never
+ *    throws.
+ *  - Idempotent: installing more than once is a no-op.
+ */
+import { getProjectId, isPublicPath } from "./projectHeaders";
+
+const HEADER = "x-project-id";
+const INSTALLED_FLAG = "__projectIdFetchInterceptorInstalled__";
+
+/** True only for same-origin requests under `/api/`. */
+function isSameOriginApi(url: string): boolean {
+  try {
+    const origin = window.location.origin;
+    const u = new URL(url, origin);
+    return u.origin === origin && u.pathname.startsWith("/api/");
+  } catch {
+    return false;
+  }
+}
+
+function urlOf(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  // Request
+  return (input as Request).url;
+}
+
+/**
+ * Install the interceptor. Safe to call multiple times; only the first call
+ * patches `window.fetch`. Call once, as early as possible, before the app issues
+ * any requests.
+ */
+export function installFetchInterceptor(): void {
+  if (typeof window === "undefined" || typeof window.fetch !== "function") return;
+
+  const flagHost = window as unknown as Record<string, unknown>;
+  if (flagHost[INSTALLED_FLAG]) return;
+
+  const originalFetch = window.fetch.bind(window);
+
+  const patched: typeof window.fetch = (input, init) => {
+    try {
+      const url = urlOf(input);
+
+      // Out of scope: cross-origin, non-/api, or public routes pass through.
+      if (!isSameOriginApi(url) || isPublicPath(url)) {
+        return originalFetch(input, init);
+      }
+
+      // No project selected → send as-is; let the server reply with its 400.
+      const projectId = getProjectId();
+      if (!projectId) {
+        return originalFetch(input, init);
+      }
+
+      // Effective caller headers: an explicit `init.headers` overrides the
+      // Request's own headers (matching fetch semantics); otherwise use the
+      // Request's headers when the input is a Request.
+      const inputIsRequest =
+        typeof Request !== "undefined" && input instanceof Request;
+      const headerSource: HeadersInit | undefined =
+        init?.headers ??
+        (inputIsRequest ? (input as Request).headers : undefined);
+      const headers = new Headers(headerSource);
+
+      // Respect a header the caller explicitly set — never overwrite it.
+      if (headers.has(HEADER)) {
+        return originalFetch(input, init);
+      }
+
+      headers.set(HEADER, projectId);
+
+      // Rebuild preserving body/method/credentials/etc.
+      if (inputIsRequest && init === undefined) {
+        return originalFetch(new Request(input as Request, { headers }));
+      }
+      return originalFetch(input, { ...init, headers });
+    } catch {
+      // Never let the interceptor break a request.
+      return originalFetch(input, init);
+    }
+  };
+
+  window.fetch = patched;
+  flagHost[INSTALLED_FLAG] = true;
+}

--- a/client/src/lib/projectHeaders.ts
+++ b/client/src/lib/projectHeaders.ts
@@ -1,0 +1,117 @@
+/**
+ * Canonical auth + project-isolation header builder for the React client.
+ *
+ * Every project-scoped API request must carry `x-project-id`; the server returns
+ * 400 "x-project-id header is required" without it. Historically each hook built
+ * its own headers and attached the project id inconsistently — most omitted it
+ * silently, a few sent it as an empty string, some sent nothing at all. This
+ * module is the SINGLE SOURCE OF TRUTH so callers (and the shared transport
+ * helpers) stay consistent.
+ *
+ * Rules enforced here:
+ *  - `Authorization: Bearer <token>` is attached whenever a token exists.
+ *  - `x-project-id` is attached ONLY when a project is actually selected, and
+ *    NEVER as an empty string.
+ *  - Public / project-agnostic endpoints (auth, health, projects, sandbox,
+ *    federation) never receive `x-project-id` and are exempt from the guard.
+ */
+
+const AUTH_TOKEN_KEY = "auth_token";
+const PROJECT_ID_KEY = "project_id";
+
+export function getAuthToken(): string | null {
+  return localStorage.getItem(AUTH_TOKEN_KEY);
+}
+
+/**
+ * The selected project id, or `null`. An empty/whitespace value in storage is
+ * treated as "no project selected" so we never emit an empty `x-project-id`.
+ */
+export function getProjectId(): string | null {
+  const pid = localStorage.getItem(PROJECT_ID_KEY);
+  return pid && pid.trim() !== "" ? pid : null;
+}
+
+/**
+ * Public / project-agnostic endpoints. The server does NOT enforce `x-project-id`
+ * on these, so they are exempt from the "select a project" guard (a stray header
+ * is harmless and simply ignored). Kept in sync with the server's public router
+ * list — see tests/integration/require-project-middleware.test.ts. Matched by
+ * pathname prefix.
+ */
+const PUBLIC_PATH_PREFIXES = [
+  "/api/auth",
+  "/api/health",
+  "/api/projects",
+  "/api/teams",
+  "/api/sandbox",
+  "/api/federation",
+];
+
+/** Normalise an absolute-or-relative request URL to its pathname. */
+function pathOf(url: string): string {
+  try {
+    const origin =
+      typeof window !== "undefined" ? window.location.origin : "http://localhost";
+    return new URL(url, origin).pathname;
+  } catch {
+    return url.split("?")[0];
+  }
+}
+
+export function isPublicPath(url: string): boolean {
+  const path = pathOf(url);
+  return PUBLIC_PATH_PREFIXES.some(
+    (p) => path === p || path.startsWith(`${p}/`),
+  );
+}
+
+/**
+ * Build auth + project-isolation headers.
+ *
+ * @param hasBody when true, also sets `Content-Type: application/json`.
+ */
+export function buildAuthHeaders(hasBody = false): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (hasBody) headers["Content-Type"] = "application/json";
+
+  const token = getAuthToken();
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
+  const projectId = getProjectId();
+  if (projectId) headers["x-project-id"] = projectId;
+
+  return headers;
+}
+
+/**
+ * Thrown when a project-scoped request is attempted with no project selected.
+ * Lets the UI render a friendly "select a project" state instead of surfacing a
+ * raw 400 from a doomed request.
+ */
+export class ProjectRequiredError extends Error {
+  readonly isProjectRequired = true;
+  constructor(message = "Select a project to continue.") {
+    super(message);
+    this.name = "ProjectRequiredError";
+  }
+}
+
+export function isProjectRequiredError(e: unknown): e is ProjectRequiredError {
+  return (
+    e instanceof ProjectRequiredError ||
+    (typeof e === "object" && e !== null && "isProjectRequired" in e)
+  );
+}
+
+/**
+ * Guard a project-scoped request: throw a friendly typed error instead of firing
+ * a request the server will reject with 400. Public paths are exempt. Call this
+ * at the top of shared transport helpers before `fetch`.
+ */
+export function assertProjectSelected(url: string): void {
+  if (isPublicPath(url)) return;
+  if (getProjectId() === null) {
+    throw new ProjectRequiredError();
+  }
+}

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,22 +1,5 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
-
-function getAuthToken(): string | null {
-  return localStorage.getItem("auth_token");
-}
-
-function getProjectId(): string | null {
-  return localStorage.getItem("project_id");
-}
-
-function buildAuthHeaders(hasBody: boolean): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (hasBody) headers["Content-Type"] = "application/json";
-  const token = getAuthToken();
-  if (token) headers["Authorization"] = `Bearer ${token}`;
-  const projectId = getProjectId();
-  if (projectId) headers["x-project-id"] = projectId;
-  return headers;
-}
+import { buildAuthHeaders, assertProjectSelected } from "./projectHeaders";
 
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
@@ -30,6 +13,10 @@ export async function apiRequest(
   url: string,
   data?: unknown | undefined,
 ): Promise<Response> {
+  // Surface a friendly "select a project" error instead of a doomed 400 when a
+  // project-scoped call is made with no project selected. Public paths are exempt.
+  assertProjectSelected(url);
+
   const res = await fetch(url, {
     method,
     headers: buildAuthHeaders(data !== undefined),
@@ -47,7 +34,10 @@ export const getQueryFn: <T>(options: {
 }) => QueryFunction<T> =
   ({ on401: unauthorizedBehavior }) =>
   async ({ queryKey }) => {
-    const res = await fetch(queryKey.join("/") as string, {
+    const url = queryKey.join("/") as string;
+    assertProjectSelected(url);
+
+    const res = await fetch(url, {
       headers: buildAuthHeaders(false),
       credentials: "include",
     });

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,5 +1,9 @@
 import { createRoot } from "react-dom/client";
+import { installFetchInterceptor } from "./lib/installFetchInterceptor";
 import App from "./App";
 import "./index.css";
+
+// Guarantee x-project-id on same-origin /api/* requests before any fetch fires.
+installFetchInterceptor();
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/client/src/pages/Costs.tsx
+++ b/client/src/pages/Costs.tsx
@@ -31,6 +31,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+import { buildAuthHeaders, getAuthToken } from "@/lib/projectHeaders";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -97,17 +98,8 @@ interface BudgetsResponse {
 
 // ─── API helpers ──────────────────────────────────────────────────────────────
 
-function getAuthToken(): string | null {
-  return localStorage.getItem("auth_token");
-}
-
-function authHeaders(): Record<string, string> {
-  const token = getAuthToken();
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
-
 async function apiGet<T>(url: string): Promise<T> {
-  const res = await fetch(url, { headers: authHeaders() });
+  const res = await fetch(url, { headers: buildAuthHeaders(false) });
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }));
     throw new Error((err as { error?: string }).error ?? res.statusText);
@@ -118,7 +110,7 @@ async function apiGet<T>(url: string): Promise<T> {
 async function apiPost<T>(url: string, body: unknown): Promise<T> {
   const res = await fetch(url, {
     method: "POST",
-    headers: { ...authHeaders(), "Content-Type": "application/json" },
+    headers: buildAuthHeaders(true),
     body: JSON.stringify(body),
   });
   if (!res.ok) {
@@ -131,7 +123,7 @@ async function apiPost<T>(url: string, body: unknown): Promise<T> {
 async function apiPatch<T>(url: string, body: unknown): Promise<T> {
   const res = await fetch(url, {
     method: "PATCH",
-    headers: { ...authHeaders(), "Content-Type": "application/json" },
+    headers: buildAuthHeaders(true),
     body: JSON.stringify(body),
   });
   if (!res.ok) {
@@ -142,7 +134,7 @@ async function apiPatch<T>(url: string, body: unknown): Promise<T> {
 }
 
 async function apiDelete(url: string): Promise<void> {
-  const res = await fetch(url, { method: "DELETE", headers: authHeaders() });
+  const res = await fetch(url, { method: "DELETE", headers: buildAuthHeaders(false) });
   if (!res.ok && res.status !== 204) {
     const err = await res.json().catch(() => ({ error: res.statusText }));
     throw new Error((err as { error?: string }).error ?? res.statusText);
@@ -439,7 +431,7 @@ function CostsView({ workspaceId }: { workspaceId: string }) {
     const a = document.createElement("a");
     // If auth is Bearer token, open in same tab (token in header not URL)
     if (token) {
-      void fetch(url, { headers: { Authorization: `Bearer ${token}` } })
+      void fetch(url, { headers: buildAuthHeaders(false) })
         .then((r) => r.blob())
         .then((blob) => {
           const href = URL.createObjectURL(blob);

--- a/server/config-sync/apply-orchestrator.ts
+++ b/server/config-sync/apply-orchestrator.ts
@@ -54,6 +54,7 @@ import { runSafetyChecks } from "./safety-checks.js";
 import type { SafetyIssue } from "./safety-checks.js";
 import { withApplyLock, ApplyLockBusyError } from "./apply-lock.js";
 import { writeAuditEntry } from "./audit-log.js";
+import { runAsSystem } from "../context.js";
 import { checkInstanceHealth } from "./health-check.js";
 
 // ─── Public event emitter ─────────────────────────────────────────────────────
@@ -206,6 +207,10 @@ export async function runApply(
   repoPath: string,
   options: ApplyOptions = {},
 ): Promise<ApplyResult> {
+  // config-sync is a cross-project CLI operation: run the whole apply under an
+  // audited system context so the (now project-scoped) storage reads/writes are
+  // explicitly cross-project (getAll*System + withProjectInsert -> projectId=null).
+  return runAsSystem("config-sync-apply", async (): Promise<ApplyResult> => {
   const appliedAt = new Date().toISOString();
   const dryRun = options.dryRun ?? false;
   const force = options.force ?? false;
@@ -256,6 +261,7 @@ export async function runApply(
     instanceUrl,
     options,
   );
+  });
 }
 
 // ─── Core apply logic ─────────────────────────────────────────────────────────

--- a/server/config-sync/export-orchestrator.ts
+++ b/server/config-sync/export-orchestrator.ts
@@ -25,6 +25,7 @@ import { exportSkills } from "./exporters/skill-exporter.js";
 import { exportConnections } from "./exporters/connection-exporter.js";
 import { exportProviderKeys } from "./exporters/provider-key-exporter.js";
 import { exportPreferences } from "./exporters/preferences-exporter.js";
+import { runAsSystem } from "../context.js";
 
 // ─── Public types ─────────────────────────────────────────────────────────────
 
@@ -74,6 +75,10 @@ export async function runExport(
   repoPath: string,
   options: ExportOptions = {},
 ): Promise<ExportResult> {
+  // config-sync export is a cross-project CLI operation: run under an audited
+  // system context so the (now project-scoped) storage reads are explicitly
+  // cross-project (getAll*System).
+  return runAsSystem("config-sync-export", async (): Promise<ExportResult> => {
   const exportedAt = new Date().toISOString();
   const results: ExporterResult[] = [];
 
@@ -126,6 +131,7 @@ export async function runExport(
   };
 
   return { exportedAt, repoPath, exporters: results, summary };
+  });
 }
 
 // ─── Internal helpers ─────────────────────────────────────────────────────────

--- a/server/db.ts
+++ b/server/db.ts
@@ -23,7 +23,7 @@ pool.on("error", (err: Error) => {
 export const db = drizzle(pool, { schema });
 
 import { requestContext } from "./context";
-import { SQL, and, eq } from "drizzle-orm";
+import { SQL, and, eq, or, isNull } from "drizzle-orm";
 
 /**
  * Helper to wrap any Drizzle query condition with the current project ID filter.
@@ -84,6 +84,126 @@ export function withProject(table: any, condition?: SQL | undefined): SQL {
 
   const projectFilter = eq(table.projectId, ctx.projectId);
   return condition ? and(projectFilter, condition)! : projectFilter;
+}
+
+/**
+ * Project-scoping helper for NON-SECRET LIST tables (pipelines, pipeline_runs,
+ * skills, task_groups, and the parent tables used to scope traces / consilium
+ * loops).
+ *
+ * Same per-project filter as withProject in a request context, but — unlike
+ * withProject — a SYSTEM context (runAsSystem) is permitted to read
+ * cross-project even with NO extra condition: it returns the (possibly
+ * undefined) condition, i.e. "no project filter = all rows", audited by the
+ * surrounding runAsSystem() call. This is exactly what legitimate cross-project
+ * background callers need: config-sync CLI, federation peer sync, catalog
+ * reconcile, the consilium-loop sweep poller, and startup seeds.
+ *
+ * withProject (strict — throws on system + no-condition) is deliberately
+ * retained for SECRET tables (provider_keys, argocd_config, …) so system code
+ * cannot silently enumerate every project's secret rows. Use withProjectList
+ * ONLY for non-secret, listable data.
+ *
+ * FAIL-CLOSED on missing context.
+ *
+ * Usage: db.select().from(pipelines).where(withProjectList(pipelines))
+ */
+export function withProjectList(table: any, condition?: SQL | undefined): SQL | undefined {
+  const ctx = requestContext.getStore();
+
+  if (!ctx) {
+    throw new Error(
+      "withProjectList: no request context — wrap background/startup callers in " +
+        "runAsProject(projectId, fn) or runAsSystem(reason, fn). See server/context.ts.",
+    );
+  }
+
+  if (ctx.system) {
+    // System context: cross-project read, audited by runAsSystem().
+    // undefined condition → no WHERE filter → all rows across every project.
+    return condition;
+  }
+
+  if (!ctx.projectId) {
+    throw new Error(
+      "withProjectList: no projectId in context — ensure the x-project-id header " +
+        "is sent and requireProject middleware is wired, or use runAsProject(projectId, fn).",
+    );
+  }
+
+  if (table.projectId === undefined) {
+    throw new Error(
+      'withProjectList: table has no "projectId" column — use a subquery through a ' +
+        "project-scoped parent table instead.",
+    );
+  }
+
+  const projectFilter = eq(table.projectId, ctx.projectId);
+  return condition ? and(projectFilter, condition)! : projectFilter;
+}
+
+/**
+ * Project-scoping helper for GLOBAL-CATALOG tables (e.g. `models`).
+ *
+ * Unlike withProject (strict per-project isolation), this implements
+ * "global-or-current-project" visibility:
+ *
+ *     project_id IS NULL          -- the shared, cross-project catalog
+ *   OR project_id = <ctx.projectId>  -- this project's own private entries
+ *
+ * Product decision (ADR-001 / strict-project-isolation): the LLM model catalog
+ * is GLOBAL. Rows seeded by the startup reconcile run in system context and are
+ * stamped projectId=NULL (see withProjectInsert), so they remain visible in
+ * every project. A model created inside a specific project (non-null projectId)
+ * is visible ONLY in that project.
+ *
+ * FAIL-CLOSED on missing context, same as withProject.
+ *
+ * System context (runAsSystem) sees ALL rows (global + every project) so the
+ * startup seed/reconcile can compare against, upsert, and deactivate the whole
+ * catalog. This is audited by the surrounding runAsSystem() call. Returns
+ * `undefined` (no WHERE filter) when no extra condition is supplied in system
+ * context — Drizzle treats `.where(undefined)` as "no filter".
+ *
+ * Usage: db.select().from(models).where(withProjectOrGlobal(models, eq(models.isActive, true)))
+ */
+export function withProjectOrGlobal(table: any, condition?: SQL | undefined): SQL | undefined {
+  const ctx = requestContext.getStore();
+
+  if (!ctx) {
+    throw new Error(
+      "withProjectOrGlobal: no request context — this path runs outside a request handler. " +
+        "Wrap background/startup callers in runAsProject(projectId, fn) or runAsSystem(reason, fn). " +
+        "See server/context.ts and ADR-001 §3.1(c)/(d).",
+    );
+  }
+
+  if (ctx.system) {
+    // System context: catalog reconcile/seed must see the WHOLE catalog (global
+    // rows + every project's private rows) so it can diff/upsert/deactivate.
+    // Audited by the surrounding runAsSystem() call. No project filter applied.
+    return condition;
+  }
+
+  if (!ctx.projectId) {
+    throw new Error(
+      "withProjectOrGlobal: no projectId in context — ensure the x-project-id header is sent " +
+        "and requireProject middleware is wired (PR-0b), " +
+        "or use runAsProject(projectId, fn) for background callers.",
+    );
+  }
+
+  if (table.projectId === undefined) {
+    throw new Error(
+      'withProjectOrGlobal: table has no "projectId" column — global-catalog visibility ' +
+        "requires a nullable project_id column on the table.",
+    );
+  }
+
+  // Global-or-current visibility: shared catalog rows (project_id IS NULL) PLUS
+  // the current project's own rows.
+  const visibility = or(isNull(table.projectId), eq(table.projectId, ctx.projectId))!;
+  return condition ? and(visibility, condition)! : visibility;
 }
 
 /**

--- a/server/federation/config-sync.ts
+++ b/server/federation/config-sync.ts
@@ -37,6 +37,7 @@ import type { FederationMessage, PeerInfo } from "./types.js";
 import type { ConfigEventOperation } from "@shared/schema";
 import type { TriggerType, TriggerConfig } from "@shared/types";
 import type { IStorage } from "../storage.js";
+import { runAsSystem } from "../context.js";
 import type { PeerQueueService, SendEventFn } from "./peer-queue.js";
 import type { ConflictDetector } from "./config-conflict.js";
 
@@ -497,7 +498,11 @@ async function applyPipelineEvent(
   const name = typeof payload["name"] === "string" ? payload["name"] : null;
   if (!name) return;
 
-  const pipelines = await storage.getPipelines();
+  // Federation peer sync is cross-project system work: read all pipelines under
+  // an audited system context. (The create/update writes below are unchanged.)
+  const pipelines = await runAsSystem("federation-apply-pipeline-event", () =>
+    storage.getPipelines(),
+  );
   const existing = pipelines.find((p) => p.name === name);
 
   if (operation === "create" || (!existing && operation === "update")) {

--- a/server/mcp-servers/multiqlti-self/index.ts
+++ b/server/mcp-servers/multiqlti-self/index.ts
@@ -29,6 +29,7 @@
  */
 
 import type { IStorage } from "../../storage";
+import { runAsSystem } from "../../context";
 import type { PipelineController } from "../../controller/pipeline-controller";
 import { recordToolCall } from "../../tools/audit";
 import {
@@ -232,7 +233,12 @@ export class MultiqltiMcpServer {
         `Token does not have access to workspace "${args.workspace_id}".`,
       );
     }
-    const pipelines = await this.storage.getPipelines();
+    // MCP self-server listing is workspace-token scoped, not project-scoped, so it
+    // reads cross-project under an audited system context. FLAG: consider scoping
+    // to the token's project/workspace once MCP token->project mapping is defined.
+    const pipelines = await runAsSystem("mcp-self-list-pipelines", () =>
+      this.storage.getPipelines(),
+    );
     return pipelines
       .filter((p) => !p.isTemplate)
       .map((p) => ({

--- a/server/remote-agents/remote-agent-manager.ts
+++ b/server/remote-agents/remote-agent-manager.ts
@@ -1,5 +1,5 @@
 import { eq } from "drizzle-orm";
-import { db } from "../db";
+import { db, withProject, withProjectList } from "../db";
 import { runAsSystem } from "../context";
 import { remoteAgents, a2aTasks } from "@shared/schema";
 import { encrypt, decrypt } from "../crypto";
@@ -112,7 +112,9 @@ export class RemoteAgentManager {
 
   async unregisterAgent(agentId: string): Promise<void> {
     this.clients.delete(agentId);
-    await db.delete(remoteAgents).where(eq(remoteAgents.id, agentId));
+    // Project-scoped: prevents a cross-tenant DELETE-by-id IDOR (the route handler
+    // does not pre-fetch via the scoped getAgent).
+    await db.delete(remoteAgents).where(withProject(remoteAgents, eq(remoteAgents.id, agentId)));
   }
 
   // ── Connection ─────────────────────────────────────────────────────
@@ -252,6 +254,7 @@ export class RemoteAgentManager {
     const rows = await db
       .select()
       .from(remoteAgents)
+      .where(withProjectList(remoteAgents))
       .orderBy(remoteAgents.name);
     return rows.map((r) => this.rowToConfig(r));
   }
@@ -260,7 +263,7 @@ export class RemoteAgentManager {
     const [row] = await db
       .select()
       .from(remoteAgents)
-      .where(eq(remoteAgents.id, agentId));
+      .where(withProject(remoteAgents, eq(remoteAgents.id, agentId)));
     return row ? this.rowToConfig(row) : null;
   }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -529,8 +529,9 @@ export async function registerRoutes(
     }
   }
 
-  // Seed default pipeline template. getPipelines() is an unscoped global select;
-  // createPipeline() uses withProjectInsert which sets projectId=null in system context.
+  // Seed default pipeline template. getPipelines() reads cross-project
+  // under the system context; createPipeline() uses withProjectInsert which sets
+  // projectId=null (a global template visible to every project).
   await runAsSystem("startup-seed-default-pipeline", async () => {
     const existingPipelines = await storage.getPipelines();
     if (existingPipelines.length === 0) {

--- a/server/routes/library.ts
+++ b/server/routes/library.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { z } from "zod";
 import { eq, desc, ilike, sql, and } from "drizzle-orm";
-import { db } from "../db";
+import { db, withProject, withProjectList, withProjectInsert } from "../db";
 import { libraryChannels, libraryItems, LIBRARY_CHANNEL_TYPES } from "@shared/schema";
 import { fetchRSSFeed } from "../services/rss-fetcher";
 
@@ -37,6 +37,7 @@ export function registerLibraryRoutes(app: Router): void {
       const channels = await db
         .select()
         .from(libraryChannels)
+        .where(withProjectList(libraryChannels))
         .orderBy(desc(libraryChannels.createdAt));
       return res.json(channels);
     } catch {
@@ -51,11 +52,11 @@ export function registerLibraryRoutes(app: Router): void {
     try {
       const [channel] = await db
         .insert(libraryChannels)
-        .values({
+        .values(withProjectInsert(libraryChannels, {
           ...parsed.data,
           config: parsed.data.config ?? {},
           createdBy: (req as unknown as { user?: { id: string } }).user?.id ?? null,
-        })
+        }))
         .returning();
       return res.status(201).json(channel);
     } catch {
@@ -71,7 +72,7 @@ export function registerLibraryRoutes(app: Router): void {
       const [updated] = await db
         .update(libraryChannels)
         .set({ ...parsed.data, updatedAt: new Date() })
-        .where(eq(libraryChannels.id, req.params.id))
+        .where(withProject(libraryChannels, eq(libraryChannels.id, req.params.id)))
         .returning();
       if (!updated) return res.status(404).json({ error: "Channel not found" });
       return res.json(updated);
@@ -82,7 +83,7 @@ export function registerLibraryRoutes(app: Router): void {
 
   app.delete("/api/library/channels/:id", async (req, res) => {
     try {
-      await db.delete(libraryChannels).where(eq(libraryChannels.id, req.params.id));
+      await db.delete(libraryChannels).where(withProject(libraryChannels, eq(libraryChannels.id, req.params.id)));
       return res.status(204).send();
     } catch {
       return res.status(500).json({ error: "Failed to delete channel" });
@@ -95,7 +96,7 @@ export function registerLibraryRoutes(app: Router): void {
       const [channel] = await db
         .select()
         .from(libraryChannels)
-        .where(eq(libraryChannels.id, req.params.id));
+        .where(withProject(libraryChannels, eq(libraryChannels.id, req.params.id)));
       if (!channel) return res.status(404).json({ error: "Channel not found" });
       if (channel.type !== "rss" || !channel.url) {
         return res.status(400).json({ error: "Only RSS channels with a URL can be polled" });
@@ -134,7 +135,7 @@ export function registerLibraryRoutes(app: Router): void {
       await db
         .update(libraryChannels)
         .set({ lastPolledAt: new Date(), errorMessage: null, updatedAt: new Date() })
-        .where(eq(libraryChannels.id, channel.id));
+        .where(withProject(libraryChannels, eq(libraryChannels.id, channel.id)));
 
       return res.json({ fetched: feedItems.length, inserted });
     } catch (e) {
@@ -143,7 +144,7 @@ export function registerLibraryRoutes(app: Router): void {
       await db
         .update(libraryChannels)
         .set({ errorMessage: msg, updatedAt: new Date() })
-        .where(eq(libraryChannels.id, req.params.id))
+        .where(withProject(libraryChannels, eq(libraryChannels.id, req.params.id)))
         .catch(() => {});
       return res.status(500).json({ error: `Poll failed: ${msg}` });
     }

--- a/server/routes/maintenance.ts
+++ b/server/routes/maintenance.ts
@@ -1,6 +1,6 @@
 import type { Router } from "express";
 import { z } from "zod";
-import { db } from "../db";
+import { db, withProject, withProjectList, withProjectInsert } from "../db";
 import { maintenancePolicies, maintenanceScans, pipelineRuns, autoTriggerAudit } from "@shared/schema";
 import { eq, desc, and } from "drizzle-orm";
 import type {
@@ -85,6 +85,7 @@ export function registerMaintenanceRoutes(router: Router): void {
       const rows = await db
         .select()
         .from(maintenancePolicies)
+        .where(withProjectList(maintenancePolicies))
         .orderBy(desc(maintenancePolicies.createdAt));
       res.json(rows);
     } catch (err) {
@@ -101,7 +102,7 @@ export function registerMaintenanceRoutes(router: Router): void {
     try {
       const [row] = await db
         .insert(maintenancePolicies)
-        .values({
+        .values(withProjectInsert(maintenancePolicies, {
           workspaceId: parsed.data.workspaceId ?? null,
           enabled: parsed.data.enabled,
           schedule: parsed.data.schedule,
@@ -109,7 +110,7 @@ export function registerMaintenanceRoutes(router: Router): void {
           severityThreshold: parsed.data.severityThreshold,
           autoMerge: parsed.data.autoMerge,
           notifyChannels: parsed.data.notifyChannels,
-        })
+        }))
         .returning();
 
       return res.status(201).json(row);
@@ -128,7 +129,7 @@ export function registerMaintenanceRoutes(router: Router): void {
       const [existing] = await db
         .select()
         .from(maintenancePolicies)
-        .where(eq(maintenancePolicies.id, req.params.id));
+        .where(withProject(maintenancePolicies, eq(maintenancePolicies.id, req.params.id)));
 
       if (!existing) {
         return res.status(404).json({ error: "Policy not found" });
@@ -148,7 +149,7 @@ export function registerMaintenanceRoutes(router: Router): void {
       const [updated] = await db
         .update(maintenancePolicies)
         .set(updateData)
-        .where(eq(maintenancePolicies.id, req.params.id))
+        .where(withProject(maintenancePolicies, eq(maintenancePolicies.id, req.params.id)))
         .returning();
 
       return res.json(updated);
@@ -162,7 +163,7 @@ export function registerMaintenanceRoutes(router: Router): void {
       const [existing] = await db
         .select()
         .from(maintenancePolicies)
-        .where(eq(maintenancePolicies.id, req.params.id));
+        .where(withProject(maintenancePolicies, eq(maintenancePolicies.id, req.params.id)));
 
       if (!existing) {
         return res.status(404).json({ error: "Policy not found" });
@@ -170,7 +171,7 @@ export function registerMaintenanceRoutes(router: Router): void {
 
       await db
         .delete(maintenancePolicies)
-        .where(eq(maintenancePolicies.id, req.params.id));
+        .where(withProject(maintenancePolicies, eq(maintenancePolicies.id, req.params.id)));
 
       return res.json({ message: "Policy deleted" });
     } catch (err) {
@@ -188,9 +189,9 @@ export function registerMaintenanceRoutes(router: Router): void {
         ? await db
             .select()
             .from(maintenanceScans)
-            .where(eq(maintenanceScans.workspaceId, workspaceId))
+            .where(withProject(maintenanceScans, eq(maintenanceScans.workspaceId, workspaceId)))
             .orderBy(desc(maintenanceScans.createdAt))
-        : await db.select().from(maintenanceScans).orderBy(desc(maintenanceScans.createdAt));
+        : await db.select().from(maintenanceScans).where(withProjectList(maintenanceScans)).orderBy(desc(maintenanceScans.createdAt));
 
       res.json(rows);
     } catch (err) {
@@ -203,7 +204,7 @@ export function registerMaintenanceRoutes(router: Router): void {
       const [row] = await db
         .select()
         .from(maintenanceScans)
-        .where(eq(maintenanceScans.id, req.params.id));
+        .where(withProject(maintenanceScans, eq(maintenanceScans.id, req.params.id)));
 
       if (!row) {
         return res.status(404).json({ error: "Scan not found" });
@@ -225,7 +226,7 @@ export function registerMaintenanceRoutes(router: Router): void {
       const [policy] = await db
         .select()
         .from(maintenancePolicies)
-        .where(eq(maintenancePolicies.id, parsed.data.policyId));
+        .where(withProject(maintenancePolicies, eq(maintenancePolicies.id, parsed.data.policyId)));
 
       if (!policy) {
         return res.status(404).json({ error: "Policy not found" });
@@ -260,13 +261,13 @@ export function registerMaintenanceRoutes(router: Router): void {
       // Create scan record in running state
       const [scan] = await db
         .insert(maintenanceScans)
-        .values({
+        .values(withProjectInsert(maintenanceScans, {
           policyId: policy.id,
           workspaceId: policy.workspaceId,
           status: "running",
           findings: [],
           importantCount: 0,
-        })
+        }))
         .returning();
 
       // Run scout synchronously
@@ -286,7 +287,7 @@ export function registerMaintenanceRoutes(router: Router): void {
         await db
           .update(maintenanceScans)
           .set({ status: "failed", completedAt: new Date() })
-          .where(eq(maintenanceScans.id, scan.id));
+          .where(withProject(maintenanceScans, eq(maintenanceScans.id, scan.id)));
         return res.status(500).json({ error: (scoutErr as Error).message });
       }
 
@@ -299,7 +300,7 @@ export function registerMaintenanceRoutes(router: Router): void {
           importantCount: scoutResult.importantCount,
           completedAt: new Date(),
         })
-        .where(eq(maintenanceScans.id, scan.id))
+        .where(withProject(maintenanceScans, eq(maintenanceScans.id, scan.id)))
         .returning();
 
       // ── Auto-trigger pipeline on critical findings ─────────────────────────
@@ -313,7 +314,7 @@ export function registerMaintenanceRoutes(router: Router): void {
         try {
           const [run] = await db
             .insert(pipelineRuns)
-            .values({
+            .values(withProjectInsert(pipelineRuns, {
               pipelineId: policy.autoTriggerPipelineId,
               status: "pending",
               input: JSON.stringify({
@@ -323,7 +324,7 @@ export function registerMaintenanceRoutes(router: Router): void {
               }),
               triggeredBy: req.user.id,
               dagMode: false,
-            })
+            }))
             .returning();
 
           const auditRows = criticalFindings.map((f) => ({
@@ -334,7 +335,7 @@ export function registerMaintenanceRoutes(router: Router): void {
           }));
 
           if (auditRows.length > 0) {
-            await db.insert(autoTriggerAudit).values(auditRows);
+            await db.insert(autoTriggerAudit).values(withProjectInsert(autoTriggerAudit, auditRows));
           }
         } catch {
           // Auto-trigger failure is non-fatal — scan result is still returned
@@ -364,7 +365,7 @@ export function registerMaintenanceRoutes(router: Router): void {
       const [scan] = await db
         .select()
         .from(maintenanceScans)
-        .where(eq(maintenanceScans.id, parsed.data.scanId));
+        .where(withProject(maintenanceScans, eq(maintenanceScans.id, parsed.data.scanId)));
 
       if (!scan) {
         return res.status(404).json({ error: "Scan not found" });
@@ -387,7 +388,7 @@ export function registerMaintenanceRoutes(router: Router): void {
       const [updated] = await db
         .update(maintenanceScans)
         .set({ findings: updatedFindings })
-        .where(eq(maintenanceScans.id, parsed.data.scanId))
+        .where(withProject(maintenanceScans, eq(maintenanceScans.id, parsed.data.scanId)))
         .returning();
 
       return res.json({ finding: updatedFindings[findingIndex], scan: updated });
@@ -401,10 +402,11 @@ export function registerMaintenanceRoutes(router: Router): void {
   router.get("/api/maintenance/dashboard", async (_req, res) => {
     try {
       const [policies, scans] = await Promise.all([
-        db.select().from(maintenancePolicies),
+        db.select().from(maintenancePolicies).where(withProjectList(maintenancePolicies)),
         db
           .select()
           .from(maintenanceScans)
+          .where(withProjectList(maintenanceScans))
           .orderBy(desc(maintenanceScans.createdAt)),
       ]);
 
@@ -444,10 +446,10 @@ export function registerMaintenanceRoutes(router: Router): void {
         .select()
         .from(maintenanceScans)
         .where(
-          and(
+          withProject(maintenanceScans, and(
             eq(maintenanceScans.workspaceId, workspaceId),
             eq(maintenanceScans.status, "completed"),
-          ),
+          )),
         )
         .orderBy(desc(maintenanceScans.completedAt));
 
@@ -531,6 +533,7 @@ export function registerMaintenanceRoutes(router: Router): void {
       const rows = await db
         .select()
         .from(autoTriggerAudit)
+        .where(withProjectList(autoTriggerAudit))
         .orderBy(desc(autoTriggerAudit.triggeredAt));
 
       return res.json(rows as AutoTriggerAuditRow[]);
@@ -549,15 +552,15 @@ export function registerMaintenanceRoutes(router: Router): void {
         db
           .select()
           .from(maintenancePolicies)
-          .where(eq(maintenancePolicies.workspaceId, workspaceId)),
+          .where(withProject(maintenancePolicies, eq(maintenancePolicies.workspaceId, workspaceId))),
         db
           .select()
           .from(maintenanceScans)
           .where(
-            and(
+            withProject(maintenanceScans, and(
               eq(maintenanceScans.workspaceId, workspaceId),
               eq(maintenanceScans.status, "completed"),
-            ),
+            )),
           )
           .orderBy(desc(maintenanceScans.completedAt)),
       ]);

--- a/server/routes/privacy.ts
+++ b/server/routes/privacy.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { z } from "zod";
 import { AnonymizerService } from "../privacy/anonymizer";
-import { db } from "../db";
+import { db, withProject, withProjectList, withProjectInsert } from "../db";
 import {
   anonymizationLog,
   anonymizationPatterns,
@@ -95,6 +95,7 @@ export function registerPrivacyRoutes(router: Router): void {
       const patterns = await db
         .select()
         .from(anonymizationPatterns)
+        .where(withProjectList(anonymizationPatterns))
         .orderBy(desc(anonymizationPatterns.createdAt));
       return res.json(patterns);
     } catch (err) {
@@ -123,14 +124,14 @@ export function registerPrivacyRoutes(router: Router): void {
     try {
       const [created] = await db
         .insert(anonymizationPatterns)
-        .values({
+        .values(withProjectInsert(anonymizationPatterns, {
           name: parsed.data.name,
           entityType: parsed.data.entityType,
           regexPattern: parsed.data.regexPattern,
           severity: parsed.data.severity,
           pseudonymTemplate: parsed.data.pseudonymTemplate ?? null,
           allowlist: parsed.data.allowlist,
-        })
+        }))
         .returning();
       return res.status(201).json(created);
     } catch (err) {
@@ -152,7 +153,7 @@ export function registerPrivacyRoutes(router: Router): void {
     try {
       await db
         .delete(anonymizationPatterns)
-        .where(eq(anonymizationPatterns.id, id));
+        .where(withProject(anonymizationPatterns, eq(anonymizationPatterns.id, id)));
       return res.status(204).send();
     } catch (err) {
       return res.status(500).json({ error: "Failed to delete pattern" });
@@ -169,6 +170,7 @@ export function registerPrivacyRoutes(router: Router): void {
       const query = db
         .select()
         .from(anonymizationLog)
+        .where(withProjectList(anonymizationLog))
         .orderBy(desc(anonymizationLog.createdAt))
         .limit(100);
 

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -39,6 +39,7 @@
  *     (D.2/D.3) so the DEV pipeline's read tools are grounded in the loop's repo.
  */
 import type { IStorage } from "../../storage.js";
+import { runAsSystem } from "../../context.js";
 import type { ConsiliumLoopRow, ConsiliumLoopState } from "@shared/schema";
 import type { ActionPoint, ConvergenceVerdict } from "@shared/types";
 import type { TaskOrchestrator } from "../task-orchestrator.js";
@@ -747,7 +748,11 @@ export class ConsiliumLoopPoller {
     if (this.sweeping) return; // never overlap sweeps
     this.sweeping = true;
     try {
-      const loops = await this.storage.getLoops();
+      // Cross-project sweep of every non-terminal loop, under an audited system
+      // context. Per-loop tick() keeps its existing (context-free) behavior.
+      const loops = await runAsSystem("consilium-loop-poller-sweep", () =>
+        this.storage.getLoops(),
+      );
       for (const loop of loops) {
         await this.controller.tick(loop.id).catch(() => undefined);
       }

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -1,6 +1,6 @@
 import { eq, desc, and, or, ilike, lt, ne, gte, lte, asc, isNull, inArray, sql as drizzleSql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
-import { db, withProject, withProjectInsert } from "./db";
+import { db, withProject, withProjectList, withProjectInsert, withProjectOrGlobal } from "./db";
 import { unscopedSystemQuery } from "./context";
 import type { IStorage, PracticeCardFilters, MorningBriefFilters, NewsItemFilters, LlmRequestFilters, LlmRequestStats, LlmStatsByModel, LlmStatsByProvider, LlmStatsByTeam, LlmTimelinePoint, RunHistoryQuery, PipelineRunHistoryRow, TaskGroupHistoryRow } from "./storage";
 import {
@@ -165,15 +165,19 @@ export class PgStorage implements IStorage {
   // ─── Models ─────────────────────────────────────────
 
   async getModels(): Promise<Model[]> {
-    return db.select().from(models);
+    // GLOBAL CATALOG: shared rows (project_id IS NULL) are visible in every
+    // project; project-specific rows are visible only in their own project.
+    // System context (startup seed / catalog reconcile) sees the whole catalog.
+    return db.select().from(models).where(withProjectOrGlobal(models));
   }
 
   async getActiveModels(): Promise<Model[]> {
-    return db.select().from(models).where(withProject(models, eq(models.isActive, true)));
+    // GLOBAL CATALOG (see getModels): global-or-current visibility, active only.
+    return db.select().from(models).where(withProjectOrGlobal(models, eq(models.isActive, true)));
   }
 
   async getModelBySlug(slug: string): Promise<Model | undefined> {
-    const [row] = await db.select().from(models).where(withProject(models, eq(models.slug, slug)));
+    const [row] = await db.select().from(models).where(withProjectOrGlobal(models, eq(models.slug, slug)));
     return row;
   }
 
@@ -220,7 +224,9 @@ export class PgStorage implements IStorage {
   // ─── Pipelines ──────────────────────────────────────
 
   async getPipelines(): Promise<Pipeline[]> {
-    return db.select().from(pipelines);
+    // Project-scoped in a request context; cross-project in a system context
+    // (config-sync, federation, catalog reconcile, startup seed) via runAsSystem.
+    return db.select().from(pipelines).where(withProjectList(pipelines));
   }
 
   async getPipeline(id: string): Promise<Pipeline | undefined> {
@@ -254,14 +260,17 @@ export class PgStorage implements IStorage {
   // ─── Pipeline Runs ──────────────────────────────────
 
   async getPipelineRuns(pipelineId?: string): Promise<PipelineRun[]> {
-    if (pipelineId) {
-      return db
-        .select()
-        .from(pipelineRuns)
-        .where(withProject(pipelineRuns, eq(pipelineRuns.pipelineId, pipelineId)))
-        .orderBy(desc(pipelineRuns.createdAt));
-    }
-    return db.select().from(pipelineRuns).orderBy(desc(pipelineRuns.createdAt));
+    // ALWAYS project-scoped — both the per-pipeline branch AND the list-all
+    // branch (the latter previously returned runs from every project). A system
+    // context (runAsSystem) reads cross-project, audited.
+    const filter = pipelineId
+      ? withProjectList(pipelineRuns, eq(pipelineRuns.pipelineId, pipelineId))
+      : withProjectList(pipelineRuns);
+    return db
+      .select()
+      .from(pipelineRuns)
+      .where(filter)
+      .orderBy(desc(pipelineRuns.createdAt));
   }
 
   async listPipelineRunHistory(query: RunHistoryQuery): Promise<PipelineRunHistoryRow[]> {
@@ -466,17 +475,17 @@ export class PgStorage implements IStorage {
   // ─── Chat Messages ──────────────────────────────────
 
   async getChatMessages(runId?: string, limit?: number): Promise<ChatMessage[]> {
-    let query = db
+    // ALWAYS project-scoped at the base — even when runId is omitted. Previously a
+    // no-runId call applied NO filter and dumped chat messages across every project.
+    // When runId is provided it is AND-ed with the project filter.
+    const filter = runId
+      ? withProjectList(chatMessages, eq(chatMessages.runId, runId))
+      : withProjectList(chatMessages);
+    const rows = await db
       .select()
       .from(chatMessages)
-      .orderBy(chatMessages.createdAt)
-      .$dynamic();
-
-    if (runId) {
-      query = query.where(withProject(chatMessages, eq(chatMessages.runId, runId)));
-    }
-
-    const rows = await query;
+      .where(filter)
+      .orderBy(chatMessages.createdAt);
     return limit ? rows.slice(-limit) : rows;
   }
 
@@ -542,7 +551,8 @@ export class PgStorage implements IStorage {
         totalOutputTokens: drizzleSql<number>`coalesce(sum(output_tokens), 0)::int`,
         totalCostUsd: drizzleSql<number>`coalesce(sum(estimated_cost_usd), 0)::float`,
       })
-      .from(llmRequests);
+      .from(llmRequests)
+      .where(withProject(llmRequests));
 
     return {
       totalRequests: row?.totalRequests ?? 0,
@@ -565,6 +575,7 @@ export class PgStorage implements IStorage {
         errorCount: drizzleSql<number>`count(*) filter (where status = 'error')::int`,
       })
       .from(llmRequests)
+      .where(withProject(llmRequests))
       .groupBy(llmRequests.modelSlug, llmRequests.provider);
 
     return rows.map((r) => ({
@@ -591,6 +602,7 @@ export class PgStorage implements IStorage {
         errorCount: drizzleSql<number>`count(*) filter (where status = 'error')::int`,
       })
       .from(llmRequests)
+      .where(withProject(llmRequests))
       .groupBy(llmRequests.provider);
 
     return rows.map((r) => ({
@@ -788,7 +800,7 @@ export class PgStorage implements IStorage {
   }
 
   async getMcpServers(): Promise<McpServerConfig[]> {
-    const rows = await db.select().from(mcpServers).orderBy(mcpServers.name);
+    const rows = await db.select().from(mcpServers).where(withProjectList(mcpServers)).orderBy(mcpServers.name);
     return rows.map((r) => this.rowToMcpServer(r));
   }
 
@@ -872,7 +884,7 @@ export class PgStorage implements IStorage {
   // ─── Specialization Profiles (Phase 5) ──────────────────────────────────────
 
   async getSpecializationProfiles(): Promise<SpecializationProfileRow[]> {
-    return db.select().from(specializationProfiles).orderBy(specializationProfiles.createdAt);
+    return db.select().from(specializationProfiles).where(withProjectList(specializationProfiles)).orderBy(specializationProfiles.createdAt);
   }
 
   async createSpecializationProfile(profile: InsertSpecializationProfile): Promise<SpecializationProfileRow> {
@@ -897,7 +909,7 @@ export class PgStorage implements IStorage {
 
     return conditions.length > 0
       ? db.select().from(skills).where(withProject(skills, and(...conditions))).orderBy(skills.name)
-      : db.select().from(skills).orderBy(skills.name);
+      : db.select().from(skills).where(withProjectList(skills)).orderBy(skills.name);
   }
 
   async getSkill(id: string): Promise<Skill | undefined> {
@@ -1087,7 +1099,7 @@ export class PgStorage implements IStorage {
   // ─── Skill Teams ─────────────────────────────────────────────────────────────
 
   async getSkillTeams(): Promise<SkillTeam[]> {
-    return db.select().from(skillTeams).orderBy(skillTeams.createdAt);
+    return db.select().from(skillTeams).where(withProject(skillTeams)).orderBy(skillTeams.createdAt);
   }
 
   async createSkillTeam(data: InsertSkillTeam): Promise<SkillTeam> {
@@ -1236,7 +1248,20 @@ export class PgStorage implements IStorage {
   }
 
   async getLoops(): Promise<ConsiliumLoopRow[]> {
-    return db.select().from(consiliumLoops).orderBy(desc(consiliumLoops.createdAt));
+    // consilium_loops has NO project_id column of its own (a loop belongs to a
+    // task group). Scope by sub-querying the loop's group through task_groups,
+    // which IS project-scoped — so only loops whose group is in the current
+    // project are returned. Same runId->pipeline_runs idea as getTraces().
+    return db
+      .select()
+      .from(consiliumLoops)
+      .where(
+        inArray(
+          consiliumLoops.groupId,
+          db.select({ id: taskGroups.id }).from(taskGroups).where(withProjectList(taskGroups)),
+        ),
+      )
+      .orderBy(desc(consiliumLoops.createdAt));
   }
 
   async getActiveLoopByGroup(groupId: string): Promise<ConsiliumLoopRow | undefined> {
@@ -1470,7 +1495,20 @@ export class PgStorage implements IStorage {
   }
 
   async getTraces(limit = 50, offset = 0): Promise<TraceRow[]> {
+    // traces has NO project_id column (a trace belongs to a pipeline run). Scope
+    // by sub-querying through pipeline_runs (which IS project-scoped) so only
+    // traces whose run is in the current project are returned. A schema migration
+    // adding traces.project_id was considered but rejected here: it would
+    // denormalize and require a backfill + dual-write, whereas the
+    // runId->pipeline_runs join is exact and cheap (indexed run_id) for the
+    // dashboard's page-sized reads.
     return db.select().from(traces)
+      .where(
+        inArray(
+          traces.runId,
+          db.select({ id: pipelineRuns.id }).from(pipelineRuns).where(withProjectList(pipelineRuns)),
+        ),
+      )
       .orderBy(desc(traces.createdAt))
       .limit(limit)
       .offset(offset);
@@ -1485,7 +1523,7 @@ export class PgStorage implements IStorage {
   // ─── Task Groups (Task Orchestrator) ────────────────────────────────────────
 
   async getTaskGroups(): Promise<TaskGroupRow[]> {
-    return db.select().from(taskGroups).orderBy(desc(taskGroups.createdAt));
+    return db.select().from(taskGroups).where(withProject(taskGroups)).orderBy(desc(taskGroups.createdAt));
   }
 
   async getTaskGroup(id: string): Promise<TaskGroupRow | undefined> {
@@ -1652,6 +1690,7 @@ export class PgStorage implements IStorage {
     const rows = await db
       .selectDistinct({ modelId: modelSkillBindings.modelId })
       .from(modelSkillBindings)
+      .where(withProjectList(modelSkillBindings))
       .orderBy(asc(modelSkillBindings.modelId));
     return rows.map((r) => r.modelId);
   }

--- a/tests/integration/maintenance-api.test.ts
+++ b/tests/integration/maintenance-api.test.ts
@@ -56,6 +56,13 @@ vi.mock("../../server/db.js", () => {
 
   // We return a proxy-like object; routes use drizzle builder API
   return {
+    // Project-scoping helpers are pure WHERE-fragment builders; the mock's
+    // .where() ignores the condition, so stubs that echo it suffice (and, unlike
+    // the real helpers, they require no ALS request context).
+    withProject: (_t: unknown, c?: unknown) => c,
+    withProjectList: (_t: unknown, c?: unknown) => c,
+    withProjectOrGlobal: (_t: unknown, c?: unknown) => c,
+    withProjectInsert: (_t: unknown, d: unknown) => d,
     db: {
       select: () => ({
         from: (tableRef: unknown) => {

--- a/tests/integration/maintenance-auto-trigger.test.ts
+++ b/tests/integration/maintenance-auto-trigger.test.ts
@@ -71,6 +71,11 @@ vi.mock("../../server/maintenance/scout.js", () => ({
 
 vi.mock("../../server/db.js", () => {
   return {
+    // Scoping helpers: pure WHERE builders the mock ignores; stubs need no context.
+    withProject: (_t: unknown, c?: unknown) => c,
+    withProjectList: (_t: unknown, c?: unknown) => c,
+    withProjectOrGlobal: (_t: unknown, c?: unknown) => c,
+    withProjectInsert: (_t: unknown, d: unknown) => d,
     db: {
       select: () => ({
         from: (tableRef: unknown) => ({

--- a/tests/unit/remote-agent-manager.test.ts
+++ b/tests/unit/remote-agent-manager.test.ts
@@ -12,6 +12,12 @@ const mockDb = {
 
 vi.mock("../../server/db", () => ({
   db: mockDb,
+  // Scoping helpers are pure WHERE-fragment builders; the chainable mock ignores
+  // the condition it's handed, so stubs that echo the (optional) condition suffice.
+  withProject: (_table: unknown, condition?: unknown) => condition,
+  withProjectList: (_table: unknown, condition?: unknown) => condition,
+  withProjectOrGlobal: (_table: unknown, condition?: unknown) => condition,
+  withProjectInsert: (_table: unknown, data: unknown) => data,
 }));
 
 // Build a chainable query-builder mock that mimics drizzle's API
@@ -297,6 +303,7 @@ describe("RemoteAgentManager", () => {
       });
       mockDb.select.mockReturnValue({
         from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnThis(),
           orderBy: vi.fn().mockReturnValue([row1, row2]),
         }),
       });
@@ -313,6 +320,7 @@ describe("RemoteAgentManager", () => {
     it("returns null when no agent matches selector", async () => {
       mockDb.select.mockReturnValue({
         from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnThis(),
           orderBy: vi.fn().mockReturnValue([]),
         }),
       });
@@ -329,6 +337,7 @@ describe("RemoteAgentManager", () => {
       const row = makeAgentRow({ id: "fallback", status: "online" });
       mockDb.select.mockReturnValue({
         from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnThis(),
           orderBy: vi.fn().mockReturnValue([row]),
         }),
       });
@@ -455,6 +464,7 @@ describe("RemoteAgentManager", () => {
       // listAgents call
       mockDb.select.mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnThis(),
           orderBy: vi.fn().mockReturnValue([row1, row2]),
         }),
       });
@@ -510,6 +520,7 @@ describe("RemoteAgentManager", () => {
       const row = makeAgentRow({ id: "list-1", name: "alpha" });
       mockDb.select.mockReturnValue({
         from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnThis(),
           orderBy: vi.fn().mockReturnValue([row]),
         }),
       });

--- a/tests/unit/scoping/list-methods-isolation.test.ts
+++ b/tests/unit/scoping/list-methods-isolation.test.ts
@@ -1,0 +1,319 @@
+/**
+ * DB-layer project scoping for LIST/READ + aggregate methods
+ * (strict-project-isolation work).
+ *
+ * Proves — WITHOUT a real database — that the storage read methods which
+ * previously did a raw `db.select().from(table)` now embed a project_id filter,
+ * and that the global-catalog methods (getModels / getActiveModels) use the
+ * "global-or-current" predicate (project_id IS NULL OR project_id = $ctx).
+ *
+ * Technique: build the SAME Drizzle query the storage method builds and call
+ * `.toSQL()` (pure serialisation — no connection). The presence of the
+ * project_id column reference + the bound projectId param in the generated SQL
+ * is the structural proof that project A's query cannot match project B's rows.
+ * For the two tables that have NO project_id column (traces, consilium_loops),
+ * we prove the SCOPED SUB-QUERY (through pipeline_runs / task_groups) carries
+ * the filter.
+ *
+ * Mirrors the harness in db-layer-isolation.test.ts.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { eq, inArray, desc, asc } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+// ─── Mock configLoader before any server module is imported ──────────────────
+vi.mock("../../../server/config/loader.js", () => ({
+  configLoader: {
+    get: () => ({
+      database: { url: undefined },
+      server: { nodeEnv: "test", port: 3000 },
+      auth: { jwtSecret: "test-secret-minimum-32-chars-xx", bcryptRounds: 4, sessionTtlDays: 1 },
+      encryption: { key: undefined },
+      providers: {},
+      features: {
+        sandbox: { enabled: false },
+        privacy: { enabled: false },
+        maintenance: { enabled: false, cronSchedule: "" },
+      },
+    }),
+  },
+}));
+
+// ─── Import AFTER mocks ───────────────────────────────────────────────────────
+import { db, withProject, withProjectList, withProjectOrGlobal } from "../../../server/db.js";
+import { runAsProject, runAsSystem } from "../../../server/context.js";
+import {
+  models,
+  pipelines,
+  pipelineRuns,
+  skills,
+  skillTeams,
+  taskGroups,
+  consiliumLoops,
+  traces,
+  llmRequests,
+  mcpServers,
+  specializationProfiles,
+  modelSkillBindings,
+  chatMessages,
+} from "../../../shared/schema.js";
+
+const dialect = new PgDialect();
+function frag(sql: import("drizzle-orm").SQL): { sql: string; params: unknown[] } {
+  const q = dialect.sqlToQuery(sql);
+  return { sql: q.sql, params: q.params };
+}
+
+const PROJ = "proj-iso-A";
+const OTHER = "proj-iso-B";
+
+// ─── Group 1: simple scoped list methods embed project_id ────────────────────
+
+describe("Scoped list methods embed the current project_id filter", () => {
+  // table, the column-qualified regex we expect in the generated SQL
+  const cases: Array<[string, any, RegExp]> = [
+    ["getPipelines -> pipelines", pipelines, /"pipelines"\."project_id"/],
+    ["getPipelineRuns -> pipeline_runs", pipelineRuns, /"pipeline_runs"\."project_id"/],
+    ["getSkills -> skills", skills, /"skills"\."project_id"/],
+    ["getSkillTeams -> skill_teams", skillTeams, /"skill_teams"\."project_id"/],
+    ["getTaskGroups -> task_groups", taskGroups, /"task_groups"\."project_id"/],
+    ["getLlmStats* -> llm_requests", llmRequests, /"llm_requests"\."project_id"/],
+  ];
+
+  for (const [label, table, colRe] of cases) {
+    it(`${label}: WHERE carries project_id + bound projectId param`, async () => {
+      const q = await runAsProject(PROJ, async () =>
+        db.select().from(table).where(withProject(table)).toSQL(),
+      );
+      expect(q.sql).toMatch(colRe);
+      expect(q.params).toContain(PROJ);
+    });
+
+    it(`${label}: project A vs B produce different bound params (isolation proof)`, async () => {
+      const qa = await runAsProject(PROJ, async () =>
+        db.select().from(table).where(withProject(table)).toSQL(),
+      );
+      const qb = await runAsProject(OTHER, async () =>
+        db.select().from(table).where(withProject(table)).toSQL(),
+      );
+      expect(qa.sql).toBe(qb.sql); // same shape
+      expect(qa.params).toContain(PROJ);
+      expect(qb.params).toContain(OTHER);
+      expect(qa.params).not.toContain(OTHER);
+    });
+  }
+
+  it("getPipelineRuns(pipelineId): both the run filter AND the project filter are present", async () => {
+    const q = await runAsProject(PROJ, async () =>
+      db
+        .select()
+        .from(pipelineRuns)
+        .where(withProject(pipelineRuns, eq(pipelineRuns.pipelineId, "pipe-7")))
+        .toSQL(),
+    );
+    expect(q.sql).toMatch(/"pipeline_runs"\."project_id"/);
+    expect(q.params).toContain(PROJ);
+    expect(q.params).toContain("pipe-7");
+  });
+});
+
+// ─── Group 2: subquery scoping for tables WITHOUT a project_id column ─────────
+
+describe("Subquery scoping: traces and consilium_loops scope through a project-scoped parent", () => {
+  it("getTraces: filters traces.run_id IN (project-scoped pipeline_runs)", async () => {
+    const q = await runAsProject(PROJ, async () =>
+      db
+        .select()
+        .from(traces)
+        .where(
+          inArray(
+            traces.runId,
+            db.select({ id: pipelineRuns.id }).from(pipelineRuns).where(withProject(pipelineRuns)),
+          ),
+        )
+        .orderBy(desc(traces.createdAt))
+        .toSQL(),
+    );
+    // The inner subquery must carry pipeline_runs.project_id + the project param.
+    expect(q.sql).toMatch(/"traces"\."run_id" in \(select/i);
+    expect(q.sql).toMatch(/"pipeline_runs"\."project_id"/);
+    expect(q.params).toContain(PROJ);
+    // traces itself has no project_id column — make sure we did NOT invent one.
+    expect(q.sql).not.toMatch(/"traces"\."project_id"/);
+  });
+
+  it("getLoops: filters consilium_loops.group_id IN (project-scoped task_groups)", async () => {
+    const q = await runAsProject(PROJ, async () =>
+      db
+        .select()
+        .from(consiliumLoops)
+        .where(
+          inArray(
+            consiliumLoops.groupId,
+            db.select({ id: taskGroups.id }).from(taskGroups).where(withProject(taskGroups)),
+          ),
+        )
+        .orderBy(desc(consiliumLoops.createdAt))
+        .toSQL(),
+    );
+    expect(q.sql).toMatch(/"consilium_loops"\."group_id" in \(select/i);
+    expect(q.sql).toMatch(/"task_groups"\."project_id"/);
+    expect(q.params).toContain(PROJ);
+    expect(q.sql).not.toMatch(/"consilium_loops"\."project_id"/);
+  });
+
+  it("traces / consilium_loops genuinely have NO project_id column (justifies the subquery)", () => {
+    expect((traces as Record<string, unknown>).projectId).toBeUndefined();
+    expect((consiliumLoops as Record<string, unknown>).projectId).toBeUndefined();
+  });
+});
+
+// ─── Group 3: GLOBAL CATALOG — getModels / getActiveModels visibility ─────────
+
+describe("Global-catalog visibility (withProjectOrGlobal) for the models table", () => {
+  it("project context: predicate is (project_id IS NULL OR project_id = $ctx)", async () => {
+    const { sql, params } = await runAsProject(PROJ, async () =>
+      frag(withProjectOrGlobal(models)!),
+    );
+    expect(sql).toMatch(/"models"\."project_id" is null/i);
+    expect(sql).toMatch(/"models"\."project_id" =/i);
+    expect(params).toContain(PROJ);
+  });
+
+  it("getModels query: global rows (NULL) stay visible alongside the current project", async () => {
+    const q = await runAsProject(PROJ, async () =>
+      db.select().from(models).where(withProjectOrGlobal(models)).toSQL(),
+    );
+    expect(q.sql).toMatch(/is null/i);
+    expect(q.sql).toMatch(/"models"\."project_id"/);
+    expect(q.params).toContain(PROJ);
+  });
+
+  it("getActiveModels: global-or-current AND is_active = true", async () => {
+    const q = await runAsProject(PROJ, async () =>
+      db.select().from(models).where(withProjectOrGlobal(models, eq(models.isActive, true))).toSQL(),
+    );
+    expect(q.sql).toMatch(/is null/i);
+    expect(q.sql).toMatch(/"models"\."project_id"/);
+    expect(q.params).toContain(PROJ);
+    expect(q.params).toContain(true);
+  });
+
+  it("project A vs B: the bound project param differs (private project models isolated)", async () => {
+    const qa = await runAsProject(PROJ, async () => frag(withProjectOrGlobal(models)!));
+    const qb = await runAsProject(OTHER, async () => frag(withProjectOrGlobal(models)!));
+    expect(qa.params).toContain(PROJ);
+    expect(qb.params).toContain(OTHER);
+    expect(qa.params).not.toContain(OTHER);
+  });
+
+  it("system context, no condition: returns undefined → no project filter (sees WHOLE catalog)", async () => {
+    const result = await runAsSystem("test-catalog-reconcile", async () =>
+      withProjectOrGlobal(models),
+    );
+    expect(result).toBeUndefined();
+    // And the resulting query has no project_id WHERE clause at all.
+    const q = await runAsSystem("test-catalog-reconcile", async () =>
+      db.select().from(models).where(withProjectOrGlobal(models)).toSQL(),
+    );
+    // No WHERE clause at all (project_id appears only in the SELECT column list).
+    expect(q.sql).not.toMatch(/\bwhere\b/i);
+  });
+
+  it("system context WITH condition: returns the condition only, no project/global filter", async () => {
+    const { sql } = await runAsSystem("test-active-reconcile", async () =>
+      frag(withProjectOrGlobal(models, eq(models.isActive, true))!),
+    );
+    expect(sql).toMatch(/is_active/i);
+    expect(sql).not.toMatch(/project_id/);
+  });
+
+  it("fail-closed: withProjectOrGlobal throws with no ALS context", () => {
+    expect(() => withProjectOrGlobal(models)).toThrow(/no request context/i);
+  });
+});
+
+
+// ─── Group 4: Second hardening pass (C1-C3, H1, L1) ──────────────────────────
+
+describe("Second pass: newly scoped raw/aggregate reads embed project_id", () => {
+  it("C1 getMcpServers: withProjectList(mcpServers) carries project_id + param", async () => {
+    const q = await runAsProject(PROJ, async () =>
+      db.select().from(mcpServers).where(withProjectList(mcpServers)).orderBy(mcpServers.name).toSQL(),
+    );
+    expect(q.sql).toMatch(/"mcp_servers"\."project_id"/);
+    expect(q.params).toContain(PROJ);
+  });
+
+  it("C2 getSpecializationProfiles: withProjectList(specialization_profiles) carries project_id", async () => {
+    const q = await runAsProject(PROJ, async () =>
+      db.select().from(specializationProfiles).where(withProjectList(specializationProfiles)).toSQL(),
+    );
+    expect(q.sql).toMatch(/"specialization_profiles"\."project_id"/);
+    expect(q.params).toContain(PROJ);
+  });
+
+  it("C3 getModelsWithSkillBindings: selectDistinct is project-scoped", async () => {
+    const q = await runAsProject(PROJ, async () =>
+      db
+        .selectDistinct({ modelId: modelSkillBindings.modelId })
+        .from(modelSkillBindings)
+        .where(withProjectList(modelSkillBindings))
+        .orderBy(asc(modelSkillBindings.modelId))
+        .toSQL(),
+    );
+    expect(q.sql).toMatch(/distinct/i);
+    expect(q.sql).toMatch(/"model_skill_bindings"\."project_id"/);
+    expect(q.params).toContain(PROJ);
+  });
+
+  it("H1 getChatMessages WITHOUT runId: base is unconditionally project-scoped (no full-tenant dump)", async () => {
+    const q = await runAsProject(PROJ, async () =>
+      db.select().from(chatMessages).where(withProjectList(chatMessages)).toSQL(),
+    );
+    expect(q.sql).toMatch(/"chat_messages"\."project_id"/);
+    expect(q.params).toContain(PROJ);
+  });
+
+  it("H1 getChatMessages WITH runId: project filter AND run_id are both present", async () => {
+    const q = await runAsProject(PROJ, async () =>
+      db
+        .select()
+        .from(chatMessages)
+        .where(withProjectList(chatMessages, eq(chatMessages.runId, "run-9")))
+        .toSQL(),
+    );
+    expect(q.sql).toMatch(/"chat_messages"\."project_id"/);
+    expect(q.sql).toMatch(/"chat_messages"\."run_id"/);
+    expect(q.params).toContain(PROJ);
+    expect(q.params).toContain("run-9");
+  });
+
+  it("H1 getChatMessages in SYSTEM context with runId: cross-project by run_id (no project filter, no throw)", async () => {
+    const q = await runAsSystem("test-handoff", async () =>
+      db
+        .select()
+        .from(chatMessages)
+        .where(withProjectList(chatMessages, eq(chatMessages.runId, "run-9")))
+        .toSQL(),
+    );
+    // project_id appears only in the SELECT column list; the WHERE clause must
+    // carry ONLY the run_id filter (cross-project, audited by runAsSystem).
+    const whereClause = q.sql.split(/ where /i)[1] ?? "";
+    expect(whereClause).not.toMatch(/project_id/);
+    expect(q.sql).toMatch(/"chat_messages"\."run_id"/);
+    expect(q.params).toContain("run-9");
+  });
+
+  it("L1 getModelBySlug: global-or-current (IS NULL OR =) AND slug — global models stay resolvable", async () => {
+    const q = await runAsProject(PROJ, async () =>
+      db.select().from(models).where(withProjectOrGlobal(models, eq(models.slug, "claude-sonnet"))).toSQL(),
+    );
+    expect(q.sql).toMatch(/is null/i);
+    expect(q.sql).toMatch(/"models"\."project_id"/);
+    expect(q.sql).toMatch(/"models"\."slug"/);
+    expect(q.params).toContain(PROJ);
+    expect(q.params).toContain("claude-sonnet");
+  });
+});


### PR DESCRIPTION
## Goal
Make every project a fully independent tenant: with project A selected, **no** data from project B appears in any list, detail view, count, or dropdown. Resolves the reported symptoms — a task group from project *omnius* showing in *boosti*'s list but 404'ing on open, and "Run again" failing with `x-project-id header is required`.

## The isolation boundary is server-side
`requireProject` (validates owner/member, sets an ALS context) + fail-closed scoping helpers in `server/db.ts`. Once a storage read is scoped, project B's rows cannot reach a project-A request **regardless of the client**. Full model in [`ISOLATION.md`](ISOLATION.md).

## Server changes (the security fix)
- **New helpers** `withProjectList` (non-secret list reads; cross-project only under `runAsSystem`) and `withProjectOrGlobal` (`project_id IS NULL OR = ctx`, for the global catalog). Both fail-closed. `withProjectInsert` already forces `projectId = ctx` (no `projectId:null` escalation via request body — verified).
- **Scoped the unscoped reads**: `getTaskGroups`, `getPipelines`, `getPipelineRuns`, `getSkills`, `getSkillTeams`, `getMcpServers`, `getSpecializationProfiles`, `getModelsWithSkillBindings`, `getChatMessages` (was dumping all projects when no `runId`), `getLlmRequestStats/ByModel/ByProvider`, `getLoops`/`getTraces` (subquery via project-owned parents — no migration), `getModels/getActiveModels/getModelBySlug` (global catalog).
- **Raw route queries** scoped in `maintenance`/`privacy`/`library`; fixed a **remote-agent `getAgent` IDOR** (loaded by id with no project scope).
- **System/background callers** (config-sync, federation, MCP self-server, consilium poller) wrapped in `runAsSystem` so scoped reads resolve instead of throwing. Verified the trigger→run path keeps project context (no fail-closed throw).
- **Global by design** (product decision): LLM model catalog + skill marketplace registry stay global; configs, provider keys, installed skills, bindings, teams stay strictly per-project.

## Client changes (UX, not the boundary)
- `lib/projectHeaders.ts` — one canonical header builder (always sends `x-project-id` when a project is selected, never empty); shared transports routed through it.
- `lib/installFetchInterceptor.ts` — one-time `window.fetch` patch (wired in `main.tsx`) that injects `x-project-id` on same-origin non-public `/api/*` requests if absent → no UI action 400s, without editing the ~30 inline-fetch call sites. Idempotent, never overwrites a caller-set header.
- Project switch stays a hard `window.location.reload()` (wipes cache; cannot leak stale cross-project data) — deliberate.

## Tests & verification
- `tests/unit/scoping/list-methods-isolation.test.ts` — structural SQL proof (PgDialect, no DB) that each scoped method embeds the bound `project_id`, two contexts differ, and catalog methods use `IS NULL OR =`.
- `npx tsc --noEmit` clean. Full unit suite green (5358 passed; one gateway test is a flaky timeout under parallel load — passes in isolation).
- Independent adversarial security review performed; its must-fix items (C1–C3, H1, the `getAgent` IDOR, route-level bleeds) are all addressed in this PR.

## Out of scope — follow-up tickets (need migration / design)
- [ ] `models.slug` → `unique(projectId, slug)` migration + re-assert scope in `upsertModelBySlug` conflict path.
- [ ] MCP self-server pipeline listing: needs an MCP-token→project mapping before it can be project-scoped (currently cross-project under `runAsSystem`).
- [ ] Pre-existing latent throwers: ~10 `withProject(traces/consilium_loops, …)` detail/update methods reference a non-existent `project_id` column and 500 in request context (correctness bug, **not** a leak — fail-closed). Fix via column add or subquery refactor.

## Notes for reviewers
- Built on a clean worktree from `origin/main`; **independent of PR #405** (project delete + cross-project task-group switch UX).
- The local working copy has substantial unrelated WIP on several of these client files — this branch does **not** include it; expect a rebase/merge reconciliation there.