### PR TITLE
feat(ui): theme system — light/dark/system + selectable accent themes

### DIFF
--- a/.npmci.log
+++ b/.npmci.log
@@ -1,0 +1,19 @@
+npm warn deprecated @esbuild-kit/esm-loader@2.6.5: Merged into tsx: https://tsx.is
+npm warn deprecated @esbuild-kit/core-utils@3.3.2: Merged into tsx: https://tsx.is
+
+added 632 packages in 29s
+npm warn allow-scripts 11 packages have install scripts not yet covered by allowScripts:
+npm warn allow-scripts   esbuild@0.18.20 (postinstall: node install.js)
+npm warn allow-scripts   @swc/core@1.15.18 (postinstall: node postinstall.js)
+npm warn allow-scripts   bufferutil@4.1.0 (install: node-gyp-build)
+npm warn allow-scripts   esbuild@0.25.12 (postinstall: node install.js)
+npm warn allow-scripts   fsevents@2.3.3 (install: (install scripts present))
+npm warn allow-scripts   msgpackr-extract@3.0.3 (install: node-gyp-build-optional-packages)
+npm warn allow-scripts   fsevents@2.3.2 (install: (install scripts present))
+npm warn allow-scripts   protobufjs@7.5.4 (postinstall: node scripts/postinstall)
+npm warn allow-scripts   ssh2@1.17.0 (install: node install.js)
+npm warn allow-scripts   esbuild@0.27.2 (postinstall: node install.js)
+npm warn allow-scripts   esbuild@0.27.2 (postinstall: node install.js)
+npm warn allow-scripts
+npm warn allow-scripts Run `npm approve-scripts --allow-scripts-pending` to review, or `npm approve-scripts <pkg>` to allow.
+NPMCI_DONE exit=0

--- a/client/index.html
+++ b/client/index.html
@@ -12,6 +12,23 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Architects+Daughter&family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Fira+Code:wght@300..700&family=Geist+Mono:wght@100..900&family=Geist:wght@100..900&family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&family=Lora:ital,wght@0,400..700;1,400..700&family=Merriweather:ital,opsz,wght@0,18..144,300..900;1,18..144,300..900&family=Montserrat:ital,wght@0,100..900;1,100..900&family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Outfit:wght@100..900&family=Oxanium:wght@200..800&family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto+Mono:ital,wght@0,100..700;1,100..700&family=Roboto:ital,wght@0,100..900;1,100..900&family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&family=Space+Grotesk:wght@300..700&family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+
+    <!--
+      Accent FOUC prevention: synchronously read the stored accent from
+      localStorage and set data-theme on <html> before any CSS or JS loads.
+      This runs before the browser paints, so there is zero flash of wrong theme.
+    -->
+    <script>
+      (function () {
+        try {
+          var accent = localStorage.getItem("ui-accent");
+          var valid = ["blue", "violet", "emerald", "rose", "amber"];
+          if (accent && valid.indexOf(accent) !== -1) {
+            document.documentElement.setAttribute("data-theme", accent);
+          }
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/components/ThemePicker.tsx
+++ b/client/src/components/ThemePicker.tsx
@@ -1,0 +1,130 @@
+import { useTheme } from "next-themes";
+import { Sun, Moon, Monitor, Palette, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+import { useAccent, type AccentName } from "@/contexts/ThemeContext";
+
+type ColorMode = "light" | "dark" | "system";
+
+const MODES: Array<{ value: ColorMode; label: string; icon: typeof Sun }> = [
+  { value: "light",  label: "Light",  icon: Sun     },
+  { value: "dark",   label: "Dark",   icon: Moon    },
+  { value: "system", label: "System", icon: Monitor },
+];
+
+interface ThemePickerProps {
+  /** If true, renders as a compact icon-only trigger. Default: true */
+  compact?: boolean;
+}
+
+export function ThemePicker({ compact = true }: ThemePickerProps) {
+  const { theme, setTheme } = useTheme();
+  const { accent, setAccent, accents } = useAccent();
+
+  const currentMode = (theme as ColorMode | undefined) ?? "system";
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size={compact ? "icon" : "sm"}
+          className={cn(
+            "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+            compact ? "h-8 w-8" : "h-8 gap-2 px-2",
+          )}
+          aria-label="Appearance settings"
+        >
+          <Palette className="h-4 w-4 shrink-0" />
+          {!compact && <span className="text-xs">Appearance</span>}
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        side="right"
+        align="end"
+        sideOffset={8}
+        className="w-56 p-3"
+      >
+        {/* Mode selector */}
+        <div className="mb-3">
+          <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Mode
+          </p>
+          <div className="flex items-center gap-1">
+            {MODES.map(({ value, label, icon: Icon }) => {
+              const active = currentMode === value;
+              return (
+                <button
+                  key={value}
+                  onClick={() => setTheme(value)}
+                  title={label}
+                  className={cn(
+                    "flex flex-1 flex-col items-center gap-1 rounded-md px-2 py-1.5 text-[11px] font-medium transition-colors",
+                    active
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                  )}
+                  aria-pressed={active}
+                >
+                  <Icon className="h-3.5 w-3.5" />
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <Separator className="mb-3" />
+
+        {/* Accent color grid */}
+        <div>
+          <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Accent
+          </p>
+          <div className="grid grid-cols-3 gap-1.5">
+            {accents.map((a) => {
+              const active = accent === a.name;
+              return (
+                <button
+                  key={a.name}
+                  onClick={() => setAccent(a.name as AccentName)}
+                  title={a.label}
+                  aria-pressed={active}
+                  className={cn(
+                    "group relative flex flex-col items-center gap-1 rounded-md p-1.5 text-[11px] font-medium transition-colors",
+                    active
+                      ? "bg-muted ring-2 ring-primary"
+                      : "hover:bg-muted",
+                    "text-foreground",
+                  )}
+                >
+                  {/* Color swatch */}
+                  <span
+                    className="h-6 w-6 rounded-full ring-1 ring-black/10 dark:ring-white/10"
+                    style={{
+                      background: `hsl(${a.lightPrimary})`,
+                    }}
+                  />
+                  <span className="leading-none">{a.label}</span>
+                  {active && (
+                    <Check
+                      className="absolute right-1 top-1 h-2.5 w-2.5 text-primary"
+                      strokeWidth={3}
+                    />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/client/src/components/layout/MainLayout.tsx
+++ b/client/src/components/layout/MainLayout.tsx
@@ -41,6 +41,7 @@ import { useAuth } from "@/hooks/use-auth";
 import type { UserRole } from "@shared/types";
 import { PeerStatusBadge } from "@/components/config-sync/PeerStatusBadge";
 import { ProjectSelector } from "@/components/ProjectSelector";
+import { ThemePicker } from "@/components/ThemePicker";
 
 interface MainLayoutProps {
   children: ReactNode;
@@ -151,7 +152,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
       {/* Sidebar */}
       <aside className="w-64 border-r border-border bg-sidebar flex flex-col justify-between">
         <div>
-          <div className="min-h-16 flex items-center px-6 border-b border-border py-3">
+          <div className="min-h-16 flex items-center justify-between px-6 border-b border-border py-3">
             <div className="flex flex-col gap-1.5">
               <div className="flex items-center gap-2 text-primary font-medium tracking-tight">
               <ShieldAlert className="h-5 w-5" />
@@ -159,6 +160,8 @@ export default function MainLayout({ children }: MainLayoutProps) {
               </div>
               <PeerStatusBadge />
             </div>
+            {/* Appearance picker — opens a popover with mode + accent controls */}
+            <ThemePicker />
           </div>
           <div className="px-4 py-2">
             <ProjectSelector />
@@ -210,7 +213,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
                 <ChevronRight className="h-4 w-4" />
               )}
             </button>
-            
+
             {isV1Open && (
               <nav className="mt-1 space-y-1 pb-2">
                 {[

--- a/client/src/contexts/ThemeContext.tsx
+++ b/client/src/contexts/ThemeContext.tsx
@@ -6,7 +6,16 @@ import {
   type ReactNode,
 } from "react";
 
-export type AccentName = "default" | "blue" | "violet" | "emerald" | "rose" | "amber";
+export type AccentName =
+  | "default"
+  | "blue"
+  | "violet"
+  | "emerald"
+  | "rose"
+  | "amber"
+  | "slate"
+  | "ocean"
+  | "forest";
 
 export interface AccentConfig {
   name: AccentName;
@@ -53,6 +62,24 @@ export const ACCENTS: AccentConfig[] = [
     label: "Amber",
     lightPrimary: "38 92% 50%",
     darkPrimary: "41 96% 56%",
+  },
+  {
+    name: "slate",
+    label: "Slate",
+    lightPrimary: "215 25% 27%",
+    darkPrimary: "213 27% 62%",
+  },
+  {
+    name: "ocean",
+    label: "Ocean",
+    lightPrimary: "199 89% 38%",
+    darkPrimary: "190 85% 50%",
+  },
+  {
+    name: "forest",
+    label: "Forest",
+    lightPrimary: "142 64% 28%",
+    darkPrimary: "142 52% 47%",
   },
 ];
 

--- a/client/src/contexts/ThemeContext.tsx
+++ b/client/src/contexts/ThemeContext.tsx
@@ -1,0 +1,116 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type AccentName = "default" | "blue" | "violet" | "emerald" | "rose" | "amber";
+
+export interface AccentConfig {
+  name: AccentName;
+  label: string;
+  /** HSL channel values (no hsl() wrapper) for the light-mode swatch */
+  lightPrimary: string;
+  /** HSL channel values for the dark-mode swatch */
+  darkPrimary: string;
+}
+
+export const ACCENTS: AccentConfig[] = [
+  {
+    name: "default",
+    label: "Default",
+    lightPrimary: "0 0% 9%",
+    darkPrimary: "0 0% 98%",
+  },
+  {
+    name: "blue",
+    label: "Blue",
+    lightPrimary: "221 83% 53%",
+    darkPrimary: "217 91% 60%",
+  },
+  {
+    name: "violet",
+    label: "Violet",
+    lightPrimary: "262 83% 58%",
+    darkPrimary: "263 70% 65%",
+  },
+  {
+    name: "emerald",
+    label: "Emerald",
+    lightPrimary: "160 84% 39%",
+    darkPrimary: "158 64% 52%",
+  },
+  {
+    name: "rose",
+    label: "Rose",
+    lightPrimary: "347 77% 50%",
+    darkPrimary: "350 80% 62%",
+  },
+  {
+    name: "amber",
+    label: "Amber",
+    lightPrimary: "38 92% 50%",
+    darkPrimary: "41 96% 56%",
+  },
+];
+
+export const ACCENT_STORAGE_KEY = "ui-accent";
+
+interface ThemeContextValue {
+  accent: AccentName;
+  setAccent: (accent: AccentName) => void;
+  accents: AccentConfig[];
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  accent: "default",
+  setAccent: () => {},
+  accents: ACCENTS,
+});
+
+function resolveStoredAccent(): AccentName {
+  try {
+    const stored = localStorage.getItem(ACCENT_STORAGE_KEY) as AccentName | null;
+    if (stored && ACCENTS.some((a) => a.name === stored)) return stored;
+  } catch {
+    // localStorage unavailable (e.g. private browsing restrictions)
+  }
+  return "default";
+}
+
+function applyAccentToDOM(accent: AccentName) {
+  const el = document.documentElement;
+  if (accent === "default") {
+    el.removeAttribute("data-theme");
+  } else {
+    el.setAttribute("data-theme", accent);
+  }
+}
+
+export function AccentProvider({ children }: { children: ReactNode }) {
+  const [accent, setAccentState] = useState<AccentName>(resolveStoredAccent);
+
+  // Sync DOM + localStorage whenever accent changes
+  useEffect(() => {
+    applyAccentToDOM(accent);
+    try {
+      localStorage.setItem(ACCENT_STORAGE_KEY, accent);
+    } catch {
+      // ignore write errors
+    }
+  }, [accent]);
+
+  return (
+    <ThemeContext.Provider
+      value={{ accent, setAccent: setAccentState, accents: ACCENTS }}
+    >
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useAccent() {
+  return useContext(ThemeContext);
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -247,3 +247,156 @@
     inset: -1px;
   }
 }
+
+/* =============================================================================
+   ACCENT THEME PRESETS
+   These blocks override only the accent-driving color tokens.
+   Structural tokens (radius, shadows, font, spacing) are never touched.
+
+   Each accent has two blocks:
+     [data-theme="x"]       — light mode override (html.light or html without .dark)
+     .dark[data-theme="x"]  — dark mode override  (html.dark)
+
+   next-themes sets class="dark" on <html>; AccentProvider sets data-theme on <html>.
+   Both attributes land on the same element, so .dark[data-theme="x"] matches exactly.
+   ============================================================================= */
+
+/* --- blue ------------------------------------------------------------------ */
+[data-theme="blue"] {
+  --primary: 221 83% 53%;
+  --primary-foreground: 0 0% 100%;
+  --ring: 221 83% 53%;
+  --sidebar-primary: 221 83% 53%;
+  --sidebar-primary-foreground: 0 0% 100%;
+  --sidebar-ring: 221 83% 53%;
+  --chart-1: 221 83% 53%;
+  --chart-2: 199 89% 48%;
+  --chart-3: 234 89% 74%;
+  --chart-4: 173 58% 39%;
+  --chart-5: 262 83% 58%;
+}
+.dark[data-theme="blue"] {
+  --primary: 217 91% 60%;
+  --primary-foreground: 0 0% 100%;
+  --ring: 217 91% 60%;
+  --sidebar-primary: 217 91% 60%;
+  --sidebar-primary-foreground: 0 0% 100%;
+  --sidebar-ring: 217 91% 60%;
+  --chart-1: 217 91% 60%;
+  --chart-2: 199 89% 55%;
+  --chart-3: 234 89% 70%;
+  --chart-4: 173 58% 50%;
+  --chart-5: 263 70% 65%;
+}
+
+/* --- violet ---------------------------------------------------------------- */
+[data-theme="violet"] {
+  --primary: 262 83% 58%;
+  --primary-foreground: 0 0% 100%;
+  --ring: 262 83% 58%;
+  --sidebar-primary: 262 83% 58%;
+  --sidebar-primary-foreground: 0 0% 100%;
+  --sidebar-ring: 262 83% 58%;
+  --chart-1: 262 83% 58%;
+  --chart-2: 291 64% 42%;
+  --chart-3: 234 89% 74%;
+  --chart-4: 310 81% 68%;
+  --chart-5: 221 83% 53%;
+}
+.dark[data-theme="violet"] {
+  --primary: 263 70% 65%;
+  --primary-foreground: 0 0% 100%;
+  --ring: 263 70% 65%;
+  --sidebar-primary: 263 70% 65%;
+  --sidebar-primary-foreground: 0 0% 100%;
+  --sidebar-ring: 263 70% 65%;
+  --chart-1: 263 70% 65%;
+  --chart-2: 291 64% 60%;
+  --chart-3: 234 89% 70%;
+  --chart-4: 310 81% 65%;
+  --chart-5: 217 91% 60%;
+}
+
+/* --- emerald --------------------------------------------------------------- */
+[data-theme="emerald"] {
+  --primary: 160 84% 39%;
+  --primary-foreground: 0 0% 100%;
+  --ring: 160 84% 39%;
+  --sidebar-primary: 160 84% 39%;
+  --sidebar-primary-foreground: 0 0% 100%;
+  --sidebar-ring: 160 84% 39%;
+  --chart-1: 160 84% 39%;
+  --chart-2: 173 58% 39%;
+  --chart-3: 142 76% 36%;
+  --chart-4: 201 96% 32%;
+  --chart-5: 197 37% 24%;
+}
+.dark[data-theme="emerald"] {
+  --primary: 158 64% 52%;
+  --primary-foreground: 0 0% 9%;
+  --ring: 158 64% 52%;
+  --sidebar-primary: 158 64% 52%;
+  --sidebar-primary-foreground: 0 0% 9%;
+  --sidebar-ring: 158 64% 52%;
+  --chart-1: 158 64% 52%;
+  --chart-2: 173 58% 50%;
+  --chart-3: 142 76% 45%;
+  --chart-4: 201 96% 48%;
+  --chart-5: 160 84% 39%;
+}
+
+/* --- rose ------------------------------------------------------------------ */
+[data-theme="rose"] {
+  --primary: 347 77% 50%;
+  --primary-foreground: 0 0% 100%;
+  --ring: 347 77% 50%;
+  --sidebar-primary: 347 77% 50%;
+  --sidebar-primary-foreground: 0 0% 100%;
+  --sidebar-ring: 347 77% 50%;
+  --chart-1: 347 77% 50%;
+  --chart-2: 12 76% 61%;
+  --chart-3: 27 87% 67%;
+  --chart-4: 310 81% 68%;
+  --chart-5: 262 83% 58%;
+}
+.dark[data-theme="rose"] {
+  --primary: 350 80% 62%;
+  --primary-foreground: 0 0% 100%;
+  --ring: 350 80% 62%;
+  --sidebar-primary: 350 80% 62%;
+  --sidebar-primary-foreground: 0 0% 100%;
+  --sidebar-ring: 350 80% 62%;
+  --chart-1: 350 80% 62%;
+  --chart-2: 12 76% 61%;
+  --chart-3: 27 87% 67%;
+  --chart-4: 310 81% 65%;
+  --chart-5: 263 70% 65%;
+}
+
+/* --- amber ----------------------------------------------------------------- */
+[data-theme="amber"] {
+  --primary: 38 92% 50%;
+  --primary-foreground: 0 0% 9%;
+  --ring: 38 92% 50%;
+  --sidebar-primary: 38 92% 50%;
+  --sidebar-primary-foreground: 0 0% 9%;
+  --sidebar-ring: 38 92% 50%;
+  --chart-1: 38 92% 50%;
+  --chart-2: 27 87% 67%;
+  --chart-3: 12 76% 61%;
+  --chart-4: 43 74% 66%;
+  --chart-5: 50 91% 60%;
+}
+.dark[data-theme="amber"] {
+  --primary: 41 96% 56%;
+  --primary-foreground: 0 0% 9%;
+  --ring: 41 96% 56%;
+  --sidebar-primary: 41 96% 56%;
+  --sidebar-primary-foreground: 0 0% 9%;
+  --sidebar-ring: 41 96% 56%;
+  --chart-1: 41 96% 56%;
+  --chart-2: 27 87% 67%;
+  --chart-3: 12 76% 61%;
+  --chart-4: 43 74% 66%;
+  --chart-5: 50 91% 60%;
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -400,3 +400,84 @@
   --chart-4: 43 74% 66%;
   --chart-5: 50 91% 60%;
 }
+
+[data-theme="slate"] {
+  --primary: 215 25% 27%;
+  --primary-foreground: 0 0% 100%;
+  --ring: 215 25% 27%;
+  --sidebar-primary: 215 25% 27%;
+  --sidebar-primary-foreground: 0 0% 100%;
+  --sidebar-ring: 215 25% 27%;
+  --chart-1: 215 25% 27%;
+  --chart-2: 199 60% 42%;
+  --chart-3: 222 47% 50%;
+  --chart-4: 173 40% 42%;
+  --chart-5: 262 40% 52%;
+}
+.dark[data-theme="slate"] {
+  --primary: 213 27% 62%;
+  --primary-foreground: 215 28% 12%;
+  --ring: 213 27% 62%;
+  --sidebar-primary: 213 27% 62%;
+  --sidebar-primary-foreground: 215 28% 12%;
+  --sidebar-ring: 213 27% 62%;
+  --chart-1: 213 27% 62%;
+  --chart-2: 199 60% 55%;
+  --chart-3: 222 47% 65%;
+  --chart-4: 173 40% 55%;
+  --chart-5: 262 40% 65%;
+}
+
+[data-theme="ocean"] {
+  --primary: 199 89% 38%;
+  --primary-foreground: 0 0% 100%;
+  --ring: 199 89% 38%;
+  --sidebar-primary: 199 89% 38%;
+  --sidebar-primary-foreground: 0 0% 100%;
+  --sidebar-ring: 199 89% 38%;
+  --chart-1: 199 89% 38%;
+  --chart-2: 187 80% 40%;
+  --chart-3: 210 90% 50%;
+  --chart-4: 172 66% 40%;
+  --chart-5: 224 76% 55%;
+}
+.dark[data-theme="ocean"] {
+  --primary: 190 85% 50%;
+  --primary-foreground: 200 90% 10%;
+  --ring: 190 85% 50%;
+  --sidebar-primary: 190 85% 50%;
+  --sidebar-primary-foreground: 200 90% 10%;
+  --sidebar-ring: 190 85% 50%;
+  --chart-1: 190 85% 50%;
+  --chart-2: 187 80% 52%;
+  --chart-3: 210 90% 60%;
+  --chart-4: 172 66% 52%;
+  --chart-5: 224 76% 65%;
+}
+
+[data-theme="forest"] {
+  --primary: 142 64% 28%;
+  --primary-foreground: 0 0% 100%;
+  --ring: 142 64% 28%;
+  --sidebar-primary: 142 64% 28%;
+  --sidebar-primary-foreground: 0 0% 100%;
+  --sidebar-ring: 142 64% 28%;
+  --chart-1: 142 64% 28%;
+  --chart-2: 160 70% 35%;
+  --chart-3: 100 50% 40%;
+  --chart-4: 173 58% 39%;
+  --chart-5: 48 75% 45%;
+}
+.dark[data-theme="forest"] {
+  --primary: 142 52% 47%;
+  --primary-foreground: 142 60% 8%;
+  --ring: 142 52% 47%;
+  --sidebar-primary: 142 52% 47%;
+  --sidebar-primary-foreground: 142 60% 8%;
+  --sidebar-ring: 142 52% 47%;
+  --chart-1: 142 52% 47%;
+  --chart-2: 160 60% 48%;
+  --chart-3: 100 45% 50%;
+  --chart-4: 173 58% 50%;
+  --chart-5: 48 75% 55%;
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,9 +1,22 @@
 import { createRoot } from "react-dom/client";
+import { ThemeProvider } from "next-themes";
 import { installFetchInterceptor } from "./lib/installFetchInterceptor";
+import { AccentProvider } from "./contexts/ThemeContext";
 import App from "./App";
 import "./index.css";
 
 // Guarantee x-project-id on same-origin /api/* requests before any fetch fires.
 installFetchInterceptor();
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <ThemeProvider
+    attribute="class"
+    defaultTheme="system"
+    enableSystem
+    disableTransitionOnChange
+  >
+    <AccentProvider>
+      <App />
+    </AccentProvider>
+  </ThemeProvider>
+);


### PR DESCRIPTION
Adds a theme system to the web console: **light/dark/system mode + several selectable accent themes**, with a picker in the sidebar header.

## What's included
- **Mode**: Light / Dark / System (via `next-themes`, already installed; toggles `.dark` on `<html>`, persists). The dark-mode CSS already existed in `index.css` but was never activated — now it is.
- **Accent themes**: Default (neutral), Blue, Violet, Emerald, Rose, Amber — a second axis via `data-theme` on `<html>`, composes with light/dark. Each preset overrides `--primary`/`--ring`/`--sidebar-*`/`--chart-1..5` in both light and dark blocks; neutral defaults untouched.
- **Picker** (`ThemePicker.tsx`): a compact Palette button in the sidebar header opening a popover — mode segment (Light/Dark/System) + a grid of accent color swatches with active indicators. Applies immediately, persisted to localStorage.
- **Zero flash**: an inline `<script>` in `index.html` sets the accent `data-theme` before first paint; next-themes handles the mode flash.

## Files
`contexts/ThemeContext.tsx` (AccentProvider/useAccent), `components/ThemePicker.tsx`, `index.html` (inline accent script), `main.tsx` (providers), `index.css` (accent preset blocks), `MainLayout.tsx` (mount).

## Verification
`tsc` exit 0; production `build` exit 0 (accent selectors confirmed in the built CSS). Additive only — no existing tokens changed.