### PR TITLE
fix(consilium): double-dispatch + terminal-round audit + richer PR + list grouping

### DIFF
--- a/client/src/pages/ConsiliumLoopList.tsx
+++ b/client/src/pages/ConsiliumLoopList.tsx
@@ -1,15 +1,19 @@
 /**
- * ConsiliumLoopList — the caller's consilium loops (design §7). One row per loop:
- * the WORKSPACE name (P4), state pill, round n/maxRounds, open P0, a Draft-PR link
- * when set, and a relative updated-time. Clicking a row opens its detail at
- * /consilium-loops/:id. The list polls lightly (5s) for live state.
+ * ConsiliumLoopList — the caller's consilium loops (design §7), GROUPED BY
+ * WORKSPACE (P4). Many loops/rounds can target the same workspace, so a flat
+ * list became an undifferentiated pile. We now render one SECTION per workspace
+ * (header = workspace name + loop count), most-active workspace first, and within
+ * a section order loops most-recent first (updatedAt ?? createdAt). Each row keeps
+ * a clear identity even when several share a workspace: round n/maxRounds shown
+ * prominently, the state chip (LoopStateChipFor), a short id (id.slice(0,8)),
+ * open P0, an optional Draft-PR link, and a relative timestamp. Clicking a row
+ * opens its detail at /consilium-loops/:id. The list polls lightly (5s).
  *
- * P4 — the first column is a human WORKSPACE name. Loops only carry `repoPath`
- * (no workspaceId), so we fetch the workspaces list (via the shared apiRequest
+ * P4 — the workspace name is a human label. Loops only carry `repoPath` (no
+ * workspaceId), so we fetch the workspaces list (via the shared apiRequest
  * transport, which attaches `x-project-id`) and match by `path`. When no
- * workspace matches we fall back to the repo basename, and the full repoPath is
- * always kept in the cell's title/tooltip. The short loop id + round stay visible
- * so multiple loops targeting one workspace remain distinguishable.
+ * workspace matches we fall back to the repo basename; the full repoPath stays
+ * in each section/row tooltip.
  *
  * SECURITY: loop-derived text (repoPath, prRef) and the workspace name are
  * rendered as INERT React text; the PR link uses rel="noopener noreferrer".
@@ -46,6 +50,7 @@ function normalizePath(p: string): string {
   return p.replace(/\/+$/, "");
 }
 
+/** Relative "2h ago" label; empty string for missing/unparseable timestamps. */
 function whenLabel(ts: string | Date | null | undefined): string {
   if (!ts) return "";
   try {
@@ -53,6 +58,12 @@ function whenLabel(ts: string | Date | null | undefined): string {
   } catch {
     return "";
   }
+}
+
+/** Recency epoch-ms for ordering: prefer updatedAt, fall back to createdAt. */
+function recencyOf(loop: ConsiliumLoopListItem): number {
+  const t = new Date(loop.updatedAt ?? loop.createdAt).getTime();
+  return Number.isFinite(t) ? t : 0;
 }
 
 function OpenP0({ openP0 }: { openP0: number | null | undefined }) {
@@ -80,6 +91,12 @@ function useWorkspaces() {
   });
 }
 
+type LoopGroup = {
+  name: string;
+  loops: ConsiliumLoopListItem[];
+  recency: number;
+};
+
 export default function ConsiliumLoopList() {
   const [, navigate] = useLocation();
   const { data, isLoading } = useConsiliumLoops();
@@ -93,6 +110,22 @@ export default function ConsiliumLoopList() {
   }
   const workspaceName = (repoPath: string): string =>
     nameByPath.get(normalizePath(repoPath)) ?? repoBasename(repoPath);
+
+  // Group loops by resolved workspace name. Within a group: most-recent first.
+  // Group order: the workspace with the most recently active loop floats up.
+  const byWorkspace = new Map<string, ConsiliumLoopListItem[]>();
+  for (const loop of loops) {
+    const name = workspaceName(loop.repoPath);
+    const arr = byWorkspace.get(name);
+    if (arr) arr.push(loop);
+    else byWorkspace.set(name, [loop]);
+  }
+  const groups: LoopGroup[] = Array.from(byWorkspace.entries())
+    .map(([name, ls]) => {
+      const sorted = [...ls].sort((a, b) => recencyOf(b) - recencyOf(a));
+      return { name, loops: sorted, recency: sorted.length ? recencyOf(sorted[0]) : 0 };
+    })
+    .sort((a, b) => b.recency - a.recency);
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
@@ -124,71 +157,94 @@ export default function ConsiliumLoopList() {
           </div>
         )}
 
-        {!isLoading && loops.length > 0 && (
-          <div className="rounded-md border overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Workspace</TableHead>
-                  <TableHead>State</TableHead>
-                  <TableHead>Round</TableHead>
-                  <TableHead>Open P0</TableHead>
-                  <TableHead>PR</TableHead>
-                  <TableHead>Updated</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {loops.map((loop) => (
-                  <TableRow
-                    key={loop.id}
-                    className="cursor-pointer"
-                    onClick={() => navigate(`/consilium-loops/${loop.id}`)}
+        {!isLoading && groups.length > 0 && (
+          <div className="space-y-6">
+            {groups.map((group) => (
+              <section key={group.name} data-testid="consilium-loop-group">
+                {/* Workspace header — groups many same-target loops so focus
+                    isn't lost. Full repoPath of the freshest loop in tooltip. */}
+                <div className="flex items-baseline gap-2 mb-2 px-1">
+                  <h2
+                    className="text-sm font-semibold truncate"
+                    title={group.loops[0]?.repoPath}
                   >
-                    <TableCell className="max-w-[18rem]">
-                      {/* Human workspace name first; short loop id beneath for
-                          disambiguation when several loops target one workspace.
-                          Full repoPath stays in the tooltip. */}
-                      <div className="min-w-0">
-                        <div className="truncate font-medium" title={loop.repoPath}>
-                          {workspaceName(loop.repoPath)}
-                        </div>
-                        <div className="font-mono text-[10px] text-muted-foreground truncate">
-                          {loop.id.slice(0, 8)}
-                        </div>
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <LoopStateChipFor loop={loop} />
-                    </TableCell>
-                    <TableCell className="tabular-nums">
-                      {loop.round}/{loop.maxRounds}
-                    </TableCell>
-                    <TableCell>
-                      <OpenP0 openP0={loop.openP0} />
-                    </TableCell>
-                    <TableCell>
-                      {loop.prRef ? (
-                        <a
-                          href={loop.prRef}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          onClick={(e) => e.stopPropagation()}
-                          className="inline-flex items-center gap-1 text-primary hover:underline text-xs"
+                    {group.name}
+                  </h2>
+                  <span className="text-[11px] text-muted-foreground shrink-0">
+                    {group.loops.length} {group.loops.length === 1 ? "loop" : "loops"}
+                  </span>
+                </div>
+                <div className="rounded-md border overflow-x-auto">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Round</TableHead>
+                        <TableHead>State</TableHead>
+                        <TableHead>Loop</TableHead>
+                        <TableHead>Open P0</TableHead>
+                        <TableHead>PR</TableHead>
+                        <TableHead>Updated</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {group.loops.map((loop) => (
+                        <TableRow
+                          key={loop.id}
+                          className="cursor-pointer"
+                          onClick={() => navigate(`/consilium-loops/${loop.id}`)}
                         >
-                          <ExternalLink className="h-3 w-3" />
-                          PR
-                        </a>
-                      ) : (
-                        <span className="text-muted-foreground">—</span>
-                      )}
-                    </TableCell>
-                    <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
-                      {whenLabel(loop.updatedAt)}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                          {/* Round n/maxRounds prominent — the primary
+                              disambiguator between same-workspace loops. */}
+                          <TableCell>
+                            <span className="font-semibold tabular-nums">
+                              {loop.round}/{loop.maxRounds}
+                            </span>
+                          </TableCell>
+                          <TableCell>
+                            <LoopStateChipFor loop={loop} />
+                          </TableCell>
+                          {/* Short loop id — second identity anchor. Full
+                              repoPath stays in the tooltip. */}
+                          <TableCell>
+                            <span
+                              className="font-mono text-[11px] text-muted-foreground"
+                              title={loop.repoPath}
+                            >
+                              {loop.id.slice(0, 8)}
+                            </span>
+                          </TableCell>
+                          <TableCell>
+                            <OpenP0 openP0={loop.openP0} />
+                          </TableCell>
+                          <TableCell>
+                            {loop.prRef ? (
+                              <a
+                                href={loop.prRef}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                onClick={(e) => e.stopPropagation()}
+                                className="inline-flex items-center gap-1 text-primary hover:underline text-xs"
+                              >
+                                <ExternalLink className="h-3 w-3" />
+                                PR
+                              </a>
+                            ) : (
+                              <span className="text-muted-foreground">—</span>
+                            )}
+                          </TableCell>
+                          <TableCell
+                            className="text-xs text-muted-foreground whitespace-nowrap"
+                            title={new Date(loop.updatedAt ?? loop.createdAt).toLocaleString()}
+                          >
+                            {whenLabel(loop.updatedAt ?? loop.createdAt)}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              </section>
+            ))}
           </div>
         )}
       </div>

--- a/client/src/pages/TaskGroupList.tsx
+++ b/client/src/pages/TaskGroupList.tsx
@@ -1,4 +1,14 @@
+/**
+ * TaskGroupList — multi-model task groups, GROUPED BY STATUS BUCKET to restore
+ * focus when many runs pile up. Multiple groups can target the same workspace,
+ * so a flat list buried the runs that actually need attention. We bucket into
+ * Active (running) → Pending → Terminal (completed/failed/cancelled), each a
+ * section with a count; within a section, most-recent first (createdAt desc).
+ * Rows keep their existing info (name, taskCount/completedCount, status) and add
+ * a relative timestamp. Presentation-only: the fetch (useTaskGroups) is unchanged.
+ */
 import { Link } from "wouter";
+import { formatDistanceToNow } from "date-fns";
 import { useTaskGroups, useDeleteTaskGroup } from "@/hooks/use-task-groups";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -13,6 +23,47 @@ const statusColors: Record<string, string> = {
   cancelled: "bg-gray-500 text-white",
 };
 
+type TaskGroupItem = {
+  id: string;
+  name: string;
+  description: string;
+  status: string;
+  taskCount: number;
+  completedCount: number;
+  createdAt: string;
+};
+
+type BucketKey = "active" | "pending" | "terminal";
+
+/** Status → bucket. Anything unrecognised falls into Pending (safest middle). */
+function bucketOf(status: string): BucketKey {
+  if (status === "running") return "active";
+  if (status === "completed" || status === "failed" || status === "cancelled") return "terminal";
+  return "pending";
+}
+
+/** Fixed section order — what needs attention first. */
+const BUCKET_ORDER: { key: BucketKey; label: string }[] = [
+  { key: "active", label: "Active" },
+  { key: "pending", label: "Pending" },
+  { key: "terminal", label: "Terminal" },
+];
+
+/** Relative "2h ago" label; empty string for missing/unparseable timestamps. */
+function whenLabel(ts: string | null | undefined): string {
+  if (!ts) return "";
+  try {
+    return formatDistanceToNow(new Date(ts), { addSuffix: true });
+  } catch {
+    return "";
+  }
+}
+
+function createdMs(g: TaskGroupItem): number {
+  const t = new Date(g.createdAt).getTime();
+  return Number.isFinite(t) ? t : 0;
+}
+
 export default function TaskGroupList() {
   const { data: groups, isLoading } = useTaskGroups();
   const deleteMutation = useDeleteTaskGroup();
@@ -21,15 +72,21 @@ export default function TaskGroupList() {
     return <div className="p-6 text-muted-foreground">Loading task groups...</div>;
   }
 
-  const items = (groups ?? []) as Array<{
-    id: string;
-    name: string;
-    description: string;
-    status: string;
-    taskCount: number;
-    completedCount: number;
-    createdAt: string;
-  }>;
+  const items = (groups ?? []) as TaskGroupItem[];
+
+  // Bucket by status, then order each bucket most-recent first.
+  const buckets = new Map<BucketKey, TaskGroupItem[]>();
+  for (const g of items) {
+    const key = bucketOf(g.status);
+    const arr = buckets.get(key);
+    if (arr) arr.push(g);
+    else buckets.set(key, [g]);
+  }
+  const sections = BUCKET_ORDER.map(({ key, label }) => ({
+    key,
+    label,
+    items: (buckets.get(key) ?? []).sort((a, b) => createdMs(b) - createdMs(a)),
+  })).filter((s) => s.items.length > 0);
 
   return (
     // MainLayout's <main> clips overflow, so this page owns its own vertical
@@ -59,43 +116,57 @@ export default function TaskGroupList() {
           </CardContent>
         </Card>
       ) : (
-        <div className="space-y-3">
-          {items.map((g) => (
-            <Link key={g.id} href={`/task-groups/${g.id}`}>
-              <Card className="cursor-pointer hover:border-primary/50 transition-colors">
-                <CardHeader className="pb-2">
-                  <div className="flex items-center justify-between">
-                    <CardTitle className="text-base">{g.name}</CardTitle>
-                    <div className="flex items-center gap-2">
-                      <Badge className={statusColors[g.status] ?? "bg-muted"}>
-                        {g.status}
-                      </Badge>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8 text-muted-foreground hover:text-red-500"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          if (confirm("Delete this task group?")) {
-                            deleteMutation.mutate(g.id);
-                          }
-                        }}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-sm text-muted-foreground line-clamp-2">{g.description}</p>
-                  <div className="flex items-center gap-4 mt-2 text-xs text-muted-foreground">
-                    <span>{g.completedCount}/{g.taskCount} tasks completed</span>
-                    <span>{new Date(g.createdAt).toLocaleDateString()}</span>
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
+        <div className="space-y-6">
+          {sections.map((section) => (
+            <section key={section.key} data-testid="task-group-section">
+              <div className="flex items-baseline gap-2 mb-2 px-1">
+                <h2 className="text-sm font-semibold">{section.label}</h2>
+                <span className="text-[11px] text-muted-foreground">
+                  {section.items.length}
+                </span>
+              </div>
+              <div className="space-y-3">
+                {section.items.map((g) => (
+                  <Link key={g.id} href={`/task-groups/${g.id}`}>
+                    <Card className="cursor-pointer hover:border-primary/50 transition-colors">
+                      <CardHeader className="pb-2">
+                        <div className="flex items-center justify-between">
+                          <CardTitle className="text-base">{g.name}</CardTitle>
+                          <div className="flex items-center gap-2">
+                            <Badge className={statusColors[g.status] ?? "bg-muted"}>
+                              {g.status}
+                            </Badge>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8 text-muted-foreground hover:text-red-500"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                if (confirm("Delete this task group?")) {
+                                  deleteMutation.mutate(g.id);
+                                }
+                              }}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        </div>
+                      </CardHeader>
+                      <CardContent>
+                        <p className="text-sm text-muted-foreground line-clamp-2">{g.description}</p>
+                        <div className="flex items-center gap-4 mt-2 text-xs text-muted-foreground">
+                          <span>{g.completedCount}/{g.taskCount} tasks completed</span>
+                          <span title={new Date(g.createdAt).toLocaleString()}>
+                            {whenLabel(g.createdAt)}
+                          </span>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </Link>
+                ))}
+              </div>
+            </section>
           ))}
         </div>
       )}

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -73,11 +73,36 @@ export interface LoopTransition {
 const ANTI_STALL_MIN_ROUND = 3;
 
 /**
- * H-2: the developing-state crash-stranded grace MUST exceed the SDLC coder's
- * hard timeout (executor/coder default 600s) — otherwise a normal long coder run
- * is mistaken for a crash and a SECOND coder is launched mid-run. 600s + 60s.
+ * Per-coder reference grace (one coder run + buffer). The SDLC coder's hard
+ * timeout is configurable (coder default 1_200_000ms / 20min); this is only a
+ * reference floor. The AUTHORITATIVE developing re-drive guard is the process-
+ * local `sdlcRuns` registry consulted in `redriveStranded` (H-2 / BUG-1), NOT a
+ * timer — a per-AP round runs N sequential coders and routinely outlives any
+ * single-coder grace.
  */
 const SDLC_DEV_GRACE_MS = 660_000;
+
+/**
+ * Upper bound on action points implemented in ONE round. A per-AP round runs N
+ * SEQUENTIAL coder sessions, so the round's wall-clock is N x the per-coder
+ * timeout — far longer than a single coder run. Used only to SIZE the cross-
+ * restart time fallback below.
+ */
+const SDLC_DEV_MAX_ACTION_POINTS = 24;
+
+/**
+ * Registry-EMPTY (cross-restart / lost-registry) developing re-drive grace: a
+ * WHOLE multi-AP round, not one coder run. Within a LIVE process the `sdlcRuns`
+ * registry gate — not this timer — prevents a double dispatch, so erring large
+ * here is safe: it only bounds how long a genuinely crashed (registry-lost) run
+ * waits before another process re-dispatches it.
+ *
+ * BUG-1: the old single-coder 660s grace mistook a long multi-AP run for a crash
+ * and `redriveStranded(developing)` re-dispatched a SECOND `runSdlcHandoff` on
+ * the SAME branch ("already used by worktree"), whose null-prRef settle then won
+ * the developing->awaiting_merge CAS and clobbered the real PR.
+ */
+export const SDLC_DEV_REDRIVE_GRACE_MS = SDLC_DEV_GRACE_MS * SDLC_DEV_MAX_ACTION_POINTS;
 
 /** Process-local handle for a BACKGROUND SDLC close-out run (H-2). */
 interface SdlcRun {
@@ -269,9 +294,11 @@ export class ConsiliumLoopController {
    */
   private redriveGraceMs(state?: ConsiliumLoopState): number {
     const base = Math.max(2 * this.loopConfig().pollIntervalMs, 30_000);
-    // H-2: developing waits on a background coder (~10 min), so its grace must
-    // exceed the coder timeout or a normal long run looks stranded.
-    if (state === "developing") return Math.max(base, SDLC_DEV_GRACE_MS);
+    // H-2 / BUG-1: developing waits on a BACKGROUND multi-AP coder round (N
+    // sequential coders). Its TIME fallback is sized to a WHOLE round and only
+    // governs the registry-empty (cross-restart) case; the authoritative
+    // in-process guard is the `sdlcRuns` registry consulted in redriveStranded.
+    if (state === "developing") return Math.max(base, SDLC_DEV_REDRIVE_GRACE_MS);
     return base;
   }
 
@@ -425,6 +452,24 @@ export class ConsiliumLoopController {
       (loop.state === "developing" && loop.devGroupId == null);
     if (!nullRef) return null; // child ref set — not stranded, advance normally
 
+    // BUG-1 (double-dispatch) REGISTRY GATE: for developing, the process-local
+    // `sdlcRuns` registry is AUTHORITATIVE. A per-AP round legitimately runs N
+    // sequential coders (N x the per-coder timeout), so it routinely outlives any
+    // single-coder time grace — a time-only check would mistake a LIVE long run
+    // for a crash and re-dispatch a SECOND `runSdlcHandoff` on the SAME branch
+    // ("already used by worktree"). If THIS process has a registered run for this
+    // loop+round it is NOT stranded: in-flight => wait; settled => deriveDevEvent
+    // advances it. Re-dispatch ONLY when the registry has NO entry for this
+    // loop+round (a genuine crash/restart that LOST the in-process registry),
+    // gated further by the whole-round time fallback below.
+    if (loop.state === "developing") {
+      const run = this.sdlcRuns.get(loop.id);
+      if (run && run.round === loop.round) {
+        this.log(loop.id, `developing has a registered SDLC run (round ${run.round}, done=${run.done}) — not stranded, no re-drive`);
+        return null;
+      }
+    }
+
     const ageMs = Date.now() - new Date(loop.updatedAt).getTime();
     if (ageMs < this.redriveGraceMs(loop.state)) {
       this.log(loop.id, `null child ref in ${loop.state} but within grace (${ageMs}ms) — assume in-flight, no re-drive`);
@@ -541,6 +586,20 @@ export class ConsiliumLoopController {
       this.sdlcRuns.delete(loop.id);
       return {};
     }
+    // Verdict-terminal exits (converged / stopped_cap / escalated) leave DECIDING
+    // WITHOUT entering developing, so recordRound (which otherwise runs inside
+    // startDevHandoff) was never called — the detail-page Rounds panel was empty
+    // for them. Record the round audit here too. appendLoopRound is idempotent
+    // (UNIQUE(loop,round)) and this runs only on the CAS winner.
+    if (
+      event.kind === "decided" &&
+      (transition.to === "converged" ||
+        transition.to === "stopped_cap" ||
+        transition.to === "escalated")
+    ) {
+      await this.recordRound(loop, event.verdict);
+      return {};
+    }
     return {};
   }
 
@@ -654,15 +713,46 @@ export class ConsiliumLoopController {
     this.log(loop.id, `dispatchSdlc -> background coder round ${loop.round} (${verdict.openActionPoints.length} action points)`);
     void this.closeout(loop, verdict)
       .then((result) => {
-        run.result = result;
-        run.done = true;
-        this.log(loop.id, `SDLC settled -> prRef=${result.prRef ?? "null"}${result.error ? ` (${result.error})` : ""}`);
+        this.settleSdlcRun(loop.id, run, result);
+        this.log(loop.id, `SDLC settled -> prRef=${run.result?.prRef ?? "null"}${run.result?.error ? ` (${run.result.error})` : ""}`);
       })
       .catch((err: unknown) => {
-        run.result = { prRef: null, headCommit: "", error: scrubErr(err instanceof Error ? err.message : String(err)) };
-        run.done = true;
-        this.log(loop.id, `SDLC threw (degraded) -> ${run.result.error}`);
+        this.settleSdlcRun(loop.id, run, {
+          prRef: null,
+          headCommit: "",
+          error: scrubErr(err instanceof Error ? err.message : String(err)),
+        });
+        this.log(loop.id, `SDLC threw (degraded) -> ${run.result?.error}`);
       });
+  }
+
+  /**
+   * Idempotent settle of a BACKGROUND SDLC run into the process-local registry
+   * (BUG-1, defensive). A `null` prRef must NEVER clobber a NON-null prRef already
+   * recorded for the SAME loop+round: with the redrive registry gate there is only
+   * one run per round, but a late/duplicate settle (a pre-gate double dispatch, or
+   * a redrive after a registry loss) must not downgrade a real Draft PR to a
+   * branch-only null. The good-PR entry stays authoritative and the late run
+   * mirrors it, so `deriveDevEvent` (and thus the developing->awaiting_merge
+   * persistence) can only ever observe the good PR.
+   */
+  private settleSdlcRun(loopId: string, run: SdlcRun, result: DevCloseoutResult): void {
+    const existing = this.sdlcRuns.get(loopId);
+    if (
+      existing &&
+      existing.done &&
+      existing.round === run.round &&
+      existing.result?.prRef &&
+      !result.prRef
+    ) {
+      this.log(loopId, `idempotent settle: null prRef IGNORED — keeping prRef=${existing.result.prRef} (round ${run.round})`);
+      run.result = existing.result;
+      run.done = true;
+      this.sdlcRuns.set(loopId, existing); // keep the good-PR entry authoritative
+      return;
+    }
+    run.result = result;
+    run.done = true;
   }
 
   /**

--- a/server/services/consilium/pr-wrapper.ts
+++ b/server/services/consilium/pr-wrapper.ts
@@ -37,6 +37,12 @@
  *          URL instead of opening a duplicate.
  *   - M-7: `gh pr create` failing with "already exists" is treated as REUSE —
  *          recover the URL via `pr list` instead of stranding the loop (TOCTOU).
+ *   - M-8 (enrichment): the Draft PR is self-assigned (`--assignee @me`) and
+ *          tagged with a server-FIXED label set (ensured to exist idempotently
+ *          via `gh label create ... || true` first). Both assignee + label names
+ *          are SERVER CONSTANTS (never model text). Applying them is BEST-EFFORT:
+ *          a `gh` that rejects them degrades to a plain Draft PR — metadata never
+ *          fails the PR.
  */
 import { execFile } from "child_process";
 import { promisify } from "util";
@@ -89,6 +95,35 @@ const execFileAsync: ExecFileFn = promisify(execFile);
 const BRANCH_RE = /^consilium\/loop-[0-9a-f-]{36}\/round-[0-9]+$/;
 /** Well-formed `owner/repo` (GitHub slug chars only) — H-7 origin validation. */
 const OWNER_REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
+// ─── Server-fixed PR metadata (assignee + labels) ─────────────────────────────
+//
+// SECURITY: assignee + label NAMES are SERVER CONSTANTS — they NEVER come from
+// model/action-point text, so they can never carry a flag/shell payload. They
+// are passed as arg-array elements to `gh`, and each is `^[a-z0-9@_-]+$`-shaped
+// (no leading dash) so it is option-safe even as an argv value. Applying them is
+// BEST-EFFORT: a `gh` that rejects `--assignee`/`--label` (old version, missing
+// scope, label race) degrades to a plain Draft PR — metadata never fails the PR.
+
+/** The PR is self-assigned to the invoking GH identity (server constant). */
+export const SDLC_PR_ASSIGNEE = "@me";
+
+/** A server-fixed label + its ensure-exists color/description (idempotent create). */
+interface LabelSpec {
+  name: string;
+  color: string; // 6-hex, no leading '#'
+  description: string;
+}
+
+/** Server-fixed labels applied to every SDLC Draft PR (ensured to exist first). */
+export const SDLC_PR_LABEL_SPECS: readonly LabelSpec[] = [
+  { name: "consilium-review", color: "5319e7", description: "Opened by the consilium reconciliation loop" },
+  { name: "sdlc", color: "1d76db", description: "Produced by the SDLC executor close-out" },
+  { name: "automated", color: "ededed", description: "Automated change — review before merge" },
+];
+
+/** Just the label NAMES, in apply order (server constants). */
+export const SDLC_PR_LABELS: readonly string[] = SDLC_PR_LABEL_SPECS.map((l) => l.name);
 
 /** True iff `branch` is a server-derived consilium branch (B-3). */
 export function isValidLoopBranch(branch: string): boolean {
@@ -283,6 +318,31 @@ export async function openDraftPr(
   return createDraftPr(ownerRepo, opts, execFileFn, env);
 }
 
+/**
+ * Idempotently ensure the server-fixed labels exist on the repo before `gh pr
+ * create --label` references them (a label that does not exist makes `gh pr
+ * create` fail). Mirrors `gh label create ... 2>/dev/null || true`: each create
+ * is best-effort and its failure (label already exists / gh missing / no scope)
+ * is SWALLOWED — never fatal. Label name/color/description are server constants.
+ */
+async function ensureLabels(
+  ownerRepo: string,
+  run: ExecFileFn,
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  for (const spec of SDLC_PR_LABEL_SPECS) {
+    try {
+      await run(
+        "gh",
+        ["label", "create", spec.name, "--repo", ownerRepo, "--color", spec.color, "--description", spec.description],
+        { timeout: 30_000, env },
+      );
+    } catch {
+      // already exists / gh missing / no scope → idempotent no-op (|| true).
+    }
+  }
+}
+
 /** The create call + M-7 already-exists recovery. */
 async function createDraftPr(
   ownerRepo: string,
@@ -293,18 +353,42 @@ async function createDraftPr(
   const bodyFile = join(tmpdir(), `consilium-pr-${randomUUID()}.md`);
   try {
     await writeFile(bodyFile, opts.body, "utf8");
-    const { stdout } = await run(
-      "gh",
-      // server-fixed flags FIRST (H-6 --draft, --repo); body via --body-file
-      // (never argv). B-3+: `gh` has NO positional args and REJECTS
-      // `--end-of-options` (verified gh 2.94: "unknown flag"); `--base`/`--head`/
-      // `--title` are value-flags, so the flag-injection defense here is the
-      // leading-dash rejection of title+head above, NOT a terminator (which
-      // would break the command). `git push` DOES get a `--` terminator.
-      ["pr", "create", "--draft", "--repo", ownerRepo, "--body-file", bodyFile,
-        "--base", opts.base, "--head", opts.head, "--title", opts.title],
-      { timeout: 60_000, env },
-    );
+
+    // server-fixed flags FIRST (H-6 --draft, --repo); body via --body-file
+    // (never argv). B-3+: `gh` has NO positional args and REJECTS
+    // `--end-of-options` (verified gh 2.94: "unknown flag"); `--base`/`--head`/
+    // `--title` are value-flags, so the flag-injection defense here is the
+    // leading-dash rejection of title+head above, NOT a terminator (which would
+    // break the command). `git push` DOES get a `--` terminator.
+    const baseArgs = [
+      "pr", "create", "--draft", "--repo", ownerRepo, "--body-file", bodyFile,
+      "--base", opts.base, "--head", opts.head, "--title", opts.title,
+    ];
+
+    // Best-effort: ensure the server-fixed labels exist before referencing them.
+    await ensureLabels(ownerRepo, run, env);
+
+    // Enrich with server-fixed labels + assignee (all server constants, never
+    // model text). `--label`/`--assignee` are value-flags whose values are
+    // option-safe constants.
+    const enrichedArgs = [...baseArgs];
+    for (const name of SDLC_PR_LABELS) enrichedArgs.push("--label", name);
+    enrichedArgs.push("--assignee", SDLC_PR_ASSIGNEE);
+
+    let stdout: string;
+    try {
+      ({ stdout } = await run("gh", enrichedArgs, { timeout: 60_000, env }));
+    } catch (enrichErr) {
+      const m = enrichErr instanceof Error ? enrichErr.message : String(enrichErr);
+      // An already-exists race is REUSE, not a metadata problem — bubble it to the
+      // M-7 recovery in the outer catch.
+      if (isAlreadyExists(m)) throw enrichErr;
+      // The metadata flags may have caused it (old gh / no scope / bad label).
+      // Degrade gracefully: open a PLAIN Draft PR — metadata never fails the PR.
+      // eslint-disable-next-line no-console
+      console.warn(`[pr-wrapper] degraded: assignee/labels rejected, opening plain Draft PR: ${scrub(m)}`);
+      ({ stdout } = await run("gh", baseArgs, { timeout: 60_000, env }));
+    }
     const prUrl = parsePrUrl(stdout);
     if (!prUrl) return { ok: false, kind: "gh-failed", message: "gh returned no PR URL" };
     return { ok: true, prUrl };

--- a/server/services/sdlc/coder.ts
+++ b/server/services/sdlc/coder.ts
@@ -8,7 +8,7 @@
  *
  * Invocation (the exact arg array; prompt via STDIN — never argv/shell):
  *   claude -p --output-format json --permission-mode acceptEdits \
- *          --allowedTools Edit Write Read Bash --add-dir <worktreeDir>
+ *          --allowedTools Edit Write Read --add-dir <worktreeDir>
  *   cwd = <worktreeDir> ; stdin = <prompt> ; hard timeout (default 600s)
  *
  * Spawn discipline is reused from `cli-spawn.ts` (the same module the

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -45,6 +45,7 @@
  *     under a sanitized allowlisted env. The worktree is a server-minted temp dir.
  *   - Agents NEVER apply/merge: this opens a DRAFT PR only. No push to main.
  */
+import { basename } from "path";
 import type { ActionPoint } from "@shared/types";
 import { buildBranchName, isValidLoopBranch, pushBranch, openDraftPr } from "../consilium/pr-wrapper.js";
 import {
@@ -63,6 +64,7 @@ const COMMIT_BODY_RATIONALE_MAX = 1_000;
 const COMMIT_BODY_MAX = 4_000;
 const PRIORITY_MAX = 16;
 const PR_BODY_TITLE_MAX = 120;
+const PR_BODY_RATIONALE_MAX = 200; // 1-line rationale in the "addressed" list
 const PR_BODY_MAX = 16_000;
 
 /** Per-action-point outcome status surfaced in the Draft PR body. */
@@ -182,21 +184,73 @@ export function buildApCommitMessage(
   return { subject: subject.slice(0, 200), body: lines.join("\n").slice(0, COMMIT_BODY_MAX) };
 }
 
-/** Draft-PR body: server-fixed header + per-action-point status summary. */
-export function buildPrStatusBody(round: number, outcomes: readonly ApOutcome[]): string {
-  const lines = outcomes.map((o) => {
+/** Inputs to the enriched Draft-PR body (all values server-controlled EXCEPT the
+ *  untrusted action-point text, which is sanitized/clamped before it lands). */
+export interface PrStatusBodyInput {
+  /** Loop id (server-controlled; display-only provenance). */
+  loopId: string;
+  /** Round number (server-controlled). */
+  round: number;
+  /** Repo display name (server-derived from the allowlisted repoPath basename). */
+  repoName: string;
+  /** The verdict's open action points — UNTRUSTED text (sanitized + clamped). */
+  actionPoints: readonly ActionPoint[];
+  /** Per-AP execution outcomes the executor built. */
+  outcomes: readonly ApOutcome[];
+}
+
+/**
+ * Draft-PR body: a server-fixed provenance HEADER (loop id / round / repo), the
+ * verdict's ACTION POINTS ADDRESSED (priority + clamped title + 1-line clamped
+ * rationale — untrusted text, control-stripped via `sanitizeLine`, NEVER a shell
+ * string or argv), the PER-AP OUTCOME table (completed/partial/failed), and a
+ * FOOTER pointing at the paused human gate. Written to `--body-file` by
+ * pr-wrapper, so none of this untrusted text ever reaches argv.
+ */
+export function buildPrStatusBody(input: PrStatusBodyInput): string {
+  const { loopId, round, repoName, actionPoints, outcomes } = input;
+  const committed = outcomes.filter((o) => o.committed).length;
+
+  // Header — provenance (loopId/round/repoName are server-controlled, but still
+  // single-line sanitized as defense-in-depth).
+  const header = [
+    "## Automated SDLC Draft PR",
+    "",
+    "Opened by the **consilium reconciliation loop**'s SDLC executor (isolated worktree + agentic coder). The loop is PAUSED at the human review gate.",
+    "",
+    `- Loop: \`${sanitizeLine(loopId, 80)}\``,
+    `- Round: ${round}`,
+    `- Repo: \`${sanitizeLine(repoName, 120)}\``,
+  ];
+
+  // Action points addressed — from the verdict (UNTRUSTED -> sanitize + clamp).
+  const apLines = actionPoints.map((ap, i) => {
+    const priority = sanitizeLine(ap.priority ?? "-", PRIORITY_MAX) || "-";
+    const title = sanitizeLine(ap.title ?? "", PR_BODY_TITLE_MAX);
+    const rationale = sanitizeLine(ap.rationale ?? "", PR_BODY_RATIONALE_MAX);
+    const tail = rationale ? ` — ${rationale}` : "";
+    return `${i + 1}. [${priority}] ${title}${tail}`;
+  });
+
+  // Per-AP outcome table (existing shape).
+  const outcomeLines = outcomes.map((o) => {
     const tail = o.note ? ` — ${sanitizeLine(o.note, 120)}` : "";
     return `- [${o.status}] (${o.priority}) ${sanitizeLine(o.title, PR_BODY_TITLE_MAX)}${tail}`;
   });
-  const committed = outcomes.filter((o) => o.committed).length;
+
   return [
-    `Automated SDLC changes for consilium round ${round}.`,
+    ...header,
     "",
-    `Per action-point status (${committed}/${outcomes.length} produced commits):`,
+    "### Action points addressed (from the consilium verdict)",
     "",
-    ...lines,
+    ...(apLines.length > 0 ? apLines : ["_none recorded_"]),
     "",
-    "This is a Draft PR — a human must review and merge.",
+    `### Per action-point outcome (${committed}/${outcomes.length} produced commits)`,
+    "",
+    ...outcomeLines,
+    "",
+    "---",
+    "Draft — review the changes; the loop is paused at the human gate (a human must review and merge).",
   ].join("\n").slice(0, PR_BODY_MAX);
 }
 
@@ -363,7 +417,13 @@ async function pushAndOpenPr(
     base,
     head: branch,
     title: buildPrTitle(req.round), // server-derived; NO model text.
-    body: buildPrStatusBody(req.round, outcomes),
+    body: buildPrStatusBody({
+      loopId: req.loopId,
+      round: req.round,
+      repoName: basename(req.repoPath),
+      actionPoints: req.actionPoints,
+      outcomes,
+    }),
   });
   if (!pr.ok) {
     return { prRef: null, headCommit, error: `pushed branch ${branch}; open PR manually` };

--- a/tests/unit/consilium/loop-fsm.test.ts
+++ b/tests/unit/consilium/loop-fsm.test.ts
@@ -11,6 +11,7 @@ import {
   isAntiStall,
   pickJudgeOutput,
   ConsiliumLoopController,
+  SDLC_DEV_REDRIVE_GRACE_MS,
   type LoopEvent,
 } from "../../../server/services/consilium/consilium-loop-controller.js";
 import type { ConsiliumLoopState, ConsiliumLoopRow } from "@shared/schema";
@@ -198,8 +199,10 @@ const fakeConfig = () =>
     },
   }) as never;
 
-/** Past the DEVELOPING re-drive grace (SDLC coder timeout 600s + 60s buffer). */
-const DEV_STALE = new Date(Date.now() - 700_000);
+/** Past the DEVELOPING registry-EMPTY (cross-restart) re-drive grace — sized to a
+ *  WHOLE multi-AP round, not one coder run. Only relevant when the in-process
+ *  sdlcRuns registry is empty (a genuine crash/restart that lost it). */
+const DEV_STALE = new Date(Date.now() - SDLC_DEV_REDRIVE_GRACE_MS - 60_000);
 /** Flush microtasks + one macrotask so a fire-and-forget background run settles. */
 const flush = () => new Promise((r) => setTimeout(r, 0));
 
@@ -345,11 +348,12 @@ describe("controller tick — crash-window re-drive of stranded loops", () => {
   const STALE = new Date(Date.now() - 120_000);
   const FRESH = new Date(); // within grace → in-flight, must NOT re-drive
 
-  it("DEVELOPING with null devGroupId, past coder-length grace → re-dispatches SDLC exactly once (M-1)", async () => {
-    // H-2 crash recovery: a crash mid-coder leaves developing+null devGroupId. The
-    // developing grace must EXCEED the coder timeout (660s) — STALE (120s) is
-    // WITHIN it, so we use DEV_STALE (700s). The redrive claim re-dispatches the
-    // SDLC close-out exactly once; the loop stays developing (background run).
+  it("REGISTRY-EMPTY re-drive (b): developing past grace + NO in-flight registry entry → re-dispatches SDLC exactly once (M-1)", async () => {
+    // BUG-1 (b): a genuine crash/restart LOST the in-process sdlcRuns registry, so
+    // a fresh controller sees developing+null devGroupId with NO registered run.
+    // Only THEN (registry empty + past the whole-round time fallback) does the
+    // redrive claim re-dispatch the SDLC close-out — exactly once; the loop stays
+    // developing (background run).
     const loop = makeLoop({ state: "developing", round: 2, devGroupId: null, currentIterationNumber: 2, updatedAt: DEV_STALE });
     const { storage } = makeFakeStorage(loop, [{ round: 1, openP0: 3 }]);
     const runCloseout = vi.fn(async () => ({ prRef: "https://github.com/x/y/pull/3", headCommit: "deadbeef" }));
@@ -368,10 +372,72 @@ describe("controller tick — crash-window re-drive of stranded loops", () => {
     expect(res?.state).toBe("developing"); // background run — stays developing
   });
 
+  it("REGISTRY GATE (a) (BUG-1): developing past the TIME grace WITH an in-flight registry run → NO second dispatch", async () => {
+    // The live double-dispatch: a per-AP round runs N SEQUENTIAL coders, so it
+    // routinely outlives any single-coder time grace. The process-local sdlcRuns
+    // registry is AUTHORITATIVE — an in-flight run means NOT stranded, so
+    // redriveStranded must NOT re-dispatch a 2nd runSdlcHandoff on the SAME branch
+    // (the old behavior produced "already used by worktree" + a null-prRef clobber).
+    const loop = makeLoop({ state: "deciding", round: 2, currentIterationNumber: 2 });
+    const { storage } = makeFakeStorage(loop, [{ round: 1, openP0: 3 }]);
+    let release: (r: { prRef: string | null; headCommit: string }) => void = () => {};
+    // A closeout that does NOT settle until released → the registry entry stays in-flight.
+    const runCloseout = vi.fn(
+      () => new Promise<{ prRef: string | null; headCommit: string }>((res) => { release = res; }),
+    );
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: { startGroup: vi.fn(), startGroupAsync: vi.fn(), createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
+      config: fakeConfig,
+      readIterationVerdict: async () => verdict(false, 2),
+      readRepoHead: async () => "abc",
+      runCloseout,
+    });
+    const t1 = await controller.tick(loop.id); // deciding → developing (dispatch; in-flight)
+    expect(t1?.state).toBe("developing");
+    expect(runCloseout).toHaveBeenCalledTimes(1);
+    // Age the developing row PAST the whole-round grace — a TIME-ONLY guard would
+    // now re-drive; the registry gate must override the timer.
+    await storage.updateLoop(loop.id, { updatedAt: DEV_STALE });
+    const t2 = await controller.tick(loop.id); // developing + null devGroupId + past grace
+    expect(t2).toBeNull(); // registry says in-flight → no-op, NO re-drive
+    expect(runCloseout).toHaveBeenCalledTimes(1); // NOT re-dispatched (BUG-1 fixed)
+    release({ prRef: "https://github.com/x/y/pull/77", headCommit: "abc" }); // settle the dangling run
+    await flush();
+  });
+
+  it("IDEMPOTENT SETTLE (c) (BUG-1): a late null-prRef settle CANNOT clobber a recorded non-null prRef", () => {
+    // Defensive: with the registry gate there is only one run per round, but a
+    // late/duplicate settle (pre-gate double dispatch, or a redrive after registry
+    // loss) must never downgrade a real Draft PR to a branch-only null.
+    const controller = new ConsiliumLoopController({
+      storage: {} as never,
+      taskOrchestrator: {} as never,
+      config: fakeConfig,
+    });
+    type Run = { round: number; done: boolean; result?: { prRef: string | null; headCommit: string; error?: string } };
+    const c = controller as unknown as {
+      sdlcRuns: Map<string, Run>;
+      settleSdlcRun(loopId: string, run: Run, result: { prRef: string | null; headCommit: string; error?: string }): void;
+    };
+    // The good run settles with a REAL PR.
+    const good: Run = { round: 2, done: false };
+    c.sdlcRuns.set("loop1", good);
+    c.settleSdlcRun("loop1", good, { prRef: "https://github.com/o/r/pull/7", headCommit: "abc" });
+    expect(c.sdlcRuns.get("loop1")?.result?.prRef).toBe("https://github.com/o/r/pull/7");
+    // A late/duplicate run for the SAME round settles branch-only (null prRef).
+    const late: Run = { round: 2, done: false };
+    c.settleSdlcRun("loop1", late, { prRef: null, headCommit: "def", error: "open PR manually" });
+    // The good PR is preserved — null did NOT clobber it; the late run mirrors it.
+    expect(c.sdlcRuns.get("loop1")?.result?.prRef).toBe("https://github.com/o/r/pull/7");
+    expect(late.result?.prRef).toBe("https://github.com/o/r/pull/7");
+  });
+
   it("CROSS-INSTANCE: two controllers re-driving the SAME stranded developing loop → EXACTLY ONE SDLC dispatch", async () => {
-    // Two pods, separate in-process locks, ONE storage. Both read the stranded
-    // null-devGroupId row past the coder-length grace; the atomic claimRedrive lets
-    // only ONE win → the SDLC close-out is dispatched exactly once (no double coder).
+    // Two pods, separate in-process locks AND separate (empty) sdlcRuns registries,
+    // ONE storage. Both read the stranded null-devGroupId row past the whole-round
+    // grace with NO registered run; the atomic claimRedrive lets only ONE win → the
+    // SDLC close-out is dispatched exactly once (no double coder).
     const loop = makeLoop({ state: "developing", round: 2, devGroupId: null, currentIterationNumber: 2, updatedAt: DEV_STALE });
     const { storage, claimRedrive } = makeFakeStorage(loop, [{ round: 1, openP0: 3 }]);
     const runCloseout = vi.fn(async () => ({ prRef: "https://github.com/x/y/pull/4", headCommit: "deadbeef" }));

--- a/tests/unit/consilium/pr-wrapper.test.ts
+++ b/tests/unit/consilium/pr-wrapper.test.ts
@@ -19,6 +19,8 @@ import {
   pushBranch,
   openDraftPr,
   isValidLoopBranch,
+  SDLC_PR_ASSIGNEE,
+  SDLC_PR_LABELS,
   type GitPushClient,
   type ExecFileFn,
 } from "../../../server/services/consilium/pr-wrapper.js";
@@ -59,15 +61,19 @@ function fakeGit(over: Partial<GitPushClient> = {}): GitPushClient & {
   };
 }
 
-/** Route gh invocations by sub-command; capture argv + env per call. */
+/** Route gh invocations by (group, sub-command); capture argv + env per call.
+ *  `gh label create` is routed SEPARATELY from `gh pr create` (createDraftPr now
+ *  ensures labels exist before opening the PR). */
 function fakeExec(handlers: {
   list?: (args: string[]) => Promise<{ stdout: string; stderr: string }>;
   create?: (args: string[]) => Promise<{ stdout: string; stderr: string }>;
+  label?: (args: string[]) => Promise<{ stdout: string; stderr: string }>;
 }): ExecFileFn & ReturnType<typeof vi.fn> {
   return vi.fn(async (file: string, args: string[]) => {
     expect(file).toBe("gh"); // never a shell
-    if (args[1] === "list") return (handlers.list ?? (async () => ({ stdout: "[]", stderr: "" })))(args);
-    if (args[1] === "create") return (handlers.create ?? (async () => ({ stdout: "", stderr: "" })))(args);
+    if (args[0] === "label" && args[1] === "create") return (handlers.label ?? (async () => ({ stdout: "", stderr: "" })))(args);
+    if (args[0] === "pr" && args[1] === "list") return (handlers.list ?? (async () => ({ stdout: "[]", stderr: "" })))(args);
+    if (args[0] === "pr" && args[1] === "create") return (handlers.create ?? (async () => ({ stdout: "", stderr: "" })))(args);
     return { stdout: "", stderr: "" };
   }) as ExecFileFn & ReturnType<typeof vi.fn>;
 }
@@ -244,5 +250,65 @@ describe("openDraftPr", () => {
     expect(res.ok).toBe(true);
     if (res.ok) expect(res.prUrl).toBe("https://github.com/o/r/pull/55"); // M-7 recovery
     expect(listCalls).toBe(2); // pre-check + recovery
+  });
+
+  // ─── M-8: enrichment (server-fixed assignee + labels, graceful degrade) ──────
+
+  it("M-8: enriches the Draft PR with --assignee + every server-fixed --label, ensuring labels exist FIRST", async () => {
+    const labelCreates: string[][] = [];
+    let createArgs: string[] = [];
+    const exec = fakeExec({
+      label: async (args) => { labelCreates.push(args); return { stdout: "", stderr: "" }; },
+      create: async (args) => { createArgs = args; return { stdout: "https://github.com/o/r/pull/1\n", stderr: "" }; },
+    });
+    const res = await openDraftPr(REPO, OPTS, exec, fakeGit());
+    expect(res.ok).toBe(true);
+    // Assignee — SERVER CONSTANT, never model text, passed as an arg-array value.
+    expect(createArgs).toEqual(expect.arrayContaining(["--assignee", SDLC_PR_ASSIGNEE]));
+    // Every server-fixed label applied to `gh pr create`.
+    for (const name of SDLC_PR_LABELS) {
+      expect(createArgs).toEqual(expect.arrayContaining(["--label", name]));
+    }
+    // Labels ensured idempotently FIRST: one `gh label create` per label, --repo derived.
+    expect(labelCreates).toHaveLength(SDLC_PR_LABELS.length);
+    for (const c of labelCreates) {
+      expect(c.slice(0, 2)).toEqual(["label", "create"]);
+      expect(c).toEqual(expect.arrayContaining(["--repo", OWNER_REPO]));
+    }
+    // Still no shell metachars anywhere in the enriched argv.
+    expect(createArgs.some((a) => /[;&|`$]/.test(a))).toBe(false);
+  });
+
+  it("M-8: gh rejecting --assignee/--label DEGRADES to a plain Draft PR (never throws, never fails the PR)", async () => {
+    let createCalls = 0;
+    let plainArgs: string[] = [];
+    const exec = vi.fn(async (_file: string, args: string[]) => {
+      if (args[0] === "label" && args[1] === "create") return { stdout: "", stderr: "" };
+      if (args[0] === "pr" && args[1] === "list") return { stdout: "[]", stderr: "" };
+      if (args[0] === "pr" && args[1] === "create") {
+        createCalls += 1;
+        const hasMeta = args.includes("--assignee") || args.includes("--label");
+        if (hasMeta) throw new Error("unknown flag: --assignee"); // old gh rejects metadata
+        plainArgs = args;
+        return { stdout: "https://github.com/o/r/pull/2\n", stderr: "" };
+      }
+      return { stdout: "", stderr: "" };
+    }) as ExecFileFn;
+    const res = await openDraftPr(REPO, OPTS, exec, fakeGit());
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.prUrl).toBe("https://github.com/o/r/pull/2"); // PR still opened
+    expect(createCalls).toBe(2); // enriched (rejected) → plain (success)
+    expect(plainArgs).not.toContain("--assignee"); // degraded — no metadata
+    expect(plainArgs).not.toContain("--label");
+  });
+
+  it("M-8: a failing `gh label create` is SWALLOWED — the Draft PR still opens", async () => {
+    const exec = fakeExec({
+      label: async () => { throw new Error("gh: missing 'repo' scope"); },
+      create: async () => ({ stdout: "https://github.com/o/r/pull/3\n", stderr: "" }),
+    });
+    const res = await openDraftPr(REPO, OPTS, exec, fakeGit());
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.prUrl).toBe("https://github.com/o/r/pull/3");
   });
 });

--- a/tests/unit/sdlc/executor.test.ts
+++ b/tests/unit/sdlc/executor.test.ts
@@ -240,18 +240,53 @@ describe("buildApCommitMessage — server-fixed subject, sanitized untrusted bod
   });
 });
 
-describe("buildPrStatusBody — per-action-point status summary", () => {
-  it("lists each action point's status + a commit count header", () => {
-    const outcomes: ApOutcome[] = [
-      { index: 1, priority: "P0", title: "alpha", status: "completed", committed: true },
-      { index: 2, priority: "P0", title: "beta", status: "partial", committed: true, note: "coder timed out" },
-      { index: 3, priority: "P1", title: "gamma", status: "failed", committed: false, note: "no changes" },
-    ];
-    const body = buildPrStatusBody(2, outcomes);
+describe("buildPrStatusBody — enriched header + addressed action points + outcome table", () => {
+  const outcomes: ApOutcome[] = [
+    { index: 1, priority: "P0", title: "alpha", status: "completed", committed: true },
+    { index: 2, priority: "P0", title: "beta", status: "partial", committed: true, note: "coder timed out" },
+    { index: 3, priority: "P1", title: "gamma", status: "failed", committed: false, note: "no changes" },
+  ];
+
+  it("renders provenance header (loop/round/repo), the per-AP outcome table + footer", () => {
+    const body = buildPrStatusBody({
+      loopId: LOOP,
+      round: 2,
+      repoName: "omniscience",
+      actionPoints: APS,
+      outcomes,
+    });
+    // Header provenance — server-controlled values.
+    expect(body).toContain("Automated SDLC Draft PR");
+    expect(body).toContain(`Loop: \`${LOOP}\``);
+    expect(body).toContain("Round: 2");
+    expect(body).toContain("Repo: `omniscience`");
+    // Per-AP outcome table (unchanged shape).
     expect(body).toContain("2/3 produced commits");
     expect(body).toContain("[completed] (P0) alpha");
     expect(body).toContain("[partial] (P0) beta — coder timed out");
     expect(body).toContain("[failed] (P1) gamma — no changes");
-    expect(body).toContain("Draft PR");
+    // Footer — paused human gate.
+    expect(body).toContain("paused at the human gate");
+  });
+
+  it("lists the verdict's action points addressed (priority + clamped title + 1-line rationale), control-stripped", () => {
+    const body = buildPrStatusBody({
+      loopId: LOOP,
+      round: 2,
+      repoName: "omniscience",
+      actionPoints: APS, // APS[0] has shell metachars + newlines in title/rationale
+      outcomes,
+    });
+    expect(body).toContain("Action points addressed");
+    // Untrusted title/rationale survive ONLY control-stripped (newlines collapsed).
+    expect(body).toContain("1. [P0] Fix `;rm -rf /` in parser with newline — unsanitized input");
+    expect(body).toContain("2. [P1] Add the redactor");
+    // The clamp/strip removed the raw newline — no multi-line injection.
+    expect(body).not.toContain("parser\nwith");
+  });
+
+  it("degrades to '_none recorded_' when there are no action points", () => {
+    const body = buildPrStatusBody({ loopId: LOOP, round: 2, repoName: "r", actionPoints: [], outcomes });
+    expect(body).toContain("_none recorded_");
   });
 });


### PR DESCRIPTION
Bundle of consilium-loop fixes surfaced by **live runs** + the requested list UX.

### SDLC double-dispatch (a live run made a real Draft PR but also fired a duplicate)
A per-AP round runs N sequential coders, so it outlives the single-coder grace; `redriveStranded(developing)` re-dispatched a 2nd `runSdlcHandoff` on the **same branch** → "already used by worktree" → its null-prRef settle won the CAS and **clobbered the real PR**. Fix: the developing re-drive now consults the in-process `sdlcRuns` registry — a run registered for this loop+round is **never** re-dispatched (in-flight ⇒ wait, settled ⇒ advance); the time fallback (now whole-round sized) only covers the registry-empty cross-restart case. Plus **idempotent settle** — a null prRef can't overwrite a non-null one.

### Empty Rounds panel (converged/stopped_cap/escalated showed no rounds)
`recordRound` ran only on `deciding→developing`; verdict-terminal exits skipped it. Now recorded for those too (idempotent).

### Richer Draft PR
`--assignee @me` + labels (`consilium-review`/`sdlc`/`automated`, ensured idempotently), both degrading gracefully if gh rejects them. Body: provenance (loop/round/repo) + the verdict's action_points addressed (clamped) + per-AP outcome table + human-gate footer. Still `--body-file`.

### List UX (focus lost among many runs)
ConsiliumLoopList grouped by **workspace** (section + count); rows lead with **round n/max** + short id + relative time. TaskGroupList grouped by **status bucket** (Active/Pending/Terminal) with relative timestamps.

## Verification
`tsc --noEmit` clean; `tests/unit/sdlc` + `tests/unit/consilium` **162/162** (incl. registry-gated re-drive: in-flight past grace → no 2nd dispatch, registry-empty → re-dispatch once; idempotent settle; gh --assignee/--label + graceful degrade; recorded terminal rounds). Full unit suite green. Security properties unchanged (no Bash, sanitized env, untrusted text never in branch/title/assignee/label/shell, Draft-PR-only).