### PR TITLE
fix(sdlc): per-action-point runs + configurable timeout + partial-preserve

### DIFF
--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -326,6 +326,14 @@ export const ConfigSchema = z.object({
       allowedRepoPaths: z.array(z.string()).default([]),
       /** Default DEV pipeline used for the loop's DEV handoff step (Phase B). */
       devPipelineId: z.string().optional(),
+      /**
+       * Hard wall-clock timeout PER action-point SDLC coder run (ms). The SDLC
+       * executor runs the agentic coder once per action point sequentially in one
+       * worktree, so this bounds a SINGLE action point, not the whole round.
+       * 60s..30min; default 20min (large architectural P0s need headroom — a too
+       * small cap discards real work on timeout). NaN/out-of-range fails load.
+       */
+      sdlcTimeoutMs: z.coerce.number().int().min(60_000).max(1_800_000).default(1_200_000),
     }).default({}),
   }).default({}),
 });

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -564,6 +564,9 @@ export class ConsiliumLoopController {
       actionPoints: verdict.openActionPoints,
       allowedRepoPaths: cfg.allowedRepoPaths,
       ownerId: loop.createdBy ?? "",
+      // Per-action-point coder timeout (configurable). The executor runs the
+      // coder once per action point sequentially; this bounds a SINGLE run.
+      coderTimeoutMs: cfg.sdlcTimeoutMs,
     });
   }
 

--- a/server/services/sdlc/coder.ts
+++ b/server/services/sdlc/coder.ts
@@ -37,8 +37,12 @@ import { parseCompleteOutput } from "../../gateway/providers/claude-cli.js";
 import type { ActionPoint } from "@shared/types";
 
 const DEFAULT_BINARY = "claude";
-/** Hard wall-clock cap on a single coding session (bounded, never unbounded). */
-const DEFAULT_TIMEOUT_MS = 600_000; // 10 min
+/**
+ * Hard wall-clock cap on a single PER-ACTION-POINT coding run (bounded, never
+ * unbounded). The executor runs the coder once per action point, so this bounds
+ * ONE action point. Overridden per-call from `consiliumLoop.sdlcTimeoutMs`.
+ */
+const DEFAULT_TIMEOUT_MS = 1_200_000; // 20 min
 const DEFAULT_MAX_CONCURRENCY = 2;
 const SUMMARY_MAX = 4_000;
 const ERROR_MAX = 300;
@@ -113,7 +117,7 @@ export interface CoderResult {
 export interface CoderOptions {
   /** Binary name or absolute path. Defaults to "claude". */
   binary?: string;
-  /** Hard timeout for the session (ms). Defaults to 600_000. */
+  /** Hard timeout for this single per-action-point run (ms). Defaults to 1_200_000. */
   timeoutMs?: number;
   /** Cancels the session mid-flight. */
   signal?: AbortSignal;

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -3,35 +3,46 @@
  *
  * `runSdlcHandoff` is the REAL DEVELOPING side effect for the consilium loop. It
  * replaces the legacy single-file `dev-closeout` (which wrote a `.md` checklist
- * and mutated the user's checkout via `switchBranch`). One worktree + one branch
- * + ONE agentic coder session per ROUND (not per action point) → a single,
- * coherent Draft PR. Rationale for one-session-per-round: the action points of a
- * round are usually interdependent remediations of the same review; a single
- * agent session with all of them in scope produces a cohesive change set and one
- * reviewable PR, instead of N conflicting branches/PRs that each see only part of
- * the picture.
+ * and mutated the user's checkout via `switchBranch`).
+ *
+ * ONE worktree + ONE branch per ROUND, but the agentic coder runs ONCE PER
+ * ACTION POINT, SEQUENTIALLY, in that single worktree. After each run the
+ * worktree is staged (`git add -A`) and committed — so each action point becomes
+ * its own commit on the round branch. At the end, if the branch has ANY commits,
+ * we push + open ONE Draft PR aggregating them.
+ *
+ * Why per-action-point (a live run hit the old single-session 600s timeout on 3
+ * large architectural P0s → no commit → all work discarded): a smaller unit of
+ * work per coder run fits under the timeout, and — crucially — PARTIAL PRESERVE
+ * means a run that times out or errors still has its work committed (with a
+ * `[partial]` marker) before moving on, so the human gate sees real progress
+ * instead of an empty timeout. Within a round the per-AP runs are SEQUENTIAL (one
+ * shared worktree → avoid edit conflicts); the coder's ConcurrencyLimiter still
+ * bounds concurrent coders ACROSS loops.
  *
  * Lifecycle (cleanup GUARANTEED):
  *   1. createSdlcWorktree(repo, B-3 branch, baseRef=default-branch HEAD)
- *   2. coder.run(worktreeDir, actionPoints)            ← real edits, confined
- *   3. git add -A (worktree is DEDICATED → add-all is safe, unlike dev-closeout)
- *   4. commit (server-sanitized message), read HEAD
- *   5. pushBranch + openDraftPr   (reused from pr-wrapper: B-3/H-6/H-7/M-6/M-7)
- *   6. removeSdlcWorktree in a `finally` — even on coder throw / timeout.
+ *   2. for each action point, sequentially:
+ *        a. coder.run(worktreeDir, [ap], { timeoutMs })   ← real edits, confined
+ *        b. git add -A; if dirty → commit (server-fixed subject; `[partial]` body
+ *           marker when the run timed out / errored). Track per-AP outcome.
+ *   3. if ANY commit → pushBranch + openDraftPr (body = per-AP status summary)
+ *   4. removeSdlcWorktree in a `finally` — even on coder throw / timeout.
  *
  * NEVER THROWS. Returns `{ prRef, headCommit, error? }` (structurally the loop's
  * `DevCloseoutResult`), so the controller's DEVELOPING→AWAITING_MERGE transition
- * consumes `prRef` + `headCommit` exactly as before. Any failure degrades to a
- * branch-only / no-PR result with a scrubbed note; the loop is never failed here.
+ * consumes `prRef` + `headCommit` exactly as before. Only when ZERO commits exist
+ * does it degrade to `{ prRef: null, headCommit: "", error }`.
  *
- * SECURITY (BINDING — adversarial-review surface):
+ * SECURITY (BINDING — adversarial-review surface; UNCHANGED from before):
  *   - branch + PR title are SERVER-DERIVED ONLY (buildBranchName / fixed prefix).
  *     Action-point text NEVER reaches a branch, a PR title, or any shell string.
  *   - Untrusted action-point text reaches: the coder prompt (stdin only) and the
- *     commit BODY (sanitized + clamped, passed as an arg-array `-m` element —
- *     never a shell string). That is the ONLY place model text is persisted.
- *   - The coder is confined to the worktree (cwd + --add-dir). The worktree is a
- *     server-minted temp dir, physically separate from the user's checkout.
+ *     commit SUBJECT + BODY + PR-body status lines — all sanitized (control chars
+ *     stripped) + clamped and passed as arg-array elements (commit via `-m`, PR
+ *     body via `--body-file` in pr-wrapper), NEVER a shell string.
+ *   - The coder is confined to the worktree (cwd + --add-dir); NO Bash; spawned
+ *     under a sanitized allowlisted env. The worktree is a server-minted temp dir.
  *   - Agents NEVER apply/merge: this opens a DRAFT PR only. No push to main.
  */
 import type { ActionPoint } from "@shared/types";
@@ -46,9 +57,32 @@ import {
 } from "./worktree.js";
 import { SdlcCoder, type CoderResult, type CoderOptions } from "./coder.js";
 
-const COMMIT_SUBJECT_PREFIX = "consilium: SDLC changes for round";
+const COMMIT_SUBJECT_TITLE_MAX = 100;
 const COMMIT_BODY_TITLE_MAX = 120;
+const COMMIT_BODY_RATIONALE_MAX = 1_000;
 const COMMIT_BODY_MAX = 4_000;
+const PRIORITY_MAX = 16;
+const PR_BODY_TITLE_MAX = 120;
+const PR_BODY_MAX = 16_000;
+
+/** Per-action-point outcome status surfaced in the Draft PR body. */
+export type ApStatus = "completed" | "partial" | "failed";
+
+export interface ApOutcome {
+  /** 1-based position in the round. */
+  index: number;
+  /** Sanitized priority (e.g. "P0"). */
+  priority: string;
+  /** Sanitized title (display only). */
+  title: string;
+  /** completed = ran clean + committed (or a clean no-op); partial = timed out /
+   *  errored but committed work-in-progress; failed = errored with nothing to commit. */
+  status: ApStatus;
+  /** Whether this action point produced a commit on the branch. */
+  committed: boolean;
+  /** Short server-generated note (e.g. "coder timed out", "no file changes"). */
+  note?: string;
+}
 
 export interface SdlcHandoffRequest {
   /** Allowlisted repo to operate on. */
@@ -57,7 +91,7 @@ export interface SdlcHandoffRequest {
   loopId: string;
   /** Round number — feeds the branch + commit/PR title. */
   round: number;
-  /** The round's open action points to implement. */
+  /** The round's open action points to implement (one coder run EACH). */
   actionPoints: readonly ActionPoint[];
   /** Fail-closed repo allowlist (H-5). */
   allowedRepoPaths: readonly string[];
@@ -67,12 +101,14 @@ export interface SdlcHandoffRequest {
   baseRef?: string;
   /** Loop owner (audit only). */
   ownerId?: string;
+  /** Hard timeout PER action-point coder run (ms). Defaults to the coder default. */
+  coderTimeoutMs?: number;
 }
 
 export interface SdlcHandoffResult {
-  /** Draft PR URL, or null on any non-PR path (no changes / push or gh failure). */
+  /** Draft PR URL, or null when ZERO commits were produced / push or gh failed. */
   prRef: string | null;
-  /** HEAD sha of the SDLC branch after the commit; "" when nothing was committed. */
+  /** HEAD sha of the SDLC branch after the last commit; "" when nothing committed. */
   headCommit: string;
   /** Scrubbed note present on any non-happy path. */
   error?: string;
@@ -83,7 +119,7 @@ export interface SdlcExecutorDeps {
   createWorktree?: typeof createSdlcWorktree;
   removeWorktree?: typeof removeSdlcWorktree;
   resolveDefaultBranchFn?: typeof resolveDefaultBranch;
-  /** The agentic coder (default: a shared `SdlcCoder`). */
+  /** The agentic coder (default: a shared `SdlcCoder`). Called ONCE PER action point. */
   runCoder?: (worktreeDir: string, aps: readonly ActionPoint[], opts?: CoderOptions) => Promise<CoderResult>;
   push?: typeof pushBranch;
   openPr?: typeof openDraftPr;
@@ -98,26 +134,17 @@ function scrub(raw: string): string {
 }
 
 /**
- * Sanitize an action-point title for the commit BODY: strip control chars /
- * newlines, collapse whitespace, clamp. The title is UNTRUSTED model text — even
- * though it goes in via an arg-array `-m` element (no shell), we keep it tidy and
- * bounded so it cannot bloat or smuggle terminal control sequences into git log.
+ * Sanitize UNTRUSTED model text for a SINGLE-LINE field (commit subject / PR
+ * status line): strip control chars / newlines, collapse whitespace, clamp.
+ * Passed only as arg-array / body-file content — never a shell string.
  */
-function sanitizeTitle(title: string): string {
-  // eslint-disable-next-line no-control-regex
-  return title
+function sanitizeLine(value: string, max: number): string {
+  return value
+    // eslint-disable-next-line no-control-regex
     .replace(/[\u0000-\u001f\u007f]+/g, " ") // strip control chars / newlines
     .replace(/\s+/g, " ")
     .trim()
-    .slice(0, COMMIT_BODY_TITLE_MAX);
-}
-
-/** Build the commit message: server-fixed subject + sanitized title checklist body. */
-export function buildCommitMessage(round: number, aps: readonly ActionPoint[]): { subject: string; body: string } {
-  const subject = `${COMMIT_SUBJECT_PREFIX} ${round}`;
-  const lines = aps.map((ap) => `- ${sanitizeTitle(ap.title ?? "")}`);
-  const body = ["Implements the open consilium action points:", "", ...lines].join("\n").slice(0, COMMIT_BODY_MAX);
-  return { subject, body };
+    .slice(0, max);
 }
 
 /** Build the server-derived PR title (NO model text — B-3 class guard). */
@@ -125,16 +152,57 @@ export function buildPrTitle(round: number): string {
   return `Consilium round ${round}: SDLC changes`;
 }
 
-/** Draft-PR body: server-fixed header + the agent's (clamped) own summary. */
-function prBody(round: number, coder: CoderResult): string {
-  const head = `Automated SDLC changes for consilium round ${round}.`;
-  const summary = coder.summary ? `\n\n## Coder summary\n\n${coder.summary}` : "";
-  return `${head}${summary}\n\nThis is a Draft PR — a human must review and merge.`;
+/**
+ * Build ONE action point's commit message. Subject is server-fixed shape carrying
+ * the sanitized priority + clamped title; the body carries the (sanitized) title,
+ * rationale, the AP position, and a `[partial]` marker + note when the run timed
+ * out / errored. All values are arg-array `-m` elements (never a shell string).
+ */
+export function buildApCommitMessage(
+  round: number,
+  ap: ActionPoint,
+  index: number,
+  total: number,
+  isPartial: boolean,
+  note?: string,
+): { subject: string; body: string } {
+  const priority = sanitizeLine(ap.priority ?? "-", PRIORITY_MAX) || "-";
+  const subject = `Consilium round ${round}: ${priority} ${sanitizeLine(ap.title ?? "", COMMIT_SUBJECT_TITLE_MAX)}`.trim();
+  const lines: string[] = [
+    sanitizeLine(ap.title ?? "", COMMIT_BODY_TITLE_MAX),
+    "",
+    `Action point ${index}/${total} (priority ${priority}) of consilium round ${round}.`,
+  ];
+  if (isPartial) {
+    lines.push("[partial] coder run timed out or errored — committing work-in-progress.");
+  }
+  if (note) lines.push(`Note: ${sanitizeLine(note, 200)}`);
+  const rationale = sanitizeLine(ap.rationale ?? "", COMMIT_BODY_RATIONALE_MAX);
+  if (rationale) lines.push(`Rationale: ${rationale}`);
+  return { subject: subject.slice(0, 200), body: lines.join("\n").slice(0, COMMIT_BODY_MAX) };
+}
+
+/** Draft-PR body: server-fixed header + per-action-point status summary. */
+export function buildPrStatusBody(round: number, outcomes: readonly ApOutcome[]): string {
+  const lines = outcomes.map((o) => {
+    const tail = o.note ? ` — ${sanitizeLine(o.note, 120)}` : "";
+    return `- [${o.status}] (${o.priority}) ${sanitizeLine(o.title, PR_BODY_TITLE_MAX)}${tail}`;
+  });
+  const committed = outcomes.filter((o) => o.committed).length;
+  return [
+    `Automated SDLC changes for consilium round ${round}.`,
+    "",
+    `Per action-point status (${committed}/${outcomes.length} produced commits):`,
+    "",
+    ...lines,
+    "",
+    "This is a Draft PR — a human must review and merge.",
+  ].join("\n").slice(0, PR_BODY_MAX);
 }
 
 /**
  * Run the full SDLC handoff for one round. Never throws. The worktree is removed
- * in a `finally`, so it is cleaned up even when the coder throws or times out.
+ * in a `finally`, so it is cleaned up even when a coder run throws / times out.
  */
 export async function runSdlcHandoff(
   req: SdlcHandoffRequest,
@@ -153,6 +221,9 @@ export async function runSdlcHandoff(
   if (!isValidLoopBranch(branch)) {
     return { prRef: null, headCommit: "", error: "rejected branch name (B-3)" };
   }
+  if (req.actionPoints.length === 0) {
+    return { prRef: null, headCommit: "", error: "no action points to implement" };
+  }
 
   try {
     const base = req.base ?? (await resolveDefault(req.repoPath, gitRaw));
@@ -164,46 +235,121 @@ export async function runSdlcHandoff(
       gitRaw,
     });
     try {
-      // Real edits in isolation. May throw (binary missing / timeout); the finally
-      // below still removes the worktree.
-      const coder = await runCoder(wt.worktreeDir, req.actionPoints);
-      return await commitAndOpenPr(req, branch, base, wt, coder, { gitRaw, push, openPr });
+      // SEQUENTIAL per-action-point runs in the ONE shared worktree (avoid edit
+      // conflicts). Each `runActionPoint` NEVER throws — a coder timeout/error is
+      // caught, its work committed `[partial]`, and the loop continues.
+      const outcomes: ApOutcome[] = [];
+      let committedCount = 0;
+      for (let i = 0; i < req.actionPoints.length; i++) {
+        const outcome = await runActionPoint(
+          { gitRaw, runCoder },
+          wt,
+          req,
+          req.actionPoints[i],
+          i + 1,
+          req.actionPoints.length,
+        );
+        outcomes.push(outcome);
+        if (outcome.committed) committedCount += 1;
+      }
+      return await pushAndOpenPr(req, branch, base, wt, outcomes, committedCount, { gitRaw, push, openPr });
     } finally {
-      // Cleanup GUARANTEE: remove the worktree even on coder throw / timeout.
+      // Cleanup GUARANTEE: remove the worktree even on any failure above.
       await removeWorktree(req.repoPath, wt.worktreeDir, { baseDir: wt.baseDir, gitRaw });
     }
   } catch (err) {
-    // createWorktree failed (disallowed repo / bad branch / git error) OR the
-    // coder threw — degrade, never fail the loop.
+    // createWorktree failed (disallowed repo / bad branch / git error) — degrade.
     return { prRef: null, headCommit: "", error: scrub(err instanceof Error ? err.message : String(err)) };
   }
 }
 
-/** Stage everything in the dedicated worktree, commit, push, open the Draft PR. */
-async function commitAndOpenPr(
+/**
+ * Run ONE action point: coder → `git add -A` → commit (partial-preserve on
+ * timeout/error). NEVER throws — every failure is captured into the returned
+ * outcome so the round continues and partial work is preserved.
+ */
+async function runActionPoint(
+  io: { gitRaw: GitRunner; runCoder: NonNullable<SdlcExecutorDeps["runCoder"]> },
+  wt: CreateWorktreeResult,
+  req: SdlcHandoffRequest,
+  ap: ActionPoint,
+  index: number,
+  total: number,
+): Promise<ApOutcome> {
+  const priority = sanitizeLine(ap.priority ?? "-", PRIORITY_MAX) || "-";
+  const title = sanitizeLine(ap.title ?? "", PR_BODY_TITLE_MAX);
+  const base: Omit<ApOutcome, "status" | "committed" | "note"> = { index, priority, title };
+
+  // 1. Run the coder for THIS action point only. A throw (timeout / binary
+  //    missing) is caught — its partial edits are still committed below.
+  let threw = false;
+  let coder: CoderResult | null = null;
+  let runNote: string | undefined;
+  try {
+    coder = await io.runCoder(wt.worktreeDir, [ap], { timeoutMs: req.coderTimeoutMs });
+  } catch (err) {
+    threw = true;
+    runNote = scrub(err instanceof Error ? err.message : String(err));
+  }
+
+  // 2. Stage whatever the run produced (partial or complete) and check for change.
+  let dirty = false;
+  try {
+    await io.gitRaw(wt.worktreeDir, ["add", "-A"]);
+    dirty = (await io.gitRaw(wt.worktreeDir, ["status", "--porcelain"])).trim().length > 0;
+  } catch (err) {
+    // A git failure here means we cannot commit this AP — mark failed, continue.
+    return { ...base, status: "failed", committed: false, note: scrub(err instanceof Error ? err.message : String(err)) };
+  }
+
+  const ranClean = !threw && coder !== null && coder.ok;
+
+  // 3a. Nothing to commit.
+  if (!dirty) {
+    if (ranClean) {
+      return { ...base, status: "completed", committed: false, note: "no file changes" };
+    }
+    return { ...base, status: "failed", committed: false, note: runNote ?? coder?.error ?? "no changes produced" };
+  }
+
+  // 3b. There are changes → commit them. A clean run → "completed"; a
+  //     timed-out/errored run that still produced edits → "partial".
+  const isPartial = threw || (coder !== null && !coder.ok);
+  const note = isPartial ? (runNote ?? coder?.error ?? "coder did not finish") : undefined;
+  const { subject, body } = buildApCommitMessage(req.round, ap, index, total, isPartial, note);
+  try {
+    // Arg-array `-m` elements — never a shell string. Untrusted text only here.
+    await io.gitRaw(wt.worktreeDir, ["commit", "-m", subject, "-m", body]);
+  } catch (err) {
+    return { ...base, status: "failed", committed: false, note: scrub(err instanceof Error ? err.message : String(err)) };
+  }
+  return {
+    ...base,
+    status: isPartial ? "partial" : "completed",
+    committed: true,
+    note,
+  };
+}
+
+/**
+ * After all action points: if ANY commit exists, push the branch + open ONE Draft
+ * PR whose body summarizes per-AP status. ZERO commits → `{ prRef: null }` + error.
+ */
+async function pushAndOpenPr(
   req: SdlcHandoffRequest,
   branch: string,
   base: string,
   wt: CreateWorktreeResult,
-  coder: CoderResult,
+  outcomes: readonly ApOutcome[],
+  committedCount: number,
   io: { gitRaw: GitRunner; push: typeof pushBranch; openPr: typeof openDraftPr },
 ): Promise<SdlcHandoffResult> {
-  // The worktree is DEDICATED (server-minted, single round) → `add -A` is safe
-  // here: there are no unrelated user files to sweep in (unlike dev-closeout's
-  // single-file constraint over the user's shared checkout).
-  await io.gitRaw(wt.worktreeDir, ["add", "-A"]);
-
-  // Nothing produced (coder made no edits / failed before editing) → no PR.
-  const staged = (await io.gitRaw(wt.worktreeDir, ["status", "--porcelain"])).trim();
-  if (staged.length === 0) {
-    const note = coder.ok ? "no changes produced" : `coder failed: ${coder.error ?? "unknown"}`;
-    return { prRef: null, headCommit: "", error: note };
+  if (committedCount === 0) {
+    // Every action point failed / produced nothing — no branch to PR (as today).
+    const failed = outcomes.find((o) => o.note)?.note;
+    return { prRef: null, headCommit: "", error: failed ? `no commits produced: ${failed}` : "no changes produced" };
   }
 
-  const { subject, body } = buildCommitMessage(req.round, req.actionPoints);
-  // Arg-array `-m` elements — never a shell string. Untrusted title lives only in
-  // the (sanitized) body element.
-  await io.gitRaw(wt.worktreeDir, ["commit", "-m", subject, "-m", body]);
   const headCommit = (await io.gitRaw(wt.worktreeDir, ["rev-parse", "HEAD"])).trim();
 
   // Push from the worktree (shares the repo's object store + remotes). pr-wrapper
@@ -217,7 +363,7 @@ async function commitAndOpenPr(
     base,
     head: branch,
     title: buildPrTitle(req.round), // server-derived; NO model text.
-    body: prBody(req.round, coder),
+    body: buildPrStatusBody(req.round, outcomes),
   });
   if (!pr.ok) {
     return { prRef: null, headCommit, error: `pushed branch ${branch}; open PR manually` };

--- a/tests/unit/sdlc/executor.test.ts
+++ b/tests/unit/sdlc/executor.test.ts
@@ -1,23 +1,26 @@
 /**
- * executor.test.ts — SDLC orchestration (component 5).
+ * executor.test.ts — SDLC orchestration (component 5), PER-ACTION-POINT model.
  *
  * Drives `runSdlcHandoff` over FULLY injected seams (worktree / coder / push /
  * openPr / git runner) — no real repo, no claude, no gh. Load-bearing:
- *   - CLEANUP GUARANTEE: the worktree is removed even when the coder THROWS
- *     (timeout / binary missing) — the removal runs in a `finally`.
- *   - the handoff NEVER throws — every failure degrades to `{ prRef:null, ... }`.
- *   - BRANCH GATING: a non-uuid loopId yields a non-B-3 branch → rejected BEFORE
- *     a worktree is ever cut.
- *   - happy path → `{ prRef:<url>, headCommit }`; the commit/PR title are
- *     server-derived (no model text); untrusted titles only reach the commit body.
- *   - no-changes / push-fail / pr-fail degrade correctly and STILL clean up.
+ *   - PER-AP loop: N action points → N coder runs + N commit attempts in ONE
+ *     worktree, sequentially.
+ *   - CONFIGURABLE timeout: `req.coderTimeoutMs` is threaded into every coder run.
+ *   - PARTIAL PRESERVE: a coder run that THROWS (timeout) but left edits is still
+ *     committed `[partial]` and the round still pushes + opens ONE Draft PR; the
+ *     PR body summarizes per-AP status.
+ *   - CLEANUP GUARANTEE: the worktree is removed even when a coder run throws.
+ *   - the handoff NEVER throws; ZERO commits → `{ prRef:null, error }`.
+ *   - BRANCH/PR title are server-derived; untrusted text only in commit/PR body.
  */
 import { describe, it, expect, vi } from "vitest";
 import {
   runSdlcHandoff,
-  buildCommitMessage,
+  buildApCommitMessage,
+  buildPrStatusBody,
   buildPrTitle,
   type SdlcHandoffRequest,
+  type ApOutcome,
 } from "../../../server/services/sdlc/executor.js";
 import type { ActionPoint } from "@shared/types";
 
@@ -27,7 +30,7 @@ const ROOTS = ["/allowlisted"];
 const BRANCH = `consilium/loop-${LOOP}/round-2`;
 
 const APS: ActionPoint[] = [
-  { title: "Fix `;rm -rf /` in parser\nwith newline", priority: "P0" },
+  { title: "Fix `;rm -rf /` in parser\nwith newline", priority: "P0", rationale: "unsanitized\ninput" },
   { title: "Add the redactor", priority: "P1" },
 ];
 
@@ -42,7 +45,7 @@ const baseReq = (over: Partial<SdlcHandoffRequest> = {}): SdlcHandoffRequest => 
 
 const FAKE_WT = { worktreeDir: "/tmp/sdlc-wt-XXXX/tree", baseDir: "/tmp/sdlc-wt-XXXX", branch: BRANCH, baseRef: "main" };
 
-/** git runner whose `status --porcelain` reports `hasChanges`. */
+/** git runner whose `status --porcelain` reports `hasChanges`; records all calls. */
 function makeGitRaw(hasChanges: boolean) {
   return vi.fn(async (_repo: string, args: string[]) => {
     if (args[0] === "status") return hasChanges ? " M server/x.ts\n" : "";
@@ -51,12 +54,22 @@ function makeGitRaw(hasChanges: boolean) {
   });
 }
 
+/** Commits the git runner was asked to make: [subject, body] pairs. */
+function commitMessages(gitRaw: ReturnType<typeof vi.fn>): Array<{ subject: string; body: string }> {
+  return gitRaw.mock.calls
+    .filter((c) => (c[1] as string[])[0] === "commit")
+    .map((c) => {
+      const args = c[1] as string[];
+      return { subject: args[2], body: args[4] };
+    });
+}
+
 function makeDeps(over: Record<string, unknown> = {}) {
   return {
     createWorktree: vi.fn(async () => FAKE_WT),
     removeWorktree: vi.fn(async () => undefined),
     resolveDefaultBranchFn: vi.fn(async () => "main"),
-    runCoder: vi.fn(async () => ({ ok: true, summary: "edited 2 files", tokensUsed: 5 })),
+    runCoder: vi.fn(async () => ({ ok: true, summary: "edited", tokensUsed: 5 })),
     push: vi.fn(async () => ({ ok: true as const, branch: BRANCH })),
     openPr: vi.fn(async () => ({ ok: true as const, prUrl: "https://github.com/x/y/pull/9" })),
     gitRaw: makeGitRaw(true),
@@ -64,29 +77,87 @@ function makeDeps(over: Record<string, unknown> = {}) {
   };
 }
 
-describe("runSdlcHandoff — cleanup guarantee", () => {
-  it("removes the worktree even when the coder THROWS (finally)", async () => {
-    const deps = makeDeps({
-      runCoder: vi.fn(async () => {
-        throw new Error("CLI timed out after 600000ms at /home/u/.claude");
-      }),
-    });
-    const res = await runSdlcHandoff(baseReq(), deps as never);
-    // No throw — degraded result.
-    expect(res.prRef).toBeNull();
-    expect(res.error).toBeDefined();
-    expect(res.error).not.toContain("/home/u"); // fs layout scrubbed
-    // The worktree was STILL removed.
-    expect(deps.removeWorktree).toHaveBeenCalledTimes(1);
-    expect(deps.removeWorktree).toHaveBeenCalledWith(REPO, FAKE_WT.worktreeDir, expect.objectContaining({ baseDir: FAKE_WT.baseDir }));
-  });
-
-  it("removes the worktree on the happy path too", async () => {
+describe("runSdlcHandoff — per-action-point loop", () => {
+  it("runs the coder ONCE PER action point (single-AP prompt) and commits each", async () => {
     const deps = makeDeps();
     const res = await runSdlcHandoff(baseReq(), deps as never);
+    // N action points → N coder runs, each handed a SINGLE-element AP array.
+    expect(deps.runCoder).toHaveBeenCalledTimes(APS.length);
+    for (let i = 0; i < APS.length; i++) {
+      const [dir, aps] = (deps.runCoder as ReturnType<typeof vi.fn>).mock.calls[i];
+      expect(dir).toBe(FAKE_WT.worktreeDir);
+      expect(aps).toHaveLength(1); // one action point per run
+      expect(aps[0]).toBe(APS[i]);
+    }
+    // One commit per AP (all dirty), then ONE PR aggregating them.
+    expect(commitMessages(deps.gitRaw as ReturnType<typeof vi.fn>)).toHaveLength(APS.length);
+    expect(deps.openPr).toHaveBeenCalledTimes(1);
     expect(res.prRef).toBe("https://github.com/x/y/pull/9");
     expect(res.headCommit).toBe("headsha000");
     expect(deps.removeWorktree).toHaveBeenCalledTimes(1);
+  });
+
+  it("threads the CONFIGURABLE per-AP timeout into every coder run", async () => {
+    const deps = makeDeps();
+    await runSdlcHandoff(baseReq({ coderTimeoutMs: 1_234_000 }), deps as never);
+    for (const call of (deps.runCoder as ReturnType<typeof vi.fn>).mock.calls) {
+      expect(call[2]?.timeoutMs).toBe(1_234_000);
+    }
+  });
+});
+
+describe("runSdlcHandoff — partial preserve on timeout/error", () => {
+  it("a coder run that THROWS but left edits is committed [partial]; the round STILL opens a PR", async () => {
+    // AP0 runs clean; AP1 times out (throws) but the worktree is dirty → its work
+    // is preserved as a [partial] commit. The round still pushes + opens ONE PR.
+    const runCoder = vi
+      .fn()
+      .mockImplementationOnce(async () => ({ ok: true, summary: "did ap0", tokensUsed: 1 }))
+      .mockImplementationOnce(async () => {
+        throw new Error("CLI timed out after 1200000ms at /home/u/.claude");
+      });
+    const deps = makeDeps({ runCoder });
+    const res = await runSdlcHandoff(baseReq(), deps as never);
+
+    const commits = commitMessages(deps.gitRaw as ReturnType<typeof vi.fn>);
+    expect(commits).toHaveLength(2); // BOTH APs committed — partial work preserved
+    const partial = commits.find((c) => c.body.includes("[partial]"));
+    expect(partial).toBeDefined();
+    expect(partial?.body).not.toContain("/home/u"); // scrubbed note
+    // The PR still opens, aggregating the work.
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+    const [, opts] = (deps.openPr as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(opts.body).toMatch(/\[completed\]/);
+    expect(opts.body).toMatch(/\[partial\]/);
+    expect(deps.removeWorktree).toHaveBeenCalledTimes(1);
+  });
+
+  it("ZERO commits (all runs failed, nothing staged) → prRef null + error, worktree removed", async () => {
+    const runCoder = vi.fn(async () => {
+      throw new Error("CLI binary not installed");
+    });
+    const deps = makeDeps({ runCoder, gitRaw: makeGitRaw(false) }); // nothing dirty
+    const res = await runSdlcHandoff(baseReq(), deps as never);
+    expect(res.prRef).toBeNull();
+    expect(res.error).toMatch(/no commits/);
+    expect(deps.openPr).not.toHaveBeenCalled();
+    expect(deps.removeWorktree).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("runSdlcHandoff — cleanup guarantee", () => {
+  it("removes the worktree even when a coder run throws (finally)", async () => {
+    const deps = makeDeps({
+      runCoder: vi.fn(async () => {
+        throw new Error("CLI timed out after 1200000ms at /home/u/.claude");
+      }),
+      gitRaw: makeGitRaw(false), // no edits preserved → no PR, but cleanup still runs
+    });
+    const res = await runSdlcHandoff(baseReq(), deps as never);
+    expect(res.prRef).toBeNull();
+    expect(res.error).not.toContain("/home/u"); // scrubbed
+    expect(deps.removeWorktree).toHaveBeenCalledTimes(1);
+    expect(deps.removeWorktree).toHaveBeenCalledWith(REPO, FAKE_WT.worktreeDir, expect.objectContaining({ baseDir: FAKE_WT.baseDir }));
   });
 });
 
@@ -98,6 +169,14 @@ describe("runSdlcHandoff — branch gating", () => {
     expect(res.error).toMatch(/B-3/);
     expect(deps.createWorktree).not.toHaveBeenCalled();
     expect(deps.removeWorktree).not.toHaveBeenCalled();
+  });
+
+  it("REJECTS an empty action-point list before cutting a worktree", async () => {
+    const deps = makeDeps();
+    const res = await runSdlcHandoff(baseReq({ actionPoints: [] }), deps as never);
+    expect(res.prRef).toBeNull();
+    expect(res.error).toMatch(/no action points/);
+    expect(deps.createWorktree).not.toHaveBeenCalled();
   });
 });
 
@@ -112,27 +191,9 @@ describe("runSdlcHandoff — server-derived branch/PR title, untrusted text quar
     expect(opts.head).toBe(BRANCH); // server-derived branch
     expect(opts.base).toBe("main");
   });
-
-  it("commit subject is server-fixed; untrusted titles only in the sanitized body", () => {
-    const { subject, body } = buildCommitMessage(2, APS);
-    expect(subject).toBe("consilium: SDLC changes for round 2");
-    expect(subject).not.toMatch(/rm -rf/);
-    // The body carries the title but with control chars / newlines stripped.
-    expect(body).toContain("Add the redactor");
-    expect(body).not.toMatch(/\n.*rm -rf.*\n.*with newline/); // newline inside title collapsed
-  });
 });
 
 describe("runSdlcHandoff — degraded paths still clean up", () => {
-  it("no changes produced → no PR, error note, worktree removed", async () => {
-    const deps = makeDeps({ gitRaw: makeGitRaw(false) });
-    const res = await runSdlcHandoff(baseReq(), deps as never);
-    expect(res.prRef).toBeNull();
-    expect(res.error).toMatch(/no changes/);
-    expect(deps.openPr).not.toHaveBeenCalled();
-    expect(deps.removeWorktree).toHaveBeenCalledTimes(1);
-  });
-
   it("push fail → branch-only, openPr NOT attempted, worktree removed", async () => {
     const deps = makeDeps({ push: vi.fn(async () => ({ ok: false, kind: "unknown", message: "no remote" })) });
     const res = await runSdlcHandoff(baseReq(), deps as never);
@@ -149,5 +210,48 @@ describe("runSdlcHandoff — degraded paths still clean up", () => {
     expect(res.headCommit).toBe("headsha000");
     expect(res.error).toMatch(/open PR manually/);
     expect(deps.removeWorktree).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("buildApCommitMessage — server-fixed subject, sanitized untrusted body", () => {
+  const ap: ActionPoint = { title: "Fix `;rm -rf /`\nthing", priority: "P0", rationale: "because\nreasons" };
+
+  it("subject is the server shape `Consilium round N: <prio> <clamped title>` (single line)", () => {
+    const { subject } = buildApCommitMessage(2, ap, 1, 3, false);
+    expect(subject.startsWith("Consilium round 2: P0 ")).toBe(true);
+    expect(subject).toContain("Fix `;rm -rf /` thing"); // control chars / newline collapsed
+    expect(subject).not.toContain("\n");
+  });
+
+  it("body carries the sanitized title + rationale (newlines collapsed)", () => {
+    const { body } = buildApCommitMessage(2, ap, 1, 3, false);
+    expect(body).toContain("Fix `;rm -rf /` thing");
+    expect(body).toContain("Rationale: because reasons");
+    expect(body).toContain("Action point 1/3 (priority P0)");
+    expect(body).not.toContain("[partial]");
+  });
+
+  it("a partial run adds the [partial] marker + a sanitized note", () => {
+    // buildApCommitMessage sanitizes (control-strips) but does NOT path-scrub —
+    // runActionPoint scrubs the throw message before passing it as the note.
+    const { body } = buildApCommitMessage(2, ap, 2, 3, true, "coder timed out");
+    expect(body).toContain("[partial] coder run timed out or errored");
+    expect(body).toContain("Note: coder timed out");
+  });
+});
+
+describe("buildPrStatusBody — per-action-point status summary", () => {
+  it("lists each action point's status + a commit count header", () => {
+    const outcomes: ApOutcome[] = [
+      { index: 1, priority: "P0", title: "alpha", status: "completed", committed: true },
+      { index: 2, priority: "P0", title: "beta", status: "partial", committed: true, note: "coder timed out" },
+      { index: 3, priority: "P1", title: "gamma", status: "failed", committed: false, note: "no changes" },
+    ];
+    const body = buildPrStatusBody(2, outcomes);
+    expect(body).toContain("2/3 produced commits");
+    expect(body).toContain("[completed] (P0) alpha");
+    expect(body).toContain("[partial] (P0) beta — coder timed out");
+    expect(body).toContain("[failed] (P1) gamma — no changes");
+    expect(body).toContain("Draft PR");
   });
 });


### PR DESCRIPTION
Follow-up to #414. A **live run** proved the SDLC executor's mechanics (non-blocking dispatch, single-flight, settle, cleanup all worked end-to-end), but the **single coder session for all action_points** hit the 600s timeout on 3 large architectural P0s → killed before commit → no PR, partial edits discarded with the worktree.

### Fixes
- **Per-action-point runs:** one worktree+branch per round, run the coder **once per action_point** (prompt = that AP only, via stdin) sequentially; commit after each (one commit per AP); push **one** aggregated Draft PR at round end.
- **Configurable timeout:** `consiliumLoop.sdlcTimeoutMs` (min 60s / max 30m / **default 20m per run**) in config schema, threaded into every run.
- **Partial-preserve:** a run that times out/errors but left edits is committed with a `[partial]` marker before continuing/cleanup; per-AP outcome (completed/partial/failed) is summarized in the **Draft PR body** so the human gate sees real progress. `prRef=null` only when ZERO commits exist.

Security properties unchanged (no Bash, sanitized env, untrusted text never reaches a branch/PR-title/shell; non-blocking + single-flight + crash recovery intact).

tsc clean; `tests/unit/sdlc` + consilium + scoping **212/212** (per-AP loop, config timeout, partial-preserve on mocked timeout, zero-commit degrade, cleanup-on-throw).