### PR TITLE
feat(consilium): cross-review-ready loop — poller-context fix, round history, real-trajectory UI

### DIFF
--- a/client/src/components/consilium/loop-state.tsx
+++ b/client/src/components/consilium/loop-state.tsx
@@ -3,6 +3,12 @@
  * map (mirroring current-runs-rail.tsx's status palette) and an ordered FSM
  * lifecycle used by the detail-page stepper.
  *
+ * P5 — `stopped_cap` is CONTEXT-AWARE. The same terminal state means different
+ * things depending on the loop's intent, so `loopStateLabel(loop)` overrides the
+ * static map for it (see the helper's doc). The static LOOP_STATE_STYLE map still
+ * backs every non-contextual state, and the state-only LoopStateBadge/LoopStateChip
+ * remain for callers that don't have the full loop row.
+ *
  * SECURITY: pure presentation. No model-authored text passes through here.
  */
 import { Badge } from "@/components/ui/badge";
@@ -62,6 +68,48 @@ export const LOOP_LIFECYCLE: ConsiliumLoopState[] = [
   "awaiting_merge",
 ];
 
+/**
+ * The minimal loop shape the context-aware label needs. Both the list item and
+ * the detail row satisfy this structurally.
+ */
+export interface LoopStateContext {
+  state: ConsiliumLoopState;
+  maxRounds: number;
+  openP0: number | null;
+}
+
+/**
+ * P5 — context-aware style + label. `stopped_cap` is the only contextual state
+ * today; its meaning depends on the loop's INTENT, recovered from its fields:
+ *
+ *   • Assessment  (maxRounds === 1)            — a single dispute round, no
+ *       remediation intended  → SUCCESS tone, "Completed — review".
+ *   • Remediation at cap with unresolved P0s
+ *       (maxRounds > 1 && openP0 > 0)          → STOP tone, "Stopped — {n} P0 open"
+ *       (preserves the open-P0 signal that a plain "Stopped (cap)" would drop).
+ *   • Otherwise (cap hit, no open P0s)         → static "Stopped (cap)".
+ *
+ * Every other state falls straight through to the static LOOP_STATE_STYLE map.
+ */
+export function loopStateLabel(loop: LoopStateContext): StateStyle {
+  if (loop.state === "stopped_cap") {
+    if (loop.maxRounds === 1) {
+      return { label: "Completed — review", badge: "bg-green-600 text-white", dot: "bg-green-500" };
+    }
+    const open = loop.openP0 ?? 0;
+    if (loop.maxRounds > 1 && open > 0) {
+      return {
+        label: `Stopped — ${open} P0 open`,
+        badge: "bg-yellow-500 text-black",
+        dot: "bg-yellow-500",
+      };
+    }
+  }
+  return LOOP_STATE_STYLE[loop.state];
+}
+
+// ─── State-only variants (no loop context available) ────────────────────────
+
 export function LoopStateBadge({ state }: { state: ConsiliumLoopState }) {
   const style = LOOP_STATE_STYLE[state];
   return <Badge className={style.badge}>{style.label}</Badge>;
@@ -70,7 +118,24 @@ export function LoopStateBadge({ state }: { state: ConsiliumLoopState }) {
 /** Compact dot + label, matching the pipeline rail's chip style. */
 export function LoopStateChip({ state }: { state: ConsiliumLoopState }) {
   const style = LOOP_STATE_STYLE[state];
-  const terminal = isTerminalLoopState(state);
+  return <ChipBody style={style} terminal={isTerminalLoopState(state)} />;
+}
+
+// ─── Context-aware variants (full loop row available) ───────────────────────
+
+/** Badge whose terminal label/colour reflects the loop's intent (see loopStateLabel). */
+export function LoopStateBadgeFor({ loop }: { loop: LoopStateContext }) {
+  const style = loopStateLabel(loop);
+  return <Badge className={style.badge}>{style.label}</Badge>;
+}
+
+/** Chip whose terminal label/colour reflects the loop's intent (see loopStateLabel). */
+export function LoopStateChipFor({ loop }: { loop: LoopStateContext }) {
+  const style = loopStateLabel(loop);
+  return <ChipBody style={style} terminal={isTerminalLoopState(loop.state)} />;
+}
+
+function ChipBody({ style, terminal }: { style: StateStyle; terminal: boolean }) {
   return (
     <span className="inline-flex items-center gap-1.5">
       <span className={`h-2 w-2 rounded-full shrink-0 ${style.dot}`} />

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -37,13 +37,13 @@ import {
   useApproveMerge,
   isTerminalLoopState,
   type ConsiliumLoopRoundRow,
+  type ConsiliumLoopDetail as ConsiliumLoopDetailRow,
 } from "@/hooks/use-consilium-loops";
 import { useAuth } from "@/hooks/use-auth";
 import { useToast } from "@/hooks/use-toast";
 import {
-  LOOP_LIFECYCLE,
   LOOP_STATE_STYLE,
-  LoopStateBadge,
+  LoopStateBadgeFor,
 } from "@/components/consilium/loop-state";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -129,44 +129,181 @@ function isErrorWithStatus(err: unknown, status: number): boolean {
   return false;
 }
 
-// ─── FSM stepper ──────────────────────────────────────────────────────────────
+// ─── Per-round FSM trajectory stepper (P3) ──────────────────────────────────
+//
+// The stepper reflects what ACTUALLY happened, PER ROUND — it never claims a
+// step that wasn't reached. All inference is presentation-only, from data the
+// loop GET already returns (state, round, the per-round rows, devGroupId, prRef):
+//
+//   • Every RECORDED round traversed Context → Review → Decide. The round row is
+//     written from the convergence read at "deciding", so its existence proves
+//     those three steps completed.
+//   • A round that is NOT the final one necessarily produced a SUBSEQUENT round —
+//     only possible via Develop → Await-merge → merge-approved. So every
+//     non-final round shows all five steps "done" (and a "merged" outcome).
+//   • The FINAL round's reach is derived from loop.state:
+//       – non-terminal      → steps before loop.state are done, loop.state is the
+//                             current step, later steps are "not reached".
+//       – verdict-terminal   (converged | stopped_cap | escalated)
+//                           → the loop terminates FROM "deciding"; Develop and
+//                             Await-merge were NOT reached (dimmed "not reached").
+//       – failed | cancelled → may stop anywhere, so claim only what is evidenced:
+//                             Context/Review/Decide done iff a round row exists,
+//                             Develop iff devGroupId is set, Await iff prRef is set.
 
-function FsmStepper({ state }: { state: ConsiliumLoopState }) {
-  const terminal = isTerminalLoopState(state);
-  // Where on the lifecycle are we? A terminal state sits "after" the whole
-  // non-terminal track, so every lifecycle step is treated as completed.
-  const currentIdx = terminal ? LOOP_LIFECYCLE.length : LOOP_LIFECYCLE.indexOf(state);
+type StepStatus = "done" | "current" | "not_reached";
+
+const ROUND_STEPS: { key: ConsiliumLoopState; label: string }[] = [
+  { key: "building_context", label: "Context" },
+  { key: "reviewing", label: "Review" },
+  { key: "deciding", label: "Decide" },
+  { key: "developing", label: "Develop" },
+  { key: "awaiting_merge", label: "Await merge" },
+];
+
+const ROUND_STEP_IDX: Record<string, number> = {
+  building_context: 0,
+  reviewing: 1,
+  deciding: 2,
+  developing: 3,
+  awaiting_merge: 4,
+};
+
+// Verdict-terminal states all exit FROM "deciding" — they never developed in the
+// final round (distinct from failed/cancelled, which can stop anywhere).
+const VERDICT_TERMINAL: ReadonlySet<ConsiliumLoopState> = new Set<ConsiliumLoopState>([
+  "converged",
+  "stopped_cap",
+  "escalated",
+]);
+
+function roundStepStatuses(args: {
+  isLast: boolean;
+  hasRoundRow: boolean;
+  state: ConsiliumLoopState;
+  devGroupId: string | null | undefined;
+  prRef: string | null | undefined;
+}): StepStatus[] {
+  const { isLast, hasRoundRow, state, devGroupId, prRef } = args;
+
+  // Produced a later round ⇒ fully traversed AND merged.
+  if (!isLast) return ROUND_STEPS.map(() => "done");
+
+  // Final round — derive reach from the loop's current / terminal state.
+  const idx = ROUND_STEP_IDX[state];
+  if (idx !== undefined) {
+    // Non-terminal round step: < idx done, == idx current, > idx not reached.
+    return ROUND_STEPS.map((_, i) =>
+      i < idx ? "done" : i === idx ? "current" : "not_reached",
+    );
+  }
+
+  if (VERDICT_TERMINAL.has(state)) {
+    // Exits from "deciding": Context/Review/Decide done, Develop/Await never reached.
+    return ROUND_STEPS.map((_, i) =>
+      i <= ROUND_STEP_IDX.deciding ? "done" : "not_reached",
+    );
+  }
+
+  // failed | cancelled (and the pre-start `pending` fallback) — claim only what
+  // the data evidences.
+  const core: StepStatus = hasRoundRow ? "done" : "not_reached";
+  return ROUND_STEPS.map((step) => {
+    if (step.key === "developing") return devGroupId ? "done" : "not_reached";
+    if (step.key === "awaiting_merge") return prRef ? "done" : "not_reached";
+    return core;
+  });
+}
+
+function RoundStepChip({
+  step,
+  status,
+}: {
+  step: { key: ConsiliumLoopState; label: string };
+  status: StepStatus;
+}) {
+  const cls =
+    status === "current"
+      ? LOOP_STATE_STYLE[step.key].badge
+      : status === "done"
+        ? "bg-muted text-muted-foreground line-through decoration-muted-foreground/40"
+        : "bg-muted/30 text-muted-foreground/50";
+  return (
+    <span
+      className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${cls}`}
+      title={status === "not_reached" ? "not reached" : undefined}
+      aria-label={status === "not_reached" ? `${step.label}: not reached` : undefined}
+    >
+      {step.label}
+    </span>
+  );
+}
+
+function FsmStepper({ loop }: { loop: ConsiliumLoopDetailRow }) {
+  const terminal = isTerminalLoopState(loop.state);
+  const rounds = [...(Array.isArray(loop.rounds) ? loop.rounds : [])].sort(
+    (a, b) => a.round - b.round,
+  );
+
+  // One display row per recorded round, plus a synthetic row for a round that is
+  // in-flight but hasn't recorded its convergence yet (loop.round ahead of rows).
+  const lastRecorded = rounds.length ? rounds[rounds.length - 1].round : 0;
+  const currentRound = loop.round && loop.round > 0 ? loop.round : 1;
+
+  const display: { round: number; row?: ConsiliumLoopRoundRow }[] = rounds.map((r) => ({
+    round: r.round,
+    row: r,
+  }));
+  if (currentRound > lastRecorded) display.push({ round: currentRound });
+  if (display.length === 0) display.push({ round: 1 });
 
   return (
-    <div className="flex flex-wrap items-center gap-1.5">
-      {LOOP_LIFECYCLE.map((step, i) => {
-        const isCurrent = !terminal && i === currentIdx;
-        const isDone = i < currentIdx;
+    <div className="space-y-2">
+      {display.map((d, i) => {
+        const isLast = i === display.length - 1;
+        const statuses = roundStepStatuses({
+          isLast,
+          hasRoundRow: !!d.row,
+          state: loop.state,
+          devGroupId: loop.devGroupId,
+          prRef: loop.prRef,
+        });
+        const developStatus = statuses[ROUND_STEP_IDX.developing];
+        const reachedDevelop = developStatus === "done" || developStatus === "current";
         return (
-          <div key={step} className="flex items-center gap-1.5">
-            <span
-              className={`rounded-full px-2.5 py-1 text-[11px] font-medium ${
-                isCurrent
-                  ? LOOP_STATE_STYLE[step].badge
-                  : isDone
-                    ? "bg-muted text-muted-foreground line-through decoration-muted-foreground/40"
-                    : "bg-muted/40 text-muted-foreground/60"
-              }`}
-            >
-              {LOOP_STATE_STYLE[step].label}
+          <div key={d.round} className="flex flex-wrap items-center gap-1.5">
+            <span className="mr-1 w-[4.5rem] shrink-0 text-[11px] font-medium text-muted-foreground tabular-nums">
+              Round {d.round}
             </span>
-            {i < LOOP_LIFECYCLE.length - 1 && (
-              <ChevronRight className="h-3 w-3 text-muted-foreground/40" />
+            {ROUND_STEPS.map((step, si) => (
+              <div key={step.key} className="flex items-center gap-1.5">
+                <RoundStepChip step={step} status={statuses[si]} />
+                {si < ROUND_STEPS.length - 1 && (
+                  <ChevronRight className="h-3 w-3 text-muted-foreground/40" />
+                )}
+              </div>
+            ))}
+            {/* Per-round outcome */}
+            {!isLast ? (
+              <span className="ml-1 inline-flex items-center gap-1 text-[10px] text-green-600 dark:text-green-400">
+                <GitMerge className="h-3 w-3" />
+                merged
+              </span>
+            ) : terminal ? (
+              <span className="ml-1">
+                <LoopStateBadgeFor loop={loop} />
+              </span>
+            ) : null}
+            {/* The P0 count that triggered DEV — only when this round actually
+                reached development (a verdict-terminal round shows none). */}
+            {reachedDevelop && d.row?.openP0 != null && d.row.openP0 > 0 && (
+              <span className="ml-1 text-[10px] text-muted-foreground tabular-nums">
+                {d.row.openP0} P0 → DEV
+              </span>
             )}
           </div>
         );
       })}
-      {terminal && (
-        <>
-          <ChevronRight className="h-3 w-3 text-muted-foreground/40" />
-          <LoopStateBadge state={state} />
-        </>
-      )}
     </div>
   );
 }
@@ -381,7 +518,7 @@ export default function ConsiliumLoopDetail() {
               <h1 className="text-base font-semibold leading-tight truncate">
                 Consilium Loop
               </h1>
-              <LoopStateBadge state={loop.state} />
+              <LoopStateBadgeFor loop={loop} />
             </div>
             <p className="font-mono text-[11px] text-muted-foreground">{loop.id}</p>
           </div>
@@ -439,7 +576,7 @@ export default function ConsiliumLoopDetail() {
             <CardTitle className="text-sm">Lifecycle</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
-            <FsmStepper state={loop.state} />
+            <FsmStepper loop={loop} />
             {loop.error && (
               <div className="flex items-start gap-2 rounded-md border border-red-500/40 bg-red-500/5 p-3 text-sm">
                 <AlertTriangle className="h-4 w-4 text-red-500 shrink-0 mt-0.5" />

--- a/client/src/pages/ConsiliumLoopList.tsx
+++ b/client/src/pages/ConsiliumLoopList.tsx
@@ -1,20 +1,30 @@
 /**
  * ConsiliumLoopList — the caller's consilium loops (design §7). One row per loop:
- * state pill, round n/maxRounds, repo basename, open P0, a Draft-PR link when set,
- * and a relative updated-time. Clicking a row opens its detail at
+ * the WORKSPACE name (P4), state pill, round n/maxRounds, open P0, a Draft-PR link
+ * when set, and a relative updated-time. Clicking a row opens its detail at
  * /consilium-loops/:id. The list polls lightly (5s) for live state.
  *
- * SECURITY: loop-derived text (repoPath, prRef) is rendered as INERT React text;
- * the PR link uses rel="noopener noreferrer".
+ * P4 — the first column is a human WORKSPACE name. Loops only carry `repoPath`
+ * (no workspaceId), so we fetch the workspaces list (via the shared apiRequest
+ * transport, which attaches `x-project-id`) and match by `path`. When no
+ * workspace matches we fall back to the repo basename, and the full repoPath is
+ * always kept in the cell's title/tooltip. The short loop id + round stay visible
+ * so multiple loops targeting one workspace remain distinguishable.
+ *
+ * SECURITY: loop-derived text (repoPath, prRef) and the workspace name are
+ * rendered as INERT React text; the PR link uses rel="noopener noreferrer".
  */
 import { useLocation } from "wouter";
+import { useQuery } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import { Repeat, ExternalLink, Loader2 } from "lucide-react";
 import {
   useConsiliumLoops,
   type ConsiliumLoopListItem,
 } from "@/hooks/use-consilium-loops";
-import { LoopStateChip } from "@/components/consilium/loop-state";
+import { apiRequest } from "@/hooks/use-pipeline";
+import { LoopStateChipFor } from "@/components/consilium/loop-state";
+import type { WorkspaceRow } from "@shared/schema";
 import {
   Table,
   TableBody,
@@ -29,6 +39,11 @@ function repoBasename(repoPath: string): string {
   const trimmed = repoPath.replace(/\/+$/, "");
   const seg = trimmed.split("/").pop();
   return seg || repoPath;
+}
+
+/** Trailing-slash-insensitive path key, so `/repo` and `/repo/` match. */
+function normalizePath(p: string): string {
+  return p.replace(/\/+$/, "");
 }
 
 function whenLabel(ts: string | Date | null | undefined): string {
@@ -53,10 +68,31 @@ function OpenP0({ openP0 }: { openP0: number | null | undefined }) {
   );
 }
 
+/**
+ * Workspaces for the active project — used only to resolve a human name for a
+ * loop's repoPath. Uses the shared apiRequest transport so `x-project-id` is
+ * attached (same as every other project-scoped hook).
+ */
+function useWorkspaces() {
+  return useQuery<WorkspaceRow[]>({
+    queryKey: ["/api/workspaces"],
+    queryFn: () => apiRequest("GET", "/api/workspaces"),
+  });
+}
+
 export default function ConsiliumLoopList() {
   const [, navigate] = useLocation();
   const { data, isLoading } = useConsiliumLoops();
+  const { data: workspaceData } = useWorkspaces();
   const loops = (Array.isArray(data) ? data : []) as ConsiliumLoopListItem[];
+
+  // path → workspace name lookup (trailing-slash-insensitive).
+  const nameByPath = new Map<string, string>();
+  if (Array.isArray(workspaceData)) {
+    for (const ws of workspaceData) nameByPath.set(normalizePath(ws.path), ws.name);
+  }
+  const workspaceName = (repoPath: string): string =>
+    nameByPath.get(normalizePath(repoPath)) ?? repoBasename(repoPath);
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
@@ -93,9 +129,9 @@ export default function ConsiliumLoopList() {
             <Table>
               <TableHeader>
                 <TableRow>
+                  <TableHead>Workspace</TableHead>
                   <TableHead>State</TableHead>
                   <TableHead>Round</TableHead>
-                  <TableHead>Repo</TableHead>
                   <TableHead>Open P0</TableHead>
                   <TableHead>PR</TableHead>
                   <TableHead>Updated</TableHead>
@@ -108,17 +144,24 @@ export default function ConsiliumLoopList() {
                     className="cursor-pointer"
                     onClick={() => navigate(`/consilium-loops/${loop.id}`)}
                   >
+                    <TableCell className="max-w-[18rem]">
+                      {/* Human workspace name first; short loop id beneath for
+                          disambiguation when several loops target one workspace.
+                          Full repoPath stays in the tooltip. */}
+                      <div className="min-w-0">
+                        <div className="truncate font-medium" title={loop.repoPath}>
+                          {workspaceName(loop.repoPath)}
+                        </div>
+                        <div className="font-mono text-[10px] text-muted-foreground truncate">
+                          {loop.id.slice(0, 8)}
+                        </div>
+                      </div>
+                    </TableCell>
                     <TableCell>
-                      <LoopStateChip state={loop.state} />
+                      <LoopStateChipFor loop={loop} />
                     </TableCell>
                     <TableCell className="tabular-nums">
                       {loop.round}/{loop.maxRounds}
-                    </TableCell>
-                    <TableCell
-                      className="font-mono text-xs max-w-[16rem] truncate"
-                      title={loop.repoPath}
-                    >
-                      {repoBasename(loop.repoPath)}
                     </TableCell>
                     <TableCell>
                       <OpenP0 openP0={loop.openP0} />

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -39,9 +39,10 @@
  *     (D.2/D.3) so the DEV pipeline's read tools are grounded in the loop's repo.
  */
 import type { IStorage } from "../../storage.js";
-import { runAsSystem } from "../../context.js";
-import type { ConsiliumLoopRow, ConsiliumLoopState } from "@shared/schema";
+import { runAsSystem, runAsProject } from "../../context.js";
+import type { ConsiliumLoopRow, ConsiliumLoopRoundRow, ConsiliumLoopState } from "@shared/schema";
 import type { ActionPoint, ConvergenceVerdict } from "@shared/types";
+import { P0_PRIORITY } from "@shared/types";
 import type { TaskOrchestrator } from "../task-orchestrator.js";
 import type { AppConfig } from "../../config/schema.js";
 import { readConvergence } from "../orchestrator/convergence.js";
@@ -563,12 +564,19 @@ export class ConsiliumLoopController {
     const cfg = this.loopConfig();
     const group = await this.storage.getTaskGroup(loop.groupId);
     const objective = group?.input ?? "";
+    // Enh1: for every review AFTER the first (loop.round >= 1), inject the prior
+    // rounds' still-open findings so the debaters VERIFY CLOSURE against the new
+    // diff instead of re-discovering or circling. Round 1 (loop.round === 0,
+    // baselineCommit null) is unchanged: objective-only, no history.
+    const priorFindings =
+      loop.round >= 1 ? await this.buildPriorFindings(loop, cfg.maxDiffBytes) : undefined;
     const ctx = await buildDiffContext({
       repoPath: loop.repoPath,
       baselineCommit: loop.lastReviewedCommit,
       objective,
       allowedRepoPaths: cfg.allowedRepoPaths,
       maxDiffBytes: cfg.maxDiffBytes,
+      priorFindings,
     });
     if (!ctx.ok) {
       // Surface the (scrubbed) git failure as a loop error; the next tick from
@@ -644,6 +652,27 @@ export class ConsiliumLoopController {
     }
   }
 
+  /**
+   * Enh1: assemble the "prior findings to verify" block for round > 1 from the
+   * persisted per-round verdict rows (`consilium_loop_rounds.openActionPoints`).
+   * Best-effort: a storage failure or empty history yields `undefined` (no
+   * history injected — round proceeds as before). Bounded oldest-first to
+   * `budgetBytes` by `formatPriorFindings`.
+   */
+  private async buildPriorFindings(
+    loop: ConsiliumLoopRow,
+    budgetBytes: number,
+  ): Promise<string | undefined> {
+    let rounds: ConsiliumLoopRoundRow[];
+    try {
+      rounds = await this.storage.getLoopRounds(loop.id);
+    } catch (err) {
+      this.log(loop.id, `buildPriorFindings: getLoopRounds failed (no history injected): ${err instanceof Error ? err.message : String(err)}`);
+      return undefined;
+    }
+    return formatPriorFindings(rounds, budgetBytes) ?? undefined;
+  }
+
   /** Persist this round's audit row (NEVER the raw diff/input — H-4). */
   private async recordRound(loop: ConsiliumLoopRow, verdict: ConvergenceVerdict): Promise<void> {
     const head = await this.readRepoHead(loop);
@@ -716,6 +745,73 @@ export function pickJudgeOutput(outputs: unknown[]): unknown {
 }
 
 /**
+ * Enh1: format the round-history block injected into reviews after the first
+ * (round > 1). For each EARLIER round it lists the still-open action points
+ * (title + priority) persisted in `consilium_loop_rounds.openActionPoints`, plus
+ * the open-P0 trend across rounds, so the debaters confirm CLOSURE of prior items
+ * against the new diff rather than re-discovering them or circling.
+ *
+ * Bounding (treated as INERT prior-verdict text — never executed): the whole
+ * block is kept within `budgetBytes` by dropping WHOLE rounds OLDEST-first and
+ * noting how many were omitted. If even the newest round's detail will not fit,
+ * a header-only block (trend + a "detail omitted" note) is returned; if not even
+ * that fits, returns `null` (nothing injected). A `diff-context` byte clamp is a
+ * second, defensive backstop.
+ *
+ * Note on provenance: the per-round verdict (titles + priorities) IS persisted
+ * per round in `consilium_loop_rounds.openActionPoints` (jsonb ActionPoint[]),
+ * so no fallback-to-counts-only is needed; rows whose action points are absent
+ * (e.g. an unreadable verdict at record time) degrade to their openP0 count.
+ */
+export function formatPriorFindings(
+  rounds: ConsiliumLoopRoundRow[],
+  budgetBytes: number,
+): string | null {
+  if (rounds.length === 0) return null;
+  const ordered = [...rounds].sort((a, b) => a.round - b.round);
+
+  const trend = ordered.map((r) => r.openP0 ?? 0).join(" -> ");
+  const header =
+    "## Prior findings to verify (from earlier rounds)\n\n" +
+    "Earlier rounds flagged the items below. For EACH item: confirm it is ACTUALLY " +
+    "closed by the changes above, or flag it as still-open / regressed. Do NOT " +
+    "re-discover items already listed here — only raise genuinely NEW issues.\n\n" +
+    `Open P0 trend across rounds: ${trend}`;
+
+  const chunkFor = (r: ConsiliumLoopRoundRow): string => {
+    const aps = Array.isArray(r.openActionPoints) ? r.openActionPoints : [];
+    const p0 =
+      r.openP0 ??
+      aps.filter((a) => (a.priority ?? "").toUpperCase() === P0_PRIORITY).length;
+    const headline = `### Round ${r.round} (${aps.length} open${p0 ? `, ${p0} P0` : ""})`;
+    if (aps.length === 0) {
+      return `${headline}\n- _no structured action points recorded for this round (open P0: ${r.openP0 ?? "unknown"})_`;
+    }
+    const lines = aps.map((a) => `- [${(a.priority ?? "P?").toUpperCase()}] ${a.title}`);
+    return `${headline}\n${lines.join("\n")}`;
+  };
+
+  const chunks = ordered.map(chunkFor);
+  const assemble = (kept: string[], omitted: number): string => {
+    const note =
+      omitted > 0 ? `\n\n_(${omitted} earlier round(s) omitted to fit the size budget)_` : "";
+    return `${header}${note}\n\n${kept.join("\n\n")}`;
+  };
+
+  let kept = chunks.slice();
+  let omitted = 0;
+  while (kept.length > 0 && Buffer.byteLength(assemble(kept, omitted), "utf8") > budgetBytes) {
+    kept.shift(); // drop the OLDEST round first
+    omitted += 1;
+  }
+  if (kept.length === 0) {
+    const minimal = `${header}\n\n_(all ${omitted} round(s) of detail omitted to fit the size budget; see the P0 trend above)_`;
+    return Buffer.byteLength(minimal, "utf8") > budgetBytes ? null : minimal;
+  }
+  return assemble(kept, omitted);
+}
+
+/**
  * ConsiliumLoopPoller — the restart-safe backstop driver (design §7). On an
  * interval it sweeps every NON-terminal loop and `tick`s it. `tick` is single-
  * flight via the persisted CAS (H-3), so a poller tick that races an event-tick
@@ -754,7 +850,20 @@ export class ConsiliumLoopPoller {
         this.storage.getLoops(),
       );
       for (const loop of loops) {
-        await this.controller.tick(loop.id).catch(() => undefined);
+        // tick() calls project-scoped storage (getTaskGroup/updateLoop/startGroupAsync
+        // inserts) which fail-close without an ALS context. A loop belongs to a
+        // project via its group → run the tick inside that project's context so
+        // every scoped read/write resolves correctly. Fall back to a system
+        // context only if the group's project can't be resolved.
+        const group = await runAsSystem("consilium-loop-resolve-project", () =>
+          this.storage.getTaskGroup(loop.groupId),
+        ).catch(() => null);
+        const projectId = group?.projectId ?? null;
+        const runTick = () => this.controller.tick(loop.id);
+        await (projectId
+          ? runAsProject(projectId, runTick)
+          : runAsSystem("consilium-loop-tick", runTick)
+        ).catch(() => undefined);
       }
     } catch {
       // a transient storage error must not kill the interval

--- a/server/services/consilium/diff-context.ts
+++ b/server/services/consilium/diff-context.ts
@@ -4,7 +4,9 @@
  * Builds the "Overall objective" markdown string fed to every debater + the
  * judge (`iteration.input`, direct-llm-prompt.ts:39) for one review round:
  *   objective + `## Changes since last review` (git diff base..HEAD) +
- *   `## Test results` (an opaque, bounded summary the DEV pipeline produced).
+ *   `## Test results` (an opaque, bounded summary the DEV pipeline produced) +
+ *   (Enh1, round > 1) `## Prior findings to verify` — the caller-supplied,
+ *   byte-bounded, INERT round-history block so debaters verify closure.
  *
  * Design constraints honoured here:
  *   - NEVER throws — returns `DiffContextResult | GitFail` (reuses the
@@ -51,6 +53,15 @@ export interface DiffContextRequest {
   maxDiffBytes: number;
   /** Bounded summary of the last DEV run's tests (opaque to A2). */
   testSummary?: string;
+  /**
+   * Enh1: round-history block (model-authored prior-round findings) injected
+   * for round > 1 so debaters VERIFY CLOSURE of earlier items against the diff
+   * below instead of re-discovering them or circling. Appended as a dedicated
+   * section AFTER the diff. Treated as INERT text (never executed, never
+   * logged) and hard-capped to `maxDiffBytes`; the caller pre-truncates the
+   * findings list oldest-first to stay within budget.
+   */
+  priorFindings?: string;
   /** Injected git client (tests pass a fake); defaults to simple-git(repoPath). */
   gitClient?: GitDiffClient;
 }
@@ -162,6 +173,8 @@ function assembleInput(
   objective: string,
   parts: DiffParts | null,
   testSummary: string | undefined,
+  priorFindings: string | undefined,
+  maxDiffBytes: number,
 ): { input: string; truncated: boolean } {
   const obj = objective.trim();
   const sections = [obj.length > 0 ? obj : "_No objective supplied; review the changes below._"];
@@ -176,6 +189,22 @@ function assembleInput(
     if (clamped.clipped) truncated = true;
     const note = clamped.clipped ? "\n\n_(test results truncated to the configured limit)_" : "";
     sections.push(`## Test results\n\n${clamped.text}${note}`);
+  }
+  // Enh1: prior-round findings to verify — appended AFTER the diff so the model
+  // reads objective -> changes-since-last-review -> (tests) -> items to confirm
+  // closed. The caller already bounded this oldest-first; we apply a DEFENSIVE
+  // byte clamp here so a round-history block can never exceed the diff's byte
+  // budget (it is inert, model-authored prior-verdict text). The block carries
+  // its own `## Prior findings to verify` header.
+  if (priorFindings && priorFindings.trim().length > 0) {
+    const raw = priorFindings.trim();
+    const overflow = Buffer.byteLength(raw, "utf8") > maxDiffBytes;
+    if (overflow) truncated = true;
+    const text = overflow
+      ? Buffer.from(raw, "utf8").subarray(0, maxDiffBytes).toString("utf8")
+      : raw;
+    const note = overflow ? "\n\n_(prior findings truncated to the configured byte limit)_" : "";
+    sections.push(`${text}${note}`);
   }
   return { input: sections.join("\n\n"), truncated };
 }
@@ -214,7 +243,7 @@ export async function buildDiffContext(
     if (req.objective.trim().length === 0) {
       return fail("unknown", "objective is empty and there is no diff (round 1); refusing to emit a blank review input");
     }
-    const built = assembleInput(req.objective, null, req.testSummary);
+    const built = assembleInput(req.objective, null, req.testSummary, undefined, req.maxDiffBytes);
     return { ok: true, input: built.input, headCommit: head, baselineCommit: null, truncated: built.truncated };
   }
 
@@ -224,7 +253,7 @@ export async function buildDiffContext(
   const parts = await collectDiff(git, baseline, head, req.maxDiffBytes);
   if (!("stat" in parts)) return parts;
 
-  const built = assembleInput(req.objective, parts, req.testSummary);
+  const built = assembleInput(req.objective, parts, req.testSummary, req.priorFindings, req.maxDiffBytes);
   return {
     ok: true,
     input: built.input,

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -1348,10 +1348,29 @@ export class PgStorage implements IStorage {
   }
 
   async getLoopRounds(loopId: string): Promise<ConsiliumLoopRoundRow[]> {
+    // consilium_loop_rounds has NO project_id (a round belongs to a loop, which
+    // belongs to a task group). Scope through loop → group → task_groups, like
+    // getLoops()/getTraces(). In a system context withProjectList returns all.
     return db
       .select()
       .from(consiliumLoopRounds)
-      .where(withProject(consiliumLoopRounds, eq(consiliumLoopRounds.loopId, loopId)))
+      .where(
+        and(
+          eq(consiliumLoopRounds.loopId, loopId),
+          inArray(
+            consiliumLoopRounds.loopId,
+            db
+              .select({ id: consiliumLoops.id })
+              .from(consiliumLoops)
+              .where(
+                inArray(
+                  consiliumLoops.groupId,
+                  db.select({ id: taskGroups.id }).from(taskGroups).where(withProjectList(taskGroups)),
+                ),
+              ),
+          ),
+        ),
+      )
       .orderBy(asc(consiliumLoopRounds.round));
   }
 

--- a/tests/unit/consilium/prior-findings.test.ts
+++ b/tests/unit/consilium/prior-findings.test.ts
@@ -1,0 +1,187 @@
+/**
+ * prior-findings.test.ts — Enh1 unit coverage for the round-history block.
+ *
+ * Covers the PURE `formatPriorFindings` (round > 1 inheritance) and its
+ * round-trip through `buildDiffContext`'s new `priorFindings` param:
+ *   - lists earlier rounds' open action points (title + priority) + P0 trend
+ *   - rows with no action points degrade to their openP0 count
+ *   - oldest-first whole-round truncation under a byte budget (+ omitted note)
+ *   - header-only fallback, then null, when even one round will not fit
+ *   - buildDiffContext appends the block AFTER the diff and byte-clamps it
+ */
+import { describe, it, expect, vi } from "vitest";
+import { formatPriorFindings } from "../../../server/services/consilium/consilium-loop-controller.js";
+import { buildDiffContext, type GitDiffClient } from "../../../server/services/consilium/diff-context.js";
+import type { ConsiliumLoopRoundRow } from "@shared/schema";
+
+const REPO = process.cwd();
+const ALLOW = [REPO];
+const HEAD_SHA = "a".repeat(40);
+const BASE_SHA = "b".repeat(40);
+
+function fakeGit(overrides: Partial<GitDiffClient> = {}): GitDiffClient {
+  return {
+    revparse: vi.fn(async (args: string[]) => {
+      const ref = args[args.length - 1];
+      if (ref === "HEAD^{commit}") return HEAD_SHA + "\n";
+      return ref.replace(/\^\{commit\}$/, "") + "\n";
+    }),
+    diff: vi.fn(async (args: string[]) =>
+      args.includes("--stat") ? "stat" : "diff --git a/f b/f\n+x",
+    ),
+    ...overrides,
+  };
+}
+
+function round(partial: Partial<ConsiliumLoopRoundRow> & { round: number }): ConsiliumLoopRoundRow {
+  return {
+    id: `r${partial.round}`,
+    loopId: "loop-1",
+    iterationNumber: partial.round,
+    converged: false,
+    openP0: 0,
+    openActionPoints: [],
+    baselineCommit: null,
+    headCommit: null,
+    testSummary: null,
+    createdAt: new Date(),
+    ...partial,
+  } as ConsiliumLoopRoundRow;
+}
+
+describe("formatPriorFindings — assembly", () => {
+  it("returns null with no rounds", () => {
+    expect(formatPriorFindings([], 10_000)).toBeNull();
+  });
+
+  it("lists each round's action points (title + priority) and the P0 trend", () => {
+    const rows = [
+      round({
+        round: 1,
+        openP0: 2,
+        openActionPoints: [
+          { title: "Fix the race", priority: "P0" },
+          { title: "Validate input", priority: "P0" },
+          { title: "Add a metric", priority: "P2" },
+        ],
+      }),
+      round({
+        round: 2,
+        openP0: 1,
+        openActionPoints: [{ title: "Close the leak", priority: "P0" }],
+      }),
+    ];
+    const out = formatPriorFindings(rows, 10_000);
+    expect(out).not.toBeNull();
+    expect(out).toContain("## Prior findings to verify (from earlier rounds)");
+    expect(out).toContain("Open P0 trend across rounds: 2 -> 1");
+    expect(out).toContain("### Round 1 (3 open, 2 P0)");
+    expect(out).toContain("- [P0] Fix the race");
+    expect(out).toContain("- [P2] Add a metric");
+    expect(out).toContain("### Round 2 (1 open, 1 P0)");
+    expect(out).toContain("- [P0] Close the leak");
+    expect(out).toContain("VERIFY".toLowerCase()); // instruction present (lowercase 'verify')
+  });
+
+  it("degrades a round with no structured action points to its openP0 count", () => {
+    const out = formatPriorFindings([round({ round: 1, openP0: 4, openActionPoints: null })], 10_000);
+    expect(out).toContain("no structured action points recorded");
+    expect(out).toContain("open P0: 4");
+  });
+
+  it("sorts rounds oldest-first regardless of input order", () => {
+    const out = formatPriorFindings(
+      [round({ round: 3, openP0: 0 }), round({ round: 1, openP0: 2 })],
+      10_000,
+    )!;
+    expect(out.indexOf("### Round 1")).toBeLessThan(out.indexOf("### Round 3"));
+    expect(out).toContain("Open P0 trend across rounds: 2 -> 0");
+  });
+});
+
+describe("formatPriorFindings — oldest-first truncation under budget", () => {
+  const big = (n: number, p: number) =>
+    round({
+      round: n,
+      openP0: p,
+      openActionPoints: Array.from({ length: 40 }, (_, i) => ({
+        title: `round-${n}-item-${i}-${"x".repeat(60)}`,
+        priority: "P0",
+      })),
+    });
+
+  it("drops whole rounds oldest-first and notes the omission", () => {
+    const out = formatPriorFindings([big(1, 5), big(2, 4), big(3, 3)], 4500)!;
+    expect(out).not.toBeNull();
+    expect(Buffer.byteLength(out, "utf8")).toBeLessThanOrEqual(4500);
+    expect(out).toContain("earlier round(s) omitted to fit the size budget");
+    // newest round survives; oldest is dropped
+    expect(out).toContain("round-3-item-0");
+    expect(out).not.toContain("round-1-item-0");
+  });
+
+  it("falls back to a header-only block when not even the newest round fits", () => {
+    const out = formatPriorFindings([big(1, 5), big(2, 4)], 600)!;
+    expect(out).not.toBeNull();
+    expect(Buffer.byteLength(out, "utf8")).toBeLessThanOrEqual(600);
+    expect(out).toContain("round(s) of detail omitted to fit the size budget");
+    expect(out).toContain("Open P0 trend across rounds");
+  });
+
+  it("returns null when even the header will not fit the budget", () => {
+    expect(formatPriorFindings([big(1, 5)], 50)).toBeNull();
+  });
+});
+
+describe("buildDiffContext — priorFindings round-trip (Enh1)", () => {
+  it("appends the prior-findings block AFTER the diff section on round > 1", async () => {
+    const res = await buildDiffContext({
+      repoPath: REPO,
+      baselineCommit: BASE_SHA,
+      objective: "Obj",
+      allowedRepoPaths: ALLOW,
+      maxDiffBytes: 10_000,
+      priorFindings: "## Prior findings to verify (from earlier rounds)\n\n- [P0] Fix the race",
+      gitClient: fakeGit(),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.input.indexOf("## Changes since last review")).toBeLessThan(
+      res.input.indexOf("## Prior findings to verify"),
+    );
+    expect(res.input).toContain("- [P0] Fix the race");
+  });
+
+  it("byte-clamps an oversized prior-findings block and sets truncated", async () => {
+    const huge = "## Prior findings to verify\n" + "Z".repeat(5000);
+    const res = await buildDiffContext({
+      repoPath: REPO,
+      baselineCommit: BASE_SHA,
+      objective: "Obj",
+      allowedRepoPaths: ALLOW,
+      maxDiffBytes: 1024,
+      priorFindings: huge,
+      gitClient: fakeGit(),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.truncated).toBe(true);
+    expect(res.input).toContain("prior findings truncated");
+  });
+
+  it("never injects prior findings on round 1 (null baseline)", async () => {
+    const res = await buildDiffContext({
+      repoPath: REPO,
+      baselineCommit: null,
+      objective: "Obj",
+      allowedRepoPaths: ALLOW,
+      maxDiffBytes: 10_000,
+      priorFindings: "## Prior findings to verify\n- [P0] should NOT appear",
+      gitClient: fakeGit(),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.input).toBe("Obj");
+    expect(res.input).not.toContain("Prior findings");
+  });
+});


### PR DESCRIPTION
## Summary
Makes the consilium loop a real reconciliation loop and fixes a regression the project-isolation merge introduced. Demonstrated end-to-end on a live cross-review dispute (Opus 4.8 ⇄ Gemini 3.1 Pro High → judge).

### Server
- **Fix poller regression (was silently stalling every loop):** the poller sweep called `controller.tick()` with **no ALS context**, so project-scoped storage (`getTaskGroup`/`updateLoop`/`startGroupAsync` inserts) threw "no request context" and the loop stuck at `building_context`. The sweep now resolves each loop's project (via its group) and runs `tick()` inside `runAsProject(projectId)` (system-context fallback). *(Regression from #406.)*
- **Fix `getLoopRounds`:** `consilium_loop_rounds` has no `project_id`; it now scopes through loop → group → `task_groups` via subquery (the `getLoops`/`getTraces` pattern) instead of `withProject` on a non-existent column (which 500'd the detail GET).
- **Round-history inheritance (Enh1):** on round > 1, `startReviewRound` injects prior rounds' open `action_points` into the review input (`## Prior findings to verify`) so debaters verify closure against the diff instead of circling. `diff-context` gains an optional, byte-capped `priorFindings` section.

### Client
- **Real per-round trajectory stepper:** the old stepper marked EVERY step done for any terminal state — a `stopped_cap` loop (exits from `deciding`, never develops) wrongly showed Developing/Awaiting-merge ✓. Now reach is derived per round from `state`/`round`/`rounds`/`devGroupId`/`prRef`; verdict-terminal rounds render Develop/Await as not-reached.
- **Loop list first column = workspace name** (matched `repoPath` → `workspace.path`, fallback repo basename).
- **Context-aware `stopped_cap` label:** assessment loop (`maxRounds==1`) → "Completed — review"; remediation loop that hit the cap with open P0s → "Stopped — N P0 open".

### Cross-review dispute (no server change)
The "primary → mutual rebuttal → judge" structure is a task-group `dependsOn` DAG; only the judge emits `action_points`, so `pickJudgeOutput` selects it. Verified live: 5 tasks, judge synthesized 12 survived-rebuttal findings.

## Verification
`tsc --noEmit` clean; `tests/unit/consilium` + `tests/unit/scoping` **176/176** (incl. new `prior-findings.test.ts`, 10 tests). Live: a cross-review loop ran round 1 → stopped_cap with a correct judge verdict; detail stepper no longer shows phantom Developing; list shows "omnius".

## Follow-up
`loop.openP0` isn't populated from the judge verdict's P0 count (remediation label / anti-stall would benefit) — tracked separately.