### PR TITLE
fix(antigravity): CLI timeout is not retryable (+SIGKILL) — unblocks hung cross-reviews

### DIFF
--- a/server/gateway/providers/antigravity-cli.ts
+++ b/server/gateway/providers/antigravity-cli.ts
@@ -55,12 +55,27 @@ const MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
 const MAX_CONCURRENCY = 4;
 
 /**
+ * Signal used to reap a child that overruns its wall-clock `timeout`. execFile
+ * defaults to SIGTERM, but `agy` has been observed to IGNORE SIGTERM and keep
+ * running (orphaned, still holding the single-tenant slot). SIGKILL cannot be
+ * trapped, so a wedged agy is actually reaped rather than left alive past the
+ * deadline.
+ */
+const KILL_SIGNAL = "SIGKILL" as const;
+
+/**
  * Total attempts for one invocation. `agy --print` intermittently exits 0 with
  * EMPTY stdout (a transient agentic-mode drop) or a transient spawn failure;
  * with no retry a single blip kills a whole multi-stage run after discarding
  * the work already done by earlier stages. Other CLI/HTTP providers retry once;
  * this brings Antigravity in line. Permanent errors (binary missing, not logged
  * in) are NOT retried — they carry `retryable = false`.
+ *
+ * A WALL-CLOCK TIMEOUT is explicitly NOT retried (see `toCliError`): each
+ * attempt is given the FULL `timeoutMs`, so retrying a hung agy would burn
+ * MAX_ATTEMPTS × timeoutMs (e.g. 3 × 10 min = 30 min) and block any downstream
+ * stage that depends on it (the consilium Judge waiting on the primary). A
+ * timeout fails after ONE attempt.
  */
 const MAX_ATTEMPTS = 3;
 
@@ -94,8 +109,10 @@ export interface AntigravityCliResult {
 export class AntigravityCliError extends Error {
   /**
    * Whether a fresh attempt could plausibly succeed. True for transient blips
-   * (empty stdout, killed/timed-out child); false for deterministic config
-   * faults (binary missing, not logged in) where retrying only wastes time.
+   * (empty stdout, a generic non-timeout spawn failure); false for deterministic
+   * config faults (binary missing, not logged in), a caller abort, AND a
+   * wall-clock TIMEOUT — a timeout means the model did not answer inside the cap,
+   * and a re-attempt only burns another full cap (the bug this guards against).
    */
   readonly retryable: boolean;
 
@@ -117,13 +134,61 @@ export function buildCliArgs(input: AntigravityCliInput): string[] {
   ];
 }
 
-/** Translate a raw spawn/exec failure into a clear, actionable error. */
-function toCliError(err: NodeJS.ErrnoException, stderr: string): AntigravityCliError {
+/**
+ * The error object execFile passes to its callback. It extends ErrnoException
+ * (`code`, `errno`, …) with the process-outcome fields the Node typings keep on
+ * `ExecFileException`: `killed` (true when execFile reaped the child for
+ * overrunning `timeout`) and `signal` (the kill signal it used).
+ */
+type ChildExecError = NodeJS.ErrnoException & {
+  killed?: boolean;
+  signal?: NodeJS.Signals | null;
+};
+
+/**
+ * Detect a child reaped by execFile's own wall-clock `timeout` (SIGTERM/SIGKILL
+ * kill) versus a normal non-zero exit. On timeout Node sets `err.killed = true`
+ * and `err.signal` to the kill signal; some runtimes/wrappers also surface
+ * `err.code === "ETIMEDOUT"`. A normal failed exit has `killed === false`,
+ * `signal === null`, and a numeric/ string `code` — so it is NOT matched here
+ * and stays retryable.
+ */
+function isTimeoutKill(err: ChildExecError): boolean {
+  return (
+    err.killed === true ||
+    err.code === "ETIMEDOUT" ||
+    err.signal === "SIGTERM" ||
+    err.signal === "SIGKILL"
+  );
+}
+
+/** Detect a caller-initiated abort (AbortSignal) so it is never mislabeled. */
+function isAbort(err: ChildExecError): boolean {
+  return err.name === "AbortError" || err.code === "ABORT_ERR";
+}
+
+/**
+ * Translate a raw spawn/exec failure into a clear, actionable error and set
+ * `retryable` correctly. Classification order matters:
+ *   1. ENOENT          → binary missing            → NOT retryable
+ *   2. caller abort    → request cancelled         → NOT retryable
+ *   3. not logged in   → auth fault                → NOT retryable
+ *   4. timeout kill    → model didn't answer in cap → NOT retryable (the fix)
+ *   5. anything else   → generic transient blip    → retryable
+ */
+function toCliError(
+  err: ChildExecError,
+  stderr: string,
+  timeoutMs?: number,
+): AntigravityCliError {
   if (err.code === "ENOENT") {
     return new AntigravityCliError(
       "Antigravity CLI binary not found on PATH. Install Antigravity and run `agy install`.",
       err,
     );
+  }
+  if (isAbort(err)) {
+    return new AntigravityCliError("Antigravity CLI request aborted.", err, false);
   }
   const detail = stderr.trim() || err.message;
   if (/not logged in|unauthor|login|sign in/i.test(detail)) {
@@ -132,8 +197,20 @@ function toCliError(err: NodeJS.ErrnoException, stderr: string): AntigravityCliE
       err,
     );
   }
-  // A killed/timed-out child (execFile timeout → err.killed) or a generic spawn
-  // failure is transient → retryable.
+  // A wall-clock timeout kill is NOT transient: the model failed to respond
+  // within the cap, and each retry would be given the SAME full cap again. Fail
+  // after ONE attempt instead of MAX_ATTEMPTS × timeoutMs (the amplification bug).
+  if (isTimeoutKill(err)) {
+    const seconds =
+      timeoutMs != null ? Math.round(timeoutMs / MS_PER_SECOND) : null;
+    const window = seconds != null ? `${seconds}s` : "the wall-clock cap";
+    return new AntigravityCliError(
+      `Antigravity CLI timed out after ${window} — the model did not respond within the wall-clock cap.`,
+      err,
+      false,
+    );
+  }
+  // Generic non-timeout spawn/exec failure → transient → retryable.
   return new AntigravityCliError(`Antigravity CLI failed: ${detail}`, err, true);
 }
 
@@ -164,10 +241,16 @@ function runProcess(input: AntigravityCliInput): Promise<AntigravityCliResult> {
     const child = execFile(
       input.binPath,
       args,
-      { timeout: input.timeoutMs, maxBuffer: MAX_OUTPUT_BYTES, signal: input.signal, shell: false },
+      {
+        timeout: input.timeoutMs,
+        killSignal: KILL_SIGNAL,
+        maxBuffer: MAX_OUTPUT_BYTES,
+        signal: input.signal,
+        shell: false,
+      },
       (err, stdout, stderr) => {
         if (err) {
-          reject(toCliError(err as NodeJS.ErrnoException, stderr ?? ""));
+          reject(toCliError(err as ChildExecError, stderr ?? "", input.timeoutMs));
           return;
         }
         const text = (stdout ?? "").trim();
@@ -206,9 +289,11 @@ function delay(ms: number, signal?: AbortSignal): Promise<void> {
 
 /**
  * Invoke the Antigravity CLI non-interactively and return its text output.
- * Concurrency is capped; the prompt is never passed through a shell. Transient
- * failures (empty stdout, killed/timed-out child) are retried up to
- * MAX_ATTEMPTS with linear backoff; permanent ones fail fast.
+ * Concurrency is capped; the prompt is never passed through a shell. TRANSIENT
+ * failures (empty stdout, a generic non-timeout spawn failure) are retried up to
+ * MAX_ATTEMPTS with linear backoff. PERMANENT ones fail fast after one attempt:
+ * binary missing, not logged in, a caller abort, and — critically — a wall-clock
+ * TIMEOUT (so a hung agy fails after 1 × timeoutMs, never MAX_ATTEMPTS ×).
  */
 export async function invokeAntigravityCli(
   input: AntigravityCliInput,
@@ -256,10 +341,16 @@ export async function listAntigravityModels(
       const child = execFile(
         binPath,
         ["models"],
-        { timeout: timeoutMs, maxBuffer: MAX_OUTPUT_BYTES, signal, shell: false },
+        {
+          timeout: timeoutMs,
+          killSignal: KILL_SIGNAL,
+          maxBuffer: MAX_OUTPUT_BYTES,
+          signal,
+          shell: false,
+        },
         (err, stdout, stderr) => {
           if (err) {
-            reject(toCliError(err as NodeJS.ErrnoException, stderr ?? ""));
+            reject(toCliError(err as ChildExecError, stderr ?? "", timeoutMs));
             return;
           }
           const labels = (stdout ?? "")

--- a/tests/unit/providers/antigravity-cli.test.ts
+++ b/tests/unit/providers/antigravity-cli.test.ts
@@ -5,9 +5,11 @@
  * Tests verify:
  *   - invokeAntigravityCli() resolves with trimmed stdout + prompt byte count
  *   - execFile is called with shell:false and the injection-safe ARG ARRAY
- *   - ENOENT → "binary not found" error
- *   - not-logged-in stderr → clear auth error
- *   - empty stdout → "empty output" error
+ *   - execFile is called with killSignal:"SIGKILL" so a wedged agy is reaped
+ *   - ENOENT → "binary not found" error (non-retryable, ONE attempt)
+ *   - not-logged-in stderr → clear auth error (non-retryable, ONE attempt)
+ *   - empty stdout → "empty output" error (retried up to MAX_ATTEMPTS)
+ *   - a wall-clock TIMEOUT kill → "timed out" error, NOT retried (ONE attempt)
  *   - concurrency cap serialises calls beyond the limit
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -59,8 +61,8 @@ function respondWith(err: NodeJS.ErrnoException | null, stdout: string, stderr =
  * so the mock must supply a response for EVERY attempt — otherwise attempt 2 hits
  * an unmocked execFile that returns `undefined`, and `undefined.stdin.end()`
  * throws a TypeError that MASKS the error under test. Register the same response
- * for all 3 attempts. (Non-retryable cases — ENOENT, not-logged-in — fail fast
- * after one attempt and keep the single-response respondWith.)
+ * for all 3 attempts. (Non-retryable cases — ENOENT, not-logged-in, timeout —
+ * fail fast after one attempt and keep the single-response respondWith.)
  */
 function respondWithRetryable(
   err: NodeJS.ErrnoException | null,
@@ -104,6 +106,19 @@ describe("invokeAntigravityCli", () => {
     expect(opts.timeout).toBe(30_000);
   });
 
+  it("passes killSignal:'SIGKILL' so a SIGTERM-ignoring agy is force-reaped", async () => {
+    respondWith(null, "ok");
+
+    await invokeAntigravityCli({ ...BASE_INPUT });
+
+    const [, , opts] = execFileMock.mock.calls[0] as [
+      string,
+      string[],
+      { killSignal?: string; timeout?: number },
+    ];
+    expect(opts.killSignal).toBe("SIGKILL");
+  });
+
   it("maps ENOENT to a clear 'binary not found' error", async () => {
     const enoent = Object.assign(new Error("spawn agy ENOENT"), { code: "ENOENT" });
     respondWith(enoent, "", "");
@@ -111,6 +126,8 @@ describe("invokeAntigravityCli", () => {
     await expect(invokeAntigravityCli({ ...BASE_INPUT })).rejects.toThrow(
       /not found on PATH/i,
     );
+    // Non-retryable: fails after exactly ONE attempt.
+    expect(execFileMock).toHaveBeenCalledTimes(1);
   });
 
   it("maps a not-logged-in stderr to a clear auth error", async () => {
@@ -120,6 +137,8 @@ describe("invokeAntigravityCli", () => {
     await expect(invokeAntigravityCli({ ...BASE_INPUT })).rejects.toThrow(
       /not logged in/i,
     );
+    // Non-retryable: fails after exactly ONE attempt.
+    expect(execFileMock).toHaveBeenCalledTimes(1);
   });
 
   it("maps a generic non-zero exit to a CLI failure error", async () => {
@@ -132,13 +151,50 @@ describe("invokeAntigravityCli", () => {
     );
   });
 
-  it("rejects empty stdout as malformed output", async () => {
-    // Retryable: empty output is re-attempted up to MAX_ATTEMPTS.
+  it("does NOT retry a wall-clock timeout kill — fails after ONE attempt", async () => {
+    // execFile's `timeout` fired: it killed the child, so Node sets
+    // `killed: true` and `signal` to the kill signal. This must NOT be retried —
+    // retrying would burn another full timeoutMs (the amplification bug).
+    const timedOut = Object.assign(new Error("Command failed: agy"), {
+      killed: true,
+      signal: "SIGKILL",
+      code: null as unknown as string,
+    });
+    // Register only ONE response. If the run loop wrongly retried, attempt 2
+    // would hit an unmocked execFile (returns undefined) and throw a different
+    // TypeError — so the call-count + message assertions below would fail.
+    respondWith(timedOut, "", "");
+
+    const err = await invokeAntigravityCli({ ...BASE_INPUT }).catch((e) => e);
+    expect(err).toBeInstanceOf(AntigravityCliError);
+    expect((err as AntigravityCliError).retryable).toBe(false);
+    expect((err as Error).message).toMatch(/timed out after 30s/i);
+    expect((err as Error).message).toMatch(/did not respond within the wall-clock cap/i);
+    // The critical assertion: exactly ONE attempt, never MAX_ATTEMPTS.
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("also treats an ETIMEDOUT-coded child as a non-retryable timeout", async () => {
+    const timedOut = Object.assign(new Error("ETIMEDOUT"), {
+      code: "ETIMEDOUT",
+    });
+    respondWith(timedOut, "", "");
+
+    const err = await invokeAntigravityCli({ ...BASE_INPUT }).catch((e) => e);
+    expect((err as AntigravityCliError).retryable).toBe(false);
+    expect((err as Error).message).toMatch(/timed out/i);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects empty stdout as malformed output and retries up to MAX_ATTEMPTS", async () => {
+    // Retryable: empty output is re-attempted up to MAX_ATTEMPTS (3).
     respondWithRetryable(null, "   \n  ");
 
     await expect(invokeAntigravityCli({ ...BASE_INPUT })).rejects.toThrow(
       /empty output/i,
     );
+    // Proves the retry path is intact for genuinely transient failures.
+    expect(execFileMock).toHaveBeenCalledTimes(3);
   });
 
   it("throws AntigravityCliError instances (not bare Error)", async () => {


### PR DESCRIPTION
A consilium **Gemini primary** step ran ~25 min and blocked the whole cross-review (the Judge depends on it). 

## Root cause
`toCliError` marked a **killed/timed-out** child (execFile wall-clock timeout) as `retryable = true`, lumped with generic transient spawn failures. The run loop retries up to `MAX_ATTEMPTS = 3`, and each attempt gets the **full** `timeoutMs` (direct_llm `taskTimeoutMs`, default 600s). So a hung/slow `agy` burned up to **3 × 600s = 30 min** before failing.

## Fix
- `isTimeoutKill(err)` detects an execFile timeout-kill (`err.killed` / `code ETIMEDOUT` / `signal SIGTERM|SIGKILL`). `toCliError` now orders: ENOENT → caller-abort → not-logged-in → **timeout-kill (NON-retryable, the fix)** → generic transient (retryable). A hung agy fails after **one** attempt, not three. Empty-stdout + normal non-zero exit unchanged.
- `killSignal: "SIGKILL"` on execFile (`runProcess` + `listAntigravityModels`) — `agy` was observed to ignore the default SIGTERM and orphan, holding a single-tenant concurrency slot.

Follow-up (noted, not done): a shared total-latency budget across retried non-timeout attempts; with the timeout now non-retryable the realistic exposure is gone (retried cases — empty-stdout / fast spawn fail — return near-instantly).

tsc clean; `antigravity-cli` **12/12**, siblings **26/26**.