### PR TITLE
feat(consilium): per-action-point progress + live SDLC stepper in the verdict panel

### DIFF
--- a/client/src/components/task-groups/verdict-panel.tsx
+++ b/client/src/components/task-groups/verdict-panel.tsx
@@ -21,6 +21,7 @@ import { apiRequest } from "@/hooks/use-pipeline";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
 import { useToast } from "@/hooks/use-toast";
 import { copyText } from "@/lib/clipboard";
 import {
@@ -131,11 +132,51 @@ function buildFullText(data: VerdictOutput, groupName: string, source: string): 
   return lines.join("\n");
 }
 
+/**
+ * Live progress emitted by the SDLC executor mid-run. EVERY subfield is optional:
+ * older status responses omit `progress` entirely, and any individual field may be
+ * missing for a given poll — so every read below is defensive.
+ */
+interface SdlcProgress {
+  phase?: "coding" | "committing" | "pushing" | "opening_pr" | "done";
+  actionPointIndex?: number;
+  actionPointTotal?: number;
+  actionPointTitle?: string;
+  completedCount?: number;
+}
+
+/**
+ * Humanize the current phase into a single Russian status line. Falls back to a
+ * generic "SDLC идёт…" whenever `progress` (or the specific phase) is absent.
+ */
+function humanizePhase(progress: SdlcProgress | undefined, total: number): string {
+  switch (progress?.phase) {
+    case "committing":
+      return "Коммичу…";
+    case "pushing":
+      return "Пушу ветку…";
+    case "opening_pr":
+      return "Открываю Draft PR…";
+    case "coding": {
+      const idx = progress?.actionPointIndex;
+      const pos =
+        typeof idx === "number" ? `${idx + 1}${total > 0 ? `/${total}` : ""}` : "";
+      const title = progress?.actionPointTitle;
+      const titlePart = title ? `: «${title}»` : "";
+      return pos
+        ? `Кодирую action point ${pos}${titlePart}`
+        : `Кодирую action point${titlePart}`;
+    }
+    default:
+      return "SDLC идёт…";
+  }
+}
+
 /** SDLC hand-off lifecycle. Drives the primary action button + the PR callout. */
 type ExecState =
   | { status: "idle" }
   | { status: "starting" }
-  | { status: "running" }
+  | { status: "running"; progress?: SdlcProgress }
   | { status: "done"; prRef?: string }
   | { status: "failed"; error?: string };
 
@@ -143,6 +184,7 @@ interface SdlcStatusResponse {
   status: "running" | "done" | "failed";
   prRef?: string;
   error?: string;
+  progress?: SdlcProgress;
 }
 
 export function VerdictPanel({
@@ -191,8 +233,10 @@ export function VerdictPanel({
             title: "SDLC не удался",
             description: s.error || "Исполнение завершилось ошибкой.",
           });
+        } else {
+          // still running — refresh the live progress so the panel re-renders.
+          setExec({ status: "running", progress: s.progress });
         }
-        // else: still running — keep polling.
       } catch (err) {
         if (cancelled) return;
         const message = err instanceof Error ? err.message : String(err);
@@ -397,6 +441,48 @@ export function VerdictPanel({
               </Button>
             </div>
 
+            {exec.status === "running" &&
+              (() => {
+                const progress = exec.progress;
+                const total = progress?.actionPointTotal ?? actionPoints.length;
+                const completedRaw =
+                  typeof progress?.completedCount === "number"
+                    ? Math.max(0, progress.completedCount)
+                    : undefined;
+                const completed =
+                  completedRaw !== undefined && total > 0
+                    ? Math.min(completedRaw, total)
+                    : completedRaw;
+                const pct =
+                  total > 0 && completed !== undefined
+                    ? Math.round((completed / total) * 100)
+                    : 0;
+                return (
+                  <div className="space-y-2 rounded-md border border-primary/30 bg-primary/5 p-3">
+                    <div className="flex items-center gap-2 text-sm font-medium">
+                      <Loader2 className="h-4 w-4 shrink-0 animate-spin text-primary" />
+                      <span>{humanizePhase(progress, total)}</span>
+                    </div>
+
+                    {total > 0 && (
+                      <div className="space-y-1">
+                        <Progress value={pct} className="h-2" />
+                        <div className="text-xs tabular-nums text-muted-foreground">
+                          {completed ?? 0}/{total} готово
+                        </div>
+                      </div>
+                    )}
+
+                    <p className="text-xs leading-relaxed text-muted-foreground">
+                      SDLC-агент кодит каждый action point в изолированном
+                      git-worktree (твоё рабочее дерево не затрагивается), коммитит
+                      по одному на пункт, затем откроет Draft PR. Агенты не
+                      мержат — ревью и merge за тобой.
+                    </p>
+                  </div>
+                );
+              })()}
+
             {exec.status === "done" && (
               <div className="flex flex-wrap items-center gap-1.5 rounded-md border border-green-600/40 bg-green-600/5 p-3 text-sm">
                 <Check className="h-4 w-4 text-green-600" />
@@ -419,6 +505,12 @@ export function VerdictPanel({
                   <span className="text-muted-foreground">ссылка недоступна</span>
                 )}
               </div>
+            )}
+
+            {exec.status === "done" && (
+              <p className="text-xs text-muted-foreground">
+                Дальше: проверь и смержи Draft PR.
+              </p>
             )}
 
             {exec.status === "failed" && exec.error && (

--- a/server/services/consilium/execute-sdlc.ts
+++ b/server/services/consilium/execute-sdlc.ts
@@ -61,7 +61,7 @@ import { randomUUID } from "crypto";
 import type { IStorage } from "../../storage.js";
 import type { AppConfig } from "../../config/schema.js";
 import type { ActionPoint } from "@shared/types";
-import { runSdlcHandoff } from "../sdlc/executor.js";
+import { runSdlcHandoff, type SdlcProgress } from "../sdlc/executor.js";
 import { pickJudgeOutput } from "./consilium-loop-controller.js";
 import { extractActionPoints } from "../orchestrator/convergence.js";
 import { assertAllowedRepoPath } from "./repo-allowlist.js";
@@ -129,6 +129,10 @@ export interface ExecuteSdlcStatus {
   startedAt: number;
   /** epoch ms the run settled (absent while running). */
   settledAt?: number;
+  /** Latest per-action-point progress beat (display-only): which phase + index/
+   *  total + clamped title + completed count. The LAST-SEEN beat while running;
+   *  retained as the last-seen beat once settled. Absent before the first beat. */
+  progress?: SdlcProgress;
 }
 
 /** The 202 handle the route returns (a subset of the status, plus `deduped`). */
@@ -153,6 +157,9 @@ interface ExecuteSdlcRun {
   error?: string;
   startedAt: number;
   settledAt?: number;
+  /** Latest display-only progress beat (written synchronously by the executor's
+   *  onProgress sink while the run is `running`; never after settle). */
+  progress?: SdlcProgress;
   /** MED-2: the anti-wedge timer, armed at dispatch and cleared on settle. */
   watchdog?: ReturnType<typeof setTimeout>;
 }
@@ -283,6 +290,7 @@ export class SdlcExecutionService {
       error: run.error,
       startedAt: run.startedAt,
       settledAt: run.settledAt,
+      progress: run.progress,
     };
   }
 
@@ -395,15 +403,28 @@ export class SdlcExecutionService {
     }, budgetMs);
     if (typeof run.watchdog.unref === "function") run.watchdog.unref();
 
-    void exec({
-      repoPath,
-      loopId: run.runId, // fresh uuid → server-derived branch consilium/loop-<id>/round-1
-      round: run.round, // 1 — round-shape invariant
-      actionPoints,
-      allowedRepoPaths: cfg.allowedRepoPaths,
-      ownerId,
-      coderTimeoutMs: cfg.sdlcTimeoutMs,
-    })
+    // Record the LATEST progress beat onto the registry row so the status poll can
+    // show WHAT the executor is doing (coding AP i/N, pushing, opening PR, done).
+    // GUARD on `running`: a late beat must NEVER resurrect / mutate a settled
+    // (done / failed / force-settled) row. Synchronous + single-process → no lock.
+    const onProgress = (p: SdlcProgress): void => {
+      if (run.status !== "running") return;
+      run.progress = p;
+    };
+
+    void exec(
+      {
+        repoPath,
+        loopId: run.runId, // fresh uuid → server-derived branch consilium/loop-<id>/round-1
+        round: run.round, // 1 — round-shape invariant
+        actionPoints,
+        allowedRepoPaths: cfg.allowedRepoPaths,
+        ownerId,
+        coderTimeoutMs: cfg.sdlcTimeoutMs,
+      },
+      undefined,
+      onProgress,
+    )
       .then((result) => {
         this.finalize(groupId, run, {
           status: result.error && result.prRef === null ? "failed" : "done",

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -20,6 +20,13 @@
  * shared worktree → avoid edit conflicts); the coder's ConcurrencyLimiter still
  * bounds concurrent coders ACROSS loops.
  *
+ * PROGRESS (optional, display-only): the per-AP loop + commit/push/PR phases emit
+ * a cheap SYNCHRONOUS {@link SdlcProgress} beat through an OPTIONAL `onProgress`
+ * callback, so a UI can show WHAT the executor is doing (coding AP 2/3, pushing,
+ * opening PR, done) instead of only a binary running/done. The consilium LOOP
+ * caller passes no callback ⇒ zero behavior change. The untrusted action-point
+ * title in a beat is control-stripped + clamped (`sanitizeLine`) — never a sink.
+ *
  * Lifecycle (cleanup GUARANTEED):
  *   1. createSdlcWorktree(repo, B-3 branch, baseRef=default-branch HEAD)
  *   2. for each action point, sequentially:
@@ -37,10 +44,11 @@
  * SECURITY (BINDING — adversarial-review surface; UNCHANGED from before):
  *   - branch + PR title are SERVER-DERIVED ONLY (buildBranchName / fixed prefix).
  *     Action-point text NEVER reaches a branch, a PR title, or any shell string.
- *   - Untrusted action-point text reaches: the coder prompt (stdin only) and the
- *     commit SUBJECT + BODY + PR-body status lines — all sanitized (control chars
- *     stripped) + clamped and passed as arg-array elements (commit via `-m`, PR
- *     body via `--body-file` in pr-wrapper), NEVER a shell string.
+ *   - Untrusted action-point text reaches: the coder prompt (stdin only), the
+ *     commit SUBJECT + BODY + PR-body status lines, AND the display-only progress
+ *     `actionPointTitle` — all sanitized (control chars stripped) + clamped and
+ *     passed as arg-array elements (commit via `-m`, PR body via `--body-file`) or
+ *     as a JSON field (progress), NEVER a shell string.
  *   - The coder is confined to the worktree (cwd + --add-dir); NO Bash; spawned
  *     under a sanitized allowlisted env. The worktree is a server-minted temp dir.
  *   - Agents NEVER apply/merge: this opens a DRAFT PR only. No push to main.
@@ -66,6 +74,7 @@ const PRIORITY_MAX = 16;
 const PR_BODY_TITLE_MAX = 120;
 const PR_BODY_RATIONALE_MAX = 200; // 1-line rationale in the "addressed" list
 const PR_BODY_MAX = 16_000;
+const PROGRESS_TITLE_MAX = 120; // display-only progress title clamp (matches PR_BODY_TITLE_MAX)
 
 /** Per-action-point outcome status surfaced in the Draft PR body. */
 export type ApStatus = "completed" | "partial" | "failed";
@@ -85,6 +94,37 @@ export interface ApOutcome {
   /** Short server-generated note (e.g. "coder timed out", "no file changes"). */
   note?: string;
 }
+
+/**
+ * A cheap, SYNCHRONOUS progress beat emitted at each meaningful SDLC step so a UI
+ * can show WHAT the executor is doing right now (not just running/done). This is
+ * DISPLAY-ONLY JSON.
+ *
+ * SECURITY: `actionPointTitle` is UNTRUSTED verdict text. It is already
+ * control-stripped + clamped via `sanitizeLine` (the SAME clamp/scrub used on the
+ * commit/PR path) BEFORE it lands here, and it NEVER reaches a shell / branch /
+ * PR title through this path — it is only ever serialized into the status JSON.
+ *
+ * The consilium LOOP caller passes NO callback, so emitting is zero-overhead and a
+ * complete no-op for it (behavior identical to before this field existed).
+ */
+export interface SdlcProgress {
+  /** Which phase the executor is in right now. */
+  phase: "coding" | "committing" | "pushing" | "opening_pr" | "done";
+  /** 1-based position of the action point being worked. For the push/opening_pr/
+   *  done phases (no single AP) this carries the action-point TOTAL. */
+  actionPointIndex: number;
+  /** How many action points this round carries (one coder run + commit each). */
+  actionPointTotal: number;
+  /** The current action point's title — UNTRUSTED, control-stripped + clamped
+   *  (`sanitizeLine`). Empty for the push/opening_pr/done phases. Display only. */
+  actionPointTitle: string;
+  /** How many action points have produced a commit so far. */
+  completedCount: number;
+}
+
+/** Optional progress sink threaded through the per-AP loop + push/PR phases. */
+export type SdlcProgressFn = (progress: SdlcProgress) => void;
 
 export interface SdlcHandoffRequest {
   /** Allowlisted repo to operate on. */
@@ -137,8 +177,9 @@ function scrub(raw: string): string {
 
 /**
  * Sanitize UNTRUSTED model text for a SINGLE-LINE field (commit subject / PR
- * status line): strip control chars / newlines, collapse whitespace, clamp.
- * Passed only as arg-array / body-file content — never a shell string.
+ * status line / progress title): strip control chars / newlines, collapse
+ * whitespace, clamp. Passed only as arg-array / body-file content / display JSON
+ * — never a shell string.
  */
 function sanitizeLine(value: string, max: number): string {
   return value
@@ -255,12 +296,33 @@ export function buildPrStatusBody(input: PrStatusBodyInput): string {
 }
 
 /**
+ * Wrap the optional progress sink so a THROWING callback can NEVER break the
+ * executor's NEVER-THROWS guarantee (the sink is best-effort + display-only).
+ * Returns a no-op when no callback was supplied (the consilium LOOP path).
+ */
+function makeEmit(onProgress?: SdlcProgressFn): SdlcProgressFn {
+  if (!onProgress) return () => {};
+  return (p: SdlcProgress) => {
+    try {
+      onProgress(p);
+    } catch {
+      // Progress is best-effort; a bad sink must not affect the SDLC run.
+    }
+  };
+}
+
+/**
  * Run the full SDLC handoff for one round. Never throws. The worktree is removed
  * in a `finally`, so it is cleaned up even when a coder run throws / times out.
+ *
+ * @param onProgress OPTIONAL display-only progress sink. The consilium LOOP caller
+ *   passes nothing ⇒ zero behavior change; the human-triggered service passes one
+ *   to surface per-AP progress on the status poll.
  */
 export async function runSdlcHandoff(
   req: SdlcHandoffRequest,
   deps: SdlcExecutorDeps = {},
+  onProgress?: SdlcProgressFn,
 ): Promise<SdlcHandoffResult> {
   const gitRaw = deps.gitRaw ?? defaultGitRaw;
   const createWorktree = deps.createWorktree ?? createSdlcWorktree;
@@ -269,6 +331,7 @@ export async function runSdlcHandoff(
   const runCoder = deps.runCoder ?? ((dir, aps, opts) => sharedCoder.run(dir, aps, opts));
   const push = deps.push ?? pushBranch;
   const openPr = deps.openPr ?? openDraftPr;
+  const emit = makeEmit(onProgress);
 
   // B-3: server-derived branch; defensively re-gate before anything runs.
   const branch = buildBranchName(req.loopId, req.round);
@@ -292,21 +355,37 @@ export async function runSdlcHandoff(
       // SEQUENTIAL per-action-point runs in the ONE shared worktree (avoid edit
       // conflicts). Each `runActionPoint` NEVER throws — a coder timeout/error is
       // caught, its work committed `[partial]`, and the loop continues.
+      const total = req.actionPoints.length;
       const outcomes: ApOutcome[] = [];
       let committedCount = 0;
-      for (let i = 0; i < req.actionPoints.length; i++) {
+      for (let i = 0; i < total; i++) {
         const outcome = await runActionPoint(
-          { gitRaw, runCoder },
+          { gitRaw, runCoder, emit, completedBefore: committedCount },
           wt,
           req,
           req.actionPoints[i],
           i + 1,
-          req.actionPoints.length,
+          total,
         );
         outcomes.push(outcome);
         if (outcome.committed) committedCount += 1;
       }
-      return await pushAndOpenPr(req, branch, base, wt, outcomes, committedCount, { gitRaw, push, openPr });
+      const result = await pushAndOpenPr(req, branch, base, wt, outcomes, committedCount, {
+        gitRaw,
+        push,
+        openPr,
+        emit,
+      });
+      // Terminal beat — the executor finished its work for this round (the SERVICE
+      // separately classifies done/failed from the result; this is phase-only).
+      emit({
+        phase: "done",
+        actionPointIndex: total,
+        actionPointTotal: total,
+        actionPointTitle: "",
+        completedCount: committedCount,
+      });
+      return result;
     } finally {
       // Cleanup GUARANTEE: remove the worktree even on any failure above.
       await removeWorktree(req.repoPath, wt.worktreeDir, { baseDir: wt.baseDir, gitRaw });
@@ -320,10 +399,17 @@ export async function runSdlcHandoff(
 /**
  * Run ONE action point: coder → `git add -A` → commit (partial-preserve on
  * timeout/error). NEVER throws — every failure is captured into the returned
- * outcome so the round continues and partial work is preserved.
+ * outcome so the round continues and partial work is preserved. Emits a `coding`
+ * beat before the coder runs and a `committing` beat before the commit.
  */
 async function runActionPoint(
-  io: { gitRaw: GitRunner; runCoder: NonNullable<SdlcExecutorDeps["runCoder"]> },
+  io: {
+    gitRaw: GitRunner;
+    runCoder: NonNullable<SdlcExecutorDeps["runCoder"]>;
+    emit: SdlcProgressFn;
+    /** Commits produced by EARLIER action points (this AP not yet counted). */
+    completedBefore: number;
+  },
   wt: CreateWorktreeResult,
   req: SdlcHandoffRequest,
   ap: ActionPoint,
@@ -332,7 +418,18 @@ async function runActionPoint(
 ): Promise<ApOutcome> {
   const priority = sanitizeLine(ap.priority ?? "-", PRIORITY_MAX) || "-";
   const title = sanitizeLine(ap.title ?? "", PR_BODY_TITLE_MAX);
+  // Display-only progress title — clamped + control-stripped (UNTRUSTED text).
+  const progressTitle = sanitizeLine(ap.title ?? "", PROGRESS_TITLE_MAX);
   const base: Omit<ApOutcome, "status" | "committed" | "note"> = { index, priority, title };
+
+  // 0. Beat: about to run the coder for THIS action point.
+  io.emit({
+    phase: "coding",
+    actionPointIndex: index,
+    actionPointTotal: total,
+    actionPointTitle: progressTitle,
+    completedCount: io.completedBefore,
+  });
 
   // 1. Run the coder for THIS action point only. A throw (timeout / binary
   //    missing) is caught — its partial edits are still committed below.
@@ -371,6 +468,14 @@ async function runActionPoint(
   const isPartial = threw || (coder !== null && !coder.ok);
   const note = isPartial ? (runNote ?? coder?.error ?? "coder did not finish") : undefined;
   const { subject, body } = buildApCommitMessage(req.round, ap, index, total, isPartial, note);
+  // Beat: about to commit THIS action point's work.
+  io.emit({
+    phase: "committing",
+    actionPointIndex: index,
+    actionPointTotal: total,
+    actionPointTitle: progressTitle,
+    completedCount: io.completedBefore,
+  });
   try {
     // Arg-array `-m` elements — never a shell string. Untrusted text only here.
     await io.gitRaw(wt.worktreeDir, ["commit", "-m", subject, "-m", body]);
@@ -388,6 +493,7 @@ async function runActionPoint(
 /**
  * After all action points: if ANY commit exists, push the branch + open ONE Draft
  * PR whose body summarizes per-AP status. ZERO commits → `{ prRef: null }` + error.
+ * Emits a `pushing` beat before the push and an `opening_pr` beat before gh.
  */
 async function pushAndOpenPr(
   req: SdlcHandoffRequest,
@@ -396,8 +502,9 @@ async function pushAndOpenPr(
   wt: CreateWorktreeResult,
   outcomes: readonly ApOutcome[],
   committedCount: number,
-  io: { gitRaw: GitRunner; push: typeof pushBranch; openPr: typeof openDraftPr },
+  io: { gitRaw: GitRunner; push: typeof pushBranch; openPr: typeof openDraftPr; emit: SdlcProgressFn },
 ): Promise<SdlcHandoffResult> {
+  const total = req.actionPoints.length;
   if (committedCount === 0) {
     // Every action point failed / produced nothing — no branch to PR (as today).
     const failed = outcomes.find((o) => o.note)?.note;
@@ -406,12 +513,30 @@ async function pushAndOpenPr(
 
   const headCommit = (await io.gitRaw(wt.worktreeDir, ["rev-parse", "HEAD"])).trim();
 
+  // Beat: pushing the branch.
+  io.emit({
+    phase: "pushing",
+    actionPointIndex: total,
+    actionPointTotal: total,
+    actionPointTitle: "",
+    completedCount: committedCount,
+  });
+
   // Push from the worktree (shares the repo's object store + remotes). pr-wrapper
   // re-gates the branch (B-3) and runs under a sanitized env (H-7).
   const pushed = await io.push(wt.worktreeDir, branch);
   if (!pushed.ok) {
     return { prRef: null, headCommit, error: scrub(`push failed: ${pushed.message}`) };
   }
+
+  // Beat: opening the Draft PR.
+  io.emit({
+    phase: "opening_pr",
+    actionPointIndex: total,
+    actionPointTotal: total,
+    actionPointTitle: "",
+    completedCount: committedCount,
+  });
 
   const pr = await io.openPr(wt.worktreeDir, {
     base,

--- a/tests/unit/consilium/execute-sdlc-route.test.ts
+++ b/tests/unit/consilium/execute-sdlc-route.test.ts
@@ -20,7 +20,7 @@ import express from "express";
 import request from "supertest";
 import type { AppConfig } from "../../../server/config/schema.js";
 import type { IStorage } from "../../../server/storage.js";
-import type { SdlcHandoffResult } from "../../../server/services/sdlc/executor.js";
+import type { SdlcHandoffResult, SdlcProgress } from "../../../server/services/sdlc/executor.js";
 import { SdlcExecutionService } from "../../../server/services/consilium/execute-sdlc.js";
 import { registerExecuteSdlcRoutes } from "../../../server/routes/execute-sdlc.js";
 
@@ -239,6 +239,36 @@ describe("GET /api/task-groups/:groupId/execute-sdlc/status", () => {
     expect(done.body.status).toBe("done");
     expect(done.body.prRef).toBe("https://gh/pr/42");
     expect(done.body.headCommit).toBe("deadbeef");
+  });
+
+  it("surfaces the per-AP PROGRESS beat for a running run", async () => {
+    // The executor emits one synchronous beat, then stays running.
+    const runSdlc = vi.fn((_req: unknown, _deps: unknown, onProgress?: (p: SdlcProgress) => void) => {
+      onProgress?.({
+        phase: "coding",
+        actionPointIndex: 1,
+        actionPointTotal: 2,
+        actionPointTitle: "SERVER AP1",
+        completedCount: 0,
+      });
+      return new Promise<SdlcHandoffResult>(() => {}); // stay running
+    });
+    const { app } = makeApp(makeStorage(), runSdlc as never);
+
+    const post = await request(app).post(`/api/task-groups/${GROUP}/execute-sdlc`).send({});
+    expect(post.status).toBe(202);
+
+    const status = await request(app).get(`/api/task-groups/${GROUP}/execute-sdlc/status`);
+    expect(status.status).toBe(200);
+    expect(status.body.status).toBe("running");
+    // The progress is surfaced ALONGSIDE the existing fields.
+    expect(status.body.progress).toMatchObject({
+      phase: "coding",
+      actionPointIndex: 1,
+      actionPointTotal: 2,
+      actionPointTitle: "SERVER AP1",
+      completedCount: 0,
+    });
   });
 
   it("a non-owner cannot read another user's run status (403)", async () => {

--- a/tests/unit/sdlc/execute-sdlc-service.test.ts
+++ b/tests/unit/sdlc/execute-sdlc-service.test.ts
@@ -23,7 +23,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { AppConfig } from "../../../server/config/schema.js";
 import type { IStorage } from "../../../server/storage.js";
-import type { SdlcHandoffResult } from "../../../server/services/sdlc/executor.js";
+import type { SdlcHandoffResult, SdlcProgress } from "../../../server/services/sdlc/executor.js";
 import {
   SdlcExecutionService,
   ExecuteSdlcError,
@@ -377,5 +377,77 @@ describe("SdlcExecutionService — MED-2 watchdog + settled-row GC", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("SdlcExecutionService — per-AP progress recording", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const beat = (over: Partial<SdlcProgress> = {}): SdlcProgress => ({
+    phase: "coding",
+    actionPointIndex: 1,
+    actionPointTotal: 2,
+    actionPointTitle: "AP1",
+    completedCount: 0,
+    ...over,
+  });
+
+  it("records the LATEST progress beat onto the run row; the status surfaces it", async () => {
+    // A runSdlc that emits two beats SYNCHRONOUSLY, then stays running (holds the row).
+    const runSdlc = vi.fn((_req: unknown, _deps: unknown, onProgress?: (p: SdlcProgress) => void) => {
+      onProgress?.(beat({ phase: "coding", actionPointIndex: 1, completedCount: 0 }));
+      onProgress?.(beat({ phase: "committing", actionPointIndex: 2, actionPointTitle: "AP2", completedCount: 1 }));
+      return new Promise<SdlcHandoffResult>(() => {}); // never settles → stays running
+    });
+    const { service } = makeService(makeStorage({}), runSdlc as never);
+
+    await service.execute(GROUP, OWNER);
+    const status = service.getStatus(GROUP)!;
+    expect(status.status).toBe("running");
+    // The LATEST beat (committing AP2) wins — not the earlier coding beat.
+    expect(status.progress).toEqual({
+      phase: "committing",
+      actionPointIndex: 2,
+      actionPointTotal: 2,
+      actionPointTitle: "AP2",
+      completedCount: 1,
+    });
+  });
+
+  it("a progress beat AFTER settle does NOT mutate / resurrect a settled run", async () => {
+    let captured: ((p: SdlcProgress) => void) | undefined;
+    // Emit one beat, capture the sink, then RESOLVE (settles the row to done).
+    const runSdlc = vi.fn(async (_req: unknown, _deps: unknown, onProgress?: (p: SdlcProgress) => void) => {
+      captured = onProgress;
+      onProgress?.(beat({ phase: "coding", actionPointIndex: 1, completedCount: 0 }));
+      return PR_RESULT;
+    });
+    const { service } = makeService(makeStorage({}), runSdlc as never);
+
+    await service.execute(GROUP, OWNER);
+    await vi.waitFor(() => expect(service.getStatus(GROUP)?.status).toBe("done"));
+    const settled = service.getStatus(GROUP)!;
+    const progressAtSettle = settled.progress;
+
+    // A LATE beat arrives after the run settled — the running-guard must drop it.
+    captured?.(beat({ phase: "done", actionPointIndex: 2, actionPointTitle: "LATE", completedCount: 2 }));
+
+    const after = service.getStatus(GROUP)!;
+    expect(after.status).toBe("done"); // unchanged — not resurrected
+    expect(after.progress).toEqual(progressAtSettle); // the late beat did NOT overwrite it
+    expect(after.progress?.actionPointTitle).not.toBe("LATE");
+  });
+
+  it("status carries the LAST-SEEN progress once a run is settled (done)", async () => {
+    const runSdlc = vi.fn(async (_req: unknown, _deps: unknown, onProgress?: (p: SdlcProgress) => void) => {
+      onProgress?.(beat({ phase: "opening_pr", actionPointIndex: 2, actionPointTitle: "", completedCount: 2 }));
+      return PR_RESULT;
+    });
+    const { service } = makeService(makeStorage({}), runSdlc as never);
+    await service.execute(GROUP, OWNER);
+    await vi.waitFor(() => expect(service.getStatus(GROUP)?.status).toBe("done"));
+    const status = service.getStatus(GROUP)!;
+    expect(status.prRef).toBe("https://gh/pr/1"); // final fields kept
+    expect(status.progress?.phase).toBe("opening_pr"); // last-seen progress retained
   });
 });

--- a/tests/unit/sdlc/executor.test.ts
+++ b/tests/unit/sdlc/executor.test.ts
@@ -21,6 +21,7 @@ import {
   buildPrTitle,
   type SdlcHandoffRequest,
   type ApOutcome,
+  type SdlcProgress,
 } from "../../../server/services/sdlc/executor.js";
 import type { ActionPoint } from "@shared/types";
 
@@ -288,5 +289,90 @@ describe("buildPrStatusBody — enriched header + addressed action points + outc
   it("degrades to '_none recorded_' when there are no action points", () => {
     const body = buildPrStatusBody({ loopId: LOOP, round: 2, repoName: "r", actionPoints: [], outcomes });
     expect(body).toContain("_none recorded_");
+  });
+});
+
+describe("runSdlcHandoff — progress reporting (onProgress)", () => {
+  /** Collect a deep copy of every beat (the executor may reuse fields across emits). */
+  function collect() {
+    const events: SdlcProgress[] = [];
+    return { events, onProgress: (p: SdlcProgress) => events.push({ ...p }) };
+  }
+
+  it("emits coding+committing per AP with INCREASING index, then pushing→opening_pr→done", async () => {
+    const deps = makeDeps(); // both APs dirty → both commit
+    const { events, onProgress } = collect();
+    await runSdlcHandoff(baseReq(), deps as never, onProgress);
+
+    const phases = events.map((e) => e.phase);
+    // One coding + one committing beat per AP (both committed), then the tail phases.
+    expect(phases.filter((p) => p === "coding")).toHaveLength(APS.length);
+    expect(phases.filter((p) => p === "committing")).toHaveLength(APS.length);
+    expect(phases).toContain("pushing");
+    expect(phases).toContain("opening_pr");
+    // The LAST beat is the terminal "done".
+    expect(phases[phases.length - 1]).toBe("done");
+
+    // coding indices increase 1..N and carry the right total.
+    const codingIdx = events.filter((e) => e.phase === "coding").map((e) => e.actionPointIndex);
+    expect(codingIdx).toEqual([1, 2]);
+    expect(events.every((e) => e.actionPointTotal === APS.length)).toBe(true);
+
+    // completedCount climbs as commits land: AP1 coding sees 0 committed, AP2 coding sees 1.
+    const coding = events.filter((e) => e.phase === "coding");
+    expect(coding[0].completedCount).toBe(0);
+    expect(coding[1].completedCount).toBe(1);
+    // The terminal beat reports all N committed.
+    expect(events[events.length - 1]).toMatchObject({
+      phase: "done",
+      actionPointIndex: APS.length,
+      actionPointTotal: APS.length,
+      completedCount: APS.length,
+    });
+  });
+
+  it("CLAMPS + control-strips the UNTRUSTED action-point title in every coding beat", async () => {
+    const deps = makeDeps();
+    const { events, onProgress } = collect();
+    await runSdlcHandoff(baseReq(), deps as never, onProgress);
+
+    const coding0 = events.find((e) => e.phase === "coding" && e.actionPointIndex === 1)!;
+    // APS[0].title carries shell metachars + a newline — survives ONLY control-stripped.
+    expect(coding0.actionPointTitle).not.toMatch(/[\n\r]/);
+    expect(coding0.actionPointTitle).toBe("Fix `;rm -rf /` in parser with newline");
+    // The tail phases carry no AP title.
+    expect(events.find((e) => e.phase === "pushing")!.actionPointTitle).toBe("");
+    expect(events.find((e) => e.phase === "done")!.actionPointTitle).toBe("");
+  });
+
+  it("a THROWING onProgress sink never breaks the executor's NEVER-THROWS guarantee", async () => {
+    const deps = makeDeps();
+    const res = await runSdlcHandoff(baseReq(), deps as never, () => {
+      throw new Error("malicious progress sink");
+    });
+    // The run still completes + opens the PR; the bad sink is swallowed.
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+    expect(deps.removeWorktree).toHaveBeenCalledTimes(1);
+  });
+
+  it("omitting onProgress (the consilium LOOP path) is a zero-behavior-change no-op", async () => {
+    const deps = makeDeps();
+    const res = await runSdlcHandoff(baseReq(), deps as never);
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+    expect(res.headCommit).toBe("headsha000");
+  });
+
+  it("ZERO-commit round still emits a terminal done (no pushing/opening_pr beats)", async () => {
+    // Nothing dirty → no commits → no push/PR — but the terminal done still fires.
+    const deps = makeDeps({ gitRaw: makeGitRaw(false) });
+    const { events, onProgress } = collect();
+    await runSdlcHandoff(baseReq(), deps as never, onProgress);
+    const phases = events.map((e) => e.phase);
+    expect(phases).toContain("coding");
+    expect(phases).not.toContain("committing"); // never reached the commit step
+    expect(phases).not.toContain("pushing");
+    expect(phases).not.toContain("opening_pr");
+    expect(phases[phases.length - 1]).toBe("done");
+    expect(events[events.length - 1].completedCount).toBe(0);
   });
 });


### PR DESCRIPTION
Clicking **"Передать в SDLC → Draft PR"** was a black box — a bare spinner, no sense of where the work went or what happens next. This surfaces real progress.

## Executor
`runSdlcHandoff` gains an **optional `onProgress(SdlcProgress)`** callback, emitted at each step: `coding` (per action point — 1-based index/total + title), `committing`, `pushing`, `opening_pr`, terminal `done`. The `actionPointTitle` is **untrusted** verdict text → clamped + control-scrubbed (`sanitizeLine`, 120-char cap) before it enters the progress object; display-only JSON, never a shell/branch/PR title. A throwing sink is swallowed (the never-throws guarantee holds). The **consilium loop caller passes no callback → zero behavior change**.

## execute-sdlc service + status
Writes the latest `SdlcProgress` onto the run row, **guarded on `status==="running"`** (a late beat can't resurrect a settled/force-settled run). `GET …/execute-sdlc/status` returns `progress` alongside the existing fields. Single-flight, global cap, watchdog, GC, scrub unchanged.

## verdict-panel (UI)
The running state shows a **progress panel**: a humanized **phase line** ("Кодирую action point 2/5: «…»" → коммит → push → Draft PR), a **progress bar** (completed/total), and an always-on **explainer** — *isolated worktree (your tree untouched), commit-per-AP, opens a Draft PR; agents never merge — review/merge is yours*. Renders defensively when `progress` is absent. `done` adds a "проверь и смержи Draft PR" hint.

## Verification
`tsc` clean; `tests/unit/sdlc` + `tests/unit/consilium` **315/315** (+9: per-AP emit order, title scrub, throwing-sink safe, no-callback no-op, settle-guard, status surfaces progress).