### PR TITLE
feat: final-state re-verification for consilium loop develop phase

### DIFF
--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -394,6 +394,13 @@ function CriterionLeaf({ c }: { c: ExecutionCriterion }) {
       {typeof c.fixIterations === "number" && c.fixIterations > 0 && (
         <span className="text-muted-foreground">· {c.fixIterations} fix</span>
       )}
+      {/* Stage A: final-state re-verification of the whole worktree. A false here
+          (esp. alongside passed:true) reveals a late-AP regression. */}
+      {typeof c.passedAtFinal === "boolean" && (
+        <span className={c.passedAtFinal ? "text-muted-foreground" : "text-red-600 font-medium"}>
+          · final {c.passedAtFinal ? "green" : "regressed"}
+        </span>
+      )}
       <span className="text-foreground/80">{c.criterion || "—"}</span>
       {c.summary && !c.passed && (
         <span className="w-full text-muted-foreground font-mono text-[10px] break-words">{c.summary}</span>

--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -443,6 +443,33 @@ export const ConfigSchema = z.object({
            */
           model: z.string().min(1).default(DEFAULT_TASK_MODEL),
         }).default({}),
+        /**
+         * Stage A (design §3D CONVERGE): FINAL-STATE re-verification. Action points are
+         * implemented SEQUENTIALLY in ONE shared worktree and Stage-2b per-criterion
+         * verification runs at the TIME each AP is implemented — so a LATER AP can regress
+         * what an EARLIER AP's tests verified, and NOTHING re-checks the FINAL combined
+         * worktree before the Draft PR opens. When `enabled` (default FALSE) AND the
+         * Stage-2b sandbox gate is ALREADY satisfied (`effectiveVerificationEnabled` —
+         * final verification obeys the SAME host-exec gate as per-AP test runs), the
+         * executor runs the test suite ONCE against the final state after the last AP and
+         * before the PR, then a bounded fix loop. A failure is RECORDED (round testSummary
+         * + execution trace + PR body) but NEVER blocks PR creation (same never-throw
+         * contract as the per-AP path). Ships INERT: with it false the develop phase is
+         * byte-for-byte unchanged. Gated by the parent `consiliumLoop.enabled`,
+         * `implement.enabled`, AND the verification sandbox gate.
+         */
+        finalVerification: z.object({
+          /** Kill-switch: false (default) → no final re-verification runs (INERT). */
+          enabled: z.boolean().default(false),
+          /**
+           * Bounded FINAL code→test→fix budget: how many times the coder may be re-invoked
+           * with the final-state test-failure summary before the loop stops (on green or
+           * budget). 0..3; default 1. 0 ⇒ verify-only (record the regression, attempt no
+           * fix). Kept small — this is a convergence BACKSTOP, not the main per-AP fix
+           * budget (`maxFixIterations`). NaN/out-of-range fails load (Security M-5).
+           */
+          maxFinalFixIterations: z.coerce.number().int().min(0).max(3).default(1),
+        }).default({}),
       }).default({}),
     }).default({}),
   }).default({}),

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -1215,6 +1215,12 @@ export class ConsiliumLoopController {
     // it degrades to Stage-2a (NO test runs) with a one-line warning. Single source of
     // truth: `effectiveVerificationEnabled`.
     const verifyOn = skilled && effectiveVerificationEnabled(this.deps.config());
+    // Stage A: FINAL-STATE re-verification. Gated by its OWN kill-switch ON TOP of the
+    // SAME sandbox gate as per-AP verification (`verifyOn`) — final verification re-runs
+    // the repo's test command on the host exactly as Stage 2b does, so it must obey the
+    // identical fail-closed gate. Optional-chained so a hand-built test config that omits
+    // the block degrades to OFF (never throws). null ⇒ the executor skips Stage A.
+    const finalOn = verifyOn && (cfg.implement.finalVerification?.enabled ?? false);
     if (skilled && cfg.implement.verification.enabled && !verifyOn && !this.warnedVerificationGate) {
       this.warnedVerificationGate = true;
       // eslint-disable-next-line no-console
@@ -1247,6 +1253,14 @@ export class ConsiliumLoopController {
             maxFixIterations: cfg.implement.maxFixIterations,
             testCommand: cfg.implement.testCommand,
             testRunTimeoutMs: cfg.implement.testRunTimeoutMs,
+          }
+        : null,
+      // Stage A: final-state re-verification config (null when the kill-switch is off OR
+      // the verification sandbox gate is closed ⇒ INERT, byte-for-byte the prior path).
+      finalVerification: finalOn
+        ? {
+            enabled: true,
+            maxFinalFixIterations: cfg.implement.finalVerification.maxFinalFixIterations,
           }
         : null,
     }, skilled ? { getSkills: () => this.storage.getSkills() } : undefined, onProgress);

--- a/server/services/consilium/execution-trace.ts
+++ b/server/services/consilium/execution-trace.ts
@@ -95,6 +95,8 @@ function clampCriterion(c: ExecutionCriterion): ExecutionCriterion {
     out.fixIterations = Math.max(0, Math.trunc(c.fixIterations));
   }
   if (c.summary !== undefined) out.summary = scrub(c.summary, SUMMARY_MAX);
+  // Stage A: additive final-state flag — carried through the clamp verbatim (boolean).
+  if (typeof c.passedAtFinal === "boolean") out.passedAtFinal = c.passedAtFinal;
   return out;
 }
 
@@ -182,11 +184,17 @@ function skillFromName(skillName: string, green: boolean): ExecutionSkill {
  * Controller green = a PR was opened AND no P0 acceptance-criterion is unmet. Each
  * outcome → one worker; `skills` → skill nodes (green iff the worker did not fail);
  * `verification` → one criterion leaf. Clamped before it is returned.
+ *
+ * `finalPassed` (Stage A): when the FINAL-STATE re-verification ran, its whole-suite
+ * pass/fail is stamped onto every `test-run` criterion as `passedAtFinal` (a single
+ * suite run covers all criteria). undefined ⇒ final verification did not run ⇒ the
+ * field is omitted (byte-for-byte the pre-Stage-A trace).
  */
 export function buildSdlcTrace(
   archetype: Archetype | null,
   outcomes: readonly SdlcOutcomeLike[],
   result: { prRef: string | null; error?: string },
+  finalPassed?: boolean,
 ): ExecutionTrace {
   const unmetP0 = outcomes.some(
     (o) => o.priority.toUpperCase().startsWith("P0") && o.verification !== undefined && !o.verification.passed,
@@ -203,6 +211,8 @@ export function buildSdlcTrace(
             passed: o.verification.passed,
             fixIterations: o.verification.fixIterations,
             summary: o.verification.summary,
+            // Stage A: stamp the final whole-suite result on the (test-run) criterion.
+            ...(finalPassed !== undefined ? { passedAtFinal: finalPassed } : {}),
           },
         ]
       : [];

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -146,6 +146,27 @@ export interface ApVerification {
 }
 
 /**
+ * Stage A: the FINAL-STATE re-verification outcome — ONE whole-suite test run against
+ * the final combined worktree (after every action point), plus a bounded fix loop.
+ * Distinct from {@link ApVerification} (which is per-action-point): this is the round's
+ * single "does the combined tree still pass?" convergence check. All text is
+ * sanitized/clamped — it lands only in the round `testSummary` + Draft-PR body, never a
+ * shell/branch/PR-title sink.
+ */
+export interface FinalVerification {
+  /** How the final state was checked (Stage A wires only `test-run`). */
+  method: "test-run";
+  /** Whether a test command actually ran (false ⇒ no command resolved → not green). */
+  ran: boolean;
+  /** Whether the full suite passed against the FINAL worktree. false ⇒ regression. */
+  passed: boolean;
+  /** Bounded, fs-scrubbed final test summary (status + output tail). */
+  summary: string;
+  /** How many FINAL fix re-invocations of the coder ran after the initial re-verify. */
+  fixIterations: number;
+}
+
+/**
  * A cheap, SYNCHRONOUS progress beat emitted at each meaningful SDLC step so a UI
  * can show WHAT the executor is doing right now (not just running/done). This is
  * DISPLAY-ONLY JSON.
@@ -211,6 +232,14 @@ export interface SdlcHandoffRequest {
    * `consiliumLoop.implement.verification.enabled` is true.
    */
   verification?: VerificationConfig | null;
+  /**
+   * Stage A: FINAL-STATE re-verification config. ABSENT or `{ enabled: false }` ⇒ NO
+   * final re-verify runs (byte-for-byte the pre-Stage-A path). Threaded by the
+   * controller ONLY when `consiliumLoop.implement.finalVerification.enabled` is true
+   * AND the SAME sandbox gate as per-AP verification is satisfied — so the executor
+   * runs it only when a `verification` context (test runner + fixer step) exists.
+   */
+  finalVerification?: FinalVerificationConfig | null;
 }
 
 /**
@@ -227,6 +256,18 @@ export interface VerificationConfig {
   testCommand: string | null;
   /** Hard per-run test timeout (ms, config-clamped). */
   testRunTimeoutMs: number;
+}
+
+/**
+ * Stage A final-verification knobs (from `consiliumLoop.implement.finalVerification`).
+ * When `enabled` is false the executor never runs the final re-verify — the kill-switch
+ * is the single gate that keeps Stage A INERT.
+ */
+export interface FinalVerificationConfig {
+  /** Master Stage-A kill-switch (default false at the config layer). */
+  enabled: boolean;
+  /** Bounded FINAL code→test→fix budget (config-clamped 0..3). 0 ⇒ verify-only. */
+  maxFinalFixIterations: number;
 }
 
 export interface SdlcHandoffResult {
@@ -252,6 +293,14 @@ export interface SdlcHandoffResult {
    * unchanged. Display-only; permission NAMES only.
    */
   executionTrace?: ExecutionTrace;
+  /**
+   * Stage A: the FINAL-STATE re-verification outcome, present ONLY when it ran (the
+   * kill-switch on + the sandbox gate satisfied); undefined otherwise (so the pre-
+   * Stage-A result shape is identical). Its regression signal is ALSO folded into
+   * `testSummary`, `executionTrace` (`passedAtFinal`), and the Draft-PR body — this
+   * field surfaces it structurally for observability/tests. NEVER blocks PR creation.
+   */
+  finalVerification?: FinalVerification;
 }
 
 /** Injectable seams (unit tests inject fakes — no real repo / claude / gh). */
@@ -409,6 +458,12 @@ export interface PrStatusBodyInput {
   actionPoints: readonly ActionPoint[];
   /** Per-AP execution outcomes the executor built. */
   outcomes: readonly ApOutcome[];
+  /**
+   * Stage A: the round's FINAL-STATE re-verification outcome, or undefined when it did
+   * not run (kill-switch off / gate closed) ⇒ the block is omitted (byte-for-byte the
+   * pre-Stage-A body).
+   */
+  finalVerification?: FinalVerification;
 }
 
 /**
@@ -420,7 +475,7 @@ export interface PrStatusBodyInput {
  * pr-wrapper, so none of this untrusted text ever reaches argv.
  */
 export function buildPrStatusBody(input: PrStatusBodyInput): string {
-  const { loopId, round, repoName, actionPoints, outcomes } = input;
+  const { loopId, round, repoName, actionPoints, outcomes, finalVerification } = input;
   const committed = outcomes.filter((o) => o.committed).length;
 
   // Header — provenance (loopId/round/repoName are server-controlled, but still
@@ -495,6 +550,28 @@ export function buildPrStatusBody(input: PrStatusBodyInput): string {
     }
   }
 
+  // Stage A: FINAL-STATE re-verification block. The action points are implemented
+  // SEQUENTIALLY in one worktree, so a later AP can regress an earlier AP's verified
+  // criterion; this re-runs the WHOLE suite against the FINAL tree. Absent ⇒ omitted
+  // (byte-for-byte the pre-Stage-A body). The PR is a Draft regardless — a regression is
+  // FLAGGED for the human reviewer, never a merge block.
+  const finalBlock: string[] = [];
+  if (finalVerification) {
+    const fv = finalVerification;
+    const status = !fv.ran ? "NOT-RUN" : fv.passed ? "GREEN" : "RED";
+    const fixTag = fv.fixIterations > 0 ? ` (after ${fv.fixIterations} final fix attempt(s))` : "";
+    finalBlock.push(
+      "",
+      `### Final-state re-verification: ${status}${fixTag}`,
+      "",
+      fv.passed
+        ? "The full test suite passes against the FINAL combined worktree (all action points applied) — no cross-AP regression detected."
+        : !fv.ran
+          ? "The full test suite could NOT be re-run against the final worktree (no test command resolved). The final combined state is UNVERIFIED — review before merging."
+          : "REGRESSION — the full test suite does NOT pass against the FINAL combined worktree. A later action point may have regressed an earlier one. This Draft PR still opens for human review; review before merging.",
+    );
+  }
+
   return [
     ...header,
     "",
@@ -506,6 +583,7 @@ export function buildPrStatusBody(input: PrStatusBodyInput): string {
     "",
     ...outcomeLines,
     ...gateBlock,
+    ...finalBlock,
     "",
     "---",
     "Draft — review the changes; the loop is paused at the human gate (a human must review and merge).",
@@ -614,24 +692,45 @@ export async function runSdlcHandoff(
         outcomes.push(outcome);
         if (outcome.committed) committedCount += 1;
       }
+
+      // Stage A: FINAL-STATE re-verification. After every action point has been applied
+      // SEQUENTIALLY in the shared worktree, re-run the test suite ONCE against the FINAL
+      // combined tree to catch a LATER AP regressing what an EARLIER AP's per-criterion
+      // tests verified (nothing else re-checks the combined state before the PR). Gated by
+      // BOTH finalVerification.enabled AND `verifyCtx` — the SAME sandbox gate as per-AP
+      // verification (verifyCtx is non-null only when verification is on AND skilled steps
+      // exist, so a test runner + a fixer step are both available). INERT by default ⇒
+      // when off this whole block is skipped and behavior is byte-for-byte unchanged. A
+      // final fix may edit the worktree, so it is staged + committed BEFORE the push;
+      // NEVER throws / blocks PR creation (same contract as the per-AP path).
+      let finalVerification: FinalVerification | undefined;
+      if (verifyCtx && (req.finalVerification?.enabled ?? false)) {
+        finalVerification = await runFinalVerification(runCoder, verifyCtx, req.finalVerification!, req, wt);
+        if (await commitFinalFixes(gitRaw, wt, req)) committedCount += 1;
+      }
+
       const result = await pushAndOpenPr(req, branch, base, wt, outcomes, committedCount, {
         gitRaw,
         push,
         openPr,
         emit,
-      });
+      }, finalVerification);
       // Stage 2b: aggregate the per-criterion verification into ONE bounded round
       // testSummary, surfaced on the result so the controller can persist it to
       // `consilium_loop_rounds.testSummary` (the convergence wire). Undefined when
-      // verification did not run ⇒ the Stage-2a result shape is unchanged.
+      // verification did not run ⇒ the Stage-2a result shape is unchanged. Stage A folds
+      // its whole-suite result into the SAME summary (so the next review sees regressions).
       if (verifyCtx) {
-        const summary = aggregateTestSummary(outcomes);
+        const summary = aggregateTestSummary(outcomes, finalVerification);
         if (summary) result.testSummary = summary;
       }
+      // Stage A: surface the structured final-verification outcome (observability/tests).
+      if (finalVerification) result.finalVerification = finalVerification;
       // Stage 4: build the observability trace from the per-AP outcomes (always — it
       // rescues data we already computed). Rides the result out-of-band, exactly like
-      // testSummary; the dev_completed event / FSM are untouched.
-      result.executionTrace = buildSdlcTrace(req.archetype ?? null, outcomes, result);
+      // testSummary; the dev_completed event / FSM are untouched. Stage A stamps the
+      // final whole-suite pass/fail onto each test-run criterion (`passedAtFinal`).
+      result.executionTrace = buildSdlcTrace(req.archetype ?? null, outcomes, result, finalVerification?.passed);
       // Terminal beat — the executor finished its work for this round (the SERVICE
       // separately classifies done/failed from the result; this is phase-only).
       emit({
@@ -801,6 +900,112 @@ async function runActionPoint(
 }
 
 /**
+ * Run the resolved test command ONCE against the worktree via the round's runner.
+ * NEVER throws: the runner is itself never-throw, but a defensive catch degrades any
+ * unexpected throw to a not-green, not-ran result (scrubbed). Shared by the per-AP
+ * verify loop (Stage 2b) and the final re-verification (Stage A) so both resolve the
+ * command + timeout from the SAME config and degrade identically.
+ */
+async function runTestOnce(vc: VerifyContext, wt: CreateWorktreeResult): Promise<TestRunResult> {
+  try {
+    return await vc.runTests({
+      worktreeDir: wt.worktreeDir,
+      testCommand: vc.config.testCommand,
+      timeoutMs: vc.config.testRunTimeoutMs,
+    });
+  } catch (err) {
+    return {
+      passed: false,
+      ran: false,
+      summary: scrub(err instanceof Error ? err.message : String(err)),
+      exitCode: null,
+      timedOut: false,
+    };
+  }
+}
+
+/**
+ * Stage A: run the FINAL-STATE re-verification for a round. After all action points are
+ * implemented in the shared worktree, run the WHOLE test suite ONCE; if it fails, run a
+ * bounded fix loop (up to `maxFinalFixIterations` coder re-invocations, reusing the SAME
+ * capability-scoped implementer step + fenced-failure-summary machinery as the per-AP
+ * loop), re-running the suite after each fix. Stops on green, on the FINAL fix budget, on
+ * a coder throw, or on the whole-run wall-clock deadline (defense-in-depth, shared with
+ * the per-AP loop's `vc.deadline`). NEVER throws — a failure is RECORDED, never blocks PR
+ * creation.
+ *
+ * Unlike the per-AP loop this is NOT scoped to a single acceptance criterion — a
+ * regression can live anywhere in the combined tree — so the fix coder is handed the
+ * round's FULL action-point set as context (via the SAME stdin-only, fenced-data path).
+ * The test command is resolved (inside the runner) from config/package.json ONLY, never
+ * from that untrusted text.
+ */
+async function runFinalVerification(
+  runCoder: NonNullable<SdlcExecutorDeps["runCoder"]>,
+  vc: VerifyContext,
+  config: FinalVerificationConfig,
+  req: SdlcHandoffRequest,
+  wt: CreateWorktreeResult,
+): Promise<FinalVerification> {
+  let result = await runTestOnce(vc, wt);
+  let fixIterations = 0;
+  while (!result.passed && fixIterations < config.maxFinalFixIterations) {
+    // Whole-run wall-clock backstop (shared budget): stop fixing once the run overran.
+    if (vc.now() >= vc.deadline) break;
+    fixIterations += 1;
+    try {
+      const fixed = await runCoder(wt.worktreeDir, req.actionPoints, {
+        timeoutMs: req.coderTimeoutMs,
+        allowedTools: vc.fixerStep.allowedTools, // capability ceiling (no widening).
+        systemPrompt: buildFixPrompt(vc.fixerStep.systemPrompt, result.summary),
+      });
+      if (!fixed.ok) break; // a fix coder that errored stops the loop; work preserved.
+    } catch {
+      break; // a crashed fix coder stops the loop; whatever landed is still committed.
+    }
+    result = await runTestOnce(vc, wt);
+  }
+
+  return {
+    method: "test-run",
+    ran: result.ran,
+    passed: result.passed,
+    summary: clampStr(result.summary, FIX_SUMMARY_MAX),
+    fixIterations,
+  };
+}
+
+/**
+ * Stage A: stage + commit any edits the FINAL fix loop produced so they land in the
+ * Draft PR (the per-AP loop already committed each AP; a final fix runs AFTER the last
+ * AP commit, so its edits would otherwise be uncommitted at push time). NEVER throws —
+ * a git failure just leaves the last AP as HEAD (the final fix is lost, but the PR still
+ * opens). Returns whether a commit was actually made (so the caller can count it toward
+ * the push gate). The commit message is server-fixed (no untrusted text).
+ */
+async function commitFinalFixes(
+  gitRaw: GitRunner,
+  wt: CreateWorktreeResult,
+  req: SdlcHandoffRequest,
+): Promise<boolean> {
+  try {
+    await gitRaw(wt.worktreeDir, ["add", "-A"]);
+    const dirty = (await gitRaw(wt.worktreeDir, ["status", "--porcelain"])).trim().length > 0;
+    if (!dirty) return false; // verify-only (0 fixes) or a fix that changed nothing.
+    await gitRaw(wt.worktreeDir, [
+      "commit",
+      "-m",
+      `Consilium round ${req.round}: final-state re-verification fixes`,
+      "-m",
+      "Fixes applied by the final-state re-verification loop after all action points were implemented (Stage A).",
+    ]);
+    return true;
+  } catch {
+    return false; // never throw — the push still opens the PR from the last AP HEAD.
+  }
+}
+
+/**
  * Stage 2b: run the per-criterion verification + bounded code→test→fix loop for ONE
  * action point. NEVER throws (degrades to `passed:false`). Flow:
  *   verify #0 → if green, done (0 fixes); else, up to `maxFixIterations` times:
@@ -823,24 +1028,7 @@ async function runVerifyFixLoop(
   ap: ActionPoint,
 ): Promise<ApVerification> {
   const criterion = sanitizeLine(ap.acceptanceCriterion ?? "", CRITERION_MAX);
-  const runOnce = async (): Promise<TestRunResult> => {
-    try {
-      return await vc.runTests({
-        worktreeDir: wt.worktreeDir,
-        testCommand: vc.config.testCommand,
-        timeoutMs: vc.config.testRunTimeoutMs,
-      });
-    } catch (err) {
-      // The runner is never-throw, but be defensive — degrade to a not-green result.
-      return {
-        passed: false,
-        ran: false,
-        summary: scrub(err instanceof Error ? err.message : String(err)),
-        exitCode: null,
-        timedOut: false,
-      };
-    }
-  };
+  const runOnce = (): Promise<TestRunResult> => runTestOnce(vc, wt);
 
   let result = await runOnce();
   let fixIterations = 0;
@@ -907,19 +1095,45 @@ function buildFixPrompt(baseSystemPrompt: string, failureSummary: string): strin
  * next review's convergence verdict). Only action points that actually carried a
  * verification contribute. Returns null when none did (nothing to persist).
  */
-function aggregateTestSummary(outcomes: readonly ApOutcome[]): string | null {
+function aggregateTestSummary(
+  outcomes: readonly ApOutcome[],
+  finalVerification?: FinalVerification,
+): string | null {
+  const sections: string[] = [];
+
   const verified = outcomes.filter((o) => o.verification);
-  if (verified.length === 0) return null;
-  const passed = verified.filter((o) => o.verification?.passed).length;
-  const header = `Per-criterion verification: ${passed}/${verified.length} green.`;
-  const lines = verified.map((o) => {
-    const v = o.verification as ApVerification;
-    const status = !v.ran ? "NOT-RUN" : v.passed ? "PASS" : "FAIL";
-    const fixes = v.fixIterations > 0 ? ` after ${v.fixIterations} fix attempt(s)` : "";
-    const crit = v.criterion ? ` — criterion: ${v.criterion}` : "";
-    return `- [${status}] (${o.priority}) ${o.title}${fixes}${crit}\n    ${sanitizeLine(v.summary, 280)}`;
-  });
-  return clampStr([header, "", ...lines].join("\n"), TEST_SUMMARY_MAX);
+  if (verified.length > 0) {
+    const passed = verified.filter((o) => o.verification?.passed).length;
+    const header = `Per-criterion verification: ${passed}/${verified.length} green.`;
+    const lines = verified.map((o) => {
+      const v = o.verification as ApVerification;
+      const status = !v.ran ? "NOT-RUN" : v.passed ? "PASS" : "FAIL";
+      const fixes = v.fixIterations > 0 ? ` after ${v.fixIterations} fix attempt(s)` : "";
+      const crit = v.criterion ? ` — criterion: ${v.criterion}` : "";
+      return `- [${status}] (${o.priority}) ${o.title}${fixes}${crit}\n    ${sanitizeLine(v.summary, 280)}`;
+    });
+    sections.push([header, "", ...lines].join("\n"));
+  }
+
+  // Stage A: fold the final whole-suite re-verification into the SAME summary so the
+  // next review round's judge grounds convergence on the FINAL state, not just the
+  // per-AP snapshots taken as each AP landed.
+  if (finalVerification) sections.push(buildFinalVerificationSummary(finalVerification));
+
+  if (sections.length === 0) return null;
+  return clampStr(sections.join("\n\n"), TEST_SUMMARY_MAX);
+}
+
+/** Stage A: the round `testSummary` block for the final whole-suite re-verification. */
+function buildFinalVerificationSummary(fv: FinalVerification): string {
+  const status = !fv.ran ? "NOT-RUN" : fv.passed ? "PASS" : "FAIL";
+  const fixes = fv.fixIterations > 0 ? ` after ${fv.fixIterations} final fix attempt(s)` : "";
+  const verdict = fv.passed
+    ? "The full test suite passes against the final combined worktree (no cross-AP regression)."
+    : !fv.ran
+      ? "The full test suite could not be re-run against the final worktree (no test command)."
+      : "REGRESSION: the full test suite does NOT pass against the final combined worktree.";
+  return [`Final-state re-verification: [${status}]${fixes}.`, verdict, `    ${sanitizeLine(fv.summary, 280)}`].join("\n");
 }
 
 /**
@@ -935,6 +1149,7 @@ async function pushAndOpenPr(
   outcomes: readonly ApOutcome[],
   committedCount: number,
   io: { gitRaw: GitRunner; push: typeof pushBranch; openPr: typeof openDraftPr; emit: SdlcProgressFn },
+  finalVerification?: FinalVerification,
 ): Promise<SdlcHandoffResult> {
   const total = req.actionPoints.length;
   if (committedCount === 0) {
@@ -980,6 +1195,7 @@ async function pushAndOpenPr(
       repoName: basename(req.repoPath),
       actionPoints: req.actionPoints,
       outcomes,
+      finalVerification,
     }),
   });
   if (!pr.ok) {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1980,6 +1980,13 @@ export interface ExecutionCriterion {
   fixIterations?: number;
   /** Scrubbed, clamped verification summary. */
   summary?: string;
+  /**
+   * Stage A (final-state re-verification): whether this criterion still held when the
+   * WHOLE test suite was re-run against the FINAL worktree (after every action point).
+   * OPTIONAL/ADDITIVE — absent unless final verification ran; set only for `test-run`
+   * criteria. A `false` here alongside `passed:true` reveals a late-AP REGRESSION.
+   */
+  passedAtFinal?: boolean;
 }
 
 /** A worker agent: one action point (coder) or one research step. */

--- a/tests/unit/consilium/consilium-config.test.ts
+++ b/tests/unit/consilium/consilium-config.test.ts
@@ -96,6 +96,34 @@ describe("pipeline.consiliumLoop schema", () => {
     expect(res.data.pipeline.consiliumLoop.implement.trustedRepoAck).toBe(false);
   });
 
+  it("Stage A: implement.finalVerification defaults to INERT (off) with bounded knobs", () => {
+    const res = ConfigSchema.safeParse({});
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    const fv = res.data.pipeline.consiliumLoop.implement.finalVerification;
+    expect(fv.enabled).toBe(false); // kill-switch default OFF ⇒ ships inert
+    expect(fv.maxFinalFixIterations).toBe(1); // small convergence backstop
+  });
+
+  it("Stage A: accepts valid finalVerification overrides", () => {
+    const res = parseLoop({
+      implement: { enabled: true, finalVerification: { enabled: true, maxFinalFixIterations: 3 } },
+    });
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    const fv = res.data.pipeline.consiliumLoop.implement.finalVerification;
+    expect(fv.enabled).toBe(true);
+    expect(fv.maxFinalFixIterations).toBe(3);
+  });
+
+  it("Stage A: allows maxFinalFixIterations=0 (verify-only) and enforces bounds (int 0..3)", () => {
+    expect(parseLoop({ implement: { finalVerification: { maxFinalFixIterations: 0 } } }).success).toBe(true);
+    expect(parseLoop({ implement: { finalVerification: { maxFinalFixIterations: 4 } } }).success).toBe(false);
+    expect(parseLoop({ implement: { finalVerification: { maxFinalFixIterations: -1 } } }).success).toBe(false);
+    expect(parseLoop({ implement: { finalVerification: { maxFinalFixIterations: 1.5 } } }).success).toBe(false);
+    expect(parseLoop({ implement: { finalVerification: { maxFinalFixIterations: "abc" } } }).success).toBe(false);
+  });
+
   it("Stage 3: implement.research defaults to INERT (off) with bounded knobs", () => {
     const res = ConfigSchema.safeParse({});
     expect(res.success).toBe(true);

--- a/tests/unit/consilium/execution-trace.test.ts
+++ b/tests/unit/consilium/execution-trace.test.ts
@@ -44,6 +44,44 @@ describe("execution-trace — buildSdlcTrace (coder path)", () => {
     expect(t.controller.workers[1].note).toBe("coder errored");
   });
 
+  it("Stage A: stamps passedAtFinal on every test-run criterion when finalPassed is given", () => {
+    const green = buildSdlcTrace("repo-assessment", outcomes, { prRef: "x" }, true);
+    expect(green.controller.workers[0].criteria[0].passedAtFinal).toBe(true);
+    const red = buildSdlcTrace("repo-assessment", outcomes, { prRef: "x" }, false);
+    expect(red.controller.workers[0].criteria[0].passedAtFinal).toBe(false);
+    // A regression: the criterion passed at implement time but NOT at final re-verify.
+    expect(red.controller.workers[0].criteria[0].passed).toBe(true);
+    expect(red.controller.workers[0].criteria[0].passedAtFinal).toBe(false);
+  });
+
+  it("Stage A: OMITS passedAtFinal when finalPassed is undefined (byte-for-byte the prior trace)", () => {
+    const t = buildSdlcTrace("repo-assessment", outcomes, { prRef: "x" });
+    expect("passedAtFinal" in t.controller.workers[0].criteria[0]).toBe(false);
+  });
+
+  it("Stage A: clampTrace preserves an already-set passedAtFinal", () => {
+    const t = clampTrace({
+      schemaVersion: 1,
+      archetype: "repo-assessment",
+      controller: {
+        kind: "sdlc-executor",
+        label: "x",
+        green: false,
+        workers: [
+          {
+            index: 1,
+            priority: "P0",
+            title: "t",
+            status: "completed",
+            skills: [],
+            criteria: [{ criterion: "c", method: "test-run", ran: true, passed: true, passedAtFinal: false }],
+          },
+        ],
+      },
+    });
+    expect(t.controller.workers[0].criteria[0].passedAtFinal).toBe(false);
+  });
+
   it("controller green requires a PR AND no unmet P0 criterion", () => {
     expect(buildSdlcTrace("repo-assessment", outcomes, { prRef: "x" }).controller.green).toBe(true);
     expect(buildSdlcTrace("repo-assessment", outcomes, { prRef: null }).controller.green).toBe(false);

--- a/tests/unit/consilium/loop-testsummary-wire.test.ts
+++ b/tests/unit/consilium/loop-testsummary-wire.test.ts
@@ -84,6 +84,7 @@ interface CfgOver {
   verificationEnabled?: boolean;
   trustedRepoAck?: boolean;
   sandbox?: boolean;
+  finalVerificationEnabled?: boolean;
 }
 
 const makeConfig =
@@ -106,6 +107,7 @@ const makeConfig =
             maxFixIterations: 3,
             testCommand: null,
             testRunTimeoutMs: 300000,
+            finalVerification: { enabled: over.finalVerificationEnabled ?? false, maxFinalFixIterations: 1 },
           },
         },
       },
@@ -245,5 +247,63 @@ describe("MED-2 — fail-closed enable-gate (sandbox OR trustedRepoAck required)
     await controller.tick(loop.id);
     await flush();
     expect(runSdlc.mock.calls[0][0].verification).toEqual(expect.objectContaining({ enabled: true }));
+  });
+});
+
+describe("Stage A — controller threads finalVerification under the SAME sandbox gate", () => {
+  function controllerWith(config: () => unknown, runSdlc: ReturnType<typeof vi.fn>, storage: unknown) {
+    return new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: { startGroup: vi.fn(), startGroupAsync: vi.fn(), createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
+      config: config as never,
+      readIterationVerdict: async () => verdict(2),
+      runSdlc: runSdlc as never,
+    });
+  }
+
+  it("finalVerification.enabled + verification gate satisfied ⇒ runSdlc gets finalVerification ENABLED", async () => {
+    const loop = makeLoop({ state: "deciding", round: 2, repoPath: process.cwd() });
+    const { storage } = fakeStorage(loop);
+    const runSdlc = vi.fn(async () => ({ prRef: null, headCommit: "" }));
+    const controller = controllerWith(
+      makeConfig({ verificationEnabled: true, trustedRepoAck: true, finalVerificationEnabled: true }),
+      runSdlc,
+      storage,
+    );
+    await controller.tick(loop.id);
+    await flush();
+    expect(runSdlc.mock.calls[0][0].finalVerification).toEqual(
+      expect.objectContaining({ enabled: true, maxFinalFixIterations: 1 }),
+    );
+  });
+
+  it("finalVerification.enabled but the verification sandbox gate is CLOSED ⇒ finalVerification NULL", async () => {
+    const loop = makeLoop({ state: "deciding", round: 2, repoPath: process.cwd() });
+    const { storage } = fakeStorage(loop);
+    const runSdlc = vi.fn(async () => ({ prRef: null, headCommit: "" }));
+    // verification on but NEITHER sandbox NOR ack ⇒ effectiveVerificationEnabled=false ⇒
+    // final verification must ALSO be gated off (it runs the host test command too).
+    const controller = controllerWith(
+      makeConfig({ verificationEnabled: true, trustedRepoAck: false, sandbox: false, finalVerificationEnabled: true }),
+      runSdlc,
+      storage,
+    );
+    await controller.tick(loop.id);
+    await flush();
+    expect(runSdlc.mock.calls[0][0].finalVerification).toBeNull();
+  });
+
+  it("finalVerification OFF (default) ⇒ runSdlc gets finalVerification NULL (INERT)", async () => {
+    const loop = makeLoop({ state: "deciding", round: 2, repoPath: process.cwd() });
+    const { storage } = fakeStorage(loop);
+    const runSdlc = vi.fn(async () => ({ prRef: null, headCommit: "" }));
+    const controller = controllerWith(
+      makeConfig({ verificationEnabled: true, trustedRepoAck: true, finalVerificationEnabled: false }),
+      runSdlc,
+      storage,
+    );
+    await controller.tick(loop.id);
+    await flush();
+    expect(runSdlc.mock.calls[0][0].finalVerification).toBeNull();
   });
 });

--- a/tests/unit/sdlc/final-verification.test.ts
+++ b/tests/unit/sdlc/final-verification.test.ts
@@ -1,0 +1,291 @@
+/**
+ * final-verification.test.ts — Stage A: the executor's FINAL-STATE re-verification.
+ *
+ * Action points are implemented SEQUENTIALLY in ONE shared worktree, so a LATER AP can
+ * regress what an EARLIER AP's per-criterion tests verified. Stage A re-runs the WHOLE
+ * suite ONCE against the FINAL combined tree (after the last AP, before the PR), with a
+ * bounded fix loop. The subprocess is mocked (injected runTests).
+ *
+ * Asserts:
+ *   - DISABLED (finalVerification null/absent) ⇒ ZERO behavior change: no extra test run,
+ *     no final fix, no final block in the PR body / testSummary / trace.
+ *   - GATED: the SAME sandbox gate as per-AP verification — with verification OFF (no
+ *     verify context) final verification NEVER runs even if its own flag is on.
+ *   - PASS: one final run, GREEN in the PR body + [PASS] in the round testSummary.
+ *   - FAIL→FIX→GREEN: the bounded fix loop re-invokes the implementer (fenced failure
+ *     summary) with the FULL action-point set, commits the fix, reaches green.
+ *   - REGRESSION (budget exhausted): the PR still opens (Draft), FLAGGED RED; the trace
+ *     criterion shows passed:true but passedAtFinal:false.
+ *   - VERIFY-ONLY (maxFinalFixIterations=0): records the outcome, attempts NO fix.
+ *   - the whole-run wall-clock budget short-circuits final fixes.
+ *   - NEVER blocks PR creation.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  runSdlcHandoff,
+  type SdlcHandoffRequest,
+  type VerificationConfig,
+  type FinalVerificationConfig,
+} from "../../../server/services/sdlc/executor.js";
+import type { TestRunResult } from "../../../server/services/sdlc/test-runner.js";
+import type { ActionPoint } from "@shared/types";
+import type { Skill } from "@shared/schema";
+
+const LOOP = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const REPO = "/allowlisted/omniscience";
+const BRANCH = `consilium/loop-${LOOP}/round-2`;
+const WT = "/tmp/sdlc-wt-XXXX/tree";
+const FAKE_WT = { worktreeDir: WT, baseDir: "/tmp/sdlc-wt-XXXX", branch: BRANCH, baseRef: "main" };
+
+const VCFG = (over: Partial<VerificationConfig> = {}): VerificationConfig => ({
+  enabled: true,
+  maxFixIterations: 3,
+  testCommand: "npm test",
+  testRunTimeoutMs: 300_000,
+  ...over,
+});
+
+const FVCFG = (over: Partial<FinalVerificationConfig> = {}): FinalVerificationConfig => ({
+  enabled: true,
+  maxFinalFixIterations: 1,
+  ...over,
+});
+
+/** An AP WITHOUT an acceptance criterion ⇒ NO per-AP verification runs, so every
+ *  runTests call in these tests comes PURELY from the final re-verification. */
+const AP = (over: Partial<ActionPoint> = {}): ActionPoint => ({
+  title: "Fix the parser",
+  priority: "P0",
+  rationale: "bug",
+  ...over,
+});
+
+const baseReq = (over: Partial<SdlcHandoffRequest> = {}): SdlcHandoffRequest => ({
+  repoPath: REPO,
+  loopId: LOOP,
+  round: 2,
+  actionPoints: [AP()],
+  allowedRepoPaths: ["/allowlisted"],
+  archetype: "repo-assessment", // ⇒ skilled steps ⇒ a verify context can be built
+  verification: VCFG(),
+  ...over,
+});
+
+const pass: TestRunResult = { passed: true, ran: true, summary: "PASSED\nall green", exitCode: 0, timedOut: false };
+const fail: TestRunResult = { passed: false, ran: true, summary: "FAILED (exit 1)\n1 failing", exitCode: 1, timedOut: false };
+const notRun: TestRunResult = { passed: false, ran: false, summary: "not verified — no test command", exitCode: null, timedOut: false };
+
+function makeGitRaw() {
+  return vi.fn(async (_repo: string, args: string[]) => {
+    if (args[0] === "status") return " M server/x.ts\n";
+    if (args[0] === "rev-parse") return "headsha000\n";
+    return "";
+  });
+}
+
+/** Commit [subject, body] pairs the git runner was asked to make. */
+function commitMessages(gitRaw: ReturnType<typeof vi.fn>): Array<{ subject: string; body: string }> {
+  return gitRaw.mock.calls
+    .filter((c) => (c[1] as string[])[0] === "commit")
+    .map((c) => ({ subject: (c[1] as string[])[2], body: (c[1] as string[])[4] }));
+}
+
+function makeDeps(over: Record<string, unknown> = {}) {
+  return {
+    createWorktree: vi.fn(async () => FAKE_WT),
+    removeWorktree: vi.fn(async () => undefined),
+    resolveDefaultBranchFn: vi.fn(async () => "main"),
+    runCoder: vi.fn(async () => ({ ok: true, summary: "edited", tokensUsed: 5 })),
+    push: vi.fn(async () => ({ ok: true as const, branch: BRANCH })),
+    openPr: vi.fn(async () => ({ ok: true as const, prUrl: "https://github.com/x/y/pull/9" })),
+    gitRaw: makeGitRaw(),
+    getSkills: vi.fn(async () => [] as Skill[]),
+    ...over,
+  };
+}
+
+/** A runTests fake returning a SCRIPTED sequence (then repeats the last entry). */
+function sequencedRunTests(seq: TestRunResult[]) {
+  let i = 0;
+  return vi.fn(async () => seq[Math.min(i++, seq.length - 1)]);
+}
+
+const prBody = (deps: ReturnType<typeof makeDeps>) =>
+  (deps.openPr as ReturnType<typeof vi.fn>).mock.calls[0][1].body as string;
+
+describe("Stage A — DISABLED ⇒ zero behavior change", () => {
+  it("finalVerification null ⇒ NO final test run, NO final block anywhere", async () => {
+    const runTests = vi.fn(async () => pass);
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(baseReq({ finalVerification: null }), deps as never);
+    // AP has no criterion ⇒ no per-AP verify; final off ⇒ runTests NEVER called.
+    expect(runTests).not.toHaveBeenCalled();
+    // 2 skilled steps × 1 AP, no final fix invocations.
+    expect((deps.runCoder as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+    expect(res.finalVerification).toBeUndefined();
+    expect(res.testSummary).toBeUndefined();
+    expect(prBody(deps)).not.toMatch(/Final-state re-verification/);
+    // No final-fix commit — only the AP commit exists.
+    expect(commitMessages(deps.gitRaw as ReturnType<typeof vi.fn>)).toHaveLength(1);
+  });
+
+  it("finalVerification.enabled:false ⇒ NO final test run", async () => {
+    const runTests = vi.fn(async () => pass);
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(baseReq({ finalVerification: FVCFG({ enabled: false }) }), deps as never);
+    expect(runTests).not.toHaveBeenCalled();
+    expect(res.finalVerification).toBeUndefined();
+  });
+});
+
+describe("Stage A — sandbox gate (same as per-AP verification)", () => {
+  it("verification OFF (no verify context) ⇒ final verification NEVER runs even if its flag is on", async () => {
+    const runTests = vi.fn(async () => pass);
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(
+      baseReq({ verification: null, finalVerification: FVCFG({ enabled: true }) }),
+      deps as never,
+    );
+    expect(runTests).not.toHaveBeenCalled();
+    expect(res.finalVerification).toBeUndefined();
+  });
+
+  it("no skilled steps (archetype null) ⇒ no verify context ⇒ no final verification", async () => {
+    const runTests = vi.fn(async () => pass);
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(
+      baseReq({ archetype: null, finalVerification: FVCFG({ enabled: true }) }),
+      deps as never,
+    );
+    expect(runTests).not.toHaveBeenCalled();
+    expect(res.finalVerification).toBeUndefined();
+  });
+});
+
+describe("Stage A — PASS", () => {
+  it("runs the final suite ONCE; GREEN in the PR body + [PASS] in the testSummary", async () => {
+    const runTests = sequencedRunTests([pass]);
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(baseReq({ finalVerification: FVCFG() }), deps as never);
+    expect(runTests).toHaveBeenCalledTimes(1); // one final run, no per-AP verify
+    // The final run uses the CONFIG test command + timeout (never AP text).
+    const arg = runTests.mock.calls[0][0] as { testCommand: string | null; timeoutMs: number; worktreeDir: string };
+    expect(arg.testCommand).toBe("npm test");
+    expect(arg.worktreeDir).toBe(WT);
+    expect(res.finalVerification).toEqual(
+      expect.objectContaining({ method: "test-run", ran: true, passed: true, fixIterations: 0 }),
+    );
+    expect(prBody(deps)).toMatch(/Final-state re-verification: GREEN/);
+    expect(res.testSummary).toMatch(/Final-state re-verification: \[PASS\]/);
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+  });
+});
+
+describe("Stage A — FAIL → bounded fix loop → GREEN", () => {
+  it("re-invokes the implementer with the FULL AP set + fenced summary, commits the fix, reaches green", async () => {
+    const runTests = sequencedRunTests([fail, pass]); // final#0 fail → fix → re-verify pass
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(
+      baseReq({ finalVerification: FVCFG({ maxFinalFixIterations: 1 }) }),
+      deps as never,
+    );
+    expect(runTests).toHaveBeenCalledTimes(2); // initial final + one re-verify
+    const coderCalls = (deps.runCoder as ReturnType<typeof vi.fn>).mock.calls;
+    // 2 skilled steps + 1 final fix = 3 coder calls.
+    expect(coderCalls).toHaveLength(3);
+    const fixCall = coderCalls[2];
+    // The final fix is handed the ROUND's full action-point set (not a single criterion).
+    expect(fixCall[0]).toBe(WT);
+    expect(Array.isArray(fixCall[1])).toBe(true);
+    expect(fixCall[1]).toHaveLength(1); // baseReq carries one action point
+    const opts = fixCall[2] as { systemPrompt: string };
+    expect(opts.systemPrompt).toMatch(/tests are currently FAILING/i);
+    expect(opts.systemPrompt).toContain("1 failing"); // fenced failure summary
+    expect(res.finalVerification).toEqual(
+      expect.objectContaining({ ran: true, passed: true, fixIterations: 1 }),
+    );
+    // The final fix lands as its own server-fixed commit.
+    const commits = commitMessages(deps.gitRaw as ReturnType<typeof vi.fn>);
+    expect(commits.some((c) => c.subject.includes("final-state re-verification fixes"))).toBe(true);
+  });
+});
+
+describe("Stage A — REGRESSION (budget exhausted): Draft still opens, FLAGGED", () => {
+  it("final never goes green ⇒ passed:false, PR body RED, but the PR still opens", async () => {
+    const runTests = sequencedRunTests([fail]); // always fails
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(
+      baseReq({ finalVerification: FVCFG({ maxFinalFixIterations: 1 }) }),
+      deps as never,
+    );
+    // initial final + 1 fix re-verify = 2 runTests; budget caps further fixes.
+    expect(runTests).toHaveBeenCalledTimes(2);
+    expect(res.finalVerification).toEqual(expect.objectContaining({ passed: false, fixIterations: 1 }));
+    expect(prBody(deps)).toMatch(/Final-state re-verification: RED/);
+    expect(prBody(deps)).toMatch(/REGRESSION/);
+    expect(res.testSummary).toMatch(/REGRESSION/);
+    // NEVER blocks PR creation.
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+  });
+
+  it("a per-AP criterion that passed at implement time shows passed:true but passedAtFinal:false", async () => {
+    // AP WITH a criterion: per-AP verify passes; the FINAL suite then fails.
+    const runTests = sequencedRunTests([pass, fail]); // per-AP pass, then final fail (repeats)
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(
+      baseReq({
+        actionPoints: [AP({ acceptanceCriterion: "When built Then compiles" })],
+        finalVerification: FVCFG({ maxFinalFixIterations: 1 }),
+      }),
+      deps as never,
+    );
+    const crit = res.executionTrace!.controller.workers[0].criteria[0];
+    expect(crit.method).toBe("test-run");
+    expect(crit.passed).toBe(true); // green when the AP was implemented
+    expect(crit.passedAtFinal).toBe(false); // regressed by the final combined state
+    expect(res.finalVerification?.passed).toBe(false);
+  });
+});
+
+describe("Stage A — VERIFY-ONLY (maxFinalFixIterations=0)", () => {
+  it("records the failing outcome but attempts NO fix (no extra coder / re-run)", async () => {
+    const runTests = sequencedRunTests([fail]);
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(
+      baseReq({ finalVerification: FVCFG({ maxFinalFixIterations: 0 }) }),
+      deps as never,
+    );
+    expect(runTests).toHaveBeenCalledTimes(1); // ONE final run, no re-verify
+    expect((deps.runCoder as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2); // skilled steps only
+    expect(res.finalVerification).toEqual(expect.objectContaining({ passed: false, fixIterations: 0 }));
+  });
+
+  it("a non-running final command (not verified) is surfaced as NOT-RUN", async () => {
+    const runTests = sequencedRunTests([notRun]);
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(
+      baseReq({ finalVerification: FVCFG({ maxFinalFixIterations: 0 }) }),
+      deps as never,
+    );
+    expect(res.finalVerification).toEqual(expect.objectContaining({ ran: false, passed: false }));
+    expect(prBody(deps)).toMatch(/Final-state re-verification: NOT-RUN/);
+  });
+});
+
+describe("Stage A — whole-run wall-clock budget", () => {
+  it("short-circuits final fixes once the deadline is past", async () => {
+    const runTests = sequencedRunTests([fail]); // would fix, but the clock is past the deadline
+    // now(): T0 at ctx build (deadline = T0 + 2h), then a value 3h later ⇒ over budget.
+    let calls = 0;
+    const now = vi.fn(() => (calls++ === 0 ? 0 : 3 * 3_600_000));
+    const deps = makeDeps({ runTests, now });
+    const res = await runSdlcHandoff(
+      baseReq({ finalVerification: FVCFG({ maxFinalFixIterations: 3 }) }),
+      deps as never,
+    );
+    // Only the initial final run; the budget guard stopped before any fix re-invoke.
+    expect(runTests).toHaveBeenCalledTimes(1);
+    expect((deps.runCoder as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2); // steps only
+    expect(res.finalVerification).toEqual(expect.objectContaining({ passed: false, fixIterations: 0 }));
+  });
+});


### PR DESCRIPTION
## Problem

Action points (APs) are implemented **sequentially in one shared worktree** (`server/services/sdlc/executor.ts`, one coder run per AP via `runActionPoint`). Per-criterion verification (Stage 2b, `runVerifyFixLoop`) runs at the **time each AP is implemented**. A later AP can therefore regress what an earlier AP's tests verified, and **nothing re-checks the final combined worktree state before the PR is opened**. Loop convergence is then decided from the judge verdict only.

## Change (additive, kill-switched, zero FSM/DB change)

Adds **Stage A — final-state re-verification**. After the per-AP loop completes and **before** the PR is opened, when enabled and the verification sandbox gate is already satisfied:

1. Re-run the test suite **once** against the final worktree state (reusing the existing `testCommand` / `testRunTimeoutMs` plumbing).
2. On failure, run a bounded fix loop (up to `maxFinalFixIterations` coder iterations, reusing the existing code→test→fix machinery + fenced-failure-summary prompt), re-running after each fix.
3. Record the outcome in:
   - the round `testSummary` (merged with the per-AP summary — grounds the next review's convergence),
   - the execution trace via a new **optional additive** `ExecutionCriterion.passedAtFinal` on `test-run` criteria (no `schemaVersion` bump),
   - the Draft-PR body (GREEN / RED / NOT-RUN block).
4. A failure **never throws or blocks PR creation** (same never-throw contract as `runActionPoint`) — the PR still opens, but the body + trace clearly flag the regression.

Gating reuses the exact same host-exec sandbox gate as per-AP verification (`effectiveVerificationEnabled` / `trustedRepoAck` via the executor's verify context), so final verification can never run a test on the host under weaker conditions than Stage 2b.

The loop page execution tree surfaces `passedAtFinal` (`· final green` / `· final regressed`).

## Config keys

New under `pipeline.consiliumLoop.implement`:

```
finalVerification:
  enabled: boolean            # default FALSE (kill-switch)
  maxFinalFixIterations: int  # 0..3, default 1 (0 = verify-only)
```

**Default OFF:** with `finalVerification.enabled=false` runtime behavior is byte-identical to today. No changes to the loop FSM/reducer or DB schema (`execution_trace` is jsonb — additive field only).

## Test evidence

- `npm run check` (tsc): clean.
- New/updated unit tests, all green:
  - `tests/unit/consilium/consilium-config.test.ts` — config parsing/defaults/bounds (incl. `maxFinalFixIterations=0` verify-only, int 0..3, NaN rejection).
  - `tests/unit/sdlc/final-verification.test.ts` — disabled → zero behavior change; sandbox gate; pass; fail→fix→green (commit lands); regression/budget-exhausted (Draft still opens, flagged); verify-only; wall-clock budget short-circuit.
  - `tests/unit/consilium/execution-trace.test.ts` — `passedAtFinal` emission + omission + clamp preservation.
  - `tests/unit/consilium/loop-testsummary-wire.test.ts` — controller threads `finalVerification` under the same sandbox gate (on / gate-closed / off).
- All touched test files together: **135 passed**. Full unit suite: only pre-existing environmental timeout flakes in unrelated files (e.g. `providers/antigravity`), which pass in isolation.

Draft — do not merge; awaiting review + green CI.
