### PR TITLE
fix: preflight web_search availability for the research archetype

### DIFF
--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -566,6 +566,19 @@ export class ConsiliumLoopController {
     return cfg.enabled && cfg.implement.enabled && cfg.implement.research.enabled;
   }
 
+  /**
+   * Preflight (bug #4) for the research archetype's ONLY tool, web_search. TRUE when
+   * its research-grade backend — Tavily — has an API key. web_search's DuckDuckGo
+   * fallback needs no key, but its instant-answer API is degenerate for research
+   * queries (live trial ac1cba9c: unconfigured Tavily ⇒ a BLIND report), so the
+   * research archetype is treated as unusable without Tavily. Keys off the EXISTING
+   * providers.tavily.apiKey — no new config surface. Optional-chained so a hand-built
+   * test config that omits `providers` degrades to "unconfigured" (never throws).
+   */
+  private webSearchConfigured(): boolean {
+    return Boolean(this.deps.config().providers?.tavily?.apiKey?.trim());
+  }
+
   /** Structured controller log — one line per decision (loopId-scoped). */
   private log(loopId: string, msg: string): void {
     // eslint-disable-next-line no-console
@@ -1180,6 +1193,21 @@ export class ConsiliumLoopController {
       }
       if (!this.deps.gateway) {
         return { prRef: null, headCommit: "", error: "research gateway unavailable" };
+      }
+      // Preflight (bug #4): the research runner's ONLY tool is web_search, whose
+      // research-grade backend is Tavily. If Tavily is unconfigured the model would
+      // research BLIND and emit a report with a WRONG reason after a full LLM run
+      // (live trial ac1cba9c). Fail soft BEFORE any gateway call with a PRECISE loop
+      // error — SAME convention as the disabled guards above (an INERT no-PR result
+      // the dev_completed event carries as `error`; NO FSM change, NO LLM calls).
+      if (!this.webSearchConfigured()) {
+        return {
+          prRef: null,
+          headCommit: "",
+          error:
+            "research archetype unavailable: web_search tool is not configured " +
+            "(providers.tavily.apiKey missing)",
+        };
       }
       const runResearch = this.deps.runResearch ?? runResearchHandoff;
       const group = await this.storage.getTaskGroup(loop.groupId);

--- a/server/services/research/research-runner.ts
+++ b/server/services/research/research-runner.ts
@@ -89,6 +89,49 @@ export interface ResearchRunnerDeps {
   now?: () => number;
 }
 
+// ─── web_search unconfigured backstop (bug #4) ───────────────────────────────
+
+/**
+ * The marker web-search.ts surfaces when its research-grade backend (Tavily) has
+ * NO API key: `searchWithTavily` throws `"No Tavily API key"`, the handler falls
+ * back to DuckDuckGo, and when THAT also yields nothing the tool result carries
+ * this exact substring. DuckDuckGo's instant-answer API is a degenerate fallback
+ * (essentially empty for research queries), so an all-marker research step means
+ * the model is researching BLIND. We short-circuit rather than let synthesize/
+ * verify narrate a guessed report with a WRONG reason (live trial ac1cba9c).
+ */
+export const TAVILY_UNCONFIGURED_MARKER = "No Tavily API key";
+
+function toolCallEntryName(entry: unknown): string {
+  const e = entry as { call?: { name?: unknown } };
+  return typeof e?.call?.name === "string" ? e.call.name : "";
+}
+
+function toolCallEntryContent(entry: unknown): string {
+  const e = entry as { result?: { content?: unknown } };
+  return typeof e?.result?.content === "string" ? e.result.content : "";
+}
+
+/**
+ * Backstop detector: TRUE iff web_search was attempted at least once in this step
+ * AND every attempt surfaced the unconfigured-tool marker. This is the PRECISE
+ * blind-research signal — a genuinely-empty DuckDuckGo result does NOT carry the
+ * marker, so it never misfires on legitimately empty searches.
+ */
+export function allWebSearchCallsUnconfigured(toolCallLog: readonly unknown[]): boolean {
+  const webCalls = (toolCallLog ?? []).filter((e) => toolCallEntryName(e) === "web_search");
+  if (webCalls.length === 0) return false;
+  return webCalls.every((e) => toolCallEntryContent(e).includes(TAVILY_UNCONFIGURED_MARKER));
+}
+
+/** Sentinel thrown mid-pipeline when web_search is unconfigured (Tavily key missing). */
+class WebSearchUnconfiguredError extends Error {
+  constructor() {
+    super("web_search unconfigured");
+    this.name = "WebSearchUnconfiguredError";
+  }
+}
+
 // ─── Bounds / clamps ─────────────────────────────────────────────────────────
 
 /** Whole-run wall-clock deadline — mirrors the executor's WHOLE_RUN_BUDGET_MS (2h). */
@@ -312,7 +355,17 @@ class ResearchRun {
   ) {}
 
   async execute(): Promise<DevCloseoutResult> {
-    let report = await this.researchAndSynthesize();
+    let report: ResearchReport;
+    try {
+      report = await this.researchAndSynthesize();
+    } catch (err) {
+      // Backstop (bug #4): the research step ran BLIND — web_search is unconfigured.
+      // Skip synthesize/verify and emit a report with an ACCURATE reason instead of
+      // the model's guessed narration. Config is fixed for the run, so only the first
+      // research step needs guarding (a later re-research can't become unconfigured).
+      if (err instanceof WebSearchUnconfiguredError) return this.unconfiguredResult();
+      throw err;
+    }
     let evidence = await this.verify(report);
     let uncited = this.uncited(evidence);
 
@@ -350,6 +403,12 @@ class ResearchRun {
       options: { toolChoice: "auto" },
       maxIterations: this.maxIterations,
     });
+    // Backstop (bug #4): if EVERY web_search call in this step failed because the
+    // tool is unconfigured (Tavily key missing), the model researched BLIND — abort
+    // BEFORE the synthesize call so we never burn tokens narrating a guessed report.
+    if (allWebSearchCallsUnconfigured(draft.toolCallLog)) {
+      throw new WebSearchUnconfiguredError();
+    }
     const synth = await this.deps.gateway.completeWithTools({
       modelSlug: this.deps.config.model,
       messages: [
@@ -405,6 +464,31 @@ class ResearchRun {
 
   private uncited(evidence: CriterionEvidence[]): string[] {
     return evidence.filter((e) => !e.cited).map((e) => e.criterion);
+  }
+
+  /**
+   * Short-circuit result (bug #4) when web_search is unconfigured: a FLAGGED report
+   * whose recommendation states the ACCURATE reason (tool unconfigured — NOT a
+   * permissions problem, NOT a substantive finding), plus a matching digest so the
+   * judge is grounded in the truth. Mirrors the normal result shape (prRef null).
+   */
+  private unconfiguredResult(): DevCloseoutResult {
+    const report = clampReport({
+      question: clamp(this.req.objective, QUESTION_MAX),
+      recommendation:
+        "No recommendation: web research could not run because the web_search tool is " +
+        "not configured (providers.tavily.apiKey missing). This is a tooling gap, not a " +
+        "finding — configure the Tavily API key and re-run the research archetype.",
+      claims: [],
+      sources: [],
+      verdict: "flagged",
+      generatedAt: new Date().toISOString(),
+    });
+    const digest =
+      "web-evidence: web_search unconfigured (providers.tavily.apiKey missing) — " +
+      "FLAGGED, no web evidence gathered.";
+    const executionTrace = buildResearchTrace("research", [], report);
+    return { prRef: null, headCommit: "", report, testSummary: digest, executionTrace };
   }
 
   /** The convergence DIGEST written to `testSummary` (grounds the judge). */

--- a/tests/unit/consilium/loop-research-wire.test.ts
+++ b/tests/unit/consilium/loop-research-wire.test.ts
@@ -92,12 +92,17 @@ interface CfgOver {
   loopEnabled?: boolean;
   implementEnabled?: boolean;
   researchEnabled?: boolean;
+  /** Whether providers.tavily.apiKey is set (research web_search preflight, bug #4). */
+  tavilyKey?: boolean;
 }
 const makeConfig =
   (o: CfgOver = {}) =>
   () =>
     ({
       features: { sandbox: { enabled: false } },
+      // web_search's research-grade backend. Present by default so the research
+      // archetype's preflight (bug #4) passes; toggled off to assert it blocks.
+      providers: { tavily: { apiKey: o.tavilyKey === false ? undefined : "tvly-test-key" } },
       pipeline: {
         consiliumLoop: {
           enabled: o.loopEnabled ?? true,
@@ -209,6 +214,58 @@ describe("Stage 3 kill-switch — disabled research is INERT and never the coder
     await flush();
     expect(runResearch).not.toHaveBeenCalled();
     expect(runSdlc).not.toHaveBeenCalled();
+  });
+});
+
+describe("Stage 3 web_search preflight (bug #4) — no Tavily key ⇒ fail soft, no LLM", () => {
+  it("research enabled but providers.tavily.apiKey missing ⇒ INERT precise error; NO gateway call", async () => {
+    const loop = makeLoop({ state: "deciding", round: 2, archetype: "research" });
+    const { storage } = fakeStorage(loop);
+    const runResearch = vi.fn(async () => ({ prRef: null, headCommit: "", report: REPORT, testSummary: "x" }));
+    const runSdlc = vi.fn(async () => ({ prRef: null, headCommit: "" }));
+    // A real gateway whose completeWithTools MUST NOT be reached (assert via the spy).
+    const gw = gateway();
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: orchestrator(),
+      config: makeConfig({ tavilyKey: false }),
+      gateway: gw,
+      readIterationVerdict: async () => verdict(2),
+      runResearch: runResearch as never,
+      runSdlc: runSdlc as never,
+    });
+    // Tick until the background closeout settles and dev_completed drives the loop to
+    // awaiting_merge (carrying the error) — bounded so a hang can't spin forever.
+    for (let i = 0; i < 5 && (await storage.getLoop(loop.id)).state !== "awaiting_merge"; i++) {
+      await controller.tick(loop.id);
+      await flush();
+    }
+    // The preflight blocked dispatch BEFORE any research/LLM work.
+    expect(runResearch).not.toHaveBeenCalled();
+    expect(runSdlc).not.toHaveBeenCalled();
+    expect((gw as { completeWithTools: ReturnType<typeof vi.fn> }).completeWithTools).not.toHaveBeenCalled();
+    // The loop still advanced via dev_completed carrying the PRECISE error.
+    const l = await storage.getLoop(loop.id);
+    expect(l.state).toBe("awaiting_merge");
+    expect(l.error).toContain("web_search tool is not configured");
+    expect(l.error).toContain("providers.tavily.apiKey missing");
+  });
+
+  it("research enabled WITH a Tavily key ⇒ today's path unchanged (runResearch called)", async () => {
+    const loop = makeLoop({ state: "deciding", round: 2, archetype: "research" });
+    const { storage } = fakeStorage(loop);
+    const runResearch = vi.fn(async () => ({ prRef: null, headCommit: "", report: REPORT, testSummary: "x" }));
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: orchestrator(),
+      config: makeConfig({ tavilyKey: true }),
+      gateway: gateway(),
+      readIterationVerdict: async () => verdict(2),
+      runResearch: runResearch as never,
+    });
+    await controller.tick(loop.id);
+    await flush();
+    expect(runResearch).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/unit/research/research-runner.test.ts
+++ b/tests/unit/research/research-runner.test.ts
@@ -137,6 +137,51 @@ describe("runResearchHandoff — NEVER throws (degrade-not-throw)", () => {
   });
 });
 
+describe("runResearchHandoff — web_search unconfigured backstop (bug #4)", () => {
+  /** A tool log whose every web_search call carries the unconfigured-Tavily marker. */
+  const unconfiguredLog = (n = 2) =>
+    Array.from({ length: n }, (_, i) => ({
+      iteration: i + 1,
+      call: { id: `c${i}`, name: "web_search", arguments: { query: "q" } },
+      result: { toolCallId: `c${i}`, content: "Search failed. Tavily: No Tavily API key. DuckDuckGo: API error 502", isError: false },
+    }));
+
+  it("short-circuits synthesize/verify with an ACCURATE flagged report when web_search is unconfigured", async () => {
+    const spy = vi.fn(async () => ({ content: "draft", tokensUsed: 1, toolCallLog: unconfiguredLog() as unknown[] }));
+    const gateway: ResearchGateway = { completeWithTools: spy };
+    const res = await runResearchHandoff(baseReq(), { gateway, config: cfg(), webSearchTool: WEB_SEARCH });
+
+    // Only the research step ran — synthesize + verify were SKIPPED (no wasted LLM run).
+    expect(spy).toHaveBeenCalledTimes(1);
+    const report = res.report as ResearchReport;
+    expect(report).toBeDefined();
+    expect(report.verdict).toBe("flagged");
+    expect(report.claims).toHaveLength(0);
+    expect(report.sources).toHaveLength(0);
+    // The reason is ACCURATE (tool unconfigured), NOT the model's wrong "permissions" guess.
+    expect(report.recommendation).toContain("web_search tool is");
+    expect(report.recommendation).toContain("providers.tavily.apiKey");
+    expect(report.recommendation).not.toMatch(/permission/i);
+    expect(res.testSummary).toContain("unconfigured");
+    expect(res.prRef).toBeNull();
+  });
+
+  it("does NOT misfire when web_search returns genuinely-empty (non-marker) results", async () => {
+    const emptyLog = [{ iteration: 1, call: { id: "c0", name: "web_search", arguments: {} }, result: { toolCallId: "c0", content: "No results found via DuckDuckGo.", isError: false } }];
+    const spy = vi.fn(async (p: { messages: Array<{ content: string }> }) => {
+      const sys = String(p.messages[0].content);
+      if (sys.includes("web researcher")) return { content: "draft", tokensUsed: 1, toolCallLog: emptyLog as unknown[] };
+      if (sys.includes("structured report author")) return { content: REPORT_JSON, tokensUsed: 1, toolCallLog: [] as unknown[] };
+      return { content: VERIFY_CITED, tokensUsed: 1, toolCallLog: [] as unknown[] };
+    });
+    const gateway: ResearchGateway = { completeWithTools: spy };
+    const res = await runResearchHandoff(baseReq(), { gateway, config: cfg(), webSearchTool: WEB_SEARCH });
+    // Empty results are a legitimate outcome — the normal pipeline runs to completion.
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect((res.report as ResearchReport).verdict).toBe("green");
+  });
+});
+
 describe("runResearchHandoff — web-evidence verifier tool wiring (R3) + no SSRF surface", () => {
   it("passes tools=[web_search] EXPLICITLY to the verifier — and web_search ONLY (no url_reader)", async () => {
     const { gateway, calls } = fakeGateway({ research: "draft", synthesize: REPORT_JSON, verify: VERIFY_CITED });


### PR DESCRIPTION
## Bug (#4 from Phase-0 loop trials)

The research archetype runs a full research handoff even when its **only** tool (`web_search`) is unconfigured, producing a blind report with a **misleading reason**.

### Trial evidence (live loop `ac1cba9c`)
`config.yaml` has no `providers.tavily.apiKey`. `server/tools/builtin/web-search.ts:27-28` throws `"No Tavily API key"` on every Tavily call. The research handoff (`web_search` the ONLY tool) still ran end-to-end; the model, unable to search, produced:

```json
{ "verdict": "flagged", "sources": [],
  "recommendation": "No recommendation can be made — ... session lacked granted permission for WebSearch and WebFetch ..." }
```

An honest refusal with a **WRONG reason** (it is not a permissions problem — the tool is unconfigured), after burning the full LLM run.

## The seam

The research runner's **only** tool is `web_search` (`research-runner.ts`: `tools = [webSearch]`; `url_reader` deliberately excluded). `web_search`'s research-grade backend is **Tavily**; its DuckDuckGo fallback needs no key but its instant-answer API is degenerate for research queries — the trial's blind report *is* the DDG-empty outcome. So "web_search is research-usable" ⇔ `providers.tavily.apiKey` is set. The gate keys off that **existing** config value (no new keys), via the controller's injectable `config()` seam.

## Change (minimal, no FSM change)

1. **Controller preflight** (`consilium-loop-controller.ts`, `closeout()` research branch): before dispatching the research handoff, `webSearchConfigured()` checks `config().providers?.tavily?.apiKey`. If unset → fail soft with a precise loop error — `research archetype unavailable: web_search tool is not configured (providers.tavily.apiKey missing)` — mirroring the existing `dev_completed` fail-soft convention used for "implement path disabled by config". **No gateway/LLM calls are made.**
2. **Runner backstop** (`research-runner.ts`): if **every** `web_search` call in the research step surfaces the unconfigured marker (`"No Tavily API key"`), short-circuit synthesize/verify and emit a `flagged` report with an **accurate** reason (tool unconfigured), instead of letting the model narrate its own guess. The marker match is precise, so a genuinely-empty search result never misfires.

Keys off the **existing** `providers.tavily.apiKey`. No new config keys. No FSM changes. `executor.ts` (PR #444's zone) untouched.

## Adversarial self-review

- **Risk: blocking research when an alternative web tool exists.** Checked — `web_search` is genuinely the runner's only research tool (`url_reader` excluded by design). The DuckDuckGo fallback needs no key but is a degenerate instant-answer backend (the trial's blind report is the DDG-empty path), so gating on Tavily = gating on the tool the runner actually uses being research-usable. Documented in-code.
- **Backstop precision:** fires only on the `"No Tavily API key"` marker; a legitimately-empty DuckDuckGo result (`"No results found via DuckDuckGo."`) does **not** carry it → the normal pipeline runs to completion (covered by a test).
- **No web_search attempts** ⇒ backstop returns false (no misfire).

## Test evidence

- **Preflight** (`loop-research-wire.test.ts`): no Tavily key ⇒ dispatch blocked, `runResearch`/`runSdlc`/gateway **never called** (asserted via injected fakes), loop advances to `awaiting_merge` carrying the precise error. Tavily key present ⇒ today's path unchanged (`runResearch` called).
- **Backstop** (`research-runner.test.ts`): all-unconfigured tool log ⇒ synthesize/verify skipped (gateway called once), flagged report with accurate reason, no "permission" wording; genuinely-empty results ⇒ full pipeline runs, verdict green.
- `npm run check` (tsc) clean.
- Full unit suite: **4838 passed / 245 files, 0 failures** (the known providers/antigravity flakes did not surface this run).