### PR TITLE
chore: translate all user-facing strings to English

### DIFF
--- a/client/src/components/consilium/new-review-dialog.tsx
+++ b/client/src/components/consilium/new-review-dialog.tsx
@@ -472,8 +472,8 @@ export function NewConsiliumReviewDialog({
           <div className="space-y-2">
             <div className="flex items-baseline justify-between gap-2">
               <Label htmlFor="new-review-engineer-instruction">
-                Инструкции инженеру{" "}
-                <span className="text-muted-foreground">(тон/требования для оценки)</span>
+                Instructions to the engineer{" "}
+                <span className="text-muted-foreground">(tone / requirements for the evaluation)</span>
               </Label>
               <span
                 className={
@@ -490,13 +490,13 @@ export function NewConsiliumReviewDialog({
               id="new-review-engineer-instruction"
               value={engineerInstruction}
               onChange={(e) => setEngineerInstruction(e.target.value)}
-              placeholder="Напр.: оценивай строго по безопасности; требуй тесты на каждый P0; тон — без воды."
+              placeholder="E.g.: evaluate strictly on security; require tests for every P0; keep the tone concise."
               rows={3}
               data-testid="new-review-engineer-instruction"
             />
             {engineerInstruction.length > MAX_INSTRUCTION_LEN && (
               <p className="text-xs text-destructive">
-                Слишком длинно — сервер примет не более {MAX_INSTRUCTION_LEN} символов.
+                Too long — the server accepts at most {MAX_INSTRUCTION_LEN} characters.
               </p>
             )}
           </div>

--- a/client/src/components/pipeline/current-runs-rail.tsx
+++ b/client/src/components/pipeline/current-runs-rail.tsx
@@ -1,7 +1,7 @@
 /**
  * CurrentRunsRail — the left rail on the Pipelines page listing the actual
  * pipeline RUNS (not definitions). This is where action points handed off from
- * a planning verdict (VerdictPanel → "Передать в пайплайн") show up once they
+ * a planning verdict (VerdictPanel → "Hand off to pipeline") show up once they
  * start executing.
  *
  * Active runs (running / queued / paused) float to the top; finished runs follow
@@ -28,19 +28,19 @@ interface PipelineRun {
 }
 
 const STATUS: Record<string, { dot: string; label: string; text: string }> = {
-  running: { dot: "bg-blue-500 animate-pulse", label: "идёт", text: "text-blue-600 dark:text-blue-400" },
-  queued: { dot: "bg-amber-500", label: "в очереди", text: "text-amber-600 dark:text-amber-400" },
-  paused: { dot: "bg-violet-500", label: "пауза", text: "text-violet-600 dark:text-violet-400" },
-  completed: { dot: "bg-green-500", label: "готово", text: "text-green-600 dark:text-green-400" },
-  failed: { dot: "bg-red-500", label: "ошибка", text: "text-red-600 dark:text-red-400" },
-  cancelled: { dot: "bg-slate-400", label: "отменён", text: "text-muted-foreground" },
+  running: { dot: "bg-blue-500 animate-pulse", label: "running", text: "text-blue-600 dark:text-blue-400" },
+  queued: { dot: "bg-amber-500", label: "queued", text: "text-amber-600 dark:text-amber-400" },
+  paused: { dot: "bg-violet-500", label: "paused", text: "text-violet-600 dark:text-violet-400" },
+  completed: { dot: "bg-green-500", label: "done", text: "text-green-600 dark:text-green-400" },
+  failed: { dot: "bg-red-500", label: "failed", text: "text-red-600 dark:text-red-400" },
+  cancelled: { dot: "bg-slate-400", label: "cancelled", text: "text-muted-foreground" },
 };
 
 const ACTIVE = new Set(["running", "queued", "paused"]);
 
 /** A run's display title: handoff runs store JSON input ({feature,source,…}). */
 function runTitle(input: string | null): string {
-  if (!input) return "Запуск пайплайна";
+  if (!input) return "Pipeline run";
   try {
     const o = JSON.parse(input) as Record<string, unknown>;
     const feature = typeof o.feature === "string" ? o.feature : "";
@@ -84,9 +84,9 @@ export function CurrentRunsRail({
   async function copyId(e: React.MouseEvent, id: string) {
     e.stopPropagation(); // don't navigate when copying
     if (await copyText(id)) {
-      toast({ title: "ID скопирован", description: id });
+      toast({ title: "ID copied", description: id });
     } else {
-      toast({ variant: "destructive", title: "Не удалось скопировать ID" });
+      toast({ variant: "destructive", title: "Couldn't copy ID" });
     }
   }
 
@@ -109,9 +109,9 @@ export function CurrentRunsRail({
       <div className="h-16 border-b border-border flex items-center gap-2 px-4 shrink-0">
         <Activity className="h-4 w-4 text-primary" />
         <div className="min-w-0">
-          <h3 className="text-sm font-semibold leading-tight">Текущие пайплайны</h3>
+          <h3 className="text-sm font-semibold leading-tight">Current pipelines</h3>
           <p className="text-[11px] text-muted-foreground">
-            {activeCount > 0 ? `${activeCount} активных` : "Запуски пайплайнов"}
+            {activeCount > 0 ? `${activeCount} active` : "Pipeline runs"}
           </p>
         </div>
       </div>
@@ -120,16 +120,16 @@ export function CurrentRunsRail({
         {isLoading && (
           <div className="flex items-center justify-center py-10 text-muted-foreground text-xs gap-2">
             <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            Загрузка…
+            Loading…
           </div>
         )}
 
         {!isLoading && runs.length === 0 && (
           <div className="px-4 py-10 text-center">
-            <p className="text-xs text-muted-foreground">Активных запусков нет</p>
+            <p className="text-xs text-muted-foreground">No active runs</p>
             <p className="text-[11px] text-muted-foreground/70 mt-1">
-              Передайте action points из вердикта планирования в пайплайн — запуски
-              появятся здесь.
+              Hand off action points from a planning verdict to the pipeline —
+              runs will show up here.
             </p>
           </div>
         )}
@@ -161,7 +161,7 @@ export function CurrentRunsRail({
                       onKeyDown={(e) => {
                         if (e.key === "Enter" || e.key === " ") copyId(e as unknown as React.MouseEvent, run.id);
                       }}
-                      title={`${run.id} — кликните, чтобы скопировать`}
+                      title={`${run.id} — click to copy`}
                       className="font-mono text-[10px] text-muted-foreground hover:text-foreground cursor-pointer"
                     >
                       #{run.id.slice(0, 8)}

--- a/client/src/components/settings/LocalModelsSection.tsx
+++ b/client/src/components/settings/LocalModelsSection.tsx
@@ -35,8 +35,8 @@ export function LocalModelsSection({
       storageKey="settings-section-local-models"
       title={LOCAL_MODELS_SECTION_TITLE}
       icon={<Cpu className="h-4 w-4" />}
-      shortDescription="vLLM, Ollama и LM Studio — медленные, выключены по умолчанию."
-      longDescription="Локальные провайдеры (vLLM, Ollama, LM Studio) не активны, пока не задан endpoint. Они скрыты под этим блоком, чтобы не мешать облачным моделям. Сохранённые endpoint'ы не удаляются — раскройте блок и включите провайдер, чтобы вернуть прежнее поведение."
+      shortDescription="vLLM, Ollama, and LM Studio — slow, disabled by default."
+      longDescription="Local providers (vLLM, Ollama, LM Studio) stay inactive until an endpoint is set. They are tucked under this section so they don't clutter the cloud models. Saved endpoints are not deleted — expand this section and enable a provider to restore the previous behavior."
       defaultOpen={LOCAL_MODELS_SECTION_DEFAULT_OPEN}
     >
       <div className="divide-y divide-border">

--- a/client/src/components/task-groups/iterations-panel.tsx
+++ b/client/src/components/task-groups/iterations-panel.tsx
@@ -203,12 +203,12 @@ function IterationNoteEditor({
     save.mutate(note, {
       onSuccess: () => {
         setDirty(false);
-        toast({ title: "Заметка сохранена", description: "Будет учтена в следующей итерации (Run again)." });
+        toast({ title: "Note saved", description: "It will be taken into account in the next iteration (Run again)." });
       },
       onError: (e) =>
         toast({
-          title: "Не удалось сохранить заметку",
-          description: e instanceof Error ? e.message : "Ошибка",
+          title: "Couldn't save the note",
+          description: e instanceof Error ? e.message : "Error",
           variant: "destructive",
         }),
     });
@@ -219,13 +219,13 @@ function IterationNoteEditor({
       <CardHeader className="py-3 pb-1">
         <CardTitle className="flex items-center gap-2 text-sm font-medium">
           <MessageSquarePlus className="h-4 w-4" aria-hidden="true" />
-          Ваши мысли и решения
+          Your thoughts and decisions
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-2 py-2">
         <p className="text-xs text-muted-foreground">
-          Запишите выводы по этой итерации. При запуске следующей итерации («Run again») они
-          будут добавлены в контекст спора — участники и судья учтут их.
+          Jot down your takeaways from this iteration. When you start the next iteration ("Run again"),
+          they are added to the debate context — the participants and the judge will take them into account.
         </p>
         <Textarea
           value={note}
@@ -233,7 +233,7 @@ function IterationNoteEditor({
             setNote(e.target.value);
             setDirty(true);
           }}
-          placeholder="Например: судья переоценил риск X — считаю его P1; в следующем раунде сфокусируйтесь на Y…"
+          placeholder="For example: the judge overrated risk X — I consider it P1; in the next round focus on Y…"
           className="min-h-[120px] text-sm"
           data-testid="iteration-human-note"
         />
@@ -242,9 +242,9 @@ function IterationNoteEditor({
             {save.isPending ? (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
             ) : null}
-            Сохранить заметку
+            Save note
           </Button>
-          {dirty ? <span className="text-xs text-muted-foreground">Есть несохранённые изменения</span> : null}
+          {dirty ? <span className="text-xs text-muted-foreground">You have unsaved changes</span> : null}
         </div>
       </CardContent>
     </Card>

--- a/client/src/components/task-groups/verdict-panel.tsx
+++ b/client/src/components/task-groups/verdict-panel.tsx
@@ -115,15 +115,15 @@ function buildFullText(data: VerdictOutput, groupName: string, source: string): 
 
   const lines: string[] = [`# ${groupName}`];
   if (source) lines.push(`_${source}_`);
-  if (data.verdict) lines.push("", "## Вердикт", data.verdict);
-  if (data.pros.length) lines.push("", "## Плюсы", ...data.pros.map((p) => `- ${p}`));
-  if (data.cons.length) lines.push("", "## Минусы", ...data.cons.map((c) => `- ${c}`));
+  if (data.verdict) lines.push("", "## Verdict", data.verdict);
+  if (data.pros.length) lines.push("", "## Pros", ...data.pros.map((p) => `- ${p}`));
+  if (data.cons.length) lines.push("", "## Cons", ...data.cons.map((c) => `- ${c}`));
   if (data.action_points.length) {
     lines.push(
       "",
       "## Action Points",
       "",
-      "| # | Действие | Приоритет | Усилие | Обоснование | Трейд-офф |",
+      "| # | Action | Priority | Effort | Rationale | Trade-off |",
       "| --- | --- | --- | --- | --- | --- |",
       ...data.action_points.map(
         (ap, i) =>
@@ -135,7 +135,7 @@ function buildFullText(data: VerdictOutput, groupName: string, source: string): 
     if (data.action_points.some((ap) => ap.acceptanceCriterion)) {
       lines.push(
         "",
-        "## Критерии приёмки (DoD)",
+        "## Acceptance criteria (DoD)",
         ...data.action_points.map(
           (ap, i) => `${i + 1}. ${ap.acceptanceCriterion ?? "—"}`,
         ),
@@ -181,15 +181,15 @@ export function VerdictPanel({
     if (await copyText(fullText)) {
       setCopied(true);
       toast({
-        title: "Скопировано",
-        description: "Полный текст вердикта — в буфере обмена.",
+        title: "Copied",
+        description: "The full verdict text is on the clipboard.",
       });
       window.setTimeout(() => setCopied(false), 2000);
     } else {
       toast({
         variant: "destructive",
-        title: "Не удалось скопировать",
-        description: "Буфер обмена недоступен в этом контексте.",
+        title: "Couldn't copy",
+        description: "The clipboard is unavailable in this context.",
       });
     }
   }
@@ -206,15 +206,15 @@ export function VerdictPanel({
     try {
       await developLoop.mutateAsync(loopId);
       toast({
-        title: "Передано в SDLC",
-        description: "Раунд developing запущен — открываю луп для наблюдения.",
+        title: "Handed off to SDLC",
+        description: "The developing round has started — opening the loop to observe.",
       });
       navigate(`/consilium-loops/${loopId}`);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       toast({
         variant: "destructive",
-        title: "Не удалось передать в SDLC",
+        title: "Couldn't hand off to SDLC",
         description: message,
       });
     }
@@ -226,7 +226,7 @@ export function VerdictPanel({
         <div className="flex items-start justify-between gap-2">
           <CardTitle className="flex items-center gap-2 text-base">
             <Gavel className="h-4 w-4 text-primary" />
-            Вердикт планирования
+            Planning verdict
             {source && (
               <span className="text-xs font-normal text-muted-foreground">— {source}</span>
             )}
@@ -244,14 +244,14 @@ export function VerdictPanel({
             variant="outline"
             onClick={copyFullText}
             className="shrink-0"
-            title="Скопировать полный текст вердикта для передачи в работу вне multiqlti"
+            title="Copy the full verdict text to hand off to work outside multiqlti"
           >
             {copied ? (
               <Check className="mr-2 h-4 w-4 text-green-600" />
             ) : (
               <Copy className="mr-2 h-4 w-4" />
             )}
-            {copied ? "Скопировано" : "Скопировать текст"}
+            {copied ? "Copied" : "Copy text"}
           </Button>
         </div>
       </CardHeader>
@@ -267,7 +267,7 @@ export function VerdictPanel({
             {data.pros.length > 0 && (
               <div>
                 <h4 className="mb-2 flex items-center gap-1.5 text-sm font-semibold text-green-600 dark:text-green-400">
-                  <ThumbsUp className="h-4 w-4" /> Плюсы
+                  <ThumbsUp className="h-4 w-4" /> Pros
                 </h4>
                 <ul className="space-y-1 text-sm text-muted-foreground">
                   {data.pros.map((p, i) => (
@@ -282,7 +282,7 @@ export function VerdictPanel({
             {data.cons.length > 0 && (
               <div>
                 <h4 className="mb-2 flex items-center gap-1.5 text-sm font-semibold text-red-600 dark:text-red-400">
-                  <ThumbsDown className="h-4 w-4" /> Минусы
+                  <ThumbsDown className="h-4 w-4" /> Cons
                 </h4>
                 <ul className="space-y-1 text-sm text-muted-foreground">
                   {data.cons.map((c, i) => (
@@ -305,11 +305,11 @@ export function VerdictPanel({
                 <thead className="bg-muted/50 text-xs uppercase text-muted-foreground">
                   <tr>
                     <th className="px-3 py-2 text-left font-medium">#</th>
-                    <th className="px-3 py-2 text-left font-medium">Действие</th>
-                    <th className="px-3 py-2 text-left font-medium">Приоритет</th>
-                    <th className="px-3 py-2 text-left font-medium">Усилие</th>
-                    <th className="px-3 py-2 text-left font-medium">Обоснование</th>
-                    <th className="px-3 py-2 text-left font-medium">Трейд-офф</th>
+                    <th className="px-3 py-2 text-left font-medium">Action</th>
+                    <th className="px-3 py-2 text-left font-medium">Priority</th>
+                    <th className="px-3 py-2 text-left font-medium">Effort</th>
+                    <th className="px-3 py-2 text-left font-medium">Rationale</th>
+                    <th className="px-3 py-2 text-left font-medium">Trade-off</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-border">
@@ -339,7 +339,7 @@ export function VerdictPanel({
                           colSpan={5}
                         >
                           <span className="font-medium uppercase tracking-wide text-muted-foreground/70">
-                            Критерий приёмки (DoD):
+                            Acceptance criterion (DoD):
                           </span>{" "}
                           <span className="text-foreground/80">
                             {ap.acceptanceCriterion ?? "—"}
@@ -359,9 +359,9 @@ export function VerdictPanel({
             {loopId ? (
               <div className="flex flex-wrap items-center gap-2">
                 <span className="text-sm text-muted-foreground">
-                  Фаза планирования завершена. Передать action points в SDLC —
-                  исполнение пройдёт видимым раундом <code>developing</code> на
-                  консилиум-лупе:
+                  Planning phase complete. Hand off the action points to SDLC —
+                  execution runs as a visible <code>developing</code> round on the
+                  consilium loop:
                 </span>
                 <Button size="sm" onClick={handleDevelop} disabled={developLoop.isPending}>
                   {developLoop.isPending ? (
@@ -369,15 +369,15 @@ export function VerdictPanel({
                   ) : (
                     <GitPullRequest className="mr-2 h-4 w-4" />
                   )}
-                  Передать в SDLC (develop-раунд)
+                  Hand off to SDLC (develop round)
                 </Button>
               </div>
             ) : (
               <div className="flex items-start gap-2 rounded-md border border-border bg-muted/30 p-3 text-sm text-muted-foreground">
                 <Info className="h-4 w-4 shrink-0 mt-0.5" />
                 <span>
-                  Для этой группы нет консилиум-лупа — исполнение action points
-                  запускается через луп. Создание лупа из вердикта появится позже.
+                  There is no consilium loop for this group — executing action points
+                  runs through a loop. Creating a loop from the verdict will come later.
                 </span>
               </div>
             )}

--- a/client/src/lib/local-providers.ts
+++ b/client/src/lib/local-providers.ts
@@ -16,7 +16,7 @@ export const LOCAL_PROVIDER_KEYS = ["vllm", "ollama", "lmstudio"] as const;
 export type LocalProviderKey = (typeof LOCAL_PROVIDER_KEYS)[number];
 
 /** Label for the collapsible block that hides local model providers. */
-export const LOCAL_MODELS_SECTION_TITLE = "Локальные модели (экспериментально)";
+export const LOCAL_MODELS_SECTION_TITLE = "Local models (experimental)";
 
 /**
  * The local-models block is collapsed on a clean install. Persisted user

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -119,7 +119,7 @@ const PRIORITY_COLOR: Record<string, string> = {
 // Clarifies that the (intentionally red) P0 badge is a SEVERITY tier, not a
 // failure status — so a wall of red P0s reads as "these are the critical items".
 const PRIORITY_LEGEND =
-  "P0–P3 — приоритет важности (P0 = критический), не статус выполнения.";
+  "P0–P3 — priority (P0 = critical), not completion status.";
 
 /**
  * Open-P0 text colour. Mid-loop (non-terminal) an open P0 is EXPECTED
@@ -562,7 +562,7 @@ function RoundRow({
                       {ap.acceptanceCriterion && (
                         <p className="text-xs text-muted-foreground">
                           <span className="font-medium uppercase tracking-wide text-muted-foreground/70">
-                            Критерий приёмки (DoD):
+                            Acceptance criterion (DoD):
                           </span>{" "}
                           {ap.acceptanceCriterion}
                         </p>
@@ -729,7 +729,7 @@ function VerifiedMark({ verified }: { verified: boolean | undefined }) {
     return (
       <span
         className="inline-flex items-center gap-1 text-[10px] font-medium text-green-600 dark:text-green-400"
-        title="Проверено — заявление подтверждено цитируемым источником"
+        title="Verified — the claim is backed by a citable source"
       >
         <ShieldCheck className="h-3.5 w-3.5" />
         verified
@@ -740,7 +740,7 @@ function VerifiedMark({ verified }: { verified: boolean | undefined }) {
     return (
       <span
         className="inline-flex items-center gap-1 text-[10px] font-medium text-amber-600 dark:text-amber-400"
-        title="Не подтверждено цитируемым источником"
+        title="Not backed by a citable source"
       >
         <ShieldAlert className="h-3.5 w-3.5" />
         unverified
@@ -948,7 +948,7 @@ function ReportPanel({ report }: { report: ResearchReport }) {
                       </ul>
                     ) : (
                       <p className="text-xs text-muted-foreground">
-                        Источники не приведены.
+                        No sources provided.
                       </p>
                     )}
                   </li>
@@ -992,39 +992,39 @@ function ReportPanel({ report }: { report: ResearchReport }) {
 // React text; the PR link uses rel="noopener noreferrer".
 
 /**
- * Humanize the current SDLC phase into one Russian status line. Falls back to a
+ * Humanize the current SDLC phase into one English status line. Falls back to a
  * generic "developing…" whenever `devProgress` (or the specific phase) is absent.
  */
 function humanizeDevPhase(progress: DevProgress | undefined, total: number): string {
   switch (progress?.phase) {
     case "committing":
-      return "Коммичу…";
+      return "Committing…";
     case "final-verification": {
       // Stage A: whole-suite re-run against the final combined tree (+ a bounded fix
-      // loop). Distinct from `committing` so it never reads as a frozen "Коммичу…".
+      // loop). Distinct from `committing` so it never reads as a frozen "Committing…".
       const fi = progress?.fixIteration;
       const fb = progress?.fixBudget;
       if (progress?.step === "fix-coder" && typeof fi === "number" && fi > 0) {
         const budget = typeof fb === "number" ? `/${fb}` : "";
-        return `Финальная проверка: исправляю (фикс ${fi}${budget})…`;
+        return `Final verification: fixing (fix ${fi}${budget})…`;
       }
-      return "Финальная проверка всего дерева…";
+      return "Final verification of the whole tree…";
     }
     case "pushing":
-      return "Пушу ветку…";
+      return "Pushing the branch…";
     case "opening_pr":
-      return "Открываю Draft PR…";
+      return "Opening the Draft PR…";
     case "done":
-      return "Готово — Draft PR открыт.";
+      return "Done — Draft PR opened.";
     case "coding": {
       const idx = progress?.actionPointIndex;
       const pos =
         typeof idx === "number" ? `${idx + 1}${total > 0 ? `/${total}` : ""}` : "";
       const title = progress?.actionPointTitle;
-      const titlePart = title ? `: «${title}»` : "";
+      const titlePart = title ? `: "${title}"` : "";
       return pos
-        ? `Кодирую action point ${pos}${titlePart}`
-        : `Кодирую action point${titlePart}`;
+        ? `Coding action point ${pos}${titlePart}`
+        : `Coding action point${titlePart}`;
     }
     default:
       return "developing…";
@@ -1036,25 +1036,25 @@ function humanizeDevPhase(progress: DevProgress | undefined, total: number): str
 function ApStatusIcon({ status }: { status: NonNullable<DevProgress["aps"]>[number]["status"] }) {
   switch (status) {
     case "active":
-      return <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-primary" aria-label="в работе" />;
+      return <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-primary" aria-label="in progress" />;
     case "completed":
-      return <Check className="h-3.5 w-3.5 shrink-0 text-green-600" aria-label="готово" />;
+      return <Check className="h-3.5 w-3.5 shrink-0 text-green-600" aria-label="done" />;
     case "partial":
-      return <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-500" aria-label="частично" />;
+      return <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-500" aria-label="partial" />;
     case "failed":
-      return <X className="h-3.5 w-3.5 shrink-0 text-red-500" aria-label="ошибка" />;
+      return <X className="h-3.5 w-3.5 shrink-0 text-red-500" aria-label="failed" />;
     case "pending":
     default:
-      return <Clock className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-label="в очереди" />;
+      return <Clock className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-label="queued" />;
   }
 }
 
 /** Humanize the running agent/skill step for the active-row badge. */
 const DEV_STEP_LABELS: Record<NonNullable<DevProgress["step"]>, string> = {
-  "test-author": "автор тестов",
-  coder: "кодер",
-  "test-runner": "прогон тестов",
-  "fix-coder": "фикс",
+  "test-author": "test author",
+  coder: "coder",
+  "test-runner": "test run",
+  "fix-coder": "fix",
 };
 
 /**
@@ -1140,15 +1140,15 @@ function DevelopProgressPanel({
         <div className="space-y-1">
           <Progress value={pct} className="h-2" />
           <div className="text-xs tabular-nums text-muted-foreground">
-            {completed ?? 0}/{total} готово
+            {completed ?? 0}/{total} done
           </div>
         </div>
       )}
 
       <p className="text-xs leading-relaxed text-muted-foreground">
-        SDLC-агент кодит каждый action point в изолированном git-worktree, коммитит
-        по одному на пункт, затем пушит ветку и открывает Draft PR. Агенты не
-        мержат — ревью и merge за тобой.
+        The SDLC agent codes each action point in an isolated git worktree, commits
+        one per item, then pushes the branch and opens a Draft PR. The agents don't
+        merge — review and merge are up to you.
       </p>
 
       {/* Draft PR link appears once the executor has opened it (near completion). */}
@@ -1160,7 +1160,7 @@ function DevelopProgressPanel({
           className="inline-flex items-center gap-1 text-sm font-medium text-primary underline underline-offset-2"
         >
           <ExternalLink className="h-3.5 w-3.5" />
-          Открыть Draft PR
+          Open Draft PR
         </a>
       )}
     </div>
@@ -1244,7 +1244,7 @@ function PlannedArchetypeCard({
     } catch (err) {
       toast({
         variant: "destructive",
-        title: "Не удалось классифицировать",
+        title: "Couldn't classify",
         description: err instanceof Error ? err.message : String(err),
       });
     }
@@ -1261,7 +1261,7 @@ function PlannedArchetypeCard({
     } catch (err) {
       toast({
         variant: "destructive",
-        title: "Не удалось задать archetype",
+        title: "Couldn't set the archetype",
         description: err instanceof Error ? err.message : String(err),
       });
     }
@@ -1304,11 +1304,11 @@ function PlannedArchetypeCard({
         {planning && loop.archetype == null ? (
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
             <Sparkles className="h-4 w-4 animate-pulse text-primary" />
-            Классифицирую вердикт…
+            Classifying the verdict…
           </div>
         ) : loop.archetype == null ? (
           <p className="text-sm text-muted-foreground">
-            Архетип ещё не определён. Запусти классификацию или выбери вручную.
+            The archetype isn't determined yet. Run classification or pick one manually.
           </p>
         ) : (
           loop.archetypeRationale && (
@@ -1337,7 +1337,7 @@ function PlannedArchetypeCard({
             onValueChange={(v) => setChoice(v as Archetype)}
           >
             <SelectTrigger className="w-56" data-testid="archetype-select">
-              <SelectValue placeholder="Выбери archetype" />
+              <SelectValue placeholder="Pick an archetype" />
             </SelectTrigger>
             <SelectContent>
               {ARCHETYPES.map((a: Archetype) => (
@@ -1485,8 +1485,8 @@ export default function ConsiliumLoopDetail() {
     try {
       await developLoop.mutateAsync(id);
       toast({
-        title: "Передано в SDLC",
-        description: "Раунд developing запущен — следи за прогрессом ниже.",
+        title: "Handed off to SDLC",
+        description: "The developing round has started — follow the progress below.",
       });
     } catch (err) {
       // 400 (NO_ACTION_POINTS / REPO_NOT_*) | 409 (WRONG_STATE /
@@ -1558,7 +1558,7 @@ export default function ConsiliumLoopDetail() {
                 ) : (
                   <Hammer className="mr-2 h-4 w-4" />
                 )}
-                Передать в SDLC
+                Hand off to SDLC
               </Button>
             )}
             {canCancel && (

--- a/server/services/orchestrator/judge-prompt.ts
+++ b/server/services/orchestrator/judge-prompt.ts
@@ -8,13 +8,13 @@
  * `action_points`, so an unmodified judge keeps working — but a judge that
  * follows these instructions gives the FSM an authoritative signal.
  *
- * Kept in Russian to match the existing judge task descriptions / verdict UI.
+ * In English to match the product's user-facing judge descriptions / verdict UI.
  */
 export const JUDGE_CONVERGENCE_INSTRUCTIONS = `
-## Сигнал сходимости (convergence)
+## Convergence signal
 
-Дополнительно к полям verdict / pros / cons / action_points добавь в \`output\`
-объект \`convergence\`:
+In addition to the verdict / pros / cons / action_points fields, add a
+\`convergence\` object to \`output\`:
 
 \`\`\`json
 "convergence": {
@@ -27,22 +27,23 @@ export const JUDGE_CONVERGENCE_INSTRUCTIONS = `
       "effort": "...",
       "rationale": "...",
       "tradeoff": "...",
-      "acceptanceCriterion": "Когда <условие>, тогда <проверяемый результат>"
+      "acceptanceCriterion": "When <condition>, then <verifiable result>"
     }
   ]
 }
 \`\`\`
 
-Правила:
-- \`converged\` равно \`true\` тогда и только тогда, когда НЕ осталось ни одного
-  action point с приоритетом \`P0\`. Иначе — \`false\`.
-- \`open_p0\` — количество ещё открытых action points с приоритетом \`P0\`.
-- \`open_action_points\` — полный список ВСЕХ ещё открытых (нерешённых) action
-  points; перечисли каждый, не сокращая.
-- Приоритеты: P0 (блокирует сходимость) > P1 > P2 > P3.
-- НЕОБЯЗАТЕЛЬНО для каждого action point добавь поле \`acceptanceCriterion\`
-  (именно такой camelCase-ключ) — ОДНУ конкретную, проверяемую формулировку
-  «Когда … тогда …» (definition of done): по какому наблюдаемому условию можно
-  однозначно убедиться, что пункт закрыт. Если сформулировать проверяемый
-  критерий нельзя — просто опусти поле (verdict остаётся валидным без него).
+Rules:
+- \`converged\` is \`true\` if and only if no action point with priority \`P0\`
+  remains. Otherwise it is \`false\`.
+- \`open_p0\` — the number of still-open action points with priority \`P0\`.
+- \`open_action_points\` — the full list of ALL still-open (unresolved) action
+  points; list every one, without abbreviating.
+- Priorities: P0 (blocks convergence) > P1 > P2 > P3.
+- OPTIONALLY, for each action point add an \`acceptanceCriterion\` field
+  (exactly this camelCase key) — ONE concrete, verifiable
+  "When … then …" statement (definition of done): the observable condition by
+  which one can unambiguously confirm the item is closed. If no verifiable
+  criterion can be stated, simply omit the field (the verdict stays valid
+  without it).
 `.trim();

--- a/server/services/task-orchestrator.ts
+++ b/server/services/task-orchestrator.ts
@@ -121,7 +121,7 @@ interface ResolvedTaskFields {
 // ─── Human-in-the-loop note carry-forward ───────────────────────────────────
 
 /** Marker that opens the carried human-note block in an iteration's input. */
-export const HUMAN_NOTE_HEADING = "## Решения и заметки человека (предыдущий раунд)";
+export const HUMAN_NOTE_HEADING = "## Human decisions and notes (previous round)";
 
 /**
  * Fold the previous iteration's human note (if any) into the next iteration's

--- a/tests/unit/consilium/loop-planner.test.ts
+++ b/tests/unit/consilium/loop-planner.test.ts
@@ -24,7 +24,7 @@ import type { ConsiliumLoopRow } from "@shared/schema";
 // ─── Piece A: the silent-drop guard ─────────────────────────────────────────
 
 describe("acceptanceCriterion survives the verdict round-trip (silent-drop guard)", () => {
-  const CRIT = "Когда пользователь без прав вызывает /plan, тогда ответ 404";
+  const CRIT = "When an unauthorized user calls /plan, then the response is 404";
 
   it("extractActionPoints carries acceptanceCriterion through boundActionPoint", () => {
     const judge = {

--- a/tests/unit/local-providers.test.ts
+++ b/tests/unit/local-providers.test.ts
@@ -36,7 +36,7 @@ describe("local provider keys", () => {
 
 describe("collapsible block defaults", () => {
   it("is labelled in Russian as experimental", () => {
-    expect(LOCAL_MODELS_SECTION_TITLE).toBe("Локальные модели (экспериментально)");
+    expect(LOCAL_MODELS_SECTION_TITLE).toBe("Local models (experimental)");
   });
 
   it("is COLLAPSED by default on a clean install", () => {

--- a/tests/unit/orchestrator/direct-llm-prompt.test.ts
+++ b/tests/unit/orchestrator/direct-llm-prompt.test.ts
@@ -13,13 +13,13 @@ describe("parseDirectLlmResponse — robust summary/output extraction", () => {
 
   it("extracts the real summary from a preamble + ```json fence (the debate case)", () => {
     const content =
-      "Это задача синтеза, инструменты не нужны. Привожу решение:\n\n" +
+      "This is a synthesis task, no tools needed. Here is the solution:\n\n" +
       "```json\n" +
-      JSON.stringify({ summary: "Арбитр синтезирует спор", output: { verdict: "6.5/10" }, decisions: ["d1"] }, null, 2) +
+      JSON.stringify({ summary: "The arbiter synthesizes the debate", output: { verdict: "6.5/10" }, decisions: ["d1"] }, null, 2) +
       "\n```";
     const r = parseDirectLlmResponse(content);
     // NOT the preamble slice — the model's actual summary field.
-    expect(r.summary).toBe("Арбитр синтезирует спор");
+    expect(r.summary).toBe("The arbiter synthesizes the debate");
     expect(r.output).toEqual({ verdict: "6.5/10" });
     expect(r.decisions).toEqual(["d1"]);
   });
@@ -34,10 +34,10 @@ describe("parseDirectLlmResponse — robust summary/output extraction", () => {
   });
 
   it("falls back to the de-hashed heading + full raw text for pure markdown (no JSON)", () => {
-    const content = "## Открывающий анализ\n\nЯ открываю спор взвешенной оценкой по brief.";
+    const content = "## Opening analysis\n\nI open the debate with a balanced assessment of the brief.";
     const r = parseDirectLlmResponse(content);
     // A markdown title makes a good summary: strip the `#` markers, keep the text.
-    expect(r.summary).toBe("Открывающий анализ");
+    expect(r.summary).toBe("Opening analysis");
     expect(r.output).toEqual({ raw: content });
   });
 


### PR DESCRIPTION
The product language is now English end-to-end. This translates every user-facing Russian string in `client/`, `server/`, and the two prompt/heading strings that reach model context, and updates the tests that assert those literals. No behavior or markup changes beyond string literals and the one prompt block; TypeScript strict (`npm run check`) and the full unit suite (245 files / 4849 tests) are green.

## Files changed

### Client
- **`client/src/pages/ConsiliumLoopDetail.tsx`** — priority legend ("P0–P3 — priority (P0 = critical), not completion status."), acceptance-criterion (DoD) label, verified/unverified citation tooltips, "No sources provided.", the entire `humanizeDevPhase` status ladder (Committing / Final verification / Pushing / Opening Draft PR / Done / Coding action point…), `ApStatusIcon` aria-labels, `DEV_STEP_LABELS` (test author / coder / test run / fix), progress "done" counter, the SDLC executor blurb, "Open Draft PR", classify/archetype toasts + placeholders + empty states, and both "Hand off to SDLC" toast + button.
- **`client/src/components/task-groups/verdict-panel.tsx`** — verdict headings (Verdict/Pros/Cons), action-points table headers (Action/Priority/Effort/Rationale/Trade-off), DoD label, the markdown copy-text builder literals (`## Verdict`, `## Pros`, `## Cons`, table header row, `## Acceptance criteria (DoD)`), copy/hand-off toasts, the copy button title + label, and the "Hand off to SDLC (develop round)" footer + no-loop info text.
- **`client/src/components/task-groups/iterations-panel.tsx`** — human-note panel: save toasts, "Your thoughts and decisions", helper text, placeholder, "Save note", "You have unsaved changes".
- **`client/src/components/pipeline/current-runs-rail.tsx`** — status labels (running/queued/paused/done/failed/cancelled), "Pipeline run", "Current pipelines", "N active", "Loading…", "No active runs" + helper, copy-ID toasts, the row title attr, and the Russian doc comment at the top.
- **`client/src/components/settings/LocalModelsSection.tsx`** — short/long descriptions.
- **`client/src/lib/local-providers.ts`** — `LOCAL_MODELS_SECTION_TITLE` → "Local models (experimental)".
- **`client/src/components/consilium/new-review-dialog.tsx`** — engineer-instruction label, helper span, placeholder, and the over-length warning. (Not in the original file list but surfaced by the grep sweep; it is user-facing, so translated for the "English end-to-end" goal.)

### Server
- **`server/services/orchestrator/judge-prompt.ts`** — `JUDGE_CONVERGENCE_INSTRUCTIONS`, the whole convergence-instruction block, translated **wording only**. The `convergence` object shape, all JSON keys (`converged`, `open_p0`, `open_action_points`, `title`/`priority`/`effort`/`rationale`/`tradeoff`, camelCase `acceptanceCriterion`), the backtick-fenced JSON example, the "When … then …" acceptance-criterion format, and the P0-based convergence rule (`converged === true` iff no P0 remains) are all unchanged. The header doc comment updated from "Kept in Russian…" to "In English…".
- **`server/services/task-orchestrator.ts`** — `HUMAN_NOTE_HEADING` → "## Human decisions and notes (previous round)".

### Tests
- **`tests/unit/local-providers.test.ts`** — updated the assertion to the new English `LOCAL_MODELS_SECTION_TITLE`.
- **`tests/unit/consilium/loop-planner.test.ts`** — the `CRIT` acceptance-criterion fixture translated to the English "When … then …" form (round-trip fixture prose, not a language test; matches the new judge output format).
- **`tests/unit/orchestrator/direct-llm-prompt.test.ts`** — sample debate/preamble prose fixtures translated together with their assertions (self-contained input+expected pairs testing parser mechanics, not Russian specifically). Not in the original list; translated to leave no stray Russian.

## Sweep survivors

`grep -rn '[а-яА-ЯёЁ]' client/src/ server/ shared/` returns **zero** after the change.

Remaining Cyrillic lives only in tests and is **intentional homoglyph fixture input** — these tests verify Unicode/homoglyph detection and sanitization, so the Cyrillic must stay (translating it would destroy the test):
- `tests/unit/knowledge/allowlist.test.ts` (Cyrillic 'о' in a spoofed `opentofu.org` URL)
- `tests/unit/knowledge/source-allowlist-research.test.ts` (Cyrillic 'е' in a spoofed `medium.com`)
- `tests/unit/skills/challenger-remediation-5.test.ts`, `challenger-verification.test.ts`, `adversarial-challenger.test.ts`, `adversarial.test.ts`, `remediation.test.ts`, `security.test.ts` (Cyrillic homoglyphs in `#pаssword` / `#секрет` / `zone:grееn` / `myАpiKey` code + tag fixtures).

## Adversarial self-review

- **Risk 1 — judge prompt drives structured output.** The translated block is wording-only: every field name, the fenced JSON shape, the camelCase `acceptanceCriterion` key, the "When … then …" DoD format, and the P0-based convergence semantics (`converged` true iff zero open P0) are intact. Only prose (headings, rules, doc comment) changed.
- **Risk 2 — `HUMAN_NOTE_HEADING` producer/consumer/test consistency.** Grep confirms the constant has a single producer (`composeIterationInput` in `task-orchestrator.ts`) and **no** consumer that parses the heading and **no** test asserting it. Translating the constant keeps the emitted section self-consistent; nothing downstream parses the literal.

Draft — do not merge.
