### PR TITLE
fix: bounded retry with model fallback for judge timeouts

### DIFF
--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -333,6 +333,36 @@ export const ConfigSchema = z.object({
        */
       sdlcTimeoutMs: z.coerce.number().int().min(60_000).max(1_800_000).default(1_200_000),
       /**
+       * Judge timeout resilience (fix: bounded retry with model fallback for
+       * judge timeouts). In a consilium dispute the JUDGE task receives the FULL
+       * debate context — the largest-context call of the round — and can hit the
+       * gateway wall-clock cap (observed: latency ≈ 600_000ms, 0 output tokens),
+       * which FAILS the judge task_execution, cancels its dependents, fails the
+       * task_group_iteration, and drives the loop to FAILED.
+       *
+       * When `enabled`, a direct_llm LLM-stage task whose gateway call ends in a
+       * TIMEOUT (throw) or an EMPTY (0-token) completion is retried EXACTLY ONCE;
+       * on the retry an optional `fallbackModel` overrides the slug. Bounded to a
+       * SINGLE retry — no backoff/exponential machinery, so no retry storms. The
+       * LLM completion is a pure gateway call (no outbox/webhook side effect per
+       * attempt), so a retry cannot double-charge a business action.
+       *
+       * Default FALSE ⇒ INERT: exactly one attempt and any throw/empty propagates
+       * unchanged (byte-identical to today). The FSM/reducer failure path when the
+       * retry is disabled OR exhausted is untouched — the loop still fails cleanly.
+       */
+      judgeRetry: z.object({
+        /** Kill-switch: false → single attempt, today's failure path (inert). */
+        enabled: z.boolean().default(false),
+        /**
+         * Optional model slug used ONLY on the single retry attempt (e.g. a
+         * faster/cheaper model that fits the large judge context under the cap).
+         * Omitted ⇒ the retry re-uses the task's own model. min(1) when present
+         * so an empty string is rejected rather than silently blanking the slug.
+         */
+        fallbackModel: z.string().min(1).optional(),
+      }).default({}),
+      /**
        * Stage 1 (design §6): the intent→archetype PLANNER — a single OUT-OF-BAND
        * lightweight model call (NOT a DAG task, NOT an FSM state) that proposes one
        * of a fixed enum of archetypes for a verdict-terminal loop. The whole planner

--- a/server/services/task-orchestrator.ts
+++ b/server/services/task-orchestrator.ts
@@ -10,7 +10,13 @@ import type {
   TaskGroupIterationRow,
   TaskExecutionRow,
 } from "@shared/schema";
-import type { WsEvent, TaskResult } from "@shared/types";
+import type {
+  WsEvent,
+  TaskResult,
+  GatewayRequest,
+  GatewayResponse,
+  StreamingStageOptions,
+} from "@shared/types";
 import type { TaskTracer } from "./task-tracer";
 import { configLoader } from "../config/loader.js";
 import { DEFAULT_TASK_MODEL } from "../config/schema.js";
@@ -127,6 +133,62 @@ export function composeIterationInput(baseInput: string, humanNote: string | nul
   const note = (humanNote ?? "").trim();
   if (!note) return baseInput;
   return `${baseInput}\n\n${HUMAN_NOTE_HEADING}:\n${note}`;
+}
+
+// ─── Judge timeout resilience (fix: bounded retry with model fallback) ──────
+
+/** Structured record of the single bounded retry, surfaced for observability. */
+interface RetryNote {
+  cause: "timeout" | "empty output";
+  /** The fallback slug used, or null when the retry re-used the task's model. */
+  fallbackModel: string | null;
+  /** The slug the retry attempt actually ran under. */
+  retriedModel: string;
+}
+
+/** A direct_llm gateway call that returned no usable content (0-token/empty). */
+function isEmptyCompletion(response: GatewayResponse): boolean {
+  return response.content.trim().length === 0;
+}
+
+/**
+ * A gateway error that is a WALL-CLOCK TIMEOUT (the judge's cap on the largest-
+ * context call), as opposed to a budget/auth/other failure. Matched by the
+ * provider error name/message so it is cross-provider: the CLI providers throw
+ * `CliOverallTimeoutError` / "CLI timed out after …" / "exceeded overall cap",
+ * the API providers throw a `TimeoutError`. NON-timeout errors are NOT retried —
+ * they propagate exactly as today.
+ */
+function isTimeoutError(err: unknown): boolean {
+  const name = err instanceof Error ? err.name : "";
+  const message = err instanceof Error ? err.message : String(err);
+  return /timeout/i.test(name) || /timed out|timeout|overall cap/i.test(message);
+}
+
+/**
+ * Fold the retry note into the parsed result so an operator can SEE that the
+ * judge/LLM call retried and under which model — additive `output._retry`
+ * structured record + one human-readable `decisions[]` line. When there was no
+ * retry the result is returned byte-identical (inert path).
+ */
+function annotateRetry(result: TaskResult, note: RetryNote | null): TaskResult {
+  if (!note) return result;
+  const label = note.fallbackModel
+    ? `retried (fallback: ${note.fallbackModel})`
+    : "retried (same model)";
+  return {
+    ...result,
+    output: {
+      ...(result.output ?? {}),
+      _retry: {
+        retried: true,
+        cause: note.cause,
+        model: note.retriedModel,
+        fallbackModel: note.fallbackModel,
+      },
+    },
+    decisions: [...(result.decisions ?? []), `judge/LLM call ${label} after ${note.cause}`],
+  };
 }
 
 // ─── Task Orchestrator ──────────────────────────────────────────────────────
@@ -666,23 +728,75 @@ export class TaskOrchestrator {
     // drains deltas incrementally. Overall cap is the configurable per-task
     // timeout; no idle cap so a long initial think is not mistaken for a stall.
     const taskTimeoutMs = configLoader.get().pipeline.taskGroups.taskTimeoutMs;
-    const response = await this.gateway.completeStreaming(
-      {
-        modelSlug,
-        messages: [
-          { role: "system", content: systemPrompt },
-          { role: "user", content: inputContent },
-        ],
-        temperature: 0.7,
-        maxTokens: 4096,
-      },
-      undefined,
-      undefined,
-      { overallTimeoutMs: taskTimeoutMs },
-    );
+    const request: GatewayRequest = {
+      modelSlug,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: inputContent },
+      ],
+      temperature: 0.7,
+      maxTokens: 4096,
+    };
+    // fix (judge timeout resilience): the judge's largest-context call can hit
+    // the wall-clock cap and return 0 tokens; completeDirectLlm adds an optional
+    // single bounded retry (default OFF ⇒ byte-identical to the single call above).
+    const { response, retry } = await this.completeDirectLlm(request, {
+      overallTimeoutMs: taskTimeoutMs,
+    });
 
-    this.tracing.completeLlmSpan(group.id, llmSpanId, { response, modelSlug, inputContent });
-    return parseDirectLlmResponse(response.content);
+    this.tracing.completeLlmSpan(group.id, llmSpanId, {
+      response,
+      modelSlug: response.modelSlug,
+      inputContent,
+    });
+    return annotateRetry(parseDirectLlmResponse(response.content), retry);
+  }
+
+  /**
+   * Run the direct_llm gateway call with an OPTIONAL single bounded retry
+   * (fix: bounded retry with model fallback for judge timeouts). Config
+   * `pipeline.consiliumLoop.judgeRetry` is default-OFF ⇒ EXACTLY ONE attempt and
+   * ANY throw/empty propagates unchanged (byte-identical to pre-fix; the FSM/
+   * reducer failure path is untouched). When enabled, a first attempt that ends
+   * in a gateway TIMEOUT (throw) or an EMPTY (0-token) completion is retried
+   * EXACTLY ONCE, optionally under `fallbackModel`.
+   *
+   * Idempotency (adversarial review, risk 1): the completion is a PURE gateway
+   * call — no outbox/webhook/business side effect fires per attempt. The gateway
+   * logs one llm_request + cost row per PHYSICAL call, which is the intended
+   * per-attempt accounting, so a retry cannot double-charge a business action or
+   * duplicate a side effect.
+   *
+   * Bound (adversarial review, risk 2): EXACTLY one retry. A second timeout/error
+   * is NOT caught here — it propagates so the task fails cleanly (retry exhausted
+   * → today's failure path). No backoff/exponential machinery, so no retry storms.
+   */
+  private async completeDirectLlm(
+    request: GatewayRequest,
+    streamOptions: StreamingStageOptions,
+  ): Promise<{ response: GatewayResponse; retry: RetryNote | null }> {
+    const cfg = configLoader.get().pipeline.consiliumLoop.judgeRetry;
+
+    let cause: RetryNote["cause"];
+    try {
+      const response = await this.gateway.completeStreaming(request, undefined, undefined, streamOptions);
+      // Disabled OR a non-empty completion ⇒ today's behaviour, no retry.
+      if (!cfg.enabled || !isEmptyCompletion(response)) return { response, retry: null };
+      cause = "empty output";
+    } catch (err) {
+      // Disabled OR a non-timeout error ⇒ propagate exactly as today.
+      if (!cfg.enabled || !isTimeoutError(err)) throw err;
+      cause = "timeout";
+    }
+
+    // ── single bounded retry (enabled AND timeout/empty only) ──
+    const retriedModel = cfg.fallbackModel ?? request.modelSlug;
+    const retryRequest: GatewayRequest = { ...request, modelSlug: retriedModel };
+    const response = await this.gateway.completeStreaming(retryRequest, undefined, undefined, streamOptions);
+    return {
+      response,
+      retry: { cause, fallbackModel: cfg.fallbackModel ?? null, retriedModel },
+    };
   }
 
   private async executePipelineRun(

--- a/tests/unit/consilium/consilium-config.test.ts
+++ b/tests/unit/consilium/consilium-config.test.ts
@@ -60,6 +60,26 @@ describe("pipeline.consiliumLoop schema", () => {
     expect(impl.testRunTimeoutMs).toBe(300_000);
   });
 
+  it("judgeRetry defaults to INERT (disabled, no fallback)", () => {
+    const res = ConfigSchema.safeParse({});
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    const jr = res.data.pipeline.consiliumLoop.judgeRetry;
+    expect(jr.enabled).toBe(false); // default OFF ⇒ byte-identical to today
+    expect(jr.fallbackModel).toBeUndefined();
+  });
+
+  it("judgeRetry accepts enable + fallbackModel; rejects an empty fallback slug", () => {
+    const ok = parseLoop({ judgeRetry: { enabled: true, fallbackModel: "claude-sonnet" } });
+    expect(ok.success).toBe(true);
+    if (ok.success) {
+      expect(ok.data.pipeline.consiliumLoop.judgeRetry.enabled).toBe(true);
+      expect(ok.data.pipeline.consiliumLoop.judgeRetry.fallbackModel).toBe("claude-sonnet");
+    }
+    // min(1): an empty slug is rejected rather than silently blanking the model.
+    expect(parseLoop({ judgeRetry: { fallbackModel: "" } }).success).toBe(false);
+  });
+
   it("Stage 2b: accepts valid verification overrides", () => {
     const res = parseLoop({
       implement: {

--- a/tests/unit/task-orchestrator-judge-retry.test.ts
+++ b/tests/unit/task-orchestrator-judge-retry.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for the judge/direct_llm bounded retry with model fallback
+ * (fix/judge-timeout-resilience).
+ *
+ * Regression guard for the Phase-0 failure: in a consilium dispute the JUDGE
+ * task's LLM call receives the FULL debate context — the largest-context call of
+ * the round — and can hit the gateway wall-clock cap (observed: latency ≈
+ * 600_000ms, output_tokens = 0). Today that throws, FAILS the judge
+ * task_execution, cancels dependents, fails the iteration, and drives the loop
+ * to FAILED. The two debater calls of the same round succeeded.
+ *
+ * The fix wraps the `direct_llm` gateway call (server/services/task-orchestrator
+ * .ts `completeDirectLlm`) with an OPTIONAL single bounded retry, gated by
+ * `pipeline.consiliumLoop.judgeRetry` (default OFF ⇒ byte-identical to today).
+ *
+ * Strategy: mirror task-orchestrator-default-model.test.ts — drive a real
+ * startGroup() over MemStorage with a programmable gateway double whose
+ * `completeStreaming` is scripted per call (throw a timeout / return empty /
+ * return valid JSON). The retry config is toggled on the live cached config
+ * object and restored after each test.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { MemStorage } from "../../server/storage.js";
+import { TaskOrchestrator } from "../../server/services/task-orchestrator.js";
+import { configLoader } from "../../server/config/loader.js";
+import type { WsManager } from "../../server/ws/manager.js";
+import type { PipelineController } from "../../server/controller/pipeline-controller.js";
+import type { Gateway } from "../../server/gateway/index.js";
+import type { GatewayRequest, GatewayResponse } from "../../shared/types.js";
+
+/** A scripted behaviour for one physical completeStreaming call. */
+type CallBehaviour =
+  | { kind: "ok"; content?: string }
+  | { kind: "empty" }
+  | { kind: "timeout" }
+  | { kind: "error"; message: string };
+
+interface ScriptedGateway {
+  gateway: Gateway;
+  calls: GatewayRequest[];
+}
+
+const VALID_JSON = JSON.stringify({
+  summary: "judge verdict",
+  output: { verdict: "ship it" },
+  decisions: ["converged"],
+});
+
+/**
+ * A gateway double whose `completeStreaming` walks a fixed script of behaviours
+ * (one per physical call), recording every request. A CLI-style overall-timeout
+ * error is thrown for `timeout` so `isTimeoutError` matches it.
+ */
+function makeScriptedGateway(script: CallBehaviour[]): ScriptedGateway {
+  const calls: GatewayRequest[] = [];
+  let i = 0;
+  const completeStreaming = async (request: GatewayRequest): Promise<GatewayResponse> => {
+    calls.push(request);
+    const behaviour = script[i] ?? { kind: "ok" as const };
+    i += 1;
+    switch (behaviour.kind) {
+      case "timeout": {
+        const err = new Error("CLI exceeded overall cap of 600000ms");
+        err.name = "CliOverallTimeoutError";
+        throw err;
+      }
+      case "error":
+        throw new Error(behaviour.message);
+      case "empty":
+        return { content: "", tokensUsed: 1, modelSlug: request.modelSlug, finishReason: "stop" };
+      case "ok":
+      default:
+        return {
+          content: behaviour.content ?? VALID_JSON,
+          tokensUsed: 42,
+          modelSlug: request.modelSlug,
+          finishReason: "stop",
+        };
+    }
+  };
+  const gateway = { complete: completeStreaming, completeStreaming } as unknown as Gateway;
+  return { gateway, calls };
+}
+
+function makeOrchestrator(gateway: Gateway): { orchestrator: TaskOrchestrator; storage: MemStorage } {
+  const storage = new MemStorage();
+  const wsManager = { broadcastToRun: () => {} } as unknown as WsManager;
+  const pipelineController = {} as unknown as PipelineController;
+  const orchestrator = new TaskOrchestrator(storage, wsManager, pipelineController, gateway);
+  return { orchestrator, storage };
+}
+
+/** A one-task group standing in for the dispute's judge (a direct_llm task). */
+async function runJudge(
+  orchestrator: TaskOrchestrator,
+  storage: MemStorage,
+  modelSlug = "gemini-3-1-pro-high",
+) {
+  const { group, tasks } = await orchestrator.createTaskGroup({
+    name: "dispute",
+    description: "d",
+    input: "synthesise the verdict",
+    tasks: [{ name: "Judge verdict", description: "judge", executionMode: "direct_llm", modelSlug }],
+  });
+  const { iteration } = await orchestrator.startGroup(group.id);
+  const executions = await storage.getExecutionsByIteration(group.id, iteration.id);
+  const judge = executions.find((e) => e.taskId === tasks[0].id)!;
+  return { group, iteration, judge };
+}
+
+describe("TaskOrchestrator direct_llm bounded retry (judge timeout resilience)", () => {
+  const retryCfg = () => configLoader.get().pipeline.consiliumLoop.judgeRetry;
+  let saved: { enabled: boolean; fallbackModel?: string };
+
+  beforeEach(() => {
+    const c = retryCfg();
+    saved = { enabled: c.enabled, fallbackModel: c.fallbackModel };
+  });
+
+  afterEach(() => {
+    const c = retryCfg();
+    c.enabled = saved.enabled;
+    c.fallbackModel = saved.fallbackModel;
+  });
+
+  it("enabled: timeout → retry → success (judge task completes)", async () => {
+    retryCfg().enabled = true;
+    retryCfg().fallbackModel = undefined;
+    const spy = makeScriptedGateway([{ kind: "timeout" }, { kind: "ok" }]);
+    const { orchestrator, storage } = makeOrchestrator(spy.gateway);
+
+    const { judge } = await runJudge(orchestrator, storage);
+
+    expect(spy.calls).toHaveLength(2); // one retry
+    expect(judge.status).toBe("completed");
+    // Retry re-used the task's own model (no fallback configured).
+    expect(spy.calls[0].modelSlug).toBe("gemini-3-1-pro-high");
+    expect(spy.calls[1].modelSlug).toBe("gemini-3-1-pro-high");
+    // Observability: the retry is visible in the execution output.
+    const retry = (judge.output as Record<string, unknown>)?._retry as Record<string, unknown>;
+    expect(retry).toMatchObject({ retried: true, cause: "timeout", fallbackModel: null });
+    expect(judge.decisions).toContain("judge/LLM call retried (same model) after timeout");
+  });
+
+  it("enabled + fallbackModel: timeout → retry under fallback → success", async () => {
+    retryCfg().enabled = true;
+    retryCfg().fallbackModel = "claude-sonnet";
+    const spy = makeScriptedGateway([{ kind: "timeout" }, { kind: "ok" }]);
+    const { orchestrator, storage } = makeOrchestrator(spy.gateway);
+
+    const { judge } = await runJudge(orchestrator, storage);
+
+    expect(spy.calls).toHaveLength(2);
+    expect(judge.status).toBe("completed");
+    // First call under the task's model, retry under the fallback slug.
+    expect(spy.calls[0].modelSlug).toBe("gemini-3-1-pro-high");
+    expect(spy.calls[1].modelSlug).toBe("claude-sonnet");
+    const retry = (judge.output as Record<string, unknown>)?._retry as Record<string, unknown>;
+    expect(retry).toMatchObject({ retried: true, cause: "timeout", fallbackModel: "claude-sonnet" });
+    expect(judge.decisions).toContain("judge/LLM call retried (fallback: claude-sonnet) after timeout");
+  });
+
+  it("enabled: empty (0-token) completion → retry → success", async () => {
+    retryCfg().enabled = true;
+    retryCfg().fallbackModel = "claude-sonnet";
+    const spy = makeScriptedGateway([{ kind: "empty" }, { kind: "ok" }]);
+    const { orchestrator, storage } = makeOrchestrator(spy.gateway);
+
+    const { judge } = await runJudge(orchestrator, storage);
+
+    expect(spy.calls).toHaveLength(2);
+    expect(judge.status).toBe("completed");
+    const retry = (judge.output as Record<string, unknown>)?._retry as Record<string, unknown>;
+    expect(retry).toMatchObject({ retried: true, cause: "empty output", fallbackModel: "claude-sonnet" });
+  });
+
+  it("disabled (default): timeout → NO retry → today's failure path (loop fails cleanly)", async () => {
+    retryCfg().enabled = false;
+    const spy = makeScriptedGateway([{ kind: "timeout" }, { kind: "ok" }]);
+    const { orchestrator, storage } = makeOrchestrator(spy.gateway);
+
+    const { group, iteration, judge } = await runJudge(orchestrator, storage);
+
+    expect(spy.calls).toHaveLength(1); // single attempt, no retry
+    expect(judge.status).toBe("failed");
+    // Iteration + group fail cleanly (FSM failure path untouched).
+    const it = await storage.getIteration(group.id, iteration.iterationNumber);
+    const g = await storage.getTaskGroup(group.id);
+    expect(it?.status).toBe("failed");
+    expect(g?.status).toBe("failed");
+    expect((judge.output as Record<string, unknown> | null)?._retry).toBeUndefined();
+  });
+
+  it("enabled: retry EXHAUSTED (both calls time out) → today's failure path", async () => {
+    retryCfg().enabled = true;
+    retryCfg().fallbackModel = "claude-sonnet";
+    const spy = makeScriptedGateway([{ kind: "timeout" }, { kind: "timeout" }]);
+    const { orchestrator, storage } = makeOrchestrator(spy.gateway);
+
+    const { group, judge } = await runJudge(orchestrator, storage);
+
+    expect(spy.calls).toHaveLength(2); // exactly one retry, then give up
+    expect(judge.status).toBe("failed");
+    const g = await storage.getTaskGroup(group.id);
+    expect(g?.status).toBe("failed");
+  });
+
+  it("enabled: a NON-timeout error is NOT retried (only timeout/empty are)", async () => {
+    retryCfg().enabled = true;
+    const spy = makeScriptedGateway([{ kind: "error", message: "budget exceeded" }, { kind: "ok" }]);
+    const { orchestrator, storage } = makeOrchestrator(spy.gateway);
+
+    const { judge } = await runJudge(orchestrator, storage);
+
+    expect(spy.calls).toHaveLength(1); // no retry for a non-timeout failure
+    expect(judge.status).toBe("failed");
+  });
+});


### PR DESCRIPTION
## Problem (reproduced, twice, deterministic)

In a consilium dispute (a task group), the **JUDGE** task's LLM call to
`gemini-3-1-pro-high` hits the 600s gateway wall-clock cap and returns **0 output
tokens**. Evidence from `llm_requests` on the largest-context call of the round
(the judge receives the full debate context):

| metric | run A | run B |
|---|---|---|
| `latency_ms` | 600038 | 600021 |
| `output_tokens` | 0 | 0 |

Failure cascade (today): judge `completeStreaming` throws → judge `task_execution`
ends **failed** with empty output → dependent tasks **cancelled** →
`task_group_iteration` ends **failed** → loop controller derives `review_failed`
→ **LOOP → FAILED**. The two debater calls of the same rounds succeeded — only the
judge (full-context) call timed out.

## Seam chosen

The judge is a `direct_llm` task; it runs through the task-orchestrator →
`gateway.completeStreaming`. The single call in
`TaskOrchestrator.executeDirectLlm` is the point where a timeout/empty completion
becomes a failed execution.

I wrapped **that one call** in a new private `completeDirectLlm(request, streamOptions)`
that adds an **optional single bounded retry**. This is the generic `direct_llm`
seam (which is exactly what the judge is) — one seam, small diff, **no generic
retry framework**. Stated explicitly: when enabled, any `direct_llm` LLM-stage
task retries once on timeout/empty; the motivating and owning case is the
consilium judge, hence the config namespace.

- **No FSM/reducer change.** When the retry is disabled or exhausted, the failure
  path is exactly as-is (`onTaskFailed` → iteration/group failed → loop fails
  cleanly). Default OFF ⇒ behaviour byte-identical to today.
- **Timeout/empty detection:** a retry fires only on a wall-clock timeout throw
  (cross-provider match on `CliOverallTimeoutError` / "timed out" / "overall cap"
  / `TimeoutError`) or a 0-token/empty completion. Non-timeout errors (budget,
  auth, …) propagate unchanged.

## Config keys (`server/config/schema.ts`, house pattern)

```
pipeline.consiliumLoop.judgeRetry:
  enabled: boolean          # default FALSE — inert; single attempt, today's path
  fallbackModel?: string    # optional; used ONLY on the retry (min(1) when present)
```

## Observability

The retry is visible on the execution: additive `output._retry`
`{ retried, cause, model, fallbackModel }` plus a human-readable `decisions[]`
line, e.g. `judge/LLM call retried (fallback: claude-sonnet) after timeout`.

## Adversarial self-review

- **Risk 1 — double-charge / duplicate side effects on retry.** The completion is
  a pure `gateway.completeStreaming` call. In `executeDirectLlm` no
  outbox/webhook/business side effect fires per attempt (task-level
  `broadcast`/`onTaskCompleted` run once, after the result is produced). The
  gateway logs one `llm_requests` row per physical call — the intended
  per-attempt accounting; `recordCost` is not even invoked here (no
  `workspaceId`). A retry cannot double-charge a business action.
- **Risk 2 — retry storms.** Bound is **exactly one** retry. The retry call is
  not re-wrapped, so a second timeout propagates and the task fails cleanly. No
  backoff/exponential machinery.

## Tests

New `tests/unit/task-orchestrator-judge-retry.test.ts` (6) + schema coverage in
`tests/unit/consilium/consilium-config.test.ts` (2):

- timeout → retry → success
- timeout → retry (fallback model) → success
- empty (0-token) → retry → success
- disabled (default) → no retry → today's failure path (iteration + group fail cleanly)
- retry exhausted (both time out) → today's failure path
- non-timeout error → not retried
- schema: `judgeRetry` defaults inert; enable+fallback accepted; empty fallback slug rejected

**Results:** `npm run check` (tsc) clean. Full unit suite green:
**245 files / 4834 tests passed** (no providers/antigravity flakes triggered this run).

## Files changed

- `server/config/schema.ts` — `pipeline.consiliumLoop.judgeRetry` block
- `server/services/task-orchestrator.ts` — `completeDirectLlm` retry seam + helpers
- `tests/unit/task-orchestrator-judge-retry.test.ts` — new
- `tests/unit/consilium/consilium-config.test.ts` — schema assertions
