### PR TITLE
feat(consilium): Stage 4 — observability tree (execution_trace) — loop-consolidation COMPLETE

### DIFF
--- a/client/src/hooks/use-consilium-loops.ts
+++ b/client/src/hooks/use-consilium-loops.ts
@@ -78,17 +78,58 @@ export type ConsiliumArchetypeSource = "proposed" | "override";
 // target="_blank" rel="noopener noreferrer".
 export type { ResearchReport, ResearchClaim, ResearchCitation, ResearchSource };
 
+// ─── Execution trace (Stage 4, design §8 — the OBSERVABILITY TREE) ─────
+//
+// The `phase → controller → worker → skill → criterion` shape the FE renders as a
+// collapsible ExecutionTree on the Loop detail page. Like the Stage-3 `report`, it
+// rides the SAME out-of-band wire (a new nullable `consilium_loop_rounds.
+// execution_trace` jsonb col, migration 0034) and reaches the client on the loop
+// GET's LATEST round — no new endpoint, owner/admin-gated by the existing loop GET.
+//
+// SOURCE-OF-TRUTH NOTE: the canonical `ExecutionTrace` lives in the client-safe
+// `@shared/types` module (mirroring `ResearchReport`), authored by the parallel
+// Backend agent. Because that shared change lands on a SEPARATE branch that the
+// Lead merges, the contract is mirrored here CLIENT-SIDE so this branch is
+// `tsc --noEmit`-clean in isolation and renders nothing until the backend column
+// exists. On merge, collapse this block into `import type { … } from "@shared/
+// types"` + a re-export (the `report` treatment above) — it is structurally
+// identical, so no call site changes.
+//
+// SECURITY: every string here is model/skill-derived DATA — controller/worker
+// labels, notes, criterion text/summaries, skill names, and tool permission
+// NAMES (never secret VALUES/creds/env). It is rendered as INERT React text; the
+// tree contains NO links (permissions are names, not URLs → zero XSS surface).
+
+// The Stage-4 backend has landed, so use the canonical shared types directly
+// (imported for local use here + re-exported so the page keeps importing from here).
+// Structurally identical to the prior client mirror.
+import type {
+  ExecutionTrace,
+  ExecutionController,
+  ExecutionWorker,
+  ExecutionSkill,
+  ExecutionCriterion,
+} from "@shared/types";
+export type { ExecutionTrace, ExecutionController, ExecutionWorker, ExecutionSkill, ExecutionCriterion };
+// Convenience union aliases derived from the shared shapes (no divergence).
+export type ExecutionControllerKind = ExecutionController["kind"];
+export type ExecutionWorkerStatus = ExecutionWorker["status"];
+export type ExecutionSkillCapability = ExecutionSkill["capability"];
+export type ExecutionCriterionMethod = ExecutionCriterion["method"];
+
 /**
  * A loop round as seen by the client. It is the schema row (which already carries
- * the optional Stage-3 `report`); the `report?` here is a belt-and-braces
- * restatement so the type reads self-documenting at the call site and stays
- * resilient if the underlying row type ever narrows. A `ConsiliumLoopRoundDetail`
- * is structurally a `ConsiliumLoopRoundRow`, so every existing round consumer
- * keeps working unchanged.
+ * the optional Stage-3 `report`); the `report?` / `executionTrace?` here are a
+ * belt-and-braces restatement so the type reads self-documenting at the call site
+ * and stays resilient if the underlying row type ever narrows. A
+ * `ConsiliumLoopRoundDetail` is structurally a `ConsiliumLoopRoundRow`, so every
+ * existing round consumer keeps working unchanged.
  */
 export type ConsiliumLoopRoundDetail = ConsiliumLoopRoundRow & {
   /** The research artifact, on the latest round of a `research` loop only. */
   report?: ResearchReport | null;
+  /** The Stage-4 observability tree — present once the backend persists it. */
+  executionTrace?: ExecutionTrace | null;
 };
 
 /**

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -54,11 +54,20 @@ import {
   isTerminalLoopState,
   isVerdictTerminalLoopState,
   type ConsiliumLoopRoundRow,
+  type ConsiliumLoopRoundDetail,
   type ConsiliumLoopDetail as ConsiliumLoopDetailRow,
   type DevProgress,
   type ResearchReport,
   type ResearchCitation,
   type ResearchSource,
+  type ExecutionTrace,
+  type ExecutionController,
+  type ExecutionWorker,
+  type ExecutionSkill,
+  type ExecutionCriterion,
+  type ExecutionWorkerStatus,
+  type ExecutionSkillCapability,
+  type ExecutionCriterionMethod,
 } from "@/hooks/use-consilium-loops";
 import { useAuth } from "@/hooks/use-auth";
 import { useToast } from "@/hooks/use-toast";
@@ -357,6 +366,101 @@ function Fact({
   );
 }
 
+// ─── Execution tree (Stage 4 observability) ──────────────────────────────────
+
+/** True when a round carries a renderable execution trace. */
+function traceHasContent(trace: ExecutionTrace | null | undefined): trace is ExecutionTrace {
+  return !!trace && !!trace.controller && Array.isArray(trace.controller.workers);
+}
+
+/** A small green/red dot for a skill/worker/criterion outcome. */
+function GreenDot({ green }: { green: boolean }) {
+  return (
+    <span
+      className={`inline-block h-2 w-2 rounded-full ${green ? "bg-green-500" : "bg-red-500"}`}
+      aria-label={green ? "green" : "red"}
+    />
+  );
+}
+
+function CriterionLeaf({ c }: { c: ExecutionCriterion }) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
+      <GreenDot green={c.passed} />
+      <Badge variant="outline" className="text-[10px] py-0">{c.method}</Badge>
+      <span className={c.passed ? "text-muted-foreground" : "text-red-600"}>
+        {c.ran ? (c.passed ? "passed" : "unmet") : "not run"}
+      </span>
+      {typeof c.fixIterations === "number" && c.fixIterations > 0 && (
+        <span className="text-muted-foreground">· {c.fixIterations} fix</span>
+      )}
+      <span className="text-foreground/80">{c.criterion || "—"}</span>
+      {c.summary && !c.passed && (
+        <span className="w-full text-muted-foreground font-mono text-[10px] break-words">{c.summary}</span>
+      )}
+    </div>
+  );
+}
+
+function SkillLeaf({ s }: { s: ExecutionSkill }) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
+      <GreenDot green={s.green} />
+      <span className="font-medium">{s.skillName || "—"}</span>
+      <Badge variant="secondary" className="text-[10px] py-0">{s.capability}</Badge>
+      {s.permissionsUsed.map((p, i) => (
+        <span key={i} className="rounded bg-muted px-1 py-0.5 font-mono text-[10px] text-muted-foreground">{p}</span>
+      ))}
+    </div>
+  );
+}
+
+function WorkerNode({ w }: { w: ExecutionWorker }) {
+  const failed = w.status === "failed";
+  return (
+    <li className={`space-y-1 border-l-2 pl-3 ${failed ? "border-red-400" : "border-border/70"}`}>
+      <div className="flex flex-wrap items-center gap-1.5 text-xs">
+        {w.priority && <Badge variant="outline" className="text-[10px] py-0">{w.priority}</Badge>}
+        <span className="font-medium">{w.title || `#${w.index}`}</span>
+        <Badge variant={failed ? "destructive" : "secondary"} className="text-[10px] py-0">{w.status}</Badge>
+      </div>
+      {w.note && <p className="text-[11px] text-muted-foreground font-mono break-words">{w.note}</p>}
+      {w.skills.length > 0 && (
+        <div className="space-y-0.5 pl-1">
+          {w.skills.map((s, i) => <SkillLeaf key={i} s={s} />)}
+        </div>
+      )}
+      {w.criteria.length > 0 && (
+        <div className="space-y-0.5 pl-1">
+          {w.criteria.map((c, i) => <CriterionLeaf key={i} c={c} />)}
+        </div>
+      )}
+    </li>
+  );
+}
+
+/** Renders a settled execution trace: controller → workers → skills → criteria. */
+function SettledExecutionTree({ trace }: { trace: ExecutionTrace }) {
+  const c: ExecutionController = trace.controller;
+  return (
+    <div className="space-y-2 rounded-md border border-border/60 p-2">
+      <div className="flex flex-wrap items-center gap-1.5 text-xs">
+        <GreenDot green={c.green} />
+        <span className="font-semibold">{c.label || c.kind}</span>
+        {trace.archetype && <Badge variant="outline" className="text-[10px] py-0">{trace.archetype}</Badge>}
+      </div>
+      {c.note && <p className="text-[11px] text-muted-foreground font-mono break-words">{c.note}</p>}
+      {c.workers.length > 0 ? (
+        <ul className="space-y-2">
+          {c.workers.map((w, i) => <WorkerNode key={i} w={w} />)}
+        </ul>
+      ) : (
+        <p className="text-[11px] text-muted-foreground">No workers recorded.</p>
+      )}
+    </div>
+  );
+}
+
 // ─── Rounds table ─────────────────────────────────────────────────────────────
 
 function RoundRow({
@@ -364,7 +468,7 @@ function RoundRow({
   groupId,
   terminal,
 }: {
-  round: ConsiliumLoopRoundRow;
+  round: ConsiliumLoopRoundDetail;
   groupId: string;
   terminal: boolean;
 }) {
@@ -372,16 +476,21 @@ function RoundRow({
   const aps: ActionPoint[] = Array.isArray(round.openActionPoints)
     ? round.openActionPoints
     : [];
+  // Stage 4: this round's persisted execution trace (history). When present, the
+  // row expands to a mini-tree of how the round ran, ABOVE the still-open AP list.
+  const trace = round.executionTrace;
+  const hasTrace = traceHasContent(trace);
+  const expandable = aps.length > 0 || hasTrace;
 
   return (
     <>
       <TableRow
-        className={aps.length > 0 ? "cursor-pointer" : ""}
-        onClick={aps.length > 0 ? () => setOpen((v) => !v) : undefined}
+        className={expandable ? "cursor-pointer" : ""}
+        onClick={expandable ? () => setOpen((v) => !v) : undefined}
       >
         <TableCell className="tabular-nums">
           <span className="inline-flex items-center gap-1">
-            {aps.length > 0 &&
+            {expandable &&
               (open ? (
                 <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
               ) : (
@@ -413,10 +522,21 @@ function RoundRow({
           </Link>
         </TableCell>
       </TableRow>
-      {open && aps.length > 0 && (
+      {open && expandable && (
         <TableRow>
           <TableCell colSpan={5} className="bg-muted/30">
-            <div className="space-y-2 py-1">
+            <div className="space-y-3 py-1">
+              {/* Per-round mini-tree — how THIS round ran (Stage 4 history). */}
+              {traceHasContent(trace) && (
+                <div className="space-y-1.5">
+                  <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                    Execution
+                  </p>
+                  <SettledExecutionTree trace={trace} />
+                </div>
+              )}
+              {aps.length > 0 && (
+                <div className="space-y-2">
               <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
                 Still-open action points
               </p>
@@ -445,6 +565,8 @@ function RoundRow({
                 ))}
               </ul>
               <p className="text-[11px] text-muted-foreground/70">{PRIORITY_LEGEND}</p>
+                </div>
+              )}
             </div>
           </TableCell>
         </TableRow>

--- a/migrations/0034_consilium_loop_rounds_execution_trace.sql
+++ b/migrations/0034_consilium_loop_rounds_execution_trace.sql
@@ -1,0 +1,24 @@
+-- migration: 0034_consilium_loop_rounds_execution_trace
+-- Adds the Stage 4 (design §8) OBSERVABILITY TREE column to consilium_loop_rounds.
+-- The implement phase already computes a per-AP / per-skill / per-criterion outcome
+-- each round but discarded it after settle (surviving only as Draft-PR prose + the
+-- test_summary digest). Stage 4 rescues it as a structured execution_trace (phase →
+-- controller → worker → skill → criterion) that BOTH archetypes emit — the executor
+-- builds it from its ApOutcome[]; the research-runner from its steps + P0 evidence.
+-- The controller persists it here via `updateLoopRoundExecutionTrace` on the SAME
+-- out-of-band settle wire as `test_summary`/`report`; it reaches the client through
+-- the existing loop GET `rounds`.
+--
+--   execution_trace   the per-round trace (jsonb; UNTRUSTED model/skill text + tool
+--                     NAMES only, size-clamped + scrubbed before write). NULL for
+--                     every pre-Stage-4 round and every round with no skilled run.
+--
+-- Nullable, additive; NO FSM change (rides out-of-band, the dev_completed event is
+-- unchanged). Full back-compat. Idempotent (IF NOT EXISTS). Mirrors 0033's shape.
+
+ALTER TABLE consilium_loop_rounds
+  ADD COLUMN IF NOT EXISTS execution_trace JSONB;
+
+-- Rollback:
+--   ALTER TABLE consilium_loop_rounds
+--     DROP COLUMN execution_trace;

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -1385,6 +1385,17 @@ export class ConsiliumLoopController {
               this.log(loop.id, `report persist failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`),
             );
         }
+        // Stage 4 (observability tree): persist the per-round execution trace on the
+        // SAME out-of-band settle wire. Present whenever a skilled run produced one;
+        // best-effort; reaches the client via the existing loop GET rounds.
+        const executionTrace = result.executionTrace;
+        if (executionTrace) {
+          void this.storage
+            .updateLoopRoundExecutionTrace(loop.id, run.round, executionTrace)
+            .catch((err: unknown) =>
+              this.log(loop.id, `executionTrace persist failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`),
+            );
+        }
       })
       .catch((err: unknown) => {
         this.settleSdlcRun(loop.id, run, {

--- a/server/services/consilium/dev-closeout.ts
+++ b/server/services/consilium/dev-closeout.ts
@@ -34,7 +34,7 @@
  */
 import { simpleGit } from "simple-git";
 import type { WorkspaceRow } from "@shared/schema";
-import type { ActionPoint, ResearchReport } from "@shared/types";
+import type { ActionPoint, ResearchReport, ExecutionTrace } from "@shared/types";
 import { resolveLoopWorkspace } from "./workspace-bind.js";
 import { pushBranch, openDraftPr } from "./pr-wrapper.js";
 
@@ -63,6 +63,13 @@ export interface DevCloseoutResult {
    * same settle wire as `testSummary`.
    */
   report?: ResearchReport;
+  /**
+   * Stage 4 (observability): the per-round execution trace (phase → controller →
+   * worker → skill → criterion), built by the executor / research-runner from data
+   * they already compute. Persisted out-of-band to `consilium_loop_rounds.execution
+   * _trace` on the same settle wire as `testSummary`/`report`. Display-only.
+   */
+  executionTrace?: ExecutionTrace;
 }
 
 // ─── Injectable seams (unit tests inject fakes — no real repo / gh) ──────────

--- a/server/services/consilium/execution-trace.ts
+++ b/server/services/consilium/execution-trace.ts
@@ -1,0 +1,264 @@
+/**
+ * execution-trace.ts — Stage 4 (design §8, the observability tree): the SHARED
+ * size-clamp + string-scrub for the unified {@link ExecutionTrace}.
+ *
+ * The trace is a phase → controller → worker → skill → criterion tree BOTH archetypes
+ * emit (the coder path builds it from the executor's `ApOutcome[]`; the research path
+ * builds it from the runner's steps + P0 `CriterionEvidence[]`), so the FE has ONE
+ * tree renderer. This module is deliberately tiny and dependency-free (no worktree /
+ * git / coder machinery) so BOTH `sdlc/executor.ts` and `research/research-runner.ts`
+ * can import `clampTrace` WITHOUT dragging each other's module graph in.
+ *
+ * SECURITY (BINDING — the trace is UNTRUSTED model/skill text + tool NAMES):
+ *   - Every string is control-stripped + collapsed + LENGTH-CLAMPED (inert React text,
+ *     mirroring the report/testSummary wire). The tree is URL-FREE (no scheme sink).
+ *   - `permissionsUsed` are tool NAMES ONLY (Edit/Write/Read | web_search). NO secret
+ *     values, NO env, NO credentials, NEVER the Tavily key — the builders only ever
+ *     hand this the coder's `allowedTools` / the literal `web_search`, and `scrub`
+ *     additionally strips fs paths from the free-text `note`/`summary` fields.
+ *   - COUNTS are bounded (workers / skills / criteria / permissions) so a pathological
+ *     run can never persist an unbounded object.
+ */
+import type {
+  Archetype,
+  ExecutionTrace,
+  ExecutionController,
+  ExecutionWorker,
+  ExecutionSkill,
+  ExecutionCriterion,
+} from "@shared/types";
+
+// ─── Bounds (counts) ─────────────────────────────────────────────────────────
+const MAX_WORKERS = 200; // one per action point / research step — generously bounded
+const MAX_SKILLS_PER_WORKER = 20; // ordered skilled steps per AP (test-author, coder, …)
+const MAX_CRITERIA_PER_WORKER = 40; // acceptance-criterion leaves per worker
+const MAX_PERMISSIONS = 20; // tool names per skill
+
+// ─── Bounds (per-field lengths) ──────────────────────────────────────────────
+const LABEL_MAX = 200;
+const TITLE_MAX = 200;
+const PRIORITY_MAX = 16;
+const SKILL_NAME_MAX = 80;
+const PERMISSION_MAX = 60;
+const CRITERION_MAX = 300;
+const NOTE_MAX = 300;
+const SUMMARY_MAX = 2_000;
+
+// Control-char class (strip newlines / control bytes). Built from char codes so no
+// raw control bytes live in this source file.
+const CONTROL_CHARS = new RegExp(`[${String.fromCharCode(0)}-${String.fromCharCode(0x1f)}${String.fromCharCode(0x7f)}]+`, "g");
+
+/**
+ * Sanitize UNTRUSTED text for a SINGLE-LINE field: strip control chars / newlines,
+ * collapse whitespace, clamp. Mirrors the executor's `sanitizeLine` (kept local so
+ * this module stays dependency-free). Never a shell string — inert display text.
+ */
+function sanitizeLine(value: string, max: number): string {
+  return (value ?? "")
+    .replace(CONTROL_CHARS, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, max);
+}
+
+/**
+ * Scrub fs layout from a free-text field (note / test-summary) before persisting:
+ * replace path-like runs with `<path>`, collapse whitespace, clamp. Mirrors the
+ * executor's `scrub` (defense-in-depth over the single-line sanitize).
+ */
+function scrub(value: string, max: number): string {
+  return (value ?? "")
+    .replace(/\/[^\s'"]+/g, "<path>")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, max);
+}
+
+function clampSkill(s: ExecutionSkill): ExecutionSkill {
+  return {
+    skillName: sanitizeLine(s.skillName, SKILL_NAME_MAX),
+    capability: s.capability, // fixed union (read-only | worktree-write | web-read)
+    // NAMES ONLY — clamp each + bound the count; never values/secrets/env.
+    permissionsUsed: s.permissionsUsed.slice(0, MAX_PERMISSIONS).map((p) => sanitizeLine(p, PERMISSION_MAX)),
+    green: s.green === true,
+  };
+}
+
+function clampCriterion(c: ExecutionCriterion): ExecutionCriterion {
+  const out: ExecutionCriterion = {
+    criterion: sanitizeLine(c.criterion, CRITERION_MAX),
+    method: c.method, // fixed union (test-run | web-evidence | judge | none)
+    ran: c.ran === true,
+    passed: c.passed === true,
+  };
+  if (typeof c.fixIterations === "number" && Number.isFinite(c.fixIterations)) {
+    out.fixIterations = Math.max(0, Math.trunc(c.fixIterations));
+  }
+  if (c.summary !== undefined) out.summary = scrub(c.summary, SUMMARY_MAX);
+  return out;
+}
+
+function clampWorker(w: ExecutionWorker): ExecutionWorker {
+  const out: ExecutionWorker = {
+    index: Number.isFinite(w.index) ? Math.trunc(w.index) : 0,
+    priority: sanitizeLine(w.priority, PRIORITY_MAX),
+    title: sanitizeLine(w.title, TITLE_MAX),
+    status: w.status, // fixed union (completed | partial | failed)
+    skills: w.skills.slice(0, MAX_SKILLS_PER_WORKER).map(clampSkill),
+    criteria: w.criteria.slice(0, MAX_CRITERIA_PER_WORKER).map(clampCriterion),
+  };
+  if (w.note !== undefined) out.note = sanitizeLine(w.note, NOTE_MAX);
+  return out;
+}
+
+/**
+ * Clamp + scrub an assembled {@link ExecutionTrace} before it is persisted. Bounds
+ * every collection count and every string length; strips control chars, paths, and
+ * excess whitespace. Idempotent. The builders (executor / research-runner) call this
+ * as the LAST step so the persisted jsonb is provably inert + size-bounded.
+ */
+export function clampTrace(trace: ExecutionTrace): ExecutionTrace {
+  const c: ExecutionController = trace.controller;
+  const controller: ExecutionController = {
+    kind: c.kind, // fixed union (sdlc-executor | research-runner)
+    label: sanitizeLine(c.label, LABEL_MAX),
+    green: c.green === true,
+    workers: c.workers.slice(0, MAX_WORKERS).map(clampWorker),
+  };
+  if (c.note !== undefined) controller.note = sanitizeLine(c.note, NOTE_MAX);
+  return {
+    schemaVersion: 1,
+    archetype: trace.archetype ?? null,
+    controller,
+  };
+}
+
+// ─── Builders ────────────────────────────────────────────────────────────────
+//
+// Structural inputs (NOT the executor/research types) keep this module dependency-
+// free — the coder path and the research path both build a trace here without
+// importing each other's module graph.
+
+/** The subset of the executor's `ApOutcome` the coder trace needs. */
+export interface SdlcOutcomeLike {
+  index: number;
+  priority: string;
+  title: string;
+  status: "completed" | "partial" | "failed";
+  note?: string;
+  skills?: string[];
+  verification?: {
+    method: "test-run";
+    ran: boolean;
+    passed: boolean;
+    summary: string;
+    fixIterations: number;
+    criterion: string;
+  };
+}
+
+/**
+ * Skill NAME → (capability, tool-name ceiling). Mirrors the catalog's baked-in
+ * `selectSkillSet` defaults. Renders capability + permissions-used WITHOUT threading
+ * the per-step binding through the whole result (design §2 "fallback"): faithful in
+ * the common case; may slightly over-state permissions if a skills-table row NARROWED
+ * the tools — acceptable for a display-only observability tree.
+ */
+const SKILL_CAPABILITY: Record<string, { capability: ExecutionSkill["capability"]; tools: string[] }> = {
+  "test-author": { capability: "worktree-write", tools: ["Edit", "Write", "Read"] },
+  coder: { capability: "worktree-write", tools: ["Edit", "Write", "Read"] },
+  research: { capability: "web-read", tools: ["web_search"] },
+  synthesize: { capability: "web-read", tools: ["web_search"] },
+  verify: { capability: "web-read", tools: ["web_search"] },
+};
+
+function skillFromName(skillName: string, green: boolean): ExecutionSkill {
+  const meta = SKILL_CAPABILITY[skillName] ?? { capability: "worktree-write" as const, tools: ["Edit", "Write", "Read"] };
+  return { skillName, capability: meta.capability, permissionsUsed: [...meta.tools], green };
+}
+
+/**
+ * Build the coder-path {@link ExecutionTrace} from the executor's per-AP outcomes.
+ * Controller green = a PR was opened AND no P0 acceptance-criterion is unmet. Each
+ * outcome → one worker; `skills` → skill nodes (green iff the worker did not fail);
+ * `verification` → one criterion leaf. Clamped before it is returned.
+ */
+export function buildSdlcTrace(
+  archetype: Archetype | null,
+  outcomes: readonly SdlcOutcomeLike[],
+  result: { prRef: string | null; error?: string },
+): ExecutionTrace {
+  const unmetP0 = outcomes.some(
+    (o) => o.priority.toUpperCase().startsWith("P0") && o.verification !== undefined && !o.verification.passed,
+  );
+  const workers: ExecutionWorker[] = outcomes.map((o) => {
+    const stepGreen = o.status !== "failed";
+    const skills: ExecutionSkill[] = (o.skills ?? []).map((n) => skillFromName(n, stepGreen));
+    const criteria: ExecutionCriterion[] = o.verification
+      ? [
+          {
+            criterion: o.verification.criterion,
+            method: o.verification.method,
+            ran: o.verification.ran,
+            passed: o.verification.passed,
+            fixIterations: o.verification.fixIterations,
+            summary: o.verification.summary,
+          },
+        ]
+      : [];
+    const w: ExecutionWorker = { index: o.index, priority: o.priority, title: o.title, status: o.status, skills, criteria };
+    if (o.note !== undefined) w.note = o.note;
+    return w;
+  });
+  const controller: ExecutionController = {
+    kind: "sdlc-executor",
+    label: "SDLC executor (coder)",
+    green: result.prRef !== null && !unmetP0,
+    workers,
+  };
+  if (result.error !== undefined) controller.note = result.error;
+  return clampTrace({ schemaVersion: 1, archetype, controller });
+}
+
+/** The subset of a research P0-criterion evidence the research trace needs. */
+export interface ResearchEvidenceLike {
+  criterion: string;
+  cited: boolean;
+}
+
+/**
+ * Build the research-path {@link ExecutionTrace}: three fixed step-workers (research,
+ * synthesize, verify), each with its web-read skill; the verify worker carries a
+ * web-evidence criterion leaf per P0 evidence. Controller green = report verdict
+ * `green`. Clamped before it is returned.
+ */
+export function buildResearchTrace(
+  archetype: Archetype | null,
+  evidence: readonly ResearchEvidenceLike[],
+  report: { verdict: "green" | "flagged" } | null,
+  error?: string,
+): ExecutionTrace {
+  const stepGreen = report !== null;
+  const worker = (index: number, title: string, criteria: ExecutionCriterion[]): ExecutionWorker => ({
+    index,
+    priority: "",
+    title,
+    status: stepGreen ? "completed" : "failed",
+    skills: [skillFromName(title, stepGreen)],
+    criteria,
+  });
+  const verifyCriteria: ExecutionCriterion[] = evidence.map((e) => ({
+    criterion: e.criterion,
+    method: "web-evidence",
+    ran: true,
+    passed: e.cited,
+  }));
+  const controller: ExecutionController = {
+    kind: "research-runner",
+    label: "Research runner (web-evidence)",
+    green: report?.verdict === "green",
+    workers: [worker(1, "research", []), worker(2, "synthesize", []), worker(3, "verify", verifyCriteria)],
+  };
+  if (error !== undefined) controller.note = error;
+  return clampTrace({ schemaVersion: 1, archetype, controller });
+}

--- a/server/services/research/research-runner.ts
+++ b/server/services/research/research-runner.ts
@@ -34,6 +34,7 @@
 import type { ProviderMessage, ToolDefinition, ActionPoint, ResearchReport, ResearchClaim, ResearchCitation, ResearchSource } from "@shared/types";
 import type { DevCloseoutResult } from "../consilium/dev-closeout.js";
 import { backtickFence, stripControlMultiline } from "../consilium/review-factory.js";
+import { buildResearchTrace } from "../consilium/execution-trace.js";
 import { toolRegistry } from "../../tools/index.js";
 
 // ─── The gateway slice this runner needs (R2) ───────────────────────────────
@@ -330,7 +331,10 @@ class ResearchRun {
     report.verdict = uncited.length === 0 ? "green" : "flagged";
     const finalReport = clampReport(report);
     const digest = this.buildDigest(citedP0, totalP0, uncited);
-    return { prRef: null, headCommit: "", report: finalReport, testSummary: digest };
+    // Stage 4: the observability trace (research → synthesize → verify, with a
+    // web-evidence criterion leaf per P0). Rides the result out-of-band like report.
+    const executionTrace = buildResearchTrace("research", evidence, finalReport);
+    return { prRef: null, headCommit: "", report: finalReport, testSummary: digest, executionTrace };
   }
 
   /** research step → draft, then synthesize step → a structured report. */

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -54,9 +54,10 @@
  *   - Agents NEVER apply/merge: this opens a DRAFT PR only. No push to main.
  */
 import { basename } from "path";
-import type { ActionPoint, Archetype } from "@shared/types";
+import type { ActionPoint, Archetype, ExecutionTrace } from "@shared/types";
 import type { Skill } from "@shared/schema";
 import { selectSkillSet, bindSkillStep, type BoundSkillStep } from "../consilium/skills/catalog.js";
+import { buildSdlcTrace } from "../consilium/execution-trace.js";
 import { buildBranchName, isValidLoopBranch, pushBranch, openDraftPr } from "../consilium/pr-wrapper.js";
 import {
   createSdlcWorktree,
@@ -243,6 +244,14 @@ export interface SdlcHandoffResult {
    * its convergence verdict in REAL test results.
    */
   testSummary?: string;
+  /**
+   * Stage 4 (observability): the per-round execution trace (phase → controller →
+   * worker → skill → criterion). Built from the per-AP `outcomes` this executor
+   * already computes; the controller persists it to `consilium_loop_rounds.execution
+   * _trace` out-of-band (like `testSummary`), so the FSM/`dev_completed` contract is
+   * unchanged. Display-only; permission NAMES only.
+   */
+  executionTrace?: ExecutionTrace;
 }
 
 /** Injectable seams (unit tests inject fakes — no real repo / claude / gh). */
@@ -619,6 +628,10 @@ export async function runSdlcHandoff(
         const summary = aggregateTestSummary(outcomes);
         if (summary) result.testSummary = summary;
       }
+      // Stage 4: build the observability trace from the per-AP outcomes (always — it
+      // rescues data we already computed). Rides the result out-of-band, exactly like
+      // testSummary; the dev_completed event / FSM are untouched.
+      result.executionTrace = buildSdlcTrace(req.archetype ?? null, outcomes, result);
       // Terminal beat — the executor finished its work for this round (the SERVICE
       // separately classifies done/failed from the result; this is phase-only).
       emit({

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -139,7 +139,7 @@ import {
   type DecisionLogRow,
 } from "@shared/schema";
 import type { LessonRecallFilter } from "./memory/lessons/types";
-import type { TraceSpan, SkillVersionRecord, MarketplaceSkill, MarketplaceFilters, InsertSkillVersion, SharedSession, CreateSharedSessionInput, ShareRole, WorkspaceConnection, CreateWorkspaceConnectionInput, UpdateWorkspaceConnectionInput, McpToolCall, ConnectionUsageMetrics, RecordMcpToolCallInput, SessionConflict, DecisionLogEntry, RaiseConflictInput, CastConflictVoteInput, DebateJudgement, ExperimentBranchResult, ResolutionOutcome, ResearchReport } from "@shared/types";
+import type { TraceSpan, SkillVersionRecord, MarketplaceSkill, MarketplaceFilters, InsertSkillVersion, SharedSession, CreateSharedSessionInput, ShareRole, WorkspaceConnection, CreateWorkspaceConnectionInput, UpdateWorkspaceConnectionInput, McpToolCall, ConnectionUsageMetrics, RecordMcpToolCallInput, SessionConflict, DecisionLogEntry, RaiseConflictInput, CastConflictVoteInput, DebateJudgement, ExperimentBranchResult, ResolutionOutcome, ResearchReport, ExecutionTrace } from "@shared/types";
 
 import { encrypt } from "./crypto";
 // [ADR-001 Wave-2] credentialProvider routes all decrypt() calls through the broker.
@@ -1411,6 +1411,14 @@ export class PgStorage implements IStorage {
     await db
       .update(consiliumLoopRounds)
       .set({ report })
+      .where(and(eq(consiliumLoopRounds.loopId, loopId), eq(consiliumLoopRounds.round, round)));
+  }
+
+  async updateLoopRoundExecutionTrace(loopId: string, round: number, trace: ExecutionTrace): Promise<void> {
+    // Stage 4: same (loop, round) scoping + out-of-band settle wire as report/testSummary.
+    await db
+      .update(consiliumLoopRounds)
+      .set({ executionTrace: trace })
       .where(and(eq(consiliumLoopRounds.loopId, loopId), eq(consiliumLoopRounds.round, round)));
   }
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -101,7 +101,7 @@ import {
   type NewsFeedback,
   type NewsReadState,
 } from "@shared/schema";
-import type { Memory, InsertMemory, MemoryScope, MemoryType, McpServerConfig, TraceSpan, TaskTraceSpan, SkillVersionRecord, MarketplaceSkill, MarketplaceFilters, InsertSkillVersion as InsertSkillVersionType, SharedSession, CreateSharedSessionInput, SharePermissions, ShareRole, WorkspaceConnection, CreateWorkspaceConnectionInput, UpdateWorkspaceConnectionInput, McpToolCall, ConnectionUsageMetrics, RecordMcpToolCallInput, SessionConflict, DecisionLogEntry, RaiseConflictInput, CastConflictVoteInput, DebateJudgement, ExperimentBranchResult, ResolutionOutcome, ResearchReport } from "@shared/types";
+import type { Memory, InsertMemory, MemoryScope, MemoryType, McpServerConfig, TraceSpan, TaskTraceSpan, SkillVersionRecord, MarketplaceSkill, MarketplaceFilters, InsertSkillVersion as InsertSkillVersionType, SharedSession, CreateSharedSessionInput, SharePermissions, ShareRole, WorkspaceConnection, CreateWorkspaceConnectionInput, UpdateWorkspaceConnectionInput, McpToolCall, ConnectionUsageMetrics, RecordMcpToolCallInput, SessionConflict, DecisionLogEntry, RaiseConflictInput, CastConflictVoteInput, DebateJudgement, ExperimentBranchResult, ResolutionOutcome, ResearchReport, ExecutionTrace } from "@shared/types";
 import type { LessonRecallFilter } from "./memory/lessons/types";
 import { randomUUID } from "crypto";
 import { PgStorage } from "./storage-pg";
@@ -627,6 +627,8 @@ export interface IStorage {
    * (mirror of updateLoopRoundTestSummary).
    */
   updateLoopRoundReport(loopId: string, round: number, report: ResearchReport): Promise<void>;
+  /** Stage 4: persist the per-round execution trace out-of-band (mirror of report). */
+  updateLoopRoundExecutionTrace(loopId: string, round: number, trace: ExecutionTrace): Promise<void>;
 
 
   // Tracker Connections (Issue Tracker Integration)
@@ -2088,6 +2090,7 @@ export class MemStorage implements IStorage {
       headCommit: data.headCommit ?? null,
       testSummary: data.testSummary ?? null,
       report: data.report ?? null,
+      executionTrace: data.executionTrace ?? null,
       createdAt: new Date(),
     };
     this.consiliumLoopRoundsMap.set(row.id, row);
@@ -2113,6 +2116,15 @@ export class MemStorage implements IStorage {
     for (const r of this.consiliumLoopRoundsMap.values()) {
       if (r.loopId === loopId && r.round === round) {
         this.consiliumLoopRoundsMap.set(r.id, { ...r, report });
+        return;
+      }
+    }
+  }
+
+  async updateLoopRoundExecutionTrace(loopId: string, round: number, trace: ExecutionTrace): Promise<void> {
+    for (const r of this.consiliumLoopRoundsMap.values()) {
+      if (r.loopId === loopId && r.round === round) {
+        this.consiliumLoopRoundsMap.set(r.id, { ...r, executionTrace: trace });
         return;
       }
     }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -17,7 +17,7 @@ import {
 import { vector } from "drizzle-orm/pg-core/columns/vector_extension/vector";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
-import type { MaintenanceCategoryConfig, ScoutFinding, TriggerConfig, TriggerType, ManagerConfig, ManagerDecision, TraceSpan, SwarmCloneResult, SwarmMerger, SwarmSplitter, LogSourceConfig, SkillVersionConfig, TaskTraceSpan, TrackerProvider, DebateDetails, ArbitratorVerdict, OrchestratorStepType, OrchestratorStepArgs, ResearchFinding, OrchestratorRunStatus, OrchestratorStepStatus, StopReason, Confidence, ConsensusVerdict, ConsensusRunStatus, ConsensusRoundPhase, ActionPoint, Archetype, ArchetypeSource, ResearchReport } from "./types.js";
+import type { MaintenanceCategoryConfig, ScoutFinding, TriggerConfig, TriggerType, ManagerConfig, ManagerDecision, TraceSpan, SwarmCloneResult, SwarmMerger, SwarmSplitter, LogSourceConfig, SkillVersionConfig, TaskTraceSpan, TrackerProvider, DebateDetails, ArbitratorVerdict, OrchestratorStepType, OrchestratorStepArgs, ResearchFinding, OrchestratorRunStatus, OrchestratorStepStatus, StopReason, Confidence, ConsensusVerdict, ConsensusRunStatus, ConsensusRoundPhase, ActionPoint, Archetype, ArchetypeSource, ResearchReport, ExecutionTrace } from "./types.js";
 
 // ─── RBAC ────────────────────────────────────────────
 
@@ -2812,6 +2812,11 @@ export const consiliumLoopRounds = pgTable(
     // out-of-band by `updateLoopRoundReport` after the research run settles (mirror of
     // testSummary). NULL for every non-research round. Size-clamped before write.
     report: jsonb("report").$type<ResearchReport>(),
+    // Stage 4 (observability tree): the per-round execution trace (phase → controller
+    // → worker → skill → criterion) both archetypes emit. Nullable; written out-of-band
+    // by `updateLoopRoundExecutionTrace` after settle (mirror of report/testSummary).
+    // NULL for pre-Stage-4 rounds / rounds with no skilled run. Clamped before write.
+    executionTrace: jsonb("execution_trace").$type<ExecutionTrace>(),
     createdAt: timestamp("created_at").notNull().defaultNow(),
   },
   (table) => ({

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1947,6 +1947,76 @@ export interface ResearchReport {
   generatedAt: string;
 }
 
+// ─── Execution trace (Stage 4 — the observability tree, design §8) ──────────────
+//
+// A phase → controller → worker → skill → criterion tree BOTH archetypes emit (the
+// coder path builds it from the executor's ApOutcome[]; the research path from its
+// steps + P0 CriterionEvidence[]) so the FE has ONE renderer. It rides the loop GET
+// `rounds[]` out-of-band (like `report`/`testSummary`) — never on the dev_completed
+// event, so the FSM is unchanged. Display-only, inert, URL-free; `permissionsUsed`
+// are tool NAMES only (never secrets/values/env).
+
+/** One skilled step an agent carried (its skill, capability scope, and green). */
+export interface ExecutionSkill {
+  /** e.g. "test-author" | "coder" | "research" | "synthesize" | "verify". */
+  skillName: string;
+  capability: "read-only" | "worktree-write" | "web-read";
+  /** Tool NAMES the step was allowed (Edit/Write/Read | web_search). Never values. */
+  permissionsUsed: string[];
+  /** Skill-green: the step ran clean. */
+  green: boolean;
+}
+
+/** A per-acceptance-criterion verification leaf. */
+export interface ExecutionCriterion {
+  /** The Definition-of-Done text (clamped, inert). */
+  criterion: string;
+  method: "test-run" | "web-evidence" | "judge" | "none";
+  /** Whether the verification method actually ran. */
+  ran: boolean;
+  /** Acceptance-criterion green. */
+  passed: boolean;
+  /** test-run fix re-invocations | re-research iterations. */
+  fixIterations?: number;
+  /** Scrubbed, clamped verification summary. */
+  summary?: string;
+}
+
+/** A worker agent: one action point (coder) or one research step. */
+export interface ExecutionWorker {
+  /** 1-based position in the round. */
+  index: number;
+  /** e.g. "P0" (coder); "" for research steps. */
+  priority: string;
+  /** The AP title, or the step role. */
+  title: string;
+  status: "completed" | "partial" | "failed";
+  /** Ordered skilled steps (test-author→coder | research→synthesize→verify). */
+  skills: ExecutionSkill[];
+  /** Acceptance-criterion leaves. */
+  criteria: ExecutionCriterion[];
+  /** Scrubbed worker-level note. */
+  note?: string;
+}
+
+/** The implement-phase orchestrator (the coder executor or the research runner). */
+export interface ExecutionController {
+  kind: "sdlc-executor" | "research-runner";
+  label: string;
+  /** All workers green + the aggregation criterion (§4). */
+  green: boolean;
+  /** Scrubbed controller-level error/degradation. */
+  note?: string;
+  workers: ExecutionWorker[];
+}
+
+/** The full per-round execution trace persisted on `consilium_loop_rounds`. */
+export interface ExecutionTrace {
+  schemaVersion: 1;
+  archetype: Archetype | null;
+  controller: ExecutionController;
+}
+
 // ─── Platform Version Types ────────────────────────────────────────────────────
 
 export interface VersionsResponse {

--- a/tests/unit/consilium/execution-trace.test.ts
+++ b/tests/unit/consilium/execution-trace.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildSdlcTrace,
+  buildResearchTrace,
+  clampTrace,
+  type SdlcOutcomeLike,
+} from "../../../server/services/consilium/execution-trace";
+import type { ExecutionTrace } from "@shared/types";
+
+describe("execution-trace — buildSdlcTrace (coder path)", () => {
+  const outcomes: SdlcOutcomeLike[] = [
+    {
+      index: 1,
+      priority: "P0",
+      title: "fix logger type error",
+      status: "completed",
+      skills: ["test-author", "coder"],
+      verification: { method: "test-run", ran: true, passed: true, summary: "ok", fixIterations: 1, criterion: "When built Then compiles" },
+    },
+    {
+      index: 2,
+      priority: "P1",
+      title: "pin helm image",
+      status: "failed",
+      note: "coder errored",
+    },
+  ];
+
+  it("maps outcomes → workers with skills (capability from the name map) + criterion leaves", () => {
+    const t = buildSdlcTrace("repo-assessment", outcomes, { prRef: "https://gh/pr/1" });
+    expect(t.controller.kind).toBe("sdlc-executor");
+    expect(t.controller.workers).toHaveLength(2);
+    const w0 = t.controller.workers[0];
+    expect(w0.skills.map((s) => s.skillName)).toEqual(["test-author", "coder"]);
+    // capability + permissions derived from the skill-name map (worktree-write → Edit/Write/Read)
+    expect(w0.skills[0].capability).toBe("worktree-write");
+    expect(w0.skills[0].permissionsUsed).toEqual(["Edit", "Write", "Read"]);
+    expect(w0.skills[0].green).toBe(true); // status !== failed
+    expect(w0.criteria).toHaveLength(1);
+    expect(w0.criteria[0].method).toBe("test-run");
+    expect(w0.criteria[0].passed).toBe(true);
+    // failed worker → skills green=false-derived (none here) + status failed
+    expect(t.controller.workers[1].status).toBe("failed");
+    expect(t.controller.workers[1].note).toBe("coder errored");
+  });
+
+  it("controller green requires a PR AND no unmet P0 criterion", () => {
+    expect(buildSdlcTrace("repo-assessment", outcomes, { prRef: "x" }).controller.green).toBe(true);
+    expect(buildSdlcTrace("repo-assessment", outcomes, { prRef: null }).controller.green).toBe(false);
+    const unmetP0: SdlcOutcomeLike[] = [
+      { index: 1, priority: "P0", title: "t", status: "completed", verification: { method: "test-run", ran: true, passed: false, summary: "red", fixIterations: 3, criterion: "c" } },
+    ];
+    expect(buildSdlcTrace("repo-assessment", unmetP0, { prRef: "x" }).controller.green).toBe(false);
+  });
+});
+
+describe("execution-trace — buildResearchTrace (research path)", () => {
+  it("builds a research-runner controller with research→synthesize→verify + web-evidence criteria", () => {
+    const t = buildResearchTrace(
+      "research",
+      [{ criterion: "cite source A", cited: true }, { criterion: "cite source B", cited: false }],
+      { verdict: "flagged" },
+    );
+    expect(t.controller.kind).toBe("research-runner");
+    expect(t.controller.green).toBe(false); // verdict flagged
+    expect(t.controller.workers.map((w) => w.title)).toEqual(["research", "synthesize", "verify"]);
+    const verify = t.controller.workers[2];
+    expect(verify.skills[0].capability).toBe("web-read");
+    expect(verify.skills[0].permissionsUsed).toEqual(["web_search"]);
+    expect(verify.criteria).toHaveLength(2);
+    expect(verify.criteria[0].method).toBe("web-evidence");
+    expect(verify.criteria[0].passed).toBe(true);
+    expect(verify.criteria[1].passed).toBe(false);
+  });
+
+  it("green when the report verdict is green; degraded (null report) → failed steps", () => {
+    expect(buildResearchTrace("research", [], { verdict: "green" }).controller.green).toBe(true);
+    const degraded = buildResearchTrace("research", [], null, "web_search unavailable");
+    expect(degraded.controller.green).toBe(false);
+    expect(degraded.controller.note).toBe("web_search unavailable");
+    expect(degraded.controller.workers.every((w) => w.status === "failed")).toBe(true);
+  });
+});
+
+describe("execution-trace — clampTrace", () => {
+  it("bounds counts + strips control chars (note) / paths (criterion summary); permission names survive", () => {
+    const huge: ExecutionTrace = {
+      schemaVersion: 1,
+      archetype: "repo-assessment",
+      controller: {
+        kind: "sdlc-executor",
+        label: "ctl\n\tlabel",
+        green: true,
+        note: "error\n\there",
+        workers: Array.from({ length: 500 }, (_, i) => ({
+          index: i,
+          priority: "P0",
+          title: "t",
+          status: "completed" as const,
+          skills: [{ skillName: "coder", capability: "worktree-write" as const, permissionsUsed: ["Edit", "Write", "Read"], green: true }],
+          criteria: [{ criterion: "c", method: "test-run" as const, ran: true, passed: false, summary: "failed at /Users/secret/file.ts" }],
+        })),
+      },
+    };
+    const c = clampTrace(huge);
+    expect(c.controller.workers.length).toBeLessThanOrEqual(200);
+    expect(c.controller.label).toBe("ctl label"); // control chars collapsed
+    expect(c.controller.note).toBe("error here"); // control-stripped
+    // criterion summary is path-scrubbed via scrub()
+    expect(c.controller.workers[0].criteria[0].summary).not.toContain("/Users/secret");
+    expect(c.controller.workers[0].skills[0].permissionsUsed).toEqual(["Edit", "Write", "Read"]);
+  });
+});


### PR DESCRIPTION
**Final stage.** The implement phase already computed a per-AP/skill/criterion outcome each round but **discarded it after settle** (it survived only as Draft-PR prose + the testSummary digest). Stage 4 **rescues** it into a structured, durable `execution_trace` and renders the **phase → controller → worker → skill → green/red / permissions-used / per-criterion method+result** tree — failures first-class + recoverable, the opposite of the invisible execute-sdlc that motivated the redesign. Additive; **NO FSM change**; permission **NAMES only**; **URL-free** tree (no XSS).

- `shared` `ExecutionTrace`; `execution-trace.ts` = `buildSdlcTrace` (from `ApOutcome[]`) + `buildResearchTrace` + `clampTrace` (bounds + scrubs, names-only). Capability/permissions from a skill-name map (design §2 "fallback" — no executor control-flow touch).
- executor + research-runner return `executionTrace`; the controller persists it **out-of-band at settle** (mirror of report/testSummary) → `consilium_loop_rounds.execution_trace` jsonb (**migration 0034**) → the existing loop GET `rounds`.
- UI: a `SettledExecutionTree` in each RoundRow expansion — inert + link-free.

> Implemented by the Lead directly — the dev-team subagents hit their weekly limit mid-task.

## Verification
migration 0034 applied to dev DB; `tsc` clean; new `execution-trace.test.ts` (builders + clamp) + full unit suite **5734 pass**.

## loop-consolidation 0→4 COMPLETE
Stage 0 removed the invisible execute-sdlc → the Loop's visible develop phase; Stage 1 acceptance criteria + intent→archetype planner; Stage 2 skilled + capability-scoped implement (2a) + per-criterion test verification (2b); Stage 3 the research archetype (web-evidence report); Stage 4 makes the pipeline observable. Every stage additive + inert-by-default behind kill-switches with **zero FSM/reduce change** — the Loop is now the single user-facing unit of work.