### PR TITLE
feat(sdlc): worktree-isolated agentic SDLC executor for consilium dev handoff

### DIFF
--- a/client/src/components/task-groups/verdict-panel.tsx
+++ b/client/src/components/task-groups/verdict-panel.tsx
@@ -207,9 +207,21 @@ export function VerdictPanel({
         })),
       };
       const created = (await apiRequest("POST", "/api/task-groups", payload)) as { id: string };
+      // #2b: AUTO-START the handoff so it runs immediately instead of sitting
+      // pending until the user opens the group and clicks Run. The group already
+      // exists; a failed start is non-fatal (it can be retried from the group
+      // page), so we surface a softer toast rather than failing the whole handoff.
+      let started = true;
+      try {
+        await apiRequest("POST", `/api/task-groups/${created.id}/start`, {});
+      } catch {
+        started = false;
+      }
       toast({
-        title: "Передано на исполнение",
-        description: `${actionPoints.length} action points → ${pipeline?.name}. Откройте группу и нажмите Run.`,
+        title: started ? "Передано и запущено" : "Передано на исполнение",
+        description: started
+          ? `${actionPoints.length} action points → ${pipeline?.name}. Исполнение запущено.`
+          : `${actionPoints.length} action points → ${pipeline?.name}. Откройте группу и нажмите Run.`,
       });
       navigate(`/task-groups/${created.id}`);
     } catch (err) {

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -148,8 +148,10 @@ function isErrorWithStatus(err: unknown, status: number): boolean {
 //                           → the loop terminates FROM "deciding"; Develop and
 //                             Await-merge were NOT reached (dimmed "not reached").
 //       – failed | cancelled → may stop anywhere, so claim only what is evidenced:
-//                             Context/Review/Decide done iff a round row exists,
-//                             Develop iff devGroupId is set, Await iff prRef is set.
+//                             Context/Review/Decide/Develop done iff a round row
+//                             exists (the round row is written on entering
+//                             DEVELOPING; H-2 SDLC sets no devGroupId), Await iff
+//                             prRef is set.
 
 type StepStatus = "done" | "current" | "not_reached";
 
@@ -181,10 +183,9 @@ function roundStepStatuses(args: {
   isLast: boolean;
   hasRoundRow: boolean;
   state: ConsiliumLoopState;
-  devGroupId: string | null | undefined;
   prRef: string | null | undefined;
 }): StepStatus[] {
-  const { isLast, hasRoundRow, state, devGroupId, prRef } = args;
+  const { isLast, hasRoundRow, state, prRef } = args;
 
   // Produced a later round ⇒ fully traversed AND merged.
   if (!isLast) return ROUND_STEPS.map(() => "done");
@@ -207,9 +208,11 @@ function roundStepStatuses(args: {
 
   // failed | cancelled (and the pre-start `pending` fallback) — claim only what
   // the data evidences.
+  // H-2: the SDLC handoff no longer mints a DEV task group (devGroupId is always
+  // null), so a recorded round row (written on entering DEVELOPING) is the
+  // "developing reached" signal; prRef is the await/PR signal.
   const core: StepStatus = hasRoundRow ? "done" : "not_reached";
   return ROUND_STEPS.map((step) => {
-    if (step.key === "developing") return devGroupId ? "done" : "not_reached";
     if (step.key === "awaiting_merge") return prRef ? "done" : "not_reached";
     return core;
   });
@@ -265,7 +268,6 @@ function FsmStepper({ loop }: { loop: ConsiliumLoopDetailRow }) {
           isLast,
           hasRoundRow: !!d.row,
           state: loop.state,
-          devGroupId: loop.devGroupId,
           prRef: loop.prRef,
         });
         const developStatus = statuses[ROUND_STEP_IDX.developing];

--- a/server/gateway/providers/cli-spawn.ts
+++ b/server/gateway/providers/cli-spawn.ts
@@ -114,6 +114,20 @@ export interface CliSpawnRequest {
   signal?: AbortSignal;
   /** Extra env vars merged over process.env. */
   env?: Record<string, string>;
+  /**
+   * Working directory for the child. Used by agentic CLI callers (e.g. the SDLC
+   * coder) to confine the process to an isolated worktree; omitted = inherit the
+   * server cwd (the prior behaviour for short LLM callers).
+   */
+  cwd?: string;
+  /**
+   * COMPLETE replacement env for the child (H-1). When set, the child gets EXACTLY
+   * this map — `process.env` is NOT merged in — so a caller can spawn an agentic
+   * coder under a sanitized, allowlisted env that omits inherited secrets
+   * (DB creds, GH/AWS tokens, …). When undefined, the prior merge behaviour
+   * (`{...process.env, ...env}`) applies for the short LLM callers.
+   */
+  envOverride?: NodeJS.ProcessEnv;
 }
 
 export interface CliSpawnResult {
@@ -228,7 +242,8 @@ export function spawnCli(request: CliSpawnRequest): Promise<CliSpawnResult> {
 
   return new Promise<CliSpawnResult>((resolve, reject) => {
     const child = spawn(request.binary, request.args, {
-      env: { ...process.env, ...request.env },
+      cwd: request.cwd,
+      env: request.envOverride ?? { ...process.env, ...request.env },
       stdio: ["pipe", "pipe", "pipe"],
     });
 
@@ -290,7 +305,8 @@ export async function* streamCliLines(
   const maxLineBytes = request.maxLineBytes ?? DEFAULT_MAX_LINE_BYTES;
 
   const child = spawn(request.binary, request.args, {
-    env: { ...process.env, ...request.env },
+    cwd: request.cwd,
+    env: request.envOverride ?? { ...process.env, ...request.env },
     stdio: ["pipe", "pipe", "pipe"],
   });
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -56,7 +56,6 @@ import { registerTaskGroupRoutes } from "./routes/task-groups";
 import { registerTaskGroupResolveRoute } from "./routes/task-group-resolve";
 import { registerConsiliumLoopRoutes } from "./routes/consilium-loops";
 import { ConsiliumLoopController, ConsiliumLoopPoller } from "./services/consilium/consilium-loop-controller";
-import { WorkspaceManager } from "./workspace/manager";
 import { registerSkillTeamRoutes } from "./routes/skill-teams";
 import { registerModelSkillBindingRoutes } from "./routes/model-skill-bindings";
 import { registerGitSkillSourceRoutes } from "./routes/git-skill-sources";
@@ -298,9 +297,9 @@ export async function registerRoutes(
       storage,
       taskOrchestrator,
       config: () => appConfigLoader.get(),
-      // §14.2/D.5: the WorkspaceManager seam the DEV close-out drives (branch +
-      // write the bounded `.md` artifact); push/PR go through pr-wrapper (D.4).
-      closeoutManager: new WorkspaceManager(),
+      // §14.4: the DEVELOPING→AWAITING_MERGE close-out runs the SDLC executor
+      // (isolated worktree + agentic coder + Draft PR) by default — no manager
+      // seam needed here. Push/PR go through pr-wrapper (B-3/H-6/H-7/M-6/M-7).
     });
     registerConsiliumLoopRoutes(app, storage, consiliumLoopController, () => appConfigLoader.get());
     consiliumLoopPoller = new ConsiliumLoopPoller(

--- a/server/routes/task-groups.ts
+++ b/server/routes/task-groups.ts
@@ -110,11 +110,21 @@ export function registerTaskGroupRoutes(
       const visible = groups.filter((g) => isVisible(g.createdBy, req.user));
       const result = await Promise.all(
         visible.map(async (g) => {
+          // #3: `completedCount` must reflect the LATEST ITERATION's executions,
+          // not the task DEFINITION statuses (which stay blocked/ready, so a fully
+          // executed group used to show 0/N). taskCount = number of definitions;
+          // completedCount = executions with status "completed" in the latest
+          // iteration. One extra latest-iteration + executions read per group
+          // (project-scoped via the storage context) — bounded, no N+1 blow-up.
           const tasks = await storage.getTasksByGroup(g.id);
+          const latest = await storage.getLatestIteration(g.id);
+          const executions = latest
+            ? await storage.getExecutionsByIteration(g.id, latest.id)
+            : [];
           const row: Record<string, unknown> = {
             ...g,
             taskCount: tasks.length,
-            completedCount: tasks.filter((t) => t.status === "completed").length,
+            completedCount: executions.filter((e) => e.status === "completed").length,
           };
           // Owner attribution is admin-only; hide createdBy from non-admins.
           if (!isAdmin) delete row.createdBy;

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -30,7 +30,7 @@
  *     on KICKOFF (milliseconds), not after the child completes. `deriveReviewEvent`
  *     /`deriveDevEvent` then poll the settled child to advance — they are now the
  *     primary completion driver (§14.5), not vestigial.
- *   - The DEVELOPING→AWAITING_MERGE side effect runs `DevPrCloseout` (D.5) to
+ *   - The DEVELOPING→AWAITING_MERGE side effect runs the SDLC executor
  *     produce a REAL branch + Draft PR; `prRef` + `headCommitAtReview` are
  *     persisted on the won row (§14.4). The close-out runs ONLY on the CAS/claim
  *     winner (single-flight, §13) — a re-driven DEVELOPING never double-runs it;
@@ -47,9 +47,8 @@ import type { TaskOrchestrator } from "../task-orchestrator.js";
 import type { AppConfig } from "../../config/schema.js";
 import { readConvergence } from "../orchestrator/convergence.js";
 import { buildDiffContext } from "./diff-context.js";
-import { buildDevHandoffGroup } from "./dev-handoff.js";
-import { resolveLoopWorkspace, type WorkspaceBindStorage } from "./workspace-bind.js";
-import { DevPrCloseout, type DevCloseoutResult } from "./dev-closeout.js";
+import type { DevCloseoutResult } from "./dev-closeout.js";
+import { runSdlcHandoff } from "../sdlc/executor.js";
 
 // ─── FSM events (design §3 "Event / guard" column) ──────────────────────────
 
@@ -60,7 +59,7 @@ export type LoopEvent =
   | { kind: "review_completed"; verdict: ConvergenceVerdict }
   | { kind: "review_failed"; error: string }
   | { kind: "decided"; verdict: ConvergenceVerdict; priorOpenP0: number[] }
-  | { kind: "dev_completed"; prRef: string | null; headCommit: string }
+  | { kind: "dev_completed"; prRef: string | null; headCommit: string; error?: string }
   | { kind: "merge_approved" }
   | { kind: "cancel" };
 
@@ -72,6 +71,28 @@ export interface LoopTransition {
 }
 
 const ANTI_STALL_MIN_ROUND = 3;
+
+/**
+ * H-2: the developing-state crash-stranded grace MUST exceed the SDLC coder's
+ * hard timeout (executor/coder default 600s) — otherwise a normal long coder run
+ * is mistaken for a crash and a SECOND coder is launched mid-run. 600s + 60s.
+ */
+const SDLC_DEV_GRACE_MS = 660_000;
+
+/** Process-local handle for a BACKGROUND SDLC close-out run (H-2). */
+interface SdlcRun {
+  /** The loop round this run implements (guards a stale prior-round entry). */
+  round: number;
+  /** Flips true once the background close-out settles (success OR degraded). */
+  done: boolean;
+  /** The settled `{ prRef, headCommit, error? }`; absent while in-flight. */
+  result?: DevCloseoutResult;
+}
+
+/** Minimal error scrub (strip fs paths) for the background-run catch. */
+function scrubErr(raw: string): string {
+  return raw.replace(/\/[^\s'"]+/g, "<path>").replace(/\s+/g, " ").trim().slice(0, 200);
+}
 
 /**
  * Decide whether the open-P0 count failed to decrease across two consecutive
@@ -118,15 +139,19 @@ export function reduce(state: ConsiliumLoopState, event: LoopEvent): LoopTransit
 
     case "developing":
       if (event.kind === "dev_completed") {
-        // §14.4: the REAL `prRef` + `headCommit` are produced by `DevPrCloseout`
-        // in `runSideEffect` AFTER this CAS wins (so the close-out runs only on
-        // the winning path). The event carries placeholders here; the won row's
-        // follow-up `updateLoop` persists the real values. The transition still
-        // seeds whatever the event happens to carry (null/"" by default).
+        // H-2: the SDLC close-out ran in the BACKGROUND while the loop sat in
+        // `developing`; the event carries the REAL prRef/headCommit (+ optional
+        // error) the coder produced. The CAS persists them atomically with the
+        // state change, so AWAITING_MERGE always opens with a real PR (never a
+        // half-open gate).
         return {
           from: "developing",
           to: "awaiting_merge",
-          extra: { prRef: event.prRef, headCommitAtReview: event.headCommit },
+          extra: {
+            prRef: event.prRef,
+            headCommitAtReview: event.headCommit,
+            ...(event.error ? { error: event.error } : {}),
+          },
         };
       }
       return null;
@@ -186,16 +211,17 @@ export interface ConsiliumLoopControllerDeps {
    */
   readRepoHead?: (loop: ConsiliumLoopRow) => Promise<string>;
   /**
-   * §14.2/D.5 DEV→repo→PR close-out. Injectable so unit tests assert prRef flow
-   * with a fake (no real repo / gh). The default runs the real `DevPrCloseout`
-   * over the injected `closeoutManager` + the controller's `storage`.
+   * §14.2/§14.4 DEVELOPING→AWAITING_MERGE close-out. Injectable so unit tests
+   * assert the prRef/headCommit flow with a fake (no real repo / claude / gh).
+   * The default runs the REAL SDLC executor (`runSdlc` below).
    */
   runCloseout?: (loop: ConsiliumLoopRow, verdict: ConvergenceVerdict) => Promise<DevCloseoutResult>;
   /**
-   * The `WorkspaceManager`-shaped seam the default close-out drives (branch +
-   * write). Required only when `runCloseout` is NOT injected.
+   * The SDLC handoff: cut an ISOLATED worktree, run the agentic coder for REAL
+   * edits, commit + open a Draft PR. Defaults to the real `runSdlcHandoff`.
+   * Injectable so tests can assert the close-out path without a worktree/coder.
    */
-  closeoutManager?: ConstructorParameters<typeof DevPrCloseout>[0]["manager"];
+  runSdlc?: typeof runSdlcHandoff;
 }
 
 export class ConsiliumLoopController {
@@ -210,6 +236,14 @@ export class ConsiliumLoopController {
    * This lock + the grace guard below close that window. Both, not either.
    */
   private readonly inFlight = new Set<string>();
+
+  /**
+   * H-2: process-local registry of in-flight/settled BACKGROUND SDLC close-out
+   * runs, keyed by loopId. The coder runs OFF the tick path (it can take ~10 min),
+   * so a tick never blocks the sequential poller sweep; `deriveDevEvent` reads the
+   * settled result here and the developing->awaiting_merge CAS consumes it.
+   */
+  private readonly sdlcRuns = new Map<string, SdlcRun>();
 
   constructor(private readonly deps: ConsiliumLoopControllerDeps) {}
 
@@ -233,8 +267,12 @@ export class ConsiliumLoopController {
    * re-driven; only a loop whose `updatedAt` predates this window — i.e. the
    * state was persisted and then the process died — is re-driven.
    */
-  private redriveGraceMs(): number {
-    return Math.max(2 * this.loopConfig().pollIntervalMs, 30_000);
+  private redriveGraceMs(state?: ConsiliumLoopState): number {
+    const base = Math.max(2 * this.loopConfig().pollIntervalMs, 30_000);
+    // H-2: developing waits on a background coder (~10 min), so its grace must
+    // exceed the coder timeout or a normal long run looks stranded.
+    if (state === "developing") return Math.max(base, SDLC_DEV_GRACE_MS);
+    return base;
   }
 
   /** Begin round 1. 409s (returns null) unless the loop is PENDING. */
@@ -275,6 +313,7 @@ export class ConsiliumLoopController {
     const transition = reduce(loop.state, { kind: "cancel" });
     if (!transition) return null;
     await this.deps.taskOrchestrator.cancelGroup(loop.groupId).catch(() => undefined);
+    this.sdlcRuns.delete(loopId); // H-2: drop any in-flight SDLC handle (terminal).
     return this.commit(loop, transition);
   }
 
@@ -335,7 +374,7 @@ export class ConsiliumLoopController {
     if (!transition) return null;
 
     // H-3 (BLOCKER fix): CLAIM the transition with the CAS FIRST, then run any
-    // non-idempotent side effect (createTaskGroup / startGroup / the DevPrCloseout
+    // non-idempotent side effect (createTaskGroup / startGroup / the SDLC executor
     // branch+push+PR — all mint NEW external state with no idempotency key) ONLY
     // on the row that WON the CAS. Under multi-instance (>=2 pollers reading the
     // same `deciding`/`developing` row) exactly one CAS updates a row; the loser
@@ -387,13 +426,13 @@ export class ConsiliumLoopController {
     if (!nullRef) return null; // child ref set — not stranded, advance normally
 
     const ageMs = Date.now() - new Date(loop.updatedAt).getTime();
-    if (ageMs < this.redriveGraceMs()) {
+    if (ageMs < this.redriveGraceMs(loop.state)) {
       this.log(loop.id, `null child ref in ${loop.state} but within grace (${ageMs}ms) — assume in-flight, no re-drive`);
       return null; // in-flight side effect — must NOT re-drive (cheap pre-check)
     }
 
     // Cross-instance ATOMIC claim: only the winner proceeds (H-3 re-drive guard).
-    const claimed = await this.storage.claimRedrive(loop.id, loop.state, this.redriveGraceMs());
+    const claimed = await this.storage.claimRedrive(loop.id, loop.state, this.redriveGraceMs(loop.state));
     if (!claimed) {
       this.log(loop.id, `re-drive claim lost in ${loop.state} (another instance is re-driving) — no-op`);
       return null;
@@ -463,26 +502,20 @@ export class ConsiliumLoopController {
   }
 
   /**
-   * DEVELOPING: poll the DEV handoff group; completed → open the merge gate.
-   *
-   * §14.4: this returns a PLACEHOLDER `dev_completed` (prRef null / headCommit
-   * "") — the REAL `prRef` + `headCommit` come from `DevPrCloseout`, which runs
-   * in `runSideEffect` AFTER the `developing→awaiting_merge` CAS WINS, so the
-   * close-out (a non-idempotent branch+push+PR) runs ONLY on the winning path
-   * (single-flight, §13). Running it here would let a losing tick open a
-   * duplicate PR before the CAS rejects it.
+   * DEVELOPING (H-2): read the BACKGROUND SDLC run's settle from the process-local
+   * registry. The coder was dispatched OFF the tick path on entry
+   * (`startDevHandoff`) or by a redrive claim. Settled → `dev_completed` carrying
+   * the REAL prRef/headCommit/error → the developing->awaiting_merge CAS persists
+   * them. In-flight → null (no-op; the tick returns fast, never blocking the
+   * sweep). No local entry (crash/restart, or another instance is the dispatcher)
+   * → null; the developing redrive (null devGroupId past the coder-length grace)
+   * re-dispatches on this instance only after the dispatcher is presumed dead.
    */
-  private async deriveDevEvent(loop: ConsiliumLoopRow): Promise<LoopEvent | null> {
-    if (!loop.devGroupId) return null;
-    const group = await this.storage.getTaskGroup(loop.devGroupId);
-    if (!group) return null;
-    if (group.status === "completed") {
-      return { kind: "dev_completed", prRef: null, headCommit: "" };
-    }
-    if (group.status === "failed" || group.status === "cancelled") {
-      return { kind: "review_failed", error: `DEV group ${group.status}` };
-    }
-    return null;
+  private deriveDevEvent(loop: ConsiliumLoopRow): LoopEvent | null {
+    const run = this.sdlcRuns.get(loop.id);
+    if (!run || run.round !== loop.round || !run.done || !run.result) return null;
+    const { prRef, headCommit, error } = run.result;
+    return { kind: "dev_completed", prRef, headCommit, error };
   }
 
   /**
@@ -500,56 +533,37 @@ export class ConsiliumLoopController {
     if (transition.to === "developing" && event.kind === "decided") {
       return this.startDevHandoff(loop, event.verdict);
     }
-    // §14.4: DEVELOPING→AWAITING_MERGE — run the close-out on the WON row and
-    // persist the real prRef + reviewed HEAD. The verdict (open action points)
-    // is re-resolved here for the close-out artifact body.
-    if (transition.to === "awaiting_merge") return this.runDevCloseout(loop);
+    // §14.4 H-2: the SDLC close-out already ran in the BACKGROUND during
+    // `developing`; the `dev_completed` event carried prRef/headCommit/error which
+    // `reduce` wrote into this transition's extra. Nothing to run here — just drop
+    // the settled registry entry so it can never be re-read.
+    if (transition.to === "awaiting_merge") {
+      this.sdlcRuns.delete(loop.id);
+      return {};
+    }
     return {};
   }
 
-  /**
-   * DEVELOPING→AWAITING_MERGE side effect (§14.2/§14.4). Runs `DevPrCloseout`
-   * (real branch + Draft PR) and returns `{ prRef, headCommitAtReview, error? }`
-   * for the follow-up `updateLoop` on the won row. The close-out NEVER throws
-   * (branch-only fallback on any VCS failure) so the loop is never failed here.
-   * Runs ONLY on the CAS winner — a re-driven DEVELOPING never double-runs it.
-   */
-  private async runDevCloseout(loop: ConsiliumLoopRow): Promise<Record<string, unknown>> {
-    const verdict = await this.resolveVerdict(loop);
-    if (!verdict) {
-      this.log(loop.id, "close-out skipped — verdict unreadable; AWAITING_MERGE with null prRef");
-      return { prRef: null, error: "verdict unreadable at close-out" };
-    }
-    const result = await this.closeout(loop, verdict);
-    this.log(loop.id, `close-out done -> prRef=${result.prRef ?? "null"}${result.error ? ` (${result.error})` : ""}`);
-    return {
-      prRef: result.prRef,
-      headCommitAtReview: result.headCommit,
-      ...(result.error ? { error: result.error } : {}),
-    };
-  }
-
-  /** Resolve the close-out fn: injected fake (tests) or the real DevPrCloseout. */
+  /** Resolve the close-out fn: injected fake (tests) or the real SDLC executor. */
   private async closeout(
     loop: ConsiliumLoopRow,
     verdict: ConvergenceVerdict,
   ): Promise<DevCloseoutResult> {
     if (this.deps.runCloseout) return this.deps.runCloseout(loop, verdict);
     const cfg = this.loopConfig();
-    if (!this.deps.closeoutManager) {
-      return { prRef: null, headCommit: "", error: "no close-out manager configured" };
-    }
-    const closeout = new DevPrCloseout({
-      manager: this.deps.closeoutManager,
-      storage: this.storage as unknown as WorkspaceBindStorage,
-    });
-    return closeout.run({
+    const run = this.deps.runSdlc ?? runSdlcHandoff;
+    // REAL path: the SDLC executor cuts an ISOLATED worktree (NEVER the user's
+    // checkout), runs the agentic coder to make REAL multi-file edits, then
+    // commits + opens a Draft PR. baseRef defaults to the repo's default-branch
+    // HEAD (resolved inside the executor) so the PR diffs cleanly against it.
+    // Never throws (degrades to a no-PR result), so the loop is never failed here.
+    return run({
+      repoPath: loop.repoPath,
       loopId: loop.id,
       round: loop.round,
-      repoPath: loop.repoPath,
-      ownerId: loop.createdBy ?? "",
+      actionPoints: verdict.openActionPoints,
       allowedRepoPaths: cfg.allowedRepoPaths,
-      openActionPoints: verdict.openActionPoints,
+      ownerId: loop.createdBy ?? "",
     });
   }
 
@@ -600,56 +614,52 @@ export class ConsiliumLoopController {
   }
 
   /**
-   * DECIDING → DEVELOPING: persist the round audit row, resolve the loop's
-   * workspace (D.3, grounds the DEV pipeline's read tools §14.3), then hand the
-   * open action points to the DEV pipeline as a `pipeline_run` group started
-   * NON-BLOCKINGLY (D.1). `devGroupId` is persisted on KICKOFF (§14.5).
+   * DECIDING → DEVELOPING (H-2): persist the round audit row, then dispatch the
+   * SDLC close-out as a BACKGROUND job (`dispatchSdlc`). `devGroupId` is left NULL
+   * — it is the in-progress/stranded marker `claimRedrive(developing)` already
+   * understands, so a crash mid-coder is recoverable (M-1). The tick returns
+   * immediately (non-blocking); `deriveDevEvent` polls the background settle and
+   * the developing->awaiting_merge CAS consumes the prRef/headCommit.
+   *
+   * Single-flight: this runs ONLY on the deciding->developing CAS winner (or a
+   * redrive claim), so exactly one coder is launched per round per process.
    */
   private async startDevHandoff(
     loop: ConsiliumLoopRow,
     verdict: ConvergenceVerdict,
   ): Promise<Record<string, unknown>> {
-    const devPipelineId = loop.devPipelineId ?? this.loopConfig().devPipelineId;
-    if (!devPipelineId) {
-      return { state: "escalated", error: "no DEV pipeline configured", completedAt: new Date() };
-    }
     await this.recordRound(loop, verdict);
-    const workspaceId = await this.resolveWorkspaceId(loop); // §14.3 grounding.
-    const payload = buildDevHandoffGroup({
-      openActionPoints: verdict.openActionPoints,
-      devPipelineId,
-      source: loop.id,
-      createdBy: loop.createdBy ?? undefined,
-      workspaceId,
-    });
-    this.log(loop.id, `startDevHandoff -> createTaskGroup (${verdict.openActionPoints.length} action points, ws=${workspaceId ?? "none"})`);
-    const { group } = await this.deps.taskOrchestrator.createTaskGroup(payload);
-    // §14.5: NON-BLOCKING — `devGroupId` is persisted on KICKOFF; `deriveDevEvent`
-    // polls the DEV group's settle to open the merge gate.
-    await this.deps.taskOrchestrator.startGroupAsync(group.id, { triggeredBy: loop.createdBy });
-    this.log(loop.id, `startDevHandoff done -> devGroup ${group.id} (dispatched)`);
-    return { devGroupId: group.id, openP0: verdict.openP0 };
+    this.dispatchSdlc(loop, verdict);
+    // Persist openP0 + bump updatedAt so the freshly-entered developing loop reads
+    // as in-flight (within grace), not stranded. devGroupId stays null (marker).
+    return { openP0: verdict.openP0 };
   }
 
   /**
-   * §14.3: resolve (scan-or-create) the `local` workspace bound to the loop's
-   * repo so the DEV handoff's read tools are grounded in the repo. Best-effort:
-   * a bind failure (non-allowlisted path / fs error) must NOT block the handoff
-   * — it degrades to today's no-workspace behaviour (undefined).
+   * H-2: launch the SDLC close-out (isolated worktree + agentic coder + Draft PR)
+   * as a fire-and-forget BACKGROUND job tracked in the process-local registry.
+   * The coder may run ~10 min; running it inline would block the sequential
+   * poller sweep across ALL loops/projects (attacker-amplifiable via the untrusted
+   * action-point text driving coder runtime). The executor's own ConcurrencyLimiter
+   * bounds how many coders actually spawn at once. The close-out never throws; the
+   * catch is purely defensive so the registry ALWAYS settles (else the redrive
+   * recovers after the coder-length grace).
    */
-  private async resolveWorkspaceId(loop: ConsiliumLoopRow): Promise<string | undefined> {
-    try {
-      const ws = await resolveLoopWorkspace(
-        this.storage as unknown as WorkspaceBindStorage,
-        loop.repoPath,
-        loop.createdBy ?? "",
-        this.loopConfig().allowedRepoPaths,
-      );
-      return ws.id;
-    } catch (err) {
-      this.log(loop.id, `workspace bind failed (DEV runs without workspace): ${err instanceof Error ? err.message : String(err)}`);
-      return undefined;
-    }
+  private dispatchSdlc(loop: ConsiliumLoopRow, verdict: ConvergenceVerdict): void {
+    const run: SdlcRun = { round: loop.round, done: false };
+    this.sdlcRuns.set(loop.id, run);
+    this.log(loop.id, `dispatchSdlc -> background coder round ${loop.round} (${verdict.openActionPoints.length} action points)`);
+    void this.closeout(loop, verdict)
+      .then((result) => {
+        run.result = result;
+        run.done = true;
+        this.log(loop.id, `SDLC settled -> prRef=${result.prRef ?? "null"}${result.error ? ` (${result.error})` : ""}`);
+      })
+      .catch((err: unknown) => {
+        run.result = { prRef: null, headCommit: "", error: scrubErr(err instanceof Error ? err.message : String(err)) };
+        run.done = true;
+        this.log(loop.id, `SDLC threw (degraded) -> ${run.result.error}`);
+      });
   }
 
   /**

--- a/server/services/consilium/pr-wrapper.ts
+++ b/server/services/consilium/pr-wrapper.ts
@@ -95,6 +95,19 @@ export function isValidLoopBranch(branch: string): boolean {
   return BRANCH_RE.test(branch);
 }
 
+/**
+ * Build the ONE server-derived branch shape (`consilium/loop-<uuid>/round-<n>`)
+ * from server-controlled `loopId` + `round` — NEVER from model/action-point text
+ * (B-3). Co-located with `BRANCH_RE`/`isValidLoopBranch` so the close-out (D.5)
+ * and the SDLC executor share a single source of truth for the shape; both gate
+ * the result through `isValidLoopBranch` before it reaches git/gh. A malformed
+ * `loopId` (non-uuid) yields a string the gate then REJECTS — it never silently
+ * widens the allowed shape.
+ */
+export function buildBranchName(loopId: string, round: number): string {
+  return `consilium/loop-${loopId}/round-${round}`;
+}
+
 function badBranch(branch: string): WrapFail {
   return { ok: false, kind: "bad-branch", message: `rejected branch name (B-3): ${branch}` };
 }
@@ -253,6 +266,11 @@ export async function openDraftPr(
   if (opts.head.startsWith("-") || !isValidLoopBranch(opts.head)) return badBranch(opts.head); // B-3 / B-3+.
   if (opts.title.startsWith("-")) {
     return { ok: false, kind: "bad-title", message: "rejected leading-dash title (B-3+ flag injection)" };
+  }
+  // L-1: `base` is a value-flag arg (`--base <base>`); reject a leading-dash base
+  // so a malformed/poisoned base can't be parsed by `gh` as a flag (option injection).
+  if (opts.base.startsWith("-")) {
+    return { ok: false, kind: "bad-title", message: "rejected leading-dash base (B-3+ flag injection)" };
   }
 
   const env = sanitizedEnv(); // H-7b

--- a/server/services/sdlc/coder.ts
+++ b/server/services/sdlc/coder.ts
@@ -1,0 +1,233 @@
+/**
+ * coder.ts — SDLC executor, component 2: the agentic coder.
+ *
+ * Runs the LOCAL `claude` CLI in AGENTIC mode INSIDE an isolated worktree to make
+ * real, multi-file code/spec edits implementing the round's open action points.
+ * Unlike the legacy single-shot pipeline stages, this is a full coding agent with
+ * file-write tools — so confinement is the whole game.
+ *
+ * Invocation (the exact arg array; prompt via STDIN — never argv/shell):
+ *   claude -p --output-format json --permission-mode acceptEdits \
+ *          --allowedTools Edit Write Read Bash --add-dir <worktreeDir>
+ *   cwd = <worktreeDir> ; stdin = <prompt> ; hard timeout (default 600s)
+ *
+ * Spawn discipline is reused from `cli-spawn.ts` (the same module the
+ * subscription `claude-cli` provider uses): arg-array spawn (no shell), per-proc
+ * timeout with SIGTERM→SIGKILL escalation, ENOENT→typed CliNotInstalledError,
+ * bounded concurrency. Output is parsed via the provider's `parseCompleteOutput`
+ * (`--output-format json` → one JSON object).
+ *
+ * SECURITY (BINDING — adversarial-review surface):
+ *   - The action-point text is UNTRUSTED model output. It reaches ONLY the prompt,
+ *     and ONLY via STDIN (a safe channel) — never an argv element, never a shell
+ *     string. Every field is clamped before it enters the prompt.
+ *   - File-tool access is confined to the worktree via `cwd` + `--add-dir
+ *     <worktreeDir>` (Edit/Write/Read cannot reach the user's checkout or `main`).
+ *   - `--permission-mode acceptEdits` auto-approves EDITS only; we do NOT pass
+ *     `--dangerously-skip-permissions`. `--allowedTools` is an explicit, minimal
+ *     allowlist of FILE tools only (Edit/Write/Read) — NO Bash (C-1: a Bash child
+ *     is not confined by `--add-dir` and would escape the worktree), NO MCP, NO web.
+ *   - The coder spawns under a SANITIZED, ALLOWLISTED env (H-1): only PATH/HOME/
+ *     locale + the claude CLI's own auth/config vars are forwarded. DB creds,
+ *     GH_TOKEN/GITHUB_TOKEN, AWS_ vars, PASSWORD/SECRET/other TOKEN vars, and
+ *     ANTHROPIC_API_KEY are NOT inherited — even with Bash gone, defense-in-depth.
+ */
+import { spawnCli, ConcurrencyLimiter, CliNotInstalledError } from "../../gateway/providers/cli-spawn.js";
+import { parseCompleteOutput } from "../../gateway/providers/claude-cli.js";
+import type { ActionPoint } from "@shared/types";
+
+const DEFAULT_BINARY = "claude";
+/** Hard wall-clock cap on a single coding session (bounded, never unbounded). */
+const DEFAULT_TIMEOUT_MS = 600_000; // 10 min
+const DEFAULT_MAX_CONCURRENCY = 2;
+const SUMMARY_MAX = 4_000;
+const ERROR_MAX = 300;
+
+/**
+ * The minimal, explicit tool allowlist handed to `--allowedTools`, passed as
+ * SEPARATE argv elements (the CLI collects them variadically).
+ *
+ * SECURITY (C-1): Bash is DELIBERATELY EXCLUDED. A Bash subprocess is a child
+ * process that is NOT path-confined by `--add-dir`/`cwd` — under headless `-p` +
+ * `acceptEdits` it would be auto-approved and could `cd` out of the worktree,
+ * read the repo `.env` symlink (live POSTGRES_PASSWORD) and write to the user's
+ * checkout or `main`. File edits do not need Bash. If a build/test step is ever
+ * required it MUST run SERVER-SIDE after the coder returns — never inside the agent.
+ */
+export const ALLOWED_TOOLS = ["Edit", "Write", "Read"] as const;
+
+/**
+ * H-1 — the coder spawns under a COMPLETE, ALLOWLISTED env (not the inherited
+ * `process.env`). Only these keys are forwarded: PATH/HOME + locale so the OS can
+ * resolve + run the `claude` binary, and the claude CLI's OWN auth/config vars so
+ * the subscription session still authenticates. EVERYTHING else — DB creds,
+ * GH_TOKEN/GITHUB_TOKEN, AWS_ vars, PASSWORD/SECRET/other TOKEN vars, and
+ * ANTHROPIC_API_KEY (subscription mode does not need it) — are dropped. Pure
+ * allowlist: a new secret env var is excluded by default (fail-closed).
+ */
+export const CODER_ENV_ALLOWLIST: readonly string[] = [
+  "PATH",
+  "HOME",
+  "SHELL",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "TERM",
+  "USER",
+  "LOGNAME",
+  "TMPDIR",
+  "TZ",
+  // The claude CLI's own config/auth (subscription session). NOT api keys.
+  "CLAUDE_CONFIG_DIR",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+];
+
+/** Build the sanitized, allowlisted env handed to the coder's `claude` child. */
+export function sanitizedCoderEnv(
+  source: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of CODER_ENV_ALLOWLIST) {
+    const value = source[key];
+    if (typeof value === "string" && value.length > 0) env[key] = value;
+  }
+  return env;
+}
+
+/** Per-field clamps so untrusted action-point text stays bounded in the prompt. */
+const TITLE_MAX = 300;
+const RATIONALE_MAX = 2_000;
+const FIELD_MAX = 80;
+
+export interface CoderResult {
+  /** True iff the CLI completed and did not report an error. */
+  ok: boolean;
+  /** The agent's final result text (clamped). */
+  summary: string;
+  /** Scrubbed error/preview on a non-ok run. */
+  error?: string;
+  /** input+output tokens the CLI reported (0 when unknown). */
+  tokensUsed: number;
+}
+
+export interface CoderOptions {
+  /** Binary name or absolute path. Defaults to "claude". */
+  binary?: string;
+  /** Hard timeout for the session (ms). Defaults to 600_000. */
+  timeoutMs?: number;
+  /** Cancels the session mid-flight. */
+  signal?: AbortSignal;
+  /** Override the spawned env (tests). Defaults to `sanitizedCoderEnv()` (H-1). */
+  env?: NodeJS.ProcessEnv;
+}
+
+function clamp(value: string, max: number): string {
+  return value.length > max ? value.slice(0, max) : value;
+}
+
+/**
+ * Render the round's action points into a single prompt. UNTRUSTED text — it goes
+ * to STDIN only. Each field is clamped; the instruction is server-fixed and tells
+ * the agent to make ONLY the file edits (the server owns commit/push/PR, so the
+ * agent must NOT touch git/branches/PRs).
+ */
+export function buildCoderPrompt(actionPoints: readonly ActionPoint[]): string {
+  const items = actionPoints.map((ap, i) => {
+    const title = clamp(ap.title ?? "", TITLE_MAX);
+    const priority = clamp(ap.priority ?? "-", FIELD_MAX);
+    const effort = clamp(ap.effort ?? "-", FIELD_MAX);
+    const rationale = clamp(ap.rationale ?? "", RATIONALE_MAX);
+    const tradeoff = clamp(ap.tradeoff ?? "", RATIONALE_MAX);
+    const lines = [`${i + 1}. [${priority}] ${title}`];
+    if (rationale) lines.push(`   Rationale: ${rationale}`);
+    if (tradeoff) lines.push(`   Trade-off: ${tradeoff}`);
+    if (effort && effort !== "-") lines.push(`   Effort: ${effort}`);
+    return lines.join("\n");
+  });
+  return [
+    "You are an autonomous coding agent working in an ISOLATED git worktree of this repository.",
+    "Implement the following review action points as REAL code/spec edits in THIS repository:",
+    "",
+    ...items,
+    "",
+    "Rules:",
+    "- Make focused, correct edits that resolve each action point. Prefer the smallest change that fixes the issue.",
+    "- Edit files ONLY inside this working directory.",
+    "- Do NOT run `git commit`, `git push`, `git checkout`, or open any PR — the server handles version control after you finish.",
+    "- Do NOT modify CI secrets, credentials, or unrelated files.",
+    "- When done, briefly summarize what you changed.",
+  ].join("\n");
+}
+
+/** Build the exact agentic arg array (prompt is supplied separately via stdin). */
+export function buildCoderArgs(worktreeDir: string): string[] {
+  return [
+    "-p",
+    "--output-format",
+    "json",
+    "--permission-mode",
+    "acceptEdits",
+    "--allowedTools",
+    ...ALLOWED_TOOLS,
+    "--add-dir",
+    worktreeDir,
+  ];
+}
+
+/** Scrub fs layout from an error string before returning it. */
+function scrub(raw: string): string {
+  return raw.replace(/\/[^\s'"]+/g, "<path>").replace(/\s+/g, " ").trim().slice(0, ERROR_MAX);
+}
+
+/**
+ * The agentic coder. Bounded concurrency across calls (a module-level limiter).
+ * Runs the CLI confined to `worktreeDir` and returns a typed result. Throws only
+ * on an infrastructural failure (binary missing / spawn error / timeout); a CLI
+ * that ran but reported an error returns `{ ok:false, error }`. The executor's
+ * worktree cleanup runs in a `finally` regardless of which path this takes.
+ */
+export class SdlcCoder {
+  private readonly binary: string;
+  private readonly limiter: ConcurrencyLimiter;
+
+  constructor(opts: { binary?: string; maxConcurrency?: number } = {}) {
+    this.binary = opts.binary ?? DEFAULT_BINARY;
+    this.limiter = new ConcurrencyLimiter(opts.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY);
+  }
+
+  async run(
+    worktreeDir: string,
+    actionPoints: readonly ActionPoint[],
+    options: CoderOptions = {},
+  ): Promise<CoderResult> {
+    const args = buildCoderArgs(worktreeDir);
+    const prompt = buildCoderPrompt(actionPoints);
+    const { stdout } = await this.limiter.run(() =>
+      spawnCli({
+        binary: options.binary ?? this.binary,
+        args,
+        stdin: prompt, // UNTRUSTED text — stdin only, never argv/shell.
+        cwd: worktreeDir, // confine the agent's working dir to the worktree.
+        envOverride: options.env ?? sanitizedCoderEnv(), // H-1: no inherited secrets.
+        timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        signal: options.signal,
+      }),
+    );
+    return parseCoderOutput(stdout);
+  }
+}
+
+/**
+ * Parse `--output-format json` stdout into a `CoderResult`. A CLI-reported error
+ * (`is_error: true`) is surfaced as `{ ok:false }` rather than thrown, so the
+ * executor can still commit whatever partial edits landed (or skip cleanly).
+ */
+export function parseCoderOutput(stdout: string): CoderResult {
+  try {
+    const parsed = parseCompleteOutput(stdout);
+    return { ok: true, summary: clamp(parsed.content, SUMMARY_MAX), tokensUsed: parsed.tokensUsed };
+  } catch (err) {
+    if (err instanceof CliNotInstalledError) throw err;
+    return { ok: false, summary: "", error: scrub(err instanceof Error ? err.message : String(err)), tokensUsed: 0 };
+  }
+}

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -1,0 +1,226 @@
+/**
+ * executor.ts — SDLC executor, component 5: orchestration.
+ *
+ * `runSdlcHandoff` is the REAL DEVELOPING side effect for the consilium loop. It
+ * replaces the legacy single-file `dev-closeout` (which wrote a `.md` checklist
+ * and mutated the user's checkout via `switchBranch`). One worktree + one branch
+ * + ONE agentic coder session per ROUND (not per action point) → a single,
+ * coherent Draft PR. Rationale for one-session-per-round: the action points of a
+ * round are usually interdependent remediations of the same review; a single
+ * agent session with all of them in scope produces a cohesive change set and one
+ * reviewable PR, instead of N conflicting branches/PRs that each see only part of
+ * the picture.
+ *
+ * Lifecycle (cleanup GUARANTEED):
+ *   1. createSdlcWorktree(repo, B-3 branch, baseRef=default-branch HEAD)
+ *   2. coder.run(worktreeDir, actionPoints)            ← real edits, confined
+ *   3. git add -A (worktree is DEDICATED → add-all is safe, unlike dev-closeout)
+ *   4. commit (server-sanitized message), read HEAD
+ *   5. pushBranch + openDraftPr   (reused from pr-wrapper: B-3/H-6/H-7/M-6/M-7)
+ *   6. removeSdlcWorktree in a `finally` — even on coder throw / timeout.
+ *
+ * NEVER THROWS. Returns `{ prRef, headCommit, error? }` (structurally the loop's
+ * `DevCloseoutResult`), so the controller's DEVELOPING→AWAITING_MERGE transition
+ * consumes `prRef` + `headCommit` exactly as before. Any failure degrades to a
+ * branch-only / no-PR result with a scrubbed note; the loop is never failed here.
+ *
+ * SECURITY (BINDING — adversarial-review surface):
+ *   - branch + PR title are SERVER-DERIVED ONLY (buildBranchName / fixed prefix).
+ *     Action-point text NEVER reaches a branch, a PR title, or any shell string.
+ *   - Untrusted action-point text reaches: the coder prompt (stdin only) and the
+ *     commit BODY (sanitized + clamped, passed as an arg-array `-m` element —
+ *     never a shell string). That is the ONLY place model text is persisted.
+ *   - The coder is confined to the worktree (cwd + --add-dir). The worktree is a
+ *     server-minted temp dir, physically separate from the user's checkout.
+ *   - Agents NEVER apply/merge: this opens a DRAFT PR only. No push to main.
+ */
+import type { ActionPoint } from "@shared/types";
+import { buildBranchName, isValidLoopBranch, pushBranch, openDraftPr } from "../consilium/pr-wrapper.js";
+import {
+  createSdlcWorktree,
+  removeSdlcWorktree,
+  resolveDefaultBranch,
+  defaultGitRaw,
+  type GitRunner,
+  type CreateWorktreeResult,
+} from "./worktree.js";
+import { SdlcCoder, type CoderResult, type CoderOptions } from "./coder.js";
+
+const COMMIT_SUBJECT_PREFIX = "consilium: SDLC changes for round";
+const COMMIT_BODY_TITLE_MAX = 120;
+const COMMIT_BODY_MAX = 4_000;
+
+export interface SdlcHandoffRequest {
+  /** Allowlisted repo to operate on. */
+  repoPath: string;
+  /** Loop id (uuid) — feeds the server-derived branch. */
+  loopId: string;
+  /** Round number — feeds the branch + commit/PR title. */
+  round: number;
+  /** The round's open action points to implement. */
+  actionPoints: readonly ActionPoint[];
+  /** Fail-closed repo allowlist (H-5). */
+  allowedRepoPaths: readonly string[];
+  /** PR base branch. Defaults to the repo's default branch. */
+  base?: string;
+  /** Worktree base commit-ish. Defaults to the repo's default branch HEAD. */
+  baseRef?: string;
+  /** Loop owner (audit only). */
+  ownerId?: string;
+}
+
+export interface SdlcHandoffResult {
+  /** Draft PR URL, or null on any non-PR path (no changes / push or gh failure). */
+  prRef: string | null;
+  /** HEAD sha of the SDLC branch after the commit; "" when nothing was committed. */
+  headCommit: string;
+  /** Scrubbed note present on any non-happy path. */
+  error?: string;
+}
+
+/** Injectable seams (unit tests inject fakes — no real repo / claude / gh). */
+export interface SdlcExecutorDeps {
+  createWorktree?: typeof createSdlcWorktree;
+  removeWorktree?: typeof removeSdlcWorktree;
+  resolveDefaultBranchFn?: typeof resolveDefaultBranch;
+  /** The agentic coder (default: a shared `SdlcCoder`). */
+  runCoder?: (worktreeDir: string, aps: readonly ActionPoint[], opts?: CoderOptions) => Promise<CoderResult>;
+  push?: typeof pushBranch;
+  openPr?: typeof openDraftPr;
+  gitRaw?: GitRunner;
+}
+
+const sharedCoder = new SdlcCoder();
+
+/** Scrub fs layout from an error string before returning it. */
+function scrub(raw: string): string {
+  return raw.replace(/\/[^\s'"]+/g, "<path>").replace(/\s+/g, " ").trim().slice(0, 200);
+}
+
+/**
+ * Sanitize an action-point title for the commit BODY: strip control chars /
+ * newlines, collapse whitespace, clamp. The title is UNTRUSTED model text — even
+ * though it goes in via an arg-array `-m` element (no shell), we keep it tidy and
+ * bounded so it cannot bloat or smuggle terminal control sequences into git log.
+ */
+function sanitizeTitle(title: string): string {
+  // eslint-disable-next-line no-control-regex
+  return title
+    .replace(/[\u0000-\u001f\u007f]+/g, " ") // strip control chars / newlines
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, COMMIT_BODY_TITLE_MAX);
+}
+
+/** Build the commit message: server-fixed subject + sanitized title checklist body. */
+export function buildCommitMessage(round: number, aps: readonly ActionPoint[]): { subject: string; body: string } {
+  const subject = `${COMMIT_SUBJECT_PREFIX} ${round}`;
+  const lines = aps.map((ap) => `- ${sanitizeTitle(ap.title ?? "")}`);
+  const body = ["Implements the open consilium action points:", "", ...lines].join("\n").slice(0, COMMIT_BODY_MAX);
+  return { subject, body };
+}
+
+/** Build the server-derived PR title (NO model text — B-3 class guard). */
+export function buildPrTitle(round: number): string {
+  return `Consilium round ${round}: SDLC changes`;
+}
+
+/** Draft-PR body: server-fixed header + the agent's (clamped) own summary. */
+function prBody(round: number, coder: CoderResult): string {
+  const head = `Automated SDLC changes for consilium round ${round}.`;
+  const summary = coder.summary ? `\n\n## Coder summary\n\n${coder.summary}` : "";
+  return `${head}${summary}\n\nThis is a Draft PR — a human must review and merge.`;
+}
+
+/**
+ * Run the full SDLC handoff for one round. Never throws. The worktree is removed
+ * in a `finally`, so it is cleaned up even when the coder throws or times out.
+ */
+export async function runSdlcHandoff(
+  req: SdlcHandoffRequest,
+  deps: SdlcExecutorDeps = {},
+): Promise<SdlcHandoffResult> {
+  const gitRaw = deps.gitRaw ?? defaultGitRaw;
+  const createWorktree = deps.createWorktree ?? createSdlcWorktree;
+  const removeWorktree = deps.removeWorktree ?? removeSdlcWorktree;
+  const resolveDefault = deps.resolveDefaultBranchFn ?? resolveDefaultBranch;
+  const runCoder = deps.runCoder ?? ((dir, aps, opts) => sharedCoder.run(dir, aps, opts));
+  const push = deps.push ?? pushBranch;
+  const openPr = deps.openPr ?? openDraftPr;
+
+  // B-3: server-derived branch; defensively re-gate before anything runs.
+  const branch = buildBranchName(req.loopId, req.round);
+  if (!isValidLoopBranch(branch)) {
+    return { prRef: null, headCommit: "", error: "rejected branch name (B-3)" };
+  }
+
+  try {
+    const base = req.base ?? (await resolveDefault(req.repoPath, gitRaw));
+    const wt = await createWorktree({
+      repoPath: req.repoPath,
+      branch,
+      baseRef: req.baseRef ?? base,
+      allowedRepoPaths: req.allowedRepoPaths,
+      gitRaw,
+    });
+    try {
+      // Real edits in isolation. May throw (binary missing / timeout); the finally
+      // below still removes the worktree.
+      const coder = await runCoder(wt.worktreeDir, req.actionPoints);
+      return await commitAndOpenPr(req, branch, base, wt, coder, { gitRaw, push, openPr });
+    } finally {
+      // Cleanup GUARANTEE: remove the worktree even on coder throw / timeout.
+      await removeWorktree(req.repoPath, wt.worktreeDir, { baseDir: wt.baseDir, gitRaw });
+    }
+  } catch (err) {
+    // createWorktree failed (disallowed repo / bad branch / git error) OR the
+    // coder threw — degrade, never fail the loop.
+    return { prRef: null, headCommit: "", error: scrub(err instanceof Error ? err.message : String(err)) };
+  }
+}
+
+/** Stage everything in the dedicated worktree, commit, push, open the Draft PR. */
+async function commitAndOpenPr(
+  req: SdlcHandoffRequest,
+  branch: string,
+  base: string,
+  wt: CreateWorktreeResult,
+  coder: CoderResult,
+  io: { gitRaw: GitRunner; push: typeof pushBranch; openPr: typeof openDraftPr },
+): Promise<SdlcHandoffResult> {
+  // The worktree is DEDICATED (server-minted, single round) → `add -A` is safe
+  // here: there are no unrelated user files to sweep in (unlike dev-closeout's
+  // single-file constraint over the user's shared checkout).
+  await io.gitRaw(wt.worktreeDir, ["add", "-A"]);
+
+  // Nothing produced (coder made no edits / failed before editing) → no PR.
+  const staged = (await io.gitRaw(wt.worktreeDir, ["status", "--porcelain"])).trim();
+  if (staged.length === 0) {
+    const note = coder.ok ? "no changes produced" : `coder failed: ${coder.error ?? "unknown"}`;
+    return { prRef: null, headCommit: "", error: note };
+  }
+
+  const { subject, body } = buildCommitMessage(req.round, req.actionPoints);
+  // Arg-array `-m` elements — never a shell string. Untrusted title lives only in
+  // the (sanitized) body element.
+  await io.gitRaw(wt.worktreeDir, ["commit", "-m", subject, "-m", body]);
+  const headCommit = (await io.gitRaw(wt.worktreeDir, ["rev-parse", "HEAD"])).trim();
+
+  // Push from the worktree (shares the repo's object store + remotes). pr-wrapper
+  // re-gates the branch (B-3) and runs under a sanitized env (H-7).
+  const pushed = await io.push(wt.worktreeDir, branch);
+  if (!pushed.ok) {
+    return { prRef: null, headCommit, error: scrub(`push failed: ${pushed.message}`) };
+  }
+
+  const pr = await io.openPr(wt.worktreeDir, {
+    base,
+    head: branch,
+    title: buildPrTitle(req.round), // server-derived; NO model text.
+    body: prBody(req.round, coder),
+  });
+  if (!pr.ok) {
+    return { prRef: null, headCommit, error: `pushed branch ${branch}; open PR manually` };
+  }
+  return { prRef: pr.prUrl, headCommit };
+}

--- a/server/services/sdlc/worktree.ts
+++ b/server/services/sdlc/worktree.ts
@@ -1,0 +1,195 @@
+/**
+ * worktree.ts — SDLC executor, component 1: worktree lifecycle.
+ *
+ * The consilium loop's DEVELOPING side effect needs REAL multi-file code edits
+ * made in ISOLATION from the user's own checkout. The legacy close-out
+ * (dev-closeout.ts) called `WorkspaceManager.switchBranch()`, which mutates the
+ * user's working tree — unacceptable while they are actively working there.
+ *
+ * Instead we cut a DEDICATED git worktree under the OS temp dir and let the
+ * agentic coder edit there. `git worktree add <absolute-temp-dir> -b <branch>
+ * <baseRef>` gives the new branch its own checked-out tree on disk that shares
+ * the repo's object store but is physically separate from the user's checkout:
+ * edits in the worktree CANNOT touch the user's files or `main`.
+ *
+ * Security (BINDING — adversarial-review surface):
+ *   - The branch is the server-derived B-3 shape (`pr-wrapper.buildBranchName` +
+ *     `isValidLoopBranch`). NOTHING from action-point text ever reaches a branch
+ *     name. A non-B-3 / leading-dash branch is REJECTED before git runs.
+ *   - `repoPath` is re-validated against the loop's fail-closed allowlist
+ *     (`assertAllowedRepoPath`, realpath + traversal guard) every call.
+ *   - The worktree dir is server-minted via `mkdtemp` under `os.tmpdir()` — an
+ *     absolute path that NEVER overlaps the user's checkout. `baseRef` is gated
+ *     to an option-safe ref token (no leading dash, safe charset) so it cannot
+ *     inject a git flag even though every call uses an ARG ARRAY (never a shell
+ *     string — no command injection regardless).
+ *   - All git runs go through an injectable arg-array runner (default
+ *     `simple-git(...).raw([...])`), so unit tests never touch a real repo.
+ */
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import simpleGit from "simple-git";
+import { isValidLoopBranch } from "../consilium/pr-wrapper.js";
+import { assertAllowedRepoPath } from "../consilium/repo-allowlist.js";
+
+/** Arg-array git runner seam: `(repoPath, args) => stdout`. Never a shell string. */
+export type GitRunner = (repoPath: string, args: string[]) => Promise<string>;
+
+/** Default runner — simple-git `raw`, which passes args verbatim (no shell). */
+export const defaultGitRaw: GitRunner = (repoPath, args) =>
+  simpleGit({ baseDir: repoPath, config: [] }).raw(args);
+
+/** mkdtemp seam (tests inject a deterministic dir; default = real OS temp). */
+export type MkdtempFn = (prefix: string) => Promise<string>;
+const defaultMkdtemp: MkdtempFn = (prefix) => mkdtemp(prefix);
+
+/**
+ * Option-safe ref token: a branch name or a commit-ish that git will treat as a
+ * positional, never a flag. No leading dash; conservative charset (sha / branch
+ * / tag chars). `baseRef` is always server-derived (default branch or a server
+ * sha), so this is a defense-in-depth gate, not the only guard.
+ */
+const SAFE_REF_RE = /^[0-9A-Za-z._\/-]+$/;
+
+function isSafeRef(ref: string): boolean {
+  return ref.length > 0 && !ref.startsWith("-") && SAFE_REF_RE.test(ref) && !ref.includes("..");
+}
+
+export interface CreateWorktreeOptions {
+  /** Allowlisted repo to cut the worktree from (re-validated every call). */
+  repoPath: string;
+  /** Server-derived B-3 branch (`consilium/loop-<uuid>/round-<n>`). */
+  branch: string;
+  /** Commit-ish to base the new branch on. Defaults to the repo's default branch. */
+  baseRef?: string;
+  /** Fail-closed repo allowlist (H-5). */
+  allowedRepoPaths: readonly string[];
+  /** Injectable git runner (tests). */
+  gitRaw?: GitRunner;
+  /** Injectable mkdtemp (tests). */
+  mkdtempFn?: MkdtempFn;
+}
+
+export interface CreateWorktreeResult {
+  /** Absolute path of the isolated worktree (under os.tmpdir()). */
+  worktreeDir: string;
+  /** The temp PARENT dir mkdtemp created — removed wholesale on cleanup. */
+  baseDir: string;
+  /** The branch checked out in the worktree. */
+  branch: string;
+  /** The commit-ish the branch was based on. */
+  baseRef: string;
+}
+
+/**
+ * Resolve the repo's default branch NAME (e.g. "main"). Order: `origin/HEAD`
+ * symbolic-ref → current branch → "main". Never throws (best-effort) and the
+ * result is gated `isSafeRef` by callers before it reaches git as a positional.
+ */
+export async function resolveDefaultBranch(
+  repoPath: string,
+  gitRaw: GitRunner = defaultGitRaw,
+): Promise<string> {
+  try {
+    const ref = (await gitRaw(repoPath, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"])).trim();
+    const name = ref.startsWith("origin/") ? ref.slice("origin/".length) : ref;
+    if (name && isSafeRef(name)) return name;
+  } catch {
+    // fall through to the local-HEAD probe
+  }
+  try {
+    const b = (await gitRaw(repoPath, ["rev-parse", "--abbrev-ref", "HEAD"])).trim();
+    if (b && b !== "HEAD" && isSafeRef(b)) return b;
+  } catch {
+    // fall through to the static default
+  }
+  return "main";
+}
+
+/**
+ * Create an isolated worktree + branch for an SDLC round. Throws (fail-closed)
+ * on a disallowed repo, a non-B-3/unsafe branch, or an unsafe baseRef — the
+ * caller (executor) catches and degrades. On a git failure mid-create it removes
+ * the temp dir before rethrowing so no orphan tree is left behind.
+ */
+export async function createSdlcWorktree(opts: CreateWorktreeOptions): Promise<CreateWorktreeResult> {
+  const gitRaw = opts.gitRaw ?? defaultGitRaw;
+  const mkdtempFn = opts.mkdtempFn ?? defaultMkdtemp;
+
+  // H-5: re-validate the repo against the fail-closed allowlist (realpath +
+  // traversal + denylist). Throws when the path escapes confinement.
+  const repo = assertAllowedRepoPath(opts.repoPath, opts.allowedRepoPaths);
+
+  // B-3: the branch must be the EXACT server-derived shape. Reject anything else
+  // (incl. a leading-dash branch) before git runs.
+  if (opts.branch.startsWith("-") || !isValidLoopBranch(opts.branch)) {
+    throw new Error(`createSdlcWorktree: rejected branch name (B-3): ${opts.branch}`);
+  }
+
+  const baseRef = opts.baseRef ?? (await resolveDefaultBranch(repo, gitRaw));
+  if (!isSafeRef(baseRef)) {
+    throw new Error(`createSdlcWorktree: rejected unsafe baseRef`);
+  }
+
+  // Server-minted isolated dir under the OS temp root — NEVER the user's checkout.
+  const baseDir = await mkdtempFn(join(tmpdir(), "sdlc-wt-"));
+  const worktreeDir = join(baseDir, "tree"); // non-existent subdir git will create.
+
+  try {
+    // Clear any stale worktree registrations first (best-effort — a prior crash
+    // could leave a dangling entry that would otherwise block re-creation).
+    await gitRaw(repo, ["worktree", "prune"]).catch(() => undefined);
+    await addWorktree(gitRaw, repo, worktreeDir, opts.branch, baseRef);
+    return { worktreeDir, baseDir, branch: opts.branch, baseRef };
+  } catch (err) {
+    // No orphan tree: drop the temp dir we minted before bubbling the failure up.
+    await rm(baseDir, { recursive: true, force: true }).catch(() => undefined);
+    throw err;
+  }
+}
+
+/**
+ * `git worktree add -b <branch> <path> <baseRef>`. Options precede the
+ * positionals so an (already-gated) value can never be mis-parsed as a flag. If
+ * the branch already exists (a re-driven round / a stale ref), recover by
+ * force-recreating it from `baseRef` with `-B` so the round is coherent.
+ */
+async function addWorktree(
+  gitRaw: GitRunner,
+  repo: string,
+  worktreeDir: string,
+  branch: string,
+  baseRef: string,
+): Promise<void> {
+  try {
+    await gitRaw(repo, ["worktree", "add", "-b", branch, worktreeDir, baseRef]);
+  } catch (err) {
+    if (!/already (exists|used by worktree|checked out)/i.test(errMsg(err))) throw err;
+    await gitRaw(repo, ["worktree", "prune"]).catch(() => undefined);
+    await gitRaw(repo, ["worktree", "add", "-B", branch, worktreeDir, baseRef]);
+  }
+}
+
+/**
+ * Remove the worktree (and the temp parent dir it lived in). NEVER throws — the
+ * executor calls this from a `finally`, so a removal failure must not mask the
+ * coder's result. Leaves the branch + any pushed PR intact (only the tree goes).
+ */
+export async function removeSdlcWorktree(
+  repoPath: string,
+  worktreeDir: string,
+  opts: { baseDir?: string; gitRaw?: GitRunner } = {},
+): Promise<void> {
+  const gitRaw = opts.gitRaw ?? defaultGitRaw;
+  // Primary: ask git to drop the worktree (also clears its admin entry).
+  await gitRaw(repoPath, ["worktree", "remove", "--force", worktreeDir]).catch(() => undefined);
+  // Belt-and-braces: nuke the on-disk dir + prune the admin entry in case the
+  // `remove` above failed (e.g. the dir was already gone / locked).
+  await rm(opts.baseDir ?? worktreeDir, { recursive: true, force: true }).catch(() => undefined);
+  await gitRaw(repoPath, ["worktree", "prune"]).catch(() => undefined);
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/tests/integration/task-groups-api.test.ts
+++ b/tests/integration/task-groups-api.test.ts
@@ -136,25 +136,34 @@ describe("Task Groups API", () => {
       expect(Array.isArray(res.body)).toBe(true);
     });
 
-    it("returns groups with taskCount and completedCount properties", async () => {
-      // Create a group with tasks directly in storage
+    it("returns groups with taskCount (definitions) and completedCount (latest-iteration executions)", async () => {
+      // #3: completedCount reflects the LATEST ITERATION's executions, not the
+      // task DEFINITION statuses (which stay blocked/ready even after a full run).
       const group = await storage.createTaskGroup({
         name: "Count Test Group",
         description: "Testing counts",
         input: "test input",
         createdBy: TEST_ADMIN.id,
       });
-      await storage.createTask({ groupId: group.id, name: "Task 1", description: "d1", sortOrder: 0 });
+      const t1 = await storage.createTask({ groupId: group.id, name: "Task 1", description: "d1", sortOrder: 0 });
       const t2 = await storage.createTask({ groupId: group.id, name: "Task 2", description: "d2", sortOrder: 1 });
-      await storage.updateTask(t2.id, { status: "completed" });
+      // Definitions intentionally stay non-completed — the old bug counted these.
+      const iteration = await storage.createIteration({
+        groupId: group.id,
+        iterationNumber: 1,
+        status: "running",
+        input: "test input",
+      });
+      await storage.createExecution({ groupId: group.id, iterationId: iteration.id, taskId: t1.id, taskName: "Task 1", status: "completed" });
+      await storage.createExecution({ groupId: group.id, iterationId: iteration.id, taskId: t2.id, taskName: "Task 2", status: "running" });
 
       const res = await request(app).get("/api/task-groups");
       expect(res.status).toBe(200);
       const groups = res.body as Array<{ id: string; taskCount: number; completedCount: number }>;
       const found = groups.find((g) => g.id === group.id);
       expect(found).toBeDefined();
-      expect(found?.taskCount).toBe(2);
-      expect(found?.completedCount).toBe(1);
+      expect(found?.taskCount).toBe(2); // definitions
+      expect(found?.completedCount).toBe(1); // completed executions in the latest iteration
     });
   });
 

--- a/tests/unit/consilium/loop-fsm.test.ts
+++ b/tests/unit/consilium/loop-fsm.test.ts
@@ -198,6 +198,11 @@ const fakeConfig = () =>
     },
   }) as never;
 
+/** Past the DEVELOPING re-drive grace (SDLC coder timeout 600s + 60s buffer). */
+const DEV_STALE = new Date(Date.now() - 700_000);
+/** Flush microtasks + one macrotask so a fire-and-forget background run settles. */
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
 describe("controller tick — startGroup + cap precedence + CAS no-op", () => {
   it("BUILDING_CONTEXT tick CLAIMS the CAS then CALLS orchestrator.startGroup exactly once", async () => {
     // repoPath = the real repo cwd (round 1, null baseline) so the A2
@@ -221,48 +226,48 @@ describe("controller tick — startGroup + cap precedence + CAS no-op", () => {
     expect(res?.currentIterationNumber).toBe(1);
   });
 
-  it("in-process lock: two concurrent same-process ticks → exactly ONE createTaskGroup (2nd is locked out)", async () => {
+  it("in-process lock: two concurrent same-process ticks → exactly ONE SDLC dispatch (2nd is locked out)", async () => {
     const loop = makeLoop({ state: "deciding", round: 2, maxRounds: 6, currentIterationNumber: 2 });
     const { storage } = makeFakeStorage(loop, [{ round: 1, openP0: 3 }]);
-    // A slow createTaskGroup keeps the first tick's side effect in flight while
-    // the second tick fires — the in-process lock must bar the 2nd before CAS.
-    const createTaskGroup = vi.fn(async () => {
-      await new Promise((r) => setTimeout(r, 25));
-      return { group: { id: "devgrp" }, tasks: [] };
-    });
+    // H-2: the DEVELOPING side effect dispatches the SDLC close-out (background).
+    // The in-process lock must bar the 2nd concurrent tick before it can dispatch.
+    const runCloseout = vi.fn(async () => ({ prRef: "https://github.com/x/y/pull/1", headCommit: "abc" }));
     const startGroup = vi.fn(async () => ({ group: {}, iteration: { iterationNumber: 1 } }));
     const controller = new ConsiliumLoopController({
       storage: storage as never,
-      taskOrchestrator: { startGroup, startGroupAsync: startGroup, createTaskGroup, cancelGroup: vi.fn() } as never,
+      taskOrchestrator: { startGroup, startGroupAsync: startGroup, createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
       config: fakeConfig,
       readIterationVerdict: async () => verdict(false, 2), // open P0s, room left → DEVELOPING
+      runCloseout,
     });
     const [a, b] = await Promise.all([controller.tick(loop.id), controller.tick(loop.id)]);
     const winners = [a, b].filter((r) => r !== null);
     expect(winners).toHaveLength(1);
     expect(winners[0]?.state).toBe("developing");
-    // The non-idempotent DEV-group mint fires for the single in-flight tick ONLY.
-    expect(createTaskGroup).toHaveBeenCalledTimes(1);
+    // The non-idempotent SDLC dispatch fires for the single in-flight tick ONLY.
+    expect(runCloseout).toHaveBeenCalledTimes(1);
   });
 
   it("cross-instance CAS: a 2nd controller (separate process) that loses the CAS is a no-op", async () => {
     // Two controllers share storage but NOT the in-process lock (simulating two
-    // pods). The first wins the CAS deciding->developing; the second's CAS sees
-    // state !== deciding → undefined → no-op, no second createTaskGroup.
+    // pods). The first wins the CAS deciding->developing and dispatches the SDLC
+    // close-out; the second's CAS sees state !== deciding → undefined → no-op, so
+    // the background coder is launched exactly ONCE (H-2 single-flight on entry).
     const loop = makeLoop({ state: "deciding", round: 2, maxRounds: 6, currentIterationNumber: 2 });
     const { storage, cas } = makeFakeStorage(loop, [{ round: 1, openP0: 3 }]);
-    const createTaskGroup = vi.fn(async () => ({ group: { id: "devgrp" }, tasks: [] }));
+    const runCloseout = vi.fn(async () => ({ prRef: "https://github.com/x/y/pull/2", headCommit: "abc" }));
     const mkController = () =>
       new ConsiliumLoopController({
         storage: storage as never,
-        taskOrchestrator: (() => { const sg = vi.fn(async () => ({ group: {}, iteration: { iterationNumber: 1 } })); return { startGroup: sg, startGroupAsync: sg, createTaskGroup, cancelGroup: vi.fn() }; })() as never,
+        taskOrchestrator: (() => { const sg = vi.fn(async () => ({ group: {}, iteration: { iterationNumber: 1 } })); return { startGroup: sg, startGroupAsync: sg, createTaskGroup: vi.fn(), cancelGroup: vi.fn() }; })() as never,
         config: fakeConfig,
         readIterationVerdict: async () => verdict(false, 2),
+        runCloseout,
       });
     const [a, b] = await Promise.all([mkController().tick(loop.id), mkController().tick(loop.id)]);
     const winners = [a, b].filter((r) => r !== null);
     expect(winners).toHaveLength(1);
-    expect(createTaskGroup).toHaveBeenCalledTimes(1);
+    expect(runCloseout).toHaveBeenCalledTimes(1);
     // Both instances attempted the deciding->developing CAS; only one row updated.
     expect(cas.mock.calls.filter((c) => c[1] === "deciding" && c[2] === "developing").length).toBe(2);
   });
@@ -340,49 +345,48 @@ describe("controller tick — crash-window re-drive of stranded loops", () => {
   const STALE = new Date(Date.now() - 120_000);
   const FRESH = new Date(); // within grace → in-flight, must NOT re-drive
 
-  it("DEVELOPING with null devGroupId, past grace → re-drives → exactly one createTaskGroup", async () => {
-    // Genuinely stranded: a crash between the CAS claim (deciding→developing) and
-    // the updateLoop that writes devGroupId left devGroupId null, AND updatedAt is
-    // older than the grace window. tick re-runs the dev handoff once.
-    const loop = makeLoop({ state: "developing", round: 2, devGroupId: null, currentIterationNumber: 2, updatedAt: STALE });
+  it("DEVELOPING with null devGroupId, past coder-length grace → re-dispatches SDLC exactly once (M-1)", async () => {
+    // H-2 crash recovery: a crash mid-coder leaves developing+null devGroupId. The
+    // developing grace must EXCEED the coder timeout (660s) — STALE (120s) is
+    // WITHIN it, so we use DEV_STALE (700s). The redrive claim re-dispatches the
+    // SDLC close-out exactly once; the loop stays developing (background run).
+    const loop = makeLoop({ state: "developing", round: 2, devGroupId: null, currentIterationNumber: 2, updatedAt: DEV_STALE });
     const { storage } = makeFakeStorage(loop, [{ round: 1, openP0: 3 }]);
-    const createTaskGroup = vi.fn(async () => ({ group: { id: "devgrp-redrive" }, tasks: [] }));
+    const runCloseout = vi.fn(async () => ({ prRef: "https://github.com/x/y/pull/3", headCommit: "deadbeef" }));
     const startGroup = vi.fn(async () => ({ group: {}, iteration: { iterationNumber: 1 } }));
     const controller = new ConsiliumLoopController({
       storage: storage as never,
-      taskOrchestrator: { startGroup, startGroupAsync: startGroup, createTaskGroup, cancelGroup: vi.fn() } as never,
+      taskOrchestrator: { startGroup, startGroupAsync: startGroup, createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
       config: fakeConfig,
-      readIterationVerdict: async () => verdict(false, 2), // open P0s → real handoff
-      readRepoHead: async () => "deadbeef", // no real git
+      readIterationVerdict: async () => verdict(false, 2),
+      readRepoHead: async () => "deadbeef",
+      runCloseout,
     });
     const res = await controller.tick(loop.id);
-    expect(createTaskGroup).toHaveBeenCalledTimes(1);
-    expect(res?.devGroupId).toBe("devgrp-redrive");
-    expect(res?.state).toBe("developing"); // state unchanged — only the ref filled
+    expect(runCloseout).toHaveBeenCalledTimes(1); // re-dispatched
+    expect(res?.devGroupId ?? null).toBeNull(); // marker still null
+    expect(res?.state).toBe("developing"); // background run — stays developing
   });
 
-  it("CROSS-INSTANCE: two controllers (two in-process Sets) re-driving the SAME stranded loop → EXACTLY ONE createTaskGroup", async () => {
-    // Security gap closer: two pods, separate in-process locks, ONE storage. Both
-    // read the stranded null-ref row past grace; the atomic claimRedrive lets only
-    // ONE win (the other's grace predicate fails after the winner bumps
-    // updatedAt) → exactly one non-idempotent side effect.
-    const loop = makeLoop({ state: "developing", round: 2, devGroupId: null, currentIterationNumber: 2, updatedAt: STALE });
+  it("CROSS-INSTANCE: two controllers re-driving the SAME stranded developing loop → EXACTLY ONE SDLC dispatch", async () => {
+    // Two pods, separate in-process locks, ONE storage. Both read the stranded
+    // null-devGroupId row past the coder-length grace; the atomic claimRedrive lets
+    // only ONE win → the SDLC close-out is dispatched exactly once (no double coder).
+    const loop = makeLoop({ state: "developing", round: 2, devGroupId: null, currentIterationNumber: 2, updatedAt: DEV_STALE });
     const { storage, claimRedrive } = makeFakeStorage(loop, [{ round: 1, openP0: 3 }]);
-    const createTaskGroup = vi.fn(async () => {
-      await new Promise((r) => setTimeout(r, 20)); // keep the winner's side effect in flight
-      return { group: { id: "devgrp-x" }, tasks: [] };
-    });
+    const runCloseout = vi.fn(async () => ({ prRef: "https://github.com/x/y/pull/4", headCommit: "deadbeef" }));
     const mk = () =>
       new ConsiliumLoopController({
         storage: storage as never,
-        taskOrchestrator: (() => { const sg = vi.fn(async () => ({ group: {}, iteration: { iterationNumber: 1 } })); return { startGroup: sg, startGroupAsync: sg, createTaskGroup, cancelGroup: vi.fn() }; })() as never,
+        taskOrchestrator: (() => { const sg = vi.fn(async () => ({ group: {}, iteration: { iterationNumber: 1 } })); return { startGroup: sg, startGroupAsync: sg, createTaskGroup: vi.fn(), cancelGroup: vi.fn() }; })() as never,
         config: fakeConfig,
         readIterationVerdict: async () => verdict(false, 2),
         readRepoHead: async () => "deadbeef",
+        runCloseout,
       });
     // Two SEPARATE controllers → two independent in-process Sets (simulating pods).
     const [a, b] = await Promise.all([mk().tick(loop.id), mk().tick(loop.id)]);
-    expect(createTaskGroup).toHaveBeenCalledTimes(1); // atomic claim → no double-fire
+    expect(runCloseout).toHaveBeenCalledTimes(1); // atomic claim → no double dispatch
     const winners = [a, b].filter((r) => r !== null);
     expect(winners).toHaveLength(1);
     expect(claimRedrive).toHaveBeenCalledTimes(2); // both attempted; one won
@@ -428,34 +432,29 @@ describe("controller tick — crash-window re-drive of stranded loops", () => {
     expect(winners[0]?.currentIterationNumber).toBe(1);
   });
 
-  it("DEVELOPING WITH a devGroupId → does NOT re-create (advances on the existing group)", async () => {
-    // Not stranded: devGroupId is set. tick must NOT re-create; it advances on
-    // the existing DEV group's status (here: completed → AWAITING_MERGE).
-    const loop = makeLoop({ state: "developing", round: 2, devGroupId: "existing-grp", currentIterationNumber: 2, prRef: "pr/9" });
+  it("DEVELOPING whose BACKGROUND SDLC settled → advances to AWAITING_MERGE with the real prRef (H-2)", async () => {
+    // H-2: dispatch on entry (tick 1, stays developing) → background settles →
+    // a later tick (tick 2) reads the settle and CASes developing→awaiting_merge
+    // with the REAL prRef/headCommit. AWAITING_MERGE never opens half-formed.
+    const loop = makeLoop({ state: "deciding", round: 2, currentIterationNumber: 2 });
     const { storage } = makeFakeStorage(loop, [{ round: 1, openP0: 3 }]);
-    // The existing DEV group reports completed so the loop opens the merge gate.
-    storage.getTaskGroup = vi.fn(async (id: string) =>
-      id === "existing-grp"
-        ? { id, status: "completed" }
-        : { id: loop.groupId, input: "objective" },
-    ) as never;
-    const createTaskGroup = vi.fn(async () => ({ group: { id: "SHOULD-NOT-HAPPEN" }, tasks: [] }));
-    // §14.4 (D.6): the DEVELOPING→AWAITING_MERGE side effect runs DevPrCloseout;
-    // the REAL prRef + headCommit come from the close-out result, NOT readRepoHead.
     const runCloseout = vi.fn(async () => ({ prRef: "https://github.com/x/y/pull/42", headCommit: "cafef00d" }));
     const controller = new ConsiliumLoopController({
       storage: storage as never,
-      taskOrchestrator: { startGroup: vi.fn(), startGroupAsync: vi.fn(), createTaskGroup, cancelGroup: vi.fn() } as never,
+      taskOrchestrator: { startGroup: vi.fn(), startGroupAsync: vi.fn(), createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
       config: fakeConfig,
-      readIterationVerdict: async () => verdict(false, 2), // open APs for the close-out body
+      readIterationVerdict: async () => verdict(false, 2),
+      readRepoHead: async () => "abc",
       runCloseout,
     });
-    const res = await controller.tick(loop.id);
-    expect(createTaskGroup).not.toHaveBeenCalled(); // no re-create on a set ref
-    expect(res?.state).toBe("awaiting_merge"); // advanced on the existing group
-    expect(runCloseout).toHaveBeenCalledTimes(1); // close-out ran on the WON row
-    expect(res?.prRef).toBe("https://github.com/x/y/pull/42"); // real PR persisted (§14.4)
-    expect(res?.headCommitAtReview).toBe("cafef00d"); // M-3 captured from close-out
+    const t1 = await controller.tick(loop.id); // deciding → developing (dispatch SDLC)
+    expect(t1?.state).toBe("developing");
+    await flush(); // the background close-out settles into the registry
+    const t2 = await controller.tick(loop.id); // developing → awaiting_merge
+    expect(t2?.state).toBe("awaiting_merge");
+    expect(runCloseout).toHaveBeenCalledTimes(1); // dispatched ONCE, never inline-repeated
+    expect(t2?.prRef).toBe("https://github.com/x/y/pull/42"); // real PR persisted
+    expect(t2?.headCommitAtReview).toBe("cafef00d"); // M-3 captured from the settle
   });
 
   it("REVIEWING with null currentIterationNumber, past grace → re-drives the review side effect", async () => {
@@ -527,62 +526,56 @@ describe("controller — D.6 non-blocking startGroupAsync + prRef close-out flow
     expect(res?.state).toBe("reviewing");
   });
 
-  it("startDevHandoff uses startGroupAsync for the DEV group (non-blocking) + binds the workspace id", async () => {
+  it("startDevHandoff dispatches the SDLC close-out in the BACKGROUND (no pipeline group; devGroupId stays null)", async () => {
+    // H-2: the DECIDING→DEVELOPING side effect no longer mints a `pipeline_run`
+    // group. It records the round and DISPATCHES the SDLC close-out off the tick
+    // path. devGroupId stays null (the in-progress/stranded marker); openP0 persists.
     const loop = makeLoop({ state: "deciding", round: 2, maxRounds: 6, currentIterationNumber: 2 });
     const { storage } = makeFakeStorage(loop, [{ round: 1, openP0: 3 }]);
-    // workspace bind: an existing local workspace at the loop repo path resolves.
-    storage.getWorkspaces = vi.fn(async () => [
-      { id: "ws-bound", type: "local", path: process.cwd(), branch: "main" },
-    ]) as never;
-    storage.createWorkspace = vi.fn() as never;
-    const createTaskGroup = vi.fn(async () => ({ group: { id: "devgrp" }, tasks: [] }));
-    const startGroupAsync = vi.fn(async () => ({ group: {}, iteration: { iterationNumber: 1 } }));
-    const startGroup = vi.fn();
+    const createTaskGroup = vi.fn();
+    const startGroupAsync = vi.fn();
+    const runCloseout = vi.fn(async () => ({ prRef: "https://github.com/x/y/pull/5", headCommit: "abc1234" }));
     const controller = new ConsiliumLoopController({
       storage: storage as never,
-      taskOrchestrator: { startGroup, startGroupAsync, createTaskGroup, cancelGroup: vi.fn() } as never,
+      taskOrchestrator: { startGroup: vi.fn(), startGroupAsync, createTaskGroup, cancelGroup: vi.fn() } as never,
       config: fakeConfig,
       readIterationVerdict: async () => verdict(false, 2),
       readRepoHead: async () => "abc1234",
+      runCloseout,
     });
     const res = await controller.tick(loop.id);
     expect(res?.state).toBe("developing");
-    expect(res?.devGroupId).toBe("devgrp");
-    // DEV group started via the NON-BLOCKING path (D.6), never the awaiting one.
-    expect(startGroupAsync).toHaveBeenCalledWith("devgrp", expect.anything());
-    expect(startGroup).not.toHaveBeenCalled();
-    // §14.3: the handoff payload carried the resolved workspaceId on every task.
-    const payload = createTaskGroup.mock.calls[0][0] as { tasks: Array<{ workspaceId?: string }> };
-    expect(payload.tasks.every((t) => t.workspaceId === "ws-bound")).toBe(true);
+    expect(res?.devGroupId ?? null).toBeNull(); // marker stays null (H-2)
+    expect(res?.openP0).toBe(2);
+    expect(createTaskGroup).not.toHaveBeenCalled(); // no legacy pipeline_run group
+    expect(startGroupAsync).not.toHaveBeenCalled();
+    expect(runCloseout).toHaveBeenCalledTimes(1); // SDLC dispatched (background)
   });
 
-  it("prRef extraction: a close-out returning a URL → AWAITING_MERGE persists exactly that prRef", async () => {
-    const loop = makeLoop({ state: "developing", round: 2, devGroupId: "existing-grp", currentIterationNumber: 2 });
+  it("prRef extraction: a settled close-out URL → AWAITING_MERGE persists exactly that prRef", async () => {
+    const loop = makeLoop({ state: "deciding", round: 2, currentIterationNumber: 2 });
     const { storage } = makeFakeStorage(loop, [{ round: 1, openP0: 3 }]);
-    storage.getTaskGroup = vi.fn(async (id: string) =>
-      id === "existing-grp" ? { id, status: "completed" } : { id: loop.groupId, input: "objective" },
-    ) as never;
     const runCloseout = vi.fn(async () => ({ prRef: "https://github.com/o/r/pull/99", headCommit: "feedbead" }));
     const controller = new ConsiliumLoopController({
       storage: storage as never,
       taskOrchestrator: { startGroup: vi.fn(), startGroupAsync: vi.fn(), createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
       config: fakeConfig,
       readIterationVerdict: async () => verdict(false, 2),
+      readRepoHead: async () => "abc",
       runCloseout,
     });
-    const res = await controller.tick(loop.id);
+    await controller.tick(loop.id); // deciding → developing (dispatch)
+    await flush();
+    const res = await controller.tick(loop.id); // developing → awaiting_merge
     expect(res?.state).toBe("awaiting_merge");
     expect(res?.prRef).toBe("https://github.com/o/r/pull/99");
     expect(res?.headCommitAtReview).toBe("feedbead");
     expect(res?.error ?? null).toBeNull();
   });
 
-  it("prRef extraction: a branch-only close-out → prRef null + error, still AWAITING_MERGE (loop NOT failed)", async () => {
-    const loop = makeLoop({ state: "developing", round: 2, devGroupId: "existing-grp", currentIterationNumber: 2 });
+  it("prRef extraction: a branch-only settle → prRef null + error, still AWAITING_MERGE (loop NOT failed)", async () => {
+    const loop = makeLoop({ state: "deciding", round: 2, currentIterationNumber: 2 });
     const { storage } = makeFakeStorage(loop, [{ round: 1, openP0: 3 }]);
-    storage.getTaskGroup = vi.fn(async (id: string) =>
-      id === "existing-grp" ? { id, status: "completed" } : { id: loop.groupId, input: "objective" },
-    ) as never;
     const runCloseout = vi.fn(async () => ({
       prRef: null,
       headCommit: "feedbead",
@@ -593,39 +586,36 @@ describe("controller — D.6 non-blocking startGroupAsync + prRef close-out flow
       taskOrchestrator: { startGroup: vi.fn(), startGroupAsync: vi.fn(), createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
       config: fakeConfig,
       readIterationVerdict: async () => verdict(false, 2),
+      readRepoHead: async () => "abc",
       runCloseout,
     });
-    const res = await controller.tick(loop.id);
+    await controller.tick(loop.id); // deciding → developing (dispatch)
+    await flush();
+    const res = await controller.tick(loop.id); // developing → awaiting_merge
     expect(res?.state).toBe("awaiting_merge"); // NOT failed — gate still meaningful
     expect(res?.prRef).toBeNull();
     expect(res?.error).toContain("open PR manually");
   });
 
-  it("close-out single-flight: a 2nd concurrent DEVELOPING tick does NOT double-run the close-out (gated by CAS)", async () => {
-    const loop = makeLoop({ state: "developing", round: 2, devGroupId: "existing-grp", currentIterationNumber: 2 });
+  it("dispatch single-flight: two concurrent DECIDING→DEVELOPING ticks dispatch the close-out ONCE (CAS-gated)", async () => {
+    // H-2: the SDLC close-out is dispatched on the deciding→developing CAS WINNER
+    // only. Two pods (separate in-process Sets) over one storage both attempt the
+    // CAS; exactly one wins → exactly one background coder (no duplicate PR).
+    const loop = makeLoop({ state: "deciding", round: 2, currentIterationNumber: 2 });
     const { storage } = makeFakeStorage(loop, [{ round: 1, openP0: 3 }]);
-    storage.getTaskGroup = vi.fn(async (id: string) =>
-      id === "existing-grp" ? { id, status: "completed" } : { id: loop.groupId, input: "objective" },
-    ) as never;
-    // A slow close-out keeps the winner's side effect in flight while a 2nd tick
-    // fires; the in-process lock bars same-process re-entry and the CAS bars the
-    // cross-instance case — exactly one close-out runs.
-    const runCloseout = vi.fn(async () => {
-      await new Promise((r) => setTimeout(r, 20));
-      return { prRef: "https://github.com/o/r/pull/1", headCommit: "abc" };
-    });
+    const runCloseout = vi.fn(async () => ({ prRef: "https://github.com/o/r/pull/1", headCommit: "abc" }));
     const mk = () =>
       new ConsiliumLoopController({
         storage: storage as never,
         taskOrchestrator: { startGroup: vi.fn(), startGroupAsync: vi.fn(), createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
         config: fakeConfig,
         readIterationVerdict: async () => verdict(false, 2),
+        readRepoHead: async () => "abc",
         runCloseout,
       });
-    // Two separate controllers (two in-process Sets) over ONE storage = two pods.
     const [a, b] = await Promise.all([mk().tick(loop.id), mk().tick(loop.id)]);
-    expect(runCloseout).toHaveBeenCalledTimes(1); // the CAS gate prevents a duplicate PR
-    const winners = [a, b].filter((r) => r !== null && r.state === "awaiting_merge");
+    expect(runCloseout).toHaveBeenCalledTimes(1); // the CAS gate prevents a duplicate coder
+    const winners = [a, b].filter((r) => r !== null && r.state === "developing");
     expect(winners).toHaveLength(1);
   });
 });

--- a/tests/unit/sdlc/coder.test.ts
+++ b/tests/unit/sdlc/coder.test.ts
@@ -1,0 +1,155 @@
+/**
+ * coder.test.ts — SDLC agentic coder (component 2).
+ *
+ * DRY checks only — NO live `claude` session is spawned (that is an integration
+ * concern the Lead will smoke). Asserts:
+ *   - the EXACT agentic arg array (the load-bearing security construction):
+ *     `-p --output-format json --permission-mode acceptEdits
+ *      --allowedTools Edit Write Read Bash --add-dir <worktreeDir>`.
+ *   - the prompt carries the (clamped) UNTRUSTED action-point text and the
+ *     server-fixed "do not touch git/PR" instruction. It is a plain string fed to
+ *     STDIN — there is no argv/shell surface for it to escape into.
+ *   - output parsing: a clean `result` JSON → ok; an `is_error` JSON → ok:false
+ *     (surfaced, not thrown) with a scrubbed message.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  buildCoderArgs,
+  buildCoderPrompt,
+  parseCoderOutput,
+  sanitizedCoderEnv,
+  ALLOWED_TOOLS,
+  CODER_ENV_ALLOWLIST,
+} from "../../../server/services/sdlc/coder.js";
+import type { ActionPoint } from "@shared/types";
+
+const WT = "/tmp/sdlc-wt-XXXX/tree";
+
+describe("buildCoderArgs — exact agentic arg array (DRY security check)", () => {
+  it("is the confined acceptEdits invocation with the minimal tool allowlist", () => {
+    expect(buildCoderArgs(WT)).toEqual([
+      "-p",
+      "--output-format",
+      "json",
+      "--permission-mode",
+      "acceptEdits",
+      "--allowedTools",
+      "Edit",
+      "Write",
+      "Read",
+      "--add-dir",
+      WT,
+    ]);
+  });
+
+  it("never passes --dangerously-skip-permissions, has NO Bash (C-1), confines via --add-dir", () => {
+    const args = buildCoderArgs(WT);
+    expect(args).not.toContain("--dangerously-skip-permissions");
+    expect(args).not.toContain("Bash"); // C-1: a Bash child escapes --add-dir/cwd
+    expect(args[args.indexOf("--add-dir") + 1]).toBe(WT); // confinement dir
+    expect(ALLOWED_TOOLS).toEqual(["Edit", "Write", "Read"]);
+  });
+});
+
+describe("buildCoderPrompt — untrusted text stays in the prompt only", () => {
+  const aps: ActionPoint[] = [
+    { title: "Fix `; rm -rf /` injection in the parser", priority: "P0", rationale: "unsanitized input" },
+    { title: "Add the redactor", priority: "P1" },
+  ];
+
+  it("includes the action-point text and the do-not-touch-git instruction", () => {
+    const prompt = buildCoderPrompt(aps);
+    // The untrusted title appears verbatim — but this is a STDIN string, not argv.
+    expect(prompt).toContain("Fix `; rm -rf /` injection in the parser");
+    expect(prompt).toContain("[P0]");
+    expect(prompt).toContain("unsanitized input");
+    expect(prompt).toMatch(/Do NOT run `git commit`/);
+    expect(prompt).toMatch(/ISOLATED git worktree/);
+  });
+
+  it("clamps an over-long title so the prompt stays bounded", () => {
+    const huge: ActionPoint[] = [{ title: "x".repeat(5_000), priority: "P0" }];
+    const prompt = buildCoderPrompt(huge);
+    // The 5k title is clamped well under its raw length.
+    expect(prompt).not.toContain("x".repeat(1_000));
+  });
+});
+
+describe("parseCoderOutput", () => {
+  it("ok on a clean result JSON, with token accounting", () => {
+    const stdout = JSON.stringify({
+      type: "result",
+      result: "Edited 3 files.",
+      usage: { input_tokens: 10, output_tokens: 20 },
+    });
+    const res = parseCoderOutput(stdout);
+    expect(res.ok).toBe(true);
+    expect(res.summary).toBe("Edited 3 files.");
+    expect(res.tokensUsed).toBe(30);
+  });
+
+  it("ok:false (surfaced, not thrown) when the CLI reports an error", () => {
+    const stdout = JSON.stringify({ type: "result", is_error: true, result: "boom at /home/user/secret" });
+    const res = parseCoderOutput(stdout);
+    expect(res.ok).toBe(false);
+    expect(res.error).toBeDefined();
+    expect(res.error).not.toContain("/home/user"); // fs layout scrubbed
+  });
+
+  it("ok:false on unparseable stdout", () => {
+    const res = parseCoderOutput("not json at all");
+    expect(res.ok).toBe(false);
+    expect(res.error).toBeDefined();
+  });
+});
+
+describe("sanitizedCoderEnv — H-1: no inherited secrets reach the coder", () => {
+  const SOURCE: NodeJS.ProcessEnv = {
+    PATH: "/usr/bin:/bin",
+    HOME: "/home/agent",
+    LANG: "en_US.UTF-8",
+    // Secrets that MUST NOT be forwarded:
+    GH_TOKEN: "gh-secret",
+    GITHUB_TOKEN: "github-secret",
+    AWS_SECRET_ACCESS_KEY: "aws-secret",
+    AWS_ACCESS_KEY_ID: "aws-id",
+    POSTGRES_PASSWORD: "pg-secret",
+    DATABASE_URL: "postgres://u:p@h/db",
+    ANTHROPIC_API_KEY: "sk-ant-secret",
+    SOME_OTHER_SECRET: "nope",
+  };
+
+  it("forwards ONLY the allowlisted keys (PATH/HOME/locale)", () => {
+    const env = sanitizedCoderEnv(SOURCE);
+    expect(env.PATH).toBe("/usr/bin:/bin");
+    expect(env.HOME).toBe("/home/agent");
+    expect(env.LANG).toBe("en_US.UTF-8");
+  });
+
+  it("DROPS every DB/cloud/VCS/API secret (fail-closed allowlist)", () => {
+    const env = sanitizedCoderEnv(SOURCE);
+    for (const leaked of [
+      "GH_TOKEN",
+      "GITHUB_TOKEN",
+      "AWS_SECRET_ACCESS_KEY",
+      "AWS_ACCESS_KEY_ID",
+      "POSTGRES_PASSWORD",
+      "DATABASE_URL",
+      "ANTHROPIC_API_KEY",
+      "SOME_OTHER_SECRET",
+    ]) {
+      expect(env[leaked]).toBeUndefined();
+    }
+    // No value in the sanitized env equals any known secret string.
+    const values = Object.values(env);
+    for (const secret of ["gh-secret", "github-secret", "aws-secret", "pg-secret", "sk-ant-secret", "nope"]) {
+      expect(values).not.toContain(secret);
+    }
+  });
+
+  it("the allowlist itself contains no obvious secret-bearing keys", () => {
+    for (const key of CODER_ENV_ALLOWLIST) {
+      expect(key).not.toMatch(/PASSWORD|SECRET|AWS_|GITHUB_TOKEN|^GH_TOKEN$|DATABASE_URL|ANTHROPIC_API_KEY/);
+    }
+  });
+});

--- a/tests/unit/sdlc/completed-count.test.ts
+++ b/tests/unit/sdlc/completed-count.test.ts
@@ -1,0 +1,58 @@
+/**
+ * completed-count.test.ts — bug #3: the `/api/task-groups` list route's
+ * `completedCount` must reflect the LATEST ITERATION's EXECUTIONS, not the task
+ * DEFINITION statuses (which stay blocked/ready, so a fully executed group used to
+ * report 0/N). Drives the REAL route over MemStorage via the shared test app.
+ */
+import { describe, it, expect } from "vitest";
+import request from "supertest";
+import { createTaskGroupTestApp } from "../../helpers/test-task-group-app.js";
+
+describe("GET /api/task-groups — completedCount (#3)", () => {
+  it("counts the latest iteration's completed EXECUTIONS, not definition statuses", async () => {
+    const { app, storage, userId } = createTaskGroupTestApp();
+
+    // A group owned by the caller, with 3 task DEFINITIONS that stay non-completed
+    // (the bug: their status is blocked/ready/pending even after a full run).
+    const group = await storage.createTaskGroup({
+      name: "consilium sdlc handoff",
+      description: "d",
+      input: "i",
+      createdBy: userId,
+    });
+    const defs = [];
+    for (let i = 0; i < 3; i++) {
+      defs.push(await storage.createTask({ groupId: group.id, name: `t${i}`, description: "d", sortOrder: i }));
+    }
+    // The definitions remain non-completed — exactly the state that produced 0/N.
+    for (const d of defs) expect(d.status).not.toBe("completed");
+
+    // Latest iteration with 3 executions; 2 completed, 1 running.
+    const iteration = await storage.createIteration({
+      groupId: group.id,
+      iterationNumber: 1,
+      status: "running",
+      input: "i",
+    });
+    await storage.createExecution({ groupId: group.id, iterationId: iteration.id, taskId: defs[0].id, taskName: "t0", status: "completed" });
+    await storage.createExecution({ groupId: group.id, iterationId: iteration.id, taskId: defs[1].id, taskName: "t1", status: "completed" });
+    await storage.createExecution({ groupId: group.id, iterationId: iteration.id, taskId: defs[2].id, taskName: "t2", status: "running" });
+
+    const res = await request(app).get("/api/task-groups").expect(200);
+    const row = (res.body as Array<{ id: string; taskCount: number; completedCount: number }>).find((r) => r.id === group.id);
+    expect(row).toBeDefined();
+    expect(row?.taskCount).toBe(3); // number of definitions
+    expect(row?.completedCount).toBe(2); // completed EXECUTIONS in the latest iteration
+  });
+
+  it("reports 0 completed when there is no iteration yet (never started)", async () => {
+    const { app, storage, userId } = createTaskGroupTestApp();
+    const group = await storage.createTaskGroup({ name: "fresh", description: "d", input: "i", createdBy: userId });
+    await storage.createTask({ groupId: group.id, name: "t", description: "d", sortOrder: 0 });
+
+    const res = await request(app).get("/api/task-groups").expect(200);
+    const row = (res.body as Array<{ id: string; taskCount: number; completedCount: number }>).find((r) => r.id === group.id);
+    expect(row?.taskCount).toBe(1);
+    expect(row?.completedCount).toBe(0);
+  });
+});

--- a/tests/unit/sdlc/executor.test.ts
+++ b/tests/unit/sdlc/executor.test.ts
@@ -1,0 +1,153 @@
+/**
+ * executor.test.ts — SDLC orchestration (component 5).
+ *
+ * Drives `runSdlcHandoff` over FULLY injected seams (worktree / coder / push /
+ * openPr / git runner) — no real repo, no claude, no gh. Load-bearing:
+ *   - CLEANUP GUARANTEE: the worktree is removed even when the coder THROWS
+ *     (timeout / binary missing) — the removal runs in a `finally`.
+ *   - the handoff NEVER throws — every failure degrades to `{ prRef:null, ... }`.
+ *   - BRANCH GATING: a non-uuid loopId yields a non-B-3 branch → rejected BEFORE
+ *     a worktree is ever cut.
+ *   - happy path → `{ prRef:<url>, headCommit }`; the commit/PR title are
+ *     server-derived (no model text); untrusted titles only reach the commit body.
+ *   - no-changes / push-fail / pr-fail degrade correctly and STILL clean up.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  runSdlcHandoff,
+  buildCommitMessage,
+  buildPrTitle,
+  type SdlcHandoffRequest,
+} from "../../../server/services/sdlc/executor.js";
+import type { ActionPoint } from "@shared/types";
+
+const LOOP = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const REPO = "/allowlisted/omniscience";
+const ROOTS = ["/allowlisted"];
+const BRANCH = `consilium/loop-${LOOP}/round-2`;
+
+const APS: ActionPoint[] = [
+  { title: "Fix `;rm -rf /` in parser\nwith newline", priority: "P0" },
+  { title: "Add the redactor", priority: "P1" },
+];
+
+const baseReq = (over: Partial<SdlcHandoffRequest> = {}): SdlcHandoffRequest => ({
+  repoPath: REPO,
+  loopId: LOOP,
+  round: 2,
+  actionPoints: APS,
+  allowedRepoPaths: ROOTS,
+  ...over,
+});
+
+const FAKE_WT = { worktreeDir: "/tmp/sdlc-wt-XXXX/tree", baseDir: "/tmp/sdlc-wt-XXXX", branch: BRANCH, baseRef: "main" };
+
+/** git runner whose `status --porcelain` reports `hasChanges`. */
+function makeGitRaw(hasChanges: boolean) {
+  return vi.fn(async (_repo: string, args: string[]) => {
+    if (args[0] === "status") return hasChanges ? " M server/x.ts\n" : "";
+    if (args[0] === "rev-parse") return "headsha000\n";
+    return "";
+  });
+}
+
+function makeDeps(over: Record<string, unknown> = {}) {
+  return {
+    createWorktree: vi.fn(async () => FAKE_WT),
+    removeWorktree: vi.fn(async () => undefined),
+    resolveDefaultBranchFn: vi.fn(async () => "main"),
+    runCoder: vi.fn(async () => ({ ok: true, summary: "edited 2 files", tokensUsed: 5 })),
+    push: vi.fn(async () => ({ ok: true as const, branch: BRANCH })),
+    openPr: vi.fn(async () => ({ ok: true as const, prUrl: "https://github.com/x/y/pull/9" })),
+    gitRaw: makeGitRaw(true),
+    ...over,
+  };
+}
+
+describe("runSdlcHandoff — cleanup guarantee", () => {
+  it("removes the worktree even when the coder THROWS (finally)", async () => {
+    const deps = makeDeps({
+      runCoder: vi.fn(async () => {
+        throw new Error("CLI timed out after 600000ms at /home/u/.claude");
+      }),
+    });
+    const res = await runSdlcHandoff(baseReq(), deps as never);
+    // No throw — degraded result.
+    expect(res.prRef).toBeNull();
+    expect(res.error).toBeDefined();
+    expect(res.error).not.toContain("/home/u"); // fs layout scrubbed
+    // The worktree was STILL removed.
+    expect(deps.removeWorktree).toHaveBeenCalledTimes(1);
+    expect(deps.removeWorktree).toHaveBeenCalledWith(REPO, FAKE_WT.worktreeDir, expect.objectContaining({ baseDir: FAKE_WT.baseDir }));
+  });
+
+  it("removes the worktree on the happy path too", async () => {
+    const deps = makeDeps();
+    const res = await runSdlcHandoff(baseReq(), deps as never);
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+    expect(res.headCommit).toBe("headsha000");
+    expect(deps.removeWorktree).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("runSdlcHandoff — branch gating", () => {
+  it("REJECTS a non-uuid loopId (non-B-3 branch) BEFORE cutting a worktree", async () => {
+    const deps = makeDeps();
+    const res = await runSdlcHandoff(baseReq({ loopId: "not-a-uuid" }), deps as never);
+    expect(res.prRef).toBeNull();
+    expect(res.error).toMatch(/B-3/);
+    expect(deps.createWorktree).not.toHaveBeenCalled();
+    expect(deps.removeWorktree).not.toHaveBeenCalled();
+  });
+});
+
+describe("runSdlcHandoff — server-derived branch/PR title, untrusted text quarantined", () => {
+  it("opens the Draft PR with a server-derived title + head, never model text", async () => {
+    const deps = makeDeps();
+    await runSdlcHandoff(baseReq(), deps as never);
+    expect(deps.openPr).toHaveBeenCalledTimes(1);
+    const [, opts] = (deps.openPr as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(opts.title).toBe(buildPrTitle(2));
+    expect(opts.title).not.toMatch(/rm -rf/); // no action-point text in the title
+    expect(opts.head).toBe(BRANCH); // server-derived branch
+    expect(opts.base).toBe("main");
+  });
+
+  it("commit subject is server-fixed; untrusted titles only in the sanitized body", () => {
+    const { subject, body } = buildCommitMessage(2, APS);
+    expect(subject).toBe("consilium: SDLC changes for round 2");
+    expect(subject).not.toMatch(/rm -rf/);
+    // The body carries the title but with control chars / newlines stripped.
+    expect(body).toContain("Add the redactor");
+    expect(body).not.toMatch(/\n.*rm -rf.*\n.*with newline/); // newline inside title collapsed
+  });
+});
+
+describe("runSdlcHandoff — degraded paths still clean up", () => {
+  it("no changes produced → no PR, error note, worktree removed", async () => {
+    const deps = makeDeps({ gitRaw: makeGitRaw(false) });
+    const res = await runSdlcHandoff(baseReq(), deps as never);
+    expect(res.prRef).toBeNull();
+    expect(res.error).toMatch(/no changes/);
+    expect(deps.openPr).not.toHaveBeenCalled();
+    expect(deps.removeWorktree).toHaveBeenCalledTimes(1);
+  });
+
+  it("push fail → branch-only, openPr NOT attempted, worktree removed", async () => {
+    const deps = makeDeps({ push: vi.fn(async () => ({ ok: false, kind: "unknown", message: "no remote" })) });
+    const res = await runSdlcHandoff(baseReq(), deps as never);
+    expect(res.prRef).toBeNull();
+    expect(res.error).toMatch(/push failed/);
+    expect(deps.openPr).not.toHaveBeenCalled();
+    expect(deps.removeWorktree).toHaveBeenCalledTimes(1);
+  });
+
+  it("gh fail → branch pushed, prRef null, headCommit kept, worktree removed", async () => {
+    const deps = makeDeps({ openPr: vi.fn(async () => ({ ok: false, kind: "gh-failed", message: "gh unauth" })) });
+    const res = await runSdlcHandoff(baseReq(), deps as never);
+    expect(res.prRef).toBeNull();
+    expect(res.headCommit).toBe("headsha000");
+    expect(res.error).toMatch(/open PR manually/);
+    expect(deps.removeWorktree).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/sdlc/worktree.test.ts
+++ b/tests/unit/sdlc/worktree.test.ts
@@ -1,0 +1,189 @@
+/**
+ * worktree.test.ts — SDLC worktree lifecycle (component 1).
+ *
+ * Drives `createSdlcWorktree` / `removeSdlcWorktree` / `resolveDefaultBranch`
+ * over an injected ARG-ARRAY git runner + a fake `mkdtemp` — no real repo, no
+ * real worktree on disk. Load-bearing assertions:
+ *   - BRANCH-NAME GATING (B-3): a non-`consilium/loop-<uuid>/round-<n>` branch
+ *     (and a leading-dash branch) is REJECTED before any git command runs.
+ *   - the repo is re-validated against the fail-closed allowlist (H-5).
+ *   - an unsafe `baseRef` (leading dash / `..`) is rejected.
+ *   - the worktree dir is the server-minted temp dir (NEVER the user's checkout)
+ *     and `git worktree add` gets the gated branch + baseRef as POSITIONALS.
+ *   - `removeSdlcWorktree` NEVER throws (finally-safe cleanup).
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  createSdlcWorktree,
+  removeSdlcWorktree,
+  resolveDefaultBranch,
+  type GitRunner,
+} from "../../../server/services/sdlc/worktree.js";
+
+const LOOP = "11111111-2222-3333-4444-555555555555";
+const REPO = "/allowlisted/omniscience";
+const ROOTS = ["/allowlisted"];
+const BRANCH = `consilium/loop-${LOOP}/round-2`;
+
+/** A git runner that records calls and returns canned stdout per subcommand. */
+function fakeGit(over: (args: string[]) => string | Promise<string> = () => ""): {
+  raw: GitRunner;
+  calls: string[][];
+} {
+  const calls: string[][] = [];
+  const raw: GitRunner = async (_repo, args) => {
+    calls.push(args);
+    return over(args);
+  };
+  return { raw, calls };
+}
+
+const fakeMkdtemp = vi.fn(async (_prefix: string) => "/tmp/sdlc-wt-XXXX");
+
+describe("createSdlcWorktree — gating", () => {
+  it("REJECTS a non-B-3 branch before any git runs", async () => {
+    const git = fakeGit();
+    await expect(
+      createSdlcWorktree({
+        repoPath: REPO,
+        branch: "feature/evil; rm -rf /", // not the server-derived shape
+        allowedRepoPaths: ROOTS,
+        gitRaw: git.raw,
+        mkdtempFn: fakeMkdtemp,
+      }),
+    ).rejects.toThrow(/B-3/);
+    expect(git.calls).toHaveLength(0); // gate is BEFORE git
+  });
+
+  it("REJECTS a leading-dash branch (flag-injection shape)", async () => {
+    const git = fakeGit();
+    await expect(
+      createSdlcWorktree({
+        repoPath: REPO,
+        branch: "--upload-pack=evil",
+        allowedRepoPaths: ROOTS,
+        gitRaw: git.raw,
+        mkdtempFn: fakeMkdtemp,
+      }),
+    ).rejects.toThrow(/B-3/);
+    expect(git.calls).toHaveLength(0);
+  });
+
+  it("REJECTS a repo outside the fail-closed allowlist (H-5)", async () => {
+    const git = fakeGit();
+    await expect(
+      createSdlcWorktree({
+        repoPath: "/etc",
+        branch: BRANCH,
+        allowedRepoPaths: ROOTS,
+        gitRaw: git.raw,
+        mkdtempFn: fakeMkdtemp,
+      }),
+    ).rejects.toThrow(/repo-allowlist|allowlist|outside/);
+    expect(git.calls).toHaveLength(0);
+  });
+
+  it("REJECTS an empty allowlist (fail-closed)", async () => {
+    const git = fakeGit();
+    await expect(
+      createSdlcWorktree({ repoPath: REPO, branch: BRANCH, allowedRepoPaths: [], gitRaw: git.raw, mkdtempFn: fakeMkdtemp }),
+    ).rejects.toThrow();
+    expect(git.calls).toHaveLength(0);
+  });
+
+  it("REJECTS an unsafe baseRef (leading dash)", async () => {
+    const git = fakeGit();
+    await expect(
+      createSdlcWorktree({
+        repoPath: REPO,
+        branch: BRANCH,
+        baseRef: "--output=/evil",
+        allowedRepoPaths: ROOTS,
+        gitRaw: git.raw,
+        mkdtempFn: fakeMkdtemp,
+      }),
+    ).rejects.toThrow(/baseRef/);
+  });
+});
+
+describe("createSdlcWorktree — happy path", () => {
+  it("creates the worktree under the server-minted temp dir with the gated positionals", async () => {
+    const git = fakeGit();
+    const res = await createSdlcWorktree({
+      repoPath: REPO,
+      branch: BRANCH,
+      baseRef: "main",
+      allowedRepoPaths: ROOTS,
+      gitRaw: git.raw,
+      mkdtempFn: fakeMkdtemp,
+    });
+    // The worktree dir is INSIDE the mkdtemp dir — never the user's checkout.
+    expect(res.worktreeDir.startsWith("/tmp/sdlc-wt-XXXX")).toBe(true);
+    expect(res.worktreeDir).not.toContain("omniscience");
+    expect(res.branch).toBe(BRANCH);
+    expect(res.baseRef).toBe("main");
+
+    const add = git.calls.find((c) => c[0] === "worktree" && c[1] === "add");
+    expect(add).toBeDefined();
+    // `-b <branch> <path> <baseRef>` — branch + baseRef are gated positionals.
+    expect(add).toEqual(["worktree", "add", "-b", BRANCH, res.worktreeDir, "main"]);
+  });
+
+  it("recovers from an already-existing branch via `-B`", async () => {
+    let firstAdd = true;
+    const git = fakeGit((args) => {
+      if (args[0] === "worktree" && args[1] === "add" && args[2] === "-b" && firstAdd) {
+        firstAdd = false;
+        throw new Error("fatal: a branch named '...' already exists");
+      }
+      return "";
+    });
+    const res = await createSdlcWorktree({
+      repoPath: REPO,
+      branch: BRANCH,
+      baseRef: "main",
+      allowedRepoPaths: ROOTS,
+      gitRaw: git.raw,
+      mkdtempFn: fakeMkdtemp,
+    });
+    const forced = git.calls.find((c) => c[0] === "worktree" && c[1] === "add" && c[2] === "-B");
+    expect(forced).toEqual(["worktree", "add", "-B", BRANCH, res.worktreeDir, "main"]);
+  });
+});
+
+describe("resolveDefaultBranch", () => {
+  it("strips `origin/` from the symbolic-ref result", async () => {
+    const git = fakeGit((args) =>
+      args[0] === "symbolic-ref" ? "origin/main\n" : "should-not-be-used\n",
+    );
+    expect(await resolveDefaultBranch(REPO, git.raw)).toBe("main");
+  });
+
+  it("falls back to the local HEAD branch, then to `main`", async () => {
+    const git = fakeGit((args) => {
+      if (args[0] === "symbolic-ref") throw new Error("no origin/HEAD");
+      if (args[0] === "rev-parse") return "develop\n";
+      return "";
+    });
+    expect(await resolveDefaultBranch(REPO, git.raw)).toBe("develop");
+
+    const git2 = fakeGit(() => {
+      throw new Error("not a git repo");
+    });
+    expect(await resolveDefaultBranch(REPO, git2.raw)).toBe("main");
+  });
+});
+
+describe("removeSdlcWorktree — finally-safe", () => {
+  it("calls `worktree remove --force` and NEVER throws (even when git fails)", async () => {
+    const git = fakeGit((args) => {
+      if (args[0] === "worktree" && args[1] === "remove") throw new Error("locked");
+      return "";
+    });
+    await expect(
+      removeSdlcWorktree(REPO, "/tmp/sdlc-wt-XXXX/tree", { baseDir: "/tmp/sdlc-wt-XXXX", gitRaw: git.raw }),
+    ).resolves.toBeUndefined();
+    const remove = git.calls.find((c) => c[0] === "worktree" && c[1] === "remove");
+    expect(remove).toEqual(["worktree", "remove", "--force", "/tmp/sdlc-wt-XXXX/tree"]);
+  });
+});


### PR DESCRIPTION
## Summary
Replaces the consilium loop's inadequate dev handoff (single-shot LLM stages + `switchBranch` on the **user's own checkout**) with a real, **worktree-isolated, agentic** coding executor that implements verdict action_points and opens a **Draft PR**.

### Components (`server/services/sdlc/`)
- **worktree.ts** — `git worktree add -b <branch> <mkdtemp> <base>` under `os.tmpdir()`: an absolute, server-minted path that **never overlaps the user's checkout** (no `switchBranch`), removed in a `finally` (even on coder throw/timeout). Branch = the server-derived consilium B-3 shape (reuses pr-wrapper).
- **coder.ts** — runs the local `claude` CLI **agentically in the worktree** (`-p --output-format json --permission-mode acceptEdits --allowedTools Edit Write Read --add-dir <wt>`, `cwd=wt`); the prompt (from the **untrusted** action_point) is fed via **stdin only**; 600 s timeout; **sanitized minimal env** (allowlist PATH/HOME/claude-auth; strips `GH_*`/`*TOKEN*`/`*PASSWORD*`/`*SECRET*`/`AWS_*`/DB creds — fail-closed).
- **executor.ts** — worktree → coder → `git add -A` + commit (server-fixed subject; untrusted text only in the clamped/stripped body) → push `origin` → **Draft PR** (pr-wrapper; draft only, never merges) → cleanup.

### Loop integration (non-blocking)
The DEVELOPING phase dispatches the coder **fire-and-forget**; the loop stays in `developing`, every poller tick stays fast (**no 600 s stall of the cross-project sweep**), and a later tick CASes `developing→awaiting_merge` with the PR ref once it settles. Single-flight via the `deciding→developing` CAS + in-process lock; a crash mid-coder is re-dispatched by `claimRedrive(developing)` (grace widened past the coder timeout). **No schema migration.**

### Security — adversarially reviewed, all CRITICAL/HIGH fixed
A security pass found and we fixed: **C-1** Bash tool removed (it's a child process unconfined by `--add-dir` → was a headless worktree-escape + live-`.env` read); **H-1** sanitized env (was inheriting the full `process.env` incl. `GH_TOKEN`/DB creds); **H-2** moved the 600 s coder off the synchronous sweep (was a cross-project 10-min DoS). Plus L-1 `--base` gate. The reviewer confirmed the arg-array / branch / PR / cleanup / single-flight foundations are sound (could not break them). Untrusted text never reaches a shell, branch, or PR title; Draft-PR-only (agents never merge).

### Also
- **#2b** — verdict-panel auto-starts the handoff group (was sitting pending).
- **#3** — task-groups list `completedCount` now counts the **latest iteration's executions** (was reading task-definition statuses → always 0/N).

## Verification
`tsc --noEmit` clean. `tests/unit/sdlc` + `tests/unit/consilium` + `tests/unit/scoping` **206/206** (incl. no-Bash, sanitized-env, and the non-blocking developing→settle→awaiting_merge FSM + crash-recovery tests). Broader controller/orchestrator/routes/providers suites green.

## Notes / follow-up
- Naming is user-facing **"SDLC"** (not "dev" — avoids dev-env confusion); the FSM state literal `developing` is unchanged.
- **No Docker sandbox** (trusted spec edits); revisit when the coder runs untrusted code or needs live-env creds.
- To run end-to-end against **omnius**, omnius needs a **GitHub remote** — it's currently a local-only git repo, so push/`gh pr create` would degrade to the branch-only fallback. (Separate setup.)