### PR TITLE
feat(credentials): credential broker + access audit (on top of merged isolation)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -51,6 +51,7 @@ import Activity from "@/pages/Activity";
 import ConsiliumLoopList from "@/pages/ConsiliumLoopList";
 import ConsiliumLoopDetail from "@/pages/ConsiliumLoopDetail";
 import ContourObservability from "@/pages/ContourObservability";
+import CredentialAccess from "@/pages/CredentialAccess";
 
 function ProtectedRouter() {
   const { user, isLoading } = useAuth();
@@ -199,6 +200,9 @@ function ProtectedRouter() {
         )} />
         <Route path="/library" component={() => (
           <ErrorBoundary><Library /></ErrorBoundary>
+        )} />
+        <Route path="/credentials" component={() => (
+          <ErrorBoundary><CredentialAccess /></ErrorBoundary>
         )} />
         <Route component={NotFound} />
       </Switch>

--- a/client/src/components/layout/MainLayout.tsx
+++ b/client/src/components/layout/MainLayout.tsx
@@ -33,6 +33,7 @@ import {
   ChevronDown,
   ChevronRight,
   Archive,
+  KeyRound,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePendingQuestions } from "@/hooks/use-pipeline";
@@ -129,6 +130,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
       : []),
     { icon: BarChart3, label: "Statistics", href: "/stats" },
     { icon: Wrench, label: "Maintenance", href: "/maintenance" },
+    { icon: KeyRound, label: "Credential Access", href: "/credentials" },
     { icon: Settings, label: "Settings", href: "/settings" },
     { icon: Radio, label: "Config Sync", href: "/settings/peers" },
     // Admin-only: User Management

--- a/client/src/pages/CredentialAccess.tsx
+++ b/client/src/pages/CredentialAccess.tsx
@@ -1,0 +1,547 @@
+/**
+ * CredentialAccess — /credentials
+ *
+ * Three read-only sections backed by the broker credential API:
+ *   1. Credentials   — per-project metadata inventory (no secret values)
+ *   2. Access Log    — audit trail, newest first, with configurable limit
+ *   3. Active Leases — in-flight leases with expiry countdown
+ *
+ * All three endpoints are project-scoped server-side via x-project-id.
+ * The header is injected automatically by lib/queryClient.ts (apiRequest →
+ * buildAuthHeaders) and by the global window.fetch interceptor installed at
+ * app startup (lib/installFetchInterceptor.ts). No manual header logic here.
+ *
+ * If an endpoint 404s (not yet deployed) the section silently shows an empty
+ * state rather than crashing the page.
+ */
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/queryClient";
+import { useProjects } from "@/hooks/use-projects";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Clock,
+  FileText,
+  KeyRound,
+  Lock,
+  ShieldOff,
+  XCircle,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ── API types ─────────────────────────────────────────────────────────────────
+
+interface Credential {
+  id: string;
+  projectId: string;
+  provider: string;
+  scope: string;
+  description: string;
+  hasSecret: boolean;
+  lastRotatedAt?: string | null;
+}
+
+interface AccessLogEntry {
+  id: string;
+  leaseId: string | null;
+  credentialId: string;
+  projectId: string;
+  runId: string | null;
+  stageId: string | null;
+  action: string;
+  requestedBy: string;
+  justification: string | null;
+  success: boolean;
+  errorMessage: string | null;
+  ttlSeconds: number | null;
+  createdAt: string;
+}
+
+interface Lease {
+  id: string;
+  credentialId: string;
+  projectId: string;
+  runId: string | null;
+  stageId: string | null;
+  requestedBy: string;
+  issuedAt: string;
+  expiresAt: string;
+  revokedAt: string | null;
+  status: string;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch JSON array, treating 404 as an empty result so the UI degrades
+ * gracefully when the API endpoint isn't deployed yet.
+ *
+ * apiRequest (lib/queryClient) calls buildAuthHeaders which automatically
+ * injects x-project-id — no manual header injection needed here.
+ */
+async function fetchArrayWithEmptyOn404<T>(url: string): Promise<T[]> {
+  try {
+    const res = await apiRequest("GET", url);
+    return (await res.json()) as T[];
+  } catch (e) {
+    if (e instanceof Error && e.message.startsWith("404")) return [];
+    throw e;
+  }
+}
+
+function formatDateTime(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const ms = Date.parse(iso);
+  return Number.isFinite(ms) ? new Date(ms).toLocaleString() : "—";
+}
+
+/** Returns a short human-readable remaining time, or "Expired". */
+function expiryCountdown(iso: string): string {
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return "—";
+  const diff = ms - Date.now();
+  if (diff <= 0) return "Expired";
+  const secs = Math.floor(diff / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ${mins % 60}m`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+// Badge colour maps
+
+const ACTION_COLORS: Record<string, string> = {
+  list_metadata: "bg-muted text-muted-foreground border-border",
+  get_metadata: "bg-sky-500/15 text-sky-600 border-sky-500/30",
+  lease_issued: "bg-emerald-500/15 text-emerald-600 border-emerald-500/30",
+  lease_used: "bg-amber-500/15 text-amber-600 border-amber-500/30",
+  lease_revoked: "bg-destructive/15 text-destructive border-destructive/30",
+  lease_expired: "bg-muted text-muted-foreground/70 border-border",
+  secret_accessed: "bg-red-600/15 text-red-700 border-red-600/30",
+};
+
+const LEASE_STATUS_COLORS: Record<string, string> = {
+  active: "bg-emerald-500/15 text-emerald-600 border-emerald-500/30",
+  expired: "bg-muted text-muted-foreground/70 border-border",
+  revoked: "bg-destructive/15 text-destructive border-destructive/30",
+};
+
+// ── Shared section states ─────────────────────────────────────────────────────
+
+function SectionLoading({ rows = 4 }: { rows?: number }) {
+  return (
+    <div className="space-y-2 p-4 pb-5">
+      {Array.from({ length: rows }).map((_, i) => (
+        <Skeleton key={i} className="h-9 w-full rounded" />
+      ))}
+    </div>
+  );
+}
+
+function SectionEmpty({ message }: { message: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-10 gap-2 text-muted-foreground">
+      <ShieldOff className="h-8 w-8 opacity-30" />
+      <p className="text-sm">{message}</p>
+    </div>
+  );
+}
+
+function SectionError({ error }: { error: unknown }) {
+  const msg =
+    error instanceof Error ? error.message : "An unexpected error occurred.";
+  return (
+    <div className="flex flex-col items-center justify-center py-10 gap-2 text-destructive">
+      <AlertCircle className="h-8 w-8 opacity-60" />
+      <p className="text-sm">{msg}</p>
+    </div>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default function CredentialAccess() {
+  const { currentProject } = useProjects();
+  const projectId = currentProject?.id ?? null;
+
+  const [logLimit, setLogLimit] = useState<number>(100);
+
+  // ── Credential inventory ────────────────────────────────────────────────
+  // projectId is included in the queryKey so react-query automatically refetches
+  // when the user switches projects (ProjectContext calls invalidateQueries() on switch).
+
+  const credentialsQuery = useQuery<Credential[]>({
+    queryKey: ["/api/credentials", projectId],
+    queryFn: () => fetchArrayWithEmptyOn404<Credential>("/api/credentials"),
+    enabled: !!projectId,
+  });
+
+  // ── Access log ──────────────────────────────────────────────────────────
+
+  const accessLogQuery = useQuery<AccessLogEntry[]>({
+    queryKey: ["/api/credentials/access-log", projectId, logLimit],
+    queryFn: () =>
+      fetchArrayWithEmptyOn404<AccessLogEntry>(
+        `/api/credentials/access-log?limit=${logLimit}`
+      ),
+    enabled: !!projectId,
+  });
+
+  // ── Active leases ───────────────────────────────────────────────────────
+
+  const leasesQuery = useQuery<Lease[]>({
+    queryKey: ["/api/credentials/leases", projectId],
+    queryFn: () =>
+      fetchArrayWithEmptyOn404<Lease>("/api/credentials/leases?status=active"),
+    enabled: !!projectId,
+  });
+
+  // ── No project selected ─────────────────────────────────────────────────
+
+  if (!projectId) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        <p className="text-sm">Select a project to view credential access.</p>
+      </div>
+    );
+  }
+
+  // ── Render ──────────────────────────────────────────────────────────────
+
+  return (
+    <ScrollArea className="h-full">
+      <div className="p-6 space-y-6 max-w-6xl mx-auto">
+
+        {/* ── Page header ──────────────────────────────────────────────────── */}
+        <div className="flex items-start gap-3">
+          <Lock className="h-6 w-6 text-primary mt-0.5 shrink-0" />
+          <div>
+            <h1 className="text-xl font-semibold">Credential Access</h1>
+            <p className="text-sm text-muted-foreground mt-0.5">
+              Per-project credential inventory, audit log, and active leases.
+              Secret values are <strong>never</strong> exposed here — metadata
+              only.
+            </p>
+          </div>
+        </div>
+
+        {/* ── Section 1: Credential inventory ──────────────────────────────── */}
+        <Card>
+          <CardHeader className="pb-3">
+            <div className="flex items-center gap-2">
+              <KeyRound className="h-4 w-4 text-muted-foreground" />
+              <CardTitle className="text-base">Credentials</CardTitle>
+            </div>
+            <CardDescription>
+              Registered credentials for this project. The secret value is
+              stored encrypted in the broker and is never returned to the UI.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="p-0">
+            {credentialsQuery.isLoading && <SectionLoading rows={3} />}
+            {credentialsQuery.isError && (
+              <SectionError error={credentialsQuery.error} />
+            )}
+            {credentialsQuery.isSuccess &&
+              credentialsQuery.data.length === 0 && (
+                <SectionEmpty message="No credentials configured for this project." />
+              )}
+            {credentialsQuery.isSuccess &&
+              credentialsQuery.data.length > 0 && (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Provider</TableHead>
+                      <TableHead>Scope</TableHead>
+                      <TableHead>Description</TableHead>
+                      <TableHead>Secret</TableHead>
+                      <TableHead>Last Rotated</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {credentialsQuery.data.map((cred) => (
+                      <TableRow key={cred.id}>
+                        <TableCell className="font-medium font-mono text-xs">
+                          {cred.provider}
+                        </TableCell>
+                        <TableCell className="font-mono text-xs text-muted-foreground">
+                          {cred.scope}
+                        </TableCell>
+                        <TableCell className="text-sm">
+                          {cred.description}
+                        </TableCell>
+                        <TableCell>
+                          {cred.hasSecret ? (
+                            <Badge
+                              variant="outline"
+                              className="text-xs bg-emerald-500/10 text-emerald-600 border-emerald-500/30"
+                            >
+                              Configured
+                            </Badge>
+                          ) : (
+                            <Badge
+                              variant="outline"
+                              className="text-xs bg-muted text-muted-foreground border-border"
+                            >
+                              Not set
+                            </Badge>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
+                          {formatDateTime(cred.lastRotatedAt)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+          </CardContent>
+        </Card>
+
+        {/* ── Section 2: Access log ─────────────────────────────────────────── */}
+        <Card>
+          <CardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <FileText className="h-4 w-4 text-muted-foreground" />
+                <CardTitle className="text-base">Access Log</CardTitle>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-muted-foreground">Show</span>
+                <Select
+                  value={String(logLimit)}
+                  onValueChange={(v) => setLogLimit(Number(v))}
+                >
+                  <SelectTrigger className="h-7 w-24 text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="100">100</SelectItem>
+                    <SelectItem value="250">250</SelectItem>
+                    <SelectItem value="500">500</SelectItem>
+                  </SelectContent>
+                </Select>
+                <span className="text-xs text-muted-foreground">entries</span>
+              </div>
+            </div>
+            <CardDescription>
+              Audit trail for all credential access events. Newest first.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="p-0">
+            {accessLogQuery.isLoading && <SectionLoading rows={5} />}
+            {accessLogQuery.isError && (
+              <SectionError error={accessLogQuery.error} />
+            )}
+            {accessLogQuery.isSuccess && accessLogQuery.data.length === 0 && (
+              <SectionEmpty message="No access log entries found." />
+            )}
+            {accessLogQuery.isSuccess && accessLogQuery.data.length > 0 && (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="whitespace-nowrap">Time</TableHead>
+                    <TableHead>Action</TableHead>
+                    <TableHead>Credential</TableHead>
+                    <TableHead>Run / Stage</TableHead>
+                    <TableHead>Requested By</TableHead>
+                    <TableHead>Result</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {accessLogQuery.data.map((entry) => (
+                    <TableRow key={entry.id}>
+                      <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
+                        {formatDateTime(entry.createdAt)}
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant="outline"
+                          className={cn(
+                            "text-xs font-medium",
+                            ACTION_COLORS[entry.action] ??
+                              "bg-muted text-muted-foreground border-border"
+                          )}
+                        >
+                          {entry.action}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="font-mono text-xs text-muted-foreground">
+                        {entry.credentialId}
+                      </TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {entry.runId ? (
+                          <span className="font-mono">
+                            {entry.runId}
+                            {entry.stageId ? (
+                              <span className="text-muted-foreground/60">
+                                /{entry.stageId}
+                              </span>
+                            ) : null}
+                          </span>
+                        ) : (
+                          "—"
+                        )}
+                      </TableCell>
+                      <TableCell className="text-xs">
+                        {entry.requestedBy}
+                      </TableCell>
+                      <TableCell>
+                        {entry.success ? (
+                          <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+                        ) : (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <XCircle className="h-4 w-4 text-destructive cursor-help" />
+                            </TooltipTrigger>
+                            <TooltipContent side="left">
+                              <p className="max-w-xs break-words text-xs">
+                                {entry.errorMessage ?? "Unknown error"}
+                              </p>
+                            </TooltipContent>
+                          </Tooltip>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* ── Section 3: Active leases ──────────────────────────────────────── */}
+        <Card>
+          <CardHeader className="pb-3">
+            <div className="flex items-center gap-2">
+              <Clock className="h-4 w-4 text-muted-foreground" />
+              <CardTitle className="text-base">Active Leases</CardTitle>
+            </div>
+            <CardDescription>
+              In-flight credential leases. Leases expire automatically by TTL
+              and can be revoked at any time.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="p-0">
+            {leasesQuery.isLoading && <SectionLoading rows={3} />}
+            {leasesQuery.isError && (
+              <SectionError error={leasesQuery.error} />
+            )}
+            {leasesQuery.isSuccess && leasesQuery.data.length === 0 && (
+              <SectionEmpty message="No active leases." />
+            )}
+            {leasesQuery.isSuccess && leasesQuery.data.length > 0 && (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Credential</TableHead>
+                    <TableHead>Run / Stage</TableHead>
+                    <TableHead>Requested By</TableHead>
+                    <TableHead className="whitespace-nowrap">Issued At</TableHead>
+                    <TableHead className="whitespace-nowrap">Expires At</TableHead>
+                    <TableHead>Status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {leasesQuery.data.map((lease) => {
+                    const isExpired =
+                      Date.parse(lease.expiresAt) <= Date.now();
+                    const countdown = expiryCountdown(lease.expiresAt);
+                    return (
+                      <TableRow key={lease.id}>
+                        <TableCell className="font-mono text-xs text-muted-foreground">
+                          {lease.credentialId}
+                        </TableCell>
+                        <TableCell className="text-xs text-muted-foreground">
+                          {lease.runId ? (
+                            <span className="font-mono">
+                              {lease.runId}
+                              {lease.stageId ? (
+                                <span className="text-muted-foreground/60">
+                                  /{lease.stageId}
+                                </span>
+                              ) : null}
+                            </span>
+                          ) : (
+                            "—"
+                          )}
+                        </TableCell>
+                        <TableCell className="text-xs">
+                          {lease.requestedBy}
+                        </TableCell>
+                        <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
+                          {formatDateTime(lease.issuedAt)}
+                        </TableCell>
+                        <TableCell className="whitespace-nowrap">
+                          <span className="text-xs text-muted-foreground">
+                            {formatDateTime(lease.expiresAt)}
+                          </span>
+                          <span
+                            className={cn(
+                              "ml-1.5 text-[10px] font-semibold",
+                              isExpired
+                                ? "text-destructive"
+                                : "text-amber-500"
+                            )}
+                          >
+                            {countdown}
+                          </span>
+                        </TableCell>
+                        <TableCell>
+                          <Badge
+                            variant="outline"
+                            className={cn(
+                              "text-xs",
+                              LEASE_STATUS_COLORS[lease.status] ??
+                                "bg-muted text-muted-foreground border-border"
+                            )}
+                          >
+                            {lease.status}
+                          </Badge>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+
+      </div>
+    </ScrollArea>
+  );
+}

--- a/migrations/0028_phase1_credential_broker.sql
+++ b/migrations/0028_phase1_credential_broker.sql
@@ -1,0 +1,96 @@
+-- migration: 0028_phase1_credential_broker
+-- ADR-001 Phase 1a — credential_leases and credential_access_log tables.
+--
+-- Purpose:
+--   Introduces the two audit/lease tables needed by the CredentialProvider broker.
+--   Both tables carry projectId NOT NULL → projects(id) to ensure hard project
+--   isolation.  The application layer (DbCryptoCredentialProvider) asserts
+--   projectId === getProjectId() on every public method before reaching the DB.
+--
+-- Deploy sequence (push-based):
+--   1. psql "$DATABASE_URL" -f migrations/0028_phase1_credential_broker.sql
+--   2. npm run db:push   (schema.ts already declares the new tables; push is a no-op
+--      for the DDL once the DB has the tables; safe to run regardless)
+--
+-- Idempotent: all DDL uses IF NOT EXISTS.
+-- Transactional: wrapped in BEGIN/COMMIT.
+--
+-- credential_leases    — issued lease records (active | revoked | expired).
+-- credential_access_log — append-only audit trail (one row per broker action).
+--
+-- Indexes:
+--   credential_leases: (project_id), (run_id), (status) — supports issueLease
+--     checks, revokeRunLeases, and the expiry sweeper.
+--   credential_access_log: (project_id), (credential_id) — supports per-project
+--     and per-credential audit queries.
+
+BEGIN;
+
+-- ─── credential_leases ─────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS credential_leases (
+  id            TEXT        PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  credential_id TEXT        NOT NULL,
+  project_id    TEXT        NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  run_id        TEXT        NOT NULL,
+  stage_id      TEXT        NOT NULL,
+  requested_by  TEXT        NOT NULL,
+  issued_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at    TIMESTAMPTZ NOT NULL,
+  revoked_at    TIMESTAMPTZ,
+  -- status: 'active' | 'revoked' | 'expired'
+  status        TEXT        NOT NULL DEFAULT 'active'
+);
+
+CREATE INDEX IF NOT EXISTS credential_leases_project_id_idx
+  ON credential_leases(project_id);
+
+CREATE INDEX IF NOT EXISTS credential_leases_run_id_idx
+  ON credential_leases(run_id);
+
+CREATE INDEX IF NOT EXISTS credential_leases_status_idx
+  ON credential_leases(status);
+
+-- Composite index for the expiry sweeper: status + expires_at
+CREATE INDEX IF NOT EXISTS credential_leases_status_expires_idx
+  ON credential_leases(status, expires_at)
+  WHERE status = 'active';
+
+-- ─── credential_access_log ─────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS credential_access_log (
+  id             TEXT        PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  lease_id       TEXT,           -- nullable: list_metadata / get_metadata have no lease
+  credential_id  TEXT        NOT NULL,
+  project_id     TEXT        NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  run_id         TEXT,           -- nullable: plan-time actions have no run
+  stage_id       TEXT,           -- nullable: plan-time actions have no stage
+  -- action: list_metadata | get_metadata | lease_issued | lease_used |
+  --         lease_revoked | lease_expired | secret_accessed
+  action         TEXT        NOT NULL,
+  requested_by   TEXT        NOT NULL,
+  justification  TEXT,
+  success        BOOLEAN     NOT NULL DEFAULT TRUE,
+  error_message  TEXT,
+  ttl_seconds    INTEGER,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS credential_access_log_project_id_idx
+  ON credential_access_log(project_id);
+
+CREATE INDEX IF NOT EXISTS credential_access_log_credential_id_idx
+  ON credential_access_log(credential_id);
+
+CREATE INDEX IF NOT EXISTS credential_access_log_lease_id_idx
+  ON credential_access_log(lease_id)
+  WHERE lease_id IS NOT NULL;
+
+COMMIT;
+
+-- ─── Rollback (for reference — not auto-applied) ───────────────────────────────
+--
+--   BEGIN;
+--   DROP TABLE IF EXISTS credential_access_log;
+--   DROP TABLE IF EXISTS credential_leases;
+--   COMMIT;

--- a/server/credentials/db-crypto-provider.ts
+++ b/server/credentials/db-crypto-provider.ts
@@ -1,0 +1,779 @@
+/**
+ * DbCryptoCredentialProvider — Phase 1 broker implementation (ADR-001 §3.2).
+ *
+ * Credential SOURCE: `workspaceConnections` table.
+ * Each workspace connection that has `secretsEncrypted !== null` is a credential.
+ * Project scoping is resolved by joining with `workspaces` (which carries projectId).
+ *
+ * Hardened contract [ADR-001 §3.2]:
+ *   [R3-SEC-2] issueLease reads approvalStatus + run.status from DB; throws ForbiddenError.
+ *   [R3-SEC-3] Every public method asserts projectId === getProjectId() at entry.
+ *   [R3-SEC-10] issueLease rate-limited per (projectId, runId); lease_used emitted by
+ *               markLeaseUsed() helper (called by the Wave-2 pipeline controller).
+ *
+ * Expiry sweeper: expireStaleLeases() is exported for Wave-2 scheduling.
+ * markLeaseUsed():  exported for Wave-2 to call immediately before spawnBuiltinServer.
+ *
+ * NOT wired into the pipeline controller yet — that is Wave 2.
+ */
+
+import { eq, and, lt } from "drizzle-orm";
+import { db } from "../db.js";
+import { getProjectId, requestContext } from "../context.js";
+import { decrypt } from "../crypto.js";
+import {
+  workspaceConnections,
+  workspaces,
+  pipelineRuns,
+  stageExecutions,
+  credentialLeases,
+  credentialAccessLog,
+} from "../../shared/schema.js";
+import type {
+  CredentialMetadata,
+  CredentialLease,
+  CredentialProvider,
+  CredentialSecret,
+  AccessSecretParams,
+} from "./types.js";
+import { ForbiddenError } from "./types.js";
+
+// ─── Rate limiting ────────────────────────────────────────────────────────────
+//
+// In-memory, process-local.  Sufficient for Wave 1.  A process restart clears the
+// window — the DB-level sweeper is the authoritative backstop.
+//
+// Limits: max RATE_LIMIT_MAX lease requests per (projectId, runId) within
+// RATE_LIMIT_WINDOW_MS.  Exceeding throws ForbiddenError so a compromised agent
+// cannot burst-issue credentials.
+
+const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
+const RATE_LIMIT_MAX = 10;           // 10 leases per (projectId, runId) per window
+
+interface RateLimitEntry {
+  count: number;
+  windowStart: number;
+}
+
+const _rateLimitStore = new Map<string, RateLimitEntry>();
+
+/** Exported for test reset between cases. */
+export function _resetRateLimitStore(): void {
+  _rateLimitStore.clear();
+}
+
+function checkRateLimit(projectId: string, runId: string): void {
+  const key = `${projectId}:${runId}`;
+  const now = Date.now();
+  const entry = _rateLimitStore.get(key);
+
+  if (!entry || now - entry.windowStart > RATE_LIMIT_WINDOW_MS) {
+    _rateLimitStore.set(key, { count: 1, windowStart: now });
+    return;
+  }
+
+  if (entry.count >= RATE_LIMIT_MAX) {
+    throw new ForbiddenError(
+      `Rate limit exceeded: too many lease requests for runId=${runId} in project ${projectId}. ` +
+        `Max ${RATE_LIMIT_MAX} per ${RATE_LIMIT_WINDOW_MS / 1000}s window.`,
+    );
+  }
+
+  entry.count++;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Asserts that the provided projectId matches the current ALS context.
+ * Throws ForbiddenError on mismatch.
+ * getProjectId() already throws in system context and when context is absent —
+ * those errors propagate as-is (they are also security barriers).
+ */
+function assertProject(projectId: string): void {
+  const ctx = getProjectId();
+  if (ctx !== projectId) {
+    throw new ForbiddenError(
+      `Context projectId (${ctx}) does not match provided projectId (${projectId}). ` +
+        "Cross-project credential access is forbidden.",
+    );
+  }
+}
+
+/**
+ * Write one row to credential_access_log.  Uses db directly (no withProject) so
+ * it works both from project-context methods and from the system-scoped sweeper.
+ */
+async function writeAccessLog(entry: {
+  leaseId?: string | null;
+  credentialId: string;
+  projectId: string;
+  runId?: string | null;
+  stageId?: string | null;
+  action: typeof credentialAccessLog.$inferInsert["action"];
+  requestedBy: string;
+  justification?: string | null;
+  success: boolean;
+  errorMessage?: string | null;
+  ttlSeconds?: number | null;
+}): Promise<void> {
+  await db.insert(credentialAccessLog).values({
+    leaseId: entry.leaseId ?? null,
+    credentialId: entry.credentialId,
+    projectId: entry.projectId,
+    runId: entry.runId ?? null,
+    stageId: entry.stageId ?? null,
+    action: entry.action,
+    requestedBy: entry.requestedBy,
+    justification: entry.justification ?? null,
+    success: entry.success,
+    errorMessage: entry.errorMessage ?? null,
+    ttlSeconds: entry.ttlSeconds ?? null,
+  });
+}
+
+/**
+ * Resolve a workspace connection that belongs to the given project.
+ * Returns null if not found or if the connection's workspace belongs to a
+ * different project (project-isolation check in the query itself).
+ */
+async function getConnectionForProject(
+  credentialId: string,
+  projectId: string,
+): Promise<typeof workspaceConnections.$inferSelect | null> {
+  // JOIN workspace_connections → workspaces to verify project ownership.
+  // workspaceConnections has no direct projectId column; projectId lives on workspaces.
+  const [row] = await db
+    .select({
+      id: workspaceConnections.id,
+      workspaceId: workspaceConnections.workspaceId,
+      type: workspaceConnections.type,
+      name: workspaceConnections.name,
+      configJson: workspaceConnections.configJson,
+      secretsEncrypted: workspaceConnections.secretsEncrypted,
+      status: workspaceConnections.status,
+      lastTestedAt: workspaceConnections.lastTestedAt,
+      createdAt: workspaceConnections.createdAt,
+      updatedAt: workspaceConnections.updatedAt,
+      createdBy: workspaceConnections.createdBy,
+    })
+    .from(workspaceConnections)
+    .innerJoin(workspaces, eq(workspaces.id, workspaceConnections.workspaceId))
+    .where(
+      and(
+        eq(workspaceConnections.id, credentialId),
+        eq(workspaces.projectId, projectId),
+      ),
+    );
+
+  return row ?? null;
+}
+
+/** Convert a workspace connection row to CredentialMetadata. */
+function toMetadata(
+  row: typeof workspaceConnections.$inferSelect,
+  projectId: string,
+): CredentialMetadata {
+  return {
+    id: row.id,
+    projectId,
+    provider: row.type,
+    scope: row.workspaceId,
+    description: row.name,
+    hasSecret: row.secretsEncrypted !== null,
+    lastRotatedAt: row.updatedAt,
+  };
+}
+
+// ─── DbCryptoCredentialProvider ───────────────────────────────────────────────
+
+export class DbCryptoCredentialProvider implements CredentialProvider {
+  // ── PLAN-TIME ───────────────────────────────────────────────────────────────
+
+  /**
+   * List all workspace connections for the project.
+   * Writes a credential_access_log row per call (action='list_metadata').
+   * NEVER returns secret material — only CredentialMetadata.
+   */
+  async listCredentials(projectId: string): Promise<CredentialMetadata[]> {
+    assertProject(projectId);
+
+    const rows = await db
+      .select({
+        id: workspaceConnections.id,
+        workspaceId: workspaceConnections.workspaceId,
+        type: workspaceConnections.type,
+        name: workspaceConnections.name,
+        configJson: workspaceConnections.configJson,
+        secretsEncrypted: workspaceConnections.secretsEncrypted,
+        status: workspaceConnections.status,
+        lastTestedAt: workspaceConnections.lastTestedAt,
+        createdAt: workspaceConnections.createdAt,
+        updatedAt: workspaceConnections.updatedAt,
+        createdBy: workspaceConnections.createdBy,
+      })
+      .from(workspaceConnections)
+      .innerJoin(workspaces, eq(workspaces.id, workspaceConnections.workspaceId))
+      .where(eq(workspaces.projectId, projectId));
+
+    const metadata = rows.map((r) => toMetadata(r, projectId));
+
+    await writeAccessLog({
+      credentialId: "*",
+      projectId,
+      action: "list_metadata",
+      requestedBy: projectId,
+      success: true,
+    });
+
+    return metadata;
+  }
+
+  /**
+   * Get metadata for a single workspace connection.
+   * Returns null if not found or if it belongs to a different project.
+   * NEVER returns secret material.
+   */
+  async getCredentialMetadata(
+    projectId: string,
+    credentialId: string,
+  ): Promise<CredentialMetadata | null> {
+    assertProject(projectId);
+
+    const row = await getConnectionForProject(credentialId, projectId);
+
+    await writeAccessLog({
+      credentialId,
+      projectId,
+      action: "get_metadata",
+      requestedBy: projectId,
+      success: row !== null,
+    });
+
+    return row ? toMetadata(row, projectId) : null;
+  }
+
+  // ── EXEC-TIME ───────────────────────────────────────────────────────────────
+
+  /**
+   * Issue a short-TTL credential lease.
+   *
+   * Enforcement order (ALL must pass before any secret is decrypted):
+   *   1. [R3-SEC-3] projectId === getProjectId()
+   *   2. [R3-SEC-10] Rate limit (projectId, runId)
+   *   3. [R3-SEC-2] stage_executions.approvalStatus === 'approved'
+   *   4. [R3-SEC-2] pipeline_runs.status === 'running'
+   *   5. Credential exists in project
+   *   6. Credential has a secret
+   *
+   * Writes credential_leases row + credential_access_log(action='lease_issued').
+   */
+  async issueLease(p: {
+    projectId: string;
+    credentialId: string;
+    runId: string;
+    stageId: string;
+    ttlSeconds?: number;
+    requestedBy: string;
+    justification?: string;
+  }): Promise<CredentialLease> {
+    // [R3-SEC-3] Context assertion — FIRST, before any DB access.
+    assertProject(p.projectId);
+
+    // [R3-SEC-10] Rate limit — SECOND, before expensive DB reads.
+    checkRateLimit(p.projectId, p.runId);
+
+    // [R3-SEC-2] Check stage execution approval status.
+    // Look up by stage execution ID AND runId to prevent cross-run confusion.
+    const [stageExec] = await db
+      .select()
+      .from(stageExecutions)
+      .where(
+        and(
+          eq(stageExecutions.id, p.stageId),
+          eq(stageExecutions.runId, p.runId),
+          eq(stageExecutions.projectId, p.projectId),
+        ),
+      );
+
+    if (!stageExec) {
+      const msg =
+        `Stage execution ${p.stageId} not found for run ${p.runId} ` +
+        `in project ${p.projectId}`;
+      await writeAccessLog({
+        credentialId: p.credentialId,
+        projectId: p.projectId,
+        runId: p.runId,
+        stageId: p.stageId,
+        action: "lease_issued",
+        requestedBy: p.requestedBy,
+        justification: p.justification,
+        success: false,
+        errorMessage: msg,
+      });
+      throw new ForbiddenError(msg);
+    }
+
+    if (stageExec.approvalStatus !== "approved") {
+      const msg =
+        `Stage ${p.stageId} is not approved ` +
+        `(approvalStatus=${stageExec.approvalStatus ?? "null"})`;
+      await writeAccessLog({
+        credentialId: p.credentialId,
+        projectId: p.projectId,
+        runId: p.runId,
+        stageId: p.stageId,
+        action: "lease_issued",
+        requestedBy: p.requestedBy,
+        justification: p.justification,
+        success: false,
+        errorMessage: msg,
+      });
+      throw new ForbiddenError(msg);
+    }
+
+    // [R3-SEC-2] Check pipeline run status.
+    const [run] = await db
+      .select()
+      .from(pipelineRuns)
+      .where(
+        and(
+          eq(pipelineRuns.id, p.runId),
+          eq(pipelineRuns.projectId, p.projectId),
+        ),
+      );
+
+    if (!run) {
+      const msg = `Pipeline run ${p.runId} not found in project ${p.projectId}`;
+      await writeAccessLog({
+        credentialId: p.credentialId,
+        projectId: p.projectId,
+        runId: p.runId,
+        stageId: p.stageId,
+        action: "lease_issued",
+        requestedBy: p.requestedBy,
+        justification: p.justification,
+        success: false,
+        errorMessage: msg,
+      });
+      throw new ForbiddenError(msg);
+    }
+
+    if (run.status !== "running") {
+      const msg =
+        `Pipeline run ${p.runId} is not in 'running' state ` +
+        `(status=${run.status})`;
+      await writeAccessLog({
+        credentialId: p.credentialId,
+        projectId: p.projectId,
+        runId: p.runId,
+        stageId: p.stageId,
+        action: "lease_issued",
+        requestedBy: p.requestedBy,
+        justification: p.justification,
+        success: false,
+        errorMessage: msg,
+      });
+      throw new ForbiddenError(msg);
+    }
+
+    // Get the credential (workspace connection), verify it belongs to this project.
+    const conn = await getConnectionForProject(p.credentialId, p.projectId);
+
+    if (!conn) {
+      const msg =
+        `Credential ${p.credentialId} not found in project ${p.projectId}`;
+      await writeAccessLog({
+        credentialId: p.credentialId,
+        projectId: p.projectId,
+        runId: p.runId,
+        stageId: p.stageId,
+        action: "lease_issued",
+        requestedBy: p.requestedBy,
+        justification: p.justification,
+        success: false,
+        errorMessage: msg,
+      });
+      throw new ForbiddenError(msg);
+    }
+
+    if (!conn.secretsEncrypted) {
+      const msg = `Credential ${p.credentialId} has no secret`;
+      await writeAccessLog({
+        credentialId: p.credentialId,
+        projectId: p.projectId,
+        runId: p.runId,
+        stageId: p.stageId,
+        action: "lease_issued",
+        requestedBy: p.requestedBy,
+        justification: p.justification,
+        success: false,
+        errorMessage: msg,
+      });
+      throw new Error(msg);
+    }
+
+    // Decrypt — only here, after all checks have passed.
+    const secrets: Record<string, string> = JSON.parse(
+      decrypt(conn.secretsEncrypted),
+    );
+
+    // Compute TTL: default 300 s, max 900 s.
+    const ttl = Math.min(p.ttlSeconds ?? 300, 900);
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + ttl * 1000);
+
+    // Persist the lease row.
+    const [leaseRow] = await db
+      .insert(credentialLeases)
+      .values({
+        credentialId: p.credentialId,
+        projectId: p.projectId,
+        runId: p.runId,
+        stageId: p.stageId,
+        requestedBy: p.requestedBy,
+        issuedAt: now,
+        expiresAt,
+        status: "active",
+      })
+      .returning();
+
+    // Audit: lease_issued.
+    await writeAccessLog({
+      leaseId: leaseRow.id,
+      credentialId: p.credentialId,
+      projectId: p.projectId,
+      runId: p.runId,
+      stageId: p.stageId,
+      action: "lease_issued",
+      requestedBy: p.requestedBy,
+      justification: p.justification,
+      success: true,
+      ttlSeconds: ttl,
+    });
+
+    // Build the static secret — Wave 1 serialises the entire secrets map.
+    // Wave 2 pipeline controller parses it back before passing to spawnBuiltinServer.
+    const secret: CredentialSecret = {
+      type: "static",
+      value: JSON.stringify(secrets),
+    };
+
+    return {
+      leaseId: leaseRow.id,
+      credentialId: p.credentialId,
+      projectId: p.projectId,
+      runId: p.runId,
+      stageId: p.stageId,
+      issuedAt: now,
+      expiresAt,
+      secret,
+    };
+  }
+
+  /**
+   * Revoke a single lease by ID.
+   * Idempotent — no-op (no error) when already revoked.
+   */
+  async revokeLease(leaseId: string): Promise<void> {
+    const projectId = getProjectId(); // [R3-SEC-3] throws in system context
+
+    const [lease] = await db
+      .select()
+      .from(credentialLeases)
+      .where(eq(credentialLeases.id, leaseId));
+
+    if (!lease) {
+      throw new Error(`Lease ${leaseId} not found`);
+    }
+
+    // [R3-SEC-3] Verify lease belongs to current project.
+    if (lease.projectId !== projectId) {
+      throw new ForbiddenError(
+        `Lease ${leaseId} belongs to project ${lease.projectId}, ` +
+          `not ${projectId}. Cross-project revocation is forbidden.`,
+      );
+    }
+
+    // Idempotent: already revoked → do nothing.
+    if (lease.status !== "active") return;
+
+    await db
+      .update(credentialLeases)
+      .set({ status: "revoked", revokedAt: new Date() })
+      .where(eq(credentialLeases.id, leaseId));
+
+    await writeAccessLog({
+      leaseId,
+      credentialId: lease.credentialId,
+      projectId,
+      runId: lease.runId,
+      stageId: lease.stageId,
+      action: "lease_revoked",
+      requestedBy: projectId,
+      success: true,
+    });
+  }
+
+  /**
+   * Revoke all active leases for a run, scoped to the current project.
+   * Safe to call in a `finally` block — must not throw when no active leases exist
+   * or when leases are already revoked.
+   */
+  async revokeRunLeases(runId: string): Promise<void> {
+    const projectId = getProjectId(); // [R3-SEC-3] throws in system context
+
+    // Find all active leases for this run in this project.
+    const activeLeases = await db
+      .select()
+      .from(credentialLeases)
+      .where(
+        and(
+          eq(credentialLeases.runId, runId),
+          eq(credentialLeases.projectId, projectId),
+          eq(credentialLeases.status, "active"),
+        ),
+      );
+
+    if (activeLeases.length === 0) return;
+
+    await db
+      .update(credentialLeases)
+      .set({ status: "revoked", revokedAt: new Date() })
+      .where(
+        and(
+          eq(credentialLeases.runId, runId),
+          eq(credentialLeases.projectId, projectId),
+          eq(credentialLeases.status, "active"),
+        ),
+      );
+
+    for (const lease of activeLeases) {
+      await writeAccessLog({
+        leaseId: lease.id,
+        credentialId: lease.credentialId,
+        projectId,
+        runId,
+        stageId: lease.stageId,
+        action: "lease_revoked",
+        requestedBy: projectId,
+        success: true,
+      });
+    }
+  }
+
+  // ── NON-LEASE DIRECT ACCESS (Wave 2, ADR-001 PR-1d) ────────────────────────────
+
+  /**
+   * Decrypt a pre-fetched ciphertext and write a credential_access_log row
+   * (action='secret_accessed').
+   *
+   * Context behaviour:
+   *   - Project context (getProjectId() returns a string): asserts
+   *     params.projectId === getProjectId() before decrypting.
+   *   - System context (requestContext.getStore()?.system === true): skips the
+   *     project assertion; getProjectId() would throw in system context.
+   *     The caller supplies the credential's projectId for the audit row.
+   *   - No ALS context at all: throws — requires runAsProject or runAsSystem.
+   *
+   * If params.projectId is empty (legacy row without projectId), the audit row is
+   * skipped with a console warning and the plaintext is still returned.
+   *
+   * After Wave 2 this is the ONLY permitted path to crypto.decrypt() outside of
+   * rekey/migration scripts.  A CI grep enforces this:
+   *   grep -rn "decrypt(" server/ | grep -v credentials/db-crypto-provider | grep -v scripts/
+   * must return nothing.
+   */
+  async accessSecret(params: AccessSecretParams): Promise<string> {
+    const ctx = requestContext.getStore();
+
+    if (!ctx) {
+      throw new Error(
+        "accessSecret requires an ALS context. " +
+          "Wrap the caller in runAsProject(projectId, fn) or runAsSystem(reason, fn).",
+      );
+    }
+
+    if (!ctx.system) {
+      // Project context: enforce that provided projectId matches the current context.
+      // assertProject throws ForbiddenError on mismatch (and if context has no projectId).
+      assertProject(params.projectId);
+    }
+    // System context: skip the project assertion — getProjectId() throws in system context.
+    // The caller (always a runAsSystem-wrapped function) must pass the correct projectId.
+
+    const requestedBy =
+      params.requestedBy ??
+      (ctx.system ? "system" : (ctx.projectId ?? params.projectId));
+
+    let plaintext: string;
+    try {
+      // ─── The ONLY permitted crypto.decrypt() call outside rekey/migration scripts. ───
+      plaintext = decrypt(params.ciphertext);
+    } catch (e) {
+      // Best-effort audit on decrypt failure.
+      if (params.projectId) {
+        await writeAccessLog({
+          credentialId: params.credentialId,
+          projectId: params.projectId,
+          action: "secret_accessed",
+          requestedBy,
+          justification: params.purpose,
+          success: false,
+          errorMessage: (e as Error).message,
+        }).catch((auditErr: unknown) => {
+          console.warn(
+            "[credential-broker] audit write failed on decrypt error:",
+            auditErr,
+          );
+        });
+      }
+      throw e;
+    }
+
+    // Write the audit row.
+    if (params.projectId) {
+      await writeAccessLog({
+        credentialId: params.credentialId,
+        projectId: params.projectId,
+        action: "secret_accessed",
+        requestedBy,
+        justification: params.purpose,
+        success: true,
+      }).catch((auditErr: unknown) => {
+        console.warn("[credential-broker] audit write failed:", auditErr);
+      });
+    } else {
+      console.warn(
+        "[credential-broker] accessSecret: no projectId for credential " +
+          params.credentialId +
+          " — audit log skipped (legacy unscoped row). Purpose: " +
+          params.purpose,
+      );
+    }
+
+    return plaintext;
+  }
+
+  // ── CREDENTIAL STORE ─────────────────────────────────────────────────────────
+
+  /**
+   * putCredential — not implemented in Wave 1.
+   *
+   * The `workspaceConnections` store requires a `workspaceId` that the broker
+   * interface does not carry.  This method will be fully implemented in Wave 2
+   * when the Vault backend (which has its own key-value store) is wired in.
+   *
+   * Callers who need to create workspace connections should use the workspace
+   * connections API directly (POST /api/workspaces/:id/connections).
+   */
+  async putCredential(_p: {
+    projectId: string;
+    provider: string;
+    scope: string;
+    description: string;
+    secret: string;
+  }): Promise<CredentialMetadata> {
+    throw new Error(
+      "putCredential is not implemented in Wave 1. " +
+        "Use the workspace connections API to create credentials. " +
+        "This method will be implemented in Wave 2 (Vault backend).",
+    );
+  }
+
+  /**
+   * deleteCredential — not implemented in Wave 1.
+   * Use the workspace connections DELETE endpoint instead.
+   */
+  async deleteCredential(_projectId: string, _credentialId: string): Promise<void> {
+    throw new Error(
+      "deleteCredential is not implemented in Wave 1. " +
+        "Use the workspace connections API to delete credentials. " +
+        "This method will be implemented in Wave 2 (Vault backend).",
+    );
+  }
+}
+
+// ─── Standalone exports for Wave-2 scheduling ─────────────────────────────────
+
+/**
+ * Mark a lease as used immediately before spawnBuiltinServer is called.
+ * Called by the Wave-2 pipeline controller — NOT by the broker itself.
+ *
+ * Writes credential_access_log(action='lease_used').
+ * Does NOT require an ALS context (the leaseId carries projectId).
+ */
+export async function markLeaseUsed(
+  leaseId: string,
+  requestedBy: string,
+): Promise<void> {
+  const [lease] = await db
+    .select()
+    .from(credentialLeases)
+    .where(eq(credentialLeases.id, leaseId));
+
+  if (!lease) {
+    throw new Error(
+      `markLeaseUsed: lease ${leaseId} not found`,
+    );
+  }
+
+  await writeAccessLog({
+    leaseId,
+    credentialId: lease.credentialId,
+    projectId: lease.projectId,
+    runId: lease.runId,
+    stageId: lease.stageId,
+    action: "lease_used",
+    requestedBy,
+    success: true,
+  });
+}
+
+/**
+ * Expiry sweeper — marks all active leases where expiresAt < now() as 'expired'.
+ * Backend-independent: pure DB timestamp comparison, no Vault calls.
+ *
+ * Designed to be scheduled by the Wave-2 pipeline controller (e.g. setInterval
+ * or a BullMQ job).  Do NOT call setInterval here.
+ *
+ * Wraps the caller in runAsSystem if cross-project context is required;
+ * this function uses db directly (no withProject) so it works in any context.
+ *
+ * Returns the number of leases that were expired.
+ */
+export async function expireStaleLeases(): Promise<number> {
+  const now = new Date();
+
+  const expired = await db
+    .update(credentialLeases)
+    .set({ status: "expired", revokedAt: now })
+    .where(
+      and(
+        eq(credentialLeases.status, "active"),
+        lt(credentialLeases.expiresAt, now),
+      ),
+    )
+    .returning();
+
+  // Write audit log for each expired lease.
+  for (const lease of expired) {
+    await writeAccessLog({
+      leaseId: lease.id,
+      credentialId: lease.credentialId,
+      projectId: lease.projectId,
+      runId: lease.runId,
+      stageId: lease.stageId,
+      action: "lease_expired",
+      requestedBy: "system-sweeper",
+      success: true,
+    });
+  }
+
+  return expired.length;
+}
+
+// ─── Singleton export ─────────────────────────────────────────────────────────
+
+/** Default singleton — import this in Wave-2 wiring. */
+export const credentialProvider: CredentialProvider = new DbCryptoCredentialProvider();

--- a/server/credentials/types.ts
+++ b/server/credentials/types.ts
@@ -1,0 +1,225 @@
+/**
+ * Credential Broker types — Phase 1 (ADR-001 §3.2)
+ *
+ * Two surfaces:
+ *   PLAN-TIME  — listCredentials / getCredentialMetadata: metadata only, no secret material.
+ *   EXEC-TIME  — issueLease: short-TTL scoped lease, approval + run-state gated, audited.
+ *
+ * Wave 2 adds:
+ *   NON-LEASE  — accessSecret: direct decrypt with project-scope + audit, no lease gating.
+ *                Routes ALL crypto.decrypt() calls outside db-crypto-provider.ts through
+ *                the broker.  After Wave 2, crypto.decrypt() is called only inside
+ *                db-crypto-provider.ts.
+ *
+ * CredentialSecret is discriminated by `type`.  Wave 1 only produces `static`.
+ * `aws-sts` and `github-app-token` variants are reserved for Wave 2 (Vault backend).
+ */
+
+// ─── Error types ─────────────────────────────────────────────────────────────
+
+/** Thrown when an operation is denied due to project context mismatch,
+ *  unapproved stage, non-running pipeline run, or rate-limit breach. */
+export class ForbiddenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ForbiddenError";
+  }
+}
+
+// ─── Plan-time shape ─────────────────────────────────────────────────────────
+
+/**
+ * Public metadata for a credential.  Never contains secret material.
+ * Mirrors the `hasSecrets` convention from `workspaceConnections`.
+ *
+ * [R3-SEC-3] listCredentials / getCredentialMetadata MUST only return this shape —
+ * never the decrypted secret.
+ */
+export interface CredentialMetadata {
+  /** Corresponds to workspaceConnections.id — the ID passed to issueLease. */
+  id: string;
+  /** Project that owns this credential. */
+  projectId: string;
+  /** Connection type — e.g. "github", "kubernetes", "gitlab". */
+  provider: string;
+  /** Workspace ID the connection belongs to (scope hint for the caller). */
+  scope: string;
+  /** Human-readable name of the workspace connection. */
+  description: string;
+  /** True when secretsEncrypted IS NOT NULL for the underlying connection. */
+  hasSecret: boolean;
+  /** Last time the connection (and thus its secrets) was updated. */
+  lastRotatedAt?: Date;
+}
+
+// ─── Exec-time shapes ────────────────────────────────────────────────────────
+
+/**
+ * Discriminated union of secret variants.
+ *
+ * Wave 1: only `static` is produced by DbCryptoCredentialProvider.
+ * Wave 2: `aws-sts` and `github-app-token` are produced by VaultCredentialProvider.
+ *
+ * The `value` field in `static` contains the JSON-serialised Record<string,string>
+ * of all decrypted secrets from the workspace connection.  The pipeline controller
+ * (Wave 2) parses it back to pass to spawnBuiltinServer.
+ */
+export type CredentialSecret =
+  | { type: "static"; value: string }
+  | {
+      type: "aws-sts";
+      accessKeyId: string;
+      secretAccessKey: string;
+      sessionToken: string;
+      region?: string;
+    }
+  | { type: "github-app-token"; token: string; expiresAt: Date };
+
+/**
+ * A short-TTL credential lease.  The `secret` field ONLY appears here, never in
+ * CredentialMetadata.  The caller MUST NOT store or log `secret` after handing
+ * it to spawnBuiltinServer.
+ */
+export interface CredentialLease {
+  leaseId: string;
+  credentialId: string;
+  projectId: string;
+  runId: string;
+  stageId: string;
+  issuedAt: Date;
+  expiresAt: Date;
+  /** Secret material — do not persist or log. */
+  secret: CredentialSecret;
+}
+
+// ─── Non-lease access shape (Wave 2) ─────────────────────────────────────────
+
+/**
+ * Parameters for accessSecret — the non-lease, direct-decrypt surface.
+ *
+ * accessSecret is the SYSTEM/non-run analogue of issueLease.  It has no approval
+ * or run-state gate.  Every call writes a credential_access_log row
+ * (action='secret_accessed') unless projectId is empty (legacy row).
+ *
+ * Context rules:
+ *   - Project context (getProjectId() returns a string): asserts
+ *     params.projectId === getProjectId() before decrypting.
+ *   - System context (requestContext.getStore()?.system === true): skips
+ *     the project assertion.  The caller must pass the correct projectId for audit.
+ *   - No ALS context at all: throws — requires runAsProject or runAsSystem.
+ */
+export interface AccessSecretParams {
+  /** Pre-fetched ciphertext to decrypt. */
+  ciphertext: string;
+  /** Logical credential ID for the audit log (not a DB foreign key — can be any
+   *  stable identifier like "trackerConn:<id>" or "providerKey:<provider>"). */
+  credentialId: string;
+  /** Project that owns this credential.  Empty string skips the audit log (legacy rows). */
+  projectId: string;
+  /** Human-readable purpose for the audit log. */
+  purpose: string;
+  /** Optional override for the requestedBy audit field.  Defaults to projectId or "system". */
+  requestedBy?: string;
+}
+
+// ─── Provider interface ───────────────────────────────────────────────────────
+
+/**
+ * CredentialProvider — the broker interface (ADR-001 §3.2).
+ *
+ * Hard invariants enforced by every implementation:
+ *
+ *   [R3-SEC-3] Every public method asserts `projectId === getProjectId()` at entry
+ *   and throws ForbiddenError on mismatch.  System context (runAsSystem) causes
+ *   getProjectId() to throw, so system-context callers structurally cannot call
+ *   issueLease or lease-management methods.
+ *
+ *   accessSecret is the exception: it accepts BOTH project and system context,
+ *   enforcing project assertion only in project context and skipping it in system
+ *   context (while still auditing the access).
+ *
+ *   [R3-SEC-2] issueLease reads stage_executions.approvalStatus === 'approved' AND
+ *   pipeline_runs.status === 'running' from the DB and throws ForbiddenError
+ *   otherwise.  The approval gate is a broker invariant, not a caller convention.
+ *
+ *   [R3-SEC-10] issueLease is rate-limited per (projectId, runId).
+ */
+export interface CredentialProvider {
+  // ── PLAN-TIME ─────────────────────────────────────────────────────────────
+
+  /** Returns metadata for all credentials in the project.  Never decrypts. */
+  listCredentials(projectId: string): Promise<CredentialMetadata[]>;
+
+  /** Returns metadata for a single credential, or null if not found.  Never decrypts. */
+  getCredentialMetadata(
+    projectId: string,
+    credentialId: string,
+  ): Promise<CredentialMetadata | null>;
+
+  // ── NON-LEASE DIRECT ACCESS (Wave 2) ──────────────────────────────────────
+
+  /**
+   * Decrypt a pre-fetched ciphertext and write a credential_access_log row
+   * (action='secret_accessed').
+   *
+   * Context behaviour:
+   *   - Project context: asserts params.projectId === getProjectId() before decrypting.
+   *     The DB query that fetched the ciphertext must already be scoped via withProject.
+   *   - System context: skips the project assertion (getProjectId() would throw).
+   *     The caller is responsible for passing the correct projectId for audit.
+   *
+   * This is the SYSTEM/non-run analogue of issueLease — no approval/run gating but
+   * always project- or system-scoped and always audited.
+   *
+   * After Wave 2, the ONLY place crypto.decrypt() may be called is INSIDE the broker
+   * (DbCryptoCredentialProvider.accessSecret) and rekey/migration scripts.
+   * Add a CI-grep check to enforce this: no decrypt() outside credentials/ and scripts/.
+   */
+  accessSecret(params: AccessSecretParams): Promise<string>;
+
+  // ── EXEC-TIME ─────────────────────────────────────────────────────────────
+
+  /**
+   * Issue a short-TTL credential lease.
+   *
+   * Enforces internally:
+   *   - stage_executions.approvalStatus === 'approved'
+   *   - pipeline_runs.status === 'running'
+   *   - rate-limit per (projectId, runId)
+   *
+   * Writes credential_leases row + credential_access_log(action='lease_issued').
+   * TTL default 300 s, max 900 s.
+   */
+  issueLease(p: {
+    projectId: string;
+    credentialId: string;
+    runId: string;
+    stageId: string;
+    ttlSeconds?: number;
+    requestedBy: string;
+    justification?: string;
+  }): Promise<CredentialLease>;
+
+  /** Mark a lease revoked.  No-op if already revoked (idempotent). */
+  revokeLease(leaseId: string): Promise<void>;
+
+  /**
+   * Revoke all active leases for a run.  Safe to call in a `finally` block —
+   * must NOT throw when no active leases exist or when leases are already revoked.
+   */
+  revokeRunLeases(runId: string): Promise<void>;
+
+  // ── CREDENTIAL STORE ──────────────────────────────────────────────────────
+
+  /** Create or update a credential for the project (project-scoped write). */
+  putCredential(p: {
+    projectId: string;
+    provider: string;
+    scope: string;
+    description: string;
+    secret: string;
+  }): Promise<CredentialMetadata>;
+
+  /** Delete a credential for the project (project-scoped write). */
+  deleteCredential(projectId: string, credentialId: string): Promise<void>;
+}

--- a/server/remote-agents/remote-agent-manager.ts
+++ b/server/remote-agents/remote-agent-manager.ts
@@ -2,7 +2,9 @@ import { eq } from "drizzle-orm";
 import { db, withProject, withProjectList } from "../db";
 import { runAsSystem } from "../context";
 import { remoteAgents, a2aTasks } from "@shared/schema";
-import { encrypt, decrypt } from "../crypto";
+import { encrypt } from "../crypto";
+// [ADR-001 Wave-2] credentialProvider routes all decrypt() calls through the broker.
+import { credentialProvider } from "../credentials/db-crypto-provider";
 import { A2AClient } from "./a2a-client";
 import { AgentDiscoveryService } from "./agent-discovery";
 import type {
@@ -107,7 +109,7 @@ export class RemoteAgentManager {
       })
       .returning();
 
-    return this.rowToConfig(created);
+    return await this.rowToConfig(created);
   }
 
   async unregisterAgent(agentId: string): Promise<void> {
@@ -256,7 +258,7 @@ export class RemoteAgentManager {
       .from(remoteAgents)
       .where(withProjectList(remoteAgents))
       .orderBy(remoteAgents.name);
-    return rows.map((r) => this.rowToConfig(r));
+    return Promise.all(rows.map((r) => this.rowToConfig(r)));
   }
 
   async getAgent(agentId: string): Promise<RemoteAgentConfig | null> {
@@ -264,7 +266,7 @@ export class RemoteAgentManager {
       .select()
       .from(remoteAgents)
       .where(withProject(remoteAgents, eq(remoteAgents.id, agentId)));
-    return row ? this.rowToConfig(row) : null;
+    return row ? await this.rowToConfig(row) : null;
   }
 
   getConnectionStatus(agentId: string): boolean {
@@ -295,9 +297,27 @@ export class RemoteAgentManager {
 
   // ── Helpers ────────────────────────────────────────────────────────
 
-  private rowToConfig(
+  /**
+   * [ADR-001 Wave-2] rowToConfig is now async — it routes authTokenEnc through
+   * the credential broker instead of calling crypto.decrypt() directly.
+   * All callers are updated to await this method or use Promise.all.
+   */
+  private async rowToConfig(
     row: typeof remoteAgents.$inferSelect,
-  ): RemoteAgentConfig {
+  ): Promise<RemoteAgentConfig> {
+    // Decrypt auth token via the broker (project or system context both accepted).
+    // row.projectId is the credential-owning project for the audit log.
+    // row.projectId may be null for legacy rows; passing "" triggers audit-skip
+    // with a warning in accessSecret but still decrypts correctly.
+    let authToken: string | null = null;
+    if (row.authTokenEnc) {
+      authToken = await credentialProvider.accessSecret({
+        ciphertext: row.authTokenEnc,
+        credentialId: `remoteAgent:${row.id}`,
+        projectId: row.projectId ?? "",
+        purpose: "remote-agent-auth-token-read",
+      });
+    }
     return {
       id: row.id,
       name: row.name,
@@ -307,9 +327,9 @@ export class RemoteAgentManager {
       cluster: row.cluster,
       namespace: row.namespace,
       labels: row.labels as Record<string, string> | null,
-      // Decrypt at the DB boundary so all callers receive the plaintext token.
-      // The DB column stores AES-256-GCM ciphertext; the config field holds plaintext.
-      authTokenEnc: row.authTokenEnc ? decrypt(row.authTokenEnc) : null,
+      // authToken is decrypted by the credential broker above.
+      // HTTP responses MUST strip this via toPublicAgent() in the route layer.
+      authTokenEnc: authToken,
       enabled: row.enabled,
       autoConnect: row.autoConnect,
       status: row.status as RemoteAgentConfig["status"],

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -64,6 +64,8 @@ import { registerTaskTraceRoutes } from "./routes/task-traces";
 import { registerTaskIterationRoutes } from "./routes/task-iterations";
 import { registerTaskTemplateRoutes } from "./routes/task-templates";
 import { registerTrackerRoutes } from "./routes/tracker";
+import { registerCredentialRoutes } from "./routes/credentials";
+import { expireStaleLeases } from "./credentials/db-crypto-provider";
 import { TaskOrchestrator } from "./services/task-orchestrator";
 import { TaskTracer } from "./services/task-tracer";
 import { TaskSplitter } from "./services/task-splitter";
@@ -174,6 +176,7 @@ export async function registerRoutes(
   app.use("/api/tracker-connections", requireAuth, requireProject);
   app.use("/api/remote-agents", requireAuth, requireProject);
   app.use("/api/skill-market", requireAuth, requireProject);   // UNCERTAIN — see note above
+  app.use("/api/credentials", requireAuth, requireProject);
   // /api/workspaces/:id/knowledge is already covered by /api/workspaces above;
   // keep this explicit mount for clarity and so the middleware fires even if the
   // /api/workspaces mount is ever narrowed.
@@ -335,6 +338,22 @@ export async function registerRoutes(
   const trackerSync = new TrackerSyncService(storage);
   registerTrackerRoutes(app, storage, taskSplitter, trackerSync, taskOrchestrator);
 
+  // ADR-001 Phase 1 — Credential broker read-only UI endpoints
+  registerCredentialRoutes(app);
+
+  // ADR-001 Wave-2: credential lease sweeper — runs every 60s as system context.
+  // Marks leases with expiresAt < now() as expired regardless of backend state.
+  const leaseSweeper = setInterval(async () => {
+    try {
+      const count = await runAsSystem("lease-sweeper", () => expireStaleLeases());
+      if (count > 0) {
+        log(`[credential-broker] sweeper expired ${count} stale lease(s)`, "sweeper");
+      }
+    } catch (e) {
+      log(`[credential-broker] sweeper error: ${(e as Error).message}`, "sweeper");
+    }
+  }, 60_000);
+
   // Phase 6.3 — Trigger subsystem
   let triggerService: TriggerService | null = null;
   let webhookRoutesRegistered = false;
@@ -452,6 +471,8 @@ export async function registerRoutes(
 
   // Graceful shutdown
   httpServer.on("close", async () => {
+    // ADR-001 Wave-2: clear the credential lease sweeper first.
+    clearInterval(leaseSweeper);
     cronScheduler?.stopAll();
     consiliumLoopPoller?.stop();
     fileWatcherService?.stopAll();

--- a/server/routes/credentials.ts
+++ b/server/routes/credentials.ts
@@ -1,0 +1,130 @@
+/**
+ * Credentials API — read-only broker UI endpoints (ADR-001 §3.2 plan-time surface).
+ *
+ * All three endpoints:
+ *   - require authentication + project context (enforced in routes.ts via
+ *     requireAuth + requireProject on /api/credentials)
+ *   - scope every query to the current project (via withProject or credentialProvider)
+ *   - NEVER return secret material
+ *
+ * Endpoints:
+ *   GET /api/credentials              → CredentialMetadata[]
+ *   GET /api/credentials/access-log   → CredentialAccessLogRow[] (newest createdAt first)
+ *   GET /api/credentials/leases       → CredentialLeaseRow[] (newest issuedAt first)
+ */
+
+import type { Express } from "express";
+import { db, withProject } from "../db.js";
+import {
+  credentialLeases,
+  credentialAccessLog,
+  CREDENTIAL_LEASE_STATUSES,
+} from "../../shared/schema.js";
+import { credentialProvider } from "../credentials/db-crypto-provider.js";
+import { getProjectId } from "../context.js";
+import { desc, eq, and } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+
+export function registerCredentialRoutes(app: Express): void {
+  // ── GET /api/credentials ──────────────────────────────────────────────────────
+  // List all credentials for the current project — metadata only, no secrets.
+  // Delegates entirely to credentialProvider which enforces assertProject() and
+  // writes a list_metadata audit row on every call.
+  app.get("/api/credentials", async (_req, res) => {
+    try {
+      const projectId = getProjectId();
+      const credentials = await credentialProvider.listCredentials(projectId);
+      res.json(credentials);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  // ── GET /api/credentials/access-log ──────────────────────────────────────────
+  // Returns credential_access_log rows for the current project, newest first.
+  //
+  // Query params:
+  //   limit        — row cap (default 100, max 500)
+  //   credentialId — narrow to a single credential ID
+  //   runId        — narrow to a single pipeline run ID
+  app.get("/api/credentials/access-log", async (req, res) => {
+    try {
+      const rawLimit = parseInt(String(req.query.limit ?? "100"), 10);
+      const limit =
+        isNaN(rawLimit) || rawLimit < 1 ? 100 : Math.min(rawLimit, 500);
+
+      const credentialId = req.query.credentialId
+        ? String(req.query.credentialId)
+        : undefined;
+      const runId = req.query.runId ? String(req.query.runId) : undefined;
+
+      // Build WHERE: start with the project scope, then layer optional filters.
+      const conditions: SQL[] = [withProject(credentialAccessLog)];
+      if (credentialId) {
+        conditions.push(eq(credentialAccessLog.credentialId, credentialId));
+      }
+      if (runId) {
+        conditions.push(eq(credentialAccessLog.runId, runId));
+      }
+      const where =
+        conditions.length === 1 ? conditions[0] : and(...conditions)!;
+
+      const rows = await db
+        .select()
+        .from(credentialAccessLog)
+        .where(where)
+        .orderBy(desc(credentialAccessLog.createdAt))
+        .limit(limit);
+
+      res.json(rows);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  // ── GET /api/credentials/leases ───────────────────────────────────────────────
+  // Returns credential_leases rows for the current project, newest issuedAt first.
+  //
+  // Query params:
+  //   status — filter by lease status: active | revoked | expired
+  app.get("/api/credentials/leases", async (req, res) => {
+    try {
+      const status = req.query.status ? String(req.query.status) : undefined;
+
+      if (
+        status !== undefined &&
+        !(CREDENTIAL_LEASE_STATUSES as readonly string[]).includes(status)
+      ) {
+        res.status(400).json({
+          error: `Invalid status: must be one of ${CREDENTIAL_LEASE_STATUSES.join(", ")}`,
+        });
+        return;
+      }
+
+      const conditions: SQL[] = [withProject(credentialLeases)];
+      if (status) {
+        conditions.push(
+          eq(
+            credentialLeases.status,
+            status as (typeof CREDENTIAL_LEASE_STATUSES)[number],
+          ),
+        );
+      }
+      const where =
+        conditions.length === 1 ? conditions[0] : and(...conditions)!;
+
+      const rows = await db
+        .select()
+        .from(credentialLeases)
+        .where(where)
+        .orderBy(desc(credentialLeases.issuedAt));
+
+      res.json(rows);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
+  });
+}

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -5,8 +5,11 @@ import { spawnSync } from "child_process";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 import { db, withProject, withProjectInsert } from "../db";
+import { unscopedSystemQuery } from "../context";
 import { providerKeys } from "@shared/schema";
-import { encrypt, decrypt } from "../crypto";
+import { encrypt } from "../crypto";
+// [ADR-001 Wave-2] credentialProvider routes all decrypt() calls through the broker.
+import { credentialProvider } from "../credentials/db-crypto-provider";
 import type { Gateway } from "../gateway/index";
 import { configLoader } from "../config/loader";
 import type { VersionsResponse } from "@shared/types";
@@ -239,14 +242,37 @@ export function registerSettingsRoutes(router: Router, gateway: Gateway) {
   });
 }
 
-/** Load DB-stored keys and return a map of provider → decrypted key. */
+/**
+ * Load DB-stored keys and return a map of provider → decrypted key.
+ *
+ * M-8 fix: the query was unscoped and decrypted ALL projects' keys. It is now
+ * guarded by unscopedSystemQuery, which throws if called outside a runAsSystem()
+ * context. Callers MUST use:
+ *
+ *   await runAsSystem("startup-load-provider-keys", () => loadProviderKeysFromDb())
+ *
+ * Per-project gateway key resolution will move to the Phase-1 credential broker;
+ * this function is a transitional helper for startup-time gateway seeding only.
+ */
 export async function loadProviderKeysFromDb(): Promise<Map<string, string>> {
   try {
-    const rows = await db.select().from(providerKeys);
+    // unscopedSystemQuery throws if not called inside runAsSystem() — this ensures
+    // callers always establish an explicit audit context before reading all-project keys.
+    const rows = await unscopedSystemQuery("gateway-load-provider-keys", () =>
+      db.select().from(providerKeys),
+    );
     const map = new Map<string, string>();
     for (const row of rows) {
       try {
-        map.set(row.provider, decrypt(row.apiKeyEncrypted));
+        // [ADR-001 Wave-2] Route through credential broker — no decrypt() outside broker.
+        const plaintext = await credentialProvider.accessSecret({
+          ciphertext: row.apiKeyEncrypted,
+          credentialId: `providerKey:${row.provider}`,
+          projectId: row.projectId ?? "",
+          purpose: "llm-gateway-provider-key-load",
+          requestedBy: "system-gateway-seeder",
+        });
+        map.set(row.provider, plaintext);
       } catch {
         console.warn(`[settings] Failed to decrypt key for provider: ${row.provider}`);
       }

--- a/server/services/git-skill-sync.ts
+++ b/server/services/git-skill-sync.ts
@@ -19,7 +19,10 @@ import { eq, and } from "drizzle-orm";
 import { db } from "../db";
 import { gitSkillSources, skills } from "@shared/schema";
 import type { GitSkillSourceRow } from "@shared/schema";
-import { decrypt } from "../crypto";
+// [ADR-001 Wave-2] No longer imports crypto.decrypt() directly — all decryption
+// is routed through the credential broker.
+import { credentialProvider } from "../credentials/db-crypto-provider";
+import { getProjectId } from "../context";
 import { SkillYamlSchema } from "../skills/yaml-service";
 import yaml from "js-yaml";
 
@@ -197,7 +200,16 @@ export async function syncGitSkillSource(sourceId: string): Promise<void> {
     let cloneUrl = source.repoUrl;
     if (source.encryptedPat) {
       try {
-        const pat = decrypt(source.encryptedPat);
+        // [ADR-001 Wave-2] Route through credential broker (no direct decrypt).
+        // source.projectId may be null for legacy rows; fall back to getProjectId()
+        // in project context (syncGitSkillSource is called from route handlers).
+        const projectId = source.projectId ?? getProjectId();
+        const pat = await credentialProvider.accessSecret({
+          ciphertext: source.encryptedPat,
+          credentialId: `gitSkillPat:${source.id}`,
+          projectId,
+          purpose: "git-skill-source-clone-pat",
+        });
         cloneUrl = injectPat(source.repoUrl, pat);
       } catch (cryptoErr) {
         throw new Error(`Failed to decrypt PAT: ${(cryptoErr as Error).message}`);

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -1,7 +1,7 @@
 import { eq, desc, and, or, ilike, lt, ne, gte, lte, asc, isNull, inArray, sql as drizzleSql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { db, withProject, withProjectList, withProjectInsert, withProjectOrGlobal } from "./db";
-import { unscopedSystemQuery } from "./context";
+import { unscopedSystemQuery, getProjectId } from "./context";
 import type { IStorage, PracticeCardFilters, MorningBriefFilters, NewsItemFilters, LlmRequestFilters, LlmRequestStats, LlmStatsByModel, LlmStatsByProvider, LlmStatsByTeam, LlmTimelinePoint, RunHistoryQuery, PipelineRunHistoryRow, TaskGroupHistoryRow } from "./storage";
 import {
   TASK_GROUP_V2_MAX_LIMIT,
@@ -141,7 +141,9 @@ import {
 import type { LessonRecallFilter } from "./memory/lessons/types";
 import type { TraceSpan, SkillVersionRecord, MarketplaceSkill, MarketplaceFilters, InsertSkillVersion, SharedSession, CreateSharedSessionInput, ShareRole, WorkspaceConnection, CreateWorkspaceConnectionInput, UpdateWorkspaceConnectionInput, McpToolCall, ConnectionUsageMetrics, RecordMcpToolCallInput, SessionConflict, DecisionLogEntry, RaiseConflictInput, CastConflictVoteInput, DebateJudgement, ExperimentBranchResult, ResolutionOutcome } from "@shared/types";
 
-import { encrypt, decrypt } from "./crypto";
+import { encrypt } from "./crypto";
+// [ADR-001 Wave-2] credentialProvider routes all decrypt() calls through the broker.
+import { credentialProvider } from "./credentials/db-crypto-provider";
 
 export class PgStorage implements IStorage {
 
@@ -1641,18 +1643,30 @@ export class PgStorage implements IStorage {
 
   // ─── Tracker Connections (Issue Tracker Integration) ────────────────────────
 
-  /** Decrypt the api_token column for a tracker connection row. Null-safe. */
-  private decryptTrackerToken(row: typeof trackerConnections.$inferSelect): TrackerConnectionRow {
-    return {
-      ...row,
-      apiToken: row.apiToken ? decrypt(row.apiToken) : null,
-    };
+  /**
+   * Decrypt the api_token column for a tracker connection row. Null-safe.
+   * [ADR-001 Wave-2] Routes crypto.decrypt() through the credential broker.
+   */
+  private async decryptTrackerToken(row: typeof trackerConnections.$inferSelect): Promise<TrackerConnectionRow> {
+    if (!row.apiToken) {
+      return { ...row, apiToken: null };
+    }
+    // In project context row.projectId should always be set (withProject scoping).
+    // Fall back to getProjectId() for legacy null-projectId rows to avoid empty string.
+    const projectId = row.projectId ?? getProjectId();
+    const plaintext = await credentialProvider.accessSecret({
+      ciphertext: row.apiToken,
+      credentialId: `trackerConn:${row.id}`,
+      projectId,
+      purpose: "tracker-api-token-read",
+    });
+    return { ...row, apiToken: plaintext };
   }
 
   async getTrackerConnectionsByGroup(taskGroupId: string): Promise<TrackerConnectionRow[]> {
     const rows = await db.select().from(trackerConnections)
       .where(withProject(trackerConnections, eq(trackerConnections.taskGroupId, taskGroupId)));
-    return rows.map((r) => this.decryptTrackerToken(r));
+    return Promise.all(rows.map((r) => this.decryptTrackerToken(r)));
   }
 
   async getTrackerConnection(id: string): Promise<TrackerConnectionRow | undefined> {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -2804,3 +2804,96 @@ export const insertConsiliumLoopRoundSchema = createInsertSchema(consiliumLoopRo
 });
 export type InsertConsiliumLoopRound = typeof consiliumLoopRounds.$inferInsert;
 export type ConsiliumLoopRoundRow = typeof consiliumLoopRounds.$inferSelect;
+
+// ─── Credential Broker — Phase 1 (ADR-001) ──────────────────────────────────
+//
+// credential_leases:    short-TTL scoped lease records (active | revoked | expired)
+// credential_access_log: append-only audit trail for all broker operations
+//
+// Both tables carry projectId NOT NULL to enforce hard project isolation.
+// The application-layer broker asserts projectId === getProjectId() on entry
+// before any DB access.
+//
+// Deploy: psql "$DATABASE_URL" -f migrations/0028_phase1_credential_broker.sql
+
+export const CREDENTIAL_LEASE_STATUSES = ["active", "revoked", "expired"] as const;
+export type CredentialLeaseStatus = typeof CREDENTIAL_LEASE_STATUSES[number];
+
+export const CREDENTIAL_ACCESS_ACTIONS = [
+  "list_metadata",
+  "get_metadata",
+  "lease_issued",
+  "lease_used",
+  "lease_revoked",
+  "lease_expired",
+  // [Wave-2] Non-lease direct secret accesses through the broker (ADR-001 PR-1d).
+  "secret_accessed",
+] as const;
+export type CredentialAccessAction = typeof CREDENTIAL_ACCESS_ACTIONS[number];
+
+export const credentialLeases = pgTable(
+  "credential_leases",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    credentialId: text("credential_id").notNull(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    runId: text("run_id").notNull(),
+    stageId: text("stage_id").notNull(),
+    requestedBy: text("requested_by").notNull(),
+    issuedAt: timestamp("issued_at").notNull().defaultNow(),
+    expiresAt: timestamp("expires_at").notNull(),
+    revokedAt: timestamp("revoked_at"),
+    status: text("status")
+      .notNull()
+      .default("active")
+      .$type<CredentialLeaseStatus>(),
+  },
+  (table) => ({
+    projectIdx: index("credential_leases_project_id_idx").on(table.projectId),
+    runIdx: index("credential_leases_run_id_idx").on(table.runId),
+    statusIdx: index("credential_leases_status_idx").on(table.status),
+  }),
+);
+
+export type CredentialLease = typeof credentialLeases.$inferSelect;
+export type InsertCredentialLease = typeof credentialLeases.$inferInsert;
+
+export const credentialAccessLog = pgTable(
+  "credential_access_log",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    /** Null for plan-time actions (list_metadata, get_metadata) that have no lease. */
+    leaseId: text("lease_id"),
+    credentialId: text("credential_id").notNull(),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    /** Null for plan-time actions that have no run context. */
+    runId: text("run_id"),
+    /** Null for plan-time actions that have no stage context. */
+    stageId: text("stage_id"),
+    action: text("action")
+      .notNull()
+      .$type<CredentialAccessAction>(),
+    requestedBy: text("requested_by").notNull(),
+    justification: text("justification"),
+    success: boolean("success").notNull().default(true),
+    errorMessage: text("error_message"),
+    /** TTL in seconds — only set for lease_issued actions. */
+    ttlSeconds: integer("ttl_seconds"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (table) => ({
+    projectIdx: index("credential_access_log_project_id_idx").on(table.projectId),
+    credentialIdx: index("credential_access_log_credential_id_idx").on(table.credentialId),
+  }),
+);
+
+export type CredentialAccessLogRow = typeof credentialAccessLog.$inferSelect;
+export type InsertCredentialAccessLog = typeof credentialAccessLog.$inferInsert;

--- a/tests/integration/credentials-api.test.ts
+++ b/tests/integration/credentials-api.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Integration tests — Credentials API (ADR-001 Phase 1 broker UI endpoints).
+ *
+ * Verifies:
+ *   - GET /api/credentials            — 400 without x-project-id header;
+ *                                       200 + CredentialMetadata[] when header present
+ *   - GET /api/credentials/access-log — 400 without x-project-id;
+ *                                       200 + rows ordered newest-first with header
+ *   - GET /api/credentials/leases     — 400 without x-project-id;
+ *                                       200 + rows ordered newest-first with header;
+ *                                       200 + filtered rows with ?status=active;
+ *                                       400 on unrecognised ?status value
+ *
+ * Strategy:
+ *   - server/db.js is mocked so tests are DB-free.
+ *   - server/credentials/db-crypto-provider.js is mocked so listCredentials
+ *     does not exercise the real provider's complex workspace-connection JOIN.
+ *   - requireProject middleware is exercised for real (using the mocked db).
+ *   - The test app mirrors the middleware chain in routes.ts:
+ *       injectUser → requireProject → registerCredentialRoutes.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import request from "supertest";
+import express from "express";
+import { createServer } from "http";
+import type { Express, Request, Response, NextFunction } from "express";
+import type { User } from "../../shared/types.js";
+
+// ─── Hoisted mutable state ────────────────────────────────────────────────────
+//
+// vi.hoisted() is required so these values are available inside vi.mock()
+// factories which are hoisted above imports.
+
+const STORE = vi.hoisted(() => ({
+  /** Rows returned when requireProject queries the projects table. */
+  projectsRows: [
+    {
+      id: "proj-1",
+      name: "Test Project",
+      ownerId: "user-test",
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    },
+  ] as unknown[],
+  /** Rows returned when requireProject queries projectMembers (not needed when user is owner). */
+  membersRows: [] as unknown[],
+  /** Rows returned for credential_access_log queries. */
+  accessLogRows: [] as unknown[],
+  /** Rows returned for credential_leases queries. */
+  leasesRows: [] as unknown[],
+}));
+
+const MOCK_CREDS = vi.hoisted(() => ({
+  /** CredentialMetadata[] returned by the mocked listCredentials. */
+  credentials: [] as unknown[],
+}));
+
+// ─── Mock server/db.js ───────────────────────────────────────────────────────
+//
+// Returns controlled rows based on the Drizzle table name symbol.
+// withProject returns the optional condition unchanged (or {} when called with
+// no condition) — the mock db.where() ignores the SQL value entirely.
+
+vi.mock("../../server/db.js", () => {
+  const TABLE = Symbol.for("drizzle:BaseName");
+
+  /**
+   * Returns a fluent chain that ignores WHERE/ORDER-BY/LIMIT conditions and
+   * resolves to the provided rows when awaited at any chain depth.
+   */
+  function makeChain(getRows: () => unknown[]) {
+    const chain: Record<string, unknown> = {};
+    chain.where = () => chain;
+    chain.innerJoin = () => chain;
+    chain.orderBy = () => chain;
+    // Terminate the chain with .limit() — returns a real Promise.
+    chain.limit = () => Promise.resolve(getRows());
+    // Make the chain itself awaitable so await chain.orderBy(...) works
+    // (used by the leases endpoint which has no .limit() call).
+    (chain as unknown as PromiseLike<unknown>).then = (
+      resolve: (v: unknown) => void,
+      reject?: (e: unknown) => void,
+    ) => Promise.resolve(getRows()).then(resolve, reject);
+    return chain;
+  }
+
+  return {
+    pool: { on: () => {} },
+    /** Pass-through: the mock db ignores the SQL condition anyway. */
+    withProject: (_t: unknown, cond?: unknown) => cond ?? {},
+    withProjectInsert: (_t: unknown, data: unknown) => data,
+    runMigrations: async () => {},
+    db: {
+      select: () => ({
+        from: (table: unknown) => {
+          const name = (table as Record<symbol, string>)[TABLE];
+          if (name === "projects") return makeChain(() => STORE.projectsRows);
+          if (name === "project_members")
+            return makeChain(() => STORE.membersRows);
+          if (name === "credential_access_log")
+            return makeChain(() => STORE.accessLogRows);
+          if (name === "credential_leases")
+            return makeChain(() => STORE.leasesRows);
+          return makeChain(() => []);
+        },
+      }),
+    },
+  };
+});
+
+// ─── Mock server/credentials/db-crypto-provider.js ───────────────────────────
+//
+// Replaces the real provider so listCredentials does not hit the DB
+// (it has its own complex workspace-connection JOIN + audit write).
+
+vi.mock("../../server/credentials/db-crypto-provider.js", () => ({
+  credentialProvider: {
+    listCredentials: vi.fn(
+      async (_projectId: string) => MOCK_CREDS.credentials,
+    ),
+  },
+  expireStaleLeases: async () => 0,
+}));
+
+// ─── Synthetic user ───────────────────────────────────────────────────────────
+
+const TEST_USER: User = {
+  id: "user-test",
+  email: "cred-test@example.com",
+  name: "Credential Tester",
+  isActive: true,
+  role: "admin",
+  lastLoginAt: null,
+  createdAt: new Date(0),
+};
+
+function injectUser(req: Request, _res: Response, next: NextFunction) {
+  req.user = TEST_USER;
+  next();
+}
+
+// ─── Test fixtures ────────────────────────────────────────────────────────────
+
+const NOW = new Date("2026-06-29T00:00:00Z");
+const LATER = new Date("2026-06-29T01:00:00Z");
+
+const SAMPLE_CREDENTIAL = {
+  id: "conn-1",
+  projectId: "proj-1",
+  provider: "github",
+  scope: "ws-1",
+  description: "My GitHub Connection",
+  hasSecret: true,
+  lastRotatedAt: NOW,
+};
+
+const SAMPLE_LOG_ROW = {
+  id: "log-1",
+  leaseId: "lease-1",
+  credentialId: "conn-1",
+  projectId: "proj-1",
+  runId: "run-1",
+  stageId: "stage-1",
+  action: "lease_issued",
+  requestedBy: "proj-1",
+  justification: "automated",
+  success: true,
+  errorMessage: null,
+  ttlSeconds: 300,
+  createdAt: NOW,
+};
+
+const SAMPLE_LEASE_ROW = {
+  id: "lease-1",
+  credentialId: "conn-1",
+  projectId: "proj-1",
+  runId: "run-1",
+  stageId: "stage-1",
+  requestedBy: "proj-1",
+  issuedAt: NOW,
+  expiresAt: LATER,
+  revokedAt: null,
+  status: "active",
+};
+
+// ─── Test app factory ─────────────────────────────────────────────────────────
+
+async function createTestApp() {
+  const { requireProject } = await import(
+    "../../server/middleware/project.js"
+  );
+  const { registerCredentialRoutes } = await import(
+    "../../server/routes/credentials.js"
+  );
+
+  const app = express();
+  app.use(express.json());
+  app.use(injectUser);
+
+  // Mirror the middleware chain from routes.ts.
+  app.use("/api/credentials", requireProject);
+
+  registerCredentialRoutes(app);
+
+  const httpServer = createServer(app);
+  return {
+    app,
+    close: () => new Promise<void>((r) => httpServer.close(() => r())),
+  };
+}
+
+// ─── Test suite ───────────────────────────────────────────────────────────────
+
+describe("Credentials API", () => {
+  let app: Express;
+  let closeApp: () => Promise<void>;
+
+  beforeAll(async () => {
+    const ctx = await createTestApp();
+    app = ctx.app;
+    closeApp = ctx.close;
+  }, 15_000);
+
+  afterAll(async () => {
+    await closeApp();
+  });
+
+  // ── 400 without x-project-id ────────────────────────────────────────────────
+
+  describe("GET /api/credentials — no x-project-id → 400", () => {
+    it("returns 400 when x-project-id header is absent", async () => {
+      const res = await request(app).get("/api/credentials");
+      expect(res.status).toBe(400);
+      expect((res.body as { error: string }).error).toMatch(/x-project-id/);
+    });
+  });
+
+  describe("GET /api/credentials/access-log — no x-project-id → 400", () => {
+    it("returns 400 when x-project-id header is absent", async () => {
+      const res = await request(app).get("/api/credentials/access-log");
+      expect(res.status).toBe(400);
+      expect((res.body as { error: string }).error).toMatch(/x-project-id/);
+    });
+  });
+
+  describe("GET /api/credentials/leases — no x-project-id → 400", () => {
+    it("returns 400 when x-project-id header is absent", async () => {
+      const res = await request(app).get("/api/credentials/leases");
+      expect(res.status).toBe(400);
+      expect((res.body as { error: string }).error).toMatch(/x-project-id/);
+    });
+  });
+
+  // ── 200 with x-project-id ───────────────────────────────────────────────────
+
+  describe("GET /api/credentials — with x-project-id → 200", () => {
+    it("returns CredentialMetadata[] for the project", async () => {
+      MOCK_CREDS.credentials = [SAMPLE_CREDENTIAL];
+
+      const res = await request(app)
+        .get("/api/credentials")
+        .set("x-project-id", "proj-1");
+
+      expect(res.status).toBe(200);
+      const body = res.body as typeof SAMPLE_CREDENTIAL[];
+      expect(Array.isArray(body)).toBe(true);
+      expect(body).toHaveLength(1);
+      expect(body[0].id).toBe("conn-1");
+      expect(body[0].provider).toBe("github");
+      // No secret material in the response.
+      expect("secretsEncrypted" in body[0]).toBe(false);
+    });
+
+    it("returns empty array when project has no credentials", async () => {
+      MOCK_CREDS.credentials = [];
+
+      const res = await request(app)
+        .get("/api/credentials")
+        .set("x-project-id", "proj-1");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+  });
+
+  describe("GET /api/credentials/access-log — with x-project-id → 200", () => {
+    it("returns access log rows for the project", async () => {
+      STORE.accessLogRows = [SAMPLE_LOG_ROW];
+
+      const res = await request(app)
+        .get("/api/credentials/access-log")
+        .set("x-project-id", "proj-1");
+
+      expect(res.status).toBe(200);
+      const body = res.body as typeof SAMPLE_LOG_ROW[];
+      expect(Array.isArray(body)).toBe(true);
+      expect(body).toHaveLength(1);
+      expect(body[0].id).toBe("log-1");
+      expect(body[0].action).toBe("lease_issued");
+      expect(body[0].projectId).toBe("proj-1");
+    });
+
+    it("returns empty array when project has no log entries", async () => {
+      STORE.accessLogRows = [];
+
+      const res = await request(app)
+        .get("/api/credentials/access-log")
+        .set("x-project-id", "proj-1");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+
+    it("respects the ?limit query param (accepts values 1–500)", async () => {
+      STORE.accessLogRows = [SAMPLE_LOG_ROW];
+
+      // The mock returns STORE rows regardless of limit; we just verify 200.
+      const res = await request(app)
+        .get("/api/credentials/access-log?limit=50")
+        .set("x-project-id", "proj-1");
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+    });
+  });
+
+  describe("GET /api/credentials/leases — with x-project-id → 200", () => {
+    it("returns lease rows for the project", async () => {
+      STORE.leasesRows = [SAMPLE_LEASE_ROW];
+
+      const res = await request(app)
+        .get("/api/credentials/leases")
+        .set("x-project-id", "proj-1");
+
+      expect(res.status).toBe(200);
+      const body = res.body as typeof SAMPLE_LEASE_ROW[];
+      expect(Array.isArray(body)).toBe(true);
+      expect(body).toHaveLength(1);
+      expect(body[0].id).toBe("lease-1");
+      expect(body[0].status).toBe("active");
+      expect(body[0].projectId).toBe("proj-1");
+    });
+
+    it("returns empty array when project has no leases", async () => {
+      STORE.leasesRows = [];
+
+      const res = await request(app)
+        .get("/api/credentials/leases")
+        .set("x-project-id", "proj-1");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+
+    it("accepts ?status=active filter and returns 200", async () => {
+      STORE.leasesRows = [SAMPLE_LEASE_ROW];
+
+      const res = await request(app)
+        .get("/api/credentials/leases?status=active")
+        .set("x-project-id", "proj-1");
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+    });
+
+    it("accepts ?status=revoked filter and returns 200", async () => {
+      STORE.leasesRows = [];
+
+      const res = await request(app)
+        .get("/api/credentials/leases?status=revoked")
+        .set("x-project-id", "proj-1");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
+    });
+
+    it("returns 400 for an unrecognised ?status value", async () => {
+      const res = await request(app)
+        .get("/api/credentials/leases?status=unknown")
+        .set("x-project-id", "proj-1");
+
+      expect(res.status).toBe(400);
+      const body = res.body as { error: string };
+      expect(body.error).toMatch(/Invalid status/);
+    });
+  });
+});

--- a/tests/unit/credentials/db-crypto-provider.test.ts
+++ b/tests/unit/credentials/db-crypto-provider.test.ts
@@ -1,0 +1,1136 @@
+/**
+ * Unit tests for DbCryptoCredentialProvider (ADR-001 Phase 1b + Wave 2).
+ *
+ * Covers:
+ *   1.  projectId-mismatch throws ForbiddenError on every public method.
+ *   2.  Plan-time methods (listCredentials, getCredentialMetadata) never return
+ *       secret material.
+ *   3.  issueLease throws ForbiddenError when stage is not approved.
+ *   4.  issueLease throws ForbiddenError when pipeline run is not 'running'.
+ *   5.  issueLease succeeds (approved + running) and returns a CredentialLease
+ *       with the decrypted secret.
+ *   6.  Rate limit: issueLease throws after RATE_LIMIT_MAX requests in one window.
+ *   7.  revokeLease marks the lease revoked (idempotent on already-revoked).
+ *   8.  revokeRunLeases marks all active leases for the run revoked; no-op when
+ *       no active leases exist.
+ *   9.  expireStaleLeases marks active leases past their expiresAt as 'expired'.
+ *   10. Audit rows are written with correct action on each operation.
+ *   11. accessSecret (Wave-2): project-scope, system-context, audit, no-context throw.
+ *   12. No direct crypto.decrypt() import outside the broker (grep-style assertion).
+ *
+ * Strategy:
+ *   - `server/db.js` is fully mocked: each test controls what the DB returns via
+ *     `MOCK_DB`.  The mock tracks inserts/updates through `inserted` and `updated`
+ *     spy arrays so tests can assert on audit log rows and lease mutations.
+ *   - `server/crypto.js` is mocked: decrypt returns a deterministic secret map.
+ *   - `server/context.js` is NOT mocked — we use runAsProject() so the real ALS
+ *     context is set.  This tests the assertProject() invariant end-to-end.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// ─── Hoisted mutable state (available inside vi.mock factories) ───────────────
+
+const MOCK_DB = vi.hoisted(() => ({
+  // Tables that SELECT queries resolve from.
+  workspaceConnectionsRows: [] as Record<string, unknown>[],
+  workspacesRows: [] as Record<string, unknown>[],
+  pipelineRunsRows: [] as Record<string, unknown>[],
+  stageExecutionsRows: [] as Record<string, unknown>[],
+  credentialLeasesRows: [] as Record<string, unknown>[],
+
+  // Spy arrays for write operations.
+  inserted: [] as { table: string; values: Record<string, unknown> }[],
+  updated: [] as { table: string; set: Record<string, unknown>; where: unknown }[],
+
+  // Next UUID to return from insert().returning()
+  nextLeaseId: "lease-uuid-1",
+}));
+
+// ─── DB mock ──────────────────────────────────────────────────────────────────
+//
+// We mock the db object returned by "server/db.js".
+// withProject is a no-op passthrough (the broker does its own context assertion).
+// withProjectInsert is a no-op passthrough.
+//
+// The SELECT query builder resolves based on the first .from() table name
+// (identified via Symbol.for("drizzle:BaseName")).
+//
+// The SELECT join path (workspaceConnections + workspaces) resolves from
+// workspaceConnectionsRows filtered by workspaceId → workspacesRows.
+
+vi.mock("../../../server/db.js", () => {
+  const TABLE = Symbol.for("drizzle:BaseName");
+
+  function makeSelectChain(rows: () => Record<string, unknown>[]) {
+    let _where: unknown;
+    const chain: Record<string, unknown> = {};
+
+    chain.from = vi.fn().mockReturnValue(chain);
+    chain.innerJoin = vi.fn().mockReturnValue(chain);
+    chain.where = vi.fn().mockImplementation((w: unknown) => {
+      _where = w;
+      return chain;
+    });
+    chain.orderBy = vi.fn().mockReturnValue(rows());
+
+    // Make the chain awaitable (resolves on .where() result).
+    // Vitest awaits the chain directly using Symbol.iterator / Promise-like.
+    // The simplest approach: make the chain a thenable that returns rows().
+    (chain as any)[Symbol.for("vitest:resolved")] = rows;
+    (chain as any).then = (resolve: (v: unknown) => void, reject: (e: unknown) => void) => {
+      try { resolve(rows()); } catch (e) { reject(e); }
+      return Promise.resolve(rows());
+    };
+
+    return chain;
+  }
+
+  return {
+    db: {
+      select: vi.fn().mockImplementation((columns?: unknown) => {
+        // Track which table is being queried from the .from() call.
+        let tableName = "";
+        const outerChain: Record<string, unknown> = {};
+
+        outerChain.from = vi.fn().mockImplementation((table: unknown) => {
+          tableName = (table as Record<symbol, string>)[TABLE] ?? "";
+
+          let innerChain: Record<string, unknown> = {};
+
+          // ── JOIN path: workspaceConnections ─────────────────────────────
+          if (tableName === "workspace_connections") {
+            innerChain.innerJoin = vi.fn().mockReturnValue(innerChain);
+            innerChain.where = vi.fn().mockImplementation(() => innerChain);
+            (innerChain as any).then = (resolve: (v: unknown) => void) => {
+              resolve(MOCK_DB.workspaceConnectionsRows);
+              return Promise.resolve(MOCK_DB.workspaceConnectionsRows);
+            };
+            return innerChain;
+          }
+
+          // ── Simple SELECT paths ─────────────────────────────────────────
+          const rowsForTable = () => {
+            if (tableName === "workspaces")           return MOCK_DB.workspacesRows;
+            if (tableName === "pipeline_runs")        return MOCK_DB.pipelineRunsRows;
+            if (tableName === "stage_executions")     return MOCK_DB.stageExecutionsRows;
+            if (tableName === "credential_leases")    return MOCK_DB.credentialLeasesRows;
+            return [];
+          };
+
+          innerChain.where = vi.fn().mockImplementation(() => innerChain);
+          innerChain.orderBy = vi.fn().mockImplementation(() => rowsForTable());
+          (innerChain as any).then = (resolve: (v: unknown) => void) => {
+            resolve(rowsForTable());
+            return Promise.resolve(rowsForTable());
+          };
+          return innerChain;
+        });
+
+        return outerChain;
+      }),
+
+      insert: vi.fn().mockImplementation((table: unknown) => {
+        const tableName = (table as Record<symbol, string>)[TABLE] ?? "";
+        return {
+          values: vi.fn().mockImplementation((vals: Record<string, unknown>) => {
+            // Record the insert for assertions.
+            MOCK_DB.inserted.push({ table: tableName, values: vals });
+
+            const returning = () => {
+              if (tableName === "credential_leases") {
+                return [{ ...vals, id: MOCK_DB.nextLeaseId }];
+              }
+              return [{ ...vals, id: "log-uuid-1" }];
+            };
+
+            return {
+              returning: vi.fn().mockReturnValue(returning()),
+              // Make INSERT awaitable without .returning()
+              then: (resolve: (v: unknown) => void) => {
+                resolve(undefined);
+                return Promise.resolve(undefined);
+              },
+            };
+          }),
+        };
+      }),
+
+      update: vi.fn().mockImplementation((table: unknown) => {
+        const tableName = (table as Record<symbol, string>)[TABLE] ?? "";
+        const updateEntry: { table: string; set: Record<string, unknown>; where: unknown } = {
+          table: tableName,
+          set: {},
+          where: null,
+        };
+        MOCK_DB.updated.push(updateEntry);
+
+        const chain: Record<string, unknown> = {};
+        chain.set = vi.fn().mockImplementation((s: Record<string, unknown>) => {
+          updateEntry.set = s;
+          return chain;
+        });
+        chain.where = vi.fn().mockImplementation((w: unknown) => {
+          updateEntry.where = w;
+          return chain;
+        });
+        chain.returning = vi.fn().mockReturnValue([]);
+        (chain as any).then = (resolve: (v: unknown) => void) => {
+          resolve(undefined);
+          return Promise.resolve(undefined);
+        };
+
+        return chain;
+      }),
+
+      delete: vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockReturnValue(Promise.resolve()),
+      })),
+    },
+    pool: { on: vi.fn() },
+    withProject: (_t: unknown, cond?: unknown) => cond ?? {},
+    withProjectInsert: (_t: unknown, data: unknown) => data,
+    runMigrations: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+// ─── Crypto mock ──────────────────────────────────────────────────────────────
+
+vi.mock("../../../server/crypto.js", () => ({
+  encrypt: vi.fn((v: string) => `v2:${v}`),
+  decrypt: vi.fn((_ciphertext: string) =>
+    JSON.stringify({ API_TOKEN: "secret-value-123" }),
+  ),
+  isV2: vi.fn(() => true),
+}));
+
+// ─── Config mock (required by crypto.ts import chain) ─────────────────────────
+
+vi.mock("../../../server/config/loader.js", () => ({
+  configLoader: {
+    get: () => ({
+      encryption: { key: "test-key-32-chars-exactly-paddedX" },
+      database: { url: undefined },
+    }),
+  },
+}));
+
+// ─── Import under test AFTER mocks ───────────────────────────────────────────
+
+import {
+  DbCryptoCredentialProvider,
+  expireStaleLeases,
+  markLeaseUsed,
+  _resetRateLimitStore,
+} from "../../../server/credentials/db-crypto-provider.js";
+import { ForbiddenError } from "../../../server/credentials/types.js";
+import { runAsProject, runAsSystem } from "../../../server/context.js";
+import type { CredentialLease } from "../../../server/credentials/types.js";
+
+// ─── Test fixtures ────────────────────────────────────────────────────────────
+
+const PROJECT_A = "proj-a";
+const PROJECT_B = "proj-b";
+const WORKSPACE_ID = "ws-1";
+const CONN_ID = "conn-abc";
+const RUN_ID = "run-xyz";
+const STAGE_ID = "stage-001";
+const USER = "user-test";
+
+function makeConn(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: CONN_ID,
+    workspaceId: WORKSPACE_ID,
+    type: "github",
+    name: "My GitHub",
+    configJson: {},
+    secretsEncrypted: "v2:enc-secrets",
+    status: "active",
+    lastTestedAt: null,
+    createdAt: new Date("2026-01-01"),
+    updatedAt: new Date("2026-01-15"),
+    createdBy: null,
+    ...overrides,
+  };
+}
+
+function makeApprovedStageExec(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: STAGE_ID,
+    runId: RUN_ID,
+    projectId: PROJECT_A,
+    approvalStatus: "approved",
+    stageIndex: 0,
+    ...overrides,
+  };
+}
+
+function makeRunningPipelineRun(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: RUN_ID,
+    projectId: PROJECT_A,
+    status: "running",
+    pipelineId: "pipe-1",
+    input: "",
+    currentStageIndex: 0,
+    dagMode: false,
+    ...overrides,
+  };
+}
+
+function makeLease(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "lease-uuid-1",
+    credentialId: CONN_ID,
+    projectId: PROJECT_A,
+    runId: RUN_ID,
+    stageId: STAGE_ID,
+    requestedBy: USER,
+    issuedAt: new Date(Date.now() - 1000),
+    expiresAt: new Date(Date.now() + 290_000),  // expires in 290 s
+    revokedAt: null,
+    status: "active",
+    ...overrides,
+  };
+}
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+function resetMock() {
+  MOCK_DB.workspaceConnectionsRows = [];
+  MOCK_DB.workspacesRows = [];
+  MOCK_DB.pipelineRunsRows = [];
+  MOCK_DB.stageExecutionsRows = [];
+  MOCK_DB.credentialLeasesRows = [];
+  MOCK_DB.inserted = [];
+  MOCK_DB.updated = [];
+  MOCK_DB.nextLeaseId = "lease-uuid-1";
+  _resetRateLimitStore();
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("DbCryptoCredentialProvider", () => {
+  let provider: DbCryptoCredentialProvider;
+
+  beforeEach(() => {
+    resetMock();
+    provider = new DbCryptoCredentialProvider();
+  });
+
+  // ── 1. projectId-mismatch ────────────────────────────────────────────────────
+
+  describe("projectId context assertion", () => {
+    it("listCredentials throws ForbiddenError when projectId !== context", async () => {
+      await runAsProject(PROJECT_A, async () => {
+        await expect(provider.listCredentials(PROJECT_B)).rejects.toThrow(
+          ForbiddenError,
+        );
+      });
+    });
+
+    it("getCredentialMetadata throws ForbiddenError when projectId !== context", async () => {
+      await runAsProject(PROJECT_A, async () => {
+        await expect(
+          provider.getCredentialMetadata(PROJECT_B, CONN_ID),
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+
+    it("issueLease throws ForbiddenError when projectId !== context", async () => {
+      await runAsProject(PROJECT_A, async () => {
+        await expect(
+          provider.issueLease({
+            projectId: PROJECT_B,
+            credentialId: CONN_ID,
+            runId: RUN_ID,
+            stageId: STAGE_ID,
+            requestedBy: USER,
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+  });
+
+  // ── 2. Plan-time methods never return secret material ────────────────────────
+
+  describe("plan-time metadata methods", () => {
+    it("listCredentials returns CredentialMetadata array — no secret fields", async () => {
+      MOCK_DB.workspaceConnectionsRows = [makeConn()];
+
+      const result = await runAsProject(PROJECT_A, () =>
+        provider.listCredentials(PROJECT_A),
+      );
+
+      expect(result).toHaveLength(1);
+      const meta = result[0];
+      expect(meta.id).toBe(CONN_ID);
+      expect(meta.projectId).toBe(PROJECT_A);
+      expect(meta.provider).toBe("github");
+      expect(meta.hasSecret).toBe(true);
+      // No secret material on the metadata shape.
+      expect((meta as any).secret).toBeUndefined();
+      expect((meta as any).secretsEncrypted).toBeUndefined();
+      expect((meta as any).value).toBeUndefined();
+    });
+
+    it("listCredentials returns hasSecret=false when no secretsEncrypted", async () => {
+      MOCK_DB.workspaceConnectionsRows = [makeConn({ secretsEncrypted: null })];
+
+      const result = await runAsProject(PROJECT_A, () =>
+        provider.listCredentials(PROJECT_A),
+      );
+
+      expect(result[0].hasSecret).toBe(false);
+    });
+
+    it("getCredentialMetadata returns metadata — no secret fields", async () => {
+      MOCK_DB.workspaceConnectionsRows = [makeConn()];
+
+      const result = await runAsProject(PROJECT_A, () =>
+        provider.getCredentialMetadata(PROJECT_A, CONN_ID),
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(CONN_ID);
+      expect((result as any).secret).toBeUndefined();
+      expect((result as any).secretsEncrypted).toBeUndefined();
+    });
+
+    it("getCredentialMetadata returns null for unknown credential", async () => {
+      MOCK_DB.workspaceConnectionsRows = [];
+
+      const result = await runAsProject(PROJECT_A, () =>
+        provider.getCredentialMetadata(PROJECT_A, "unknown-id"),
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("listCredentials writes list_metadata audit log", async () => {
+      MOCK_DB.workspaceConnectionsRows = [];
+
+      await runAsProject(PROJECT_A, () => provider.listCredentials(PROJECT_A));
+
+      const auditInserts = MOCK_DB.inserted.filter(
+        (i) => i.table === "credential_access_log",
+      );
+      expect(auditInserts).toHaveLength(1);
+      expect(auditInserts[0].values.action).toBe("list_metadata");
+      expect(auditInserts[0].values.success).toBe(true);
+    });
+  });
+
+  // ── 3. issueLease throws on unapproved stage ──────────────────────────────────
+
+  describe("issueLease — approval gate", () => {
+    it("throws ForbiddenError when stage not found", async () => {
+      MOCK_DB.stageExecutionsRows = [];
+      MOCK_DB.pipelineRunsRows = [makeRunningPipelineRun()];
+
+      await runAsProject(PROJECT_A, async () => {
+        await expect(
+          provider.issueLease({
+            projectId: PROJECT_A,
+            credentialId: CONN_ID,
+            runId: RUN_ID,
+            stageId: STAGE_ID,
+            requestedBy: USER,
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+
+    it("throws ForbiddenError when approvalStatus is pending", async () => {
+      MOCK_DB.stageExecutionsRows = [
+        makeApprovedStageExec({ approvalStatus: "pending" }),
+      ];
+      MOCK_DB.pipelineRunsRows = [makeRunningPipelineRun()];
+
+      await runAsProject(PROJECT_A, async () => {
+        await expect(
+          provider.issueLease({
+            projectId: PROJECT_A,
+            credentialId: CONN_ID,
+            runId: RUN_ID,
+            stageId: STAGE_ID,
+            requestedBy: USER,
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+
+    it("throws ForbiddenError when approvalStatus is rejected", async () => {
+      MOCK_DB.stageExecutionsRows = [
+        makeApprovedStageExec({ approvalStatus: "rejected" }),
+      ];
+      MOCK_DB.pipelineRunsRows = [makeRunningPipelineRun()];
+
+      await runAsProject(PROJECT_A, async () => {
+        await expect(
+          provider.issueLease({
+            projectId: PROJECT_A,
+            credentialId: CONN_ID,
+            runId: RUN_ID,
+            stageId: STAGE_ID,
+            requestedBy: USER,
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+
+    it("throws ForbiddenError when approvalStatus is null", async () => {
+      MOCK_DB.stageExecutionsRows = [
+        makeApprovedStageExec({ approvalStatus: null }),
+      ];
+      MOCK_DB.pipelineRunsRows = [makeRunningPipelineRun()];
+
+      await runAsProject(PROJECT_A, async () => {
+        await expect(
+          provider.issueLease({
+            projectId: PROJECT_A,
+            credentialId: CONN_ID,
+            runId: RUN_ID,
+            stageId: STAGE_ID,
+            requestedBy: USER,
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+  });
+
+  // ── 4. issueLease throws on non-running run ───────────────────────────────────
+
+  describe("issueLease — run-state gate", () => {
+    it("throws ForbiddenError when pipeline run not found", async () => {
+      MOCK_DB.stageExecutionsRows = [makeApprovedStageExec()];
+      MOCK_DB.pipelineRunsRows = [];
+
+      await runAsProject(PROJECT_A, async () => {
+        await expect(
+          provider.issueLease({
+            projectId: PROJECT_A,
+            credentialId: CONN_ID,
+            runId: RUN_ID,
+            stageId: STAGE_ID,
+            requestedBy: USER,
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+
+    it("throws ForbiddenError when pipeline run status is paused", async () => {
+      MOCK_DB.stageExecutionsRows = [makeApprovedStageExec()];
+      MOCK_DB.pipelineRunsRows = [makeRunningPipelineRun({ status: "paused" })];
+
+      await runAsProject(PROJECT_A, async () => {
+        await expect(
+          provider.issueLease({
+            projectId: PROJECT_A,
+            credentialId: CONN_ID,
+            runId: RUN_ID,
+            stageId: STAGE_ID,
+            requestedBy: USER,
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+
+    it("throws ForbiddenError when pipeline run status is completed", async () => {
+      MOCK_DB.stageExecutionsRows = [makeApprovedStageExec()];
+      MOCK_DB.pipelineRunsRows = [
+        makeRunningPipelineRun({ status: "completed" }),
+      ];
+
+      await runAsProject(PROJECT_A, async () => {
+        await expect(
+          provider.issueLease({
+            projectId: PROJECT_A,
+            credentialId: CONN_ID,
+            runId: RUN_ID,
+            stageId: STAGE_ID,
+            requestedBy: USER,
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+
+    it("throws ForbiddenError when pipeline run status is failed", async () => {
+      MOCK_DB.stageExecutionsRows = [makeApprovedStageExec()];
+      MOCK_DB.pipelineRunsRows = [makeRunningPipelineRun({ status: "failed" })];
+
+      await runAsProject(PROJECT_A, async () => {
+        await expect(
+          provider.issueLease({
+            projectId: PROJECT_A,
+            credentialId: CONN_ID,
+            runId: RUN_ID,
+            stageId: STAGE_ID,
+            requestedBy: USER,
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+  });
+
+  // ── 5. issueLease succeeds on approved + running ──────────────────────────────
+
+  describe("issueLease — happy path", () => {
+    it("returns a CredentialLease with static secret on approved+running", async () => {
+      MOCK_DB.stageExecutionsRows = [makeApprovedStageExec()];
+      MOCK_DB.pipelineRunsRows = [makeRunningPipelineRun()];
+      MOCK_DB.workspaceConnectionsRows = [makeConn()];
+
+      const lease = await runAsProject(PROJECT_A, () =>
+        provider.issueLease({
+          projectId: PROJECT_A,
+          credentialId: CONN_ID,
+          runId: RUN_ID,
+          stageId: STAGE_ID,
+          requestedBy: USER,
+        }),
+      );
+
+      expect(lease.leaseId).toBe("lease-uuid-1");
+      expect(lease.credentialId).toBe(CONN_ID);
+      expect(lease.projectId).toBe(PROJECT_A);
+      expect(lease.runId).toBe(RUN_ID);
+      expect(lease.stageId).toBe(STAGE_ID);
+      expect(lease.secret.type).toBe("static");
+      // Secret value is the JSON-serialised secrets map.
+      expect(JSON.parse((lease.secret as { type: "static"; value: string }).value)).toEqual({
+        API_TOKEN: "secret-value-123",
+      });
+    });
+
+    it("respects custom ttlSeconds (capped at 900)", async () => {
+      MOCK_DB.stageExecutionsRows = [makeApprovedStageExec()];
+      MOCK_DB.pipelineRunsRows = [makeRunningPipelineRun()];
+      MOCK_DB.workspaceConnectionsRows = [makeConn()];
+
+      const before = Date.now();
+      const lease = await runAsProject(PROJECT_A, () =>
+        provider.issueLease({
+          projectId: PROJECT_A,
+          credentialId: CONN_ID,
+          runId: RUN_ID,
+          stageId: STAGE_ID,
+          requestedBy: USER,
+          ttlSeconds: 600,
+        }),
+      );
+      const after = Date.now();
+
+      const ttlMs = lease.expiresAt.getTime() - lease.issuedAt.getTime();
+      expect(ttlMs).toBe(600_000);
+      expect(lease.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 600_000);
+      expect(lease.expiresAt.getTime()).toBeLessThanOrEqual(after + 600_000 + 100);
+    });
+
+    it("caps ttlSeconds at 900 when provided value exceeds max", async () => {
+      MOCK_DB.stageExecutionsRows = [makeApprovedStageExec()];
+      MOCK_DB.pipelineRunsRows = [makeRunningPipelineRun()];
+      MOCK_DB.workspaceConnectionsRows = [makeConn()];
+
+      const lease = await runAsProject(PROJECT_A, () =>
+        provider.issueLease({
+          projectId: PROJECT_A,
+          credentialId: CONN_ID,
+          runId: RUN_ID,
+          stageId: STAGE_ID,
+          requestedBy: USER,
+          ttlSeconds: 9999,
+        }),
+      );
+
+      const ttlMs = lease.expiresAt.getTime() - lease.issuedAt.getTime();
+      expect(ttlMs).toBe(900_000);
+    });
+
+    it("writes lease_issued audit log row", async () => {
+      MOCK_DB.stageExecutionsRows = [makeApprovedStageExec()];
+      MOCK_DB.pipelineRunsRows = [makeRunningPipelineRun()];
+      MOCK_DB.workspaceConnectionsRows = [makeConn()];
+
+      await runAsProject(PROJECT_A, () =>
+        provider.issueLease({
+          projectId: PROJECT_A,
+          credentialId: CONN_ID,
+          runId: RUN_ID,
+          stageId: STAGE_ID,
+          requestedBy: USER,
+          justification: "deploy-job",
+        }),
+      );
+
+      const auditInserts = MOCK_DB.inserted.filter(
+        (i) => i.table === "credential_access_log",
+      );
+      expect(auditInserts).toHaveLength(1);
+      const log = auditInserts[0].values;
+      expect(log.action).toBe("lease_issued");
+      expect(log.credentialId).toBe(CONN_ID);
+      expect(log.projectId).toBe(PROJECT_A);
+      expect(log.runId).toBe(RUN_ID);
+      expect(log.stageId).toBe(STAGE_ID);
+      expect(log.success).toBe(true);
+      expect(log.justification).toBe("deploy-job");
+      expect(log.ttlSeconds).toBe(300); // default
+    });
+
+    it("writes lease row to credential_leases", async () => {
+      MOCK_DB.stageExecutionsRows = [makeApprovedStageExec()];
+      MOCK_DB.pipelineRunsRows = [makeRunningPipelineRun()];
+      MOCK_DB.workspaceConnectionsRows = [makeConn()];
+
+      await runAsProject(PROJECT_A, () =>
+        provider.issueLease({
+          projectId: PROJECT_A,
+          credentialId: CONN_ID,
+          runId: RUN_ID,
+          stageId: STAGE_ID,
+          requestedBy: USER,
+        }),
+      );
+
+      const leaseInserts = MOCK_DB.inserted.filter(
+        (i) => i.table === "credential_leases",
+      );
+      expect(leaseInserts).toHaveLength(1);
+      const row = leaseInserts[0].values;
+      expect(row.credentialId).toBe(CONN_ID);
+      expect(row.projectId).toBe(PROJECT_A);
+      expect(row.status).toBe("active");
+    });
+  });
+
+  // ── 6. Rate limiting ──────────────────────────────────────────────────────────
+
+  describe("issueLease — rate limiting", () => {
+    it("allows up to RATE_LIMIT_MAX requests then throws ForbiddenError", async () => {
+      // We can't reach the DB check easily without a full happy-path setup.
+      // Instead test that ForbiddenError is thrown after the limit.
+      // Use a unique runId per test suite to avoid cross-test contamination.
+      const RUN = "rate-limit-run";
+
+      MOCK_DB.stageExecutionsRows = [makeApprovedStageExec({ runId: RUN })];
+      MOCK_DB.pipelineRunsRows = [makeRunningPipelineRun({ id: RUN })];
+      MOCK_DB.workspaceConnectionsRows = [makeConn()];
+
+      // Send 10 successful requests (the limit).
+      const results: CredentialLease[] = [];
+      for (let i = 0; i < 10; i++) {
+        MOCK_DB.nextLeaseId = `lease-rate-${i}`;
+        MOCK_DB.inserted = [];
+        const r = await runAsProject(PROJECT_A, () =>
+          provider.issueLease({
+            projectId: PROJECT_A,
+            credentialId: CONN_ID,
+            runId: RUN,
+            stageId: STAGE_ID,
+            requestedBy: USER,
+          }),
+        );
+        results.push(r);
+      }
+      expect(results).toHaveLength(10);
+
+      // The 11th request must throw ForbiddenError.
+      await runAsProject(PROJECT_A, async () => {
+        await expect(
+          provider.issueLease({
+            projectId: PROJECT_A,
+            credentialId: CONN_ID,
+            runId: RUN,
+            stageId: STAGE_ID,
+            requestedBy: USER,
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+  });
+
+  // ── 7. revokeLease ────────────────────────────────────────────────────────────
+
+  describe("revokeLease", () => {
+    it("marks lease revoked and writes audit log", async () => {
+      MOCK_DB.credentialLeasesRows = [makeLease()];
+
+      await runAsProject(PROJECT_A, () => provider.revokeLease("lease-uuid-1"));
+
+      // The update should have status='revoked'.
+      const leaseUpdates = MOCK_DB.updated.filter(
+        (u) => u.table === "credential_leases",
+      );
+      expect(leaseUpdates).toHaveLength(1);
+      expect(leaseUpdates[0].set.status).toBe("revoked");
+      expect(leaseUpdates[0].set.revokedAt).toBeDefined();
+
+      // Audit log written.
+      const auditInserts = MOCK_DB.inserted.filter(
+        (i) => i.table === "credential_access_log",
+      );
+      expect(auditInserts).toHaveLength(1);
+      expect(auditInserts[0].values.action).toBe("lease_revoked");
+    });
+
+    it("is idempotent — no-op when lease is already revoked", async () => {
+      MOCK_DB.credentialLeasesRows = [makeLease({ status: "revoked" })];
+
+      await runAsProject(PROJECT_A, () => provider.revokeLease("lease-uuid-1"));
+
+      // No update should be issued.
+      expect(MOCK_DB.updated).toHaveLength(0);
+    });
+
+    it("throws ForbiddenError when lease belongs to a different project", async () => {
+      MOCK_DB.credentialLeasesRows = [makeLease({ projectId: PROJECT_B })];
+
+      await runAsProject(PROJECT_A, async () => {
+        await expect(provider.revokeLease("lease-uuid-1")).rejects.toThrow(
+          ForbiddenError,
+        );
+      });
+    });
+  });
+
+  // ── 8. revokeRunLeases ───────────────────────────────────────────────────────
+
+  describe("revokeRunLeases", () => {
+    it("marks all active leases for the run revoked", async () => {
+      MOCK_DB.credentialLeasesRows = [
+        makeLease({ id: "l1", status: "active" }),
+        makeLease({ id: "l2", status: "active" }),
+      ];
+
+      await runAsProject(PROJECT_A, () => provider.revokeRunLeases(RUN_ID));
+
+      const leaseUpdates = MOCK_DB.updated.filter(
+        (u) => u.table === "credential_leases",
+      );
+      expect(leaseUpdates).toHaveLength(1);
+      expect(leaseUpdates[0].set.status).toBe("revoked");
+
+      // Two audit log rows (one per lease).
+      const auditInserts = MOCK_DB.inserted.filter(
+        (i) => i.table === "credential_access_log",
+      );
+      expect(auditInserts).toHaveLength(2);
+      auditInserts.forEach((a) => expect(a.values.action).toBe("lease_revoked"));
+    });
+
+    it("is a no-op when no active leases exist for the run", async () => {
+      MOCK_DB.credentialLeasesRows = [];
+
+      // Must not throw.
+      await expect(
+        runAsProject(PROJECT_A, () => provider.revokeRunLeases(RUN_ID)),
+      ).resolves.toBeUndefined();
+
+      expect(MOCK_DB.updated).toHaveLength(0);
+      expect(MOCK_DB.inserted).toHaveLength(0);
+    });
+
+    it("is a no-op when all leases are already revoked", async () => {
+      MOCK_DB.credentialLeasesRows = [
+        makeLease({ id: "l1", status: "revoked" }),
+      ];
+      // Filter on status='active' returns nothing.
+      // But our mock returns all rows from credentialLeasesRows regardless of filter.
+      // We need to filter in the mock result for this test.
+      // Since the mock returns all rows from credentialLeasesRows, we simulate no active
+      // leases by setting the array to an already-revoked lease and then overriding the
+      // WHERE-filter result. The simplest approach: set rows to empty so the broker
+      // sees no active leases.
+      MOCK_DB.credentialLeasesRows = [];
+
+      await expect(
+        runAsProject(PROJECT_A, () => provider.revokeRunLeases(RUN_ID)),
+      ).resolves.toBeUndefined();
+
+      expect(MOCK_DB.updated).toHaveLength(0);
+    });
+  });
+
+  // ── 9. expireStaleLeases sweeper ─────────────────────────────────────────────
+
+  describe("expireStaleLeases", () => {
+    it("returns 0 when no leases to expire", async () => {
+      // update().returning() returns [] by default.
+      const count = await expireStaleLeases();
+      expect(count).toBe(0);
+    });
+
+    it("marks active expired leases as expired and writes audit rows", async () => {
+      // Override update chain to return fake expired leases.
+      const expiredLease = makeLease({
+        id: "old-lease",
+        status: "active",
+        expiresAt: new Date(Date.now() - 60_000), // expired 1 min ago
+      });
+
+      // Patch the db.update mock to return expired lease for the first call.
+      const { db: mockDb } = await import("../../../server/db.js");
+      (mockDb.update as ReturnType<typeof vi.fn>).mockImplementationOnce(
+        (table: unknown) => {
+          const tableName = (table as Record<symbol, string>)[Symbol.for("drizzle:BaseName")] ?? "";
+          const entry = { table: tableName, set: {} as Record<string, unknown>, where: null };
+          MOCK_DB.updated.push(entry);
+          const chain: Record<string, unknown> = {};
+          chain.set = vi.fn().mockImplementation((s: Record<string, unknown>) => {
+            entry.set = s;
+            return chain;
+          });
+          chain.where = vi.fn().mockReturnValue(chain);
+          chain.returning = vi.fn().mockReturnValue([expiredLease]);
+          return chain;
+        },
+      );
+
+      const count = await expireStaleLeases();
+      expect(count).toBe(1);
+
+      // Should have written a lease_expired audit log row.
+      const auditInserts = MOCK_DB.inserted.filter(
+        (i) => i.table === "credential_access_log",
+      );
+      expect(auditInserts).toHaveLength(1);
+      expect(auditInserts[0].values.action).toBe("lease_expired");
+      expect(auditInserts[0].values.leaseId).toBe("old-lease");
+      expect(auditInserts[0].values.requestedBy).toBe("system-sweeper");
+    });
+  });
+
+  // ── 10. markLeaseUsed ────────────────────────────────────────────────────────
+
+  describe("markLeaseUsed", () => {
+    it("writes a lease_used audit log row", async () => {
+      MOCK_DB.credentialLeasesRows = [makeLease()];
+
+      await markLeaseUsed("lease-uuid-1", USER);
+
+      const auditInserts = MOCK_DB.inserted.filter(
+        (i) => i.table === "credential_access_log",
+      );
+      expect(auditInserts).toHaveLength(1);
+      expect(auditInserts[0].values.action).toBe("lease_used");
+      expect(auditInserts[0].values.leaseId).toBe("lease-uuid-1");
+      expect(auditInserts[0].values.requestedBy).toBe(USER);
+    });
+
+    it("throws when lease not found", async () => {
+      MOCK_DB.credentialLeasesRows = [];
+
+      await expect(markLeaseUsed("unknown-lease", USER)).rejects.toThrow(
+        /not found/,
+      );
+    });
+  });
+
+  // ── 11. accessSecret — Wave-2 non-lease direct access ────────────────────────
+  //
+  // accessSecret is the SYSTEM/non-run analogue of issueLease.  It routes ALL
+  // remaining crypto.decrypt() calls through the broker with project-scope +
+  // audit enforcement (ADR-001 PR-1d).
+
+  describe("accessSecret", () => {
+    const CIPHERTEXT = "v2:enc-secret-abc";
+    const CRED_ID = "trackerConn:tc-1";
+    const PURPOSE = "test-purpose";
+
+    it("returns decrypted plaintext in project context", async () => {
+      const result = await runAsProject(PROJECT_A, () =>
+        provider.accessSecret({
+          ciphertext: CIPHERTEXT,
+          credentialId: CRED_ID,
+          projectId: PROJECT_A,
+          purpose: PURPOSE,
+        }),
+      );
+      // decrypt mock returns JSON.stringify({ API_TOKEN: "secret-value-123" })
+      expect(result).toBe(JSON.stringify({ API_TOKEN: "secret-value-123" }));
+    });
+
+    it("throws ForbiddenError in project context when projectId !== context", async () => {
+      // Project A context but requesting PROJECT_B credential — must be rejected.
+      await runAsProject(PROJECT_A, async () => {
+        await expect(
+          provider.accessSecret({
+            ciphertext: CIPHERTEXT,
+            credentialId: CRED_ID,
+            projectId: PROJECT_B,
+            purpose: PURPOSE,
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+
+    it("writes secret_accessed audit row on success (project context)", async () => {
+      await runAsProject(PROJECT_A, () =>
+        provider.accessSecret({
+          ciphertext: CIPHERTEXT,
+          credentialId: CRED_ID,
+          projectId: PROJECT_A,
+          purpose: PURPOSE,
+          requestedBy: USER,
+        }),
+      );
+
+      const auditRows = MOCK_DB.inserted.filter(
+        (i) => i.table === "credential_access_log",
+      );
+      expect(auditRows).toHaveLength(1);
+      const row = auditRows[0].values;
+      expect(row.action).toBe("secret_accessed");
+      expect(row.credentialId).toBe(CRED_ID);
+      expect(row.projectId).toBe(PROJECT_A);
+      expect(row.justification).toBe(PURPOSE);
+      expect(row.requestedBy).toBe(USER);
+      expect(row.success).toBe(true);
+    });
+
+    it("succeeds in system context without project assertion", async () => {
+      // In system context, getProjectId() would throw — but accessSecret skips
+      // assertProject() in system context and should succeed.
+      const result = await runAsSystem("test-system-context", () =>
+        provider.accessSecret({
+          ciphertext: CIPHERTEXT,
+          credentialId: CRED_ID,
+          projectId: PROJECT_B,  // arbitrary project — no assertion in system context
+          purpose: PURPOSE,
+        }),
+      );
+      expect(result).toBe(JSON.stringify({ API_TOKEN: "secret-value-123" }));
+    });
+
+    it("writes secret_accessed audit row in system context", async () => {
+      await runAsSystem("test-system-access", () =>
+        provider.accessSecret({
+          ciphertext: CIPHERTEXT,
+          credentialId: CRED_ID,
+          projectId: PROJECT_A,  // passed explicitly by caller for audit
+          purpose: PURPOSE,
+          requestedBy: "system-loader",
+        }),
+      );
+
+      const auditRows = MOCK_DB.inserted.filter(
+        (i) => i.table === "credential_access_log",
+      );
+      expect(auditRows).toHaveLength(1);
+      const row = auditRows[0].values;
+      expect(row.action).toBe("secret_accessed");
+      expect(row.projectId).toBe(PROJECT_A);
+      expect(row.requestedBy).toBe("system-loader");
+      expect(row.success).toBe(true);
+    });
+
+    it("throws when called outside any ALS context", async () => {
+      // No runAsProject / runAsSystem wrapper — should throw.
+      await expect(
+        provider.accessSecret({
+          ciphertext: CIPHERTEXT,
+          credentialId: CRED_ID,
+          projectId: PROJECT_A,
+          purpose: PURPOSE,
+        }),
+      ).rejects.toThrow(/requires an ALS context/);
+    });
+
+    it("skips audit and still decrypts when projectId is empty (legacy row)", async () => {
+      // Empty projectId signals a legacy row without a projectId column value.
+      // The broker should still decrypt but skip the audit write (with a warning).
+      const result = await runAsSystem("test-legacy-row", () =>
+        provider.accessSecret({
+          ciphertext: CIPHERTEXT,
+          credentialId: CRED_ID,
+          projectId: "",  // empty: audit row skipped, decrypt still succeeds
+          purpose: PURPOSE,
+        }),
+      );
+      expect(result).toBe(JSON.stringify({ API_TOKEN: "secret-value-123" }));
+      // No audit row should have been written for an empty projectId.
+      const auditRows = MOCK_DB.inserted.filter(
+        (i) => i.table === "credential_access_log",
+      );
+      expect(auditRows).toHaveLength(0);
+    });
+  });
+
+  // ── 12. No direct crypto.decrypt() import outside the broker ─────────────────
+  //
+  // Enforcement test: verifies that no server/ TypeScript file outside the
+  // credential broker (and a short allowlist of legitimately different decrypt
+  // implementations) imports `decrypt` from the main ../crypto module.
+  //
+  // After ADR-001 Wave-2, crypto.decrypt() must ONLY be called inside
+  // server/credentials/db-crypto-provider.ts (and rekey/migration scripts).
+
+  describe("ADR-001 PR-1d enforcement: no direct crypto.decrypt() outside broker", () => {
+    it("no server/ .ts file outside the allowlist imports decrypt from main crypto", async () => {
+      const { readFileSync, readdirSync, statSync } = await import("fs");
+      const { join } = await import("path");
+
+      // Resolve repo root from this test file's location.
+      // test is at tests/unit/credentials/ → root is 3 levels up.
+      const testDir = new URL(".", import.meta.url).pathname;
+      const root = join(testDir, "..", "..", "..");
+      const serverDir = join(root, "server");
+
+      // Walk server/ and collect all .ts files.
+      function walk(dir: string): string[] {
+        const out: string[] = [];
+        for (const entry of readdirSync(dir)) {
+          const full = join(dir, entry);
+          try {
+            if (statSync(full).isDirectory()) {
+              out.push(...walk(full));
+            } else if (entry.endsWith(".ts") && !entry.endsWith(".d.ts")) {
+              out.push(full);
+            }
+          } catch {
+            // ignore unreadable entries
+          }
+        }
+        return out;
+      }
+
+      // Files that are ALLOWED to reference decrypt from main crypto (or that have their
+      // own different decrypt function).
+      const ALLOWED = [
+        // The broker: the ONLY permitted caller of crypto.decrypt().
+        "server/credentials/db-crypto-provider.ts",
+        // The function definition itself.
+        "server/crypto.ts",
+        // age-crypto has its own decrypt(EncryptedFile, KeyObject) — different function.
+        "server/config-sync/age-crypto.ts",
+        // Federation encryption: class method, not main crypto.
+        "server/federation/encryption.ts",
+        "server/federation/transport.ts",
+        // TriggerCrypto.decrypt — different key (TRIGGER_SECRET_KEY), ADR-deferred.
+        "server/services/trigger-crypto.ts",
+        "server/services/trigger-service.ts",
+      ];
+
+      // Pattern: any import statement that includes { decrypt } or { ..., decrypt, ... }
+      // targeting the main crypto module (../crypto, ./crypto, ...crypto.js).
+      const IMPORT_RE = /import[^;'"]*\bdecrypt\b[^;'"]*from\s*['"][^'"]*\/crypto(?:\.js)?['"]/m;
+
+      const violations: string[] = [];
+      for (const file of walk(serverDir)) {
+        // Normalise to forward-slash relative path from repo root.
+        const rel = file.replace(/\\/g, "/").replace(root.replace(/\\/g, "/") + "/", "");
+        const isAllowed = ALLOWED.some((a) => rel === a || rel.endsWith("/" + a.replace("server/", "")));
+        if (isAllowed) continue;
+
+        const text = readFileSync(file, "utf-8");
+        if (IMPORT_RE.test(text)) {
+          violations.push(rel);
+        }
+      }
+
+      // All decrypt imports from the main crypto module outside the allowlist are violations.
+      expect(violations).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Net-new **credential broker** ported onto current main (which already has strict project isolation via #405–408). This adds the dosed/audited credential layer that isolation alone doesn't provide.

## What this adds (none of it is on main yet)
- **`CredentialProvider` + `DbCryptoCredentialProvider`** (`server/credentials/`).
- **Live access layer**: `accessSecret()` — every real `crypto.decrypt()` (provider keys, tracker tokens, remote-agent tokens, git PATs) now flows through the broker, project/system-scoped + written to `credential_access_log`. Invariant: `crypto.decrypt()` is called ONLY inside the broker (the separate age/federation/trigger crypto subsystems are out of scope).
- **Read API** (project-scoped, under `requireProject`): `GET /api/credentials`, `/access-log`, `/leases`.
- **UI**: `/credentials` page (Credential Access) — credential inventory (metadata only, never secret values), access audit log, active leases with TTL countdown. Uses main's global fetch interceptor + per-project query keys.
- **Tables**: `credential_leases`, `credential_access_log` (migration `0028_phase1_credential_broker.sql`).
- **Per-run lease machinery** (`issueLease` w/ approval+run-state checks, `projectId` assertion, rate-limit, sweeper) is present and tested but **dormant** — there is no live per-run credential consumer in the codebase yet (tools are pre-connected; `spawnBuiltinServer` is unused). Its natural consumer is Phase 2 Vault dynamic secrets (per ADR-002 #402).

## Verification
`tsc` exit 0; production `build` exit 0; credential unit+API suites 53/53; full suite green except pre-existing order-sensitive flakes (pass in isolation).

## Supersedes
Replaces the old #404 (which was built before isolation landed on main and duplicated it). Isolation itself is already merged (#405–408). Depends conceptually on ADR-001 #394 / ADR-002 #402.