### PR TITLE
feat(dashboard+consilium): task-group/loop stats (24h breakdown) + loop-detail result panel

### DIFF
--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -412,6 +412,119 @@ function RoundRow({
   );
 }
 
+// ─── Result panel — the human-gate outcome surface ─────────────────────────────
+//
+// What did the latest SDLC round actually produce? The stepper shows WHERE the
+// loop is; this panel shows WHAT to decide on. It is rendered near the top so a
+// human arriving at `awaiting_merge` is never met with a blank gate. Every field
+// comes straight from the loop GET (loop.error, loop.prRef, the latest round's
+// openP0 / openActionPoints) — nothing is invented.
+//
+// SECURITY: error text and action-point titles are model/loop-authored and are
+// rendered as INERT React text; the PR link uses rel="noopener noreferrer".
+function ResultPanel({
+  loop,
+  terminal,
+}: {
+  loop: ConsiliumLoopDetailRow;
+  terminal: boolean;
+}) {
+  const rounds = Array.isArray(loop.rounds) ? loop.rounds : [];
+  const latest = rounds.length
+    ? [...rounds].sort((a, b) => b.round - a.round)[0]
+    : undefined;
+  const latestAps: ActionPoint[] = Array.isArray(latest?.openActionPoints)
+    ? (latest!.openActionPoints as ActionPoint[])
+    : [];
+  const awaiting = loop.state === "awaiting_merge";
+
+  // Nothing worth surfacing yet (a fresh/pending loop with no round, no error,
+  // no PR, not at the gate) — keep the page lean and skip the panel.
+  if (!loop.error && !loop.prRef && !awaiting && latest == null) return null;
+
+  return (
+    <Card className="border-amber-500/40">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm">Result</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Last-round error — the most important signal when a round degraded. */}
+        {loop.error && (
+          <div className="flex items-start gap-2 rounded-md border border-amber-500/50 bg-amber-500/10 p-3 text-sm">
+            <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+            <div className="min-w-0">
+              <p className="font-medium text-amber-700 dark:text-amber-300">Last round error</p>
+              {/* INERT loop-authored error text */}
+              <p className="text-amber-700/90 dark:text-amber-300/90 break-words">{loop.error}</p>
+            </div>
+          </div>
+        )}
+
+        {/* PR outcome — link when there is one, explicit note when there is not. */}
+        {loop.prRef ? (
+          <div className="flex items-center justify-between gap-4">
+            <div className="min-w-0">
+              <p className="text-sm font-medium">Draft PR ready for review</p>
+              <p className="font-mono text-xs text-muted-foreground truncate">{loop.prRef}</p>
+            </div>
+            <a
+              href={loop.prRef}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 shrink-0"
+            >
+              <ExternalLink className="h-4 w-4" />
+              Open Draft PR
+            </a>
+          </div>
+        ) : awaiting ? (
+          <div className="rounded-md border border-border bg-muted/30 p-3 text-sm text-muted-foreground">
+            The SDLC round produced{" "}
+            <span className="font-medium text-foreground">no PR</span> — there is nothing
+            to merge. {loop.error ? "See the error above" : "No error was recorded"}; you
+            can cancel the loop, or approve to advance it against the current HEAD.
+          </div>
+        ) : null}
+
+        {/* Latest round's verdict — what the human is deciding on. */}
+        {latest && (
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-sm">
+              <span className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                Round {latest.round} verdict
+              </span>
+              <ConvergenceMark converged={latest.converged} terminal={terminal} />
+              <span className={`tabular-nums font-medium ${p0ClassName(latest.openP0, terminal)}`}>
+                {latest.openP0 ?? "—"} open P0
+              </span>
+            </div>
+            {latestAps.length > 0 ? (
+              <ul className="space-y-1.5">
+                {latestAps.map((ap, i) => (
+                  <li key={i} className="flex items-start gap-2 text-sm">
+                    {ap.priority && (
+                      <Badge className={`${PRIORITY_COLOR[ap.priority] ?? "bg-muted"} shrink-0`}>
+                        {ap.priority}
+                      </Badge>
+                    )}
+                    {/* INERT model-authored text */}
+                    <span>{ap.title}</span>
+                  </li>
+                ))}
+                <p className="text-[11px] text-muted-foreground/70">{PRIORITY_LEGEND}</p>
+              </ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No open action points recorded for this round.
+              </p>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 // ─── Page ───────────────────────────────────────────────────────────────────
 
 export default function ConsiliumLoopDetail() {
@@ -572,6 +685,9 @@ export default function ConsiliumLoopDetail() {
       </header>
 
       <div className="flex-1 overflow-y-auto p-6 space-y-5">
+        {/* Result — the outcome the human gate decides on (near the top). */}
+        <ResultPanel loop={loop} terminal={terminal} />
+
         {/* FSM progress */}
         <Card>
           <CardHeader className="pb-3">
@@ -579,36 +695,8 @@ export default function ConsiliumLoopDetail() {
           </CardHeader>
           <CardContent className="space-y-3">
             <FsmStepper loop={loop} />
-            {loop.error && (
-              <div className="flex items-start gap-2 rounded-md border border-red-500/40 bg-red-500/5 p-3 text-sm">
-                <AlertTriangle className="h-4 w-4 text-red-500 shrink-0 mt-0.5" />
-                {/* INERT loop-authored error text */}
-                <span className="text-red-700 dark:text-red-300">{loop.error}</span>
-              </div>
-            )}
           </CardContent>
         </Card>
-
-        {/* Draft PR call-out */}
-        {loop.prRef && (
-          <Card className="border-primary/40">
-            <CardContent className="flex items-center justify-between gap-4 py-4">
-              <div className="min-w-0">
-                <p className="text-sm font-medium">Draft PR ready for review</p>
-                <p className="font-mono text-xs text-muted-foreground truncate">{loop.prRef}</p>
-              </div>
-              <a
-                href={loop.prRef}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 shrink-0"
-              >
-                <ExternalLink className="h-4 w-4" />
-                Open Draft PR
-              </a>
-            </CardContent>
-          </Card>
-        )}
 
         {/* Key facts */}
         <Card>
@@ -729,11 +817,19 @@ export default function ConsiliumLoopDetail() {
             </AlertDialogTitle>
             <AlertDialogDescription asChild>
               <div className="space-y-3">
-                <span className="block">
-                  You are approving the merge of autonomously-produced code toward{" "}
-                  <strong>main</strong>. This advances the loop to its next round and
-                  triggers a fresh review against the merged HEAD.
-                </span>
+                {loop.prRef ? (
+                  <span className="block">
+                    You are approving the merge of autonomously-produced code toward{" "}
+                    <strong>main</strong>. This advances the loop to its next round and
+                    triggers a fresh review against the merged HEAD.
+                  </span>
+                ) : (
+                  <span className="block">
+                    This round produced <strong>no PR</strong>, so there is nothing to
+                    merge. Approving simply advances the loop to its next round against the
+                    current <strong>main</strong> HEAD — review the recorded error first.
+                  </span>
+                )}
                 {loop.prRef && (
                   <a
                     href={loop.prRef}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,31 +1,50 @@
 import { useQuery } from "@tanstack/react-query";
+import { Link } from "wouter";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Activity, Cpu, MessageCircleQuestion } from "lucide-react";
-import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts';
+import { Cpu, Layers, MessageCircleQuestion, Repeat } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useModels, usePendingQuestions, useGatewayStatus } from "@/hooks/use-pipeline";
 
-interface StatsSummary {
-  totalRuns: number;
-  activePipelines: number;
-  modelsConfigured: number;
-  runsLast7Days: number[];
+interface Loops24h {
+  passed: number;
+  broke: number;
+  stopped: number;
+  waiting: number;
+  running: number;
+  total: number;
 }
+
+interface StatsSummary {
+  modelsConfigured: number;
+  taskGroupsTotal: number;
+  taskGroupsActive: number;
+  consiliumLoopsTotal: number;
+  consiliumLoopsActive: number;
+  // 24h status breakdown of consilium loops (see /api/stats/summary). Optional
+  // on the wire so an older/partial response never crashes the card.
+  loops24h?: Loops24h;
+}
+
+// Display order + tone for the 24h pills. Greens/reds/ambers loosely track the
+// loop-state palette (components/consilium/loop-state.tsx). `mark` is a tiny
+// glyph cue; pills with a zero count are hidden to keep the card compact.
+const LOOP_24H_PILLS: {
+  key: keyof Omit<Loops24h, "total">;
+  label: string;
+  mark: string;
+  className: string;
+}[] = [
+  { key: "passed", label: "passed", mark: "\u2713", className: "text-green-600 dark:text-green-400" },
+  { key: "broke", label: "broke", mark: "\u2717", className: "text-red-600 dark:text-red-400" },
+  { key: "waiting", label: "waiting", mark: "\u23f3", className: "text-amber-600 dark:text-amber-400" },
+  { key: "stopped", label: "stopped", mark: "\u25cf", className: "text-yellow-600 dark:text-yellow-400" },
+  { key: "running", label: "running", mark: "\u25cf", className: "text-blue-600 dark:text-blue-400" },
+];
 
 function useStatsSummary() {
   return useQuery<StatsSummary>({
     queryKey: ["/api/stats/summary"],
     refetchInterval: 30_000,
-  });
-}
-
-function buildChartData(runsLast7Days: number[]): Array<{ day: string; runs: number }> {
-  const now = new Date();
-  return runsLast7Days.map((runs, i) => {
-    const d = new Date(now);
-    d.setDate(d.getDate() - (6 - i));
-    const label = d.toLocaleDateString("en-US", { weekday: "short" });
-    return { day: label, runs };
   });
 }
 
@@ -38,21 +57,23 @@ export default function Dashboard() {
   const pendingCount = Array.isArray(pendingQuestions) ? pendingQuestions.length : 0;
   const gwMode = gwStatus?.vllm ? 'vLLM' : gwStatus?.ollama ? 'Ollama' : 'Mock';
 
-  const totalRuns = stats?.totalRuns ?? 0;
-  const activePipelines = stats?.activePipelines ?? 0;
   const modelsConfigured = stats?.modelsConfigured ?? 0;
-  const chartData = buildChartData(stats?.runsLast7Days ?? Array(7).fill(0));
+  const taskGroupsTotal = stats?.taskGroupsTotal ?? 0;
+  const taskGroupsActive = stats?.taskGroupsActive ?? 0;
+  const consiliumLoopsTotal = stats?.consiliumLoopsTotal ?? 0;
+  const consiliumLoopsActive = stats?.consiliumLoopsActive ?? 0;
+  const loops24h = stats?.loops24h;
 
   return (
     <div className="p-8 h-full overflow-y-auto">
       <div className="mb-8">
         <h1 className="text-2xl font-semibold tracking-tight text-foreground">Overview</h1>
         <p className="text-sm text-muted-foreground mt-1">
-          SDLC pipeline orchestration status. Gateway: <span className="font-mono text-xs">{gwMode}</span>
+          Task group &amp; consilium orchestration status. Gateway: <span className="font-mono text-xs">{gwMode}</span>
         </p>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
         <Card className="border-border shadow-sm">
           <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-sm font-medium text-muted-foreground">Active Models</CardTitle>
@@ -64,16 +85,52 @@ export default function Dashboard() {
           </CardContent>
         </Card>
 
-        <Card className="border-border shadow-sm">
-          <CardHeader className="flex flex-row items-center justify-between pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">Total Pipeline Runs</CardTitle>
-            <Activity className="h-4 w-4 text-primary" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{totalRuns}</div>
-            <p className="text-xs text-muted-foreground mt-1">{activePipelines} active pipeline{activePipelines !== 1 ? "s" : ""}</p>
-          </CardContent>
-        </Card>
+        <Link href="/task-groups" data-testid="link-stat-task-groups">
+          <Card className="border-border shadow-sm cursor-pointer hover:bg-accent/40 transition-colors">
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">Task Groups</CardTitle>
+              <Layers className="h-4 w-4 text-primary" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{taskGroupsTotal}</div>
+              <p className="text-xs text-muted-foreground mt-1">{taskGroupsActive} running</p>
+            </CardContent>
+          </Card>
+        </Link>
+
+        <Link href="/consilium-loops" data-testid="link-stat-consilium-loops">
+          <Card className="border-border shadow-sm cursor-pointer hover:bg-accent/40 transition-colors">
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">Consilium Loops</CardTitle>
+              <Repeat className="h-4 w-4 text-primary" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{consiliumLoopsTotal}</div>
+              <p className="text-xs text-muted-foreground mt-1">{consiliumLoopsActive} active</p>
+              <div className="mt-2 border-t border-border/60 pt-2">
+                {loops24h && loops24h.total > 0 ? (
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                    {LOOP_24H_PILLS.filter((pill) => (loops24h[pill.key] ?? 0) > 0).map(
+                      (pill, i, shown) => (
+                        <span key={pill.key} className="inline-flex items-center">
+                          <span className={cn("text-[11px] font-medium tabular-nums", pill.className)}>
+                            {pill.mark} {loops24h[pill.key]} {pill.label}
+                          </span>
+                          {i < shown.length - 1 && (
+                            <span className="ml-2 text-muted-foreground/40 text-[11px]">&middot;</span>
+                          )}
+                        </span>
+                      ),
+                    )}
+                  </div>
+                ) : (
+                  <p className="text-[11px] text-muted-foreground/70">no loop activity in 24h</p>
+                )}
+                <p className="mt-0.5 text-[10px] uppercase tracking-wide text-muted-foreground/50">last 24h</p>
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
 
         <Card className="border-border shadow-sm">
           <CardHeader className="flex flex-row items-center justify-between pb-2">
@@ -87,35 +144,7 @@ export default function Dashboard() {
         </Card>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <Card className="col-span-2 border-border shadow-sm">
-          <CardHeader>
-            <CardTitle className="text-base font-medium">Pipeline Runs — Last 7 Days</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="h-[300px] w-full mt-4">
-              <ResponsiveContainer width="100%" height="100%">
-                <AreaChart data={chartData}>
-                  <defs>
-                    <linearGradient id="colorRuns" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%" stopColor="hsl(var(--primary))" stopOpacity={0.1}/>
-                      <stop offset="95%" stopColor="hsl(var(--primary))" stopOpacity={0}/>
-                    </linearGradient>
-                  </defs>
-                  <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" />
-                  <XAxis dataKey="day" axisLine={false} tickLine={false} tick={{ fontSize: 12, fill: 'hsl(var(--muted-foreground))' }} />
-                  <YAxis axisLine={false} tickLine={false} tick={{ fontSize: 12, fill: 'hsl(var(--muted-foreground))' }} allowDecimals={false} />
-                  <Tooltip
-                    contentStyle={{ backgroundColor: 'hsl(var(--card))', borderRadius: '8px', border: '1px solid hsl(var(--border))' }}
-                    itemStyle={{ color: 'hsl(var(--foreground))' }}
-                  />
-                  <Area type="monotone" dataKey="runs" stroke="hsl(var(--primary))" strokeWidth={2} fillOpacity={1} fill="url(#colorRuns)" />
-                </AreaChart>
-              </ResponsiveContainer>
-            </div>
-          </CardContent>
-        </Card>
-
+      <div className="grid grid-cols-1 gap-6">
         <Card className="border-border shadow-sm">
           <CardHeader>
             <CardTitle className="text-base font-medium">Registered Models</CardTitle>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -50,6 +50,7 @@ import { requireAuth } from "./auth/middleware";
 import { requireProject } from "./middleware/project";
 import { tracer } from "./tracing/tracer";
 import { DEFAULT_MODELS, DEFAULT_PIPELINE_STAGES } from "@shared/constants";
+import { CONSILIUM_LOOP_TERMINAL_STATES } from "@shared/schema";
 import { log } from "./index";
 import { registerArgoCdSettingsRoutes, autoConnectArgoCdFromEnv } from "./routes/argocd-settings";
 import { registerTaskGroupRoutes } from "./routes/task-groups";
@@ -620,30 +621,103 @@ export async function registerRoutes(
     res.json(stats);
   });
 
-  // Stats summary endpoint (protected by /api/stats middleware above)
+  // Stats summary endpoint (protected by /api/stats middleware above —
+  // requireAuth + requireProject, so every storage read is project-scoped via
+  // the request ALS context). Surfaces the home dashboard's headline counts:
+  // active models, task groups, and consilium loops for the CURRENT project.
   app.get("/api/stats/summary", async (_req, res) => {
-    const [allRuns, allPipelines, allModels] = await Promise.all([
-      storage.getPipelineRuns(),
-      storage.getPipelines(),
+    const [allModels, allGroups, allLoops] = await Promise.all([
       storage.getModels(),
+      storage.getTaskGroups(),
+      storage.getLoops(),
     ]);
 
-    const totalRuns = allRuns.length;
-    const activePipelines = allPipelines.filter((p) => !p.isTemplate).length;
     const modelsConfigured = allModels.filter((m) => m.isActive).length;
 
-    const now = Date.now();
-    const dayMs = 86_400_000;
-    const runsLast7Days: number[] = Array.from({ length: 7 }, (_, offset) => {
-      const dayStart = now - (6 - offset) * dayMs;
-      const dayEnd = dayStart + dayMs;
-      return allRuns.filter((r) => {
-        const ts = r.startedAt ? new Date(r.startedAt).getTime() : 0;
-        return ts >= dayStart && ts < dayEnd;
-      }).length;
-    });
+    // Task groups: total + how many are currently running. "Running" is read
+    // from the LATEST ITERATION's status (the authoritative run state — the
+    // same source the /api/task-groups list route uses), not the task
+    // definitions which stay blocked/ready. One latest-iteration read per
+    // group — bounded by the project's group count, no executions fetch.
+    const taskGroupsTotal = allGroups.length;
+    const latestIterations = await Promise.all(
+      allGroups.map((g) => storage.getLatestIteration(g.id)),
+    );
+    const taskGroupsActive = latestIterations.filter(
+      (it) => it?.status === "running",
+    ).length;
 
-    res.json({ totalRuns, activePipelines, modelsConfigured, runsLast7Days });
+    // Consilium loops: total + non-terminal (still ticking). Terminal set is
+    // the shared source of truth (converged/stopped_cap/escalated/failed/
+    // cancelled).
+    const consiliumLoopsTotal = allLoops.length;
+    const consiliumLoopsActive = allLoops.filter(
+      (l) =>
+        !CONSILIUM_LOOP_TERMINAL_STATES.includes(
+          l.state as (typeof CONSILIUM_LOOP_TERMINAL_STATES)[number],
+        ),
+    ).length;
+
+    // Consilium loops: 24h status breakdown. Bucket each loop by a coarse status
+    // derived from its FSM `state`, counting ONLY loops whose relevant timestamp
+    // falls in the last 24h: completedAt for terminal loops (the moment they
+    // settled), updatedAt for still-active ones (their last tick). Buckets:
+    //   passed   = converged
+    //   broke    = failed + escalated
+    //   stopped  = stopped_cap + cancelled
+    //   waiting  = awaiting_merge   (the human merge gate)
+    //   running  = pending + building_context + reviewing + deciding + developing
+    // Reuses the same single `allLoops` read above — no extra fetch, bounded by
+    // the project's loop count and project-scoped via the request ALS context.
+    const DAY_MS = 24 * 60 * 60 * 1000;
+    const since = Date.now() - DAY_MS;
+    const LOOP_STATE_BUCKET: Record<
+      string,
+      "passed" | "broke" | "stopped" | "waiting" | "running"
+    > = {
+      converged: "passed",
+      failed: "broke",
+      escalated: "broke",
+      stopped_cap: "stopped",
+      cancelled: "stopped",
+      awaiting_merge: "waiting",
+      pending: "running",
+      building_context: "running",
+      reviewing: "running",
+      deciding: "running",
+      developing: "running",
+    };
+    const loops24h = {
+      passed: 0,
+      broke: 0,
+      stopped: 0,
+      waiting: 0,
+      running: 0,
+      total: 0,
+    };
+    for (const l of allLoops) {
+      const isTerminal = CONSILIUM_LOOP_TERMINAL_STATES.includes(
+        l.state as (typeof CONSILIUM_LOOP_TERMINAL_STATES)[number],
+      );
+      // Terminal loops carry completedAt; fall back to updatedAt if (defensively)
+      // unset. Active loops are dated by their last tick (updatedAt).
+      const ts = isTerminal ? (l.completedAt ?? l.updatedAt) : l.updatedAt;
+      if (!ts) continue;
+      if (new Date(ts).getTime() < since) continue;
+      const bucket = LOOP_STATE_BUCKET[l.state];
+      if (!bucket) continue;
+      loops24h[bucket] += 1;
+      loops24h.total += 1;
+    }
+
+    res.json({
+      modelsConfigured,
+      taskGroupsTotal,
+      taskGroupsActive,
+      consiliumLoopsTotal,
+      consiliumLoopsActive,
+      loops24h,
+    });
   });
 
   return httpServer;


### PR DESCRIPTION
Home dashboard showed pipeline stats; pipelines are no longer the unit of work. Replaces them with **Task Groups** + **Consilium Loops** cards.

- `/api/stats/summary` → `{ modelsConfigured, taskGroupsTotal, taskGroupsActive, consiliumLoopsTotal, consiliumLoopsActive }` (project-scoped, behind requireAuth+requireProject). Dropped `totalRuns`/`activePipelines`/`runsLast7Days` (Dashboard was the sole consumer; Statistics uses a separate `/stats/overview`).
- Dashboard: Task Groups card (total + running) + Consilium Loops card (total + active), both clickable to their lists; kept Active Models + Pending Questions; removed the pipeline-runs chart; subtitle fixed.

tsc clean; verified live: `{taskGroupsTotal:5, consiliumLoopsTotal:3, consiliumLoopsActive:1}`.