### PR TITLE
feat(projects): enforce per-owner unique project name

### DIFF
--- a/migrations/0029_projects_unique_owner_name.sql
+++ b/migrations/0029_projects_unique_owner_name.sql
@@ -1,0 +1,5 @@
+-- Enforce per-owner project name uniqueness (no two projects with the same
+-- name under the same owner). Backstops the route-level 409 check against the
+-- create-create race. Idempotent.
+CREATE UNIQUE INDEX IF NOT EXISTS projects_owner_id_name_unique
+  ON projects (owner_id, name);

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { db } from "../db";
 import { projects, projectMembers, insertProjectSchema } from "../../shared/schema";
-import { eq, or } from "drizzle-orm";
+import { eq, or, and } from "drizzle-orm";
 import { requireAuth } from "../auth/middleware";
 
 const router = Router();
@@ -48,6 +48,16 @@ router.post("/", requireAuth, async (req, res) => {
     const data = insertProjectSchema.omit({ ownerId: true }).parse(req.body);
     const userId = req.user!.id;
 
+    // Reject a duplicate name for the same owner (409). A DB unique index on
+    // (owner_id, name) is the hard backstop against the create-create race.
+    const [existing] = await db
+      .select({ id: projects.id })
+      .from(projects)
+      .where(and(eq(projects.ownerId, userId), eq(projects.name, data.name)));
+    if (existing) {
+      return res.status(409).json({ error: `A project named "${data.name}" already exists` });
+    }
+
     const [newProject] = await db
       .insert(projects)
       .values({
@@ -58,6 +68,10 @@ router.post("/", requireAuth, async (req, res) => {
 
     res.status(201).json(newProject);
   } catch (error: any) {
+    // 23505 = Postgres unique_violation (the (owner_id, name) index backstop).
+    if (error?.code === "23505") {
+      return res.status(409).json({ error: "A project with this name already exists" });
+    }
     console.error("Error creating project:", error);
     res.status(400).json({ error: error.message || "Failed to create project" });
   }


### PR DESCRIPTION
## Summary
Two projects with the same name under one owner could be created (the UI even auto-created a duplicate `weRush`), making the project selector ambiguous.

- `POST /api/projects` → **409** when the owner already has a project with that name (checked before insert); also maps Postgres `unique_violation` (23505) → 409 as the create-create race backstop.
- **Migration 0029** adds a `UNIQUE` index on `projects(owner_id, name)`.

## Verification
`tsc --noEmit` clean. Live: after dedup, re-creating `weRush` returns **409**; the unique index is present in the DB.