### PR TITLE
fix: classify test-runner launch failures as not-run and skip the fix loop

### DIFF
--- a/client/src/hooks/use-consilium-loops.ts
+++ b/client/src/hooks/use-consilium-loops.ts
@@ -43,7 +43,10 @@ export type ConsiliumLoopListItem = Omit<ConsiliumLoopRow, "createdBy"> & {
  * every consumer reads it defensively.
  */
 export interface DevProgress {
-  phase?: "coding" | "committing" | "pushing" | "opening_pr" | "done";
+  /** `final-verification` = the Stage-A whole-suite re-run against the FINAL tree (after
+   *  the last action point, before the push). Optional/additive — an older snapshot omits
+   *  it and the UI degrades to the generic "developing…" line. */
+  phase?: "coding" | "committing" | "final-verification" | "pushing" | "opening_pr" | "done";
   actionPointIndex?: number;
   actionPointTotal?: number;
   actionPointTitle?: string;

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -999,6 +999,17 @@ function humanizeDevPhase(progress: DevProgress | undefined, total: number): str
   switch (progress?.phase) {
     case "committing":
       return "Коммичу…";
+    case "final-verification": {
+      // Stage A: whole-suite re-run against the final combined tree (+ a bounded fix
+      // loop). Distinct from `committing` so it never reads as a frozen "Коммичу…".
+      const fi = progress?.fixIteration;
+      const fb = progress?.fixBudget;
+      if (progress?.step === "fix-coder" && typeof fi === "number" && fi > 0) {
+        const budget = typeof fb === "number" ? `/${fb}` : "";
+        return `Финальная проверка: исправляю (фикс ${fi}${budget})…`;
+      }
+      return "Финальная проверка всего дерева…";
+    }
     case "pushing":
       return "Пушу ветку…";
     case "opening_pr":

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -189,8 +189,14 @@ export interface FinalVerification {
  * complete no-op for it (behavior identical to before this field existed).
  */
 export interface SdlcProgress {
-  /** Which phase the executor is in right now. */
-  phase: "coding" | "committing" | "pushing" | "opening_pr" | "done";
+  /**
+   * Which phase the executor is in right now. `final-verification` (Stage A) is the
+   * whole-suite re-run against the FINAL combined tree after every action point — it
+   * runs AFTER the last AP commit but BEFORE the push, so without its own phase it was
+   * indistinguishable from a frozen `committing` beat. ADDITIVE: an old client that does
+   * not know this value degrades to its generic "developing…" line (see the FE switch).
+   */
+  phase: "coding" | "committing" | "final-verification" | "pushing" | "opening_pr" | "done";
   /** 1-based position of the action point being worked. For the push/opening_pr/
    *  done phases (no single AP) this carries the action-point TOTAL. */
   actionPointIndex: number;
@@ -582,8 +588,11 @@ export function buildPrStatusBody(input: PrStatusBodyInput): string {
         "",
         "The following P0 acceptance criteria are NOT yet verified green (the fix budget was exhausted or no test command resolved). Review before merging:",
         ...unmetP0.map(
+          // A not-run criterion surfaces its OWN reason (no test command OR a launch
+          // failure like `spawn uv ENOENT`) from the scrubbed summary, rather than
+          // always claiming "no test command" — an env error is not a missing command.
           (o) =>
-            `- (${o.priority}) ${sanitizeLine(o.title, PR_BODY_TITLE_MAX)} — ${o.verification && !o.verification.ran ? "no test command" : "tests still failing"}`,
+            `- (${o.priority}) ${sanitizeLine(o.title, PR_BODY_TITLE_MAX)} — ${o.verification && !o.verification.ran ? sanitizeLine(o.verification.summary, 160) : "tests still failing"}`,
         ),
       );
     }
@@ -797,7 +806,11 @@ export async function runSdlcHandoff(
       // NEVER throws / blocks PR creation (same contract as the per-AP path).
       let finalVerification: FinalVerification | undefined;
       if (verifyCtx && (req.finalVerification?.enabled ?? false)) {
-        finalVerification = await runFinalVerification(runCoder, verifyCtx, req.finalVerification!, req, wt);
+        finalVerification = await runFinalVerification(runCoder, verifyCtx, req.finalVerification!, req, wt, {
+          progress,
+          total,
+          completedBefore: committedCount,
+        });
         if (await commitFinalFixes(gitRaw, wt, req)) committedCount += 1;
       }
 
@@ -1065,13 +1078,39 @@ async function runFinalVerification(
   config: FinalVerificationConfig,
   req: SdlcHandoffRequest,
   wt: CreateWorktreeResult,
+  beatCtx: {
+    progress: ProgressTracker;
+    /** Round action-point total (carried on the AP-less final beats). */
+    total: number;
+    /** Commits produced by the action points before final verification. */
+    completedBefore: number;
+  },
 ): Promise<FinalVerification> {
+  // Live progress beat for the FINAL phase (was silent → looked like a frozen
+  // `committing`). `fixIteration` = 0 for the initial whole-suite run, 1..N per fix.
+  const emitFinal = (step: NonNullable<SdlcProgress["step"]>, fixIteration: number): void =>
+    beatCtx.progress.beat({
+      phase: "final-verification",
+      actionPointIndex: beatCtx.total,
+      actionPointTotal: beatCtx.total,
+      actionPointTitle: "",
+      completedCount: beatCtx.completedBefore,
+      step,
+      fixIteration,
+      fixBudget: config.maxFinalFixIterations,
+    });
+
+  emitFinal("test-runner", 0); // initial whole-suite re-verification run.
   let result = await runTestOnce(vc, wt);
   let fixIterations = 0;
-  while (!result.passed && fixIterations < config.maxFinalFixIterations) {
+  // `result.ran` gate: a command that could NOT be LAUNCHED (env broken — ran:false)
+  // must NOT enter the code→test→fix loop; no code change can make it run, so we skip
+  // the fix budget entirely (mirrors the no-test-command convention) and record NOT-RUN.
+  while (!result.passed && result.ran && fixIterations < config.maxFinalFixIterations) {
     // Whole-run wall-clock backstop (shared budget): stop fixing once the run overran.
     if (vc.now() >= vc.deadline) break;
     fixIterations += 1;
+    emitFinal("fix-coder", fixIterations); // final fix pass k is running.
     try {
       const fixed = await runCoder(wt.worktreeDir, req.actionPoints, {
         timeoutMs: req.coderTimeoutMs,
@@ -1082,6 +1121,7 @@ async function runFinalVerification(
     } catch {
       break; // a crashed fix coder stops the loop; whatever landed is still committed.
     }
+    emitFinal("test-runner", fixIterations); // re-run the whole suite after fix pass k.
     result = await runTestOnce(vc, wt);
   }
 
@@ -1172,7 +1212,13 @@ async function runVerifyFixLoop(
   emitVerify("test-runner", 0); // initial verification run (before any fix).
   let result = await runOnce();
   let fixIterations = 0;
-  while (!result.passed && fixIterations < vc.config.maxFixIterations) {
+  // `result.ran` gate: a test command that could NOT be LAUNCHED (env broken —
+  // e.g. `spawn uv ENOENT` ⇒ ran:false) must NOT enter the code→test→fix loop. No
+  // code change can make an unlaunchable command run, so burning the fix budget on it
+  // wastes every coder invocation on an error the coder cannot fix (the reported bug).
+  // We skip straight to a NOT-RUN verdict (0 fix iterations) — the SAME convention as
+  // the existing no-test-command path.
+  while (!result.passed && result.ran && fixIterations < vc.config.maxFixIterations) {
     // Whole-run wall-clock backstop: stop fixing once the run has overrun (the
     // per-AP coder/test timeouts + this cap together bound total develop time).
     if (vc.now() >= vc.deadline) break;

--- a/server/services/sdlc/test-runner.ts
+++ b/server/services/sdlc/test-runner.ts
@@ -210,6 +210,43 @@ function scrub(raw: string): string {
   return raw.replace(/\/[^\s'"]+/g, "<path>").replace(/[ \t]+/g, " ").trim();
 }
 
+/**
+ * The errno strings that mean the child NEVER STARTED — the OS could not exec the
+ * binary at all: `ENOENT` (binary not on PATH / not found) or `EACCES` (found but not
+ * executable / permission denied). Node surfaces these as the `code` on the spawn
+ * `error` event (or a synchronous spawn throw). Kept STRICT (spawn-level only) on
+ * purpose — see {@link isLaunchFailure}.
+ */
+const LAUNCH_FAILURE_CODES: ReadonlySet<string> = new Set(["ENOENT", "EACCES"]);
+
+/**
+ * Is this a spawn-LAUNCH failure — the child process NEVER executed? True IFF the
+ * error carries an errno `code` of `ENOENT`/`EACCES` (the OS could not exec the
+ * binary). This is STRICTLY distinct from a test that RAN and then failed: a non-zero
+ * exit arrives on the `close` event with a NUMERIC `exitCode` and never reaches this
+ * predicate. A test-harness crash (segfault / uncaught throw) likewise exits non-zero
+ * AFTER launching — it is NOT a launch failure. Keeping the rule to these two spawn-
+ * time errnos is what prevents misclassifying a real test failure as an env error.
+ */
+function isLaunchFailure(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | null | undefined)?.code;
+  return typeof code === "string" && LAUNCH_FAILURE_CODES.has(code);
+}
+
+/**
+ * Build the summary for a launch failure. Names the underlying spawn error (scrubbed,
+ * e.g. `spawn uv ENOENT`) and points the operator at the fix: the ENVIRONMENT or the
+ * configured `testCommand`. NO code change can make an unlaunchable command run, so
+ * this summary must read as an environment problem, never a test failure.
+ */
+function launchFailureSummary(err: unknown): string {
+  const msg = scrub(err instanceof Error ? err.message : String(err));
+  return `test command could not be launched (${msg}) — fix the environment or config testCommand`.slice(
+    0,
+    SUMMARY_MAX,
+  );
+}
+
 /** Build the bounded, scrubbed summary. Keeps the OUTPUT TAIL (failures live there). */
 function buildSummary(
   output: string,
@@ -330,10 +367,14 @@ export function runTests(opts: RunTestsOptions): Promise<TestRunResult> {
         stdio: ["ignore", "pipe", "pipe"],
       });
     } catch (err) {
-      // Spawn threw synchronously (e.g. bad binary) — degrade, never throw.
+      // Spawn threw synchronously (e.g. bad binary) — degrade, never throw. The child
+      // never started ⇒ ran:false. A launch errno (ENOENT/EACCES) gets the explicit
+      // "could not be launched" summary so the caller reads it as an ENV error.
       resolve({
         passed: false,
-        summary: scrub(err instanceof Error ? err.message : String(err)).slice(0, SUMMARY_MAX),
+        summary: isLaunchFailure(err)
+          ? launchFailureSummary(err)
+          : scrub(err instanceof Error ? err.message : String(err)).slice(0, SUMMARY_MAX),
         exitCode: null,
         timedOut: false,
         ran: false,
@@ -373,15 +414,22 @@ export function runTests(opts: RunTestsOptions): Promise<TestRunResult> {
 
     child.stdout?.on("data", append);
     child.stderr?.on("data", append);
-    child.on("error", (err: Error) =>
+    // The spawn `error` event. A LAUNCH failure (ENOENT/EACCES — the binary never
+    // exec'd, e.g. `spawn uv ENOENT`) is an ENVIRONMENT problem: the child NEVER ran,
+    // so ran:false (no code change can fix it — the caller must SKIP the fix loop). Any
+    // OTHER error event fires only AFTER the child started (e.g. an I/O error mid-run),
+    // so it ran (ran:true) and is treated as before. A non-zero test exit does NOT come
+    // through here at all — it settles via the `close` handler with a numeric exitCode.
+    child.on("error", (err: Error) => {
+      const launch = isLaunchFailure(err);
       finish({
         passed: false,
-        summary: scrub(err.message).slice(0, SUMMARY_MAX),
+        summary: launch ? launchFailureSummary(err) : scrub(err.message).slice(0, SUMMARY_MAX),
         exitCode: null,
         timedOut,
-        ran: true,
-      }),
-    );
+        ran: !launch,
+      });
+    });
     child.on("close", (code: number | null) =>
       finish({
         passed: !timedOut && code === 0,

--- a/tests/unit/sdlc/final-verification.test.ts
+++ b/tests/unit/sdlc/final-verification.test.ts
@@ -74,6 +74,15 @@ const baseReq = (over: Partial<SdlcHandoffRequest> = {}): SdlcHandoffRequest => 
 const pass: TestRunResult = { passed: true, ran: true, summary: "PASSED\nall green", exitCode: 0, timedOut: false };
 const fail: TestRunResult = { passed: false, ran: true, summary: "FAILED (exit 1)\n1 failing", exitCode: 1, timedOut: false };
 const notRun: TestRunResult = { passed: false, ran: false, summary: "not verified — no test command", exitCode: null, timedOut: false };
+/** The reported bug: the final command could NOT be LAUNCHED (env broken). ran:false ⇒
+ *  the final fix loop must be SKIPPED (no code change makes an unlaunchable command run). */
+const launchFail: TestRunResult = {
+  passed: false,
+  ran: false,
+  summary: "test command could not be launched (spawn uv ENOENT) — fix the environment or config testCommand",
+  exitCode: null,
+  timedOut: false,
+};
 
 function makeGitRaw() {
   return vi.fn(async (_repo: string, args: string[]) => {
@@ -269,6 +278,83 @@ describe("Stage A — VERIFY-ONLY (maxFinalFixIterations=0)", () => {
     );
     expect(res.finalVerification).toEqual(expect.objectContaining({ ran: false, passed: false }));
     expect(prBody(deps)).toMatch(/Final-state re-verification: NOT-RUN/);
+  });
+});
+
+describe("Stage A — launch failure (ran:false) SKIPS the final fix loop", () => {
+  it("a spawn-ENOENT final run burns ZERO final fix iterations even with budget left", async () => {
+    // The bug at the final-verification phase: an env error must NOT enter the fix loop.
+    const runTests = sequencedRunTests([launchFail]);
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(
+      baseReq({ finalVerification: FVCFG({ maxFinalFixIterations: 3 }) }),
+      deps as never,
+    );
+    // ONE final run; the loop is skipped (ran:false) despite a budget of 3.
+    expect(runTests).toHaveBeenCalledTimes(1);
+    // Only the 2 skilled implement steps; ZERO final fix coder re-invocations.
+    expect((deps.runCoder as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+    expect(res.finalVerification).toEqual(
+      expect.objectContaining({ ran: false, passed: false, fixIterations: 0 }),
+    );
+    expect(prBody(deps)).toMatch(/Final-state re-verification: NOT-RUN/);
+    // NEVER blocks PR creation.
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+  });
+});
+
+describe("Stage A — live progress beat (was silent → looked like a frozen 'committing')", () => {
+  function collect() {
+    const events: SdlcProgress[] = [];
+    return { events, onProgress: (p: SdlcProgress) => events.push(JSON.parse(JSON.stringify(p)) as SdlcProgress) };
+  }
+
+  it("emits a final-verification beat on start and per final fix iteration", async () => {
+    const runTests = sequencedRunTests([fail, pass]); // final#0 fail → fix → re-verify pass
+    const deps = makeDeps({ runTests });
+    const { events, onProgress } = collect();
+    await runSdlcHandoff(
+      baseReq({ finalVerification: FVCFG({ maxFinalFixIterations: 2 }) }),
+      deps as never,
+      onProgress,
+    );
+    const finalBeats = events.filter((e) => e.phase === "final-verification");
+    // start test-runner(0) → fix-coder(1) → re-verify test-runner(1).
+    expect(finalBeats.map((e) => `${e.step}:${e.fixIteration}`)).toEqual([
+      "test-runner:0",
+      "fix-coder:1",
+      "test-runner:1",
+    ]);
+    // The budget rides every final beat; it carries the AP total (no single AP).
+    for (const e of finalBeats) {
+      expect(e.fixBudget).toBe(2);
+      expect(e.actionPointTotal).toBe(1);
+      expect(e.actionPointTitle).toBe("");
+    }
+  });
+
+  it("verify-only (0 fixes) still emits exactly one start beat", async () => {
+    const runTests = sequencedRunTests([pass]);
+    const deps = makeDeps({ runTests });
+    const { events, onProgress } = collect();
+    await runSdlcHandoff(
+      baseReq({ finalVerification: FVCFG({ maxFinalFixIterations: 0 }) }),
+      deps as never,
+      onProgress,
+    );
+    const finalBeats = events.filter((e) => e.phase === "final-verification");
+    expect(finalBeats.map((e) => `${e.step}:${e.fixIteration}`)).toEqual(["test-runner:0"]);
+  });
+
+  it("NO callback ⇒ the final phase is a complete no-op (never throws)", async () => {
+    const runTests = sequencedRunTests([fail, pass]);
+    const deps = makeDeps({ runTests });
+    // No onProgress passed — must not throw and must still produce the final verification.
+    const res = await runSdlcHandoff(
+      baseReq({ finalVerification: FVCFG({ maxFinalFixIterations: 1 }) }),
+      deps as never,
+    );
+    expect(res.finalVerification).toEqual(expect.objectContaining({ passed: true, fixIterations: 1 }));
   });
 });
 

--- a/tests/unit/sdlc/test-runner.test.ts
+++ b/tests/unit/sdlc/test-runner.test.ts
@@ -290,11 +290,53 @@ describe("runTests / verifyInWorktree — degrade, never throw", () => {
     expect(res.exitCode).toBeNull();
   });
 
+  it("a LAUNCH failure (spawn ENOENT — binary not found) ⇒ ran:false + an env-error summary", async () => {
+    // The reported bug: `uv` not installed ⇒ Node emits an 'error' event with
+    // code:'ENOENT'. The child NEVER executed, so ran MUST be false (indistinguishable-
+    // from-a-test-failure was the bug) and the summary must read as an ENV problem.
+    const err = Object.assign(new Error("spawn uv ENOENT"), { code: "ENOENT" });
+    const { fn } = makeSpawn({ emitError: err });
+    const res = await runTests({ worktreeDir: WT, command: CMD, spawnFn: fn });
+    expect(res.passed).toBe(false);
+    expect(res.ran).toBe(false); // ← could NOT run; not a test failure
+    expect(res.exitCode).toBeNull();
+    expect(res.summary).toMatch(/could not be launched/i);
+    expect(res.summary).toMatch(/spawn uv ENOENT/);
+    expect(res.summary).toMatch(/fix the environment or config testCommand/);
+  });
+
+  it("a LAUNCH failure (spawn EACCES — not executable) ⇒ ran:false", async () => {
+    const err = Object.assign(new Error("spawn ./x EACCES"), { code: "EACCES" });
+    const { fn } = makeSpawn({ emitError: err });
+    const res = await runTests({ worktreeDir: WT, command: CMD, spawnFn: fn });
+    expect(res.ran).toBe(false);
+    expect(res.summary).toMatch(/could not be launched/i);
+  });
+
+  it("a POST-LAUNCH error event (no launch errno) ⇒ ran:true (the child DID start)", async () => {
+    // An 'error' event WITHOUT ENOENT/EACCES fires only after the child started (e.g.
+    // an I/O error mid-run). It ran ⇒ ran:true, NEVER misclassified as an env error —
+    // the STRICT spawn-level rule is what protects a legitimate harness crash.
+    const err = Object.assign(new Error("read EIO"), { code: "EIO" });
+    const { fn } = makeSpawn({ emitError: err });
+    const res = await runTests({ worktreeDir: WT, command: CMD, spawnFn: fn });
+    expect(res.ran).toBe(true);
+    expect(res.summary).not.toMatch(/could not be launched/i);
+  });
+
   it("a synchronous spawn throw ⇒ passed:false, ran:false", async () => {
     const { fn } = makeSpawn({ throwOnSpawn: new Error("bad binary") });
     const res = await runTests({ worktreeDir: WT, command: CMD, spawnFn: fn });
     expect(res.passed).toBe(false);
     expect(res.ran).toBe(false);
+  });
+
+  it("a synchronous spawn throw WITH a launch errno ⇒ ran:false + env-error summary", async () => {
+    const err = Object.assign(new Error("spawn uv ENOENT"), { code: "ENOENT" });
+    const { fn } = makeSpawn({ throwOnSpawn: err });
+    const res = await runTests({ worktreeDir: WT, command: CMD, spawnFn: fn });
+    expect(res.ran).toBe(false);
+    expect(res.summary).toMatch(/could not be launched/i);
   });
 
   it("verifyInWorktree with NO resolvable command ⇒ ran:false, passed:false (not verified)", async () => {

--- a/tests/unit/sdlc/verification-loop.test.ts
+++ b/tests/unit/sdlc/verification-loop.test.ts
@@ -61,6 +61,15 @@ const baseReq = (over: Partial<SdlcHandoffRequest> = {}): SdlcHandoffRequest => 
 const pass: TestRunResult = { passed: true, ran: true, summary: "PASSED\nall green", exitCode: 0, timedOut: false };
 const fail: TestRunResult = { passed: false, ran: true, summary: "FAILED (exit 1)\n1 failing", exitCode: 1, timedOut: false };
 const notRun: TestRunResult = { passed: false, ran: false, summary: "not verified — no test command", exitCode: null, timedOut: false };
+/** The reported bug's shape: the test command could NOT be LAUNCHED (env broken —
+ *  `uv` not installed). ran:false ⇒ the fix loop must be SKIPPED (no code fixes this). */
+const launchFail: TestRunResult = {
+  passed: false,
+  ran: false,
+  summary: "test command could not be launched (spawn uv ENOENT) — fix the environment or config testCommand",
+  exitCode: null,
+  timedOut: false,
+};
 
 function makeGitRaw() {
   return vi.fn(async (_repo: string, args: string[]) => {
@@ -172,6 +181,51 @@ describe("Stage 2b — bounded code→test→fix loop", () => {
     // Only the initial verify ran; the budget guard stopped before any fix re-invoke.
     expect(runTests).toHaveBeenCalledTimes(1);
     expect((deps.runCoder as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2); // steps only, no fixes
+  });
+});
+
+describe("Stage 2b — launch failure (ran:false) SKIPS the fix loop", () => {
+  it("a spawn-ENOENT (could-not-run) burns ZERO fix iterations even with budget left", async () => {
+    // The bug: an env error (ran:false) looked like a test failure, so the fix-coder
+    // burned its whole budget. With a HEALTHY budget of 3, a not-run result must skip
+    // the loop entirely: NO fix coder runs, NO re-verify, verification.ran:false.
+    const runTests = sequencedRunTests([launchFail]);
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(baseReq({ verification: VCFG({ maxFixIterations: 3 }) }), deps as never);
+
+    // Exactly ONE test run — the initial one — then the loop is skipped (no re-verify).
+    expect(runTests).toHaveBeenCalledTimes(1);
+    // Only the 2 skilled implement steps ran; ZERO fix-coder re-invocations.
+    expect((deps.runCoder as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+    // The Draft PR still opens (never blocked) and the env reason is surfaced verbatim.
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+    const prBody = (deps.openPr as ReturnType<typeof vi.fn>).mock.calls[0][1].body as string;
+    expect(prBody).toMatch(/could not be launched/i);
+    expect(prBody).toMatch(/spawn uv ENOENT/);
+  });
+
+  it("CONTRAST: a non-zero test EXIT (ran:true) DOES enter the fix loop", async () => {
+    // A test that ran and failed is a NORMAL signal — the fix loop must still engage.
+    const runTests = sequencedRunTests([fail, pass]); // ran:true fail → fix → pass
+    const deps = makeDeps({ runTests });
+    await runSdlcHandoff(baseReq({ verification: VCFG({ maxFixIterations: 3 }) }), deps as never);
+    // 2 skilled steps + 1 fix re-invocation (the ran:true failure engaged the loop).
+    expect((deps.runCoder as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(3);
+    expect(runTests).toHaveBeenCalledTimes(2); // initial + one re-verify
+  });
+
+  it("emits NO fix-coder progress beat for a launch failure", async () => {
+    const runTests = sequencedRunTests([launchFail]);
+    const deps = makeDeps({ runTests });
+    const events: SdlcProgress[] = [];
+    await runSdlcHandoff(
+      baseReq({ verification: VCFG({ maxFixIterations: 3 }) }),
+      deps as never,
+      (p) => events.push(JSON.parse(JSON.stringify(p)) as SdlcProgress),
+    );
+    // The initial test-runner beat fires; NO fix-coder beat (the loop never ran).
+    expect(events.some((e) => e.step === "test-runner")).toBe(true);
+    expect(events.some((e) => e.step === "fix-coder")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

A test-runner **launch failure** (the child process never executed — e.g. `spawn uv ENOENT` when `uv` is not installed) was being surfaced with `ran: true`, making an **environment error indistinguishable from a test failure**. The per-AP and final-verification fix loops then burned their whole coder budget "fixing" code that was never tested, and the criterion reported a false "tests failing" signal.

### Trial evidence (live loop `f6664c1a` on Omniscience)
Config `testCommand` was `uv run pytest -x -q`, but `uv` was not installed. Every criterion in the execution trace ended:

```
method=test-run ran=True passed=False fixIterations=3 summary="spawn uv ENOENT"
```

The final-verification phase burned its fix attempt on the same error. **10 coder invocations wasted** on an error no code change can fix.

## The classification rule (the one behavior change)

A **spawn-LAUNCH failure** = the child process **never started**: the OS could not exec the binary. Node signals this via the ChildProcess `error` event (or a synchronous `spawn` throw) with an errno `code` of **`ENOENT`** (binary not found on PATH) or **`EACCES`** (found but not executable / permission denied).

- This is **strictly distinct** from a test that RAN and then failed: a non-zero exit arrives on the **`close` event with a numeric `exitCode`** and never touches the classification → it still enters the fix loop, unchanged.
- A test-harness crash (segfault / uncaught throw) likewise exits non-zero **after** launching — **not** a launch failure.
- A post-launch `error` event without a launch errno (e.g. an I/O error mid-run) keeps `ran: true`.

Keeping the rule to those two spawn-time errnos is exactly what prevents misclassifying a legitimate test failure as an env error.

### What changed
1. **Classify launch failures** (`server/services/sdlc/test-runner.ts`): the spawn `error` handler and the synchronous-throw path now detect `ENOENT`/`EACCES` and return `ran: false` with the summary `test command could not be launched (spawn uv ENOENT) — fix the environment or config testCommand`.
2. **Skip the fix loop when `ran === false`** (`server/services/sdlc/executor.ts`): both `runVerifyFixLoop` (per-AP) and `runFinalVerification` (final) gain a `result.ran &&` guard on the loop — a result that could not RUN records **not-verified, zero fix iterations** (the same convention as the existing no-test-command path). **This is the single behavior change.** It is safe: an env error previously produced up to 3 useless coder runs per criterion and a false "tests failed" signal; now it short-circuits to an honest "could not run — fix the environment" verdict. No FSM change; the Draft PR still opens at the unchanged human gate.
3. **PR-body flag** now surfaces the criterion's own not-run reason (launch failure vs. no test command) instead of always claiming "no test command".

## Beat decision — new `phase: "final-verification"`

The final-verification phase (Stage A whole-suite re-run, after the last AP commit but before the push) previously emitted **no** progress beat, so the UI showed a frozen `committing…`.

I **extended the `phase` union with `"final-verification"`** rather than reusing `phase:"committing"`. Reusing `committing` is exactly what the UI already (mis)renders as the frozen "Коммичу…" line (`humanizeDevPhase` ignores `step` for that phase), so it would not fix the perceived freeze. A distinct phase lets the client render a live, dedicated line and reuse the existing `step` (`test-runner`/`fix-coder`) + `fixIteration`/`fixBudget` fields.

Additive / display-only and old-snapshot compatible: the field stays optional, and an older client falls through the `switch` default to the generic "developing…" line. A beat fires on final-verification start and per final fix iteration.

## Test evidence

`npm run check` clean; full unit suite **green (4845 passed, 245 files)** — no pre-existing flakes surfaced. New tests (11):

- **test-runner**: spawn-`ENOENT` → `ran:false` + env-error summary; spawn-`EACCES` → `ran:false`; a **post-launch** error event (no launch errno) → `ran:true` (the strict-rule guard); synchronous throw with a launch errno → `ran:false`.
- **per-AP (verification-loop)**: spawn-ENOENT with `maxFixIterations:3` burns **zero** fix iterations / zero fix-coder runs; **contrast** — a non-zero exit (`ran:true`) DOES enter the loop; no `fix-coder` progress beat is emitted for a launch failure.
- **final-verification**: spawn-ENOENT with `maxFinalFixIterations:3` → zero final fixes, NOT-RUN; the new final-verification beat fires on start + per fix iteration (with budget/AP-total); verify-only emits exactly one start beat; no-callback is a complete no-op.

## Constraints

Additive/display-only beat; the `ran:false` classification changes only the wasted-fix-loop behavior; no FSM changes; conventional commit, no AI/Co-Authored-By trailers. **Draft PR — do not merge.**
