### PR TITLE
fix(consilium): trigger-launched review uses project owner as createdBy (FK fix)

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -50,7 +50,9 @@ import { requireAuth } from "./auth/middleware";
 import { requireProject } from "./middleware/project";
 import { tracer } from "./tracing/tracer";
 import { DEFAULT_MODELS, DEFAULT_PIPELINE_STAGES } from "@shared/constants";
-import { CONSILIUM_LOOP_TERMINAL_STATES } from "@shared/schema";
+import { CONSILIUM_LOOP_TERMINAL_STATES, projects } from "@shared/schema";
+import { eq } from "drizzle-orm";
+import { db } from "./db";
 import { log } from "./index";
 import { registerArgoCdSettingsRoutes, autoConnectArgoCdFromEnv } from "./routes/argocd-settings";
 import { registerTaskGroupRoutes } from "./routes/task-groups";
@@ -421,6 +423,18 @@ export async function registerRoutes(
               : null,
             createReview: createConsiliumReview,
             runInProject: runAsProject,
+            // FK FIX: a trigger-launched review has no req.user; task_groups.created_by
+            // is an FK to users.id, so the old literal "system" violated the FK. Resolve
+            // the PROJECT OWNER (projects.ownerId, notNull). Run under runAsSystem so the
+            // lookup is NOT project-scoped away (fireTrigger is a cross-project system ctx).
+            resolveOwnerId: (projectId: string) =>
+              runAsSystem("resolve-trigger-owner", async () => {
+                const [row] = await db
+                  .select({ ownerId: projects.ownerId })
+                  .from(projects)
+                  .where(eq(projects.id, projectId));
+                return row?.ownerId ?? null;
+              }),
             log: (m) => log(m, "triggers"),
           },
           trigger,

--- a/server/services/consilium/trigger-dispatch.ts
+++ b/server/services/consilium/trigger-dispatch.ts
@@ -134,6 +134,16 @@ export interface ConsiliumTriggerDispatchDeps {
   ) => Promise<ConsiliumLoopRow>;
   /** Project-scoped ALS runner (the route passes `runAsProject`). T3. */
   runInProject: <T>(projectId: string, fn: () => Promise<T>) => Promise<T>;
+  /**
+   * Resolve a REAL `users.id` to own the launched review's `task_groups` row.
+   * `task_groups.created_by` is an FK to `users.id`; the literal `"system"` is
+   * NOT a user row, so a trigger-launched review (no `req.user`) must resolve a
+   * concrete owner — the PROJECT OWNER (`projects.ownerId`, notNull). Returns
+   * `null` when the project/owner cannot be resolved → the review is SKIPPED
+   * (a review must have a valid owner). The route wires this under `runAsSystem`
+   * so the lookup is not project-scoped away. T3.
+   */
+  resolveOwnerId: (projectId: string) => Promise<string | null>;
   /** Structured logger (the route passes `(m) => log(m, "triggers")`). */
   log: (message: string) => void;
 }
@@ -144,7 +154,8 @@ export interface ConsiliumTriggerDispatchDeps {
  * inspecting logs:
  *   - "noop"          → no action (back-compat record-only path)
  *   - "skipped"       → action present but un-launchable (subsystem off / no
- *                       project / no repoPath) — logged, not an error
+ *                       project / no repoPath / no resolvable project owner) —
+ *                       logged, not an error
  *   - "skipped-dedup" → a non-terminal loop already runs for (project, repoPath)
  *                       on the TRIGGER path (T5) — logged, factory NOT called
  *   - "launched"      → factory invoked successfully
@@ -185,9 +196,23 @@ export async function maybeLaunchConsiliumReview(
   // T5: dedup key — match against the CANONICAL path the factory persists.
   const resolvedRepo = canonicalRepoPath(repoPath);
 
+  // FK FIX: a trigger-launched review has no `req.user`. `task_groups.created_by`
+  // is an FK to `users.id`, so the old literal `createdBy: "system"` violated
+  // `task_groups_created_by_users_id_fk` and every trigger review failed. Resolve
+  // the PROJECT OWNER (a real user id) instead. Inside the try so a lookup throw
+  // is caught (T4) rather than crashing the watcher loop.
   const reviewDeps = deps.reviewDeps;
   let dedupLoopId: string | undefined;
   try {
+    const createdBy = await deps.resolveOwnerId(projectId);
+    if (!createdBy) {
+      // No resolvable owner ⇒ no valid FK target ⇒ do NOT call the factory.
+      deps.log(
+        `consilium_review skipped for trigger ${trigger.id} — no resolvable owner for project ${projectId}`,
+      );
+      return "skipped";
+    }
+
     const loop = await deps.runInProject(projectId, async (): Promise<ConsiliumLoopRow | null> => {
       // T5 (FIX HIGH-1): active-loop DEDUP on the TRIGGER path. `getLoops()` is
       // project-scoped by this ALS context, so we only see THIS project's loops.
@@ -209,7 +234,8 @@ export async function maybeLaunchConsiliumReview(
         projectId,
         repoPath,
         preset: action.preset,
-        createdBy: "system",
+        // FK FIX: real `users.id` (project owner), NOT the literal "system".
+        createdBy,
         // T6 (FIX MED-2): FORCE review-only on the trigger path. An autonomous
         // file-event-driven run must NEVER reach DEVELOPING / the SDLC coder, so
         // we IGNORE `action.maxRounds` here (server-side, not config-trusted).

--- a/tests/unit/consilium/trigger-dispatch.test.ts
+++ b/tests/unit/consilium/trigger-dispatch.test.ts
@@ -52,6 +52,7 @@ function makeDeps(
   runInProject: ReturnType<typeof vi.fn>;
   log: ReturnType<typeof vi.fn>;
   getLoops: ReturnType<typeof vi.fn>;
+  resolveOwnerId: ReturnType<typeof vi.fn>;
 } {
   const createReview = vi
     .fn()
@@ -61,14 +62,19 @@ function makeDeps(
   // FIX HIGH-1: the dedup read goes through reviewDeps.storage.getLoops() — empty
   // by default (no active loop) so existing dispatch tests launch as before.
   const getLoops = vi.fn().mockResolvedValue([] as ConsiliumLoopRow[]);
+  // FK FIX: a trigger-launched review must own its task_groups row with a REAL
+  // users.id. The dispatch resolves the PROJECT OWNER; mock it to a fake user id
+  // so the factory is called with createdBy === "owner-1" (NOT the literal "system").
+  const resolveOwnerId = vi.fn().mockResolvedValue("owner-1");
   const deps: ConsiliumTriggerDispatchDeps = {
     reviewDeps: { storage: { getLoops } } as unknown as ConsiliumTriggerDispatchDeps["reviewDeps"],
     createReview,
     runInProject,
+    resolveOwnerId,
     log,
     ...over,
   };
-  return { deps, createReview, runInProject, log, getLoops };
+  return { deps, createReview, runInProject, log, getLoops, resolveOwnerId };
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -130,7 +136,8 @@ describe("maybeLaunchConsiliumReview", () => {
     expect(params.repoPath).toBe("/allowed/omnius"); // action.repoPath wins
     expect(params.preset).toBe("sdlc-cross-review");
     expect(params.maxRounds).toBe(1);
-    expect(params.createdBy).toBe("system");
+    // FK FIX: the resolved PROJECT OWNER (a real users.id), NOT the literal "system".
+    expect(params.createdBy).toBe("owner-1");
     // UNTRUSTED changed-file path carried ONLY via objectiveExtra (T1).
     expect(params.objectiveExtra).toMatch(/\/allowed\/omnius\/specs\/00-overview\.md/);
   });
@@ -225,6 +232,19 @@ describe("maybeLaunchConsiliumReview", () => {
     const trigger = makeTrigger({ watchPath: "/allowed/omnius", patterns: ["**/*.md"], action: CONSILIUM_ACTION });
     expect(await maybeLaunchConsiliumReview(deps, trigger, {})).toBe("launched");
     expect(createReview).toHaveBeenCalledTimes(1);
+  });
+
+  // ─── FK FIX: a review must have a REAL owner (task_groups.created_by → users.id) ─
+
+  it("resolveOwnerId returns null (no project/owner) → skipped, factory NOT called", async () => {
+    const resolveOwnerId = vi.fn().mockResolvedValue(null);
+    const { deps, createReview, log } = makeDeps({ resolveOwnerId });
+    const trigger = makeTrigger({ watchPath: "/allowed/omnius", patterns: ["**/*.md"], action: CONSILIUM_ACTION });
+    const result = await maybeLaunchConsiliumReview(deps, trigger, {});
+    expect(result).toBe("skipped");
+    // No valid FK target ⇒ never insert a task_groups row with a bogus owner.
+    expect(createReview).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/no resolvable owner/));
   });
 
   // ─── FIX MED-2: trigger path forces review-only (maxRounds=1) (T6) ───────────


### PR DESCRIPTION
A **live** file-change trigger fired correctly but the factory threw `insert or update on "task_groups" violates foreign key constraint "task_groups_created_by_users_id_fk"`. Root cause: `trigger-dispatch.ts` hardcoded `createdBy: "system"` — not a real `users.id` (the trigger path has no `req.user`, and `triggers` has no creator column). **Every** trigger-launched review failed at task-group insert. Caught only by a live run — unit tests mocked storage and the security review didn't hit the real FK.

## Fix
Resolve a real user — the **project owner**:
- `ConsiliumTriggerDispatchDeps` gains `resolveOwnerId(projectId) → Promise<string|null>`, wired in `routes.ts` via a `projects.ownerId` lookup under `runAsSystem` (fireTrigger is a cross-project system context). The resolved id is passed as `createdBy`.
- No owner ⇒ factory NOT called → log + `"skipped"`. Resolution is inside the existing `try`, so a lookup throw is caught (never crashes the watcher). dedup, `maxRounds=1` clamp, clamped `objectiveExtra` unchanged.

## Verified end-to-end (live)
Registered an omnius `specs/**/*.md` trigger, edited a spec → `Fired trigger … → consilium_review launched (preset sdlc-cross-review, loop e1f81c06)`, loop `state=reviewing, maxRounds=1, createdBy=<project owner>`. tsc clean; `tests/unit/consilium` **160/160** (launched asserts `createdBy=owner`; new owner-null→skipped test).