### PR TITLE
fix(consilium): execute-sdlc watchdog budget covers the whole multi-AP run

### DIFF
--- a/server/services/consilium/execute-sdlc.ts
+++ b/server/services/consilium/execute-sdlc.ts
@@ -392,7 +392,11 @@ export class SdlcExecutionService {
 
     // MED-2: arm the anti-wedge watchdog BEFORE dispatch so even a synchronously
     // hung promise is covered. `finalize` clears it on a normal settle.
-    const budgetMs = cfg.sdlcTimeoutMs + WATCHDOG_MARGIN_MS;
+    // The run codes each action point SEQUENTIALLY, each bounded by sdlcTimeoutMs,
+    // so the WHOLE-run budget is N x sdlcTimeoutMs (+ margin) — sizing it for a
+    // single coder would force-settle a HEALTHY multi-AP run mid-way (the #417
+    // per-AP-vs-single-coder lesson, here applied to the watchdog).
+    const budgetMs = Math.max(1, run.actionPointCount) * cfg.sdlcTimeoutMs + WATCHDOG_MARGIN_MS;
     run.watchdog = setTimeout(() => {
       this.finalize(groupId, run, {
         status: "failed",

--- a/tests/unit/sdlc/execute-sdlc-service.test.ts
+++ b/tests/unit/sdlc/execute-sdlc-service.test.ts
@@ -298,8 +298,8 @@ describe("SdlcExecutionService — MED-2 watchdog + settled-row GC", () => {
       const first = await service.execute(GROUP, OWNER);
       expect(service.getStatus(GROUP)?.status).toBe("running");
 
-      // Advance just past coderTimeoutMs + the watchdog margin.
-      await vi.advanceTimersByTimeAsync(SDLC_TIMEOUT_MS + WATCHDOG_MARGIN_MS + 1);
+      // Advance just past the WHOLE-run budget: actionPoints(2) x coderTimeoutMs + margin.
+      await vi.advanceTimersByTimeAsync(2 * SDLC_TIMEOUT_MS + WATCHDOG_MARGIN_MS + 1);
 
       const settled = service.getStatus(GROUP)!;
       expect(settled.status).toBe("failed");
@@ -324,7 +324,8 @@ describe("SdlcExecutionService — MED-2 watchdog + settled-row GC", () => {
       const { service } = makeService(makeStorage({}), runSdlc as never);
 
       await service.execute(GROUP, OWNER);
-      await vi.advanceTimersByTimeAsync(SDLC_TIMEOUT_MS + WATCHDOG_MARGIN_MS + 1);
+      // WHOLE-run budget: actionPoints(2) x coderTimeoutMs + margin.
+      await vi.advanceTimersByTimeAsync(2 * SDLC_TIMEOUT_MS + WATCHDOG_MARGIN_MS + 1);
 
       const forced = service.getStatus(GROUP)!;
       expect(forced.status).toBe("failed");


### PR DESCRIPTION
The anti-wedge watchdog (MED-2) was armed at `sdlcTimeoutMs + margin` — a **single** coder's budget. But the run codes each action point **sequentially** (N coders), so a healthy multi-AP run (e.g. the live 12-action-point Creme run) gets **force-settled to "failed" at ~one-coder-timeout** while the coder is still working. The executor keeps running and still opens the Draft PR, but the status lies. Same per-AP-vs-single-coder class as the #417 redrive bug.

Budget is now `max(1, actionPointCount) * sdlcTimeoutMs + margin` — still force-settles a genuinely hung run, sized to the whole round. Tests advance fake timers by the 2-action-point budget. tsc clean; sdlc+consilium **315/315**.