### PR TITLE
feat(consilium): execute action points via SDLC → Draft PR (replaces pipeline handoff)

### DIFF
--- a/client/src/components/task-groups/verdict-panel.tsx
+++ b/client/src/components/task-groups/verdict-panel.tsx
@@ -7,23 +7,32 @@
  * finds that execution in the latest iteration and renders it as a real UI block
  * (verdict callout + pros/cons + an Action Points TABLE) instead of raw JSON.
  *
- * It also closes the loop: the action points can be HANDED OFF to a pipeline
- * (e.g. Full SDLC Pipeline) — one pipeline_run task per action point — which is
- * the "planning → execution" transition. Handing off is optional (the user
- * decides whether to send them on).
+ * It also closes the loop: the action points can be HANDED OFF directly to SDLC
+ * execution. One click runs the verdict's action points — each coded in an
+ * isolated worktree — and opens a single Draft PR. There is no pipeline and no
+ * re-review; this is the "planning → execution" transition. Handing off is
+ * optional (the user decides whether to send them on).
  *
  * SECURITY: all model-authored text is rendered as INERT React text.
  */
-import { useMemo, useState } from "react";
-import { useLocation } from "wouter";
+import { useEffect, useMemo, useState } from "react";
 import { useIterationDetail } from "@/hooks/use-task-iterations";
-import { usePipelines, apiRequest } from "@/hooks/use-pipeline";
+import { apiRequest } from "@/hooks/use-pipeline";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
 import { copyText } from "@/lib/clipboard";
-import { Gavel, Send, ThumbsUp, ThumbsDown, Loader2, Copy, Check } from "lucide-react";
+import {
+  Gavel,
+  GitPullRequest,
+  ThumbsUp,
+  ThumbsDown,
+  Loader2,
+  Copy,
+  Check,
+  ExternalLink,
+} from "lucide-react";
 import type { IterationExecution } from "@/lib/task-iterations";
 import type { ActionPoint } from "@shared/types";
 
@@ -122,6 +131,20 @@ function buildFullText(data: VerdictOutput, groupName: string, source: string): 
   return lines.join("\n");
 }
 
+/** SDLC hand-off lifecycle. Drives the primary action button + the PR callout. */
+type ExecState =
+  | { status: "idle" }
+  | { status: "starting" }
+  | { status: "running" }
+  | { status: "done"; prRef?: string }
+  | { status: "failed"; error?: string };
+
+interface SdlcStatusResponse {
+  status: "running" | "done" | "failed";
+  prRef?: string;
+  error?: string;
+}
+
 export function VerdictPanel({
   groupId,
   iterationNumber,
@@ -132,11 +155,8 @@ export function VerdictPanel({
   groupName: string;
 }) {
   const detail = useIterationDetail(groupId, iterationNumber);
-  const pipelinesQuery = usePipelines();
   const { toast } = useToast();
-  const [, navigate] = useLocation();
-  const [pipelineId, setPipelineId] = useState<string>("");
-  const [sending, setSending] = useState(false);
+  const [exec, setExec] = useState<ExecState>({ status: "idle" });
   const [copied, setCopied] = useState(false);
 
   const result = useMemo(
@@ -144,17 +164,60 @@ export function VerdictPanel({
     [detail.data],
   );
 
-  const pipelines = (pipelinesQuery.data ?? []) as Array<{ id: string; name: string }>;
-  const effectivePipelineId =
-    pipelineId ||
-    pipelines.find((p) => /full sdlc/i.test(p.name))?.id ||
-    pipelines[0]?.id ||
-    "";
+  // Poll the SDLC status while a hand-off is running. Re-runs whenever the
+  // lifecycle phase changes; only the "running" phase arms the 4s interval, so
+  // it self-stops on done/failed and tears down on unmount.
+  useEffect(() => {
+    if (exec.status !== "running") return;
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const s = (await apiRequest(
+          "GET",
+          `/api/task-groups/${groupId}/execute-sdlc/status`,
+        )) as SdlcStatusResponse;
+        if (cancelled) return;
+        if (s.status === "done") {
+          setExec({ status: "done", prRef: s.prRef });
+          toast({
+            title: "SDLC завершён",
+            description: s.prRef ? `Draft PR готов: ${s.prRef}` : "Draft PR готов.",
+          });
+        } else if (s.status === "failed") {
+          setExec({ status: "failed", error: s.error });
+          toast({
+            variant: "destructive",
+            title: "SDLC не удался",
+            description: s.error || "Исполнение завершилось ошибкой.",
+          });
+        }
+        // else: still running — keep polling.
+      } catch (err) {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setExec({ status: "failed", error: message });
+        toast({
+          variant: "destructive",
+          title: "SDLC не удался",
+          description: message,
+        });
+      }
+    };
+
+    void poll(); // immediate first check, then every ~4s
+    const id = window.setInterval(poll, 4000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [exec.status, groupId, toast]);
 
   if (!result) return null;
   const { data, source } = result;
   const actionPoints = data.action_points;
   const fullText = buildFullText(data, groupName, source);
+  const busy = exec.status === "starting" || exec.status === "running";
 
   async function copyFullText() {
     if (await copyText(fullText)) {
@@ -173,65 +236,29 @@ export function VerdictPanel({
     }
   }
 
-  async function sendToPipeline() {
-    if (!effectivePipelineId || actionPoints.length === 0) return;
-    setSending(true);
+  async function executeSdlc() {
+    if (actionPoints.length === 0 || busy) return;
+    setExec({ status: "starting" });
     try {
-      const pipeline = pipelines.find((p) => p.id === effectivePipelineId);
-      const payload = {
-        name: `Handoff: ${groupName} → ${pipeline?.name ?? "Pipeline"}`.slice(0, 200),
-        description:
-          `Action points из вердикта планирования переданы на исполнение в ${pipeline?.name ?? "pipeline"}.`.slice(
-            0,
-            5000,
-          ),
-        input: `Передача action points планирования (${groupName}) на исполнение.`.slice(0, 50000),
-        tasks: actionPoints.map((ap, i) => ({
-          name: `[${ap.priority ?? "-"}] ${ap.title}`.slice(0, 200),
-          description:
-            [ap.rationale, ap.tradeoff ? `Трейд-офф: ${ap.tradeoff}` : ""]
-              .filter(Boolean)
-              .join(" ")
-              .slice(0, 5000) || ap.title.slice(0, 5000),
-          executionMode: "pipeline_run" as const,
-          pipelineId: effectivePipelineId,
-          sortOrder: i,
-          input: {
-            feature: ap.title,
-            rationale: ap.rationale ?? "",
-            tradeoff: ap.tradeoff ?? "",
-            priority: ap.priority ?? "",
-            effort: ap.effort ?? "",
-            source: groupName,
-          },
-        })),
-      };
-      const created = (await apiRequest("POST", "/api/task-groups", payload)) as { id: string };
-      // #2b: AUTO-START the handoff so it runs immediately instead of sitting
-      // pending until the user opens the group and clicks Run. The group already
-      // exists; a failed start is non-fatal (it can be retried from the group
-      // page), so we surface a softer toast rather than failing the whole handoff.
-      let started = true;
-      try {
-        await apiRequest("POST", `/api/task-groups/${created.id}/start`, {});
-      } catch {
-        started = false;
-      }
+      // Empty body: the server reads the verdict's action_points and resolves
+      // the repo path itself (project-scoped via x-project-id). 202 = accepted,
+      // executor runs in the background → one Draft PR.
+      await apiRequest("POST", `/api/task-groups/${groupId}/execute-sdlc`, {});
+      setExec({ status: "running" });
       toast({
-        title: started ? "Передано и запущено" : "Передано на исполнение",
-        description: started
-          ? `${actionPoints.length} action points → ${pipeline?.name}. Исполнение запущено.`
-          : `${actionPoints.length} action points → ${pipeline?.name}. Откройте группу и нажмите Run.`,
+        title: "Передано в SDLC",
+        description: `${actionPoints.length} action points исполняются → Draft PR.`,
       });
-      navigate(`/task-groups/${created.id}`);
     } catch (err) {
+      // Covers the 400 contract (no action points / repo not allowlisted / not a
+      // workspace) AND the pre-backend 404 — server `error` text is surfaced verbatim.
+      const message = err instanceof Error ? err.message : String(err);
+      setExec({ status: "failed", error: message });
       toast({
         variant: "destructive",
-        title: "Не удалось передать",
-        description: err instanceof Error ? err.message : String(err),
+        title: "Не удалось передать в SDLC",
+        description: message,
       });
-    } finally {
-      setSending(false);
     }
   }
 
@@ -351,30 +378,54 @@ export function VerdictPanel({
         )}
 
         {actionPoints.length > 0 && (
-          <div className="flex flex-wrap items-center gap-2 border-t pt-4">
-            <span className="text-sm text-muted-foreground">
-              Фаза планирования завершена. Передать action points на исполнение:
-            </span>
-            <select
-              className="rounded-md border bg-background px-2 py-1.5 text-sm"
-              value={effectivePipelineId}
-              onChange={(e) => setPipelineId(e.target.value)}
-              aria-label="Pipeline"
-            >
-              {pipelines.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.name}
-                </option>
-              ))}
-            </select>
-            <Button size="sm" onClick={sendToPipeline} disabled={sending || !effectivePipelineId}>
-              {sending ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <Send className="mr-2 h-4 w-4" />
-              )}
-              Передать в пайплайн
-            </Button>
+          <div className="space-y-3 border-t pt-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm text-muted-foreground">
+                Фаза планирования завершена. Исполнить action points напрямую:
+              </span>
+              <Button
+                size="sm"
+                onClick={executeSdlc}
+                disabled={actionPoints.length === 0 || busy}
+              >
+                {busy ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <GitPullRequest className="mr-2 h-4 w-4" />
+                )}
+                {busy ? "SDLC идёт…" : "Передать в SDLC → Draft PR"}
+              </Button>
+            </div>
+
+            {exec.status === "done" && (
+              <div className="flex flex-wrap items-center gap-1.5 rounded-md border border-green-600/40 bg-green-600/5 p-3 text-sm">
+                <Check className="h-4 w-4 text-green-600" />
+                <span className="font-medium text-green-700 dark:text-green-400">Draft PR создан:</span>
+                {exec.prRef ? (
+                  /^https?:\/\//.test(exec.prRef) ? (
+                    <a
+                      href={exec.prRef}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 font-medium text-primary underline underline-offset-2"
+                    >
+                      {exec.prRef}
+                      <ExternalLink className="h-3.5 w-3.5" />
+                    </a>
+                  ) : (
+                    <span className="font-mono text-foreground">{exec.prRef}</span>
+                  )
+                ) : (
+                  <span className="text-muted-foreground">ссылка недоступна</span>
+                )}
+              </div>
+            )}
+
+            {exec.status === "failed" && exec.error && (
+              <div className="rounded-md border border-red-600/40 bg-red-600/5 p-3 text-sm text-red-700 dark:text-red-400">
+                {exec.error}
+              </div>
+            )}
           </div>
         )}
       </CardContent>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -59,6 +59,8 @@ import { registerTaskGroupRoutes } from "./routes/task-groups";
 import { registerTaskGroupResolveRoute } from "./routes/task-group-resolve";
 import { registerConsiliumLoopRoutes } from "./routes/consilium-loops";
 import { registerConsiliumReviewRoutes } from "./routes/consilium-reviews";
+import { registerExecuteSdlcRoutes } from "./routes/execute-sdlc";
+import { SdlcExecutionService } from "./services/consilium/execute-sdlc";
 import { createConsiliumReview } from "./services/consilium/review-factory";
 import { maybeLaunchConsiliumReview } from "./services/consilium/trigger-dispatch";
 import { ConsiliumLoopController, ConsiliumLoopPoller } from "./services/consilium/consilium-loop-controller";
@@ -324,6 +326,16 @@ export async function registerRoutes(
       controller: consiliumLoopController,
       config: () => appConfigLoader.get(),
     });
+    // POST /api/task-groups/:groupId/execute-sdlc (+ /status) — EXECUTE a
+    // consilium verdict's action_points directly via the SDLC executor (one
+    // isolated worktree + coder/commit per action point + ONE Draft PR). Same
+    // fail-closed allowlist + per-project workspace gate as the review path;
+    // action points are SERVER-READ from the verdict. Inert outside this block.
+    registerExecuteSdlcRoutes(
+      app,
+      storage,
+      new SdlcExecutionService({ storage, config: () => appConfigLoader.get() }),
+    );
     consiliumLoopPoller = new ConsiliumLoopPoller(
       consiliumLoopController,
       storage,

--- a/server/routes/execute-sdlc.ts
+++ b/server/routes/execute-sdlc.ts
@@ -1,0 +1,124 @@
+/**
+ * execute-sdlc.ts — POST /api/task-groups/:groupId/execute-sdlc
+ *                 + GET  /api/task-groups/:groupId/execute-sdlc/status
+ *
+ * The HTTP surface a maintainer's "Execute verdict" button calls: EXECUTE the
+ * group's latest consilium verdict's `action_points` directly via the SDLC
+ * executor (one isolated worktree, one coder run + commit per action point, ONE
+ * Draft PR), replacing the legacy "hand off to a pipeline" mechanism.
+ *
+ * Auth: mounted under `/api/task-groups` (requireAuth + requireProject in
+ * routes.ts), so the handler runs inside the request's project ALS. Every per-id
+ * route ALSO runs `authorizeTaskGroup` (owner-or-admin, closes the C1 IDOR) — this
+ * triggers REAL code execution + a Draft PR, so the caller MUST be able to see the
+ * group. Registered ONLY inside the consilium-loop kill-switch block (inert
+ * otherwise), exactly like POST /api/consilium-reviews.
+ *
+ * SECURITY: action points are SERVER-READ from the verdict (the body's are
+ * ignored — the zod schema only surfaces an optional repoPath). repoPath is
+ * allowlist + workspace gated inside the service. Draft-PR-only — agents never
+ * merge. See `server/services/consilium/execute-sdlc.ts` for the full surface.
+ */
+import type { Express, Request, Response } from "express";
+import { z } from "zod";
+import type { IStorage } from "../storage.js";
+import { validateBody } from "../middleware/validate.js";
+import { authorizeTaskGroup } from "./authorize-task-group.js";
+import { ExecuteSdlcError, type SdlcExecutionService } from "../services/consilium/execute-sdlc.js";
+
+/**
+ * Body schema: ONLY an optional repoPath fallback (used when the group has no
+ * consilium loop to source the repoPath from). zod `.object` STRIPS unknown keys,
+ * so a client-supplied `action_points` is silently dropped and NEVER read — the
+ * verdict is the only source of action points.
+ */
+const ExecuteSdlcSchema = z.object({
+  repoPath: z.string().min(1).max(4096).optional(),
+});
+
+export function registerExecuteSdlcRoutes(
+  app: Express,
+  storage: IStorage,
+  service: SdlcExecutionService,
+): void {
+  // POST /api/task-groups/:groupId/execute-sdlc — launch (or dedup) the run.
+  app.post(
+    "/api/task-groups/:groupId/execute-sdlc",
+    validateBody(ExecuteSdlcSchema),
+    async (req: Request, res: Response) => {
+      const groupId = String(req.params.groupId);
+      const authorized = await authorizeTaskGroup(req, res, storage, groupId);
+      if (!authorized) return; // 401/404/403 already written
+      const ownerId = req.user!.id;
+      const body = req.body as z.infer<typeof ExecuteSdlcSchema>;
+
+      try {
+        const handle = await service.execute(groupId, ownerId, body.repoPath);
+        // 202 Accepted — the coder runs in the background; poll the status route.
+        // An already-in-flight run returns its EXISTING handle (deduped:true).
+        return res.status(202).json(handle);
+      } catch (err) {
+        if (err instanceof ExecuteSdlcError) return mapExecuteError(res, groupId, body.repoPath, err);
+        return res.status(500).json({ error: "Failed to execute SDLC for this verdict" });
+      }
+    },
+  );
+
+  // GET /api/task-groups/:groupId/execute-sdlc/status — poll the run (every few s).
+  app.get(
+    "/api/task-groups/:groupId/execute-sdlc/status",
+    async (req: Request, res: Response) => {
+      const groupId = String(req.params.groupId);
+      const authorized = await authorizeTaskGroup(req, res, storage, groupId);
+      if (!authorized) return;
+
+      const status = service.getStatus(groupId);
+      if (!status) {
+        return res.status(404).json({ error: "no execute-sdlc run for this group" });
+      }
+      return res.status(200).json(status);
+    },
+  );
+}
+
+/**
+ * Map a typed {@link ExecuteSdlcError} to an ACTIONABLE 4xx (mirrors the
+ * POST /api/consilium-reviews mapping so the two surfaces agree on wording). The
+ * NO_REPO / REPO_NOT validation codes map to 400; the MED-1 global-cap code
+ * (`EXECUTOR_BUSY`) maps to 429 (transient — retry later). The repoPath is the
+ * user's own input, not an fs leak, so we name it.
+ */
+function mapExecuteError(
+  res: Response,
+  groupId: string,
+  repoPath: string | undefined,
+  err: ExecuteSdlcError,
+): Response {
+  switch (err.code) {
+    case "NO_ACTION_POINTS":
+      return res.status(400).json({
+        error: `no action points to execute: task group "${groupId}" has no consilium verdict with action points yet.`,
+      });
+    case "NO_REPO_PATH":
+      return res.status(400).json({
+        error:
+          "no repoPath: this task group has no consilium loop to source the repo from — supply a repoPath in the request body (it must be an allowed, project-workspace repo).",
+      });
+    case "REPO_NOT_WORKSPACE":
+      return res.status(400).json({
+        error: `repoPath "${repoPath ?? "(from loop)"}" is not registered as a workspace of the selected project — pick one of its workspaces or add it as a workspace.`,
+      });
+    case "REPO_NOT_ALLOWED":
+      return res.status(400).json({
+        error: `repoPath "${repoPath ?? "(from loop)"}" is not in the allowed repo paths. Add it to consiliumLoop.allowedRepoPaths in config.yaml (then restart), or pick an already-allowed workspace.`,
+      });
+    case "EXECUTOR_BUSY":
+      // MED-1: global concurrency cap reached — transient, so 429 + Retry-After.
+      res.setHeader("Retry-After", "30");
+      return res.status(429).json({
+        error: "SDLC executor busy — too many concurrent runs, retry shortly.",
+      });
+    default:
+      return res.status(400).json({ error: "execute-sdlc rejected" });
+  }
+}

--- a/server/services/consilium/execute-sdlc.ts
+++ b/server/services/consilium/execute-sdlc.ts
@@ -1,0 +1,489 @@
+/**
+ * execute-sdlc.ts — the SERVER path that EXECUTES a consilium verdict's
+ * `action_points` directly via the SDLC executor, replacing the legacy
+ * "hand off to a pipeline" mechanism.
+ *
+ * This is the consilium loop's DEVELOPING phase, now HUMAN-TRIGGERED by a button:
+ * read the group's latest-iteration Judge verdict, code EACH action point in an
+ * ISOLATED git worktree (one agentic `claude` coder run + one commit per action
+ * point), and open ONE Draft PR aggregating them. It reuses the EXACT same
+ * `runSdlcHandoff` executor the loop uses, so every SDLC security property is
+ * inherited unchanged (no Bash, sanitized env, untrusted action-point text only
+ * via stdin + clamped commit/PR body, arg-array git, Draft-PR-only — agents NEVER
+ * merge). See `server/services/sdlc/executor.ts`.
+ *
+ * SECURITY (the same surface as POST /api/consilium-reviews — get it right):
+ *   1. ACTION POINTS ARE SERVER-READ. They come ONLY from the group's latest
+ *      iteration's Judge `output` (`pickJudgeOutput` → `extractActionPoints`).
+ *      A client-supplied `action_points` is NEVER consulted (the route's zod
+ *      schema doesn't even surface it). No verdict / no action points ⇒ a clean
+ *      "no action points to execute" rejection — NOTHING runs.
+ *   2. repoPath IS ALLOWLIST + WORKSPACE GATED. The candidate (the consilium
+ *      loop's persisted `repoPath`, else an optional body `repoPath`) is run
+ *      through `assertAllowedRepoPath` (the fail-closed GLOBAL allowlist, S1) AND
+ *      THEN `assertRepoIsProjectWorkspace` (the per-project workspace confinement,
+ *      MED-3/S5) — a repo must pass BOTH. A stored loop.repoPath is RE-VALIDATED
+ *      here (never trust the row). On rejection NOTHING runs.
+ *   3. BRANCH SHAPE IS SERVER-DERIVED. A FRESH uuid (NOT the loop's id) + round 1
+ *      feeds `buildBranchName` so the executor's `consilium/loop-<uuid>/round-1`
+ *      branch can never collide with the loop's OWN developing-phase branches.
+ *      action-point text never touches the branch / PR title.
+ *   4. SINGLE-FLIGHT / DEDUP + GLOBAL CAP + ANTI-WEDGE.
+ *      - DEDUP (per-group): a process-local registry keyed by groupId is RESERVED
+ *        synchronously on entry; a concurrent second request for the SAME group
+ *        gets the EXISTING handle back instead of launching a second worktree on a
+ *        fresh branch (the #417 double-dispatch lesson). A validation failure frees
+ *        the slot so the user can retry after fixing the input.
+ *      - GLOBAL CAP (MED-1): per-group dedup did NOT bound a user who owns N verdict
+ *        groups from POSTing to ALL N → N concurrent coder subprocesses. A process
+ *        GLOBAL cap (`MAX_CONCURRENT_EXECUTE_SDLC`) refuses a NEW group's run beyond
+ *        the cap with a typed `EXECUTOR_BUSY` outcome (route → HTTP 429). The
+ *        cap-check + slot-reserve is ATOMIC (no await between). Dedup is NOT blocked
+ *        by the cap — an already-running group always gets its handle back.
+ *      - WATCHDOG + GC (MED-2): a run whose executor promise never settles past its
+ *        time budget would wedge the group at "running" forever (dedup keeps handing
+ *        the stuck handle back) until restart. A watchdog FORCE-settles such a run to
+ *        `failed` and frees its slot, so a fresh POST can relaunch. Settled rows are
+ *        GC'd after a retention window so the registry can't grow unbounded.
+ *   5. BACKGROUND RUN. The coder takes minutes; it runs fire-and-forget OFF the
+ *      request path (never blocks the HTTP response). The registry tracks
+ *      running→done/failed with { prRef, headCommit, error } for the status poll.
+ *
+ * NOTE on which action points run (FLAGGED for the adversarial reviewer): this
+ * executes the FULL `action_points` list from the verdict (ALL priorities), via
+ * `extractActionPoints`, NOT the loop's open-P0-only `readConvergence` narrowing.
+ * Rationale: a maintainer who clicks "execute this verdict" wants every flagged
+ * item implemented, and the task's "no action_points → 400" wording keys off the
+ * presence of action points, not of open P0s. The count is bounded
+ * (MAX_ACTION_POINTS = 50) + each field clamped in `extractActionPoints`.
+ */
+import { randomUUID } from "crypto";
+import type { IStorage } from "../../storage.js";
+import type { AppConfig } from "../../config/schema.js";
+import type { ActionPoint } from "@shared/types";
+import { runSdlcHandoff } from "../sdlc/executor.js";
+import { pickJudgeOutput } from "./consilium-loop-controller.js";
+import { extractActionPoints } from "../orchestrator/convergence.js";
+import { assertAllowedRepoPath } from "./repo-allowlist.js";
+import { assertRepoIsProjectWorkspace } from "./review-factory.js";
+
+/**
+ * MED-1: the process GLOBAL ceiling on simultaneously-RUNNING execute-sdlc runs.
+ * Each run spawns a real agentic coder subprocess + a git worktree, so the fan-out
+ * has to be bounded across ALL groups, not just deduped per group. A NEW group's
+ * run beyond this is refused with `EXECUTOR_BUSY` (route → 429), not queued.
+ */
+export const MAX_CONCURRENT_EXECUTE_SDLC = 3;
+
+/**
+ * MED-2: how long past `coderTimeoutMs` the watchdog waits before FORCE-settling a
+ * still-"running" row to `failed`. The executor's own timeout should fire first;
+ * this margin only catches the pathological "timeout failed to kill the subprocess
+ * and the promise never settled" wedge.
+ */
+const WATCHDOG_MARGIN_MS = 60_000;
+
+/**
+ * MED-2: how long a SETTLED (done/failed) registry row stays readable by the status
+ * poll before it is GC'd, so the registry can't grow unbounded. A still-`running`
+ * row is NEVER evicted.
+ */
+const SETTLED_RETENTION_MS = 10 * 60_000;
+
+/** Stable, machine-checkable failure codes the route maps to actionable 4xx. */
+export type ExecuteSdlcErrorCode =
+  | "NO_ACTION_POINTS" // no verdict / no parseable action points → 400
+  | "NO_REPO_PATH" // no loop repoPath and no body repoPath → 400
+  | "REPO_NOT_ALLOWED" // outside the fail-closed global allowlist → 400
+  | "REPO_NOT_WORKSPACE" // allowlisted but not a workspace of this project → 400
+  | "EXECUTOR_BUSY"; // global concurrency cap reached (MED-1) → 429
+
+/** A typed, route-mappable rejection. NOTHING has run when this is thrown. */
+export class ExecuteSdlcError extends Error {
+  constructor(
+    readonly code: ExecuteSdlcErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ExecuteSdlcError";
+  }
+}
+
+/** Public, pollable status of a group's execute-sdlc run (registry snapshot). */
+export interface ExecuteSdlcStatus {
+  /** running while the background coder works; done/failed once settled. */
+  status: "running" | "done" | "failed";
+  /** The synthetic loop id that shaped the branch (`consilium/loop-<id>/round-1`). */
+  runId: string;
+  /** Always 1 for a human-triggered run (round-shape invariant). */
+  round: number;
+  /** How many action points the verdict carried (one coder run + commit each). */
+  actionPointCount: number;
+  /** Draft PR URL once settled, or null when zero commits were produced. */
+  prRef?: string | null;
+  /** HEAD sha of the SDLC branch after the last commit; "" when nothing committed. */
+  headCommit?: string;
+  /** Scrubbed note present on any non-happy settle. */
+  error?: string;
+  /** epoch ms the run was launched. */
+  startedAt: number;
+  /** epoch ms the run settled (absent while running). */
+  settledAt?: number;
+}
+
+/** The 202 handle the route returns (a subset of the status, plus `deduped`). */
+export interface ExecuteSdlcHandle {
+  groupId: string;
+  runId: string;
+  round: number;
+  status: "running";
+  actionPointCount: number;
+  /** True when an in-flight run already existed — no new worktree was launched. */
+  deduped: boolean;
+}
+
+/** Internal registry row. */
+interface ExecuteSdlcRun {
+  status: "running" | "done" | "failed";
+  runId: string;
+  round: number;
+  actionPointCount: number;
+  prRef?: string | null;
+  headCommit?: string;
+  error?: string;
+  startedAt: number;
+  settledAt?: number;
+  /** MED-2: the anti-wedge timer, armed at dispatch and cleared on settle. */
+  watchdog?: ReturnType<typeof setTimeout>;
+}
+
+export interface SdlcExecutionDeps {
+  storage: IStorage;
+  config: () => AppConfig;
+  /** The SDLC executor. Defaults to the real `runSdlcHandoff`; tests inject a fake. */
+  runSdlc?: typeof runSdlcHandoff;
+}
+
+/**
+ * Owns the process-local execute-sdlc registry (mirrors the loop controller's
+ * `sdlcRuns` pattern) and the read→validate→launch flow. One instance per server.
+ */
+export class SdlcExecutionService {
+  /** Keyed by groupId — at most one tracked run per group (single-flight). */
+  private readonly runs = new Map<string, ExecuteSdlcRun>();
+
+  /**
+   * MED-1: the number of registry rows currently holding a GLOBAL concurrency slot
+   * (reserved at launch, freed on settle / force-settle / validation-failure). Kept
+   * as a counter — NOT derived by scanning `runs` — so the cap-check + reserve stays
+   * a single synchronous step (no await, no race) like the dedup reserve.
+   */
+  private runningCount = 0;
+
+  constructor(private readonly deps: SdlcExecutionDeps) {}
+
+  private get storage(): IStorage {
+    return this.deps.storage;
+  }
+
+  private cfg() {
+    return this.deps.config().pipeline.consiliumLoop;
+  }
+
+  /**
+   * Launch (or dedup) an execute-sdlc run for a group. Reads the action points +
+   * resolves the repoPath SERVER-side, gates the repoPath, then fires the SDLC
+   * executor in the BACKGROUND and returns immediately with a handle.
+   *
+   * Throws {@link ExecuteSdlcError} BEFORE anything runs when there is no
+   * verdict/action points, no resolvable repoPath, the repoPath fails the
+   * allowlist/workspace gate (caller maps each to 400), OR the global concurrency
+   * cap is reached for a NEW group (`EXECUTOR_BUSY` → 429). Returns
+   * `{ deduped: true }` (no new run, never capped) when an execute-sdlc run is
+   * already in flight for this group.
+   *
+   * @param groupId  the task group whose latest verdict to execute.
+   * @param ownerId  the request user id (audit only — `runSdlcHandoff.ownerId`).
+   * @param bodyRepoPath optional repoPath fallback when the group has no loop.
+   */
+  async execute(
+    groupId: string,
+    ownerId: string,
+    bodyRepoPath?: string,
+  ): Promise<ExecuteSdlcHandle> {
+    // SINGLE-FLIGHT (1): a running entry → hand the SAME run back; do NOT launch a
+    // second worktree on a fresh branch (the #417 double-dispatch lesson). Checked
+    // FIRST, so dedup is NEVER blocked by the global cap below.
+    const inflight = this.runs.get(groupId);
+    if (inflight && inflight.status === "running") {
+      return this.toHandle(groupId, inflight, true);
+    }
+
+    // MED-1 GLOBAL CAP: a NEW group's run beyond the cap is REFUSED (429), not
+    // queued. The cap-check and the slot-reserve below are ATOMIC (no await between
+    // them) so two concurrent NEW-group requests can never both slip past the cap.
+    if (this.runningCount >= MAX_CONCURRENT_EXECUTE_SDLC) {
+      throw new ExecuteSdlcError(
+        "EXECUTOR_BUSY",
+        "SDLC executor busy — too many concurrent runs, retry shortly",
+      );
+    }
+
+    // RESERVE the slot SYNCHRONOUSLY (no await before the set + count bump) so a
+    // concurrent second request for this group dedups, and a concurrent NEW group
+    // sees the bumped count — even while the reads below are still pending. Filled
+    // in once the verdict/repo are resolved.
+    const runId = `${randomUUID()}`; // fresh uuid → branch can't collide w/ the loop's rounds
+    const run: ExecuteSdlcRun = {
+      status: "running",
+      runId,
+      round: 1,
+      actionPointCount: 0,
+      startedAt: Date.now(),
+    };
+    this.runs.set(groupId, run);
+    this.runningCount += 1; // hold a global slot (freed on settle / validation-failure)
+
+    try {
+      // (2) SERVER-READ the action points from the group's latest iteration verdict.
+      const actionPoints = await this.readActionPoints(groupId);
+
+      // (3) Resolve + GATE the repoPath (global allowlist ∩ project workspace).
+      const repoPath = await this.resolveRepoPath(groupId, bodyRepoPath);
+
+      run.actionPointCount = actionPoints.length;
+
+      // (4) Fire the executor in the BACKGROUND — never blocks the HTTP response.
+      this.dispatch(groupId, run, repoPath, actionPoints, ownerId);
+
+      return this.toHandle(groupId, run, false);
+    } catch (err) {
+      // A validation rejection: FREE the reserved slot (registry row + global count)
+      // so the user can retry after fixing the input (no stuck "running" entry, and
+      // no leaked concurrency slot, on a never-launched run).
+      if (this.runs.get(groupId) === run) {
+        this.runs.delete(groupId);
+        this.runningCount = Math.max(0, this.runningCount - 1);
+      }
+      throw err;
+    }
+  }
+
+  /** The latest execute-sdlc status for a group, or undefined if none was ever run. */
+  getStatus(groupId: string): ExecuteSdlcStatus | undefined {
+    const run = this.runs.get(groupId);
+    if (!run) return undefined;
+    return {
+      status: run.status,
+      runId: run.runId,
+      round: run.round,
+      actionPointCount: run.actionPointCount,
+      prRef: run.prRef,
+      headCommit: run.headCommit,
+      error: run.error,
+      startedAt: run.startedAt,
+      settledAt: run.settledAt,
+    };
+  }
+
+  // ─── internals ────────────────────────────────────────────────────────────
+
+  /**
+   * SERVER-READ the verdict's action points: the latest iteration's executions →
+   * the Judge output (`pickJudgeOutput`) → the bounded FULL action_points list
+   * (`extractActionPoints`). NEVER reads the request body. No verdict / no action
+   * points ⇒ a clean NO_ACTION_POINTS rejection (NOTHING runs).
+   */
+  private async readActionPoints(groupId: string): Promise<readonly ActionPoint[]> {
+    const iteration = await this.storage.getLatestIteration(groupId);
+    if (!iteration) {
+      throw new ExecuteSdlcError("NO_ACTION_POINTS", "no action points to execute");
+    }
+    const executions = await this.storage.getExecutionsByIteration(groupId, iteration.id);
+    const judgeOutput = pickJudgeOutput(executions.map((e) => e.output));
+    const actionPoints = extractActionPoints(judgeOutput);
+    if (actionPoints.length === 0) {
+      throw new ExecuteSdlcError("NO_ACTION_POINTS", "no action points to execute");
+    }
+    return actionPoints;
+  }
+
+  /**
+   * Resolve the repoPath: prefer the consilium loop for this group
+   * (`loop.repoPath`); else the optional body `repoPath`. The candidate is then
+   * RE-VALIDATED (never trust a stored row) through the GLOBAL allowlist (S1) and
+   * the per-project WORKSPACE confinement (S5/MED-3) — it must pass BOTH. Returns
+   * the canonical realpath the allowlist resolved. Throws a typed rejection (the
+   * route maps to 400) on any failure; nothing is launched.
+   */
+  private async resolveRepoPath(groupId: string, bodyRepoPath?: string): Promise<string> {
+    const loop = await this.findLoopForGroup(groupId);
+    const candidate = loop?.repoPath ?? (bodyRepoPath?.trim() ? bodyRepoPath.trim() : undefined);
+    if (!candidate) {
+      throw new ExecuteSdlcError(
+        "NO_REPO_PATH",
+        "no repoPath: this group has no consilium loop and no repoPath was supplied",
+      );
+    }
+
+    let resolved: string;
+    try {
+      // S1: fail-closed GLOBAL allowlist (canonical realpath ⇒ a symlink can't escape).
+      resolved = assertAllowedRepoPath(candidate, this.cfg().allowedRepoPaths);
+    } catch (err) {
+      throw new ExecuteSdlcError(
+        "REPO_NOT_ALLOWED",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+    try {
+      // S5/MED-3: INTERSECT with THIS project's workspaces (caller is in the ALS).
+      await assertRepoIsProjectWorkspace(resolved, this.storage);
+    } catch (err) {
+      throw new ExecuteSdlcError(
+        "REPO_NOT_WORKSPACE",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+    return resolved;
+  }
+
+  /**
+   * The consilium loop for a group (most-recent if several), or undefined. Uses
+   * the project-scoped `getLoops()` (the caller runs in the request's project ALS),
+   * so it only ever sees THIS project's loops — and works for a TERMINAL review
+   * loop (maxRounds:1 ⇒ converged) where `getActiveLoopByGroup` returns nothing.
+   */
+  private async findLoopForGroup(groupId: string) {
+    const loops = await this.storage.getLoops(); // sorted newest-first
+    return loops.find((l) => l.groupId === groupId);
+  }
+
+  /**
+   * Fire `runSdlcHandoff` as a fire-and-forget BACKGROUND job and settle the
+   * registry row when it resolves. The executor NEVER throws (it degrades to a
+   * no-PR result), so the `.catch` is purely defensive — it guarantees the row
+   * always settles, so the status poll can never hang on "running" forever.
+   *
+   * MED-2: a WATCHDOG is armed at `coderTimeoutMs + WATCHDOG_MARGIN_MS`. If the
+   * executor promise never settles (a hang the timeout failed to kill), the watchdog
+   * FORCE-settles the row to `failed` and frees the global slot, so the group can
+   * relaunch with a fresh uuid → fresh branch. `finalize` is the SINGLE settle path
+   * for all three (resolve / reject / watchdog) and is idempotent, so whichever fires
+   * first wins and the others no-op (no double-settle, no double slot-free).
+   */
+  private dispatch(
+    groupId: string,
+    run: ExecuteSdlcRun,
+    repoPath: string,
+    actionPoints: readonly ActionPoint[],
+    ownerId: string,
+  ): void {
+    const cfg = this.cfg();
+    const exec = this.deps.runSdlc ?? runSdlcHandoff;
+
+    // MED-2: arm the anti-wedge watchdog BEFORE dispatch so even a synchronously
+    // hung promise is covered. `finalize` clears it on a normal settle.
+    const budgetMs = cfg.sdlcTimeoutMs + WATCHDOG_MARGIN_MS;
+    run.watchdog = setTimeout(() => {
+      this.finalize(groupId, run, {
+        status: "failed",
+        prRef: null,
+        headCommit: "",
+        error: scrub("SDLC run exceeded its time budget — force-settled"),
+      });
+    }, budgetMs);
+    if (typeof run.watchdog.unref === "function") run.watchdog.unref();
+
+    void exec({
+      repoPath,
+      loopId: run.runId, // fresh uuid → server-derived branch consilium/loop-<id>/round-1
+      round: run.round, // 1 — round-shape invariant
+      actionPoints,
+      allowedRepoPaths: cfg.allowedRepoPaths,
+      ownerId,
+      coderTimeoutMs: cfg.sdlcTimeoutMs,
+    })
+      .then((result) => {
+        this.finalize(groupId, run, {
+          status: result.error && result.prRef === null ? "failed" : "done",
+          prRef: result.prRef,
+          headCommit: result.headCommit,
+          // LOW-1: scrub the happy-path error too, so the no-leak guarantee is
+          // route-local (not merely inherited from the executor's pre-scrub).
+          error: result.error == null ? result.error : scrub(result.error),
+        });
+      })
+      .catch((err: unknown) => {
+        // Defensive: the executor shouldn't throw, but a settled row must NEVER hang.
+        this.finalize(groupId, run, {
+          status: "failed",
+          prRef: null,
+          headCommit: "",
+          error: scrub(err instanceof Error ? err.message : String(err)),
+        });
+      });
+  }
+
+  /**
+   * The SINGLE, idempotent settle path (resolve / reject / watchdog all route here).
+   * Guards on `status === "running"` so whichever caller fires FIRST wins and the
+   * rest no-op — no double-settle, no double slot-free. Clears the watchdog timer,
+   * frees the global concurrency slot, stamps `settledAt`, and schedules GC.
+   */
+  private finalize(
+    groupId: string,
+    run: ExecuteSdlcRun,
+    patch: {
+      status: "done" | "failed";
+      prRef: string | null;
+      headCommit: string;
+      error?: string;
+    },
+  ): void {
+    if (run.status !== "running") return; // already settled — DOUBLE-SETTLE guard
+    if (run.watchdog) {
+      clearTimeout(run.watchdog);
+      run.watchdog = undefined;
+    }
+    run.status = patch.status;
+    run.prRef = patch.prRef;
+    run.headCommit = patch.headCommit;
+    run.error = patch.error;
+    run.settledAt = Date.now();
+    this.runningCount = Math.max(0, this.runningCount - 1); // free the global slot
+    this.scheduleGc(groupId, run);
+  }
+
+  /**
+   * MED-2 GC: drop a SETTLED row after the retention window so the registry can't
+   * grow unbounded. Never evicts a still-`running` row, and skips a row that a fresh
+   * relaunch already replaced (object identity check) — so a force-settle→relaunch
+   * can never have its NEW running row evicted by the OLD row's timer.
+   */
+  private scheduleGc(groupId: string, run: ExecuteSdlcRun): void {
+    const gc = setTimeout(() => {
+      const current = this.runs.get(groupId);
+      if (current === run && current.status !== "running") {
+        this.runs.delete(groupId);
+      }
+    }, SETTLED_RETENTION_MS);
+    if (typeof gc.unref === "function") gc.unref();
+  }
+
+  private toHandle(groupId: string, run: ExecuteSdlcRun, deduped: boolean): ExecuteSdlcHandle {
+    return {
+      groupId,
+      runId: run.runId,
+      round: run.round,
+      status: "running",
+      actionPointCount: run.actionPointCount,
+      deduped,
+    };
+  }
+}
+
+/** Scrub fs layout from an error string before it lands in the status row. */
+function scrub(raw: string): string {
+  return raw.replace(/\/[^\s'"]+/g, "<path>").replace(/\s+/g, " ").trim().slice(0, 200);
+}

--- a/server/services/consilium/review-factory.ts
+++ b/server/services/consilium/review-factory.ts
@@ -1019,7 +1019,7 @@ function buildGroupName(preset: ConsiliumReviewPreset, repoPath: string): string
  * workspace (incl. zero workspaces) rejects every repo. Runs BEFORE any
  * createTaskGroup/createLoop, so nothing is persisted on rejection.
  */
-async function assertRepoIsProjectWorkspace(
+export async function assertRepoIsProjectWorkspace(
   resolvedRepo: string,
   storage: IStorage,
 ): Promise<void> {

--- a/server/services/orchestrator/convergence.ts
+++ b/server/services/orchestrator/convergence.ts
@@ -139,3 +139,26 @@ export function readConvergence(judgeOutput: unknown): ConvergenceVerdict {
   // "no parseable verdict" → conservatively NOT converged (see file header).
   return NOT_CONVERGED;
 }
+
+/**
+ * Extract the FULL `action_points` list from a judge output (ALL priorities, not
+ * just open P0s), bounded with the SAME caps as {@link readConvergence}
+ * (`MAX_ACTION_POINTS` count + per-field clamps). Used by the human-triggered
+ * execute-sdlc path: a maintainer who clicks "execute this verdict" wants EVERY
+ * action point the judge flagged implemented, whereas the loop's developing phase
+ * (`readConvergence().openActionPoints`) intentionally narrows to the still-open
+ * P0s. Returns `[]` for a missing/unparseable verdict (the route maps that to a
+ * 400 "no action points to execute"). Never throws.
+ *
+ * SECURITY: this is the SERVER-READ verdict — the request body's action_points (if
+ * any) are NEVER consulted. The returned text is UNTRUSTED model output; the SDLC
+ * executor sanitizes/clamps it again before it reaches a commit/PR body (never a
+ * shell string), and the Draft-PR human gate is the real containment.
+ */
+export function extractActionPoints(judgeOutput: unknown): ActionPoint[] {
+  const body = pickJudgeBody(judgeOutput);
+  if (!body) return [];
+  const parsed = z.array(actionPointSchema).safeParse(body.action_points);
+  if (!parsed.success) return [];
+  return boundActionPoints(parsed.data);
+}

--- a/tests/unit/consilium/execute-sdlc-route.test.ts
+++ b/tests/unit/consilium/execute-sdlc-route.test.ts
@@ -1,0 +1,249 @@
+/**
+ * execute-sdlc-route.test.ts — POST /api/task-groups/:groupId/execute-sdlc and
+ * its GET .../status sibling. Wires the REAL `SdlcExecutionService` (with a MOCKED
+ * `runSdlcHandoff` injected via deps.runSdlc) behind the real route + a fake
+ * storage, and a requireAuth/requireProject stand-in (applied at mount in
+ * routes.ts). Asserts:
+ *   - action points are SERVER-READ from the verdict and a CLIENT-supplied
+ *     `action_points` in the body is IGNORED (zod strips it) — the executor runs
+ *     the server verdict, never the client text;
+ *   - repoPath not allowlisted / not a project workspace → 400, executor NEVER run;
+ *   - a no-verdict group → 400 "no action points to execute";
+ *   - single-flight: a 2nd POST returns the existing handle (deduped), executor
+ *     dispatched ONCE;
+ *   - MED-1: a NEW group's run beyond the global cap → 429 (executor busy);
+ *   - the status route reflects running → done with the prRef;
+ *   - authorize: a non-owner/non-admin → 403 (no execution); status 404 when none.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import type { AppConfig } from "../../../server/config/schema.js";
+import type { IStorage } from "../../../server/storage.js";
+import type { SdlcHandoffResult } from "../../../server/services/sdlc/executor.js";
+import { SdlcExecutionService } from "../../../server/services/consilium/execute-sdlc.js";
+import { registerExecuteSdlcRoutes } from "../../../server/routes/execute-sdlc.js";
+
+const GROUP = "group-1";
+const OWNER = "user-1";
+const ALLOWED = "/repos";
+const LOOP_REPO = "/repos/widget";
+
+const JUDGE_OUTPUT = {
+  verdict: "needs work",
+  action_points: [
+    { title: "SERVER AP1", priority: "P0" },
+    { title: "SERVER AP2", priority: "P2" },
+  ],
+};
+
+interface StorageOpts {
+  group?: { id: string; createdBy: string | null } | undefined;
+  iteration?: { id: string; groupId: string; iterationNumber: number } | undefined;
+  executionOutputs?: unknown[];
+  loops?: { groupId: string; repoPath: string; createdAt: Date }[];
+  workspaces?: { path: string }[];
+}
+
+function makeStorage(opts: StorageOpts = {}): IStorage {
+  // Respect an EXPLICIT `group: undefined` / `iteration: undefined` (destructuring
+  // defaults would re-apply on undefined and mask the missing-group / no-verdict
+  // cases), so key on presence.
+  const group = "group" in opts ? opts.group : { id: GROUP, createdBy: OWNER };
+  const iteration =
+    "iteration" in opts ? opts.iteration : { id: "iter-1", groupId: GROUP, iterationNumber: 1 };
+  const {
+    executionOutputs = [JUDGE_OUTPUT],
+    loops = [{ groupId: GROUP, repoPath: LOOP_REPO, createdAt: new Date() }],
+    workspaces = [{ path: ALLOWED }],
+  } = opts;
+  return {
+    getTaskGroup: vi.fn(async (id: string) => (group && group.id === id ? group : undefined)),
+    getLatestIteration: vi.fn(async () => iteration),
+    getExecutionsByIteration: vi.fn(async () => executionOutputs.map((output) => ({ output }))),
+    getLoops: vi.fn(async () => loops),
+    getWorkspaces: vi.fn(async () => workspaces),
+  } as unknown as IStorage;
+}
+
+/**
+ * A storage that serves ANY of `groupIds` (each owned by OWNER, with its own
+ * verdict + loop), for the MED-1 cap test where several DISTINCT groups run.
+ */
+function makeMultiStorage(groupIds: string[]): IStorage {
+  return {
+    getTaskGroup: vi.fn(async (id: string) => ({ id, createdBy: OWNER })),
+    getLatestIteration: vi.fn(async (g: string) => ({ id: `iter-${g}`, groupId: g, iterationNumber: 1 })),
+    getExecutionsByIteration: vi.fn(async () => [{ output: JUDGE_OUTPUT }]),
+    getLoops: vi.fn(async () => groupIds.map((g) => ({ groupId: g, repoPath: LOOP_REPO, createdAt: new Date() }))),
+    getWorkspaces: vi.fn(async () => [{ path: ALLOWED }]),
+  } as unknown as IStorage;
+}
+
+function makeConfig(allowedRepoPaths: string[] = [ALLOWED]): () => AppConfig {
+  return () =>
+    ({ pipeline: { consiliumLoop: { allowedRepoPaths, sdlcTimeoutMs: 1_200_000 } } }) as unknown as AppConfig;
+}
+
+const PR_RESULT: SdlcHandoffResult = { prRef: "https://gh/pr/42", headCommit: "deadbeef" };
+
+function makeApp(
+  storage: IStorage,
+  runSdlc = vi.fn(async () => PR_RESULT),
+  opts: { user?: { id: string; role?: string }; config?: () => AppConfig } = {},
+) {
+  const { user = { id: OWNER }, config = makeConfig() } = opts;
+  const service = new SdlcExecutionService({ storage, config, runSdlc });
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as unknown as { user: typeof user }).user = user;
+    (req as unknown as { projectId: string }).projectId = "project-1";
+    next();
+  });
+  registerExecuteSdlcRoutes(app, storage, service);
+  return { app, service, runSdlc };
+}
+
+describe("POST /api/task-groups/:groupId/execute-sdlc", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("SERVER-READS the verdict's action points and IGNORES a client-supplied action_points body", async () => {
+    const { app, runSdlc } = makeApp(makeStorage());
+    const res = await request(app)
+      .post(`/api/task-groups/${GROUP}/execute-sdlc`)
+      // A malicious client tries to inject its own action points — must be dropped.
+      .send({ action_points: [{ title: "CLIENT EVIL — rm -rf /" }] });
+
+    expect(res.status).toBe(202);
+    expect(res.body.status).toBe("running");
+    expect(res.body.deduped).toBe(false);
+    expect(res.body.actionPointCount).toBe(2);
+
+    expect(runSdlc).toHaveBeenCalledTimes(1);
+    const titles = (runSdlc.mock.calls[0][0] as { actionPoints: { title: string }[] }).actionPoints.map(
+      (a) => a.title,
+    );
+    expect(titles).toEqual(["SERVER AP1", "SERVER AP2"]); // the verdict, NOT the client text
+    expect(titles.join(" ")).not.toMatch(/CLIENT EVIL/);
+  });
+
+  it("a NO-VERDICT group → 400 'no action points to execute', executor never run", async () => {
+    const { app, runSdlc } = makeApp(makeStorage({ iteration: undefined }));
+    const res = await request(app).post(`/api/task-groups/${GROUP}/execute-sdlc`).send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/no action points to execute/i);
+    expect(runSdlc).not.toHaveBeenCalled();
+  });
+
+  it("repoPath NOT allowlisted → 400 (allowlist message), nothing runs", async () => {
+    const { app, runSdlc } = makeApp(makeStorage(), vi.fn(async () => PR_RESULT), {
+      config: makeConfig(["/other/root"]),
+    });
+    const res = await request(app).post(`/api/task-groups/${GROUP}/execute-sdlc`).send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/allowedRepoPaths in config\.yaml/i);
+    expect(res.body.error).not.toMatch(/registered as a workspace/i);
+    expect(runSdlc).not.toHaveBeenCalled();
+  });
+
+  it("repoPath allowlisted but NOT a project workspace → 400 (workspace message), nothing runs", async () => {
+    const { app, runSdlc } = makeApp(makeStorage({ workspaces: [{ path: "/other/ws" }] }));
+    const res = await request(app).post(`/api/task-groups/${GROUP}/execute-sdlc`).send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/is not registered as a workspace of the selected project/i);
+    expect(res.body.error).not.toMatch(/allowedRepoPaths in config\.yaml/i);
+    expect(runSdlc).not.toHaveBeenCalled();
+  });
+
+  it("SINGLE-FLIGHT: a 2nd POST returns the existing handle (deduped), executor dispatched once", async () => {
+    const runSdlc = vi.fn(() => new Promise<SdlcHandoffResult>(() => {})); // never settles
+    const { app } = makeApp(makeStorage(), runSdlc as never);
+
+    const first = await request(app).post(`/api/task-groups/${GROUP}/execute-sdlc`).send({});
+    const second = await request(app).post(`/api/task-groups/${GROUP}/execute-sdlc`).send({});
+
+    expect(first.status).toBe(202);
+    expect(second.status).toBe(202);
+    expect(first.body.deduped).toBe(false);
+    expect(second.body.deduped).toBe(true);
+    expect(second.body.runId).toBe(first.body.runId);
+    expect(runSdlc).toHaveBeenCalledTimes(1);
+  });
+
+  it("MED-1: a NEW group's run beyond the global cap → 429 (busy); a dedup is NOT capped", async () => {
+    const groups = ["g1", "g2", "g3", "g4"]; // cap is 3 → g4 is over the cap
+    const runSdlc = vi.fn(() => new Promise<SdlcHandoffResult>(() => {})); // every run stays running
+    const { app } = makeApp(makeMultiStorage(groups), runSdlc as never);
+
+    // Fill the cap with 3 DISTINCT groups.
+    for (const g of ["g1", "g2", "g3"]) {
+      const r = await request(app).post(`/api/task-groups/${g}/execute-sdlc`).send({});
+      expect(r.status).toBe(202);
+      expect(r.body.deduped).toBe(false);
+    }
+
+    // The 4th DISTINCT group is over the cap → 429, NOTHING launched.
+    const over = await request(app).post(`/api/task-groups/g4/execute-sdlc`).send({});
+    expect(over.status).toBe(429);
+    expect(over.body.error).toMatch(/busy/i);
+    expect(over.headers["retry-after"]).toBe("30");
+    expect(runSdlc).toHaveBeenCalledTimes(3); // g4 never dispatched
+
+    // An ALREADY-running group still returns its handle — the cap never blocks dedup.
+    const again = await request(app).post(`/api/task-groups/g1/execute-sdlc`).send({});
+    expect(again.status).toBe(202);
+    expect(again.body.deduped).toBe(true);
+    expect(runSdlc).toHaveBeenCalledTimes(3);
+  });
+
+  it("a non-owner / non-admin → 403, executor never run", async () => {
+    const { app, runSdlc } = makeApp(makeStorage(), vi.fn(async () => PR_RESULT), {
+      user: { id: "intruder" },
+    });
+    const res = await request(app).post(`/api/task-groups/${GROUP}/execute-sdlc`).send({});
+    expect(res.status).toBe(403);
+    expect(runSdlc).not.toHaveBeenCalled();
+  });
+
+  it("a missing group → 404", async () => {
+    const { app } = makeApp(makeStorage({ group: undefined }));
+    const res = await request(app).post(`/api/task-groups/${GROUP}/execute-sdlc`).send({});
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /api/task-groups/:groupId/execute-sdlc/status", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("404 when no run has been launched for the group", async () => {
+    const { app } = makeApp(makeStorage());
+    const res = await request(app).get(`/api/task-groups/${GROUP}/execute-sdlc/status`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toMatch(/no execute-sdlc run/i);
+  });
+
+  it("reflects running → done with the prRef", async () => {
+    const { app, service } = makeApp(makeStorage());
+
+    const post = await request(app).post(`/api/task-groups/${GROUP}/execute-sdlc`).send({});
+    expect(post.status).toBe(202);
+
+    const running = await request(app).get(`/api/task-groups/${GROUP}/execute-sdlc/status`);
+    expect(running.status).toBe(200);
+    expect(["running", "done"]).toContain(running.body.status);
+
+    await vi.waitFor(() => expect(service.getStatus(GROUP)?.status).toBe("done"));
+    const done = await request(app).get(`/api/task-groups/${GROUP}/execute-sdlc/status`);
+    expect(done.status).toBe(200);
+    expect(done.body.status).toBe("done");
+    expect(done.body.prRef).toBe("https://gh/pr/42");
+    expect(done.body.headCommit).toBe("deadbeef");
+  });
+
+  it("a non-owner cannot read another user's run status (403)", async () => {
+    const { app } = makeApp(makeStorage(), vi.fn(async () => PR_RESULT), { user: { id: "intruder" } });
+    const res = await request(app).get(`/api/task-groups/${GROUP}/execute-sdlc/status`);
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/unit/sdlc/execute-sdlc-service.test.ts
+++ b/tests/unit/sdlc/execute-sdlc-service.test.ts
@@ -1,0 +1,381 @@
+/**
+ * execute-sdlc-service.test.ts — the SERVER path that EXECUTES a consilium
+ * verdict's action_points via the SDLC executor (human-triggered DEVELOPING
+ * phase). Drives `SdlcExecutionService` directly with a fake storage + a MOCKED
+ * `runSdlcHandoff` (deps.runSdlc), asserting:
+ *   - action points are SERVER-READ from the latest iteration's Judge verdict
+ *     (the FULL bounded list) and handed to the executor;
+ *   - repoPath is resolved from the loop (else the body) and RE-VALIDATED through
+ *     the global allowlist AND the per-project workspace gate — a rejection runs
+ *     NOTHING and frees the registry slot;
+ *   - no verdict / no action points → a clean NO_ACTION_POINTS rejection;
+ *   - the branch-shape invariant: a FRESH uuid loopId + round 1;
+ *   - single-flight: an in-flight run dedups (no 2nd executor dispatch);
+ *   - the status registry reflects running → done / failed;
+ *   - MED-1: a global concurrency CAP refuses an (N+1)th DISTINCT-group run with
+ *     EXECUTOR_BUSY while N run, but never caps a deduped already-running group;
+ *   - MED-2: a watchdog FORCE-settles a never-resolving run past its time budget,
+ *     frees the slot (relaunch works), and wins over a late resolve (no double-
+ *     settle); a SETTLED row is GC'd after the retention window but a running one
+ *     is never evicted;
+ *   - LOW-1: the happy-path settle scrubs `result.error` (no fs leak).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AppConfig } from "../../../server/config/schema.js";
+import type { IStorage } from "../../../server/storage.js";
+import type { SdlcHandoffResult } from "../../../server/services/sdlc/executor.js";
+import {
+  SdlcExecutionService,
+  ExecuteSdlcError,
+  MAX_CONCURRENT_EXECUTE_SDLC,
+} from "../../../server/services/consilium/execute-sdlc.js";
+
+const GROUP = "group-1";
+const OWNER = "user-1";
+const ALLOWED = "/repos";
+const LOOP_REPO = "/repos/widget";
+const SDLC_TIMEOUT_MS = 1_234_000;
+const WATCHDOG_MARGIN_MS = 60_000;
+const SETTLED_RETENTION_MS = 10 * 60_000;
+
+/** A judge execution output carrying a verdict + a mixed-priority action_points list. */
+const JUDGE_OUTPUT = {
+  verdict: "needs work",
+  action_points: [
+    { title: "AP1 fix the auth bug", priority: "P0", rationale: "security" },
+    { title: "AP2 add tests", priority: "P1" },
+  ],
+};
+
+interface FakeStorageOpts {
+  iteration?: { id: string; groupId: string; iterationNumber: number; status?: string } | undefined;
+  executionOutputs?: unknown[];
+  loops?: { groupId: string; repoPath: string; createdAt: Date }[];
+  workspaces?: { path: string }[];
+}
+
+function makeStorage(opts: FakeStorageOpts): IStorage {
+  // NOTE: respect an EXPLICIT `iteration: undefined` (a destructuring default
+  // would treat undefined as "absent" and re-apply the default — masking the
+  // no-verdict case), so key on presence.
+  const iteration =
+    "iteration" in opts
+      ? opts.iteration
+      : { id: "iter-1", groupId: GROUP, iterationNumber: 3, status: "completed" };
+  const {
+    executionOutputs = [JUDGE_OUTPUT],
+    loops = [{ groupId: GROUP, repoPath: LOOP_REPO, createdAt: new Date() }],
+    workspaces = [{ path: ALLOWED }],
+  } = opts;
+  return {
+    getLatestIteration: vi.fn(async (g: string) => (iteration && iteration.groupId === g ? iteration : undefined)),
+    getExecutionsByIteration: vi.fn(async () => executionOutputs.map((output) => ({ output }))),
+    getLoops: vi.fn(async () => loops),
+    getWorkspaces: vi.fn(async () => workspaces),
+  } as unknown as IStorage;
+}
+
+/**
+ * A storage that serves ANY of `groupIds` (each with its own verdict + loop), for
+ * the MED-1 global-cap test where several DISTINCT groups run concurrently.
+ */
+function makeMultiStorage(groupIds: string[]): IStorage {
+  return {
+    getLatestIteration: vi.fn(async (g: string) => ({ id: `iter-${g}`, groupId: g, iterationNumber: 1 })),
+    getExecutionsByIteration: vi.fn(async () => [{ output: JUDGE_OUTPUT }]),
+    getLoops: vi.fn(async () => groupIds.map((g) => ({ groupId: g, repoPath: LOOP_REPO, createdAt: new Date() }))),
+    getWorkspaces: vi.fn(async () => [{ path: ALLOWED }]),
+  } as unknown as IStorage;
+}
+
+function makeConfig(allowedRepoPaths: string[] = [ALLOWED], sdlcTimeoutMs = SDLC_TIMEOUT_MS): () => AppConfig {
+  return () => ({ pipeline: { consiliumLoop: { allowedRepoPaths, sdlcTimeoutMs } } }) as unknown as AppConfig;
+}
+
+const PR_RESULT: SdlcHandoffResult = { prRef: "https://gh/pr/1", headCommit: "abc123" };
+
+function makeService(storage: IStorage, runSdlc = vi.fn(async () => PR_RESULT), config = makeConfig()) {
+  return { service: new SdlcExecutionService({ storage, config, runSdlc }), runSdlc };
+}
+
+/** A never-resolving executor — keeps a run pinned at "running" for the test. */
+function neverResolves() {
+  return vi.fn(() => new Promise<SdlcHandoffResult>(() => {}));
+}
+
+describe("SdlcExecutionService.execute — server-read action points + executor dispatch", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("SERVER-READS the full action_points list and hands it to the executor", async () => {
+    const { service, runSdlc } = makeService(makeStorage({}));
+    const handle = await service.execute(GROUP, OWNER);
+
+    expect(handle.status).toBe("running");
+    expect(handle.deduped).toBe(false);
+    expect(handle.actionPointCount).toBe(2); // BOTH P0 and P1 — not the loop's P0-only narrowing
+    expect(runSdlc).toHaveBeenCalledTimes(1);
+
+    const arg = runSdlc.mock.calls[0][0] as Parameters<typeof runSdlc>[0];
+    expect(arg.actionPoints.map((a) => a.title)).toEqual([
+      "AP1 fix the auth bug",
+      "AP2 add tests",
+    ]);
+    // repoPath came from the loop (realpath of /repos/widget) + executor inputs.
+    expect(arg.repoPath).toBe(LOOP_REPO);
+    expect(arg.ownerId).toBe(OWNER);
+    expect(arg.coderTimeoutMs).toBe(SDLC_TIMEOUT_MS);
+    expect(arg.allowedRepoPaths).toEqual([ALLOWED]);
+    // Branch-shape invariant: a FRESH uuid loopId (NOT the loop id) + round 1.
+    expect(arg.round).toBe(1);
+    expect(arg.loopId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(handle.runId).toBe(arg.loopId);
+  });
+
+  it("status reflects running → done with the prRef once the background run settles", async () => {
+    const { service } = makeService(makeStorage({}));
+    const handle = await service.execute(GROUP, OWNER);
+    expect(handle.status).toBe("running"); // the returned handle is deterministically running
+
+    await vi.waitFor(() => expect(service.getStatus(GROUP)?.status).toBe("done"));
+    const status = service.getStatus(GROUP)!;
+    expect(status.prRef).toBe("https://gh/pr/1");
+    expect(status.headCommit).toBe("abc123");
+    expect(status.settledAt).toBeGreaterThan(0);
+  });
+
+  it("classifies a no-PR degraded result as failed", async () => {
+    const runSdlc = vi.fn(async () => ({ prRef: null, headCommit: "", error: "no changes produced" }));
+    const { service } = makeService(makeStorage({}), runSdlc);
+    await service.execute(GROUP, OWNER);
+    await vi.waitFor(() => expect(service.getStatus(GROUP)?.status).toBe("failed"));
+    expect(service.getStatus(GROUP)?.error).toBe("no changes produced");
+  });
+
+  it("a NO-VERDICT group → NO_ACTION_POINTS, executor NEVER called, slot freed", async () => {
+    const { service, runSdlc } = makeService(makeStorage({ iteration: undefined }));
+    await expect(service.execute(GROUP, OWNER)).rejects.toMatchObject({
+      code: "NO_ACTION_POINTS",
+    });
+    expect(runSdlc).not.toHaveBeenCalled();
+    expect(service.getStatus(GROUP)).toBeUndefined(); // reserved slot freed for retry
+  });
+
+  it("a verdict with NO action_points → NO_ACTION_POINTS, executor NEVER called", async () => {
+    const { service, runSdlc } = makeService(
+      makeStorage({ executionOutputs: [{ verdict: "ok", convergence: { converged: true } }] }),
+    );
+    await expect(service.execute(GROUP, OWNER)).rejects.toBeInstanceOf(ExecuteSdlcError);
+    expect(runSdlc).not.toHaveBeenCalled();
+  });
+
+  it("repoPath NOT in the global allowlist → REPO_NOT_ALLOWED, nothing runs", async () => {
+    const { service, runSdlc } = makeService(
+      makeStorage({}),
+      vi.fn(async () => PR_RESULT),
+      makeConfig(["/some/other/root"]),
+    );
+    await expect(service.execute(GROUP, OWNER)).rejects.toMatchObject({ code: "REPO_NOT_ALLOWED" });
+    expect(runSdlc).not.toHaveBeenCalled();
+    expect(service.getStatus(GROUP)).toBeUndefined();
+  });
+
+  it("repoPath allowlisted but NOT a project workspace → REPO_NOT_WORKSPACE, nothing runs", async () => {
+    const { service, runSdlc } = makeService(
+      makeStorage({ workspaces: [{ path: "/some/other/workspace" }] }),
+    );
+    await expect(service.execute(GROUP, OWNER)).rejects.toMatchObject({ code: "REPO_NOT_WORKSPACE" });
+    expect(runSdlc).not.toHaveBeenCalled();
+  });
+
+  it("no loop + no body repoPath → NO_REPO_PATH", async () => {
+    const { service, runSdlc } = makeService(makeStorage({ loops: [] }));
+    await expect(service.execute(GROUP, OWNER)).rejects.toMatchObject({ code: "NO_REPO_PATH" });
+    expect(runSdlc).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the BODY repoPath when the group has no loop", async () => {
+    const { service, runSdlc } = makeService(makeStorage({ loops: [] }));
+    const handle = await service.execute(GROUP, OWNER, LOOP_REPO);
+    expect(handle.status).toBe("running");
+    expect(runSdlc).toHaveBeenCalledTimes(1);
+    expect((runSdlc.mock.calls[0][0] as { repoPath: string }).repoPath).toBe(LOOP_REPO);
+  });
+
+  it("SINGLE-FLIGHT: a 2nd execute while one is in-flight dedups (no 2nd executor run)", async () => {
+    // A never-resolving executor keeps the first run in-flight.
+    const runSdlc = neverResolves();
+    const { service } = makeService(makeStorage({}), runSdlc as never);
+
+    const first = await service.execute(GROUP, OWNER);
+    const second = await service.execute(GROUP, OWNER);
+
+    expect(first.deduped).toBe(false);
+    expect(second.deduped).toBe(true);
+    expect(second.runId).toBe(first.runId); // the SAME run handed back
+    expect(runSdlc).toHaveBeenCalledTimes(1); // no second worktree/branch dispatched
+  });
+
+  it("LOW-1: the happy-path settle SCRUBS result.error (no fs path leak in the status)", async () => {
+    // A non-null prRef ⇒ classified "done", but the result still carries a note that
+    // embeds an absolute path. The `.then` settle must run it through scrub() too.
+    const runSdlc = vi.fn(async () => ({
+      prRef: "https://gh/pr/9",
+      headCommit: "abc",
+      error: "warning at /Users/secret/repo/file.ts — partial",
+    }));
+    const { service } = makeService(makeStorage({}), runSdlc as never);
+    await service.execute(GROUP, OWNER);
+
+    await vi.waitFor(() => expect(service.getStatus(GROUP)?.settledAt).toBeGreaterThan(0));
+    const status = service.getStatus(GROUP)!;
+    expect(status.status).toBe("done");
+    expect(status.error).not.toMatch(/\/Users\/secret/); // the fs layout is gone
+    expect(status.error).toMatch(/<path>/); // replaced by the scrub placeholder
+  });
+});
+
+describe("SdlcExecutionService — MED-1 global concurrency cap", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("refuses an (N+1)th DISTINCT-group run with EXECUTOR_BUSY while N run, but never caps a dedup", async () => {
+    expect(MAX_CONCURRENT_EXECUTE_SDLC).toBe(3);
+    const N = MAX_CONCURRENT_EXECUTE_SDLC;
+    const groups = Array.from({ length: N + 1 }, (_, i) => `cap-group-${i}`);
+    const runSdlc = neverResolves(); // every launched run stays "running" → holds its slot
+    const { service } = makeService(makeMultiStorage(groups), runSdlc as never);
+
+    // Fill the cap with N DISTINCT groups.
+    for (let i = 0; i < N; i++) {
+      const h = await service.execute(groups[i], OWNER);
+      expect(h.deduped).toBe(false);
+      expect(h.status).toBe("running");
+    }
+    expect(runSdlc).toHaveBeenCalledTimes(N);
+
+    // The (N+1)th DISTINCT group is over the cap → typed 429 outcome, NOTHING launched.
+    await expect(service.execute(groups[N], OWNER)).rejects.toMatchObject({ code: "EXECUTOR_BUSY" });
+    expect(runSdlc).toHaveBeenCalledTimes(N); // still N — no extra dispatch
+    expect(service.getStatus(groups[N])).toBeUndefined(); // no stuck reservation
+
+    // An ALREADY-running group is NOT subject to the cap — it dedups to its handle.
+    const again = await service.execute(groups[0], OWNER);
+    expect(again.deduped).toBe(true);
+    expect(again.status).toBe("running");
+    expect(runSdlc).toHaveBeenCalledTimes(N); // dedup launched nothing new
+  });
+
+  it("frees the cap slot on a validation failure so a later distinct group can run", async () => {
+    const runSdlc = neverResolves();
+    // group-A is a NO-VERDICT group (validation fails → slot freed); group-B is valid.
+    const storage = {
+      getLatestIteration: vi.fn(async (g: string) =>
+        g === "grp-A" ? undefined : { id: `iter-${g}`, groupId: g, iterationNumber: 1 },
+      ),
+      getExecutionsByIteration: vi.fn(async () => [{ output: JUDGE_OUTPUT }]),
+      getLoops: vi.fn(async () => [{ groupId: "grp-B", repoPath: LOOP_REPO, createdAt: new Date() }]),
+      getWorkspaces: vi.fn(async () => [{ path: ALLOWED }]),
+    } as unknown as IStorage;
+    const { service } = makeService(storage, runSdlc as never);
+
+    // A validation failure must NOT permanently consume a cap slot.
+    await expect(service.execute("grp-A", OWNER)).rejects.toMatchObject({ code: "NO_ACTION_POINTS" });
+    // ...so a fresh valid run still launches.
+    const ok = await service.execute("grp-B", OWNER);
+    expect(ok.deduped).toBe(false);
+    expect(runSdlc).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("SdlcExecutionService — MED-2 watchdog + settled-row GC", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("watchdog FORCE-settles a never-resolving run past the budget and frees the slot to relaunch", async () => {
+    vi.useFakeTimers();
+    try {
+      const runSdlc = neverResolves();
+      const { service } = makeService(makeStorage({}), runSdlc as never);
+
+      const first = await service.execute(GROUP, OWNER);
+      expect(service.getStatus(GROUP)?.status).toBe("running");
+
+      // Advance just past coderTimeoutMs + the watchdog margin.
+      await vi.advanceTimersByTimeAsync(SDLC_TIMEOUT_MS + WATCHDOG_MARGIN_MS + 1);
+
+      const settled = service.getStatus(GROUP)!;
+      expect(settled.status).toBe("failed");
+      expect(settled.error).toMatch(/force-settled/i);
+      expect(settled.settledAt).toBeGreaterThan(0);
+
+      // Slot freed + the group is no longer wedged → a fresh POST relaunches with a NEW uuid.
+      const second = await service.execute(GROUP, OWNER);
+      expect(second.deduped).toBe(false);
+      expect(second.runId).not.toBe(first.runId);
+      expect(runSdlc).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("watchdog force-settle WINS over a late executor resolve (no double-settle)", async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveExec!: (r: SdlcHandoffResult) => void;
+      const runSdlc = vi.fn(() => new Promise<SdlcHandoffResult>((r) => (resolveExec = r)));
+      const { service } = makeService(makeStorage({}), runSdlc as never);
+
+      await service.execute(GROUP, OWNER);
+      await vi.advanceTimersByTimeAsync(SDLC_TIMEOUT_MS + WATCHDOG_MARGIN_MS + 1);
+
+      const forced = service.getStatus(GROUP)!;
+      expect(forced.status).toBe("failed");
+      const settledAt = forced.settledAt;
+
+      // The executor finally resolves LATE — the idempotent settle guard must drop it.
+      resolveExec({ prRef: "https://gh/pr/late", headCommit: "late" });
+      await vi.advanceTimersByTimeAsync(0);
+
+      const after = service.getStatus(GROUP)!;
+      expect(after.status).toBe("failed"); // unchanged
+      expect(after.prRef).toBeNull(); // the late PR did NOT overwrite the row
+      expect(after.settledAt).toBe(settledAt); // settled exactly once
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("GC evicts a SETTLED (done) row after the retention window", async () => {
+    vi.useFakeTimers();
+    try {
+      const { service } = makeService(makeStorage({})); // default resolves to PR_RESULT
+      await service.execute(GROUP, OWNER);
+      await vi.advanceTimersByTimeAsync(0); // let the background resolve settle the row
+      expect(service.getStatus(GROUP)?.status).toBe("done");
+
+      // Still readable BEFORE the retention window elapses.
+      await vi.advanceTimersByTimeAsync(SETTLED_RETENTION_MS - 1000);
+      expect(service.getStatus(GROUP)).toBeDefined();
+
+      // Evicted once PAST the retention window.
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(service.getStatus(GROUP)).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("GC NEVER evicts a still-running row", async () => {
+    vi.useFakeTimers();
+    try {
+      const runSdlc = neverResolves();
+      const { service } = makeService(makeStorage({}), runSdlc as never);
+      await service.execute(GROUP, OWNER);
+
+      // Well past the retention window, but still BEFORE the watchdog budget — the
+      // run never settled, so no GC was ever scheduled and the row survives.
+      await vi.advanceTimersByTimeAsync(SETTLED_RETENTION_MS + 1000);
+      expect(service.getStatus(GROUP)?.status).toBe("running");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
The verdict panel's *"hand off action points for execution"* used the legacy **pipeline** mechanism (a task-group of `pipeline_run` tasks). It's replaced with **direct SDLC execution** — the same `runSdlcHandoff` the consilium loop's developing phase uses (isolated worktree, one coder + one commit per action point, **ONE Draft PR**), now human-triggered from the verdict.

## Backend
`POST /api/task-groups/:groupId/execute-sdlc` (202 + handle) + `GET …/execute-sdlc/status`:
- **AuthZ**: `requireAuth` + `requireProject` + `authorizeTaskGroup` (owner/admin) on **both** routes (closes IDOR; status isn't a weaker sibling). In the `consiliumLoop` kill-switch block.
- **action_points are SERVER-READ** from the group's latest verdict (zod strips any client `action_points`); **repoPath** resolved from the group's loop (or body) and re-validated through `assertAllowedRepoPath` ∩ `assertRepoIsProjectWorkspace` (global allowlist ∩ project workspace, MED-3). Nothing runs on rejection.
- **SdlcExecutionService**: background, process-local registry keyed by groupId, **atomic single-flight dedup** (no #417 double-dispatch), **fresh-uuid branch** (no collision with the loop's own branches). Hardening from the security review: **global concurrency cap (3) → 429 + Retry-After**; **watchdog** force-settles a run past `coderTimeoutMs+margin` so a hang can't wedge a group; **settled-row GC**; errors **scrubbed** on every settle path.

## Security (adversarial review → SAFE, no CRITICAL/HIGH)
Owner-gated + project+allowlist+workspace confined + server-read APs + **Draft-PR-only** (agents never merge). IDOR closed at two layers (project membership ∩ group ownership); cross-project blocked (all reads ALS-project-scoped).

## Frontend
verdict-panel drops `usePipelines` + the pipeline selector + the `pipeline_run` handoff; a single **"Передать в SDLC → Draft PR"** button POSTs, polls status every ~4s, and surfaces the **Draft PR link** inline (server error verbatim on failure). Verdict / pros-cons / action-points table / copy unchanged.

## Verification
`tsc` clean; `tests/unit/consilium` + `tests/unit/sdlc` **306/306** (server-read APs, allowlist/workspace gates, single-flight, global-cap 429, watchdog force-settle, GC, scrub).