### PR TITLE
fix: crypto-safe UUID for non-secure (LAN/HTTP) contexts

### DIFF
--- a/client/src/components/dag/DAGCanvas.tsx
+++ b/client/src/components/dag/DAGCanvas.tsx
@@ -11,6 +11,7 @@
  * - Stage positions persisted in the DAG config
  */
 import { useState, useRef, useCallback } from "react";
+import { generateUUID } from "@/lib/uuid";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Plus, Trash2, GitMerge, X } from "lucide-react";
@@ -170,7 +171,7 @@ export default function DAGCanvas({
       if (!exists) {
         onEdgesChange([
           ...edges,
-          { id: `e-${crypto.randomUUID()}`, from: connecting, to: targetId },
+          { id: `e-${generateUUID()}`, from: connecting, to: targetId },
         ]);
       }
       setConnecting(null);
@@ -203,7 +204,7 @@ export default function DAGCanvas({
 
   const addStage = useCallback(() => {
     const newStage: DAGStageNode = {
-      id: `stage-${crypto.randomUUID()}`,
+      id: `stage-${generateUUID()}`,
       teamId: "planning",
       modelSlug: "mock",
       enabled: true,

--- a/client/src/components/task-groups/task-form-logic.ts
+++ b/client/src/components/task-groups/task-form-logic.ts
@@ -16,6 +16,7 @@
  * payload). The reducers preserve both through every edit.
  */
 import type { TaskGroupStatus } from "@shared/types";
+import { generateUUID } from "@/lib/uuid";
 
 export type ExecutionMode = "direct_llm" | "pipeline_run";
 
@@ -61,7 +62,7 @@ export interface SiblingOption {
 
 export function emptyTask(): TaskDraft {
   return {
-    id: crypto.randomUUID(),
+    id: generateUUID(),
     name: "",
     description: "",
     executionMode: "direct_llm",
@@ -191,7 +192,7 @@ function asExecutionMode(value: ExecutionMode | string | null | undefined): Exec
  */
 export function seedTaskFromTemplate(template: TemplateSeed): TaskDraft {
   return {
-    id: crypto.randomUUID(),
+    id: generateUUID(),
     name: template.name,
     description: template.description,
     executionMode: asExecutionMode(template.executionMode),

--- a/client/src/components/workspace/ChatPanel.tsx
+++ b/client/src/components/workspace/ChatPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { Send } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { apiRequest } from "@/hooks/use-pipeline";
+import { generateUUID } from "@/lib/uuid";
 
 interface Message {
   id: string;
@@ -44,7 +45,7 @@ export function ChatPanel({ workspaceId, modelSlug, contextFilePaths = [] }: Cha
     const text = input.trim();
     if (!text || isSending) return;
 
-    const userMsg: Message = { id: crypto.randomUUID(), role: "user", content: text };
+    const userMsg: Message = { id: generateUUID(), role: "user", content: text };
     setMessages((prev) => [...prev, userMsg]);
     setInput("");
     setIsSending(true);
@@ -52,7 +53,7 @@ export function ChatPanel({ workspaceId, modelSlug, contextFilePaths = [] }: Cha
     try {
       const reply = await sendChat(workspaceId, text, modelSlug, contextFilePaths);
       const assistantMsg: Message = {
-        id: crypto.randomUUID(),
+        id: generateUUID(),
         role: "assistant",
         content: reply,
         model: modelSlug,
@@ -60,7 +61,7 @@ export function ChatPanel({ workspaceId, modelSlug, contextFilePaths = [] }: Cha
       setMessages((prev) => [...prev, assistantMsg]);
     } catch (err) {
       const errMsg: Message = {
-        id: crypto.randomUUID(),
+        id: generateUUID(),
         role: "assistant",
         content: `Error: ${(err as Error).message}`,
         model: modelSlug,

--- a/client/src/lib/uuid.ts
+++ b/client/src/lib/uuid.ts
@@ -1,0 +1,19 @@
+/**
+ * Crypto-safe UUID with a fallback for NON-secure contexts.
+ *
+ * `crypto.randomUUID()` only exists in a secure context (HTTPS or localhost).
+ * When the app is opened over plain HTTP on a LAN IP (e.g. http://192.168.x.x),
+ * `crypto.randomUUID` is undefined and calling it throws
+ * "crypto.randomUUID is not a function". This helper uses the native impl when
+ * available and otherwise generates an RFC-4122 v4 UUID via Math.random().
+ */
+export function generateUUID(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}


### PR DESCRIPTION
## Problem
Opening the app over plain HTTP on a LAN IP (e.g. `http://192.168.100.195:5050`) and creating a task group failed with **"Something went wrong — crypto.randomUUID is not a function"**. `crypto.randomUUID()` is only defined in a **secure context** (HTTPS or localhost); over HTTP to an IP it is `undefined`.

## Fix
- Add `client/src/lib/uuid.ts` → `generateUUID()`: uses native `crypto.randomUUID()` when available, falls back to an RFC-4122 v4 generator (`Math.random`) otherwise.
- Route the client's direct `crypto.randomUUID()` calls through it: `task-form-logic.ts` (task-group rows — the reported crash), `DAGCanvas.tsx` (DAG editor), `ChatPanel.tsx` (workspace chat).

## Verification
`tsc --noEmit` clean. The IDs generated here are client-side draft/edge/message ids; the server still assigns authoritative DB ids.

Note: same fix existed in the user's local WIP (`client/src/lib/uuid.ts`); it was never on `origin/main`, so the merged isolation work (served over LAN) hit the crash.