### PR TITLE
feat: live per-task progress for the loop develop phase

### DIFF
--- a/client/src/hooks/use-consilium-loops.ts
+++ b/client/src/hooks/use-consilium-loops.ts
@@ -48,6 +48,23 @@ export interface DevProgress {
   actionPointTotal?: number;
   actionPointTitle?: string;
   completedCount?: number;
+  /** Which agent/skill step is running RIGHT NOW for the active action point:
+   *  `test-author`/`coder` implement it, `test-runner` verifies, `fix-coder` is a
+   *  fix-loop re-invocation. Absent for the commit/push/opening_pr/done phases. */
+  step?: "test-author" | "coder" | "test-runner" | "fix-coder";
+  /** The active AP's current fix-loop iteration (0 = initial implement, 1..N = fix
+   *  passes) and the configured budget. Present only mid-verification. */
+  fixIteration?: number;
+  fixBudget?: number;
+  /** The FULL action-point list with LIVE per-AP status, so the UI renders the whole
+   *  round as a task list. `i` is 1-based; `title` is INERT model-authored text
+   *  (server-sanitized). Absent on old/degraded snapshots ⇒ fall back to the
+   *  single-line phase rendering. */
+  aps?: Array<{
+    i: number;
+    title: string;
+    status: "pending" | "active" | "completed" | "partial" | "failed";
+  }>;
 }
 
 /**

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -1020,6 +1020,76 @@ function humanizeDevPhase(progress: DevProgress | undefined, total: number): str
   }
 }
 
+/** One action point's live status → its leading icon (reusing the page's idioms:
+ *  a spinner for in-flight, Check/X for settled, muted Clock for not-yet-started). */
+function ApStatusIcon({ status }: { status: NonNullable<DevProgress["aps"]>[number]["status"] }) {
+  switch (status) {
+    case "active":
+      return <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-primary" aria-label="в работе" />;
+    case "completed":
+      return <Check className="h-3.5 w-3.5 shrink-0 text-green-600" aria-label="готово" />;
+    case "partial":
+      return <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-500" aria-label="частично" />;
+    case "failed":
+      return <X className="h-3.5 w-3.5 shrink-0 text-red-500" aria-label="ошибка" />;
+    case "pending":
+    default:
+      return <Clock className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-label="в очереди" />;
+  }
+}
+
+/** Humanize the running agent/skill step for the active-row badge. */
+const DEV_STEP_LABELS: Record<NonNullable<DevProgress["step"]>, string> = {
+  "test-author": "автор тестов",
+  coder: "кодер",
+  "test-runner": "прогон тестов",
+  "fix-coder": "фикс",
+};
+
+/**
+ * The LIVE task list for the developing round: one row per action point (status
+ * icon + INERT title), with a badge on the ACTIVE row naming the agent running now
+ * (`step`) and, mid-fix-loop, the `fix k/N` iteration. Rendered only when the beat
+ * carries `aps`; the panel degrades to the single-line phase view otherwise.
+ *
+ * SECURITY: every `title` is model-authored verdict text, server-sanitized and
+ * rendered as INERT React text (never HTML, never a link/attribute).
+ */
+function DevTaskList({ progress }: { progress: DevProgress }) {
+  const aps = progress.aps ?? [];
+  if (aps.length === 0) return null;
+  return (
+    <ul className="space-y-1">
+      {aps.map((ap) => {
+        const isActive = ap.status === "active";
+        return (
+          <li key={ap.i} className="flex items-start gap-2 text-xs leading-relaxed">
+            <span className="mt-0.5">
+              <ApStatusIcon status={ap.status} />
+            </span>
+            <span className="min-w-0 flex-1 break-words">
+              <span className={isActive ? "font-medium" : "text-muted-foreground"}>
+                {ap.title || `action point #${ap.i}`}
+              </span>
+              {isActive && progress.step && (
+                <Badge variant="secondary" className="ml-1.5 text-[10px] py-0 align-middle">
+                  {DEV_STEP_LABELS[progress.step]}
+                  {typeof progress.fixIteration === "number" && progress.fixIteration > 0 && (
+                    <span className="ml-1 tabular-nums">
+                      fix {progress.fixIteration}
+                      {typeof progress.fixBudget === "number" ? `/${progress.fixBudget}` : ""}
+                    </span>
+                  )}
+                </Badge>
+              )}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
 function DevelopProgressPanel({
   loop,
   fallbackTotal,
@@ -1049,6 +1119,11 @@ function DevelopProgressPanel({
         {/* INERT model-authored action-point title inside the phase line */}
         <span>{humanizeDevPhase(progress, total)}</span>
       </div>
+
+      {/* LIVE task list — one row per action point with agent + status + fix pass.
+          Absent `aps` (old/degraded snapshot) ⇒ this renders nothing and the panel
+          degrades to the phase line + progress bar above/below (today's view). */}
+      {progress?.aps && progress.aps.length > 0 && <DevTaskList progress={progress} />}
 
       {total > 0 && (
         <div className="space-y-1">

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -80,6 +80,7 @@ const PR_BODY_TITLE_MAX = 120;
 const PR_BODY_RATIONALE_MAX = 200; // 1-line rationale in the "addressed" list
 const PR_BODY_MAX = 16_000;
 const PROGRESS_TITLE_MAX = 120; // display-only progress title clamp (matches PR_BODY_TITLE_MAX)
+const PROGRESS_APS_MAX = 100; // defensive cap on the live per-AP task list carried in a beat
 const CRITERION_MAX = 300; // acceptance-criterion clamp for the PR body / round audit
 const FIX_SUMMARY_MAX = 3_000; // test-failure summary fed (fenced, stdin) into a fix coder
 const TEST_SUMMARY_MAX = 6_000; // aggregated round testSummary clamp (-> consilium_loop_rounds)
@@ -94,6 +95,14 @@ const WHOLE_RUN_BUDGET_MS = 7_200_000;
 
 /** Per-action-point outcome status surfaced in the Draft PR body. */
 export type ApStatus = "completed" | "partial" | "failed";
+
+/**
+ * Live status of ONE action point in the developing task list. A SUPERSET of the
+ * settled {@link ApStatus} with the two in-flight states (`pending` = not started,
+ * `active` = currently being worked). Display-only — it never alters the settled
+ * per-AP {@link ApOutcome} the Draft-PR body / dev_completed event are built from.
+ */
+export type ApProgressStatus = "pending" | "active" | ApStatus;
 
 export interface ApOutcome {
   /** 1-based position in the round. */
@@ -192,6 +201,36 @@ export interface SdlcProgress {
   actionPointTitle: string;
   /** How many action points have produced a commit so far. */
   completedCount: number;
+  /**
+   * Which agent/skill step is running RIGHT NOW for the ACTIVE action point:
+   * `test-author`/`coder` are the skilled implement steps (or `coder` on the
+   * unskilled path); `test-runner` is a verification run; `fix-coder` is a fix-loop
+   * re-invocation of the implementer. Absent for the commit/push/opening_pr/done
+   * phases (no single agent step). ADDITIVE + OPTIONAL: old snapshots simply omit
+   * it. Display only.
+   */
+  step?: "test-author" | "coder" | "test-runner" | "fix-coder";
+  /**
+   * The active action point's current fix-loop iteration (0 = initial implement,
+   * 1..N = fix passes) and the configured fix budget. Both present only while a
+   * verification-enabled round is working an AP; absent otherwise. Display only.
+   */
+  fixIteration?: number;
+  fixBudget?: number;
+  /**
+   * The FULL action-point list with LIVE per-AP status, so a UI can render the whole
+   * round as a task list (not just the current AP). `i` is the 1-based position.
+   *
+   * SECURITY: each `title` is UNTRUSTED verdict text, control-stripped + clamped via
+   * `sanitizeLine` EXACTLY like {@link actionPointTitle} (same scrub, same clamp),
+   * and only ever serialized into this display JSON — never a shell / branch / PR
+   * title. The array is capped at {@link PROGRESS_APS_MAX} entries (defensive).
+   *
+   * ADDITIVE + OPTIONAL: a pre-this-field snapshot omits it, so an old consumer keeps
+   * working and a new consumer degrades to the single-line rendering when it is
+   * absent. Display only.
+   */
+  aps?: Array<{ i: number; title: string; status: ApProgressStatus }>;
 }
 
 /** Optional progress sink threaded through the per-AP loop + push/PR phases. */
@@ -590,20 +629,69 @@ export function buildPrStatusBody(input: PrStatusBodyInput): string {
   ].join("\n").slice(0, PR_BODY_MAX);
 }
 
+/** One beat's per-call fields — the {@link ProgressTracker} injects the shared
+ *  live `aps` snapshot, so callers never assemble it themselves. */
+type ProgressBeat = Omit<SdlcProgress, "aps">;
+
+/** A single-beat emitter (a tracker's `beat`, threaded where the old `emit` was). */
+type ProgressBeatFn = (b: ProgressBeat) => void;
+
 /**
- * Wrap the optional progress sink so a THROWING callback can NEVER break the
- * executor's NEVER-THROWS guarantee (the sink is best-effort + display-only).
- * Returns a no-op when no callback was supplied (the consilium LOOP path).
+ * Progress emitter that OWNS the round's live per-action-point status list and
+ * injects a fresh (deep-copied) `aps` snapshot into EVERY beat, so each beat carries
+ * the WHOLE task list — not just the current AP. `setStatus` flips one AP's live
+ * status as the run progresses (pending → active → completed/partial/failed).
+ *
+ * It wraps the optional sink so a THROWING callback can NEVER break the executor's
+ * NEVER-THROWS guarantee (best-effort + display-only), and is a COMPLETE no-op when
+ * no callback was supplied (the consilium LOOP path ⇒ zero overhead, no snapshot
+ * ever built — behavior identical to before this field existed).
  */
-function makeEmit(onProgress?: SdlcProgressFn): SdlcProgressFn {
-  if (!onProgress) return () => {};
-  return (p: SdlcProgress) => {
-    try {
-      onProgress(p);
-    } catch {
-      // Progress is best-effort; a bad sink must not affect the SDLC run.
-    }
+interface ProgressTracker {
+  /** Emit one beat, augmented with the current live `aps` snapshot. */
+  beat: ProgressBeatFn;
+  /** Flip one action point's live status (1-based index; out-of-range = no-op). */
+  setStatus(index: number, status: ApProgressStatus): void;
+}
+
+function makeProgressTracker(
+  onProgress: SdlcProgressFn | undefined,
+  actionPoints: readonly ActionPoint[],
+): ProgressTracker {
+  // No callback ⇒ everything is a no-op; we never even build the snapshot.
+  if (!onProgress) return { beat: () => {}, setStatus: () => {} };
+  // Build the live task list ONCE. Titles are UNTRUSTED → sanitized + clamped EXACTLY
+  // like actionPointTitle (same scrub + PROGRESS_TITLE_MAX). Capped defensively.
+  const aps: Array<{ i: number; title: string; status: ApProgressStatus }> = actionPoints
+    .slice(0, PROGRESS_APS_MAX)
+    .map((ap, i) => ({
+      i: i + 1,
+      title: sanitizeLine(ap.title ?? "", PROGRESS_TITLE_MAX),
+      status: "pending" as ApProgressStatus,
+    }));
+  return {
+    beat(b) {
+      try {
+        // Deep-copy the snapshot so a stored beat is never mutated by a later flip.
+        onProgress({ ...b, aps: aps.map((a) => ({ ...a })) });
+      } catch {
+        // Progress is best-effort; a bad sink must not affect the SDLC run.
+      }
+    },
+    setStatus(index, status) {
+      const a = aps[index - 1];
+      if (a) a.status = status;
+    },
   };
+}
+
+/**
+ * Map a skilled-step name to the display-only progress `step`. The develop path only
+ * ever selects the `test-author` → `coder` pair (see `selectSkillSet`); any other
+ * name collapses to `coder` so the badge always shows a valid implement agent.
+ */
+function stepForSkill(skillName: string): NonNullable<SdlcProgress["step"]> {
+  return skillName === "test-author" ? "test-author" : "coder";
 }
 
 /**
@@ -626,7 +714,7 @@ export async function runSdlcHandoff(
   const runCoder = deps.runCoder ?? ((dir, aps, opts) => sharedCoder.run(dir, aps, opts));
   const push = deps.push ?? pushBranch;
   const openPr = deps.openPr ?? openDraftPr;
-  const emit = makeEmit(onProgress);
+  const progress = makeProgressTracker(onProgress, req.actionPoints);
 
   // B-3: server-derived branch; defensively re-gate before anything runs.
   const branch = buildBranchName(req.loopId, req.round);
@@ -682,7 +770,7 @@ export async function runSdlcHandoff(
       let committedCount = 0;
       for (let i = 0; i < total; i++) {
         const outcome = await runActionPoint(
-          { gitRaw, runCoder, emit, completedBefore: committedCount, skilledSteps, verify: verifyCtx },
+          { gitRaw, runCoder, progress, completedBefore: committedCount, skilledSteps, verify: verifyCtx },
           wt,
           req,
           req.actionPoints[i],
@@ -691,6 +779,10 @@ export async function runSdlcHandoff(
         );
         outcomes.push(outcome);
         if (outcome.committed) committedCount += 1;
+        // AP end: fold the settled status into the shared live snapshot. It surfaces
+        // on the very next beat (the next AP's start, or the push/done beat below) —
+        // the poll-based UI reads the latest snapshot, so no separate end beat.
+        progress.setStatus(i + 1, outcome.status);
       }
 
       // Stage A: FINAL-STATE re-verification. After every action point has been applied
@@ -713,7 +805,7 @@ export async function runSdlcHandoff(
         gitRaw,
         push,
         openPr,
-        emit,
+        emit: progress.beat,
       }, finalVerification);
       // Stage 2b: aggregate the per-criterion verification into ONE bounded round
       // testSummary, surfaced on the result so the controller can persist it to
@@ -733,7 +825,7 @@ export async function runSdlcHandoff(
       result.executionTrace = buildSdlcTrace(req.archetype ?? null, outcomes, result, finalVerification?.passed);
       // Terminal beat — the executor finished its work for this round (the SERVICE
       // separately classifies done/failed from the result; this is phase-only).
-      emit({
+      progress.beat({
         phase: "done",
         actionPointIndex: total,
         actionPointTotal: total,
@@ -761,7 +853,8 @@ async function runActionPoint(
   io: {
     gitRaw: GitRunner;
     runCoder: NonNullable<SdlcExecutorDeps["runCoder"]>;
-    emit: SdlcProgressFn;
+    /** Live progress emitter — owns the round's per-AP status snapshot. */
+    progress: ProgressTracker;
     /** Commits produced by EARLIER action points (this AP not yet counted). */
     completedBefore: number;
     /** Stage 2a: the round's ORDERED bound skilled steps. Empty ⇒ the UNCHANGED
@@ -780,14 +873,12 @@ async function runActionPoint(
   const title = sanitizeLine(ap.title ?? "", PR_BODY_TITLE_MAX);
   // Display-only progress title — clamped + control-stripped (UNTRUSTED text).
   const progressTitle = sanitizeLine(ap.title ?? "", PROGRESS_TITLE_MAX);
-  // 0. Beat: about to run the coder for THIS action point.
-  io.emit({
-    phase: "coding",
-    actionPointIndex: index,
-    actionPointTotal: total,
-    actionPointTitle: progressTitle,
-    completedCount: io.completedBefore,
-  });
+  // Fix budget surfaced on every beat once verification is on (undefined otherwise).
+  const fixBudget = io.verify ? io.verify.config.maxFixIterations : undefined;
+  // 0. This AP is now the ACTIVE row in the live task list. The per-step `coding`
+  //    beats below (one per skilled step, or one for the unskilled coder) carry the
+  //    updated snapshot; each names the agent (`step`) running RIGHT NOW.
+  io.progress.setStatus(index, "active");
 
   // 1. Run the coder for THIS action point. A throw (timeout / binary missing) is
   //    caught — its partial edits are still committed below.
@@ -804,6 +895,17 @@ async function runActionPoint(
   if (io.skilledSteps.length > 0) {
     for (const bound of io.skilledSteps) {
       ranSkills.push(bound.step.skillName);
+      // Beat: this skilled agent is running RIGHT NOW (test-author → coder, in order).
+      io.progress.beat({
+        phase: "coding",
+        actionPointIndex: index,
+        actionPointTotal: total,
+        actionPointTitle: progressTitle,
+        completedCount: io.completedBefore,
+        step: stepForSkill(bound.step.skillName),
+        fixIteration: 0,
+        fixBudget,
+      });
       try {
         coder = await io.runCoder(wt.worktreeDir, [ap], {
           timeoutMs: req.coderTimeoutMs,
@@ -821,6 +923,17 @@ async function runActionPoint(
       }
     }
   } else {
+    // Beat: the single unskilled coder is running RIGHT NOW (today's default path).
+    io.progress.beat({
+      phase: "coding",
+      actionPointIndex: index,
+      actionPointTotal: total,
+      actionPointTitle: progressTitle,
+      completedCount: io.completedBefore,
+      step: "coder",
+      fixIteration: 0,
+      fixBudget,
+    });
     try {
       coder = await io.runCoder(wt.worktreeDir, [ap], { timeoutMs: req.coderTimeoutMs });
     } catch (err) {
@@ -840,7 +953,13 @@ async function runActionPoint(
   //     carries an acceptance criterion (the definition-of-green). Never throws.
   let verification: ApVerification | undefined;
   if (io.verify && ranClean && (ap.acceptanceCriterion ?? "").trim().length > 0) {
-    verification = await runVerifyFixLoop(io.runCoder, io.verify, wt, req, ap);
+    verification = await runVerifyFixLoop(io.runCoder, io.verify, wt, req, ap, {
+      progress: io.progress,
+      index,
+      total,
+      title: progressTitle,
+      completedBefore: io.completedBefore,
+    });
   }
 
   // Outcome base (incl. the Stage-2a skills audit — undefined on the unskilled path
@@ -877,8 +996,8 @@ async function runActionPoint(
   const isPartial = threw || (coder !== null && !coder.ok);
   const note = isPartial ? (runNote ?? coder?.error ?? "coder did not finish") : undefined;
   const { subject, body } = buildApCommitMessage(req.round, ap, index, total, isPartial, note);
-  // Beat: about to commit THIS action point's work.
-  io.emit({
+  // Beat: about to commit THIS action point's work (still the active row).
+  io.progress.beat({
     phase: "committing",
     actionPointIndex: index,
     actionPointTotal: total,
@@ -1026,10 +1145,31 @@ async function runVerifyFixLoop(
   wt: CreateWorktreeResult,
   req: SdlcHandoffRequest,
   ap: ActionPoint,
+  beatCtx: {
+    progress: ProgressTracker;
+    index: number;
+    total: number;
+    title: string;
+    completedBefore: number;
+  },
 ): Promise<ApVerification> {
   const criterion = sanitizeLine(ap.acceptanceCriterion ?? "", CRITERION_MAX);
+  // Emit a verification beat (test-runner / fix-coder) for the ACTIVE AP; the tracker
+  // folds in the live snapshot. `fixIteration` = which fix pass (0 = initial test run).
+  const emitVerify = (step: NonNullable<SdlcProgress["step"]>, fixIteration: number): void =>
+    beatCtx.progress.beat({
+      phase: "coding",
+      actionPointIndex: beatCtx.index,
+      actionPointTotal: beatCtx.total,
+      actionPointTitle: beatCtx.title,
+      completedCount: beatCtx.completedBefore,
+      step,
+      fixIteration,
+      fixBudget: vc.config.maxFixIterations,
+    });
   const runOnce = (): Promise<TestRunResult> => runTestOnce(vc, wt);
 
+  emitVerify("test-runner", 0); // initial verification run (before any fix).
   let result = await runOnce();
   let fixIterations = 0;
   while (!result.passed && fixIterations < vc.config.maxFixIterations) {
@@ -1037,6 +1177,7 @@ async function runVerifyFixLoop(
     // per-AP coder/test timeouts + this cap together bound total develop time).
     if (vc.now() >= vc.deadline) break;
     fixIterations += 1;
+    emitVerify("fix-coder", fixIterations); // fix pass k is running.
     try {
       const fixed = await runCoder(wt.worktreeDir, [ap], {
         timeoutMs: req.coderTimeoutMs,
@@ -1047,6 +1188,7 @@ async function runVerifyFixLoop(
     } catch {
       break; // a crashed fix coder stops the loop; whatever landed is still committed.
     }
+    emitVerify("test-runner", fixIterations); // re-run tests after fix pass k.
     result = await runOnce();
   }
 
@@ -1148,7 +1290,7 @@ async function pushAndOpenPr(
   wt: CreateWorktreeResult,
   outcomes: readonly ApOutcome[],
   committedCount: number,
-  io: { gitRaw: GitRunner; push: typeof pushBranch; openPr: typeof openDraftPr; emit: SdlcProgressFn },
+  io: { gitRaw: GitRunner; push: typeof pushBranch; openPr: typeof openDraftPr; emit: ProgressBeatFn },
   finalVerification?: FinalVerification,
 ): Promise<SdlcHandoffResult> {
   const total = req.actionPoints.length;

--- a/tests/unit/sdlc/executor.test.ts
+++ b/tests/unit/sdlc/executor.test.ts
@@ -376,3 +376,79 @@ describe("runSdlcHandoff — progress reporting (onProgress)", () => {
     expect(events[events.length - 1].completedCount).toBe(0);
   });
 });
+
+describe("runSdlcHandoff — LIVE per-AP task list (progress.aps)", () => {
+  function collect() {
+    const events: SdlcProgress[] = [];
+    // Deep-copy each beat (the tracker deep-copies `aps` per beat, but be defensive).
+    return {
+      events,
+      onProgress: (p: SdlcProgress) => events.push(JSON.parse(JSON.stringify(p)) as SdlcProgress),
+    };
+  }
+
+  it("carries the FULL action-point list on every beat and transitions statuses live", async () => {
+    const deps = makeDeps(); // both APs dirty → both commit → both `completed`
+    const { events, onProgress } = collect();
+    await runSdlcHandoff(baseReq(), deps as never, onProgress);
+
+    // Every beat carries the whole list, in order, with stable 1-based indices.
+    for (const e of events) {
+      expect(e.aps).toBeDefined();
+      expect(e.aps!.map((a) => a.i)).toEqual([1, 2]);
+    }
+
+    // AP1 is `active` while it is coded; AP2 is still `pending`.
+    const coding1 = events.find((e) => e.phase === "coding" && e.actionPointIndex === 1)!;
+    expect(coding1.aps!.map((a) => a.status)).toEqual(["active", "pending"]);
+    expect(coding1.step).toBe("coder"); // unskilled path ⇒ single coder step
+    expect(coding1.fixIteration).toBe(0);
+    expect(coding1.fixBudget).toBeUndefined(); // verification off
+
+    // By the time AP2 is coded, AP1 has settled to `completed`.
+    const coding2 = events.find((e) => e.phase === "coding" && e.actionPointIndex === 2)!;
+    expect(coding2.aps!.map((a) => a.status)).toEqual(["completed", "active"]);
+
+    // The terminal beat shows BOTH settled.
+    expect(events[events.length - 1].aps!.map((a) => a.status)).toEqual(["completed", "completed"]);
+  });
+
+  it("SANITIZES + clamps the UNTRUSTED titles carried in the aps list", async () => {
+    const deps = makeDeps();
+    const { events, onProgress } = collect();
+    await runSdlcHandoff(baseReq(), deps as never, onProgress);
+    // APS[0].title has shell metachars + a newline — control-stripped, no newline.
+    const list = events[0].aps!;
+    expect(list[0].title).toBe("Fix `;rm -rf /` in parser with newline");
+    expect(list[0].title).not.toMatch(/[\n\r]/);
+    expect(list[1].title).toBe("Add the redactor");
+  });
+
+  it("marks partial-preserve and failed APs with the right live status", async () => {
+    // Both APs throw. Dirty worktree → committed [partial]; nothing dirty → failed.
+    const throwing = vi.fn(async () => {
+      throw new Error("CLI timed out at /home/u/.claude");
+    });
+    const partialDeps = makeDeps({ runCoder: throwing });
+    const p = collect();
+    await runSdlcHandoff(baseReq(), partialDeps as never, p.onProgress);
+    expect(p.events[p.events.length - 1].aps!.map((a) => a.status)).toEqual(["partial", "partial"]);
+
+    const failedDeps = makeDeps({ runCoder: throwing, gitRaw: makeGitRaw(false) });
+    const f = collect();
+    await runSdlcHandoff(baseReq(), failedDeps as never, f.onProgress);
+    expect(f.events[f.events.length - 1].aps!.map((a) => a.status)).toEqual(["failed", "failed"]);
+  });
+
+  it("caps the aps list defensively at 100 entries", async () => {
+    const many: ActionPoint[] = Array.from({ length: 101 }, (_, i) => ({
+      title: `AP ${i}`,
+      priority: "P2",
+    }));
+    const deps = makeDeps();
+    const { events, onProgress } = collect();
+    await runSdlcHandoff(baseReq({ actionPoints: many }), deps as never, onProgress);
+    expect(events[0].aps).toHaveLength(100);
+    expect(events[0].aps![99].i).toBe(100);
+  });
+});

--- a/tests/unit/sdlc/verification-loop.test.ts
+++ b/tests/unit/sdlc/verification-loop.test.ts
@@ -19,6 +19,7 @@ import { describe, it, expect, vi } from "vitest";
 import {
   runSdlcHandoff,
   type SdlcHandoffRequest,
+  type SdlcProgress,
   type VerificationConfig,
 } from "../../../server/services/sdlc/executor.js";
 import type { TestRunResult } from "../../../server/services/sdlc/test-runner.js";
@@ -239,5 +240,49 @@ describe("Stage 2b — convergence wire + criterion gating", () => {
     const deps = makeDeps({ runTests, runCoder });
     await runSdlcHandoff(baseReq({ verification: VCFG() }), deps as never);
     expect(runTests).not.toHaveBeenCalled();
+  });
+});
+
+describe("Stage 2b — LIVE progress steps across the skilled + verify + fix loop", () => {
+  function collect() {
+    const events: SdlcProgress[] = [];
+    return {
+      events,
+      onProgress: (p: SdlcProgress) => events.push(JSON.parse(JSON.stringify(p)) as SdlcProgress),
+    };
+  }
+
+  it("emits test-author → coder → test-runner → fix-coder → test-runner, with fix iterations + budget", async () => {
+    // Initial verify RED, then GREEN after one fix pass.
+    const runTests = sequencedRunTests([fail, pass]);
+    const deps = makeDeps({ runTests });
+    const { events, onProgress } = collect();
+    await runSdlcHandoff(baseReq({ verification: VCFG({ maxFixIterations: 3 }) }), deps as never, onProgress);
+
+    // The ordered `step` sequence of the coding-phase beats for the single AP.
+    const steps = events.filter((e) => e.phase === "coding").map((e) => e.step);
+    expect(steps).toEqual(["test-author", "coder", "test-runner", "fix-coder", "test-runner"]);
+
+    // The verify beats carry the fix iteration (0 initial, 1 for the fix pass) + budget.
+    const byStep = (s: SdlcProgress["step"]) => events.filter((e) => e.step === s);
+    expect(byStep("test-runner").map((e) => e.fixIteration)).toEqual([0, 1]);
+    expect(byStep("fix-coder").map((e) => e.fixIteration)).toEqual([1]);
+    for (const e of events.filter((e) => e.phase === "coding")) {
+      expect(e.fixBudget).toBe(3);
+    }
+
+    // The single AP is `active` throughout the develop steps, then `completed`.
+    const codingBeats = events.filter((e) => e.phase === "coding");
+    expect(codingBeats.every((e) => e.aps?.[0]?.status === "active")).toBe(true);
+    expect(events[events.length - 1].aps?.[0]?.status).toBe("completed");
+  });
+
+  it("stops fixing at maxFixIterations — the fix-coder step count is bounded by the budget", async () => {
+    const runTests = sequencedRunTests([fail]); // never turns green
+    const deps = makeDeps({ runTests });
+    const { events, onProgress } = collect();
+    await runSdlcHandoff(baseReq({ verification: VCFG({ maxFixIterations: 2 }) }), deps as never, onProgress);
+    const fixSteps = events.filter((e) => e.step === "fix-coder").map((e) => e.fixIteration);
+    expect(fixSteps).toEqual([1, 2]); // exactly the budget, no more
   });
 });


### PR DESCRIPTION
## What the user sees

On the loop detail page's round section (`#round-N`), while `state=developing`, the
develop card now renders the WHOLE round as a **live task list** instead of a single
phase line.

**Before:** one humanized phase string + the current action-point title + a
`completed/total` count. You could not see the other action points, which agent was
working, or how many fix passes an AP had taken.

**Now:** one row per action point, each with:
- a **status icon** — pending (clock) / active (spinner) / completed (check) /
  partial (warning) / failed (x)
- the action-point **title** (inert, server-sanitized)
- on the **active** row, a badge naming the **agent running right now** (test author
  / coder / test runner / fix) and, mid-verification, the **fix iteration** (`fix
  k/N`)

The card degrades to the previous single-line rendering when a beat carries no `aps`
(old / cross-instance / post-restart snapshot).

## Data flow

`SdlcProgress` (server, display-only) gains four **additive, OPTIONAL** fields so old
snapshots stay valid:
- `step?: "test-author" | "coder" | "test-runner" | "fix-coder"`
- `fixIteration?` / `fixBudget?` — the active AP's fix-loop position + budget
- `aps?: Array<{ i; title; status }>` — the full AP list with live status

A `ProgressTracker` owns the round's live status list and injects a fresh,
**deep-copied** `aps` snapshot into every beat (so a stored beat is never mutated by a
later status flip). `setStatus` flips a status as the run progresses. Beats fire at
each skilled step (`test-author` -> `coder`, or the single unskilled `coder`), the
verification run (`test-runner`), each fix iteration (`fix-coder`, `fixIteration=k`)
and its re-run, and per-AP settle. Contracts preserved:
- **zero-overhead no-callback**: with no sink the tracker builds nothing and every
  beat/setStatus is a no-op (the consilium LOOP path is byte-for-byte unchanged)
- **never-throw**: the sink stays wrapped in try/catch

Server passthrough is **unchanged** — `devProgress` is stored and returned opaquely
by the controller/route, so the new fields flow through with no route/controller edit.
Client `DevProgress` type extended to match.

### Injection surface (adversarial review)

- Every `aps[].title` is UNTRUSTED verdict text, control-stripped + clamped via the
  same `sanitizeLine` + `PROGRESS_TITLE_MAX` used for `actionPointTitle`; the array is
  capped at 100 entries. It is only ever serialized into display JSON and rendered as
  inert React text — never a shell / branch / PR-title sink.
- `step` is a server-controlled enum (never model text); `fixIteration` / `fixBudget`
  / `i` are server-controlled numbers.

## Test evidence

- `npm run check` (tsc, server + client): clean.
- `tests/unit/sdlc/executor.test.ts` + `tests/unit/sdlc/verification-loop.test.ts`
  extended: live `aps` snapshot + status transitions across a multi-AP run, title
  sanitization in `aps`, partial/failed statuses, the 100-entry cap, and the skilled
  step order `test-author -> coder -> test-runner -> fix-coder -> test-runner` with
  fix iterations + budget bounded by `maxFixIterations`.
- `tests/unit/sdlc/ tests/unit/consilium/`: 436 passed. (Full unit run has a handful
  of PRE-EXISTING flaky failures in unrelated files — providers/antigravity,
  gateway, config-sync/git, remote-agent-manager, skill-update-checker — that differ
  run-to-run and none of which import the changed modules; a separate full run passed
  clean.)

Draft — no merge. Agents never merge.
