### PR TITLE
feat(consilium): confine reviews to the project's own workspaces (MED-3)

### DIFF
--- a/server/routes/consilium-reviews.ts
+++ b/server/routes/consilium-reviews.ts
@@ -59,6 +59,16 @@ export function registerConsiliumReviewRoutes(app: Express, deps: CreateConsiliu
         if (/baselineCommit/i.test(message)) {
           return res.status(400).json({ error: "baselineCommit must be a 7–64 char hex commit SHA" });
         }
+        // MED-3: the factory applies TWO boundaries — the GLOBAL allowlist (S1)
+        // and a per-project WORKSPACE confinement (S5). Distinguish them so the
+        // 400 tells the user WHICH boundary they hit. Order: workspace first (its
+        // distinct `is not a workspace of this project` substring does not overlap
+        // the allowlist regex below).
+        if (/is not a workspace of this project/i.test(message)) {
+          return res.status(400).json({
+            error: `repoPath "${body.repoPath}" is not registered as a workspace of the selected project — pick one of its workspaces or add it as a workspace.`,
+          });
+        }
         if (/allowlist|outside every allowed|denied system|traversal|fail-closed/i.test(message)) {
           return res.status(400).json({
             error: `repoPath "${body.repoPath}" is not in the allowed repo paths. Add it to consiliumLoop.allowedRepoPaths in config.yaml (then restart), or pick an already-allowed workspace.`,

--- a/server/services/consilium/repo-allowlist.ts
+++ b/server/services/consilium/repo-allowlist.ts
@@ -13,6 +13,10 @@
  * Fail-closed: an empty allowlist throws — no implicit "allow everything".
  * `buildDiffContext` calls this itself on the persisted `repoPath` every round,
  * so a poisoned row can never widen access (never trust the caller).
+ *
+ * `realResolve` and `isWithinRoot` are exported so the per-project workspace
+ * confinement check (MED-3, in review-factory.ts) reuses the EXACT same
+ * realpath/fallback + containment semantics — the two boundaries must agree.
  */
 import { realpathSync } from "fs";
 import { resolve } from "path";
@@ -34,7 +38,7 @@ const DENIED_PATHS = [
 ];
 
 /** Resolve symlinks; fall back to lexical resolve() when the path is absent. */
-function realResolve(rawPath: string): string {
+export function realResolve(rawPath: string): string {
   try {
     return realpathSync(rawPath);
   } catch {
@@ -54,7 +58,7 @@ function assertNotDenied(resolved: string): void {
 }
 
 /** True when `resolved` is the root itself or strictly nested under it. */
-function isWithinRoot(resolved: string, root: string): boolean {
+export function isWithinRoot(resolved: string, root: string): boolean {
   const normalized = root.endsWith("/") ? root : root + "/";
   return resolved === root || resolved.startsWith(normalized);
 }

--- a/server/services/consilium/review-factory.ts
+++ b/server/services/consilium/review-factory.ts
@@ -39,6 +39,16 @@
  *       inside the request's project ALS (route: `requireProject`; trigger:
  *       `runAsProject(trigger.projectId)`), so `storage.createTaskGroup` /
  *       `createLoop` scope the new rows to the correct project (withProjectInsert).
+ *   S5. PER-PROJECT WORKSPACE CONFINEMENT (MED-3). After the GLOBAL allowlist
+ *       gate (S1, the OUTER boundary shared by every project), the resolved
+ *       repoPath MUST ALSO be within one of THIS project's registered
+ *       workspaces (the INNER per-tenant boundary). The two checks INTERSECT —
+ *       a repo must pass BOTH — so a member of project A can no longer launch a
+ *       review on project B's allowlisted-but-unowned repo. `getWorkspaces()`
+ *       is project-scoped by the caller's ALS (S4), the same scoping the trigger
+ *       dedup's `getLoops()` relies on. Fail-closed: a project with NO matching
+ *       workspace ⇒ NO repo is reviewable for it. Both checks run BEFORE
+ *       createTaskGroup/createLoop, so nothing is persisted on rejection.
  */
 import { readdirSync, readFileSync, statSync } from "fs";
 import { basename, join } from "path";
@@ -48,7 +58,7 @@ import type { ConsiliumReviewPreset } from "@shared/types";
 import type { TaskOrchestrator, CreateTaskParam } from "../task-orchestrator.js";
 import type { ConsiliumLoopController } from "./consilium-loop-controller.js";
 import type { AppConfig } from "../../config/schema.js";
-import { assertAllowedRepoPath } from "./repo-allowlist.js";
+import { assertAllowedRepoPath, isWithinRoot, realResolve } from "./repo-allowlist.js";
 import { JUDGE_CONVERGENCE_INSTRUCTIONS } from "../orchestrator/judge-prompt.js";
 
 // ─── Bounds (Security S2) ───────────────────────────────────────────────────
@@ -475,11 +485,45 @@ function buildGroupName(preset: ConsiliumReviewPreset, repoPath: string): string
 }
 
 /**
+ * S5 — PER-PROJECT WORKSPACE CONFINEMENT (MED-3). The INNER per-tenant boundary,
+ * applied AFTER the global allowlist (S1). Require `resolvedRepo` (already
+ * realpath'd + allowlisted) to be within ONE of the CURRENT project's registered
+ * workspaces. `storage.getWorkspaces()` returns ONLY this project's workspaces
+ * because the caller runs inside the project ALS (S4) and the scoped storage
+ * filters by it — the same scoping the trigger dedup's `getLoops()` relies on.
+ *
+ * Containment mirrors the allowlist EXACTLY: each workspace `path` is run through
+ * `realResolve` (realpathSync, falling back to a lexical resolve() for a
+ * not-yet-cloned workspace dir — so a missing path still compares sanely instead
+ * of throwing) and tested with the SAME `resolved === root || startsWith(root +
+ * "/")` rule via `isWithinRoot`. Fail-closed: a project with NO matching
+ * workspace (incl. zero workspaces) rejects every repo. Runs BEFORE any
+ * createTaskGroup/createLoop, so nothing is persisted on rejection.
+ */
+async function assertRepoIsProjectWorkspace(
+  resolvedRepo: string,
+  storage: IStorage,
+): Promise<void> {
+  const workspaces = await storage.getWorkspaces();
+  for (const ws of workspaces) {
+    const wsPath = ws?.path;
+    if (!wsPath) continue;
+    if (isWithinRoot(resolvedRepo, realResolve(wsPath))) return;
+  }
+  // Distinct error so the route can tell this APART from the global-allowlist
+  // rejection and surface a different, actionable message.
+  throw new Error(
+    `[project-workspace] repoPath "${resolvedRepo}" is not a workspace of this project`,
+  );
+}
+
+/**
  * Build the cross-review task-group, create + start the consilium loop, and
  * return the loop row. The CALLER supplies the project ALS context (S4).
  *
  * Throws (caller maps to 4xx / logs) when: the repoPath is outside the allowlist
- * (S1), the preset is unknown, or a non-hex baselineCommit is supplied (S3).
+ * (S1), the repoPath is not a workspace of the current project (S5), the preset
+ * is unknown, or a non-hex baselineCommit is supplied (S3).
  */
 export async function createConsiliumReview(
   deps: CreateConsiliumReviewDeps,
@@ -492,6 +536,13 @@ export async function createConsiliumReview(
   // caller — a route body OR a poisoned trigger config). Canonical realpath is
   // what we persist, so a symlink can't widen access on a later round.
   const resolvedRepo = assertAllowedRepoPath(params.repoPath, cfg.allowedRepoPaths);
+
+  // S5: INTERSECT the global allowlist with THIS project's workspaces (MED-3).
+  // The global allowlist (S1) is the outer boundary shared by every project; this
+  // confines the review to the calling project's OWN repos (inner per-tenant
+  // boundary). A repo must pass BOTH. Fail-closed: no matching workspace ⇒ reject.
+  // Runs before createTaskGroup/createLoop ⇒ nothing persisted on rejection.
+  await assertRepoIsProjectWorkspace(resolvedRepo, storage);
 
   const panel = PRESET_PANELS[params.preset];
   if (!panel) throw new Error(`unknown consilium review preset: ${String(params.preset)}`);

--- a/tests/unit/consilium/consilium-reviews-route.test.ts
+++ b/tests/unit/consilium/consilium-reviews-route.test.ts
@@ -1,0 +1,91 @@
+/**
+ * consilium-reviews-route.test.ts — the POST /api/consilium-reviews error
+ * mapping (MED-3). The route applies TWO confinement boundaries via the factory:
+ *   (a) the GLOBAL allowlist (S1) — repo not in consiliumLoop.allowedRepoPaths;
+ *   (b) the PER-PROJECT workspace check (S5/MED-3) — repo allowlisted but not a
+ *       registered workspace of the selected project.
+ * Each must surface a DISTINCT, actionable 400 so the user knows WHICH boundary
+ * they hit and how to fix it.
+ *
+ * The factory is mocked: we only assert the route's error-substring mapping, not
+ * the factory internals (covered in review-factory.test.ts).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// Mock the factory the route delegates to. Same resolved module the route imports
+// (`../services/consilium/review-factory.js`), so the mock applies there too.
+vi.mock("../../../server/services/consilium/review-factory.js", () => ({
+  createConsiliumReview: vi.fn(),
+}));
+
+import { registerConsiliumReviewRoutes } from "../../../server/routes/consilium-reviews.js";
+import { createConsiliumReview } from "../../../server/services/consilium/review-factory.js";
+
+const mockedCreate = vi.mocked(createConsiliumReview);
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  // Stand in for requireAuth + requireProject (applied at mount in routes.ts).
+  app.use((req, _res, next) => {
+    (req as unknown as { user: { id: string } }).user = { id: "user-1" };
+    (req as unknown as { projectId: string }).projectId = "project-1";
+    next();
+  });
+  // deps are unused — the factory is fully mocked.
+  registerConsiliumReviewRoutes(app, {} as never);
+  return app;
+}
+
+const VALID_BODY = { repoPath: "/repos/widget", preset: "sdlc-cross-review" as const };
+
+describe("POST /api/consilium-reviews — distinct 400s for the two confinement boundaries (MED-3)", () => {
+  beforeEach(() => mockedCreate.mockReset());
+
+  it("(a) NOT in the global allowlist → the allowlist message", async () => {
+    mockedCreate.mockRejectedValueOnce(
+      new Error(`[repo-allowlist] Path "/repos/widget" is outside every allowed repo root`),
+    );
+    const res = await request(makeApp()).post("/api/consilium-reviews").send(VALID_BODY);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/is not in the allowed repo paths/i);
+    expect(res.body.error).toMatch(/allowedRepoPaths in config\.yaml/i);
+    // Must NOT use the workspace message.
+    expect(res.body.error).not.toMatch(/registered as a workspace/i);
+  });
+
+  it("(b) allowlisted but NOT a project workspace → the workspace message", async () => {
+    mockedCreate.mockRejectedValueOnce(
+      new Error(`[project-workspace] repoPath "/repos/widget" is not a workspace of this project`),
+    );
+    const res = await request(makeApp()).post("/api/consilium-reviews").send(VALID_BODY);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/is not registered as a workspace of the selected project/i);
+    expect(res.body.error).toMatch(/pick one of its workspaces or add it as a workspace/i);
+    // Must NOT fall through to the allowlist message.
+    expect(res.body.error).not.toMatch(/allowedRepoPaths in config\.yaml/i);
+  });
+
+  it("the two messages are DISTINCT (not the same fallthrough)", async () => {
+    mockedCreate.mockRejectedValueOnce(
+      new Error(`[repo-allowlist] Path "/repos/widget" is outside every allowed repo root`),
+    );
+    const allowlistRes = await request(makeApp()).post("/api/consilium-reviews").send(VALID_BODY);
+
+    mockedCreate.mockRejectedValueOnce(
+      new Error(`[project-workspace] repoPath "/repos/widget" is not a workspace of this project`),
+    );
+    const workspaceRes = await request(makeApp()).post("/api/consilium-reviews").send(VALID_BODY);
+
+    expect(allowlistRes.body.error).not.toBe(workspaceRes.body.error);
+  });
+
+  it("a successful create returns 201 with the loop row", async () => {
+    mockedCreate.mockResolvedValueOnce({ id: "loop-1", status: "PENDING" } as never);
+    const res = await request(makeApp()).post("/api/consilium-reviews").send(VALID_BODY);
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe("loop-1");
+  });
+});

--- a/tests/unit/consilium/review-factory.test.ts
+++ b/tests/unit/consilium/review-factory.test.ts
@@ -223,19 +223,27 @@ describe("createConsiliumReview — allowlist gate, baseline threading, rounds",
     return p;
   }
 
-  function makeDeps(allowedRepoPaths: string[]) {
+  // workspacePaths defaults to the allowlist roots so a repo that is globally
+  // allowlisted is ALSO a project workspace unless a test deliberately diverges
+  // them (MED-3 intersects the two boundaries).
+  function makeDeps(allowedRepoPaths: string[], workspacePaths: string[] = allowedRepoPaths) {
     const createTaskGroup = vi.fn().mockResolvedValue({ group: { id: "g1" }, tasks: [] });
     const createLoop = vi
       .fn()
       .mockImplementation(async (row: Record<string, unknown>) => ({ id: "loop1", status: "PENDING", ...row }));
     const start = vi.fn().mockResolvedValue(null); // returns the PENDING row from createLoop
+    // getWorkspaces is project-scoped by the caller's ALS in production; here we
+    // mock it to the project's workspace set (MED-3 per-tenant confinement).
+    const getWorkspaces = vi
+      .fn()
+      .mockResolvedValue(workspacePaths.map((p, i) => ({ id: `ws${i}`, name: `ws${i}`, path: p })));
     const deps = {
-      storage: { createLoop },
+      storage: { createLoop, getWorkspaces },
       orchestrator: { createTaskGroup },
       controller: { start },
       config: () => ({ pipeline: { consiliumLoop: { allowedRepoPaths, devPipelineId: undefined } } }),
     } as unknown as CreateConsiliumReviewDeps;
-    return { deps, createTaskGroup, createLoop, start };
+    return { deps, createTaskGroup, createLoop, start, getWorkspaces };
   }
 
   it("REJECTS a repoPath outside the allowlist (S1, fail-closed, never trusts the caller)", async () => {
@@ -319,6 +327,81 @@ describe("createConsiliumReview — allowlist gate, baseline threading, rounds",
       maxRounds: 99,
     });
     expect(createLoop.mock.calls[0][0].maxRounds).toBe(6);
+  });
+
+  // ─── MED-3: per-project workspace confinement (intersection with the allowlist) ─
+
+  it("REJECTS a repo that IS globally allowlisted but is NOT a workspace of this project (MED-3) — nothing persisted", async () => {
+    // `allowed` passes the global allowlist, but the project's only workspace is
+    // `outside` → the inner per-tenant boundary rejects it.
+    const { deps, createTaskGroup, createLoop } = makeDeps([allowed], [outside]);
+    await expect(
+      createConsiliumReview(deps, {
+        projectId: "p1",
+        repoPath: allowed,
+        preset: "sdlc-cross-review",
+        createdBy: "u1",
+      }),
+    ).rejects.toThrow(/is not a workspace of this project/i);
+    // Both checks run BEFORE any persistence.
+    expect(createTaskGroup).not.toHaveBeenCalled();
+    expect(createLoop).not.toHaveBeenCalled();
+  });
+
+  it("ALLOWS a repo that is BOTH globally allowlisted AND a project workspace (intersection passes)", async () => {
+    const { deps, createTaskGroup, createLoop } = makeDeps([allowed], [allowed]);
+    const loop = await createConsiliumReview(deps, {
+      projectId: "p1",
+      repoPath: allowed,
+      preset: "sdlc-cross-review",
+      createdBy: "u1",
+    });
+    expect(loop.id).toBe("loop1");
+    expect(createTaskGroup).toHaveBeenCalledTimes(1);
+    expect(createLoop).toHaveBeenCalledTimes(1);
+    expect(createLoop.mock.calls[0][0].repoPath).toBe(allowed);
+  });
+
+  it("a subdir of a project workspace is ALLOWED (same containment rule as the allowlist)", async () => {
+    // The workspace is the parent; a repo nested under it is within the boundary.
+    const { deps, createLoop } = makeDeps([allowed], [path.dirname(allowed)]);
+    await createConsiliumReview(deps, {
+      projectId: "p1",
+      repoPath: allowed,
+      preset: "sdlc-cross-review",
+      createdBy: "u1",
+    });
+    expect(createLoop).toHaveBeenCalledTimes(1);
+  });
+
+  it("a project with NO workspaces reviews NOTHING (fail-closed) — nothing persisted", async () => {
+    const { deps, createTaskGroup, createLoop } = makeDeps([allowed], []);
+    await expect(
+      createConsiliumReview(deps, {
+        projectId: "p1",
+        repoPath: allowed,
+        preset: "sdlc-cross-review",
+        createdBy: "u1",
+      }),
+    ).rejects.toThrow(/is not a workspace of this project/i);
+    expect(createTaskGroup).not.toHaveBeenCalled();
+    expect(createLoop).not.toHaveBeenCalled();
+  });
+
+  it("the GLOBAL allowlist is checked FIRST: a repo outside it is rejected as an allowlist failure even if listed as a workspace", async () => {
+    // `outside` is a workspace but NOT allowlisted → the outer boundary (S1)
+    // rejects it before the workspace check, with the allowlist error.
+    const { deps, createTaskGroup, createLoop } = makeDeps([allowed], [outside]);
+    await expect(
+      createConsiliumReview(deps, {
+        projectId: "p1",
+        repoPath: outside,
+        preset: "sdlc-cross-review",
+        createdBy: "u1",
+      }),
+    ).rejects.toThrow(/outside every allowed|allowlist/i);
+    expect(createTaskGroup).not.toHaveBeenCalled();
+    expect(createLoop).not.toHaveBeenCalled();
   });
 
   it("is NOT deduped at the factory: two reviews of the same repo BOTH create loops (the human UI endpoint path)", async () => {


### PR DESCRIPTION
Closes the security review's **MED-3**: the global `allowedRepoPaths` was the *only* boundary, so any project member could launch a review on any allowlisted repo. Add a per-tenant inner boundary — **global allowlist ∩ project workspaces**.

## Change
- `review-factory`: after the global `assertAllowedRepoPath` (outer, fail-closed), a new `assertRepoIsProjectWorkspace` requires the resolved `repoPath` to sit within one of `storage.getWorkspaces()` — **project-scoped by the ALS** (confirmed: both the HTTP route via `requireProject` and the trigger via `runInProject` run in that context). Both checks run **before** any persist. A project with no workspaces reviews nothing (fail-closed).
- `repo-allowlist`: export `realResolve` + `isWithinRoot` so the workspace check reuses the **exact** realpath + containment semantics (no duplicated logic).
- `endpoint`: two distinct, actionable 400s — *not in allowlist* vs *not a workspace of this project*.

## Compatibility (verified)
werush keeps reviewing nimbus-mac / omnius / Creme-ala-creme (its workspaces) incl. the omnius trigger; it can no longer review Omniscience (not its workspace) — the intended tightening. Per-round `buildDiffContext` validation untouched, so in-flight loops keep validating.

## Verification
`tsc --noEmit` clean; `tests/unit/consilium` **169/169** (5 new factory tests: allowlisted-but-not-a-workspace → rejected/nothing persisted, both → allowed, subdir-of-workspace → allowed, zero-workspaces → fail-closed, allowlist-checked-first; 4 route-message tests).