### PR TITLE
feat(consilium): branch-targeted reviews (pick a branch, read at that ref, no checkout)

### DIFF
--- a/client/src/components/consilium/new-review-dialog.tsx
+++ b/client/src/components/consilium/new-review-dialog.tsx
@@ -3,7 +3,7 @@
  * for ConsiliumLoopList. Mirrors ProjectSelector's create-dialog pattern (the
  * shared Dialog primitive + a controlled form + a toast on settle).
  *
- * It POSTs `{ repoPath, preset, maxRounds?, baselineCommit? }` to
+ * It POSTs `{ repoPath, preset, maxRounds?, baselineCommit?, ref? }` to
  * `/api/consilium-reviews` via the shared apiRequest transport (carries auth +
  * `x-project-id`, same as every project-scoped call).
  *
@@ -20,18 +20,30 @@
  * back as a 400 whose `error` text we surface VERBATIM in the failure toast (so
  * "...is not in the allowed repo paths" is actionable, not a mystery).
  *
+ * BRANCH SELECTION: once a workspace is picked, we fetch its branches LIVE from
+ * `GET /api/workspaces/:id/branches` (response `{ current, branches[] }`) via a
+ * react-query keyed by the workspace id (`enabled` only when a workspace with an
+ * id is selected). A branch Select sits below the workspace Select, defaulting to
+ * the workspace's registered `branch` (then the endpoint's `current`, then
+ * "main"). While the list loads we show a disabled "Loading branches…" control;
+ * on error / empty list / custom-path (no workspace id) we fall back to a
+ * free-text branch Input so the user is never stuck. The chosen branch rides
+ * along as `ref`, but is OMITTED when it equals the workspace default or is empty
+ * — the server treats an absent `ref` as the working-tree HEAD (back-compat).
+ *
  * On success we invalidate the loops list and, if the response carries an id
  * (id / loopId / loop.id — defensive, the exact envelope is the backend's), we
  * navigate to the new loop's detail.
  *
- * SECURITY: the only free-text the user supplies (custom repoPath / baselineCommit)
- * is sent as a JSON body to an allowlist-validated server route; nothing is
- * interpolated into a URL path or shell. The server re-validates repoPath against
- * its allowlist.
+ * SECURITY: the only free-text the user supplies (custom repoPath / baselineCommit
+ * / a hand-typed branch) is sent as a JSON body to an allowlist-validated server
+ * route; nothing is interpolated into a URL path or shell. The workspace id used
+ * in the branches URL is a server-issued id, not user free-text. The server
+ * re-validates repoPath against its allowlist.
  */
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useLocation } from "wouter";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Loader2, Plus } from "lucide-react";
 import {
   Dialog,
@@ -62,8 +74,52 @@ const PRESETS = [
 ] as const;
 type Preset = (typeof PRESETS)[number]["value"];
 
-/** The slice of a workspace this dialog needs — a human `name` and a repo `path`. */
-export type ReviewWorkspaceOption = { id?: string; name: string; path: string };
+/**
+ * The slice of a workspace this dialog needs — a human `name`, a repo `path`, the
+ * server-issued `id` (keys the branches fetch) and the registered default
+ * `branch`. WorkspaceRow is structurally assignable to this.
+ */
+export type ReviewWorkspaceOption = {
+  id?: string;
+  name: string;
+  path: string;
+  branch?: string;
+};
+
+/** The `/api/workspaces/:id/branches` envelope (manager.listBranches). */
+type BranchesResponse = { current?: string; branches?: string[] };
+
+/**
+ * Normalize whatever the branches endpoint returns into a clean, de-duplicated,
+ * sorted list of short branch names. Handles both the documented
+ * `{ branches: string[], current }` shape AND a defensive bare-array fallback,
+ * strips `remotes/<remote>/` prefixes (git branch -a) down to the branch name,
+ * and drops HEAD pointers.
+ */
+function branchNames(data: BranchesResponse | string[] | undefined): string[] {
+  const raw = Array.isArray(data)
+    ? data
+    : Array.isArray(data?.branches)
+      ? data.branches
+      : [];
+  const names = new Set<string>();
+  for (const entry of raw) {
+    if (typeof entry !== "string") continue;
+    let name = entry.trim();
+    if (!name) continue;
+    const remote = name.match(/^remotes\/[^/]+\/(.+)$/);
+    if (remote) name = remote[1];
+    if (name === "HEAD" || name.endsWith("/HEAD")) continue;
+    names.add(name);
+  }
+  return [...names].sort();
+}
+
+/** The live `current` branch from the endpoint, if the object shape was used. */
+function currentBranch(data: BranchesResponse | string[] | undefined): string | undefined {
+  if (!data || Array.isArray(data)) return undefined;
+  return typeof data.current === "string" && data.current ? data.current : undefined;
+}
 
 /** Best-effort id extraction — the exact create envelope is the backend's call. */
 function createdLoopId(res: unknown): string | undefined {
@@ -92,6 +148,7 @@ export function NewConsiliumReviewDialog({
   // "Advanced: enter a custom path" — reveals the free-text input even when
   // workspaces exist (for an allowlisted repo not registered as a workspace).
   const [customMode, setCustomMode] = useState(false);
+  const [branch, setBranch] = useState("");
   const [maxRounds, setMaxRounds] = useState("1");
   const [baselineCommit, setBaselineCommit] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -99,8 +156,8 @@ export function NewConsiliumReviewDialog({
   const qc = useQueryClient();
   const { toast } = useToast();
 
-  // Whether to show the free-text input: no workspaces to pick from, or the user
-  // explicitly opted into a custom path.
+  // Whether to show the free-text REPO input: no workspaces to pick from, or the
+  // user explicitly opted into a custom path.
   const freeText = !hasWorkspaces || customMode;
 
   // Seed the repo path once the workspaces query resolves (it may arrive after
@@ -112,6 +169,67 @@ export function NewConsiliumReviewDialog({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasWorkspaces, customMode, wsList[0]?.path]);
+
+  // The workspace currently selected in the dropdown (undefined in free-text
+  // repo mode). Its server-issued `id` keys the branches fetch.
+  const selectedWorkspace = freeText
+    ? undefined
+    : wsList.find((w) => w.path === repoPath);
+  const selectedWorkspaceId = selectedWorkspace?.id;
+
+  // Live branches for the selected workspace. Keyed by the workspace id and
+  // enabled ONLY when a workspace with an id is selected (free-text repo mode has
+  // no id → no list). Re-fetches automatically when the id in the key changes.
+  const branchesQuery = useQuery<BranchesResponse>({
+    queryKey: ["/api/workspaces", selectedWorkspaceId, "branches"],
+    queryFn: () =>
+      apiRequest("GET", `/api/workspaces/${selectedWorkspaceId}/branches`),
+    enabled: !freeText && !!selectedWorkspaceId,
+  });
+
+  const liveBranches = branchNames(branchesQuery.data);
+  const liveCurrent = currentBranch(branchesQuery.data);
+  // The default branch for the selected workspace: its registered `branch`, then
+  // the endpoint's live `current`, then "main". In free-text repo mode there is
+  // no workspace default → "" (empty = HEAD on the server).
+  const workspaceDefaultBranch = selectedWorkspace
+    ? selectedWorkspace.branch || liveCurrent || "main"
+    : "";
+
+  // Re-seed the branch when the SELECTED WORKSPACE changes (id flips), resetting
+  // it to that workspace's default. A ref guards against re-seeding on every
+  // branches refetch for the SAME workspace (which would clobber a user choice),
+  // while still letting the live `current` fill in once it arrives if the
+  // workspace had no registered branch.
+  const seededFor = useRef<string | null | undefined>(undefined);
+  useEffect(() => {
+    if (seededFor.current !== selectedWorkspaceId) {
+      seededFor.current = selectedWorkspaceId;
+      setBranch(workspaceDefaultBranch);
+    } else if (selectedWorkspace && !branch && workspaceDefaultBranch) {
+      // Same workspace, branch still empty (registered branch was falsy) and the
+      // live `current` just landed → adopt it without clobbering a real choice.
+      setBranch(workspaceDefaultBranch);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedWorkspaceId, workspaceDefaultBranch]);
+
+  // Loading / failure / dropdown states for the branch control. A disabled query
+  // (free-text repo mode) is never "loading". On error OR an empty list we fall
+  // back to a free-text branch Input so the user is never stuck.
+  const branchesEnabled = !freeText && !!selectedWorkspaceId;
+  const branchesLoading = branchesEnabled && branchesQuery.isLoading;
+  const branchesFailed =
+    branchesEnabled &&
+    (branchesQuery.isError ||
+      (branchesQuery.isSuccess && liveBranches.length === 0));
+  const branchDropdown = branchesEnabled && !branchesLoading && !branchesFailed;
+  // Keep the current value selectable even if it isn't in the live list (e.g. a
+  // registered default branch the remote no longer advertises).
+  const branchOptions =
+    branch && !liveBranches.includes(branch)
+      ? [branch, ...liveBranches]
+      : liveBranches;
 
   const enterCustomPath = () => {
     // Carry the current selection into the input as a starting point.
@@ -134,6 +252,7 @@ export function NewConsiliumReviewDialog({
       preset: Preset;
       maxRounds?: number;
       baselineCommit?: string;
+      ref?: string;
     } = { repoPath: path, preset };
 
     const rounds = Number(maxRounds);
@@ -141,6 +260,16 @@ export function NewConsiliumReviewDialog({
     // baseline commit is only meaningful for a diff/PR review.
     if (preset === "diff-pr-review" && baselineCommit.trim()) {
       body.baselineCommit = baselineCommit.trim();
+    }
+    // Branch → `ref`. Omit when empty, or (in workspace mode) when it equals the
+    // workspace default — the server treats an absent ref as the working-tree
+    // HEAD, so this preserves the prior behavior for the unchanged-default case.
+    const chosenBranch = branch.trim();
+    if (
+      chosenBranch &&
+      !(selectedWorkspace && chosenBranch === workspaceDefaultBranch)
+    ) {
+      body.ref = chosenBranch;
     }
 
     try {
@@ -240,6 +369,55 @@ export function NewConsiliumReviewDialog({
                   ))}
                 </SelectContent>
               </Select>
+            )}
+          </div>
+
+          {/* Branch — a Select over the workspace's live branches, with graceful
+              loading / failure / free-text fallbacks so it's never a dead end. */}
+          <div className="space-y-2">
+            <Label>Branch</Label>
+            {branchesLoading ? (
+              <Select disabled value="">
+                <SelectTrigger data-testid="new-review-branch-loading">
+                  <span className="inline-flex items-center gap-2 text-muted-foreground">
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    Loading branches…
+                  </span>
+                </SelectTrigger>
+                <SelectContent />
+              </Select>
+            ) : branchDropdown ? (
+              <Select value={branch} onValueChange={setBranch}>
+                <SelectTrigger data-testid="new-review-branch-select">
+                  <SelectValue placeholder="Select a branch" />
+                </SelectTrigger>
+                <SelectContent>
+                  {branchOptions.map((b) => (
+                    <SelectItem key={b} value={b}>
+                      {b}
+                      {b === workspaceDefaultBranch ? " (default)" : ""}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              <>
+                <Input
+                  value={branch}
+                  onChange={(e) => setBranch(e.target.value)}
+                  placeholder={
+                    selectedWorkspace
+                      ? workspaceDefaultBranch || "branch name"
+                      : "leave empty for the repo's current branch"
+                  }
+                  data-testid="new-review-branch-input"
+                />
+                <p className="text-xs text-muted-foreground">
+                  {branchesFailed
+                    ? "Couldn't list this workspace's branches — type a branch name, or leave it to use the current branch."
+                    : "Optional — leave empty to review the repo's current branch (HEAD)."}
+                </p>
+              </>
             )}
           </div>
 

--- a/migrations/0030_consilium_loops_review_ref.sql
+++ b/migrations/0030_consilium_loops_review_ref.sql
@@ -1,0 +1,20 @@
+-- migration: 0030_consilium_loops_review_ref
+-- Adds a nullable `review_ref` text column to consilium_loops for BRANCH-targeted
+-- consilium reviews.
+--
+-- When set, the review targets THAT git ref (branch name / revision): the
+-- recorded head sha is the ref's tip, a diff-pr-review diffs baseline..<ref>, and
+-- a full-viability review reads specs/*.md AT THAT REF (git show / git ls-tree),
+-- NOT the working tree — so the checkout is never disturbed.
+--
+-- Nullable; no backfill — null means "working-tree HEAD", which is exactly the
+-- existing behavior, so every pre-existing loop keeps reviewing the working-tree
+-- HEAD (full back-compat).
+--
+-- Idempotent (IF NOT EXISTS) so re-applying against a push-managed dev DB is safe.
+
+ALTER TABLE consilium_loops
+  ADD COLUMN IF NOT EXISTS review_ref TEXT;
+
+-- Rollback:
+--   ALTER TABLE consilium_loops DROP COLUMN review_ref;

--- a/server/routes/consilium-reviews.ts
+++ b/server/routes/consilium-reviews.ts
@@ -21,6 +21,7 @@ import {
   createConsiliumReview,
   type CreateConsiliumReviewDeps,
 } from "../services/consilium/review-factory.js";
+import { REVIEW_REF_RE, INVALID_REF_MESSAGE } from "../services/consilium/ref-validator.js";
 
 const SHA_RE = /^[0-9a-f]{7,64}$/;
 
@@ -30,6 +31,11 @@ const CreateReviewSchema = z.object({
   maxRounds: z.coerce.number().int().min(1).max(6).optional(),
   // diff-pr-review baseline — strict hex sha (never a ref); ignored by other presets.
   baselineCommit: z.string().regex(SHA_RE).optional(),
+  // BRANCH-targeted review: optional git ref (branch name / revision) to target.
+  // SAME strict pattern as the factory's validateReviewRef (REVIEW_REF_RE) so the
+  // two can never drift — rejects leading `-`, `..`, `@{`, shell metachars, empty,
+  // and >255 chars. Absent ⇒ working-tree HEAD (full back-compat).
+  ref: z.string().regex(REVIEW_REF_RE, INVALID_REF_MESSAGE).optional(),
 });
 
 export function registerConsiliumReviewRoutes(app: Express, deps: CreateConsiliumReviewDeps): void {
@@ -49,6 +55,7 @@ export function registerConsiliumReviewRoutes(app: Express, deps: CreateConsiliu
           createdBy: req.user.id,
           maxRounds: body.maxRounds,
           baselineCommit: body.baselineCommit,
+          ref: body.ref,
         });
         return res.status(201).json(loop);
       } catch (err) {
@@ -58,6 +65,12 @@ export function registerConsiliumReviewRoutes(app: Express, deps: CreateConsiliu
         // an opaque "invalid" (the path is the user's own input, not an fs leak).
         if (/baselineCommit/i.test(message)) {
           return res.status(400).json({ error: "baselineCommit must be a 7–64 char hex commit SHA" });
+        }
+        // The factory STRICT-validates the optional branch/ref (ref-validator.ts)
+        // and throws INVALID_REF_MESSAGE on a bad one — surface a clear 400 (the
+        // zod gate above already rejects most, this covers defense-in-depth).
+        if (message.includes(INVALID_REF_MESSAGE)) {
+          return res.status(400).json({ error: `${INVALID_REF_MESSAGE} (allowed: letters, digits, _ - / . ; no leading -, no "..", max 255).` });
         }
         // MED-3: the factory applies TWO boundaries — the GLOBAL allowlist (S1)
         // and a per-project WORKSPACE confinement (S5). Distinguish them so the

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -649,6 +649,9 @@ export class ConsiliumLoopController {
     const ctx = await buildDiffContext({
       repoPath: loop.repoPath,
       baselineCommit: loop.lastReviewedCommit,
+      // BRANCH-targeted review: resolve the loop's chosen ref as the HEAD side
+      // (diff baseline..<ref>); null ⇒ working-tree HEAD (back-compat).
+      ref: loop.reviewRef,
       objective,
       allowedRepoPaths: cfg.allowedRepoPaths,
       maxDiffBytes: cfg.maxDiffBytes,
@@ -813,6 +816,8 @@ export class ConsiliumLoopController {
     const ctx = await buildDiffContext({
       repoPath: loop.repoPath,
       baselineCommit: null,
+      // Record the chosen ref's tip as the head sha (null ⇒ working-tree HEAD).
+      ref: loop.reviewRef,
       objective: "",
       allowedRepoPaths: cfg.allowedRepoPaths,
       maxDiffBytes: cfg.maxDiffBytes,

--- a/server/services/consilium/diff-context.ts
+++ b/server/services/consilium/diff-context.ts
@@ -33,6 +33,7 @@ import simpleGit from "simple-git";
 import type { GitErrorKind, GitFail } from "../../config-sync/git-wrapper.js";
 import { assertAllowedRepoPath } from "./repo-allowlist.js";
 import { redactSecrets } from "./diff-redactor.js";
+import { validateReviewRef } from "./ref-validator.js";
 
 /** Minimal git surface the builder needs — lets unit tests inject a fake. */
 export interface GitDiffClient {
@@ -45,6 +46,16 @@ export interface DiffContextRequest {
   repoPath: string;
   /** <last-reviewed> commit; null ⇒ first round (objective only, no diff). */
   baselineCommit: string | null;
+  /**
+   * BRANCH-targeted review: the ref (branch name / revision) to resolve as the
+   * HEAD side of the review. Defaults to "HEAD" (working-tree HEAD) for full
+   * back-compat when null/undefined. SECURITY: fed to `revparse` ONLY as an
+   * arg-array element and pinned behind `--end-of-options`, so an option-looking
+   * or leading-dash ref can never be parsed as a git flag; for `diff-pr-review`
+   * the resolved tip becomes the HEAD side of `baseline..<ref>`. The caller
+   * (review-factory) has already strict-validated it (see ref-validator.ts).
+   */
+  ref?: string | null;
   /** Standing design-idea / group.input header. */
   objective: string;
   /** Allowlist roots from config.consiliumLoop.allowedRepoPaths. */
@@ -119,10 +130,16 @@ async function resolveCommit(git: GitDiffClient, ref: string): Promise<string | 
   }
 }
 
-/** B-1: resolve HEAD to a concrete sha (server-derived, still pinned/validated). */
-async function resolveHead(git: GitDiffClient): Promise<string | GitFail> {
+/**
+ * B-1: resolve the review HEAD to a concrete sha (server-derived, still
+ * pinned/validated). `ref` defaults to "HEAD" (working-tree HEAD); a
+ * BRANCH-targeted review passes the loop's `reviewRef` so the resolved tip is the
+ * chosen branch's, WITHOUT any checkout. `--end-of-options` precedes the ref so a
+ * leading-dash/option-looking ref can never be parsed as a git flag.
+ */
+async function resolveHead(git: GitDiffClient, ref: string): Promise<string | GitFail> {
   try {
-    const head = (await git.revparse(["--verify", "--end-of-options", "HEAD^{commit}"])).trim();
+    const head = (await git.revparse(["--verify", "--end-of-options", `${ref}^{commit}`])).trim();
     if (!SHA_RE.test(head)) return fail("unknown", "resolved HEAD is not a valid sha");
     return head;
   } catch (err) {
@@ -143,6 +160,22 @@ interface DiffParts {
  * (the security guarantee). The body is redacted of secrets and clipped to
  * maxDiffBytes. Never logs the body.
  */
+/**
+ * MED-1: parse the `git diff --stat` SUMMARY line ("... N insertion(s)(+), M
+ * deletion(s)(-)") into a changed-line count WITHOUT buffering the diff body.
+ * `--stat` output is bounded (one row per file + a summary), so reading it is
+ * always safe. Used as a cheap pre-gate so a pathologically large diff is never
+ * buffered into a string before the byte clamp. Unparseable input ⇒ 0 (do not
+ * block — the post-read byte clamp still applies).
+ */
+function statChangedLines(stat: string): number {
+  const ins = /(\d+)\s+insertion/.exec(stat);
+  const del = /(\d+)\s+deletion/.exec(stat);
+  const i = ins ? Number.parseInt(ins[1], 10) : 0;
+  const d = del ? Number.parseInt(del[1], 10) : 0;
+  return (Number.isFinite(i) ? i : 0) + (Number.isFinite(d) ? d : 0);
+}
+
 async function collectDiff(
   git: GitDiffClient,
   baseline: string,
@@ -151,7 +184,26 @@ async function collectDiff(
 ): Promise<DiffParts | GitFail> {
   const range = `${baseline}..${head}`;
   try {
+    // `--stat` first: its output is bounded regardless of diff size, so it is
+    // safe to buffer and doubles as a magnitude pre-check (MED-1).
     const stat = await git.diff(["--stat", "--end-of-options", range]);
+    // MED-1 (memory DoS): if the change spans a pathologically large number of
+    // lines, DO NOT buffer the full body — emit stat-only with a truncation note
+    // so a hostile commit can't OOM the process before the clamp below. The
+    // budget is deliberately generous (≥ maxDiffBytes lines, floor 50k) so it
+    // NEVER trips for a normal diff; behaviour is identical for those.
+    //
+    // Residual (documented): a single file whose change is one enormous line
+    // counts as ~1 changed line here, so the byte clamp after the read is its
+    // only bound. That residual is the SAME trust boundary as the spec-blob DoS
+    // (MED-1, review-factory): the diff range is two SERVER-resolved commits
+    // (strict-hex baseline + validated reviewRef) inside an allowlisted repo, so
+    // the only way to reach it is a hostile committed blob — git ≥2.24 streams
+    // `--stat`/`diff` and simple-git exposes no per-call byte cap on `diff`.
+    const lineBudget = Math.max(50_000, maxDiffBytes);
+    if (statChangedLines(stat) > lineBudget) {
+      return { stat: redactSecrets(stat).trim(), body: "", truncated: true };
+    }
     const rawBody = await git.diff(["--end-of-options", range]);
     const redacted = redactSecrets(rawBody);
     const truncated = Buffer.byteLength(redacted, "utf8") > maxDiffBytes;
@@ -181,7 +233,15 @@ function assembleInput(
   let truncated = parts?.truncated ?? false;
   if (parts) {
     const note = parts.truncated ? "\n\n_(diff truncated to the configured byte limit)_" : "";
-    const changes = parts.body.length > 0 ? `${parts.stat}\n\n\`\`\`diff\n${parts.body}\n\`\`\`${note}` : "_No changes since last review._";
+    // MED-1: collectDiff returns an empty body WITH truncated=true when it refused
+    // to buffer a pathologically large diff. Surface the (bounded) --stat summary
+    // plus an explicit omission note rather than the misleading "No changes".
+    const changes =
+      parts.body.length > 0
+        ? `${parts.stat}\n\n\`\`\`diff\n${parts.body}\n\`\`\`${note}`
+        : parts.truncated
+          ? `${parts.stat}\n\n_(diff omitted — too large to embed; see the stat above)_`
+          : "_No changes since last review._";
     sections.push(`## Changes since last review\n\n${changes}`);
   }
   if (testSummary && testSummary.trim().length > 0) {
@@ -235,7 +295,23 @@ export async function buildDiffContext(
 
   const git: GitDiffClient = req.gitClient ?? simpleGit(resolvedRepo);
 
-  const head = await resolveHead(git);
+  // LOW-1 (defense-in-depth): reviewRef is write-once and strict-validated at the
+  // factory boundary, but on later rounds the controller reads it back from the DB
+  // and threads it here. Re-validate it ourselves before it touches git — an
+  // invalid stored ref fails the round CLEANLY (in-band GitFail → the loop's
+  // existing error path) instead of being passed to git. The ref is scrubbed from
+  // the message so attacker-influenced input is never echoed into logs.
+  if (req.ref != null) {
+    try {
+      validateReviewRef(req.ref);
+    } catch {
+      return fail("unknown", "stored review ref failed re-validation");
+    }
+  }
+
+  // BRANCH-targeted review: resolve the chosen ref's tip (loop.reviewRef) as the
+  // HEAD side; null/undefined ⇒ working-tree "HEAD" (full back-compat).
+  const head = await resolveHead(git, req.ref ?? "HEAD");
   if (typeof head !== "string") return head;
 
   if (req.baselineCommit === null) {

--- a/server/services/consilium/ref-validator.ts
+++ b/server/services/consilium/ref-validator.ts
@@ -1,0 +1,59 @@
+/**
+ * ref-validator.ts — strict branch/revision name validation for BRANCH-targeted
+ * consilium reviews.
+ *
+ * A review may optionally target an arbitrary git ref (a branch name like
+ * `feature/x`, a tag, or any revision). That ref flows to git ONLY as an
+ * arg-array element (never a shell string, never a branch/PR title) and is
+ * always pinned behind `--end-of-options` at the git call sites, but it is still
+ * attacker-influenced caller input, so it is gated by a STRICT allowlist HERE,
+ * at the factory boundary, BEFORE it ever reaches git. Defense in depth: even if
+ * a malformed ref slipped past, `--end-of-options` would stop it being parsed as
+ * a flag — but we reject it up front and never persist it.
+ *
+ * SECURITY (flagged for the adversarial reviewer):
+ *   - Allowed chars ONLY: letters, digits, `_`, `-`, `/`, `.`. Everything else
+ *     (whitespace, `;`, `|`, `&`, `$`, backticks, `(`, `)`, `<`, `>`, `'`, `"`,
+ *     `\`, `@`, `{`, `}`, `:`, `~`, `^`, …) is rejected — so shell metachars,
+ *     git range/peel syntax (`:`/`~`/`^`/`@{`), and option-injection payloads
+ *     can never appear in a ref.
+ *   - Leading `-` is rejected (flag/option injection, e.g. `-x` / `--upload-pack`).
+ *   - Leading `/` is rejected (absolute-path-shaped refs, e.g. `/etc/passwd`) — git
+ *     never names a ref with a leading slash; this just denies the misleading shape.
+ *   - `..` is rejected (git range syntax + path traversal).
+ *   - `@{` is rejected (reflog/upstream peel) — already covered because neither
+ *     `@` nor `{` is in the allowed set; the lookahead documents the intent.
+ *   - At least one alphanumeric is REQUIRED, so an all-dots/all-slashes ref
+ *     (`.`, `/`, `./.`) — which would resolve to nothing useful and only widens
+ *     the surface — is rejected.
+ *   - Length capped at 255; empty rejected (the `{1,255}` quantifier enforces both).
+ */
+
+/**
+ * The single canonical ref pattern, shared by the factory validator AND the HTTP
+ * endpoint's zod schema so they can NEVER drift:
+ *   `^(?!-)`            — must not start with `-` (flag injection)
+ *   `(?!/)`             — must not start with `/` (absolute-path-shaped ref)
+ *   `(?!.*\.\.)`        — must not contain `..` (range syntax / traversal)
+ *   `(?!.*@\{)`         — must not contain `@{` (redundant w/ charset; explicit)
+ *   `(?=.*[A-Za-z0-9])` — must contain ≥1 alphanumeric (reject all-dots/slashes)
+ *   `[A-Za-z0-9._/-]{1,255}$` — allowed chars only, 1..255 long (non-empty, capped)
+ */
+export const REVIEW_REF_RE =
+  /^(?!-)(?!\/)(?!.*\.\.)(?!.*@\{)(?=.*[A-Za-z0-9])[A-Za-z0-9._/-]{1,255}$/;
+
+/** Stable, user-facing rejection message (mirrored by the endpoint's 400). */
+export const INVALID_REF_MESSAGE = "ref is not a valid branch/revision name";
+
+/**
+ * Validate a caller-supplied branch/revision name. Returns the ref UNCHANGED on
+ * success (it is already in canonical, git-safe form); THROWS on any violation.
+ * The factory calls this at its boundary so an invalid ref becomes a 400 at the
+ * endpoint and is NEVER persisted as a loop's `reviewRef`.
+ */
+export function validateReviewRef(ref: unknown): string {
+  if (typeof ref !== "string" || !REVIEW_REF_RE.test(ref)) {
+    throw new Error(INVALID_REF_MESSAGE);
+  }
+  return ref;
+}

--- a/server/services/consilium/review-factory.ts
+++ b/server/services/consilium/review-factory.ts
@@ -52,6 +52,7 @@
  */
 import { readdirSync, readFileSync, statSync } from "fs";
 import { basename, join } from "path";
+import simpleGit from "simple-git";
 import type { IStorage } from "../../storage.js";
 import type { InsertConsiliumLoop, ConsiliumLoopRow } from "@shared/schema";
 import type { ConsiliumReviewPreset } from "@shared/types";
@@ -60,6 +61,7 @@ import type { ConsiliumLoopController } from "./consilium-loop-controller.js";
 import type { AppConfig } from "../../config/schema.js";
 import { assertAllowedRepoPath, isWithinRoot, realResolve } from "./repo-allowlist.js";
 import { JUDGE_CONVERGENCE_INSTRUCTIONS } from "../orchestrator/judge-prompt.js";
+import { validateReviewRef } from "./ref-validator.js";
 
 // ─── Bounds (Security S2) ───────────────────────────────────────────────────
 
@@ -382,6 +384,151 @@ function embedSpecSet(repoPath: string, budgetBytes: number): string {
   return header + body + note;
 }
 
+// ─── Spec-set embedding AT A GIT REF (BRANCH-targeted full-viability) ────────
+
+/**
+ * Minimal git surface the ref-targeted spec reader needs — lets unit tests inject
+ * a fake and assert that `git show <ref>:specs/...` / `git ls-tree <ref>` are
+ * used (NOT a filesystem read). `raw` runs git with an ARG ARRAY (no shell).
+ */
+export interface SpecGitClient {
+  raw(args: string[]): Promise<string>;
+}
+
+/** One `specs/*.md` blob at a ref: its repo-relative path + on-disk byte size. */
+interface SpecBlobAtRef {
+  path: string;
+  size: number;
+}
+
+/**
+ * List `specs/*.md` AT a git ref via `git ls-tree -r -l <ref> -- specs`, returning
+ * each blob's PATH **and on-disk byte SIZE**. The `-l` (long) format is what lets
+ * the caller budget-check a blob BEFORE reading it (FIX MED-1) so a multi-GB
+ * committed spec can never be buffered into memory. Row format:
+ *   `<mode> <type> <object> <size>\t<path>`  (size is `-` for non-blob entries).
+ * SECURITY: `--end-of-options` precedes the (already strict-validated) ref so it
+ * can never be parsed as a git option; `specs` is a fixed server-constant pathspec
+ * after `--`. Best-effort: any git error (no such ref, no specs tree) ⇒ empty list.
+ */
+async function listSpecFilesAtRef(git: SpecGitClient, ref: string): Promise<SpecBlobAtRef[]> {
+  let out: string;
+  try {
+    out = await git.raw(["ls-tree", "-r", "-l", "--end-of-options", ref, "--", "specs"]);
+  } catch {
+    return [];
+  }
+  const blobs: SpecBlobAtRef[] = [];
+  for (const line of out.split("\n")) {
+    const tab = line.indexOf("\t");
+    if (tab < 0) continue;
+    const meta = line.slice(0, tab).trim().split(/\s+/);
+    const path = line.slice(tab + 1).trim();
+    // Need "<mode> <type> <object> <size>"; only real blobs carry a numeric size
+    // (trees/gitlinks show `-` and are skipped).
+    if (meta.length < 4 || meta[1] !== "blob") continue;
+    if (path.length === 0 || !path.toLowerCase().endsWith(".md")) continue;
+    const size = Number.parseInt(meta[3], 10);
+    blobs.push({ path, size: Number.isFinite(size) ? size : Number.POSITIVE_INFINITY });
+  }
+  return blobs;
+}
+
+/**
+ * Read ONE spec blob AT a git ref via `git show <ref>:<path>` (NO checkout, no
+ * working-tree read). SECURITY: `--end-of-options` precedes the `<ref>:<path>`
+ * object spec; both `ref` (strict-validated) and `path` (server-listed from
+ * ls-tree, never caller text) are arg-array elements. Returns null on any error
+ * so one unreadable blob is skipped rather than failing the whole review.
+ */
+async function readSpecAtRef(git: SpecGitClient, ref: string, path: string): Promise<string | null> {
+  try {
+    return await git.raw(["show", "--end-of-options", `${ref}:${path}`]);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ref-targeted twin of `embedSpecSet`: read `specs/*.md` AT `ref` (via the git
+ * client, NOT the working tree) and concatenate up to `budgetBytes`, KEEPING the
+ * same byte-clamp + randomized/long backtick-fence wrapping (FIX MED-1) so an
+ * untrusted spec body cannot break out of its fence. index/readme/numbered specs
+ * sort first (mtime is unavailable at a ref, so we fall back to name order within
+ * a class — ls-tree order is already deterministic). Best-effort: a ref with no
+ * specs tree yields a short note and the review still runs on the objective.
+ */
+async function embedSpecSetAtRef(
+  git: SpecGitClient,
+  ref: string,
+  budgetBytes: number,
+): Promise<string> {
+  const blobs = await listSpecFilesAtRef(git, ref);
+  if (blobs.length === 0) {
+    return "\n\n## Spec set\n\n_No `*.md` specs found under `specs/` at the target ref; reviewing without an embedded spec set._";
+  }
+
+  const sorted = blobs
+    .map((b) => ({ path: b.path, name: basename(b.path), size: b.size, key: specSortKey(basename(b.path)) }))
+    .sort((a, b) => a.key - b.key || a.name.localeCompare(b.name));
+
+  const header = "\n\n## Spec set (embedded at the target ref, index-first)\n";
+  let body = "";
+  let used = Buffer.byteLength(header, "utf8");
+  let included = 0;
+  let truncated = false;
+
+  for (const { path, name, size } of sorted) {
+    // FIX MED-1 (memory DoS): we already have each blob's on-disk SIZE from
+    // `ls-tree -l`. If it cannot fit in the remaining budget, NEVER read it — a
+    // multi-GB committed `specs/*.md` blob would buffer entirely under `git show`
+    // and OOM the process before any clamp. Note the omission inline and keep
+    // scanning (a smaller later spec may still fit). Normal specs are far under
+    // the cap, so this gate is transparent for them.
+    const remaining = budgetBytes - used;
+    if (!Number.isFinite(size) || size > remaining) {
+      const omit = `\n### specs/${sanitizeLine(name, 200)}\n\n_[omitted: ${
+        Number.isFinite(size) ? size : "unknown"
+      } bytes over the remaining ${Math.max(0, remaining)}-byte budget]_\n`;
+      const omitBytes = Buffer.byteLength(omit, "utf8");
+      truncated = true;
+      if (used + omitBytes > budgetBytes) break; // no room even for the note
+      body += omit;
+      used += omitBytes;
+      continue;
+    }
+    const content = await readSpecAtRef(git, ref, path);
+    if (content === null) continue; // skip an unreadable blob
+    // FIX MED-1: fence the spec BODY in a strictly-longer backtick run so the
+    // untrusted spec markdown is treated as DATA and cannot inject instructions.
+    const fileFence = backtickFence(content);
+    const fileBlock = `\n### specs/${sanitizeLine(name, 200)}\n\n${fileFence}\n${content}\n${fileFence}\n`;
+    const blockBytes = Buffer.byteLength(fileBlock, "utf8");
+    if (used + blockBytes > budgetBytes) {
+      const remaining = budgetBytes - used - 64; // leave room for the note
+      if (remaining > 256) {
+        const headPart = `\n### specs/${sanitizeLine(name, 200)} (truncated)\n\n`;
+        const truncFence = backtickFence(content);
+        const fenceOverhead = Buffer.byteLength(`${truncFence}\n\n${truncFence}\n`, "utf8");
+        const room = remaining - Buffer.byteLength(headPart, "utf8") - fenceOverhead;
+        const clipped = clampUtf8(content, Math.max(0, room)).text;
+        body += headPart + truncFence + "\n" + clipped + "\n" + truncFence + "\n";
+        included += 1;
+      }
+      truncated = true;
+      break;
+    }
+    body += fileBlock;
+    used += blockBytes;
+    included += 1;
+  }
+
+  const note = truncated
+    ? `\n\n_(${included} of ${sorted.length} spec file(s) embedded at the target ref; remainder omitted to fit the ${budgetBytes}-byte input cap)_`
+    : `\n\n_(${included} of ${sorted.length} spec file(s) embedded at the target ref)_`;
+  return header + body + note;
+}
+
 // ─── Objective composition (per preset) ─────────────────────────────────────
 
 const SDLC_HEADER =
@@ -434,6 +581,36 @@ export function composeObjective(
   return clampUtf8(objective, INPUT_CAP_BYTES).text;
 }
 
+/**
+ * BRANCH-targeted twin of `composeObjective`: identical to it for every preset
+ * EXCEPT `full-viability`, which embeds `specs/*.md` read AT `ref` (via the git
+ * client, NOT the working tree) so picking branch X reviews X's specs even while
+ * the checkout sits on another branch. The same input-cap budgeting + final byte
+ * clamp apply. `ref` is the ALREADY-validated reviewRef.
+ */
+export async function composeObjectiveAtRef(
+  preset: ConsiliumReviewPreset,
+  repoPath: string,
+  objectiveExtra: string | undefined,
+  ref: string,
+  git: SpecGitClient,
+): Promise<string> {
+  const extraBlock = untrustedExtraBlock(objectiveExtra);
+
+  let objective: string;
+  if (preset === "full-viability") {
+    const fixedBytes = Buffer.byteLength(FULL_VIABILITY_HEADER + extraBlock, "utf8");
+    const specBudget = Math.max(0, INPUT_CAP_BYTES - fixedBytes);
+    objective = FULL_VIABILITY_HEADER + (await embedSpecSetAtRef(git, ref, specBudget)) + extraBlock;
+  } else if (preset === "diff-pr-review") {
+    objective = DIFF_HEADER + extraBlock;
+  } else {
+    objective = SDLC_HEADER + extraBlock;
+  }
+
+  return clampUtf8(objective, INPUT_CAP_BYTES).text;
+}
+
 // ─── Factory ─────────────────────────────────────────────────────────────────
 
 export interface CreateConsiliumReviewDeps {
@@ -441,6 +618,13 @@ export interface CreateConsiliumReviewDeps {
   orchestrator: TaskOrchestrator;
   controller: ConsiliumLoopController;
   config: () => AppConfig;
+  /**
+   * Factory for the git client used to read specs AT a target ref (full-viability
+   * + a `ref`). Defaults to `simpleGit(repoPath)`; tests inject a fake to assert
+   * `git show <ref>:specs/...` is used (NOT a filesystem read). The repoPath is
+   * the already-allowlisted+workspace-gated canonical path.
+   */
+  gitClientFactory?: (repoPath: string) => SpecGitClient;
 }
 
 export interface CreateConsiliumReviewParams {
@@ -457,6 +641,13 @@ export interface CreateConsiliumReviewParams {
   baselineCommit?: string;
   /** UNTRUSTED extra context (e.g. a changed-file path or a diff). Clamped (S2). */
   objectiveExtra?: string;
+  /**
+   * BRANCH-targeted review: an optional git ref (branch name / revision) the
+   * review targets. STRICT-validated here (ref-validator.ts) before it reaches
+   * git; persisted as the loop's `reviewRef`. Absent/null ⇒ working-tree HEAD
+   * (full back-compat). SECURITY: only ever passed to git as an arg-array element.
+   */
+  ref?: string | null;
 }
 
 /** Clamp a caller-supplied round count into the schema's 1..6 window. */
@@ -548,7 +739,27 @@ export async function createConsiliumReview(
   if (!panel) throw new Error(`unknown consilium review preset: ${String(params.preset)}`);
 
   const baseline = resolveBaseline(params.preset, params.baselineCommit); // S3
-  const objective = composeObjective(params.preset, resolvedRepo, params.objectiveExtra); // S2
+
+  // BRANCH-targeted review (S6): STRICT-validate the optional ref at the factory
+  // boundary — an invalid ref THROWS here (→ 400 at the endpoint) and is NEVER
+  // persisted. null/undefined ⇒ working-tree HEAD (full back-compat). The ref
+  // reaches git ONLY as an arg-array element (diff-context HEAD resolution +
+  // embedSpecSetAtRef), always pinned behind `--end-of-options`.
+  const reviewRef =
+    params.ref === undefined || params.ref === null ? null : validateReviewRef(params.ref);
+
+  // S2: for full-viability WITH a ref, read specs AT THE REF via git (no working
+  // tree); otherwise the existing filesystem read. Other presets ignore the ref
+  // when composing (the diff side resolves it in diff-context).
+  const objective = reviewRef
+    ? await composeObjectiveAtRef(
+        params.preset,
+        resolvedRepo,
+        params.objectiveExtra,
+        reviewRef,
+        (deps.gitClientFactory ?? ((p: string) => simpleGit(p) as SpecGitClient))(resolvedRepo),
+      )
+    : composeObjective(params.preset, resolvedRepo, params.objectiveExtra);
   const tasks = buildCrossReviewTasks(panel);
 
   // 1) Cross-review task-group (the proven 5-task DAG for the 2-model panel).
@@ -568,6 +779,8 @@ export async function createConsiliumReview(
     maxRounds: clampRounds(params.maxRounds),
     devPipelineId: cfg.devPipelineId ?? null,
     lastReviewedCommit: baseline,
+    // BRANCH-targeted review: the chosen ref (null ⇒ working-tree HEAD).
+    reviewRef,
     createdBy: params.createdBy,
   } as InsertConsiliumLoop);
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1925,6 +1925,7 @@ export class MemStorage implements IStorage {
       maxRounds: data.maxRounds ?? 6,
       repoPath: data.repoPath,
       lastReviewedCommit: data.lastReviewedCommit ?? null,
+      reviewRef: data.reviewRef ?? null,
       currentIterationNumber: data.currentIterationNumber ?? null,
       devPipelineId: data.devPipelineId ?? null,
       devGroupId: data.devGroupId ?? null,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -2736,6 +2736,10 @@ export const consiliumLoops = pgTable(
     repoPath: text("repo_path").notNull(),
     // Diff baseline; null on round 1 (objective-only, no diff).
     lastReviewedCommit: text("last_reviewed_commit"),
+    // BRANCH-targeted review: an optional git ref (branch name / revision) whose
+    // tip + tree this review targets (content read AT THAT REF, no checkout).
+    // null ⇒ working-tree HEAD (existing behavior; full back-compat).
+    reviewRef: text("review_ref"),
     currentIterationNumber: integer("current_iteration_number"),
     devPipelineId: varchar("dev_pipeline_id"),
     devGroupId: varchar("dev_group_id"),

--- a/tests/unit/consilium/consilium-reviews-route.test.ts
+++ b/tests/unit/consilium/consilium-reviews-route.test.ts
@@ -89,3 +89,36 @@ describe("POST /api/consilium-reviews — distinct 400s for the two confinement 
     expect(res.body.id).toBe("loop-1");
   });
 });
+
+
+describe("POST /api/consilium-reviews — BRANCH-targeted ref wiring", () => {
+  beforeEach(() => mockedCreate.mockReset());
+
+  it("passes a VALID ref through to the factory and returns 201", async () => {
+    mockedCreate.mockResolvedValueOnce({ id: "loop-ref", status: "PENDING" } as never);
+    const res = await request(makeApp())
+      .post("/api/consilium-reviews")
+      .send({ ...VALID_BODY, ref: "feature/x" });
+    expect(res.status).toBe(201);
+    expect(mockedCreate).toHaveBeenCalledTimes(1);
+    expect(mockedCreate.mock.calls[0][1]).toMatchObject({ ref: "feature/x" });
+  });
+
+  it("REJECTS a bad ref with 400 BEFORE the factory is ever called (zod gate)", async () => {
+    for (const bad of ["-x", "a..b", "x@{1}", "main; rm -rf /", "a".repeat(256), ""]) {
+      mockedCreate.mockClear();
+      const res = await request(makeApp())
+        .post("/api/consilium-reviews")
+        .send({ ...VALID_BODY, ref: bad });
+      expect(res.status).toBe(400);
+      expect(mockedCreate).not.toHaveBeenCalled();
+    }
+  });
+
+  it("absent ref is back-compat (factory called with ref === undefined)", async () => {
+    mockedCreate.mockResolvedValueOnce({ id: "loop-1", status: "PENDING" } as never);
+    const res = await request(makeApp()).post("/api/consilium-reviews").send(VALID_BODY);
+    expect(res.status).toBe(201);
+    expect((mockedCreate.mock.calls[0][1] as { ref?: string }).ref).toBeUndefined();
+  });
+});

--- a/tests/unit/consilium/diff-context.test.ts
+++ b/tests/unit/consilium/diff-context.test.ts
@@ -204,3 +204,110 @@ describe("buildDiffContext — input bounds (testSummary + objective)", () => {
     expect(res.input).toContain("## Changes since last review");
   });
 });
+
+
+describe("buildDiffContext — BRANCH-targeted ref resolves as the HEAD side", () => {
+  const REF_SHA = "c".repeat(40);
+
+  function refGit(): GitDiffClient {
+    return {
+      revparse: vi.fn(async (args: string[]) => {
+        const ref = args[args.length - 1];
+        if (ref === "feature/x^{commit}") return REF_SHA + "\n";
+        if (ref === "HEAD^{commit}") return HEAD_SHA + "\n";
+        if (ref.startsWith("b".repeat(7))) return BASE_SHA + "\n";
+        return ref.replace(/\^\{commit\}$/, "") + "\n";
+      }),
+      diff: vi.fn(async (args: string[]) =>
+        args.includes("--stat") ? "stat" : "diff --git a/f b/f\n+x",
+      ),
+    };
+  }
+
+  it("resolves loop.reviewRef as HEAD: records its sha and diffs baseline..<ref>", async () => {
+    const git = refGit();
+    const res = await buildDiffContext({
+      repoPath: REPO,
+      baselineCommit: BASE_SHA,
+      ref: "feature/x",
+      objective: "O",
+      allowedRepoPaths: ALLOW,
+      maxDiffBytes: 10_000,
+      gitClient: git,
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    // The recorded head sha is the REF's tip, not the working-tree HEAD.
+    expect(res.headCommit).toBe(REF_SHA);
+    expect(res.headCommit).not.toBe(HEAD_SHA);
+    // The diff range pins the ref's resolved tip as the head side.
+    for (const [args] of (git.diff as ReturnType<typeof vi.fn>).mock.calls) {
+      expect(args).toContain(`${BASE_SHA}..${REF_SHA}`);
+    }
+    // SECURITY: the ref is verified via revparse, pinned behind --end-of-options.
+    expect(git.revparse).toHaveBeenCalledWith(["--verify", "--end-of-options", "feature/x^{commit}"]);
+  });
+
+  it("ref absent ⇒ resolves the working-tree HEAD (full back-compat)", async () => {
+    const res = await buildDiffContext({
+      repoPath: REPO,
+      baselineCommit: null,
+      objective: "O",
+      allowedRepoPaths: ALLOW,
+      maxDiffBytes: 1000,
+      gitClient: refGit(),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.headCommit).toBe(HEAD_SHA);
+  });
+});
+
+describe("buildDiffContext — MED-1 oversized diff is never buffered", () => {
+  it("refuses to read the body when --stat reports a pathologically large change", async () => {
+    const git = fakeGit({
+      diff: vi.fn(async (args: string[]) => {
+        if (args.includes("--stat"))
+          return " f | 9999999 +++\n 1 file changed, 9000000 insertions(+), 1000000 deletions(-)";
+        throw new Error("MUST NOT buffer the full diff body for an oversized change");
+      }),
+    });
+    const res = await buildDiffContext({ repoPath: REPO, baselineCommit: BASE_SHA, objective: "Obj", allowedRepoPaths: ALLOW, maxDiffBytes: 1000, gitClient: git });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.truncated).toBe(true);
+    // Only the bounded --stat call happened; the full-body read was skipped.
+    const bodyReads = (git.diff as ReturnType<typeof vi.fn>).mock.calls.filter(([a]: [string[]]) => !a.includes("--stat"));
+    expect(bodyReads).toHaveLength(0);
+    expect(res.input).not.toContain("```diff");
+    expect(res.input).toContain("diff omitted");
+    expect(res.input).toContain("9000000 insertions");
+  });
+
+  it("a normal-sized diff is read and embedded unchanged (gate is transparent)", async () => {
+    const git = fakeGit();
+    const res = await buildDiffContext({ repoPath: REPO, baselineCommit: BASE_SHA, objective: "Obj", allowedRepoPaths: ALLOW, maxDiffBytes: 10_000, gitClient: git });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.input).toContain("```diff");
+    expect(res.input).toContain("added line");
+    expect(res.truncated).toBe(false);
+  });
+});
+
+describe("buildDiffContext — LOW-1 re-validates the stored reviewRef", () => {
+  it("an INVALID stored ref fails the round cleanly and NEVER reaches git", async () => {
+    const git = fakeGit();
+    const res = await buildDiffContext({ repoPath: REPO, baselineCommit: BASE_SHA, objective: "O", allowedRepoPaths: ALLOW, maxDiffBytes: 1000, ref: "-x", gitClient: git });
+    expect(res.ok).toBe(false);
+    expect(git.revparse).not.toHaveBeenCalled();
+    expect(git.diff).not.toHaveBeenCalled();
+  });
+
+  it("a VALID stored ref passes re-validation and reaches git", async () => {
+    const git = fakeGit({ revparse: vi.fn(async () => HEAD_SHA + "\n") });
+    const res = await buildDiffContext({ repoPath: REPO, baselineCommit: BASE_SHA, objective: "O", allowedRepoPaths: ALLOW, maxDiffBytes: 10_000, ref: "feature/x", gitClient: git });
+    expect(res.ok).toBe(true);
+    expect(git.revparse).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/consilium/ref-validator.test.ts
+++ b/tests/unit/consilium/ref-validator.test.ts
@@ -1,0 +1,104 @@
+/**
+ * ref-validator.test.ts — the strict branch/revision validator that gates a
+ * BRANCH-targeted consilium review's `ref` BEFORE it reaches git
+ * (server/services/consilium/ref-validator.ts).
+ *
+ * SECURITY: this is the boundary the adversarial reviewer cares about — the ref
+ * eventually reaches git (diff-context HEAD resolution + embedSpecSetAtRef) as an
+ * arg-array element. These cases prove option-injection (`-x`), range/peel
+ * syntax (`a..b`, `x@{1}`, `HEAD~1`, `ref:path`), shell metachars, empty, and
+ * overlong refs are all REJECTED, while ordinary branch names are accepted.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  validateReviewRef,
+  REVIEW_REF_RE,
+  INVALID_REF_MESSAGE,
+} from "../../../server/services/consilium/ref-validator.js";
+
+describe("validateReviewRef — accepts ordinary branch/revision names", () => {
+  const valid = [
+    "feature/x",
+    "main",
+    "develop",
+    "release/1.2.3",
+    "feat_foo-bar",
+    "users/jane/topic",
+    "v1.0.0",
+    "a",
+    "a".repeat(255), // exactly the cap
+    "renovate/lock-file-maintenance",
+    "0123456789abcdef0123456789abcdef01234567", // a full sha is also a valid rev
+  ];
+  for (const ref of valid) {
+    it(`accepts ${JSON.stringify(ref.length > 24 ? ref.slice(0, 12) + "…" : ref)}`, () => {
+      expect(validateReviewRef(ref)).toBe(ref);
+      expect(REVIEW_REF_RE.test(ref)).toBe(true);
+    });
+  }
+});
+
+describe("validateReviewRef — rejects unsafe / malformed refs (SECURITY)", () => {
+  const bad: Record<string, string> = {
+    "leading dash (flag injection)": "-x",
+    "leading double-dash (long flag)": "--upload-pack=evil",
+    "double-dot range syntax": "a..b",
+    "reflog/upstream peel @{": "x@{1}",
+    "tilde rev navigation": "HEAD~1",
+    "caret rev navigation": "HEAD^2",
+    "colon path peel": "ref:path/to/file",
+    "empty string": "",
+    "overlong (256)": "a".repeat(256),
+    "shell: semicolon + rm": "main; rm -rf /",
+    "shell: command substitution": "$(whoami)",
+    "shell: backticks": "`id`",
+    "shell: pipe": "a|b",
+    "shell: ampersand": "a&b",
+    "shell: redirect": "a>b",
+    "embedded space": "feature x",
+    "embedded newline": "a\nb",
+    "embedded tab": "a\tb",
+    "null byte": "a\u0000b",
+    "at-brace upstream": "@{upstream}",
+    "glob star": "feat/*",
+    "backslash": "a\\b",
+    "quote": "a'b",
+    // LOW-2: tightened — absolute-path-shaped + all-dots/slashes refs now rejected.
+    "leading slash (absolute path)": "/etc/passwd",
+    "leading slash bare": "/foo",
+    "single dot (no alnum)": ".",
+    "bare slash (no alnum)": "/",
+    "all dots/slashes (no alnum)": "./.",
+    "underscore only (no alnum)": "_",
+    "dash-slash (no alnum, leading dash)": "-/-",
+  };
+  for (const [name, ref] of Object.entries(bad)) {
+    it(`rejects ${name}`, () => {
+      expect(() => validateReviewRef(ref)).toThrow(INVALID_REF_MESSAGE);
+      expect(REVIEW_REF_RE.test(ref)).toBe(false);
+    });
+  }
+
+  it("rejects a non-string input", () => {
+    expect(() => validateReviewRef(undefined)).toThrow(INVALID_REF_MESSAGE);
+    expect(() => validateReviewRef(null)).toThrow(INVALID_REF_MESSAGE);
+    expect(() => validateReviewRef(123 as unknown)).toThrow(INVALID_REF_MESSAGE);
+  });
+
+  it("LOW-2: leading-slash & all-dot/slash refs rejected, ordinary nested refs still accepted", () => {
+    // newly rejected
+    for (const bad of ["/etc/passwd", "/foo", ".", "/", "./.", "_"]) {
+      expect(REVIEW_REF_RE.test(bad)).toBe(false);
+    }
+    // still accepted (regression guard)
+    for (const ok of ["feature/x", "release/1.2.3", "main"]) {
+      expect(REVIEW_REF_RE.test(ok)).toBe(true);
+      expect(validateReviewRef(ok)).toBe(ok);
+    }
+  });
+
+  it("the 255-char cap is exact (255 ok, 256 rejected)", () => {
+    expect(REVIEW_REF_RE.test("a".repeat(255))).toBe(true);
+    expect(REVIEW_REF_RE.test("a".repeat(256))).toBe(false);
+  });
+});

--- a/tests/unit/consilium/review-factory.test.ts
+++ b/tests/unit/consilium/review-factory.test.ts
@@ -21,10 +21,12 @@ import os from "os";
 import {
   buildCrossReviewTasks,
   composeObjective,
+  composeObjectiveAtRef,
   createConsiliumReview,
   PRESET_PANELS,
   DEFAULT_REVIEW_MAX_ROUNDS,
   type CreateConsiliumReviewDeps,
+  type SpecGitClient,
 } from "../../../server/services/consilium/review-factory.js";
 
 // ─── 1. The 5-task DAG ────────────────────────────────────────────────────────
@@ -415,5 +417,191 @@ describe("createConsiliumReview — allowlist gate, baseline threading, rounds",
     expect(createLoop).toHaveBeenCalledTimes(2);
     // The factory deps don't even expose getLoops — proof the factory does no dedup read.
     expect((deps.storage as unknown as Record<string, unknown>).getLoops).toBeUndefined();
+  });
+});
+
+
+// ─── BRANCH-targeted reviews: ref validation, persistence, read-AT-the-ref ────
+
+describe("composeObjectiveAtRef — reads specs AT the git ref, NOT the working tree", () => {
+  let repo: string;
+
+  beforeEach(async () => {
+    repo = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "consilium-atref-")));
+    await fs.mkdir(path.join(repo, "specs"), { recursive: true });
+    // WORKING-TREE (on-disk) content that MUST NOT appear when targeting a ref —
+    // proof the ref path reads git, not the filesystem.
+    await fs.writeFile(path.join(repo, "specs", "00-overview.md"), "# Overview\nFS-WORKING-TREE content");
+  });
+  afterEach(async () => {
+    await fs.rm(repo, { recursive: true, force: true });
+  });
+
+  function gitMock(): { client: SpecGitClient; raw: ReturnType<typeof vi.fn> } {
+    const raw = vi.fn(async (args: string[]) => {
+      if (args[0] === "ls-tree")
+        return "100644 blob aaaaaaa     218\tspecs/00-overview.md\n100644 blob bbbbbbb     256\tspecs/01-data.md\n";
+      if (args[0] === "show") {
+        const obj = args[args.length - 1];
+        if (obj === "feature/x:specs/00-overview.md") return "# Overview\nAT-REF branch content";
+        if (obj === "feature/x:specs/01-data.md") return "# Data\nAT-REF data model";
+        throw new Error("unknown object " + obj);
+      }
+      throw new Error("unexpected git call: " + args.join(" "));
+    });
+    return { client: { raw }, raw };
+  }
+
+  it("embeds the REF's spec bodies (never the working-tree copy) via ls-tree + show <ref>:path", async () => {
+    const { client, raw } = gitMock();
+    const obj = await composeObjectiveAtRef("full-viability", repo, undefined, "feature/x", client);
+
+    expect(obj).toContain("AT-REF branch content");
+    expect(obj).toContain("AT-REF data model");
+    // Critically: the working-tree copy is NOT read.
+    expect(obj).not.toContain("FS-WORKING-TREE content");
+
+    // SECURITY: ls-tree -l (long: carries blob SIZE) at the ref with --end-of-options pinned BEFORE the ref.
+    expect(raw).toHaveBeenCalledWith(["ls-tree", "-r", "-l", "--end-of-options", "feature/x", "--", "specs"]);
+    // SECURITY: git show <ref>:<path> with --end-of-options pinned.
+    expect(raw).toHaveBeenCalledWith(["show", "--end-of-options", "feature/x:specs/00-overview.md"]);
+    expect(raw).toHaveBeenCalledWith(["show", "--end-of-options", "feature/x:specs/01-data.md"]);
+    expect(Buffer.byteLength(obj, "utf8")).toBeLessThanOrEqual(50_000);
+  });
+
+  it("non-full-viability presets do NOT touch git for spec embedding (diff header only)", async () => {
+    const { client, raw } = gitMock();
+    const obj = await composeObjectiveAtRef("diff-pr-review", repo, undefined, "feature/x", client);
+    expect(obj).toMatch(/Consilium diff \/ PR review/);
+    expect(raw).not.toHaveBeenCalled();
+  });
+
+  it("a ref with no specs tree degrades gracefully (best-effort note, no throw)", async () => {
+    const raw = vi.fn(async () => {
+      throw new Error("fatal: not a tree object");
+    });
+    const obj = await composeObjectiveAtRef("full-viability", repo, undefined, "feature/x", { raw });
+    expect(obj).toMatch(/at the target ref|Spec set/);
+  });
+
+  it("MED-1: a blob LARGER than the remaining budget is OMITTED without ever being READ (no git show)", async () => {
+    const HUGE = 9_000_000_000; // ~9 GB committed spec blob — reading it would OOM
+    const raw = vi.fn(async (args: string[]) => {
+      if (args[0] === "ls-tree") {
+        // 00 is pathologically large; 01 is a normal-sized spec.
+        return `100644 blob aaaaaaa ${HUGE}\tspecs/00-overview.md\n100644 blob bbbbbbb 200\tspecs/01-data.md\n`;
+      }
+      if (args[0] === "show") {
+        const obj = args[args.length - 1];
+        if (obj === "feature/x:specs/01-data.md") return "# Data\nsmall spec body";
+        // Reading the oversized blob is the bug we are preventing.
+        throw new Error("MUST NOT read oversized blob: " + obj);
+      }
+      throw new Error("unexpected git call: " + args.join(" "));
+    });
+
+    const obj = await composeObjectiveAtRef("full-viability", repo, undefined, "feature/x", { raw });
+
+    // The oversized blob was size-checked from `ls-tree -l` and NEVER read.
+    expect(raw).not.toHaveBeenCalledWith(["show", "--end-of-options", "feature/x:specs/00-overview.md"]);
+    // It is noted as omitted; the normal-sized blob is still embedded.
+    expect(obj).toContain("omitted");
+    expect(obj).toContain("small spec body");
+    // ls-tree used the -l (size) long format so the size was known BEFORE any show.
+    expect(raw).toHaveBeenCalledWith(["ls-tree", "-r", "-l", "--end-of-options", "feature/x", "--", "specs"]);
+    expect(Buffer.byteLength(obj, "utf8")).toBeLessThanOrEqual(50_000);
+  });
+
+  it("CONTRAST: composeObjective (no ref) reads the WORKING-TREE specs from fs", () => {
+    const obj = composeObjective("full-viability", repo, undefined);
+    expect(obj).toContain("FS-WORKING-TREE content");
+    expect(obj).not.toContain("AT-REF");
+  });
+});
+
+describe("createConsiliumReview — persists reviewRef + validates it at the boundary", () => {
+  let repo: string;
+
+  beforeEach(async () => {
+    repo = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "consilium-refloop-")));
+  });
+  afterEach(async () => {
+    await fs.rm(repo, { recursive: true, force: true });
+  });
+
+  function makeRefDeps(gitClientFactory?: (p: string) => SpecGitClient) {
+    const createTaskGroup = vi.fn().mockResolvedValue({ group: { id: "g1" }, tasks: [] });
+    const createLoop = vi
+      .fn()
+      .mockImplementation(async (row: Record<string, unknown>) => ({ id: "loop1", ...row }));
+    const start = vi.fn().mockResolvedValue(null);
+    const getWorkspaces = vi.fn().mockResolvedValue([{ id: "ws0", name: "ws0", path: repo }]);
+    const deps = {
+      storage: { createLoop, getWorkspaces },
+      orchestrator: { createTaskGroup },
+      controller: { start },
+      config: () => ({ pipeline: { consiliumLoop: { allowedRepoPaths: [repo], devPipelineId: undefined } } }),
+      ...(gitClientFactory ? { gitClientFactory } : {}),
+    } as unknown as CreateConsiliumReviewDeps;
+    return { deps, createTaskGroup, createLoop };
+  }
+
+  it("persists a VALID ref as the loop's reviewRef (sdlc preset → no git read)", async () => {
+    const { deps, createLoop } = makeRefDeps();
+    await createConsiliumReview(deps, {
+      projectId: "p1",
+      repoPath: repo,
+      preset: "sdlc-cross-review",
+      createdBy: "u1",
+      ref: "feature/x",
+    });
+    expect(createLoop.mock.calls[0][0].reviewRef).toBe("feature/x");
+  });
+
+  it("persists reviewRef = null when NO ref is supplied (full back-compat)", async () => {
+    const { deps, createLoop } = makeRefDeps();
+    await createConsiliumReview(deps, {
+      projectId: "p1",
+      repoPath: repo,
+      preset: "sdlc-cross-review",
+      createdBy: "u1",
+    });
+    expect(createLoop.mock.calls[0][0].reviewRef).toBeNull();
+  });
+
+  it("REJECTS an invalid ref at the factory boundary — nothing persisted", async () => {
+    const { deps, createTaskGroup, createLoop } = makeRefDeps();
+    await expect(
+      createConsiliumReview(deps, {
+        projectId: "p1",
+        repoPath: repo,
+        preset: "sdlc-cross-review",
+        createdBy: "u1",
+        ref: "-x",
+      }),
+    ).rejects.toThrow(/not a valid branch\/revision/i);
+    expect(createTaskGroup).not.toHaveBeenCalled();
+    expect(createLoop).not.toHaveBeenCalled();
+  });
+
+  it("full-viability + ref uses the injected git client to read specs AT the ref (NOT fs)", async () => {
+    // No specs/ on disk → an fs read would yield "no specs"; the git mock returns
+    // a tree + bodies, proving the git-AT-ref path is wired through the factory.
+    const raw = vi.fn(async (args: string[]) => {
+      if (args[0] === "ls-tree") return "100644 blob aaaaaaa     201\tspecs/00-overview.md\n";
+      if (args[0] === "show") return "# Overview\nAT-REF via factory";
+      throw new Error("unexpected git call");
+    });
+    const { deps, createTaskGroup } = makeRefDeps(() => ({ raw }));
+    await createConsiliumReview(deps, {
+      projectId: "p1",
+      repoPath: repo,
+      preset: "full-viability",
+      createdBy: "u1",
+      ref: "feature/x",
+    });
+    const objective = createTaskGroup.mock.calls[0][0].input as string;
+    expect(objective).toContain("AT-REF via factory");
+    expect(raw).toHaveBeenCalledWith(["show", "--end-of-options", "feature/x:specs/00-overview.md"]);
   });
 });


### PR DESCRIPTION
A consilium review may now target a chosen git **branch/revision**. The New-review dialog shows a **branch dropdown** populated live from `GET /api/workspaces/:id/branches` (default = the workspace branch); the choice is sent as an optional `ref`. The server reads the repo **at that ref via git object reads — no checkout**, no working-tree mutation, no concurrent-review conflicts. Absent `ref` = today's working-tree HEAD (full back-compat).

## Server
- **schema**: `consilium_loops.reviewRef` (nullable; migration `0030`, idempotent — applied to dev DB).
- **ref-validator**: `REVIEW_REF_RE` rejects leading `-`/`/` (flag & abs-path injection), `..`, `@{`, non-ref charset, empty/>255, and requires an alnum. Enforced at the HTTP zod gate **and** in the factory before any git call/persist; **re-validated** when the stored ref is read on later rounds (defense-in-depth).
- **read-at-ref**: `full-viability` embeds specs via `git ls-tree -l` + `show <ref>:<path>` (paths are **server-listed**, never caller text); `diff-pr-review` diffs `baseline..<ref>`; diff-context resolves head from `reviewRef ?? HEAD`. Every git site is an arg-array + `--end-of-options`.
- **DoS guard (MED-1)**: oversized spec blobs are skipped using the `ls-tree -l` size **before** `git show`; the diff body read is gated on the bounded `--stat` summary — neither can OOM before the 50 KB clamp. Untrusted content stays inside the long-backtick fence.

## Security (adversarial review → SAFE, no CRITICAL/HIGH)
The `git show <ref>:<path>` arbitrary-read was **empirically disproven**: a committed symlink to `/etc/passwd` yields only the target **string** (git reads blobs from the object DB, not the fs); `--end-of-options` everywhere blocks option injection; the repo stays allowlist + project-workspace gated (MED-3), and the ref only selects a commit within that confined repo. Fast-follow hardening (MED-1 blob guard, LOW-1 stored-ref re-validation, LOW-2 regex) already folded in.

## Verification
`tsc --noEmit` clean; `tests/unit/consilium` **231/231** (ref validation incl. abs-path/flag/`..`/`@{`; read-at-ref vs working-tree contrast; blob & diff size guards; stored-ref re-validation; endpoint ref gate). Migration applied + column confirmed.