### PR TITLE
feat(consilium): Stage 2a — skilled, archetype-branched coder (no new execution)

### DIFF
--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -352,6 +352,23 @@ export const ConfigSchema = z.object({
          */
         model: z.string().min(1).default(DEFAULT_TASK_MODEL),
       }).default({}),
+      /**
+       * Stage 2a (design §3.C/§4): the SKILLED, archetype-branched implement
+       * (develop) phase. When `enabled` is FALSE the loop runs TODAY'S single
+       * unskilled coder per action point (byte-for-byte unchanged). When TRUE the
+       * SDLC executor selects an ordered SKILLED step set from the loop's Stage-1
+       * archetype (e.g. repo-assessment → test-author → coder) and scopes each
+       * coder invocation by the step's capability. This is a strict SUPERSET of
+       * the develop phase: Stage 2a executes NOTHING new (no test run, no FSM
+       * change) — the per-criterion sandboxed verification/fix-loop is Stage 2b and
+       * is deliberately NOT configured here (so verification can never execute).
+       */
+      implement: z.object({
+        /** Kill-switch: false → today's unskilled coder path; true → the skilled
+         *  path. Defaults FALSE (opt-in). Also gated by the parent
+         *  `consiliumLoop.enabled` (the loop only runs at all when that is true). */
+        enabled: z.boolean().default(false),
+      }).default({}),
     }).default({}),
   }).default({}),
 });

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -61,7 +61,7 @@ import { buildDiffContext } from "./diff-context.js";
 import type { DevCloseoutResult } from "./dev-closeout.js";
 import { runSdlcHandoff, type SdlcProgress } from "../sdlc/executor.js";
 import { assertAllowedRepoPath } from "./repo-allowlist.js";
-import { assertRepoIsProjectWorkspace, backtickFence } from "./review-factory.js";
+import { assertRepoIsProjectWorkspace, backtickFence, stripControlMultiline } from "./review-factory.js";
 
 // ─── FSM events (design §3 "Event / guard" column) ──────────────────────────
 
@@ -236,7 +236,11 @@ export function buildPlannerPrompt(
 ): { system: string; user: string } {
   const apBlock = formatActionPointsForPlanner(actionPoints);
   const apFence = backtickFence(apBlock);
-  const instr = (engineerInstruction ?? "").trim();
+  // Carry-in (a) — parity with the judge path (untrustedExtraBlock): strip control
+  // chars from the UNTRUSTED engineer instruction BEFORE fencing. backtickFence
+  // already blocks structural fence-breakout and the reply is enum-clamped, so this
+  // is defence-in-depth, but it keeps the planner and judge sanitisation identical.
+  const instr = stripControlMultiline(engineerInstruction ?? "").trim();
 
   const system =
     "You triage a software work item into EXACTLY ONE archetype for downstream " +
@@ -791,15 +795,28 @@ export class ConsiliumLoopController {
       return { ok: true, loop: fresh, archetype: fresh.archetype ?? null };
     }
 
-    // PLAIN partial update (NOT casLoopState) — writing a column on a terminal loop
-    // must NOT transition it. `archetypeSource: 'proposed'` marks the provenance.
-    const updated = await this.storage.updateLoop(loopId, {
+    // Carry-in (b) — SOURCE-CONDITIONAL write (now archetype is LOAD-BEARING in
+    // Stage 2a). A PLAIN partial update (NOT casLoopState — writing a column on a
+    // terminal loop must NOT transition it), but guarded so a model proposal can
+    // NEVER clobber a human override even under a sub-millisecond TOCTOU race the
+    // pre-check + re-read above cannot fully close: the UPDATE matches only when
+    // `archetype_source IS DISTINCT FROM 'override'`. 0 rows ⇒ an override landed →
+    // we keep it (re-read) and report it, never overwrite. `archetypeSource:
+    // 'proposed'` marks the provenance on a successful write.
+    const updated = await this.storage.updateLoopArchetypeIfNotOverridden(loopId, {
       archetype: parsed.archetype,
       archetypeSource: "proposed",
       archetypeRationale: parsed.rationale,
       archetypeParams: parsed.params ?? null,
       archetypeDecidedAt: new Date(),
     });
+    if (!updated) {
+      // An override won the race between the re-read and the conditional write —
+      // never clobber it. Surface the current (override) row, fail-soft.
+      this.log(loopId, "plan: conditional write skipped — human override present (not clobbered)");
+      const latest = await this.storage.getLoop(loopId);
+      return { ok: true, loop: latest ?? fresh, archetype: latest?.archetype ?? fresh.archetype ?? null };
+    }
     this.log(loopId, `plan: archetype proposed = ${parsed.archetype}`);
     return { ok: true, loop: updated, archetype: parsed.archetype };
   }
@@ -1125,6 +1142,13 @@ export class ConsiliumLoopController {
     if (this.deps.runCloseout) return this.deps.runCloseout(loop, verdict);
     const cfg = this.loopConfig();
     const run = this.deps.runSdlc ?? runSdlcHandoff;
+    // Stage 2a: thread the loop's Stage-1 archetype into the executor ONLY when the
+    // `implement` kill-switch is on. When OFF (default) we pass archetype=null and
+    // no skills resolver ⇒ selectSkillSet returns [] ⇒ the executor runs TODAY'S
+    // single unskilled coder per action point (byte-for-byte unchanged). When ON,
+    // the executor selects the archetype's skilled step set and binds it against the
+    // existing skills table (storage.getSkills). NOTHING new executes either way.
+    const skilled = cfg.implement.enabled;
     // REAL path: the SDLC executor cuts an ISOLATED worktree (NEVER the user's
     // checkout), runs the agentic coder to make REAL multi-file edits, then
     // commits + opens a Draft PR. baseRef defaults to the repo's default-branch
@@ -1140,7 +1164,10 @@ export class ConsiliumLoopController {
       // Per-action-point coder timeout (configurable). The executor runs the
       // coder once per action point sequentially; this bounds a SINGLE run.
       coderTimeoutMs: cfg.sdlcTimeoutMs,
-    }, undefined, onProgress);
+      // Stage 2a archetype-branched skilled coder (null when the kill-switch is off).
+      archetype: skilled ? loop.archetype ?? null : null,
+      archetypeParams: skilled ? loop.archetypeParams ?? null : null,
+    }, skilled ? { getSkills: () => this.storage.getSkills() } : undefined, onProgress);
   }
 
   /**

--- a/server/services/consilium/review-factory.ts
+++ b/server/services/consilium/review-factory.ts
@@ -234,7 +234,7 @@ export function buildCrossReviewTasks(panel: ConsiliumPanel): CreateTaskParam[] 
  * multi-line field. The result only ever lands in the objective body (markdown
  * fed to the model) — never a shell string, branch name, or PR title.
  */
-function stripControlMultiline(value: string): string {
+export function stripControlMultiline(value: string): string {
   // eslint-disable-next-line no-control-regex
   return value.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]+/g, " ");
 }

--- a/server/services/consilium/skills/catalog.ts
+++ b/server/services/consilium/skills/catalog.ts
@@ -1,0 +1,180 @@
+/**
+ * catalog.ts — Stage 2a skill catalog (code-side, ZERO migration).
+ *
+ * A thin SELECTION + BINDING layer over the EXISTING skills system. It turns the
+ * loop's Stage-1 `archetype` into an ordered list of SKILLED coder steps so the
+ * SDLC develop phase can run an archetype-aware, multi-step coder instead of the
+ * single unskilled coder. It is a strict SUPERSET of today's behavior:
+ *
+ *   - An archetype that maps to NO steps (`research` / `infra` / `null` / anything
+ *     unrecognised) returns `[]`, and the executor falls back to TODAY'S single
+ *     unskilled-coder-per-action-point path — BYTE-FOR-BYTE unchanged. Stage 2a
+ *     REGRESSES NOTHING.
+ *   - `repo-assessment` maps to an ordered TDD pair: a TEST AUTHOR then a CODER.
+ *
+ * Stage 2a executes NOTHING new: each `SkilledStep` only RECORDS the verification
+ * method it WOULD use (`test-run`) — the sandboxed test runner that consumes it is
+ * Stage 2b. No tests run, no network, no live env here.
+ *
+ * SECURITY (Stage 2a is low-risk — NO new execution):
+ *   - The coder baseline (isolated worktree, env allowlist, no Bash, Draft-PR-only)
+ *     is UNCHANGED. A step's `capability` can only ever NARROW the tool surface
+ *     (`read-only` ⇒ Read only); it can NEVER widen it (see `capabilityTools`).
+ *   - Step system prompts are CODE-TRUST (baked-in below). A same-named row in the
+ *     existing `skills` table MAY layer its `systemPromptOverride` (user-authored,
+ *     already in the platform) and INTERSECT its `tools` — intersection can only
+ *     narrow, so a skill row can never grant a tool outside the capability ceiling.
+ */
+import type { Archetype } from "@shared/types";
+import type { Skill } from "@shared/schema";
+import { ALLOWED_TOOLS } from "../../sdlc/coder.js";
+
+/**
+ * What a skilled step is allowed to touch. `read-only` confines the coder to the
+ * `Read` tool (no Edit/Write); `worktree-write` is the EXISTING coder baseline
+ * (Edit/Write/Read inside the isolated worktree). `deploy-live` is Stage 3 — it is
+ * deliberately NOT a member here.
+ */
+export type SkillCapability = "read-only" | "worktree-write";
+
+/**
+ * How a step's output WOULD be verified. Stage 2a only RECORDS this for the round
+ * audit / Stage 2b; it does NOT execute any verification.
+ */
+export type VerificationMethod = "test-run" | "judge" | "none";
+
+/**
+ * One ordered step of a skilled implement run. `skillName` is the lookup key into
+ * the existing `skills` table (optional layering); `systemPrompt` is the baked-in
+ * DEFAULT so the step works against an EMPTY skills table.
+ */
+export interface SkilledStep {
+  /** Stable id (archetype-scoped) for logs / the round audit. */
+  id: string;
+  /** Lookup key into the existing `skills` table for OPTIONAL layering. */
+  skillName: string;
+  /** Tool-surface ceiling for this step. Only ever NARROWS the coder baseline. */
+  capability: SkillCapability;
+  /** The verification method Stage 2b WOULD run. Stage 2a records it, never runs it. */
+  verification: VerificationMethod;
+  /** Baked-in DEFAULT system prompt (works against an EMPTY skills table). */
+  systemPrompt: string;
+}
+
+/**
+ * A {@link SkilledStep} resolved against the skills table: the effective system
+ * prompt + the capability-scoped, skill-narrowed tool allowlist handed to the
+ * coder invocation.
+ */
+export interface BoundSkillStep {
+  /** The catalog step this binding came from. */
+  step: SkilledStep;
+  /** Effective system prompt: baked-in default, plus a skill row override if present. */
+  systemPrompt: string;
+  /** Effective `--allowedTools`: capability base, narrowed by the skill row's tools. */
+  allowedTools: readonly string[];
+  /** The skills-table row id that was layered, or null (baked-in default only). */
+  boundSkillId: string | null;
+}
+
+// ─── Baked-in DEFAULT step prompts (code-trust) ──────────────────────────────
+
+const TEST_AUTHOR_PROMPT = [
+  "ROLE: TEST AUTHOR (test-driven development, RED step).",
+  "For the action point(s) below, write or update AUTOMATED TESTS that encode the",
+  "expected behavior / acceptance criteria as executable checks. Author ONLY tests",
+  "— do NOT implement the production code; a later step writes the implementation.",
+  "Place tests beside the project's existing test suite, following its conventions.",
+  "The tests should FAIL against the current code (red) and pass once the",
+  "implementation lands. Do NOT run the tests — the server runs them later.",
+].join("\n");
+
+const CODER_PROMPT = [
+  "ROLE: IMPLEMENTER (test-driven development, GREEN step).",
+  "Make the production code/spec edits that satisfy the action point(s) and that",
+  "would make the authored tests pass. Prefer the SMALLEST correct change. Do not",
+  "weaken or delete tests to make them pass; fix the implementation instead.",
+].join("\n");
+
+/**
+ * Select the ordered skilled steps for an archetype. The ONLY wired archetype in
+ * Stage 2a is `repo-assessment` (a TDD test-author → coder pair). Every other
+ * value — `research`, `infra`, `null`, or anything unrecognised — returns `[]`, so
+ * the executor falls back to today's single unskilled coder (NO regression).
+ *
+ * `params` (the loop's `archetype_params`) is carried for forward-compatibility;
+ * Stage 2a does not branch on it.
+ */
+export function selectSkillSet(
+  archetype: Archetype | null,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  params?: Record<string, string> | null,
+): SkilledStep[] {
+  switch (archetype) {
+    case "repo-assessment":
+      return [
+        {
+          id: "repo-assessment/test-author",
+          skillName: "test-author",
+          capability: "worktree-write",
+          verification: "test-run",
+          systemPrompt: TEST_AUTHOR_PROMPT,
+        },
+        {
+          id: "repo-assessment/coder",
+          skillName: "coder",
+          capability: "worktree-write",
+          verification: "test-run",
+          systemPrompt: CODER_PROMPT,
+        },
+      ];
+    // research / infra → deferred to Stage 3; null / unknown → today's path.
+    default:
+      return [];
+  }
+}
+
+/**
+ * The tool-surface CEILING for a capability. `read-only` ⇒ just `Read`;
+ * `worktree-write` ⇒ the EXISTING coder baseline ({@link ALLOWED_TOOLS}). Both are
+ * subsets of the baseline — a capability can only ever NARROW the coder, never
+ * widen it. Returns a fresh array so callers cannot mutate the shared baseline.
+ */
+export function capabilityTools(capability: SkillCapability): readonly string[] {
+  switch (capability) {
+    case "read-only":
+      return ["Read"];
+    case "worktree-write":
+      return [...ALLOWED_TOOLS];
+  }
+}
+
+/**
+ * Bind a catalog step to an OPTIONAL same-named skills-table row.
+ *
+ *   - System prompt: the baked-in default, plus the row's `systemPromptOverride`
+ *     appended when present (the override REFINES the code-trust default).
+ *   - Tools: the capability base, INTERSECTED with the row's `tools` when the row
+ *     lists any. Intersection can only NARROW (never widen past the capability
+ *     ceiling). A row whose tools are DISJOINT from the ceiling (e.g. lists only
+ *     `Bash`) imposes no usable constraint, so the capability base is kept rather
+ *     than stripping the step to zero tools — a skill row can WEAKEN but never
+ *     GRANT a capability.
+ */
+export function bindSkillStep(step: SkilledStep, skillRow: Skill | undefined): BoundSkillStep {
+  const base = capabilityTools(step.capability);
+
+  let systemPrompt = step.systemPrompt;
+  const override = (skillRow?.systemPromptOverride ?? "").trim();
+  if (override) systemPrompt = `${step.systemPrompt}\n\n${override}`;
+
+  let allowedTools = base;
+  const rowTools = skillRow?.tools ?? [];
+  if (rowTools.length > 0) {
+    const narrowed = base.filter((t) => rowTools.includes(t));
+    // Disjoint row tools ⇒ keep the capability base (no widening, no zeroing).
+    allowedTools = narrowed.length > 0 ? narrowed : base;
+  }
+
+  return { step, systemPrompt, allowedTools, boundSkillId: skillRow?.id ?? null };
+}

--- a/server/services/sdlc/coder.ts
+++ b/server/services/sdlc/coder.ts
@@ -17,6 +17,12 @@
  * bounded concurrency. Output is parsed via the provider's `parseCompleteOutput`
  * (`--output-format json` → one JSON object).
  *
+ * Stage 2a (skilled coder): the invocation is now PARAMETERISABLE by a SkilledStep
+ * — a capability-scoped `--allowedTools` (only ever NARROWS the baseline) + a
+ * prepended role `systemPrompt`. The DEFAULTS reproduce the legacy invocation
+ * BYTE-FOR-BYTE, so the unskilled path is unchanged. No new execution: the coder
+ * still only edits files; build/test stays SERVER-SIDE (Stage 2b).
+ *
  * SECURITY (BINDING — adversarial-review surface):
  *   - The action-point text is UNTRUSTED model output. It reaches ONLY the prompt,
  *     and ONLY via STDIN (a safe channel) — never an argv element, never a shell
@@ -27,6 +33,8 @@
  *     `--dangerously-skip-permissions`. `--allowedTools` is an explicit, minimal
  *     allowlist of FILE tools only (Edit/Write/Read) — NO Bash (C-1: a Bash child
  *     is not confined by `--add-dir` and would escape the worktree), NO MCP, NO web.
+ *     A Stage-2a capability can only SUBSET this (read-only ⇒ Read); the baseline is
+ *     the hard ceiling `buildCoderArgs` enforces — it is NEVER loosened.
  *   - The coder spawns under a SANITIZED, ALLOWLISTED env (H-1): only PATH/HOME/
  *     locale + the claude CLI's own auth/config vars are forwarded. DB creds,
  *     GH_TOKEN/GITHUB_TOKEN, AWS_ vars, PASSWORD/SECRET/other TOKEN vars, and
@@ -57,6 +65,9 @@ const ERROR_MAX = 300;
  * read the repo `.env` symlink (live POSTGRES_PASSWORD) and write to the user's
  * checkout or `main`. File edits do not need Bash. If a build/test step is ever
  * required it MUST run SERVER-SIDE after the coder returns — never inside the agent.
+ *
+ * Stage 2a: this is ALSO the hard CEILING `buildCoderArgs` filters every requested
+ * tool list against — a capability/skill can subset it but can NEVER add to it.
  */
 export const ALLOWED_TOOLS = ["Edit", "Write", "Read"] as const;
 
@@ -102,6 +113,10 @@ export function sanitizedCoderEnv(
 const TITLE_MAX = 300;
 const RATIONALE_MAX = 2_000;
 const FIELD_MAX = 80;
+/** Clamp on a SKILLED step's prepended role prompt (Stage 2a) — bounded like every
+ *  other prompt field. The prompt is code-trust (baked-in) or a user-authored skill
+ *  row already in the platform, but it still goes to STDIN bounded. */
+const SYSTEM_PROMPT_MAX = 4_000;
 
 export interface CoderResult {
   /** True iff the CLI completed and did not report an error. */
@@ -123,6 +138,19 @@ export interface CoderOptions {
   signal?: AbortSignal;
   /** Override the spawned env (tests). Defaults to `sanitizedCoderEnv()` (H-1). */
   env?: NodeJS.ProcessEnv;
+  /**
+   * Stage 2a: the capability-scoped tool allowlist for THIS run (a SkilledStep's
+   * `read-only` ⇒ ["Read"], `worktree-write` ⇒ the baseline). Defaults to the
+   * baseline {@link ALLOWED_TOOLS}. Hard-filtered to the baseline ceiling in
+   * `buildCoderArgs` — a capability can only ever NARROW, never widen.
+   */
+  allowedTools?: readonly string[];
+  /**
+   * Stage 2a: a SKILLED step's role prompt (code-trust baked-in default, optionally
+   * layered with a user-authored skill row), PREPENDED to the coder prompt. Absent
+   * ⇒ the legacy prompt verbatim (no regression).
+   */
+  systemPrompt?: string;
 }
 
 function clamp(value: string, max: number): string {
@@ -134,8 +162,16 @@ function clamp(value: string, max: number): string {
  * to STDIN only. Each field is clamped; the instruction is server-fixed and tells
  * the agent to make ONLY the file edits (the server owns commit/push/PR, so the
  * agent must NOT touch git/branches/PRs).
+ *
+ * Stage 2a: an OPTIONAL `systemPrompt` (a SKILLED step's role prompt — code-trust
+ * baked-in default, optionally layered with a user-authored skill row) is PREPENDED
+ * as a clamped block. When absent (the unskilled path) the result is BYTE-FOR-BYTE
+ * identical to before — no regression.
  */
-export function buildCoderPrompt(actionPoints: readonly ActionPoint[]): string {
+export function buildCoderPrompt(
+  actionPoints: readonly ActionPoint[],
+  opts: { systemPrompt?: string } = {},
+): string {
   const items = actionPoints.map((ap, i) => {
     const title = clamp(ap.title ?? "", TITLE_MAX);
     const priority = clamp(ap.priority ?? "-", FIELD_MAX);
@@ -148,7 +184,12 @@ export function buildCoderPrompt(actionPoints: readonly ActionPoint[]): string {
     if (effort && effort !== "-") lines.push(`   Effort: ${effort}`);
     return lines.join("\n");
   });
+  // Stage 2a: prepend the skilled step's role prompt (clamped) when present. Empty
+  // ⇒ no block ⇒ identical to the legacy prompt (the unskilled coder path).
+  const sys = (opts.systemPrompt ?? "").trim();
+  const preamble = sys ? [clamp(sys, SYSTEM_PROMPT_MAX), ""] : [];
   return [
+    ...preamble,
     "You are an autonomous coding agent working in an ISOLATED git worktree of this repository.",
     "Implement the following review action points as REAL code/spec edits in THIS repository:",
     "",
@@ -163,8 +204,23 @@ export function buildCoderPrompt(actionPoints: readonly ActionPoint[]): string {
   ].join("\n");
 }
 
-/** Build the exact agentic arg array (prompt is supplied separately via stdin). */
-export function buildCoderArgs(worktreeDir: string): string[] {
+/**
+ * Build the exact agentic arg array (prompt is supplied separately via stdin).
+ *
+ * Stage 2a: `allowedTools` is the capability-scoped tool allowlist (defaults to the
+ * baseline {@link ALLOWED_TOOLS} ⇒ identical to before). The requested tools are
+ * HARD-FILTERED against the baseline ceiling, so a capability/skill can only ever
+ * NARROW the surface — a value outside the baseline (e.g. `Bash`) is dropped, and a
+ * wholly-empty result degrades to the baseline (fail-safe; never a widening). A
+ * strict subset (read-only ⇒ ["Read"]) is honored exactly.
+ */
+export function buildCoderArgs(
+  worktreeDir: string,
+  allowedTools: readonly string[] = ALLOWED_TOOLS,
+): string[] {
+  const ceiling = ALLOWED_TOOLS as readonly string[];
+  const scoped = allowedTools.filter((t) => ceiling.includes(t));
+  const tools = scoped.length > 0 ? scoped : [...ALLOWED_TOOLS];
   return [
     "-p",
     "--output-format",
@@ -172,7 +228,7 @@ export function buildCoderArgs(worktreeDir: string): string[] {
     "--permission-mode",
     "acceptEdits",
     "--allowedTools",
-    ...ALLOWED_TOOLS,
+    ...tools,
     "--add-dir",
     worktreeDir,
   ];
@@ -204,8 +260,11 @@ export class SdlcCoder {
     actionPoints: readonly ActionPoint[],
     options: CoderOptions = {},
   ): Promise<CoderResult> {
-    const args = buildCoderArgs(worktreeDir);
-    const prompt = buildCoderPrompt(actionPoints);
+    // Stage 2a: a SkilledStep MAY scope the tool surface (NARROW only) + prepend a
+    // role prompt. Both default to the legacy values ⇒ the unskilled path is byte-
+    // for-byte identical.
+    const args = buildCoderArgs(worktreeDir, options.allowedTools);
+    const prompt = buildCoderPrompt(actionPoints, { systemPrompt: options.systemPrompt });
     const { stdout } = await this.limiter.run(() =>
       spawnCli({
         binary: options.binary ?? this.binary,

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -54,7 +54,9 @@
  *   - Agents NEVER apply/merge: this opens a DRAFT PR only. No push to main.
  */
 import { basename } from "path";
-import type { ActionPoint } from "@shared/types";
+import type { ActionPoint, Archetype } from "@shared/types";
+import type { Skill } from "@shared/schema";
+import { selectSkillSet, bindSkillStep, type BoundSkillStep } from "../consilium/skills/catalog.js";
 import { buildBranchName, isValidLoopBranch, pushBranch, openDraftPr } from "../consilium/pr-wrapper.js";
 import {
   createSdlcWorktree,
@@ -93,6 +95,13 @@ export interface ApOutcome {
   committed: boolean;
   /** Short server-generated note (e.g. "coder timed out", "no file changes"). */
   note?: string;
+  /**
+   * Stage 2a (audit / observability): the ordered SKILLED step names that ran for
+   * this action point (e.g. ["test-author", "coder"]). Absent for the unskilled
+   * path (no skill set selected). Display-only — does NOT alter the dev_completed
+   * event contract (`{ prRef, headCommit, error? }`).
+   */
+  skills?: string[];
 }
 
 /**
@@ -145,6 +154,15 @@ export interface SdlcHandoffRequest {
   ownerId?: string;
   /** Hard timeout PER action-point coder run (ms). Defaults to the coder default. */
   coderTimeoutMs?: number;
+  /**
+   * Stage 2a: the loop's Stage-1 archetype. Drives the SKILLED step selection
+   * (`selectSkillSet`). null/absent ⇒ NO steps ⇒ today's single unskilled coder
+   * per action point (byte-for-byte unchanged — NO regression).
+   */
+  archetype?: Archetype | null;
+  /** Stage 2a: the loop's `archetype_params` (carried to `selectSkillSet`; Stage 2a
+   *  does not branch on it). */
+  archetypeParams?: Record<string, string> | null;
 }
 
 export interface SdlcHandoffResult {
@@ -166,9 +184,46 @@ export interface SdlcExecutorDeps {
   push?: typeof pushBranch;
   openPr?: typeof openDraftPr;
   gitRaw?: GitRunner;
+  /**
+   * Stage 2a: resolver for the existing skills table, used to LAYER a same-named
+   * skill row (systemPromptOverride + tools∩capability) over a baked-in SkilledStep.
+   * Injected by the controller (`() => storage.getSkills()`) ONLY when the implement
+   * kill-switch is on. Absent ⇒ baked-in step defaults only (no layering). A throw
+   * is swallowed (steps fall back to defaults).
+   */
+  getSkills?: () => Promise<Skill[]>;
 }
 
 const sharedCoder = new SdlcCoder();
+
+/**
+ * Stage 2a: resolve the ORDERED, BOUND skilled steps for a round from its
+ * archetype. `selectSkillSet` is PURE (no I/O); an empty result (research / infra /
+ * null / unknown archetype) short-circuits to `[]` so the executor falls back to
+ * TODAY'S single unskilled coder per action point (byte-for-byte unchanged). When
+ * steps exist and a `getSkills` resolver is provided, each step is LAYERED against
+ * a same-named skills-table row (systemPromptOverride + tools∩capability). A
+ * getSkills failure is swallowed → baked-in defaults only (never fails the round).
+ */
+async function resolveSkilledSteps(
+  archetype: Archetype | null,
+  params: Record<string, string> | null,
+  getSkills?: () => Promise<Skill[]>,
+): Promise<BoundSkillStep[]> {
+  const steps = selectSkillSet(archetype, params);
+  if (steps.length === 0) return [];
+  let rows: Skill[] = [];
+  if (getSkills) {
+    try {
+      rows = await getSkills();
+    } catch {
+      rows = []; // fall back to baked-in defaults; never fail the round on this.
+    }
+  }
+  const byName = new Map<string, Skill>();
+  for (const r of rows) if (!byName.has(r.name)) byName.set(r.name, r);
+  return steps.map((s) => bindSkillStep(s, byName.get(s.skillName)));
+}
 
 /** Scrub fs layout from an error string before returning it. */
 function scrub(raw: string): string {
@@ -276,7 +331,12 @@ export function buildPrStatusBody(input: PrStatusBodyInput): string {
   // Per-AP outcome table (existing shape).
   const outcomeLines = outcomes.map((o) => {
     const tail = o.note ? ` — ${sanitizeLine(o.note, 120)}` : "";
-    return `- [${o.status}] (${o.priority}) ${sanitizeLine(o.title, PR_BODY_TITLE_MAX)}${tail}`;
+    // Stage 2a: the skilled steps that ran (code-trust names; sanitized as DiD).
+    const skillTag =
+      o.skills && o.skills.length > 0
+        ? ` [skills: ${o.skills.map((s) => sanitizeLine(s, 40)).join(" -> ")}]`
+        : "";
+    return `- [${o.status}] (${o.priority}) ${sanitizeLine(o.title, PR_BODY_TITLE_MAX)}${skillTag}${tail}`;
   });
 
   return [
@@ -352,6 +412,15 @@ export async function runSdlcHandoff(
       gitRaw,
     });
     try {
+      // Stage 2a: resolve the archetype's ordered skilled steps ONCE for the round.
+      // Empty (research / infra / null / unknown, or the kill-switch off ⇒ archetype
+      // is null) ⇒ runActionPoint takes the UNCHANGED single unskilled coder path.
+      const skilledSteps = await resolveSkilledSteps(
+        req.archetype ?? null,
+        req.archetypeParams ?? null,
+        deps.getSkills,
+      );
+
       // SEQUENTIAL per-action-point runs in the ONE shared worktree (avoid edit
       // conflicts). Each `runActionPoint` NEVER throws — a coder timeout/error is
       // caught, its work committed `[partial]`, and the loop continues.
@@ -360,7 +429,7 @@ export async function runSdlcHandoff(
       let committedCount = 0;
       for (let i = 0; i < total; i++) {
         const outcome = await runActionPoint(
-          { gitRaw, runCoder, emit, completedBefore: committedCount },
+          { gitRaw, runCoder, emit, completedBefore: committedCount, skilledSteps },
           wt,
           req,
           req.actionPoints[i],
@@ -409,6 +478,9 @@ async function runActionPoint(
     emit: SdlcProgressFn;
     /** Commits produced by EARLIER action points (this AP not yet counted). */
     completedBefore: number;
+    /** Stage 2a: the round's ORDERED bound skilled steps. Empty ⇒ the UNCHANGED
+     *  single unskilled coder path. */
+    skilledSteps: readonly BoundSkillStep[];
   },
   wt: CreateWorktreeResult,
   req: SdlcHandoffRequest,
@@ -420,8 +492,6 @@ async function runActionPoint(
   const title = sanitizeLine(ap.title ?? "", PR_BODY_TITLE_MAX);
   // Display-only progress title — clamped + control-stripped (UNTRUSTED text).
   const progressTitle = sanitizeLine(ap.title ?? "", PROGRESS_TITLE_MAX);
-  const base: Omit<ApOutcome, "status" | "committed" | "note"> = { index, priority, title };
-
   // 0. Beat: about to run the coder for THIS action point.
   io.emit({
     phase: "coding",
@@ -431,17 +501,54 @@ async function runActionPoint(
     completedCount: io.completedBefore,
   });
 
-  // 1. Run the coder for THIS action point only. A throw (timeout / binary
-  //    missing) is caught — its partial edits are still committed below.
+  // 1. Run the coder for THIS action point. A throw (timeout / binary missing) is
+  //    caught — its partial edits are still committed below.
+  //
+  //    Stage 2a: when the archetype selected SKILLED steps, run them IN ORDER, each
+  //    a capability-scoped coder invocation (NARROWED tools + the step's role
+  //    prompt) in the SHARED worktree. A step that throws OR reports !ok stops the
+  //    chain (partial-preserve: whatever landed is still committed). An EMPTY step
+  //    set takes the single unskilled coder path — BYTE-FOR-BYTE today's behavior.
   let threw = false;
   let coder: CoderResult | null = null;
   let runNote: string | undefined;
-  try {
-    coder = await io.runCoder(wt.worktreeDir, [ap], { timeoutMs: req.coderTimeoutMs });
-  } catch (err) {
-    threw = true;
-    runNote = scrub(err instanceof Error ? err.message : String(err));
+  const ranSkills: string[] = [];
+  if (io.skilledSteps.length > 0) {
+    for (const bound of io.skilledSteps) {
+      ranSkills.push(bound.step.skillName);
+      try {
+        coder = await io.runCoder(wt.worktreeDir, [ap], {
+          timeoutMs: req.coderTimeoutMs,
+          allowedTools: bound.allowedTools, // capability-scoped (NARROWS only).
+          systemPrompt: bound.systemPrompt, // baked-in default (+ skill override).
+        });
+      } catch (err) {
+        threw = true;
+        runNote = scrub(err instanceof Error ? err.message : String(err));
+        break; // a crashed step stops the chain; partial edits still committed
+      }
+      if (!coder.ok) {
+        runNote = coder.error;
+        break; // a step that ran but errored stops the chain (partial-preserve)
+      }
+    }
+  } else {
+    try {
+      coder = await io.runCoder(wt.worktreeDir, [ap], { timeoutMs: req.coderTimeoutMs });
+    } catch (err) {
+      threw = true;
+      runNote = scrub(err instanceof Error ? err.message : String(err));
+    }
   }
+
+  // Outcome base (incl. the Stage-2a skills audit — undefined on the unskilled path
+  // so the field is simply absent, preserving the legacy outcome shape).
+  const base: Omit<ApOutcome, "status" | "committed" | "note"> = {
+    index,
+    priority,
+    title,
+    skills: ranSkills.length > 0 ? ranSkills : undefined,
+  };
 
   // 2. Stage whatever the run produced (partial or complete) and check for change.
   let dirty = false;

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -1294,6 +1294,29 @@ export class PgStorage implements IStorage {
     return row;
   }
 
+  async updateLoopArchetypeIfNotOverridden(
+    id: string,
+    updates: Pick<
+      ConsiliumLoopRow,
+      "archetype" | "archetypeSource" | "archetypeRationale" | "archetypeParams" | "archetypeDecidedAt"
+    >,
+  ): Promise<ConsiliumLoopRow | undefined> {
+    // Carry-in (b): the WHERE pins id AND archetype_source IS DISTINCT FROM
+    // 'override' — NULL (never decided) and 'proposed' both MATCH; only a human
+    // 'override' is excluded → 0 rows → undefined (proposal dropped, override kept).
+    // IS DISTINCT FROM (not <>) is required so a NULL source still matches. Never
+    // touches `state` — writing a column on a terminal loop cannot transition it.
+    const [row] = await db
+      .update(consiliumLoops)
+      .set({ ...updates, updatedAt: new Date() })
+      .where(withProject(consiliumLoops, and(
+        eq(consiliumLoops.id, id),
+        drizzleSql`${consiliumLoops.archetypeSource} IS DISTINCT FROM 'override'`,
+      )))
+      .returning();
+    return row;
+  }
+
   async casLoopState(
     id: string,
     expected: ConsiliumLoopState,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -566,6 +566,22 @@ export interface IStorage {
     updates: Partial<Omit<ConsiliumLoopRow, "id" | "createdAt">>,
   ): Promise<ConsiliumLoopRow>;
   /**
+   * Carry-in (b) — SOURCE-CONDITIONAL archetype write (Stage 2a makes the archetype
+   * LOAD-BEARING). A PLAIN partial update of the archetype columns that lands ONLY
+   * when the row's `archetype_source IS DISTINCT FROM 'override'` (NULL/'proposed'
+   * match; a human 'override' does NOT), so a model PROPOSAL can never clobber a
+   * human override even under a sub-millisecond TOCTOU race. Returns the updated row,
+   * or `undefined` when an override blocked the write (0 rows). NOT a state
+   * transition (never touches `state`).
+   */
+  updateLoopArchetypeIfNotOverridden(
+    id: string,
+    updates: Pick<
+      ConsiliumLoopRow,
+      "archetype" | "archetypeSource" | "archetypeRationale" | "archetypeParams" | "archetypeDecidedAt"
+    >,
+  ): Promise<ConsiliumLoopRow | undefined>;
+  /**
    * H-3 — atomic compare-and-swap on `state`. Sets the loop to `next` (+ any
    * extra fields) ONLY when its current state equals `expected`. Returns the
    * updated row when the CAS won (1 row), or `undefined` when it lost (0 rows —
@@ -1977,6 +1993,23 @@ export class MemStorage implements IStorage {
   ): Promise<ConsiliumLoopRow> {
     const existing = this.consiliumLoopsMap.get(id);
     if (!existing) throw new Error(`ConsiliumLoop ${id} not found`);
+    const updated = { ...existing, ...updates, updatedAt: new Date() };
+    this.consiliumLoopsMap.set(id, updated);
+    return updated;
+  }
+
+  async updateLoopArchetypeIfNotOverridden(
+    id: string,
+    updates: Pick<
+      ConsiliumLoopRow,
+      "archetype" | "archetypeSource" | "archetypeRationale" | "archetypeParams" | "archetypeDecidedAt"
+    >,
+  ): Promise<ConsiliumLoopRow | undefined> {
+    const existing = this.consiliumLoopsMap.get(id);
+    if (!existing) return undefined;
+    // IS DISTINCT FROM 'override': a human override is sacrosanct (NULL/'proposed'
+    // both write). An override blocks the write → 0 rows → undefined.
+    if (existing.archetypeSource === "override") return undefined;
     const updated = { ...existing, ...updates, updatedAt: new Date() };
     this.consiliumLoopsMap.set(id, updated);
     return updated;

--- a/tests/unit/consilium/loop-fsm.test.ts
+++ b/tests/unit/consilium/loop-fsm.test.ts
@@ -196,6 +196,10 @@ const fakeConfig = () =>
         maxDiffBytes: 200000,
         allowedRepoPaths: [process.cwd()],
         devPipelineId: "dev-pipe",
+        // Stage 2a: the implement kill-switch (default off ⇒ today's unskilled coder
+        // path). These FSM tests inject runSdlc and assert the develop wiring, not the
+        // skilled path, so this stays disabled.
+        implement: { enabled: false },
       },
     },
   }) as never;

--- a/tests/unit/consilium/loop-planner.test.ts
+++ b/tests/unit/consilium/loop-planner.test.ts
@@ -73,6 +73,30 @@ describe("buildPlannerPrompt — untrusted text is fenced as data", () => {
     expect(user).toContain("ignore previous instructions"); // present, but inside a fence
     expect(user).toContain("```");
   });
+
+  it("carry-in (a): control chars in the engineer instruction are STRIPPED before fencing (judge-path parity)", () => {
+    // Build a payload of true control bytes (NUL, BEL, vertical-tab, ESC) that the
+    // judge path (untrustedExtraBlock -> stripControlMultiline) scrubs. Newlines/tabs
+    // are PRESERVED (multi-line readability); only true control chars are collapsed.
+    const ESC = String.fromCharCode(0x1b);
+    const dirty =
+      "line1" +
+      String.fromCharCode(0) +
+      ESC +
+      "[31m" +
+      String.fromCharCode(7) +
+      " bad" +
+      String.fromCharCode(0x0b) +
+      " chars\nline2\tkept";
+    const { user } = buildPlannerPrompt([{ title: "x", priority: "P0" }], dirty);
+    // The raw control bytes are gone (replaced by spaces), so they can never reach
+    // the model as escape sequences; the visible text survives.
+    // eslint-disable-next-line no-control-regex
+    expect(user).not.toMatch(/[\u0000\u0007\u000b\u001b]/);
+    expect(user).toContain("line1");
+    expect(user).toContain("bad");
+    expect(user).toContain("line2"); // newline preserved
+  });
 });
 
 describe("parsePlannerOutput — enum-clamped, fail-soft", () => {
@@ -135,15 +159,24 @@ function makePlannerStorage(loop: ConsiliumLoopRow, executions: { output: unknow
     current = { ...current, ...(extra ?? {}) };
     return current;
   });
+  // Carry-in (b): SOURCE-CONDITIONAL write — mirrors the storage contract (writes
+  // unless archetype_source is 'override'; 0 rows ⇒ undefined). The planner PROPOSE
+  // path calls THIS (not updateLoop); the override setArchetype still calls updateLoop.
+  const updateLoopArchetypeIfNotOverridden = vi.fn(async (_id: string, extra?: Record<string, unknown>) => {
+    if (current.archetypeSource === "override") return undefined;
+    current = { ...current, ...(extra ?? {}) };
+    return current;
+  });
   const casLoopState = vi.fn(async () => undefined); // assert NEVER called by the planner
   const storage = {
     getLoop: vi.fn(async () => current),
     getIteration: vi.fn(async () => ({ id: "it1", iterationNumber: current.currentIterationNumber ?? 1, status: "completed" })),
     getExecutionsByIteration: vi.fn(async () => executions),
     updateLoop,
+    updateLoopArchetypeIfNotOverridden,
     casLoopState,
   };
-  return { storage, updateLoop, casLoopState, get: () => current };
+  return { storage, updateLoop, updateLoopArchetypeIfNotOverridden, casLoopState, get: () => current };
 }
 
 interface PlannerConfigOpts {
@@ -187,7 +220,7 @@ const PROPOSAL = JSON.stringify({ archetype: "infra", rationale: "needs terrafor
 describe("controller.plan — intent→archetype planner", () => {
   it("proposes an archetype, persists it as 'proposed', and never transitions the loop", async () => {
     const loop = makeLoop({});
-    const { storage, updateLoop, casLoopState, get } = makePlannerStorage(loop);
+    const { storage, updateLoop, updateLoopArchetypeIfNotOverridden, casLoopState, get } = makePlannerStorage(loop);
     const { gateway, spy } = fakeGateway(PROPOSAL);
     const controller = makeController(storage, gateway);
 
@@ -200,9 +233,10 @@ describe("controller.plan — intent→archetype planner", () => {
     expect(spy).toHaveBeenCalledTimes(1);
     expect((spy.mock.calls[0][0] as { modelSlug: string }).modelSlug).toBe("claude-sonnet");
 
-    // Persisted via a PLAIN partial update with the right provenance.
-    expect(updateLoop).toHaveBeenCalledTimes(1);
-    const wrote = updateLoop.mock.calls[0][1] as Record<string, unknown>;
+    // Carry-in (b): persisted via the SOURCE-CONDITIONAL write (NOT plain updateLoop).
+    expect(updateLoop).not.toHaveBeenCalled();
+    expect(updateLoopArchetypeIfNotOverridden).toHaveBeenCalledTimes(1);
+    const wrote = updateLoopArchetypeIfNotOverridden.mock.calls[0][1] as Record<string, unknown>;
     expect(wrote.archetype).toBe("infra");
     expect(wrote.archetypeSource).toBe("proposed");
     expect(wrote.archetypeRationale).toBe("needs terraform + k8s");
@@ -230,14 +264,14 @@ describe("controller.plan — intent→archetype planner", () => {
 
   it("replan=1 re-proposes over a prior 'proposed' archetype", async () => {
     const loop = makeLoop({ archetype: "research", archetypeSource: "proposed" });
-    const { storage, updateLoop } = makePlannerStorage(loop);
+    const { storage, updateLoopArchetypeIfNotOverridden } = makePlannerStorage(loop);
     const { gateway, spy } = fakeGateway(PROPOSAL);
     const controller = makeController(storage, gateway);
 
     const res = await controller.plan(loop.id, { replan: true });
     expect(res.ok && res.archetype).toBe("infra");
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(updateLoop).toHaveBeenCalledTimes(1);
+    expect(updateLoopArchetypeIfNotOverridden).toHaveBeenCalledTimes(1);
   });
 
   it("FAIL-SOFT: an unparseable model reply leaves the archetype null and the loop untouched", async () => {
@@ -345,6 +379,51 @@ describe("controller.setArchetype + override is sacrosanct", () => {
     expect(res.archetype).toBe("research"); // override preserved
     expect(spy).not.toHaveBeenCalled();
     expect(updateLoop).not.toHaveBeenCalled();
+  });
+
+  it("carry-in (b): a conditional write that loses to a LATE override (TOCTOU) is NOT clobbered", async () => {
+    // pre-check + re-read both see 'proposed' (race not yet landed), the model runs,
+    // but the SOURCE-CONDITIONAL write returns undefined (an override landed in the
+    // sub-millisecond window) and the post-write re-read sees the override → plan
+    // returns the OVERRIDE, never the proposal.
+    const proposed = makeLoop({ archetype: "research", archetypeSource: "proposed" });
+    const overrideRow = makeLoop({ archetype: "research", archetypeSource: "override" });
+    let getLoopCalls = 0;
+    const updateLoopArchetypeIfNotOverridden = vi.fn(async () => undefined); // 0 rows (blocked)
+    const storage = {
+      // entry read + TOCTOU re-read see 'proposed'; the 3rd read (after the blocked
+      // write) sees the override that won the race.
+      getLoop: vi.fn(async () => (++getLoopCalls >= 3 ? overrideRow : proposed)),
+      getIteration: vi.fn(async () => ({ id: "it1", iterationNumber: 2, status: "completed" })),
+      getExecutionsByIteration: vi.fn(async () => [{ output: JUDGE_WITH_APS }]),
+      updateLoop: vi.fn(),
+      updateLoopArchetypeIfNotOverridden,
+      casLoopState: vi.fn(async () => undefined),
+    };
+    const { gateway, spy } = fakeGateway(PROPOSAL); // would propose 'infra'
+    const controller = makeController(storage, gateway);
+
+    const res = await controller.plan(proposed.id, { replan: true });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error("expected ok");
+    expect(spy).toHaveBeenCalledTimes(1); // the model DID run
+    expect(updateLoopArchetypeIfNotOverridden).toHaveBeenCalledTimes(1); // write attempted
+    expect(res.archetype).toBe("research"); // OVERRIDE preserved, NOT the proposed 'infra'
+    expect(res.loop.archetypeSource).toBe("override");
+  });
+
+  it("carry-in (b): the conditional write DOES land when the source is null/'proposed'", async () => {
+    const loop = makeLoop({}); // archetypeSource: null
+    const { storage, updateLoop, updateLoopArchetypeIfNotOverridden, get } = makePlannerStorage(loop);
+    const { gateway } = fakeGateway(PROPOSAL);
+    const controller = makeController(storage, gateway);
+
+    const res = await controller.plan(loop.id);
+    expect(res.ok && res.archetype).toBe("infra");
+    expect(updateLoop).not.toHaveBeenCalled(); // PROPOSE never uses the plain write
+    expect(updateLoopArchetypeIfNotOverridden).toHaveBeenCalledTimes(1);
+    expect(get().archetype).toBe("infra");
+    expect(get().archetypeSource).toBe("proposed");
   });
 
   it("setArchetype on a vanished loop → NOT_FOUND", async () => {

--- a/tests/unit/consilium/skill-catalog.test.ts
+++ b/tests/unit/consilium/skill-catalog.test.ts
@@ -1,0 +1,158 @@
+/**
+ * skill-catalog.test.ts — Stage 2a skill catalog (selection + binding layer).
+ *
+ * Asserts:
+ *   - selectSkillSet: repo-assessment → an ordered [test-author, coder] TDD pair;
+ *     research / infra / null / unknown → [] (⇒ executor falls back to today's
+ *     single unskilled coder; NO regression).
+ *   - capabilityTools: read-only ⇒ ["Read"]; worktree-write ⇒ the coder baseline.
+ *   - bindSkillStep: baked-in default works against an EMPTY skills table; a
+ *     same-named skills row LAYERS its systemPromptOverride and INTERSECTS its tools
+ *     with the capability ceiling — intersection can only NARROW, never widen (a row
+ *     can never grant Edit to a read-only step, nor Bash to anyone).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  selectSkillSet,
+  capabilityTools,
+  bindSkillStep,
+  type SkilledStep,
+} from "../../../server/services/consilium/skills/catalog.js";
+import { ALLOWED_TOOLS } from "../../../server/services/sdlc/coder.js";
+import type { Skill } from "@shared/schema";
+
+/** Minimal Skill row fixture (only the fields the binding layer reads matter). */
+function makeSkill(over: Partial<Skill>): Skill {
+  return {
+    projectId: null,
+    id: "skill-1",
+    name: "coder",
+    description: "",
+    teamId: "t1",
+    systemPromptOverride: "",
+    tools: [],
+    modelPreference: null,
+    outputSchema: null,
+    tags: [],
+    isBuiltin: false,
+    isPublic: true,
+    createdBy: "system",
+    version: "1.0.0",
+    sharing: "public",
+    usageCount: 0,
+    forkedFrom: null,
+    sourceType: "manual",
+    gitSourceId: null,
+    externalSource: null,
+    externalId: null,
+    externalVersion: null,
+    installedAt: null,
+    autoUpdate: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...over,
+  } as Skill;
+}
+
+describe("selectSkillSet — archetype → ordered skilled steps", () => {
+  it("repo-assessment → an ordered [test-author, coder] TDD pair (worktree-write, verify=test-run)", () => {
+    const steps = selectSkillSet("repo-assessment", null);
+    expect(steps).toHaveLength(2);
+    expect(steps.map((s) => s.skillName)).toEqual(["test-author", "coder"]);
+    for (const s of steps) {
+      expect(s.capability).toBe("worktree-write");
+      // The verification METHOD is RECORDED for Stage 2b; Stage 2a never runs it.
+      expect(s.verification).toBe("test-run");
+      expect(s.systemPrompt.length).toBeGreaterThan(0); // baked-in default exists
+      expect(s.id).toMatch(/^repo-assessment\//);
+    }
+  });
+
+  it("research / infra / null → [] (executor falls back to today's single coder — NO regression)", () => {
+    expect(selectSkillSet("research", null)).toEqual([]);
+    expect(selectSkillSet("infra", null)).toEqual([]);
+    expect(selectSkillSet(null, null)).toEqual([]);
+  });
+
+  it("an unknown/garbage archetype → [] (default branch)", () => {
+    // The column is enum-clamped on write, but defend the selector regardless.
+    expect(selectSkillSet("totally-unknown" as never, null)).toEqual([]);
+  });
+});
+
+describe("capabilityTools — the tool ceiling per capability", () => {
+  it("read-only ⇒ exactly [Read] (no Edit/Write)", () => {
+    expect(capabilityTools("read-only")).toEqual(["Read"]);
+  });
+  it("worktree-write ⇒ the EXISTING coder baseline (Edit/Write/Read)", () => {
+    expect(capabilityTools("worktree-write")).toEqual([...ALLOWED_TOOLS]);
+  });
+  it("never includes Bash (both capabilities are subsets of the baseline)", () => {
+    expect(capabilityTools("read-only")).not.toContain("Bash");
+    expect(capabilityTools("worktree-write")).not.toContain("Bash");
+  });
+});
+
+describe("bindSkillStep — layering a skills-table row over a baked-in step", () => {
+  const wwStep: SkilledStep = {
+    id: "repo-assessment/coder",
+    skillName: "coder",
+    capability: "worktree-write",
+    verification: "test-run",
+    systemPrompt: "BAKED-IN coder role.",
+  };
+  const roStep: SkilledStep = {
+    id: "x/reader",
+    skillName: "reader",
+    capability: "read-only",
+    verification: "judge",
+    systemPrompt: "BAKED-IN reader role.",
+  };
+
+  it("NO matching row ⇒ baked-in default prompt + the capability base tools (works against an EMPTY skills table)", () => {
+    const bound = bindSkillStep(wwStep, undefined);
+    expect(bound.systemPrompt).toBe("BAKED-IN coder role.");
+    expect(bound.allowedTools).toEqual([...ALLOWED_TOOLS]);
+    expect(bound.boundSkillId).toBeNull();
+  });
+
+  it("a row's systemPromptOverride is LAYERED onto (not replacing) the baked-in default", () => {
+    const row = makeSkill({ name: "coder", systemPromptOverride: "PROJECT override: prefer pytest." });
+    const bound = bindSkillStep(wwStep, row);
+    expect(bound.systemPrompt).toContain("BAKED-IN coder role."); // default kept
+    expect(bound.systemPrompt).toContain("PROJECT override: prefer pytest."); // override appended
+    expect(bound.boundSkillId).toBe("skill-1");
+  });
+
+  it("a row's tools INTERSECT the capability base (narrow only — Bash is dropped, never granted)", () => {
+    const row = makeSkill({ name: "coder", tools: ["Edit", "Read", "Bash", "WebSearch"] });
+    const bound = bindSkillStep(wwStep, row);
+    // base (Edit/Write/Read) ∩ row (Edit/Read/Bash/WebSearch) = Edit/Read. Write is
+    // narrowed away by the row; Bash/WebSearch can NEVER be granted (outside base).
+    expect([...bound.allowedTools].sort()).toEqual(["Edit", "Read"]);
+    expect(bound.allowedTools).not.toContain("Write");
+    expect(bound.allowedTools).not.toContain("Bash");
+  });
+
+  it("a row whose tools are DISJOINT from the ceiling keeps the capability base (never zeroes the step)", () => {
+    const row = makeSkill({ name: "coder", tools: ["Bash", "WebSearch"] });
+    const bound = bindSkillStep(wwStep, row);
+    expect(bound.allowedTools).toEqual([...ALLOWED_TOOLS]); // base preserved
+    expect(bound.allowedTools).not.toContain("Bash");
+  });
+
+  it("a read-only step can NEVER be widened by a row listing Edit/Write (ceiling wins)", () => {
+    const row = makeSkill({ name: "reader", tools: ["Edit", "Write", "Read"] });
+    const bound = bindSkillStep(roStep, row);
+    // read-only base is just [Read]; intersection with the row stays [Read].
+    expect(bound.allowedTools).toEqual(["Read"]);
+    expect(bound.allowedTools).not.toContain("Edit");
+    expect(bound.allowedTools).not.toContain("Write");
+  });
+
+  it("an EMPTY row.tools imposes no constraint (capability base kept)", () => {
+    const row = makeSkill({ name: "coder", tools: [] });
+    const bound = bindSkillStep(wwStep, row);
+    expect(bound.allowedTools).toEqual([...ALLOWED_TOOLS]);
+  });
+});

--- a/tests/unit/sdlc/skilled-coder.test.ts
+++ b/tests/unit/sdlc/skilled-coder.test.ts
@@ -1,0 +1,227 @@
+/**
+ * skilled-coder.test.ts — Stage 2a: capability-scoped coder invocation + the
+ * executor's archetype → skilled-step wiring.
+ *
+ * Asserts:
+ *   - buildCoderArgs capability scoping: read-only drops Edit/Write (Read only);
+ *     worktree-write = the baseline; the default call is BYTE-FOR-BYTE the legacy
+ *     arg array (no regression); a tool outside the baseline (Bash) is dropped.
+ *   - buildCoderPrompt: the unskilled call is byte-for-byte the legacy prompt; a
+ *     skilled `systemPrompt` is PREPENDED.
+ *   - the executor threads the archetype into an ordered skilled-step run (N coder
+ *     invocations per AP, each capability-scoped + role-prompted) and LAYERS a
+ *     same-named skills row; an EMPTY skill set ⇒ the single unskilled coder per AP,
+ *     called with ONLY `{ timeoutMs }` (byte-for-byte today's path).
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  buildCoderArgs,
+  buildCoderPrompt,
+  ALLOWED_TOOLS,
+} from "../../../server/services/sdlc/coder.js";
+import {
+  runSdlcHandoff,
+  type SdlcHandoffRequest,
+} from "../../../server/services/sdlc/executor.js";
+import type { ActionPoint } from "@shared/types";
+import type { Skill } from "@shared/schema";
+
+const WT = "/tmp/sdlc-wt-XXXX/tree";
+
+describe("buildCoderArgs — Stage 2a capability scoping (NARROW only, never widen)", () => {
+  it("the DEFAULT call is BYTE-FOR-BYTE the legacy arg array (no regression)", () => {
+    expect(buildCoderArgs(WT)).toEqual([
+      "-p",
+      "--output-format",
+      "json",
+      "--permission-mode",
+      "acceptEdits",
+      "--allowedTools",
+      "Edit",
+      "Write",
+      "Read",
+      "--add-dir",
+      WT,
+    ]);
+  });
+
+  it("read-only ⇒ --allowedTools Read (drops Edit/Write)", () => {
+    const args = buildCoderArgs(WT, ["Read"]);
+    const tools = args.slice(args.indexOf("--allowedTools") + 1, args.indexOf("--add-dir"));
+    expect(tools).toEqual(["Read"]);
+    expect(tools).not.toContain("Edit");
+    expect(tools).not.toContain("Write");
+    expect(args[args.indexOf("--add-dir") + 1]).toBe(WT); // confinement intact
+  });
+
+  it("worktree-write ⇒ the existing baseline (Edit Write Read)", () => {
+    const args = buildCoderArgs(WT, [...ALLOWED_TOOLS]);
+    const tools = args.slice(args.indexOf("--allowedTools") + 1, args.indexOf("--add-dir"));
+    expect(tools).toEqual(["Edit", "Write", "Read"]);
+  });
+
+  it("a tool OUTSIDE the baseline (Bash) is HARD-FILTERED away (never loosens the baseline)", () => {
+    const args = buildCoderArgs(WT, ["Edit", "Write", "Read", "Bash"]);
+    expect(args).not.toContain("Bash");
+    const tools = args.slice(args.indexOf("--allowedTools") + 1, args.indexOf("--add-dir"));
+    expect(tools).toEqual(["Edit", "Write", "Read"]);
+  });
+
+  it("a wholly-empty/all-filtered request degrades to the baseline (fail-safe, never empty/widened)", () => {
+    const args = buildCoderArgs(WT, ["Bash", "WebSearch"]); // all outside the ceiling
+    const tools = args.slice(args.indexOf("--allowedTools") + 1, args.indexOf("--add-dir"));
+    expect(tools).toEqual(["Edit", "Write", "Read"]);
+    expect(tools).not.toContain("Bash");
+  });
+});
+
+describe("buildCoderPrompt — Stage 2a skilled role prompt (prepended)", () => {
+  const aps: ActionPoint[] = [{ title: "Add the redactor", priority: "P0", rationale: "leak" }];
+
+  it("the unskilled call is BYTE-FOR-BYTE identical with or without an empty opts (no regression)", () => {
+    expect(buildCoderPrompt(aps)).toBe(buildCoderPrompt(aps, {}));
+    // No role marker leaks into the legacy prompt.
+    expect(buildCoderPrompt(aps)).not.toContain("ROLE:");
+    expect(buildCoderPrompt(aps)).toMatch(/ISOLATED git worktree/);
+  });
+
+  it("a skilled systemPrompt is PREPENDED before the standard instruction", () => {
+    const prompt = buildCoderPrompt(aps, { systemPrompt: "ROLE: TEST AUTHOR. Write tests only." });
+    expect(prompt.startsWith("ROLE: TEST AUTHOR. Write tests only.")).toBe(true);
+    // The standard agent rules still follow.
+    expect(prompt).toMatch(/ISOLATED git worktree/);
+    expect(prompt).toMatch(/Do NOT run `git commit`/);
+    expect(prompt).toContain("Add the redactor");
+  });
+});
+
+// ─── executor wiring: archetype → skilled steps ──────────────────────────────
+
+const LOOP = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const REPO = "/allowlisted/omniscience";
+const BRANCH = `consilium/loop-${LOOP}/round-2`;
+const APS: ActionPoint[] = [
+  { title: "Fix the parser", priority: "P0", rationale: "bug" },
+  { title: "Add the redactor", priority: "P1" },
+];
+
+const baseReq = (over: Partial<SdlcHandoffRequest> = {}): SdlcHandoffRequest => ({
+  repoPath: REPO,
+  loopId: LOOP,
+  round: 2,
+  actionPoints: APS,
+  allowedRepoPaths: ["/allowlisted"],
+  ...over,
+});
+
+const FAKE_WT = { worktreeDir: WT, baseDir: "/tmp/sdlc-wt-XXXX", branch: BRANCH, baseRef: "main" };
+
+function makeGitRaw() {
+  return vi.fn(async (_repo: string, args: string[]) => {
+    if (args[0] === "status") return " M server/x.ts\n";
+    if (args[0] === "rev-parse") return "headsha000\n";
+    return "";
+  });
+}
+
+function makeDeps(over: Record<string, unknown> = {}) {
+  return {
+    createWorktree: vi.fn(async () => FAKE_WT),
+    removeWorktree: vi.fn(async () => undefined),
+    resolveDefaultBranchFn: vi.fn(async () => "main"),
+    runCoder: vi.fn(async () => ({ ok: true, summary: "edited", tokensUsed: 5 })),
+    push: vi.fn(async () => ({ ok: true as const, branch: BRANCH })),
+    openPr: vi.fn(async () => ({ ok: true as const, prUrl: "https://github.com/x/y/pull/9" })),
+    gitRaw: makeGitRaw(),
+    ...over,
+  };
+}
+
+function makeSkill(over: Partial<Skill>): Skill {
+  return {
+    projectId: null, id: "s1", name: "coder", description: "", teamId: "t1",
+    systemPromptOverride: "", tools: [], modelPreference: null, outputSchema: null,
+    tags: [], isBuiltin: false, isPublic: true, createdBy: "system", version: "1.0.0",
+    sharing: "public", usageCount: 0, forkedFrom: null, sourceType: "manual",
+    gitSourceId: null, externalSource: null, externalId: null, externalVersion: null,
+    installedAt: null, autoUpdate: null, createdAt: new Date(), updatedAt: new Date(),
+    ...over,
+  } as Skill;
+}
+
+describe("runSdlcHandoff — archetype → SKILLED steps wiring", () => {
+  it("repo-assessment runs TWO ordered coder invocations PER action point (test-author → coder), each capability-scoped + role-prompted", async () => {
+    const deps = makeDeps({ getSkills: vi.fn(async () => [] as Skill[]) });
+    await runSdlcHandoff(baseReq({ archetype: "repo-assessment" }), deps as never);
+
+    const calls = (deps.runCoder as ReturnType<typeof vi.fn>).mock.calls;
+    // 2 steps × 2 action points = 4 coder invocations.
+    expect(calls).toHaveLength(2 * APS.length);
+    // Per AP the steps run in order: a test-author prompt then a coder prompt, both
+    // worktree-write (the baseline tool set), all confined to the worktree.
+    for (const call of calls) {
+      const [dir, aps, opts] = call;
+      expect(dir).toBe(WT);
+      expect(aps).toHaveLength(1);
+      expect(opts.allowedTools).toEqual([...ALLOWED_TOOLS]); // worktree-write baseline
+      expect(typeof opts.systemPrompt).toBe("string");
+      expect(opts.systemPrompt.length).toBeGreaterThan(0); // a role prompt was injected
+      expect(opts.timeoutMs).toBeUndefined(); // none set on baseReq → undefined, as before
+    }
+    // The first step for AP0 is the TEST AUTHOR, the second is the IMPLEMENTER.
+    expect(calls[0][2].systemPrompt).toMatch(/TEST AUTHOR/i);
+    expect(calls[1][2].systemPrompt).toMatch(/IMPLEMENTER/i);
+  });
+
+  it("records the skilled steps that ran in the Draft-PR body (audit), without changing the result contract", async () => {
+    const deps = makeDeps({ getSkills: vi.fn(async () => [] as Skill[]) });
+    const res = await runSdlcHandoff(baseReq({ archetype: "repo-assessment" }), deps as never);
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9"); // unchanged contract
+    const [, opts] = (deps.openPr as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(opts.body).toContain("skills: test-author -> coder");
+  });
+
+  it("LAYERS a same-named skills row's systemPromptOverride into that step's prompt", async () => {
+    const row = makeSkill({ name: "coder", systemPromptOverride: "PREFER pytest fixtures." });
+    const deps = makeDeps({ getSkills: vi.fn(async () => [row]) });
+    await runSdlcHandoff(baseReq({ archetype: "repo-assessment" }), deps as never);
+
+    const calls = (deps.runCoder as ReturnType<typeof vi.fn>).mock.calls;
+    // The 'coder' step (2nd per AP) carries the layered override; 'test-author' does not.
+    expect(calls[1][2].systemPrompt).toContain("PREFER pytest fixtures.");
+    expect(calls[0][2].systemPrompt).not.toContain("PREFER pytest fixtures.");
+  });
+
+  it("EMPTY skill set (archetype null) ⇒ the SINGLE unskilled coder per AP, called with ONLY { timeoutMs } (byte-for-byte today's path)", async () => {
+    const deps = makeDeps({ getSkills: vi.fn(async () => [] as Skill[]) });
+    await runSdlcHandoff(baseReq({ archetype: null, coderTimeoutMs: 999 }), deps as never);
+
+    const calls = (deps.runCoder as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(APS.length); // one coder per AP — UNCHANGED
+    for (const call of calls) {
+      const opts = call[2];
+      expect(opts).toEqual({ timeoutMs: 999 }); // NO allowedTools / systemPrompt keys
+    }
+    // getSkills is never even consulted for an empty skill set.
+    expect(deps.getSkills).not.toHaveBeenCalled();
+  });
+
+  it("a non-skilled archetype (research) ⇒ the single unskilled coder per AP", async () => {
+    const deps = makeDeps({ getSkills: vi.fn(async () => [] as Skill[]) });
+    await runSdlcHandoff(baseReq({ archetype: "research" }), deps as never);
+    expect((deps.runCoder as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(APS.length);
+    expect(deps.getSkills).not.toHaveBeenCalled();
+  });
+
+  it("a getSkills failure falls back to baked-in step defaults (never fails the round)", async () => {
+    const deps = makeDeps({
+      getSkills: vi.fn(async () => {
+        throw new Error("db down");
+      }),
+    });
+    const res = await runSdlcHandoff(baseReq({ archetype: "repo-assessment" }), deps as never);
+    // Steps still run on their baked-in defaults; the round still opens its PR.
+    expect((deps.runCoder as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2 * APS.length);
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+  });
+});


### PR DESCRIPTION
Stage 2a of the loop-consolidation (the architect split Stage 2 into 2a/2b). The develop coder becomes **skilled + archetype-aware** — a strict **superset** of today; **nothing new executes** (the test-runner + per-criterion verification are 2b). No FSM change.

## Skill catalog (code-side, zero migration)
`selectSkillSet(archetype)` → `repo-assessment` = ordered `[test-author, coder]`; `research`/`infra`/`null`/unknown → `[]` ⇒ executor falls back **byte-for-byte** to today's single coder (no regression). Baked-in default prompts (works on an empty skills table); a same-named `skills` row **refines** (prompt appended, tools intersected). Extends the existing skills system.

## Capability scoping — the only new surface, double-enforced
`read-only`→`[Read]`, `worktree-write`→the existing `ALLOWED_TOOLS` baseline. `bindSkillStep` intersects a row's tools to the base (narrow-only); `buildCoderArgs` then **hard-filters** to the `ALLOWED_TOOLS` ceiling — a skill row can never widen past Edit/Write/Read or add Bash; `read-only` restricts to Read. The no-Bash / isolated-worktree / env-allowlist / Draft-PR-only baseline is unchanged.

Gated by `consiliumLoop.implement.enabled` (default **false** → today's coder path). Folds the two Stage-1 carry-ins: planner-prompt control-strip parity + a **source-conditional** planner write (a model can't clobber a human archetype override).

## Security (Lead-reviewed)
2a executes nothing new; the capability ceiling is double-enforced + unit-tested. The heavyweight veto is reserved for 2b (the sandboxed test-runner).

## Verification
`tsc` clean; full unit suite **5661 passed / 290 files**; new `skill-catalog.test.ts` + `skilled-coder.test.ts` (selectSkillSet, capability narrowing, read-only ceiling, never-Bash, empty-set = no-regression, archetype threads, carry-ins).