### PR TITLE
fix: declare project_id on task/consilium tables (unbreak task-group API)

### DIFF
--- a/server/storage-task-groups-v2.ts
+++ b/server/storage-task-groups-v2.ts
@@ -109,6 +109,7 @@ export function buildVirtualIteration(group: TaskGroupRow, tasks: TaskRow[]): Vi
   const virtualIterationId = `virtual:${group.id}:1`;
   const iteration: TaskGroupIterationRow = {
     id: virtualIterationId,
+    projectId: group.projectId ?? null,
     groupId: group.id,
     iterationNumber: 1,
     status: group.status,
@@ -123,6 +124,7 @@ export function buildVirtualIteration(group: TaskGroupRow, tasks: TaskRow[]): Vi
   };
   const executions: TaskExecutionRow[] = tasks.map((t) => ({
     id: `virtual:${t.id}`,
+    projectId: group.projectId ?? null,
     iterationId: virtualIterationId,
     taskId: t.id,
     taskName: t.name,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1918,6 +1918,7 @@ export class MemStorage implements IStorage {
     const now = new Date();
     const row: ConsiliumLoopRow = {
       id: randomUUID(),
+      projectId: data.projectId ?? null,
       groupId: data.groupId,
       state,
       round: data.round ?? 0,
@@ -2309,6 +2310,7 @@ export class MemStorage implements IStorage {
     const id = randomUUID();
     const row: TaskRow = {
       id,
+      projectId: data.projectId ?? null,
       groupId: data.groupId,
       name: data.name,
       description: data.description,
@@ -3280,6 +3282,7 @@ export class MemStorage implements IStorage {
   private buildIterationRow(data: InsertTaskGroupIteration): TaskGroupIterationRow {
     return {
       id: randomUUID(),
+      projectId: data.projectId ?? null,
       groupId: data.groupId,
       iterationNumber: data.iterationNumber,
       status: (data.status as TaskGroupStatus) ?? "running",
@@ -3375,6 +3378,7 @@ export class MemStorage implements IStorage {
   private buildExecutionRow(data: InsertTaskExecution): TaskExecutionRow {
     return {
       id: randomUUID(),
+      projectId: data.projectId ?? null,
       iterationId: data.iterationId,
       taskId: data.taskId ?? null,
       taskName: data.taskName ?? null,
@@ -3485,6 +3489,7 @@ export class MemStorage implements IStorage {
     const now = new Date();
     const row: TaskTemplateRow = {
       id: randomUUID(),
+      projectId: data.projectId ?? null,
       name: data.name,
       description: data.description,
       executionMode: (data.executionMode as TaskExecutionMode) ?? "direct_llm",

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1193,6 +1193,7 @@ export const tasks = pgTable(
     id: varchar("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    projectId: text("project_id").references(() => projects.id, { onDelete: "cascade" }),
     groupId: varchar("group_id")
       .notNull()
       .references(() => taskGroups.id, { onDelete: "cascade" }),
@@ -1252,6 +1253,7 @@ export const taskTemplates = pgTable(
     id: varchar("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    projectId: text("project_id").references(() => projects.id, { onDelete: "cascade" }),
     name: text("name").notNull(),
     description: text("description").notNull(),
     executionMode: text("execution_mode").notNull().default("direct_llm").$type<TaskExecutionMode>(),
@@ -1292,6 +1294,7 @@ export const taskGroupIterations = pgTable(
     id: varchar("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    projectId: text("project_id").references(() => projects.id, { onDelete: "cascade" }),
     groupId: varchar("group_id")
       .notNull()
       .references(() => taskGroups.id, { onDelete: "cascade" }),
@@ -1344,6 +1347,7 @@ export const taskExecutions = pgTable(
     id: varchar("id")
       .primaryKey()
       .default(sql`gen_random_uuid()`),
+    projectId: text("project_id").references(() => projects.id, { onDelete: "cascade" }),
     iterationId: varchar("iteration_id")
       .notNull()
       .references(() => taskGroupIterations.id, { onDelete: "cascade" }),
@@ -2720,6 +2724,7 @@ export const consiliumLoops = pgTable(
   "consilium_loops",
   {
     id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+    projectId: text("project_id").references(() => projects.id, { onDelete: "cascade" }),
     // The consilium task group re-run each round (cascade with the group).
     groupId: varchar("group_id")
       .notNull()

--- a/tests/unit/scoping/list-methods-isolation.test.ts
+++ b/tests/unit/scoping/list-methods-isolation.test.ts
@@ -163,9 +163,12 @@ describe("Subquery scoping: traces and consilium_loops scope through a project-s
     expect(q.sql).not.toMatch(/"consilium_loops"\."project_id"/);
   });
 
-  it("traces / consilium_loops genuinely have NO project_id column (justifies the subquery)", () => {
+  it("traces genuinely has NO project_id column (justifies the subquery scoping)", () => {
     expect((traces as Record<string, unknown>).projectId).toBeUndefined();
-    expect((consiliumLoops as Record<string, unknown>).projectId).toBeUndefined();
+  });
+
+  it("consilium_loops now carries a project_id column (scoped on its own)", () => {
+    expect((consiliumLoops as Record<string, unknown>).projectId).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## Problem
After strict project isolation (#406), the task-group HTTP API returned **500** on list/open/create. Root cause: five tables (`tasks`, `task_executions`, `task_group_iterations`, `task_templates`, `consilium_loops`) **already have a `project_id` column in the DB** and the storage layer **already scopes them via `withProject(...)`**, but `shared/schema.ts` never declared the column on the Drizzle table objects. So in a **request context** every `withProject(tasks)`/`withProjectInsert(tasks)` etc. threw `withProject: table has no projectId column` → 500.

The background orchestrator was unaffected (system context bypasses the column check), which is why this wasn't caught earlier — and the mocked integration tests never exercise the real `withProject` against the real schema.

## Fix
- Declare `projectId` on the five tables in `shared/schema.ts` (matches existing DB columns — **no migration**).
- Stamp `projectId` in the `MemStorage` row builders and the virtual-iteration adapter so the in-memory impl satisfies the row type.
- `consilium_loops` now carries its own `project_id`; updated the scoping unit test accordingly (only `traces` remains column-less and is scoped via its `pipeline_runs` subquery).

## Verification
- `tsc --noEmit` clean; **unit 5360 passed**; **scoping 57/57**; task-groups / task-templates / consilium integration suites green in isolation.
- Live API proof against the running server: create task group in project A → **201**; list under A shows it; **list under B shows nothing** (cross-project isolation holds, create/list/open all work).

## Note
This is the schema half of work the user already had in local WIP; #406 was built on `origin/main` which lacked these column declarations. Follow-ups from #406 still stand (models.slug uniqueness, MCP token→project, `traces` detail methods).