### PR TITLE
feat: surface the non-P0 remainder on converged loops (finding #5)

### DIFF
--- a/client/src/hooks/use-consilium-loops.ts
+++ b/client/src/hooks/use-consilium-loops.ts
@@ -21,6 +21,7 @@ import type {
 } from "@shared/schema";
 import type {
   Archetype,
+  OpenRemainder,
   ResearchReport,
   ResearchClaim,
   ResearchCitation,
@@ -165,6 +166,13 @@ export type ConsiliumLoopRoundDetail = ConsiliumLoopRoundRow & {
 export type ConsiliumLoopDetail = ConsiliumLoopListItem & {
   rounds: ConsiliumLoopRoundDetail[];
   devProgress?: DevProgress;
+  /**
+   * Finding #5: on a TERMINAL loop, the READ-TIME count-by-priority of the last
+   * round's still-open action points (source: server-side `computeOpenRemainder`).
+   * Absent for a non-terminal loop or a clean last round — consumers render it
+   * defensively (the "converged with remainder" callout).
+   */
+  openRemainder?: OpenRemainder | null;
   /** The classified/overridden archetype, or null when not yet planned. */
   archetype?: Archetype | null;
   /** Whether the archetype was model-`proposed` or human-`override`. */

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -107,8 +107,9 @@ import {
 } from "@/components/ui/select";
 import type { ConsiliumLoopState } from "@/hooks/use-consilium-loops";
 import { IterationDetailView } from "@/components/task-groups/iterations-panel";
-import type { ActionPoint, Archetype } from "@shared/types";
+import type { ActionPoint, Archetype, OpenRemainder } from "@shared/types";
 import { ARCHETYPES } from "@shared/types";
+import { summarizeNonP0Remainder } from "@shared/consilium-remainder";
 
 // Priority palette for action-point severity tiers (P0–P3). The loop page is now
 // the canonical home of this taxonomy (the task-group verdict panel is retired).
@@ -708,6 +709,19 @@ function ResultPanel({
                 {latest.openP0 ?? "—"} open P0
               </span>
             </div>
+            {/* Finding #5 — trivial priority breakdown of the still-open remainder.
+                A CONVERGED loop gets the dedicated actionable callout above; here
+                we only enrich the OTHER terminal verdicts (stopped_cap/escalated,
+                where the verdict is already front-and-center) with the counts. */}
+            {loop.openRemainder && loop.state !== "converged" && (
+              <p className="text-[11px] text-muted-foreground">
+                Open remainder:{" "}
+                {Object.entries(loop.openRemainder.byPriority)
+                  .sort((a, b) => a[0].localeCompare(b[0]))
+                  .map(([priority, count]) => `${count} ${priority}`)
+                  .join(", ")}
+              </p>
+            )}
             {latestAps.length > 0 ? (
               <ul className="space-y-1.5">
                 {latestAps.map((ap, i) => (
@@ -729,6 +743,63 @@ function ResultPanel({
               </p>
             )}
           </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Converged-with-remainder callout (finding #5) ──────────────────────────────
+//
+// Convergence is keyed on P0 BY DESIGN: a loop reaches `converged` the moment no
+// P0 action point remains. The judge may still leave actionable non-P0 items
+// (P1/P2/…) standing — historically they silently dropped out of the lifecycle
+// unless an operator noticed the leftover verdict. This callout makes that
+// remainder VISIBLE on a CONVERGED loop and one-click actionable by REUSING the
+// existing develop-from-terminal flow (the SAME `useDevelopLoop` mutation the
+// header "Hand off to SDLC" action drives — no duplicated logic, no FSM change).
+// Renders NOTHING when the loop converged clean (no non-P0 remainder).
+//
+// SECURITY: `openRemainder` is server-computed from priority LABELS only (counts,
+// no model prose) and rendered as inert React text.
+function ConvergedRemainderCallout({
+  remainder,
+  canDevelop,
+  developing,
+  onDevelop,
+}: {
+  remainder: OpenRemainder | null | undefined;
+  canDevelop: boolean;
+  developing: boolean;
+  onDevelop: () => void;
+}) {
+  const summary = summarizeNonP0Remainder(remainder);
+  if (!summary) return null;
+  return (
+    <Card className="border-primary/40 bg-primary/5">
+      <CardContent className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-2 min-w-0">
+          <Check className="h-4 w-4 text-green-600 shrink-0 mt-0.5" />
+          <div className="min-w-0 text-sm">
+            <p className="font-medium">
+              Converged with {summary.total} open non-P0 item
+              {summary.total === 1 ? "" : "s"} ({summary.breakdown})
+            </p>
+            <p className="text-muted-foreground">
+              Convergence is keyed on P0 by design — these lower-priority items are
+              still open. Hand them off to run the existing develop-from-terminal round.
+            </p>
+          </div>
+        </div>
+        {canDevelop && (
+          <Button size="sm" onClick={onDevelop} disabled={developing} className="shrink-0">
+            {developing ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Hammer className="mr-2 h-4 w-4" />
+            )}
+            Develop the remainder
+          </Button>
         )}
       </CardContent>
     </Card>
@@ -1623,6 +1694,18 @@ export default function ConsiliumLoopDetail() {
       <div className="flex-1 overflow-y-auto p-6 space-y-5">
         {/* Result — the outcome the human gate decides on (near the top). */}
         <ResultPanel loop={loop} terminal={terminal} />
+
+        {/* Finding #5 — a CONVERGED loop still carrying non-P0 action points
+            surfaces them here + a one-click develop-from-terminal hand-off that
+            reuses the SAME `useDevelopLoop` mutation as the header action. */}
+        {loop.state === "converged" && (
+          <ConvergedRemainderCallout
+            remainder={loop.openRemainder}
+            canDevelop={canDevelop}
+            developing={developLoop.isPending}
+            onDevelop={handleDevelop}
+          />
+        )}
 
         {/* Research report (Stage 3) — the researched outcome of a `research`
             loop, on the latest round. Rendered only when a report is present

--- a/docs/design/loop-consolidation.md
+++ b/docs/design/loop-consolidation.md
@@ -80,6 +80,18 @@ earlier step's check verified. A criterion counts as met only if it holds in the
 worktree state of the round (a final re-verification pass before the PR opens); per-step
 green at implementation time is necessary but not sufficient.
 
+**Convergence is keyed on `P0` by design — the non-P0 remainder is a first-class outcome
+(finding #5).** A loop reaches CONVERGED the moment no `P0` action point remains, but the
+judge may still leave actionable non-P0 items (P1/P2/…) standing. That remainder used to
+silently drop out of the lifecycle unless an operator noticed the leftover verdict. It is now
+surfaced as an explicit **"converged with remainder"** outcome: the loop detail response
+computes, at read time from the last round's persisted `openActionPoints` (no schema/FSM
+change), a count-by-priority summary, and the UI renders a *"Converged with N open non-P0
+items (X P1, Y P2, …)"* callout. The remainder stays executable through the **existing
+develop-from-terminal** flow (§9) — the callout's button drives the same `POST /:id/develop`
+promotion into a visible `developing` round; convergence remains "no open P0", nothing new is
+persisted, and the FSM is untouched.
+
 ## 4. Skills — the unit of agent capability
 
 A loop's steps are executed by **agents**, each dynamically pulling a **skill**. multiqlti
@@ -264,6 +276,11 @@ re-raises what is still open.
 - Where exactly task groups / pipelines surface for power users once demoted.
 - Ephemeral-env provisioning for `deploy-verify` (what backs it — kind/k3d, a cloud sandbox?).
 - How acceptance criteria are authored: model-proposed then engineer-edited?
+- Converged-with-remainder (finding #5): should a `maxRounds > 1` loop **auto-develop** the
+  non-P0 remainder instead of waiting for the operator to click develop-from-terminal? Today
+  it stays a human-gated one-click action (convergence = no-P0, no auto-execution); the open
+  question is whether a multi-round loop's leftover P1/P2 items should be promoted
+  automatically, and if so under what guard (cost/round cap, priority floor).
 
 ---
 

--- a/server/routes/consilium-loops.ts
+++ b/server/routes/consilium-loops.ts
@@ -20,6 +20,8 @@ import type {
   PlanErrorCode,
 } from "../services/consilium/consilium-loop-controller.js";
 import { ARCHETYPES } from "@shared/types";
+import { CONSILIUM_LOOP_TERMINAL_STATES } from "@shared/schema";
+import { computeOpenRemainder } from "@shared/consilium-remainder";
 import type { AppConfig } from "../config/schema.js";
 import { requireRole } from "../auth/middleware.js";
 import { validateBody } from "../middleware/validate.js";
@@ -121,10 +123,21 @@ export function registerConsiliumLoopRoutes(
     // ephemeral — degrades to undefined cross-instance; DB state stays authoritative).
     const devProgress = controller.getDevProgress(auth.loop.id);
     const isAdmin = req.user?.role === "admin";
+    // Finding #5: for a TERMINAL loop, surface a READ-TIME count-by-priority of
+    // the LAST round's still-open action points so a "converged with remainder"
+    // outcome (convergence keys on P0 by design; non-P0 items still standing) is
+    // visible + executable via develop-from-terminal. Computed here from the
+    // already-fetched `rounds` — no schema change; `undefined` (omitted from the
+    // JSON) for a non-terminal loop or an empty last round.
+    const openRemainder = (CONSILIUM_LOOP_TERMINAL_STATES as readonly string[]).includes(
+      auth.loop.state,
+    )
+      ? computeOpenRemainder(rounds)
+      : undefined;
     // Stage 1: the new loop columns (engineerInstruction, archetype, archetypeSource,
     // archetypeRationale, archetypeParams, archetypeDecidedAt) ride the maskLoop
     // spread of `auth.loop` automatically — no per-field allowlist to keep in sync.
-    res.json({ ...maskLoop({ ...auth.loop }, !!isAdmin), rounds, devProgress });
+    res.json({ ...maskLoop({ ...auth.loop }, !!isAdmin), rounds, devProgress, openRemainder });
   });
 
   // ── Start (PENDING → BUILDING_CONTEXT) ──────────────────────────────────────

--- a/shared/consilium-remainder.ts
+++ b/shared/consilium-remainder.ts
@@ -1,0 +1,75 @@
+/**
+ * consilium-remainder.ts — finding #5: the READ-SIDE "converged with remainder"
+ * computation + formatter. Pure and client-safe (no drizzle, no React), so the
+ * server route, the client page, and unit tests all share ONE implementation of
+ * the same rule.
+ *
+ * Convergence is keyed on `P0` BY DESIGN: a loop reaches `converged` the moment
+ * no P0 action point remains. The judge may still leave actionable non-P0 items
+ * (P1/P2/…) standing — those used to silently drop out of the lifecycle. This
+ * module turns the LAST round's persisted `openActionPoints` into a
+ * count-by-priority summary so the remainder is visible + executable via
+ * develop-from-terminal. NOTHING is persisted: computed at read time from data
+ * already in the round rows (no schema/FSM change).
+ */
+import { P0_PRIORITY, type ActionPoint, type OpenRemainder } from "./types.js";
+
+/**
+ * The minimal round shape `computeOpenRemainder` reads. A persisted
+ * `ConsiliumLoopRoundRow` is structurally assignable to it, so the route passes
+ * its rows straight through with no adapter.
+ */
+export interface RemainderRoundInput {
+  round: number;
+  openActionPoints?: readonly ActionPoint[] | null;
+}
+
+/**
+ * Count (by priority) the STILL-OPEN action points on the LAST recorded round.
+ *
+ * ONLY the last round is read: each round persists the set of items still open AT
+ * THAT round's decide, so summing across rounds would DOUBLE-COUNT items that a
+ * later round closed. Returns `undefined` when there is no round, or the last
+ * round carries no open action points (empty → no field on the wire). Priority
+ * labels are UNTRUSTED model text — normalized (trim + uppercase) and bucketed
+ * under `"P?"` when absent; treated as data, never a sink.
+ */
+export function computeOpenRemainder(
+  rounds: readonly RemainderRoundInput[],
+): OpenRemainder | undefined {
+  if (rounds.length === 0) return undefined;
+  // Defensive: pick the highest-round row rather than trusting array order.
+  const last = rounds.reduce((a, b) => (b.round >= a.round ? b : a));
+  const aps = Array.isArray(last.openActionPoints) ? last.openActionPoints : [];
+  if (aps.length === 0) return undefined;
+  const byPriority: Record<string, number> = {};
+  for (const ap of aps) {
+    const key = (ap.priority ?? "").trim().toUpperCase() || "P?";
+    byPriority[key] = (byPriority[key] ?? 0) + 1;
+  }
+  return { total: aps.length, byPriority };
+}
+
+/**
+ * The NON-P0 view of a remainder for the "converged with remainder" callout: the
+ * non-P0 total plus a stable, highest-tier-first breakdown string (e.g.
+ * `"1 P1, 1 P2"`). Returns `null` when there is nothing non-P0 to surface — so a
+ * clean convergence (or a `P0`-only remainder) renders nothing.
+ */
+export function summarizeNonP0Remainder(
+  remainder: OpenRemainder | null | undefined,
+): { total: number; breakdown: string } | null {
+  if (!remainder) return null;
+  // Order by numeric tier ascending (P1 < P2 < …); an un-numbered "P?" sorts LAST.
+  // Ties break on the raw label so the string is deterministic.
+  const tier = (label: string): number => {
+    const n = Number.parseInt(label.replace(/^P/i, ""), 10);
+    return Number.isNaN(n) ? Number.POSITIVE_INFINITY : n;
+  };
+  const entries = Object.entries(remainder.byPriority)
+    .filter(([priority]) => priority !== P0_PRIORITY)
+    .sort((a, b) => tier(a[0]) - tier(b[0]) || a[0].localeCompare(b[0]));
+  const total = entries.reduce((sum, [, count]) => sum + count, 0);
+  if (total <= 0) return null;
+  return { total, breakdown: entries.map(([priority, count]) => `${count} ${priority}`).join(", ") };
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1735,6 +1735,30 @@ export interface ConvergenceVerdict {
   openActionPoints: ActionPoint[];
 }
 
+/**
+ * Finding #5 — the READ-TIME (never-persisted) summary of the STILL-OPEN action
+ * points carried by a TERMINAL loop's LAST recorded round. Convergence is keyed
+ * on `P0` BY DESIGN (a loop converges the moment no P0 remains), but the judge
+ * may leave actionable non-P0 items (P1/P2/…) standing; without surfacing them
+ * that remainder silently drops out of the lifecycle. The loop detail response
+ * attaches this (only when non-empty) so a "converged with remainder" outcome is
+ * VISIBLE and executable via develop-from-terminal. Computed from
+ * `consilium_loop_rounds.openActionPoints` (LAST round ONLY — each round persists
+ * the set still open AT THAT round's decide, so summing across rounds would
+ * double-count items later closed). No schema/FSM change; see
+ * `computeOpenRemainder` in `shared/consilium-remainder.ts`.
+ */
+export interface OpenRemainder {
+  /** Total still-open action points on the last recorded round (always > 0 when present). */
+  total: number;
+  /**
+   * Count per priority tier, keyed by the UPPERCASED priority label
+   * (e.g. `{ P1: 1, P2: 1 }`); an action point with no priority is counted under
+   * `"P?"`. Only tiers with a non-zero count appear.
+   */
+  byPriority: Record<string, number>;
+}
+
 // ─── Loop ARCHETYPE (Stage 1 — intent→archetype planner, design §5/§6) ──────
 // The intent class a lightweight planner proposes (and a human may override) for a
 // verdict-terminal loop. Stage 1 STORES it; it does NOT yet branch implement on it

--- a/tests/unit/consilium/consilium-loops-develop-route.test.ts
+++ b/tests/unit/consilium/consilium-loops-develop-route.test.ts
@@ -43,12 +43,14 @@ function makeApp(opts: {
   developResult?: DevelopResult;
   devProgress?: unknown;
   loop?: Record<string, unknown>;
+  rounds?: unknown[];
   user?: { id: string; role?: string };
 } = {}) {
   const {
     developResult = { ok: true, loop: { ...DEVELOPING_LOOP } as never },
     devProgress,
     loop = { ...TERMINAL_LOOP },
+    rounds = [{ round: 1, openP0: 2 }],
   } = opts;
   // Distinguish "explicitly unauthenticated" (key present, value undefined) from
   // "default to owner" (key absent) — a destructuring default would swallow the
@@ -62,7 +64,7 @@ function makeApp(opts: {
 
   const storage = {
     getLoop: vi.fn(async () => loop),
-    getLoopRounds: vi.fn(async () => [{ round: 1, openP0: 2 }]),
+    getLoopRounds: vi.fn(async () => rounds),
   } as unknown as IStorage;
 
   const app = express();
@@ -145,6 +147,50 @@ describe("GET /api/consilium-loops/:id — devProgress merge", () => {
     const res = await request(app).get(`/api/consilium-loops/${LOOP_ID}`);
     expect(res.status).toBe(200);
     expect(res.body.devProgress).toBeUndefined();
+  });
+});
+
+// Finding #5: the loop detail exposes a computed `openRemainder` (count-by-priority
+// of the LAST round's still-open action points) for a TERMINAL loop only.
+describe("GET /api/consilium-loops/:id — openRemainder (finding #5)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("a CONVERGED loop with a non-P0 remainder exposes openRemainder from the LAST round", async () => {
+    const { app } = makeApp({
+      loop: { ...TERMINAL_LOOP }, // state: converged
+      rounds: [
+        { round: 1, openP0: 2, openActionPoints: [{ title: "a", priority: "P0" }] },
+        { round: 2, openP0: 0, openActionPoints: [
+          { title: "b", priority: "P1" },
+          { title: "c", priority: "P2" },
+        ] },
+      ],
+    });
+    const res = await request(app).get(`/api/consilium-loops/${LOOP_ID}`);
+    expect(res.status).toBe(200);
+    // LAST round only — the round-1 P0 must NOT leak into the count.
+    expect(res.body.openRemainder).toEqual({ total: 2, byPriority: { P1: 1, P2: 1 } });
+  });
+
+  it("a converged-clean loop (empty last round) omits openRemainder entirely", async () => {
+    const { app } = makeApp({
+      loop: { ...TERMINAL_LOOP },
+      rounds: [{ round: 1, openP0: 0, openActionPoints: [] }],
+    });
+    const res = await request(app).get(`/api/consilium-loops/${LOOP_ID}`);
+    expect(res.status).toBe(200);
+    expect(res.body.openRemainder).toBeUndefined();
+    expect("openRemainder" in res.body).toBe(false);
+  });
+
+  it("a NON-terminal loop never computes openRemainder even when a round carries items", async () => {
+    const { app } = makeApp({
+      loop: { ...DEVELOPING_LOOP }, // non-terminal
+      rounds: [{ round: 1, openP0: 1, openActionPoints: [{ title: "a", priority: "P1" }] }],
+    });
+    const res = await request(app).get(`/api/consilium-loops/${LOOP_ID}`);
+    expect(res.status).toBe(200);
+    expect(res.body.openRemainder).toBeUndefined();
   });
 });
 

--- a/tests/unit/consilium/converged-remainder.test.ts
+++ b/tests/unit/consilium/converged-remainder.test.ts
@@ -1,0 +1,83 @@
+/**
+ * converged-remainder.test.ts — finding #5 unit coverage for the READ-SIDE
+ * "converged with remainder" helpers (`shared/consilium-remainder.ts`).
+ *
+ * Convergence is keyed on P0 by design; a loop can converge (no open P0) while
+ * still carrying actionable non-P0 items. These pure helpers compute a
+ * count-by-priority summary of the LAST round's still-open action points (no
+ * schema change, no double-count across rounds) and the non-P0 view the UI
+ * callout renders. Covers:
+ *   - priorities counted from the LAST round's openActionPoints only
+ *   - empty / absent last round → undefined (empty → no field on the wire)
+ *   - priority normalization (trim/upper; missing → "P?")
+ *   - highest-round row chosen regardless of array order
+ *   - summarizeNonP0Remainder excludes P0, sorts tier-first, and returns null
+ *     when there is nothing non-P0 to surface (clean convergence renders nothing)
+ */
+import { describe, it, expect } from "vitest";
+import {
+  computeOpenRemainder,
+  summarizeNonP0Remainder,
+  type RemainderRoundInput,
+} from "../../../shared/consilium-remainder.js";
+import type { ActionPoint } from "@shared/types";
+
+const ap = (priority?: string, title = "x"): ActionPoint => ({ title, priority });
+
+function round(r: number, aps?: ActionPoint[] | null): RemainderRoundInput {
+  return { round: r, openActionPoints: aps ?? null };
+}
+
+describe("computeOpenRemainder", () => {
+  it("counts priorities from the LAST round's action points only (no cross-round double-count)", () => {
+    const rounds = [
+      round(1, [ap("P0"), ap("P0")]), // earlier, still-open-at-round-1 set — MUST be ignored
+      round(2, [ap("P1"), ap("P2")]), // the converged round's remainder
+    ];
+    expect(computeOpenRemainder(rounds)).toEqual({ total: 2, byPriority: { P1: 1, P2: 1 } });
+  });
+
+  it("buckets multiple items of the same tier", () => {
+    const rounds = [round(1, [ap("P1"), ap("P1"), ap("P2")])];
+    expect(computeOpenRemainder(rounds)).toEqual({ total: 3, byPriority: { P1: 2, P2: 1 } });
+  });
+
+  it("normalizes priority labels (trim + uppercase) and buckets a missing priority under P?", () => {
+    const rounds = [round(1, [ap(" p1 "), ap(undefined), ap("")])];
+    expect(computeOpenRemainder(rounds)).toEqual({ total: 3, byPriority: { P1: 1, "P?": 2 } });
+  });
+
+  it("picks the highest-round row regardless of array order", () => {
+    const rounds = [round(3, [ap("P2")]), round(1, [ap("P0")]), round(2, [ap("P1")])];
+    expect(computeOpenRemainder(rounds)).toEqual({ total: 1, byPriority: { P2: 1 } });
+  });
+
+  it("returns undefined when there are no rounds (empty → no field)", () => {
+    expect(computeOpenRemainder([])).toBeUndefined();
+  });
+
+  it("returns undefined when the last round has an empty / absent action-point set", () => {
+    expect(computeOpenRemainder([round(1, [])])).toBeUndefined();
+    expect(computeOpenRemainder([round(1, null)])).toBeUndefined();
+    expect(computeOpenRemainder([{ round: 1 }])).toBeUndefined();
+  });
+});
+
+describe("summarizeNonP0Remainder", () => {
+  it("excludes P0 and formats a tier-ordered breakdown", () => {
+    const out = summarizeNonP0Remainder({ total: 4, byPriority: { P2: 1, P1: 2, "P?": 1 } });
+    expect(out).toEqual({ total: 4, breakdown: "2 P1, 1 P2, 1 P?" });
+  });
+
+  it("drops a P0 tier from the non-P0 view (stopped_cap can still carry P0)", () => {
+    const out = summarizeNonP0Remainder({ total: 3, byPriority: { P0: 1, P1: 2 } });
+    expect(out).toEqual({ total: 2, breakdown: "2 P1" });
+  });
+
+  it("returns null for a clean convergence (undefined / P0-only / empty)", () => {
+    expect(summarizeNonP0Remainder(undefined)).toBeNull();
+    expect(summarizeNonP0Remainder(null)).toBeNull();
+    expect(summarizeNonP0Remainder({ total: 1, byPriority: { P0: 1 } })).toBeNull();
+    expect(summarizeNonP0Remainder({ total: 0, byPriority: {} })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

A consilium loop reaches **CONVERGED** the moment the judge reports no open **P0** (convergence = no-P0, by design). But the same verdict can still carry actionable **non-P0** action points (P1/P2/…). Today that remainder silently drops out of the lifecycle unless the operator happens to notice the leftover verdict and manually hits develop-from-terminal.

### Live evidence
Loop `04afbca0` (repo-assessment on Omniscience): judge verdict `ACCEPT-WITH-FIXES`, `convergence.converged = true`, `open_p0 = 0`, yet `action_points = 2` live items (P1 + P2) with pytest-verifiable criteria. The FSM went CONVERGED (terminal); the two items only ran because the operator manually hit `POST /develop`.

## What this does (read-side only)

**Deliberately NO FSM change**, no reducer change, no migration, no new table/column, no new config. Convergence stays keyed on P0; the existing develop-from-terminal flow still does the execution. This only makes the remainder **visible** and **one-click actionable**.

### What is computed, where
- **`shared/consilium-remainder.ts`** (new, pure, client-safe — no drizzle/React): `computeOpenRemainder(rounds)` counts the still-open action points **by priority** from the **LAST round only**. Each round persists the set still-open *at that round's decide*, so reading only the last round avoids double-counting items a later round closed. Empty/absent → `undefined`. `summarizeNonP0Remainder` gives the UI its non-P0 view (tier-ordered, P? last).
- **`GET /api/consilium-loops/:id`**: for a **terminal** loop, computes `openRemainder` from the already-fetched `rounds` (source: `consilium_loop_rounds.openActionPoints` jsonb) and attaches it to the response. Omitted from the JSON entirely when the last round is clean. No schema change.
- **`ConsiliumLoopDetail.tsx`**: a **CONVERGED** loop with a non-empty remainder renders a distinct callout — *"Converged with N open non-P0 items (X P1, Y P2, …)"* — with a button that **reuses the existing `useDevelopLoop` mutation** (the same develop-from-terminal action as the header; no duplicated logic). `stopped_cap`/`escalated` (verdict already front-and-center) get a trivial priority-breakdown line next to the verdict.

### Doc delta
`docs/design/loop-consolidation.md`:
- **§3.D CONVERGE**: convergence is keyed on P0 by design; the non-P0 remainder is now a first-class "converged with remainder" outcome, executable via develop-from-terminal.
- **§10 Open questions**: should a `maxRounds > 1` loop auto-develop the remainder instead of waiting for the operator click, and under what guard?

## Test evidence
- `tests/unit/consilium/converged-remainder.test.ts` (new): priorities counted from the last round only (no cross-round double-count), normalization (trim/upper; missing → `P?`), highest-round chosen regardless of array order, empty/absent → `undefined`; `summarizeNonP0Remainder` excludes P0, tier-orders, and returns null on a clean convergence.
- `tests/unit/consilium/consilium-loops-develop-route.test.ts` (extended): converged loop exposes `openRemainder` from the last round (round-1 P0 does **not** leak); converged-clean omits the field; non-terminal loop never computes it.
- `npm run check` clean; full unit suite green (**238 files / 4671 tests**; known flakes providers/antigravity + config-sync-multi-instance passed this run).

## Adversarial self-review
- **Double-counting**: `openActionPoints` per round is the *still-open* set at that round's decide — the compute reads the **last round only** (by max round number, not array order). Covered by a test that seeds round-1 P0s and asserts they never appear in the count.
- Read-only: `openRemainder` is server-computed from priority **labels/counts**, rendered as inert React text.

> ⚠️ A parallel branch `feat/per-criterion-method` touches the same controller/page; this diff is intentionally tiny and read-side. Expect to rebase if it merges first.

Do not merge — draft for review.