### PR TITLE
fix: skip the fix loop on test-run timeouts (not-adjudicated, not red)

### DIFF
--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -388,14 +388,22 @@ function CriterionLeaf({ c }: { c: ExecutionCriterion }) {
     <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
       <GreenDot green={c.passed} />
       <Badge variant="outline" className="text-[10px] py-0">{c.method}</Badge>
-      <span className={c.passed ? "text-muted-foreground" : "text-red-600"}>
-        {c.ran ? (c.passed ? "passed" : "unmet") : "not run"}
+      {/* A TIMED-OUT run (ran:true, passed:false) is NOT-ADJUDICATED — checked before
+          `passed` so it reads "timed out" (amber), never "unmet" (red). */}
+      <span className={c.passed ? "text-muted-foreground" : c.timedOut ? "text-amber-600" : "text-red-600"}>
+        {!c.ran ? "not run" : c.timedOut ? "timed out" : c.passed ? "passed" : "unmet"}
       </span>
       {typeof c.fixIterations === "number" && c.fixIterations > 0 && (
         <span className="text-muted-foreground">· {c.fixIterations} fix</span>
       )}
+      {/* Timeout policy: NOT-ADJUDICATED marker (ambiguous: slow suite vs a hang; the
+          fix loop was skipped). Distinct from a red regression — a small amber note. */}
+      {c.timedOut === true && (
+        <span className="text-amber-600 font-medium">· not adjudicated (timeout)</span>
+      )}
       {/* Stage A: final-state re-verification of the whole worktree. A false here
-          (esp. alongside passed:true) reveals a late-AP regression. */}
+          (esp. alongside passed:true) reveals a late-AP regression. Omitted when the
+          final run timed out (unadjudicated — the timeout marker above carries it). */}
       {typeof c.passedAtFinal === "boolean" && (
         <span className={c.passedAtFinal ? "text-muted-foreground" : "text-red-600 font-medium"}>
           · final {c.passedAtFinal ? "green" : "regressed"}

--- a/server/services/consilium/execution-trace.ts
+++ b/server/services/consilium/execution-trace.ts
@@ -97,6 +97,8 @@ function clampCriterion(c: ExecutionCriterion): ExecutionCriterion {
   if (c.summary !== undefined) out.summary = scrub(c.summary, SUMMARY_MAX);
   // Stage A: additive final-state flag — carried through the clamp verbatim (boolean).
   if (typeof c.passedAtFinal === "boolean") out.passedAtFinal = c.passedAtFinal;
+  // Timeout policy: additive NOT-ADJUDICATED flag — carried verbatim (boolean).
+  if (typeof c.timedOut === "boolean") out.timedOut = c.timedOut;
   return out;
 }
 
@@ -156,6 +158,8 @@ export interface SdlcOutcomeLike {
     summary: string;
     fixIterations: number;
     criterion: string;
+    /** Timeout policy: this AP's own verification run was killed by the wall-clock cap. */
+    timedOut?: boolean;
   };
 }
 
@@ -189,12 +193,19 @@ function skillFromName(skillName: string, green: boolean): ExecutionSkill {
  * pass/fail is stamped onto every `test-run` criterion as `passedAtFinal` (a single
  * suite run covers all criteria). undefined ⇒ final verification did not run ⇒ the
  * field is omitted (byte-for-byte the pre-Stage-A trace).
+ *
+ * `finalTimedOut` (timeout policy): when the FINAL whole-suite run was KILLED by the
+ * wall-clock cap it was NOT adjudicated — so `passedAtFinal` is NOT stamped (there is
+ * no pass/fail to record; `finalPassed` would be a misleading `false`/"regressed"), and
+ * every criterion is marked `timedOut` instead. A per-AP run that itself timed out also
+ * marks its own criterion `timedOut` (from `verification.timedOut`).
  */
 export function buildSdlcTrace(
   archetype: Archetype | null,
   outcomes: readonly SdlcOutcomeLike[],
   result: { prRef: string | null; error?: string },
   finalPassed?: boolean,
+  finalTimedOut?: boolean,
 ): ExecutionTrace {
   const unmetP0 = outcomes.some(
     (o) => o.priority.toUpperCase().startsWith("P0") && o.verification !== undefined && !o.verification.passed,
@@ -211,8 +222,13 @@ export function buildSdlcTrace(
             passed: o.verification.passed,
             fixIterations: o.verification.fixIterations,
             summary: o.verification.summary,
-            // Stage A: stamp the final whole-suite result on the (test-run) criterion.
-            ...(finalPassed !== undefined ? { passedAtFinal: finalPassed } : {}),
+            // Stage A: stamp the final whole-suite result on the (test-run) criterion —
+            // UNLESS the final run itself TIMED OUT (unadjudicated: there is no pass/fail
+            // to stamp, and `false` here would read as a bogus regression).
+            ...(finalPassed !== undefined && !finalTimedOut ? { passedAtFinal: finalPassed } : {}),
+            // Timeout policy: NOT-ADJUDICATED iff this AP's own run timed out OR the final
+            // whole-suite run timed out (either leaves this criterion unadjudicated).
+            ...(o.verification.timedOut || finalTimedOut ? { timedOut: true } : {}),
           },
         ]
       : [];

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -152,6 +152,13 @@ export interface ApVerification {
   fixIterations: number;
   /** The action point's acceptance criterion (sanitized + clamped; display only). */
   criterion: string;
+  /**
+   * Additive: the verification run was KILLED by the wall-clock timeout (SIGKILL), not
+   * adjudicated. true ⇒ NOT-ADJUDICATED (ambiguous: a slow suite exceeding
+   * testRunTimeoutMs vs a code-introduced hang) and the fix loop was SKIPPED — `ran`
+   * stays true (the process DID run, unlike a launch failure). Absent on adjudicated runs.
+   */
+  timedOut?: boolean;
 }
 
 /**
@@ -173,6 +180,12 @@ export interface FinalVerification {
   summary: string;
   /** How many FINAL fix re-invocations of the coder ran after the initial re-verify. */
   fixIterations: number;
+  /**
+   * Additive: the FINAL whole-suite run was KILLED by the wall-clock timeout (SIGKILL),
+   * not adjudicated. true ⇒ NOT-ADJUDICATED (a slow suite vs a code-introduced hang) and
+   * the final fix loop was SKIPPED. `ran` stays true (the process DID run). Absent otherwise.
+   */
+  timedOut?: boolean;
 }
 
 /**
@@ -553,9 +566,11 @@ export function buildPrStatusBody(input: PrStatusBodyInput): string {
         ? ` [skills: ${o.skills.map((s) => sanitizeLine(s, 40)).join(" -> ")}]`
         : "";
     // Stage 2b: per-criterion verification verdict (absent ⇒ no tag, Stage-2a shape).
+    // A TIMED-OUT run (ran:true, passed:false) reads NOT-ADJUDICATED, never RED — the
+    // signal was ambiguous and the fix loop was skipped (checked before `passed`).
     const v = o.verification;
     const verifyTag = v
-      ? ` [verify: ${!v.ran ? "not-run" : v.passed ? "green" : "RED"}${v.fixIterations > 0 ? ` after ${v.fixIterations} fix` : ""}]`
+      ? ` [verify: ${!v.ran ? "not-run" : v.timedOut ? "not-adjudicated (timeout)" : v.passed ? "green" : "RED"}${v.fixIterations > 0 ? ` after ${v.fixIterations} fix` : ""}]`
       : "";
     return `- [${o.status}] (${o.priority}) ${sanitizeLine(o.title, PR_BODY_TITLE_MAX)}${skillTag}${verifyTag}${tail}`;
   });
@@ -586,14 +601,21 @@ export function buildPrStatusBody(input: PrStatusBodyInput): string {
         "",
         `### Verification gate: FLAGGED — ${unmetP0.length} unmet P0 criteria (${green}/${verified.length} green)`,
         "",
-        "The following P0 acceptance criteria are NOT yet verified green (the fix budget was exhausted or no test command resolved). Review before merging:",
-        ...unmetP0.map(
+        "The following P0 acceptance criteria are NOT yet verified green (the fix budget was exhausted, the run TIMED OUT and was not adjudicated, or no test command resolved). Review before merging:",
+        ...unmetP0.map((o) => {
           // A not-run criterion surfaces its OWN reason (no test command OR a launch
-          // failure like `spawn uv ENOENT`) from the scrubbed summary, rather than
-          // always claiming "no test command" — an env error is not a missing command.
-          (o) =>
-            `- (${o.priority}) ${sanitizeLine(o.title, PR_BODY_TITLE_MAX)} — ${o.verification && !o.verification.ran ? sanitizeLine(o.verification.summary, 160) : "tests still failing"}`,
-        ),
+          // failure like `spawn uv ENOENT`) from the scrubbed summary; a TIMED-OUT run
+          // is labelled NOT-ADJUDICATED (timeout) — ambiguous, not a confirmed red — with
+          // its summary; only a genuinely adjudicated red says "tests still failing".
+          const v = o.verification;
+          const reason =
+            v && !v.ran
+              ? sanitizeLine(v.summary, 160)
+              : v && v.timedOut
+                ? `NOT-ADJUDICATED (timeout) — ${sanitizeLine(v.summary, 160)}`
+                : "tests still failing";
+          return `- (${o.priority}) ${sanitizeLine(o.title, PR_BODY_TITLE_MAX)} — ${reason}`;
+        }),
       );
     }
   }
@@ -606,7 +628,10 @@ export function buildPrStatusBody(input: PrStatusBodyInput): string {
   const finalBlock: string[] = [];
   if (finalVerification) {
     const fv = finalVerification;
-    const status = !fv.ran ? "NOT-RUN" : fv.passed ? "GREEN" : "RED";
+    // A TIMED-OUT final run is NOT-ADJUDICATED (timeout), never RED (checked before
+    // `passed`) — the whole-suite run was killed before a verdict, so it is not a
+    // confirmed regression.
+    const status = !fv.ran ? "NOT-RUN" : fv.timedOut ? "NOT-ADJUDICATED (timeout)" : fv.passed ? "GREEN" : "RED";
     const fixTag = fv.fixIterations > 0 ? ` (after ${fv.fixIterations} final fix attempt(s))` : "";
     finalBlock.push(
       "",
@@ -614,9 +639,11 @@ export function buildPrStatusBody(input: PrStatusBodyInput): string {
       "",
       fv.passed
         ? "The full test suite passes against the FINAL combined worktree (all action points applied) — no cross-AP regression detected."
-        : !fv.ran
-          ? "The full test suite could NOT be re-run against the final worktree (no test command resolved). The final combined state is UNVERIFIED — review before merging."
-          : "REGRESSION — the full test suite does NOT pass against the FINAL combined worktree. A later action point may have regressed an earlier one. This Draft PR still opens for human review; review before merging.",
+        : fv.timedOut
+          ? "TIMED OUT — the full test suite was KILLED by the wall-clock cap before a verdict (the suite may exceed testRunTimeoutMs, or a change may have introduced a hang). NOT adjudicated; the final fix loop was skipped. This is NOT a confirmed regression — review before merging (raise the cap for a slow suite, or investigate a possible hang)."
+          : !fv.ran
+            ? "The full test suite could NOT be re-run against the final worktree (no test command resolved). The final combined state is UNVERIFIED — review before merging."
+            : "REGRESSION — the full test suite does NOT pass against the FINAL combined worktree. A later action point may have regressed an earlier one. This Draft PR still opens for human review; review before merging.",
     );
   }
 
@@ -835,7 +862,13 @@ export async function runSdlcHandoff(
       // rescues data we already computed). Rides the result out-of-band, exactly like
       // testSummary; the dev_completed event / FSM are untouched. Stage A stamps the
       // final whole-suite pass/fail onto each test-run criterion (`passedAtFinal`).
-      result.executionTrace = buildSdlcTrace(req.archetype ?? null, outcomes, result, finalVerification?.passed);
+      result.executionTrace = buildSdlcTrace(
+        req.archetype ?? null,
+        outcomes,
+        result,
+        finalVerification?.passed,
+        finalVerification?.timedOut,
+      );
       // Terminal beat — the executor finished its work for this round (the SERVICE
       // separately classifies done/failed from the result; this is phase-only).
       progress.beat({
@@ -1106,7 +1139,13 @@ async function runFinalVerification(
   // `result.ran` gate: a command that could NOT be LAUNCHED (env broken — ran:false)
   // must NOT enter the code→test→fix loop; no code change can make it run, so we skip
   // the fix budget entirely (mirrors the no-test-command convention) and record NOT-RUN.
-  while (!result.passed && result.ran && fixIterations < config.maxFinalFixIterations) {
+  // `!result.timedOut` gate: a run the wall-clock KILLED (SIGKILL) is AMBIGUOUS and
+  // UNADJUDICATED — a slow suite exceeding testRunTimeoutMs vs a code-introduced hang.
+  // A coder cannot fix a config-level cap and the NEXT final run pays the SAME wall-clock,
+  // so we SKIP the final fix loop (0 iterations) and record NOT-ADJUDICATED (loudly, in
+  // the PR body + trace + UI) rather than "fix" a state that was never adjudicated. Same
+  // shape as the ran:false skip (#444) — the failure path stays identical, PR still opens.
+  while (!result.passed && result.ran && !result.timedOut && fixIterations < config.maxFinalFixIterations) {
     // Whole-run wall-clock backstop (shared budget): stop fixing once the run overran.
     if (vc.now() >= vc.deadline) break;
     fixIterations += 1;
@@ -1131,6 +1170,8 @@ async function runFinalVerification(
     passed: result.passed,
     summary: clampStr(result.summary, FIX_SUMMARY_MAX),
     fixIterations,
+    // Additive: mark NOT-ADJUDICATED only when the final run timed out (legacy shape else).
+    ...(result.timedOut ? { timedOut: true } : {}),
   };
 }
 
@@ -1218,7 +1259,13 @@ async function runVerifyFixLoop(
   // wastes every coder invocation on an error the coder cannot fix (the reported bug).
   // We skip straight to a NOT-RUN verdict (0 fix iterations) — the SAME convention as
   // the existing no-test-command path.
-  while (!result.passed && result.ran && fixIterations < vc.config.maxFixIterations) {
+  // `!result.timedOut` gate: a run the wall-clock KILLED (SIGKILL) is AMBIGUOUS and
+  // UNADJUDICATED — the suite may just exceed testRunTimeoutMs, or the change may have
+  // introduced a hang. A coder cannot fix a config-level cap and the NEXT run pays the
+  // SAME wall-clock, so we SKIP the fix loop (0 iterations) and record NOT-ADJUDICATED,
+  // surfacing it loudly (PR body + trace + UI) instead of burning the budget "fixing"
+  // code that was never adjudicated. Mirrors the ran:false skip; failure path identical.
+  while (!result.passed && result.ran && !result.timedOut && fixIterations < vc.config.maxFixIterations) {
     // Whole-run wall-clock backstop: stop fixing once the run has overrun (the
     // per-AP coder/test timeouts + this cap together bound total develop time).
     if (vc.now() >= vc.deadline) break;
@@ -1245,6 +1292,8 @@ async function runVerifyFixLoop(
     summary: clampStr(result.summary, FIX_SUMMARY_MAX),
     fixIterations,
     criterion,
+    // Additive: mark NOT-ADJUDICATED only when this AP's run timed out (legacy shape else).
+    ...(result.timedOut ? { timedOut: true } : {}),
   };
 }
 
@@ -1295,7 +1344,9 @@ function aggregateTestSummary(
     const header = `Per-criterion verification: ${passed}/${verified.length} green.`;
     const lines = verified.map((o) => {
       const v = o.verification as ApVerification;
-      const status = !v.ran ? "NOT-RUN" : v.passed ? "PASS" : "FAIL";
+      // A TIMED-OUT run is NOT-ADJUDICATED (ambiguous, fix loop skipped), never FAIL —
+      // so the next review round grounds on "unadjudicated", not a confirmed red.
+      const status = !v.ran ? "NOT-RUN" : v.timedOut ? "NOT-ADJUDICATED (timeout)" : v.passed ? "PASS" : "FAIL";
       const fixes = v.fixIterations > 0 ? ` after ${v.fixIterations} fix attempt(s)` : "";
       const crit = v.criterion ? ` — criterion: ${v.criterion}` : "";
       return `- [${status}] (${o.priority}) ${o.title}${fixes}${crit}\n    ${sanitizeLine(v.summary, 280)}`;
@@ -1314,13 +1365,15 @@ function aggregateTestSummary(
 
 /** Stage A: the round `testSummary` block for the final whole-suite re-verification. */
 function buildFinalVerificationSummary(fv: FinalVerification): string {
-  const status = !fv.ran ? "NOT-RUN" : fv.passed ? "PASS" : "FAIL";
+  const status = !fv.ran ? "NOT-RUN" : fv.timedOut ? "NOT-ADJUDICATED (timeout)" : fv.passed ? "PASS" : "FAIL";
   const fixes = fv.fixIterations > 0 ? ` after ${fv.fixIterations} final fix attempt(s)` : "";
   const verdict = fv.passed
     ? "The full test suite passes against the final combined worktree (no cross-AP regression)."
-    : !fv.ran
-      ? "The full test suite could not be re-run against the final worktree (no test command)."
-      : "REGRESSION: the full test suite does NOT pass against the final combined worktree.";
+    : fv.timedOut
+      ? "The full test suite TIMED OUT (killed by the wall-clock cap) before a verdict — NOT adjudicated (the suite may exceed testRunTimeoutMs, or a change may have introduced a hang); the final fix loop was skipped. Not a confirmed regression."
+      : !fv.ran
+        ? "The full test suite could not be re-run against the final worktree (no test command)."
+        : "REGRESSION: the full test suite does NOT pass against the final combined worktree.";
   return [`Final-state re-verification: [${status}]${fixes}.`, verdict, `    ${sanitizeLine(fv.summary, 280)}`].join("\n");
 }
 

--- a/server/services/sdlc/test-runner.ts
+++ b/server/services/sdlc/test-runner.ts
@@ -247,6 +247,23 @@ function launchFailureSummary(err: unknown): string {
   );
 }
 
+/**
+ * Build the summary for a run the WALL-CLOCK TIMEOUT killed (SIGKILL). Unlike a red
+ * test (which RAN and was adjudicated) OR a launch failure (which never started), a
+ * timeout is AMBIGUOUS and UNADJUDICATED: the suite may simply exceed the configured
+ * `testRunTimeoutMs`, or the change may have introduced a hang. A coder cannot fix a
+ * config-level cap and the NEXT run pays the SAME wall-clock, so the caller SKIPS the
+ * fix loop and records the criterion NOT-ADJUDICATED. `ran` stays true (the process DID
+ * run, unlike ENOENT) — the message names the cap + both hypotheses so an operator (or
+ * the next review round) can act, and states the policy (fix loop skipped) explicitly.
+ */
+function timeoutSummary(timeoutMs: number): string {
+  return `TIMED OUT after ${timeoutMs}ms — suite may exceed testRunTimeoutMs (raise the cap for a slow suite) or the change introduced a hang; not adjudicated, fix loop skipped`.slice(
+    0,
+    SUMMARY_MAX,
+  );
+}
+
 /** Build the bounded, scrubbed summary. Keeps the OUTPUT TAIL (failures live there). */
 function buildSummary(
   output: string,
@@ -430,10 +447,16 @@ export function runTests(opts: RunTestsOptions): Promise<TestRunResult> {
         ran: !launch,
       });
     });
+    // A wall-clock TIMEOUT (SIGKILL) settles here via the child's close event. It is
+    // AMBIGUOUS and UNADJUDICATED — the process DID run (ran:true, unlike ENOENT) but
+    // was killed before a verdict, so it gets the explicit "not adjudicated, fix loop
+    // skipped" summary naming the configured cap. The caller SKIPS the fix loop on the
+    // `timedOut` flag (see the executor's `!result.timedOut` gate). A NORMAL exit keeps
+    // the pass/fail summary with the captured output tail.
     child.on("close", (code: number | null) =>
       finish({
         passed: !timedOut && code === 0,
-        summary: buildSummary(output, code, timedOut, truncated),
+        summary: timedOut ? timeoutSummary(timeoutMs) : buildSummary(output, code, timedOut, truncated),
         exitCode: code,
         timedOut,
         ran: true,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1954,6 +1954,16 @@ export interface ExecutionCriterion {
    * criteria. A `false` here alongside `passed:true` reveals a late-AP REGRESSION.
    */
   passedAtFinal?: boolean;
+  /**
+   * Additive: whether the verification run was KILLED by the wall-clock timeout
+   * (SIGKILL) rather than adjudicated. true ⇒ NOT-ADJUDICATED — the test-run was
+   * AMBIGUOUS (the suite may exceed `testRunTimeoutMs`, or the change introduced a
+   * hang) and the fix loop was SKIPPED (a coder cannot fix a config-level cap, and the
+   * next run pays the same wall-clock). Distinct from `passed:false` (a real, adjudicated
+   * red) and from `ran:false` (a launch failure). OPTIONAL/ADDITIVE — absent on
+   * adjudicated runs and on pre-timeout-policy snapshots (no schemaVersion bump).
+   */
+  timedOut?: boolean;
 }
 
 /** A worker agent: one action point (coder) or one research step. */

--- a/tests/unit/consilium/execution-trace.test.ts
+++ b/tests/unit/consilium/execution-trace.test.ts
@@ -82,6 +82,55 @@ describe("execution-trace — buildSdlcTrace (coder path)", () => {
     expect(t.controller.workers[0].criteria[0].passedAtFinal).toBe(false);
   });
 
+  it("Timeout policy: stamps timedOut:true from a per-AP verification that timed out", () => {
+    const apTimedOut: SdlcOutcomeLike[] = [
+      {
+        index: 1,
+        priority: "P0",
+        title: "t",
+        status: "completed",
+        verification: { method: "test-run", ran: true, passed: false, summary: "TIMED OUT after 300000ms", fixIterations: 0, criterion: "c", timedOut: true },
+      },
+    ];
+    const crit = buildSdlcTrace("repo-assessment", apTimedOut, { prRef: "x" }).controller.workers[0].criteria[0];
+    expect(crit.timedOut).toBe(true);
+    expect(crit.ran).toBe(true); // the process DID run — unlike a launch failure
+    expect(crit.passed).toBe(false);
+  });
+
+  it("Timeout policy: a FINAL timeout marks timedOut AND OMITS passedAtFinal (no bogus regression)", () => {
+    // finalPassed:false alongside finalTimedOut:true ⇒ do NOT stamp passedAtFinal (there
+    // is no adjudicated pass/fail); mark the criterion timedOut instead.
+    const t = buildSdlcTrace("repo-assessment", outcomes, { prRef: "x" }, false, true);
+    const crit = t.controller.workers[0].criteria[0];
+    expect(crit.timedOut).toBe(true);
+    expect("passedAtFinal" in crit).toBe(false);
+  });
+
+  it("Timeout policy: OMITS timedOut when neither the AP nor the final run timed out", () => {
+    const t = buildSdlcTrace("repo-assessment", outcomes, { prRef: "x" }, true);
+    expect("timedOut" in t.controller.workers[0].criteria[0]).toBe(false);
+  });
+
+  it("Timeout policy: clampTrace preserves an already-set timedOut and drops non-boolean (old snapshot)", () => {
+    const t = clampTrace({
+      schemaVersion: 1,
+      archetype: "repo-assessment",
+      controller: {
+        kind: "sdlc-executor",
+        label: "x",
+        green: false,
+        workers: [
+          { index: 1, priority: "P0", title: "t", status: "completed", skills: [], criteria: [{ criterion: "c", method: "test-run", ran: true, passed: false, timedOut: true }] },
+          // Old snapshot: absent timedOut field → stays absent (byte-for-byte legacy).
+          { index: 2, priority: "P0", title: "u", status: "completed", skills: [], criteria: [{ criterion: "d", method: "test-run", ran: true, passed: true }] },
+        ],
+      },
+    });
+    expect(t.controller.workers[0].criteria[0].timedOut).toBe(true);
+    expect("timedOut" in t.controller.workers[1].criteria[0]).toBe(false);
+  });
+
   it("controller green requires a PR AND no unmet P0 criterion", () => {
     expect(buildSdlcTrace("repo-assessment", outcomes, { prRef: "x" }).controller.green).toBe(true);
     expect(buildSdlcTrace("repo-assessment", outcomes, { prRef: null }).controller.green).toBe(false);

--- a/tests/unit/sdlc/final-verification.test.ts
+++ b/tests/unit/sdlc/final-verification.test.ts
@@ -83,6 +83,16 @@ const launchFail: TestRunResult = {
   exitCode: null,
   timedOut: false,
 };
+/** Finding #6 at the final phase: the whole-suite final run was KILLED by the wall-clock
+ *  cap. ran:true but AMBIGUOUS/UNADJUDICATED ⇒ the final fix loop must be SKIPPED. */
+const timedOut: TestRunResult = {
+  passed: false,
+  ran: true,
+  summary:
+    "TIMED OUT after 300000ms — suite may exceed testRunTimeoutMs (raise the cap for a slow suite) or the change introduced a hang; not adjudicated, fix loop skipped",
+  exitCode: null,
+  timedOut: true,
+};
 
 function makeGitRaw() {
   return vi.fn(async (_repo: string, args: string[]) => {
@@ -300,6 +310,76 @@ describe("Stage A — launch failure (ran:false) SKIPS the final fix loop", () =
     expect(prBody(deps)).toMatch(/Final-state re-verification: NOT-RUN/);
     // NEVER blocks PR creation.
     expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+  });
+});
+
+describe("Stage A — final-run TIMEOUT (ambiguous) SKIPS the final fix loop, NOT-ADJUDICATED", () => {
+  it("a TIMED-OUT final run burns ZERO final fix iterations even with budget left (finding #6)", async () => {
+    // The finding-#6 bug at the final phase: a timeout must NOT enter the fix loop — no
+    // code change makes a config-level cap pass, and the next final run pays the same
+    // wall-clock. With a budget of 3, the loop must be skipped entirely.
+    const runTests = sequencedRunTests([timedOut]);
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(
+      baseReq({ finalVerification: FVCFG({ maxFinalFixIterations: 3 }) }),
+      deps as never,
+    );
+    // ONE final run; the loop is skipped (timedOut) despite a budget of 3.
+    expect(runTests).toHaveBeenCalledTimes(1);
+    // Only the 2 skilled implement steps; ZERO final fix coder re-invocations.
+    expect((deps.runCoder as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+    expect(res.finalVerification).toEqual(
+      expect.objectContaining({ ran: true, passed: false, fixIterations: 0, timedOut: true }),
+    );
+    // NEVER blocks PR creation.
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+  });
+
+  it("classifies the final block NOT-ADJUDICATED (timeout), never RED/REGRESSION", async () => {
+    const runTests = sequencedRunTests([timedOut]);
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(
+      baseReq({ finalVerification: FVCFG({ maxFinalFixIterations: 3 }) }),
+      deps as never,
+    );
+    const body = prBody(deps);
+    expect(body).toMatch(/Final-state re-verification: NOT-ADJUDICATED \(timeout\)/);
+    expect(body).not.toMatch(/Final-state re-verification: RED/);
+    expect(body).not.toMatch(/REGRESSION/);
+    expect(body).toMatch(/not a confirmed regression/i);
+    // The testSummary (convergence wire) grounds the next review on NOT-ADJUDICATED.
+    expect(res.testSummary).toMatch(/NOT-ADJUDICATED \(timeout\)/);
+    expect(res.testSummary).not.toMatch(/REGRESSION/);
+  });
+
+  it("does NOT stamp a bogus passedAtFinal:false when the FINAL run timed out (marks timedOut instead)", async () => {
+    // AP WITH a criterion that PASSED at implement time; the final whole-suite run then
+    // TIMES OUT. passedAtFinal must be OMITTED (unadjudicated — `false` would read as a
+    // regression); the criterion is marked timedOut so the UI shows "not adjudicated".
+    const runTests = sequencedRunTests([pass, timedOut]); // per-AP pass, then final timeout
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(
+      baseReq({
+        actionPoints: [AP({ acceptanceCriterion: "When built Then compiles" })],
+        finalVerification: FVCFG({ maxFinalFixIterations: 3 }),
+      }),
+      deps as never,
+    );
+    const crit = res.executionTrace!.controller.workers[0].criteria[0];
+    expect(crit.passed).toBe(true); // green when the AP was implemented
+    expect(crit.timedOut).toBe(true); // final run unadjudicated
+    expect("passedAtFinal" in crit).toBe(false); // NOT stamped (no bogus "regressed")
+  });
+
+  it("CONTRAST: a non-timeout final RED still enters the final fix loop", async () => {
+    const runTests = sequencedRunTests([fail, pass]); // red → fix → pass
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(
+      baseReq({ finalVerification: FVCFG({ maxFinalFixIterations: 3 }) }),
+      deps as never,
+    );
+    expect(runTests).toHaveBeenCalledTimes(2); // initial + one re-verify
+    expect(res.finalVerification).toEqual(expect.objectContaining({ passed: true, fixIterations: 1 }));
   });
 });
 

--- a/tests/unit/sdlc/test-runner.test.ts
+++ b/tests/unit/sdlc/test-runner.test.ts
@@ -217,7 +217,14 @@ describe("runTests — hard timeout → SIGKILL the PROCESS GROUP (MED-1)", () =
     expect(kills).toContain("SIGKILL");
     expect(res.timedOut).toBe(true);
     expect(res.passed).toBe(false);
-    expect(res.summary).toMatch(/TIMED OUT/);
+    // The summary is ACTIONABLE + NOT-ADJUDICATED: it names the configured cap and both
+    // hypotheses (slow suite vs hang) and states the policy (fix loop skipped). ran stays
+    // true (the process DID run — unlike a launch failure).
+    expect(res.summary).toMatch(/TIMED OUT after 10000ms/);
+    expect(res.summary).toMatch(/exceed testRunTimeoutMs/);
+    expect(res.summary).toMatch(/introduced a hang/);
+    expect(res.summary).toMatch(/not adjudicated, fix loop skipped/);
+    expect(res.ran).toBe(true);
   });
 
   it("the DEFAULT killGroup targets the NEGATIVE pid via process.kill (the whole group)", async () => {

--- a/tests/unit/sdlc/verification-loop.test.ts
+++ b/tests/unit/sdlc/verification-loop.test.ts
@@ -70,6 +70,17 @@ const launchFail: TestRunResult = {
   exitCode: null,
   timedOut: false,
 };
+/** The finding-#6 bug shape: the run was KILLED by the wall-clock cap (SIGKILL). ran:true
+ *  (the process DID run, unlike ENOENT) but AMBIGUOUS/UNADJUDICATED ⇒ the fix loop must be
+ *  SKIPPED (a coder cannot fix a config-level cap; the next run pays the same wall-clock). */
+const timedOut: TestRunResult = {
+  passed: false,
+  ran: true,
+  summary:
+    "TIMED OUT after 300000ms — suite may exceed testRunTimeoutMs (raise the cap for a slow suite) or the change introduced a hang; not adjudicated, fix loop skipped",
+  exitCode: null,
+  timedOut: true,
+};
 
 function makeGitRaw() {
   return vi.fn(async (_repo: string, args: string[]) => {
@@ -224,6 +235,77 @@ describe("Stage 2b — launch failure (ran:false) SKIPS the fix loop", () => {
       (p) => events.push(JSON.parse(JSON.stringify(p)) as SdlcProgress),
     );
     // The initial test-runner beat fires; NO fix-coder beat (the loop never ran).
+    expect(events.some((e) => e.step === "test-runner")).toBe(true);
+    expect(events.some((e) => e.step === "fix-coder")).toBe(false);
+  });
+});
+
+describe("Stage 2b — test-run TIMEOUT (ambiguous) SKIPS the fix loop, NOT-ADJUDICATED", () => {
+  it("a TIMED-OUT run burns ZERO fix iterations even with budget left (finding #6)", async () => {
+    // The finding-#6 bug: a timeout was treated as a plain red, so the fix-coder burned
+    // its WHOLE budget "fixing" code that was never adjudicated (the next run pays the
+    // same wall-clock). With a healthy budget of 3, a timeout must skip the loop entirely.
+    const runTests = sequencedRunTests([timedOut]);
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(baseReq({ verification: VCFG({ maxFixIterations: 3 }) }), deps as never);
+
+    // Exactly ONE test run — the initial one — then the loop is skipped (no re-verify).
+    expect(runTests).toHaveBeenCalledTimes(1);
+    // Only the 2 skilled implement steps ran; ZERO fix-coder re-invocations.
+    expect((deps.runCoder as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+    // The Draft PR still opens (never blocked) — the failure path is identical to a red.
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+  });
+
+  it("CONTRAST: a non-timeout RED (ran:true, timedOut:false) STILL enters the fix loop", async () => {
+    // A test that ran and was adjudicated red is a NORMAL signal — the loop must engage;
+    // only the ambiguous timeout is skipped. This is the guard against over-skipping.
+    const runTests = sequencedRunTests([fail, pass]); // red → fix → pass
+    const deps = makeDeps({ runTests });
+    await runSdlcHandoff(baseReq({ verification: VCFG({ maxFixIterations: 3 }) }), deps as never);
+    expect((deps.runCoder as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(3); // 2 skilled + 1 fix
+    expect(runTests).toHaveBeenCalledTimes(2); // initial + one re-verify
+  });
+
+  it("classifies the criterion NOT-ADJUDICATED (timeout), never FAIL, in the PR body + testSummary", async () => {
+    const runTests = sequencedRunTests([timedOut]);
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(baseReq({ verification: VCFG({ maxFixIterations: 3 }) }), deps as never);
+
+    const prBody = (deps.openPr as ReturnType<typeof vi.fn>).mock.calls[0][1].body as string;
+    // The per-AP verify tag reads not-adjudicated (timeout), never RED.
+    expect(prBody).toMatch(/not-adjudicated \(timeout\)/i);
+    expect(prBody).not.toMatch(/\bRED\b/);
+    // The gate flags it (unmet P0) — surfaced loudly, nothing reported green.
+    expect(prBody).toMatch(/FLAGGED/);
+    expect(prBody).toMatch(/NOT-ADJUDICATED \(timeout\)/);
+    // The actionable summary rides through (the configured cap + both hypotheses).
+    expect(prBody).toMatch(/TIMED OUT after 300000ms/);
+    expect(prBody).toMatch(/not adjudicated, fix loop skipped/);
+    // The round testSummary (convergence wire) grounds the next review on NOT-ADJUDICATED.
+    expect(res.testSummary).toMatch(/NOT-ADJUDICATED \(timeout\)/);
+    expect(res.testSummary).not.toMatch(/\[FAIL\]/);
+  });
+
+  it("stamps timedOut:true on the trace criterion (loop page distinguishes it)", async () => {
+    const runTests = sequencedRunTests([timedOut]);
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(baseReq({ verification: VCFG({ maxFixIterations: 3 }) }), deps as never);
+    const crit = res.executionTrace?.controller.workers[0].criteria[0];
+    expect(crit?.timedOut).toBe(true);
+    expect(crit?.passed).toBe(false);
+    expect(crit?.ran).toBe(true); // the process DID run — unlike a launch failure.
+  });
+
+  it("emits NO fix-coder progress beat for a timed-out run", async () => {
+    const runTests = sequencedRunTests([timedOut]);
+    const deps = makeDeps({ runTests });
+    const events: SdlcProgress[] = [];
+    await runSdlcHandoff(
+      baseReq({ verification: VCFG({ maxFixIterations: 3 }) }),
+      deps as never,
+      (p) => events.push(JSON.parse(JSON.stringify(p)) as SdlcProgress),
+    );
     expect(events.some((e) => e.step === "test-runner")).toBe(true);
     expect(events.some((e) => e.step === "fix-coder")).toBe(false);
   });


### PR DESCRIPTION
## What

A test-run **timeout** (SIGKILL at the wall-clock cap) is **ambiguous** — a slow suite that simply exceeds `testRunTimeoutMs`, or a code-introduced hang — but the executor treated it as a plain **red** test. Both fix loops (`runVerifyFixLoop` per-AP, `runFinalVerification` final) then burned their **whole** coder budget "fixing" code that was never adjudicated.

This gates both loops on `!result.timedOut` and classifies a timed-out criterion as **NOT-ADJUDICATED (timeout)**, never FAIL/RED. It mirrors the merged ENOENT fix (#444) — with one difference: a timeout keeps `ran: true` (the process **did** run), whereas ENOENT is `ran: false`.

## Trial evidence (live loop `04afbca0` on Omniscience)

- The repo's suite takes **11m29s**; `testRunTimeoutMs` was lower.
- **Every** run was SIGKILL'd at **2–4%** progress. Both action points burned **all 3** fix iterations **plus** the final-verification fix attempt on timeouts. The trace recorded `passed=false` / `passedAtFinal=false`.
- **Ground truth** (the same suite run manually on the PR branch, no cap): **3455 passed, 0 failed** — the code was **correct**. Every red was a wall-clock artifact, and every fix-coder invocation was pure waste (the next run pays the same wall-clock; a coder cannot fix a config-level cap).

This is the Phase-0 loop-trial **finding #6**.

## Policy change

1. **Skip the loop on timeout.** In `runVerifyFixLoop` (per-AP) and `runFinalVerification` (final): a result with `timedOut === true` does **not** enter/continue the code→test→fix loop (0 fix iterations). One timeout predicts the next; a code-introduced hang is better surfaced to the operator / next re-review than "fixed" blind.
2. **Distinct, actionable classification.** The runner summary reads `TIMED OUT after <configured>ms — suite may exceed testRunTimeoutMs (raise the cap for a slow suite) or the change introduced a hang; not adjudicated, fix loop skipped`. `ran: true` is preserved (unlike ENOENT). An **additive optional** `timedOut?: boolean` is added to the `ExecutionCriterion` trace (`shared/types.ts` + `execution-trace.ts`) — **no `schemaVersion` bump** (same convention as `passedAtFinal`). The loop-detail page renders a small amber "not adjudicated (timeout)" marker on the criterion leaf.
3. **PR-body status line** for a timed-out criterion says **NOT-ADJUDICATED (timeout)**, not FAIL — in the per-AP verify tag, the verification gate, the final-state block, and the round `testSummary` convergence wire. A final timeout **omits** `passedAtFinal` (no bogus "regressed") and marks `timedOut` instead.

## Why no kill-switch

This **is** a behavior change (skipping fix iterations on timeout), but no config gate is warranted: it only **skips** work on an **unadjudicable** signal (demonstrably pure waste in trial `04afbca0`), **never blocks** a PR, and the failure path — the Draft PR opens with the criterion **FLAGGED** — stays **identical** to the pre-change red path. The old behavior was pure wall-clock waste.

## Adversarial self-review

**Risk: this masks a genuine code-introduced hang.** Answer: nothing is reported green. A timed-out P0 criterion still **FLAGS** the verification gate and lands loudly as **NOT-ADJUDICATED (timeout)** in the PR body, the round `testSummary` (which grounds the next review round's convergence verdict), the execution trace (`timedOut: true`), and the UI (amber marker). The Draft PR opens for human review; the human merge gate is unchanged. The next consilium re-review round sees the unadjudicated criterion and can act (raise the cap, or investigate the hang).

**Risk: over-skipping (skipping real reds).** The gate is strictly `!result.timedOut`; only the SIGKILL-timeout path sets that flag. Contrast tests confirm a normal red (`ran: true, timedOut: false`) **still enters** the fix loop, per-AP and final.

## Tests

- **Per-AP** (`verification-loop.test.ts`): timeout → 0 fix iterations even with budget 3; contrast red still enters the loop; NOT-ADJUDICATED in PR body + testSummary (never RED/`[FAIL]`); `timedOut: true` on the trace criterion (`ran: true`); no fix-coder progress beat.
- **Final** (`final-verification.test.ts`): final timeout → 0 final fix iterations; final block NOT-ADJUDICATED (never RED/REGRESSION); a final timeout omits `passedAtFinal` and marks `timedOut`; contrast red still fixes.
- **Trace** (`execution-trace.test.ts`): stamps/clamps `timedOut`; final-timeout omits `passedAtFinal`; absent-field (old-snapshot) compatibility.
- **Runner** (`test-runner.test.ts`): the timeout summary names the configured cap, both hypotheses, and the skipped-loop policy; `ran: true`.

`npm run check` clean; full unit suite green (`4858 passed`). Pre-existing known flake `tests/unit/providers/antigravity.test.ts` fails identically on clean `origin/main` (verified) and is untouched by this branch; `config-sync-multi-instance` passes.

## Constraints honored

No FSM changes; additive optional trace field only (no `schemaVersion` bump). Conventional commit, no Co-Authored-By trailers.

**Draft — do not merge.**
