### PR TITLE
feat: acceptance-criteria QA — lint, judge-demotion, adequacy re-check (Stage C)

### DIFF
--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -598,6 +598,19 @@ function RoundRow({
                           {ap.acceptanceCriterion}
                         </p>
                       )}
+                      {/* Stage C (design §9 "Stage 7"): a criterion that FAILED the mechanical
+                          generation-time lint (weak/absent DoD) — surfaced as a small amber
+                          marker, following the manual-ops / timed-out idioms. It was demoted
+                          to the judge method so it can never converge as "tests green". */}
+                      {ap.weakCriterion && (
+                        <span
+                          className="inline-flex items-center gap-1 text-[10px] font-medium text-amber-600 dark:text-amber-400"
+                          title="Weak/absent acceptance criterion — demoted to judge verification (never counts as tests-green)."
+                        >
+                          <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+                          weak DoD — demoted to judge
+                        </span>
+                      )}
                     </div>
                   </li>
                 ))}

--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -379,6 +379,25 @@ export const ConfigSchema = z.object({
          * (a mock model would "decide" an archetype from canned garbage at cost 0).
          */
         model: z.string().min(1).default(DEFAULT_TASK_MODEL),
+        /**
+         * Stage C (design §9 "Stage 7"): acceptance-criterion QA. A MECHANICAL, no-LLM lint
+         * over each AP's `acceptanceCriterion` at generation time (right after the planner
+         * normalizes methods): a criterion that is absent/empty, lacks the "When … Then …"
+         * shape, or — for a `test-run` criterion — is too thin to name a concrete observable
+         * signal is flagged `weakCriterion` and DEMOTED to the `judge` method, so it can
+         * NEVER converge as "tests green" on a vacuous DoD (Goodhart guard, §5). When ON it
+         * ALSO extends the re-assess prior-findings block so the judge must, for each item it
+         * confirms CLOSED, state whether the DoD itself was ADEQUATE and re-open a corrected
+         * criterion if not — riding the EXISTING re-assess judge call (no extra model call).
+         * The routing effect (demotion) bites only when `implement.perCriterionMethod` is also
+         * on (the executor routes on method); standalone it still surfaces `weakCriterion`.
+         * Kill-switch default FALSE ⇒ BYTE-IDENTICAL off: no lint, no flag, no demotion, and
+         * the prior-findings wording is unchanged. Gated by the parent `consiliumLoop.enabled`.
+         */
+        criteriaQa: z.object({
+          /** Kill-switch: false (default) → no criterion lint / demotion / adequacy re-check. */
+          enabled: z.boolean().default(false),
+        }).default({}),
       }).default({}),
       /**
        * Stage 2a (design §3.C/§4): the SKILLED, archetype-branched implement

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -57,7 +57,7 @@ import { P0_PRIORITY } from "@shared/types";
 import type { TaskOrchestrator } from "../task-orchestrator.js";
 import type { AppConfig } from "../../config/schema.js";
 import { effectiveVerificationEnabled } from "../../config/schema.js";
-import { readConvergence, extractActionPoints, normalizeActionPointMethods } from "../orchestrator/convergence.js";
+import { readConvergence, extractActionPoints, normalizeActionPointMethods, applyCriteriaQa } from "../orchestrator/convergence.js";
 import { buildDiffContext } from "./diff-context.js";
 import type { DevCloseoutResult } from "./dev-closeout.js";
 import { runSdlcHandoff, type SdlcProgress, type JudgeVerifyFn, type JudgeVerifyInput } from "../sdlc/executor.js";
@@ -930,10 +930,20 @@ export class ConsiliumLoopController {
     // perCriterionMethod kill-switch; best-effort (never fails the plan). The executor
     // re-normalizes with the SAME pure function, so this is observability, not the source of
     // truth — an absent persist never diverges the develop routing.
-    if (cfg.implement?.perCriterionMethod?.enabled) {
-      const normalized = normalizeActionPointMethods(actionPoints, parsed.archetype);
+    // Stage C (design §9 "Stage 7"): AFTER the method assignment, LINT each acceptance
+    // criterion (mechanical, NO extra LLM call) — a weak/absent DoD is flagged
+    // `weakCriterion` and DEMOTED to `judge` so it can never converge as "tests green" on a
+    // vacuous target. Gated by its OWN kill-switch; independent of perCriterionMethod for the
+    // SURFACING (flag), though the demotion only routes when perCriterionMethod is also on.
+    const criteriaQaOn = cfg.planner?.criteriaQa?.enabled ?? false;
+    const perCriterionOn = cfg.implement?.perCriterionMethod?.enabled ?? false;
+    if (perCriterionOn || criteriaQaOn) {
+      let processed = perCriterionOn
+        ? normalizeActionPointMethods(actionPoints, parsed.archetype)
+        : actionPoints;
+      if (criteriaQaOn) processed = applyCriteriaQa(processed);
       await this.storage
-        .updateLoopRoundActionPoints?.(updated.id, updated.round, normalized)
+        .updateLoopRoundActionPoints?.(updated.id, updated.round, processed)
         .catch(() => undefined);
     }
     return { ok: true, loop: updated, archetype: parsed.archetype };
@@ -1376,9 +1386,16 @@ export class ConsiliumLoopController {
     // skip / judge verify / test-run). The judge-method verifier needs the gateway; when it
     // is absent a `judge` AP degrades to not-passed inside the executor (never green).
     const perCriterionOn = cfg.implement.perCriterionMethod?.enabled ?? false;
-    const routedActionPoints = perCriterionOn
+    // Stage C (design §9 "Stage 7"): criterion QA is applied on the develop ROUTING path too
+    // (not just plan()'s observability persist) — this is the SOURCE OF TRUTH the executor
+    // routes on, so a weak/absent DoD is demoted to `judge` HERE and never reaches the
+    // test-run harness as green. Default OFF ⇒ byte-identical (no lint, no demotion).
+    // Optional-chain `planner` — a hand-built test config may omit the whole block (→ off).
+    const criteriaQaOn = cfg.planner?.criteriaQa?.enabled ?? false;
+    let routedActionPoints = perCriterionOn
       ? normalizeActionPointMethods(verdict.openActionPoints, loop.archetype ?? null)
       : verdict.openActionPoints;
+    if (criteriaQaOn) routedActionPoints = applyCriteriaQa(routedActionPoints);
     if (cfg.implement.verification.enabled && !verifyOn && !this.warnedVerificationGate) {
       this.warnedVerificationGate = true;
       // eslint-disable-next-line no-console
@@ -1635,7 +1652,10 @@ export class ConsiliumLoopController {
       this.log(loop.id, `buildPriorFindings: getLoopRounds failed (no history injected): ${err instanceof Error ? err.message : String(err)}`);
       return undefined;
     }
-    return formatPriorFindings(rounds, budgetBytes) ?? undefined;
+    // Stage C: extend the re-assess instruction with the DoD-adequacy re-check when criterion
+    // QA is on (default off ⇒ byte-identical prior-findings block).
+    const adequacyCheck = this.loopConfig().planner?.criteriaQa?.enabled ?? false;
+    return formatPriorFindings(rounds, budgetBytes, { adequacyCheck }) ?? undefined;
   }
 
   /**
@@ -1753,16 +1773,30 @@ export function pickJudgeOutput(outputs: unknown[]): unknown {
 export function formatPriorFindings(
   rounds: ConsiliumLoopRoundRow[],
   budgetBytes: number,
+  opts?: { adequacyCheck?: boolean },
 ): string | null {
   if (rounds.length === 0) return null;
   const ordered = [...rounds].sort((a, b) => a.round - b.round);
 
   const trend = ordered.map((r) => r.openP0 ?? 0).join(" -> ");
+  // Stage C (design §9 "Stage 7"): when criterion QA is on, the re-assess round must not
+  // just confirm CLOSURE — it must also re-examine whether the DoD itself was ADEQUATE, and
+  // re-open a corrected criterion if not (an inadequate DoD becomes a NEW AP). This rides the
+  // EXISTING re-assess judge call (no extra model call); it is a small, fixed clause on the
+  // header, so the function's oldest-first byte-budget clamp still governs the whole block.
+  const adequacyClause = opts?.adequacyCheck
+    ? " For each item you confirm CLOSED, ALSO state HOW you verified it and whether the " +
+      "acceptance criterion (DoD) itself was ADEQUATE to the underlying problem. If the DoD " +
+      "was vacuous or off-target, do NOT confirm closure: raise a NEW action point with a " +
+      "corrected, observable 'When … Then …' criterion instead."
+    : "";
   const header =
     "## Prior findings to verify (from earlier rounds)\n\n" +
     "Earlier rounds flagged the items below. For EACH item: confirm it is ACTUALLY " +
     "closed by the changes above, or flag it as still-open / regressed. Do NOT " +
-    "re-discover items already listed here — only raise genuinely NEW issues.\n\n" +
+    "re-discover items already listed here — only raise genuinely NEW issues." +
+    adequacyClause +
+    "\n\n" +
     `Open P0 trend across rounds: ${trend}`;
 
   const chunkFor = (r: ConsiliumLoopRoundRow): string => {

--- a/server/services/orchestrator/convergence.ts
+++ b/server/services/orchestrator/convergence.ts
@@ -212,3 +212,98 @@ export function normalizeActionPointMethods(
     ap.verificationMethod !== undefined ? ap : { ...ap, verificationMethod: fallback },
   );
 }
+
+// ─── Stage C (design §9 "Stage 7") — acceptance-criterion QA ─────────────────
+// A MECHANICAL, no-LLM lint over each AP's `acceptanceCriterion`. Acceptance
+// criteria are judge-generated and OPTIONAL; nothing validated their quality, so
+// a vacuous DoD let the implement phase converge to green on the wrong target
+// (Goodhart). This flags a WEAK criterion and demotes its AP to `judge` so it can
+// never count as "tests green" on a criterion no test actually pins.
+//
+// DESIGN BIAS — false-negatives are PREFERRED over false-positives. Demoting a GOOD
+// criterion to `judge` (a false positive) is the harmful error (it needlessly hands a
+// mechanically-checkable criterion to a subjective model), so every rule below is
+// deliberately conservative: only a criterion that is CLEARLY weak trips it. No NLP.
+
+/** A short stoplist of PURELY-ABSTRACT words — a criterion made of only these (plus
+ *  structural glue) names no concrete, observable signal. Lower-case, matched whole-token. */
+const ABSTRACT_WORDS = new Set<string>([
+  "works", "work", "working", "correct", "correctly", "proper", "properly",
+  "good", "fine", "ok", "okay", "valid", "validly", "successful", "successfully",
+  "success", "done", "complete", "completed", "passes", "pass", "passing",
+  "handled", "handles", "handle", "better", "improved", "improve", "clean",
+  "cleanly", "robust", "reliable", "reliably", "as", "expected",
+]);
+
+/** Structural/stop words that carry no signal on their own (so "purely abstract"
+ *  is judged over the CONTENT tokens, not the "when/then/the/is" glue). */
+const STRUCTURAL_WORDS = new Set<string>([
+  "when", "then", "the", "a", "an", "is", "are", "be", "and", "or", "it",
+  "to", "of", "in", "on", "for", "with", "that", "this", "should", "must",
+  "will", "shall", "at", "by",
+]);
+
+/** Minimum length a `test-run` criterion must reach to plausibly name a runnable
+ *  observable. SIMPLE + documented (see file/§9 note) — not clever NLP. */
+const MIN_TESTRUN_CRITERION_LEN = 40;
+
+/**
+ * Return `true` when `criterion` is WEAK for the given verification `method`. Rules
+ * (each conservative — false-negatives preferred):
+ *   (a) NON-EMPTY — absent or whitespace-only ⇒ weak.
+ *   (b) SHAPE — must carry the documented "When … Then …" form; case-insensitive
+ *       presence of a "when" followed later by a "then" is SUFFICIENT (we do not
+ *       parse the clause — over-fitting would demote legitimate phrasings).
+ *   (c) CONCRETE SIGNAL (test-run only) — a mechanically-checked criterion must name
+ *       something runnable/observable: length > MIN_TESTRUN_CRITERION_LEN chars AND
+ *       not composed PURELY of abstract filler ("works", "is correct", …). `judge` /
+ *       `manual-ops` criteria are adjudicated by a model/human, so the length+signal
+ *       floor does not apply to them.
+ * PURE; never throws.
+ */
+export function isWeakCriterion(
+  criterion: string | undefined,
+  method: VerificationMethod | undefined,
+): boolean {
+  const c = (criterion ?? "").trim();
+  // (a) non-empty
+  if (c.length === 0) return true;
+  // (b) "When … Then …" shape — a "when" with a LATER "then" (case-insensitive).
+  const lower = c.toLowerCase();
+  const whenIdx = lower.indexOf("when");
+  const thenIdx = lower.indexOf("then");
+  if (whenIdx === -1 || thenIdx === -1 || thenIdx <= whenIdx) return true;
+  // (c) concrete, observable signal — enforced ONLY for the mechanical test-run method.
+  if (method === "test-run") {
+    if (c.length <= MIN_TESTRUN_CRITERION_LEN) return true;
+    const contentTokens = lower
+      .split(/[^a-z0-9]+/)
+      .filter((t) => t.length > 0 && !STRUCTURAL_WORDS.has(t));
+    // "purely abstract" ⇒ EVERY content token is an abstract filler word. Requiring
+    // ALL tokens to be abstract keeps this rare (conservative / false-negative-biased).
+    const hasConcrete = contentTokens.some((t) => !ABSTRACT_WORDS.has(t));
+    if (!hasConcrete) return true;
+  }
+  return false;
+}
+
+/**
+ * Stage C — flag weak criteria and DEMOTE them to `judge`. For each AP whose criterion
+ * fails {@link isWeakCriterion} (evaluated against its CURRENT method, so a `test-run`
+ * AP is held to the stricter concrete-signal bar): set `weakCriterion: true` and force
+ * `verificationMethod: "judge"` — the Stage-B judge verifier then adjudicates it against
+ * the diff (REFUTE-by-default) instead of a test harness rubber-stamping a vacuous DoD.
+ * `manual-ops` is PRESERVED (an operational action outside the repo is never a test and
+ * never green regardless). PURE — returns a NEW array, inputs unmutated; a passing AP is
+ * returned UNCHANGED (no `weakCriterion` field ⇒ back-compat). Callers invoke this ONLY
+ * when `planner.criteriaQa.enabled`, so with the switch off the AP list is byte-identical.
+ */
+export function applyCriteriaQa(actionPoints: readonly ActionPoint[]): ActionPoint[] {
+  return actionPoints.map((ap) => {
+    if (!isWeakCriterion(ap.acceptanceCriterion, ap.verificationMethod)) return ap;
+    // manual-ops stays manual-ops; everything else (test-run / judge / absent) → judge.
+    const method: VerificationMethod =
+      ap.verificationMethod === "manual-ops" ? "manual-ops" : "judge";
+    return { ...ap, weakCriterion: true, verificationMethod: method };
+  });
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1729,6 +1729,18 @@ export interface ActionPoint {
    * bounded to the fixed union; NEVER a shell/branch/PR sink.
    */
   verificationMethod?: VerificationMethod;
+  /**
+   * Stage C (design §9 "Stage 7") — SERVER-COMPUTED criterion-QA flag: `true` when this
+   * AP's {@link acceptanceCriterion} failed the mechanical generation-time LINT
+   * (`applyCriteriaQa`): absent/empty, missing the "When … Then …" shape, or — for a
+   * `test-run` criterion — too thin to name a concrete observable signal. A flagged AP is
+   * DEMOTED to `judge` (never counts as test-run green; §5) and surfaces a small amber
+   * "weak DoD" marker in the loop UI. NOT model text — derived deterministically from the
+   * criterion + method, never a shell/branch/PR sink. Absent (⇒ `undefined`/back-compat)
+   * whenever `pipeline.consiliumLoop.planner.criteriaQa.enabled` is off (byte-identical) or
+   * the criterion passed the lint.
+   */
+  weakCriterion?: boolean;
 }
 
 /**

--- a/tests/unit/consilium/consilium-config.test.ts
+++ b/tests/unit/consilium/consilium-config.test.ts
@@ -60,6 +60,21 @@ describe("pipeline.consiliumLoop schema", () => {
     expect(impl.testRunTimeoutMs).toBe(300_000);
   });
 
+  it("Stage C: planner.criteriaQa defaults to INERT (off) ⇒ byte-identical", () => {
+    const res = ConfigSchema.safeParse({});
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    expect(res.data.pipeline.consiliumLoop.planner.criteriaQa.enabled).toBe(false);
+  });
+
+  it("Stage C: accepts planner.criteriaQa.enabled override", () => {
+    const ok = parseLoop({ planner: { criteriaQa: { enabled: true } } });
+    expect(ok.success).toBe(true);
+    if (ok.success) {
+      expect(ok.data.pipeline.consiliumLoop.planner.criteriaQa.enabled).toBe(true);
+    }
+  });
+
   it("judgeRetry defaults to INERT (disabled, no fallback)", () => {
     const res = ConfigSchema.safeParse({});
     expect(res.success).toBe(true);

--- a/tests/unit/consilium/prior-findings.test.ts
+++ b/tests/unit/consilium/prior-findings.test.ts
@@ -97,6 +97,38 @@ describe("formatPriorFindings — assembly", () => {
     expect(out.indexOf("### Round 1")).toBeLessThan(out.indexOf("### Round 3"));
     expect(out).toContain("Open P0 trend across rounds: 2 -> 0");
   });
+
+  // Stage C (design §9 "Stage 7"): the DoD-adequacy re-check clause.
+  it("byte-identical without the adequacyCheck opt (default off)", () => {
+    const rows = [round({ round: 1, openP0: 1, openActionPoints: [{ title: "Fix", priority: "P0" }] })];
+    const base = formatPriorFindings(rows, 10_000);
+    const explicitOff = formatPriorFindings(rows, 10_000, { adequacyCheck: false });
+    expect(explicitOff).toEqual(base);
+    expect(base).not.toContain("ADEQUATE");
+  });
+
+  it("adds the DoD-adequacy instruction when adequacyCheck is on", () => {
+    const rows = [round({ round: 1, openP0: 1, openActionPoints: [{ title: "Fix", priority: "P0" }] })];
+    const out = formatPriorFindings(rows, 10_000, { adequacyCheck: true })!;
+    expect(out).toContain("ADEQUATE");
+    expect(out).toContain("corrected");
+    // the round detail still renders after the extended header
+    expect(out).toContain("### Round 1");
+    expect(out).toContain("- [P0] Fix");
+  });
+
+  it("adequacyCheck respects the byte budget (extended header still clamps whole rounds)", () => {
+    const rows = [
+      round({ round: 1, openP0: 1, openActionPoints: [{ title: `A ${"x".repeat(300)}`, priority: "P0" }] }),
+      round({ round: 2, openP0: 1, openActionPoints: [{ title: `B ${"y".repeat(300)}`, priority: "P0" }] }),
+    ];
+    // A budget that fits the (larger) header + one round but not both.
+    const out = formatPriorFindings(rows, 900, { adequacyCheck: true })!;
+    expect(out).not.toBeNull();
+    expect(Buffer.byteLength(out, "utf8")).toBeLessThanOrEqual(900);
+    expect(out).toContain("ADEQUATE"); // the clause survives; a round was dropped to fit
+    expect(out).toContain("omitted to fit the size budget");
+  });
 });
 
 describe("formatPriorFindings — oldest-first truncation under budget", () => {

--- a/tests/unit/orchestrator/convergence.test.ts
+++ b/tests/unit/orchestrator/convergence.test.ts
@@ -209,3 +209,103 @@ describe("Stage B — normalizeActionPointMethods (planner assignment)", () => {
     expect(archetypeDefaultMethod(null)).toBe("test-run");
   });
 });
+
+// ─── Stage C (design §9 "Stage 7"): acceptance-criterion QA ─────────────────
+
+import { isWeakCriterion, applyCriteriaQa } from "../../../server/services/orchestrator/convergence.js";
+import type { ActionPoint } from "@shared/types";
+
+// A criterion that PASSES every rule for a test-run AP: has the shape, is long,
+// and names a concrete observable signal.
+const GOOD_TESTRUN =
+  "When the parser receives a malformed header, then it returns a 400 with error code E_HEADER";
+
+describe("Stage C — isWeakCriterion lint heuristics", () => {
+  it("(a) flags an ABSENT or empty/whitespace criterion as weak", () => {
+    expect(isWeakCriterion(undefined, "test-run")).toBe(true);
+    expect(isWeakCriterion("", "test-run")).toBe(true);
+    expect(isWeakCriterion("   ", "test-run")).toBe(true);
+    expect(isWeakCriterion(undefined, "judge")).toBe(true);
+  });
+
+  it("(b) flags a criterion missing the 'When … Then …' shape", () => {
+    // no when/then at all
+    expect(isWeakCriterion("The endpoint returns the right value for all inputs", "judge")).toBe(true);
+    // "then" before "when" is not the required order
+    expect(isWeakCriterion("Return 400 then log, when malformed", "judge")).toBe(true);
+    // only one of the two markers
+    expect(isWeakCriterion("When the input is malformed the parser rejects it", "judge")).toBe(true);
+  });
+
+  it("(c) test-run: flags a shaped-but-too-short criterion (<= 40 chars)", () => {
+    // shape present but far too thin to name a runnable observable
+    expect(isWeakCriterion("When x then y", "test-run")).toBe(true);
+  });
+
+  it("(c) test-run: flags a shaped, long criterion made of PURELY abstract filler", () => {
+    // EVERY content token is abstract glue (works/correct/passes/valid/…) — names no
+    // concrete observable. Structural words (when/then/it/is/and/the) don't count.
+    const abstract = "When done then it works correctly and passes and is valid and complete and fine";
+    expect(abstract.length).toBeGreaterThan(40);
+    expect(isWeakCriterion(abstract, "test-run")).toBe(true);
+  });
+
+  it("(c) test-run: a single concrete token is enough to survive (false-negative bias)", () => {
+    // adding one non-abstract token ("parser") makes it pass — conservative on purpose.
+    const oneConcrete = "When done then the parser works correctly and passes and is valid and complete";
+    expect(oneConcrete.length).toBeGreaterThan(40);
+    expect(isWeakCriterion(oneConcrete, "test-run")).toBe(false);
+  });
+
+  it("(c) is NOT applied to judge/manual-ops (only test-run gets the concrete-signal bar)", () => {
+    // a short but shaped criterion is fine for judge / manual-ops (adjudicated by model/human)
+    expect(isWeakCriterion("When x then y", "judge")).toBe(false);
+    expect(isWeakCriterion("When x then y", "manual-ops")).toBe(false);
+  });
+
+  it("passes a well-formed, concrete test-run criterion (false-negative bias — good ones survive)", () => {
+    expect(isWeakCriterion(GOOD_TESTRUN, "test-run")).toBe(false);
+    // absent method is treated leniently (no test-run concrete-signal bar)
+    expect(isWeakCriterion("When the flag is set then the banner renders", undefined)).toBe(false);
+  });
+});
+
+describe("Stage C — applyCriteriaQa demotion", () => {
+  it("demotes a weak/absent-criterion test-run AP to judge and flags weakCriterion", () => {
+    const aps: ActionPoint[] = [
+      { title: "no dod", priority: "P0", verificationMethod: "test-run" }, // absent criterion
+      { title: "vacuous", priority: "P0", acceptanceCriterion: "When x then y", verificationMethod: "test-run" }, // too short
+    ];
+    const out = applyCriteriaQa(aps);
+    expect(out.map((a) => a.verificationMethod)).toEqual(["judge", "judge"]);
+    expect(out.map((a) => a.weakCriterion)).toEqual([true, true]);
+  });
+
+  it("leaves a GOOD test-run criterion untouched (no weakCriterion field, method unchanged)", () => {
+    const aps: ActionPoint[] = [
+      { title: "solid", priority: "P0", acceptanceCriterion: GOOD_TESTRUN, verificationMethod: "test-run" },
+    ];
+    const out = applyCriteriaQa(aps);
+    expect(out[0].verificationMethod).toBe("test-run");
+    expect(out[0].weakCriterion).toBeUndefined();
+    // returned unchanged (referential passthrough for a passing AP)
+    expect(out[0]).toBe(aps[0]);
+  });
+
+  it("PRESERVES manual-ops even when its criterion is weak (still flagged, never a test)", () => {
+    const aps: ActionPoint[] = [
+      { title: "rotate secret", priority: "P0", verificationMethod: "manual-ops" }, // absent criterion
+    ];
+    const out = applyCriteriaQa(aps);
+    expect(out[0].verificationMethod).toBe("manual-ops");
+    expect(out[0].weakCriterion).toBe(true);
+  });
+
+  it("does not mutate the input array/objects (pure)", () => {
+    const aps: ActionPoint[] = [{ title: "x", priority: "P0", verificationMethod: "test-run" }];
+    const out = applyCriteriaQa(aps);
+    expect(aps[0].weakCriterion).toBeUndefined();
+    expect(aps[0].verificationMethod).toBe("test-run");
+    expect(out).not.toBe(aps);
+  });
+});


### PR DESCRIPTION
## Stage C — acceptance-criteria QA

Design refs: `docs/design/loop-consolidation.md` §5 (verification methods) + §9 "Stage 7" (added by #434). Builds on Stage B (#454): `ActionPoint.verificationMethod` normalized in `plan()` via `normalizeActionPointMethods`.

### Problem
Acceptance criteria are judge-generated and **optional**; nothing validated their quality. A weak/vacuous DoD lets the implement phase converge to green on the wrong target (Goodhart), an AP with **no** criterion rode whatever method it got, and the re-assess round confirmed *closure* of prior items but never re-examined whether the DoD itself was adequate.

### Change (kill-switch `pipeline.consiliumLoop.planner.criteriaQa.enabled`, default **FALSE**, byte-identical off)

1. **Generation-time criterion lint** (mechanical, no extra LLM call) — `isWeakCriterion` in `convergence.ts`, run after `normalizeActionPointMethods`. A criterion is **weak** when:
   - **(a)** absent/empty/whitespace;
   - **(b)** missing the documented `When … Then …` shape (case-insensitive "when" with a *later* "then" is sufficient — no clause parsing, to avoid over-fitting);
   - **(c)** *test-run only* — no concrete observable signal: `length ≤ 40` **or** every content token is abstract filler (`works`/`correct`/`passes`/…). `judge`/`manual-ops` are adjudicated by a model/human, so the concrete-signal bar does not apply.

   Deliberately **conservative — false-negatives preferred over demoting good criteria**. No NLP.

2. **Demotion** — `applyCriteriaQa` flags `weakCriterion: true` (additive field, same jsonb, no migration) and forces `verificationMethod = "judge"` so a weak/absent DoD **never counts as test-run green**; the Stage-B judge verifier then adjudicates against the diff (REFUTE-by-default). `manual-ops` is preserved. Applied on **both** `plan()`'s observability persist and the develop **routing** path (the source of truth the executor routes on).

3. **Re-assess adequacy re-check** — `formatPriorFindings` gains a gated clause instructing the judge, for each item it confirms CLOSED, to state *how* it verified and whether the DoD itself was **adequate**; if not, raise a new AP with a corrected `When … Then …` criterion instead of confirming closure. Rides the **existing** re-assess judge call (no extra LLM call); respects the function's existing oldest-first byte budget clamp.

4. **Surfacing** — `ConsiliumLoopDetail.tsx` renders a small amber "weak DoD — demoted to judge" marker next to the criterion, following the existing `manual-ops`/`timed-out` idioms.

### Heuristic as implemented
`isWeakCriterion(criterion, method)` → weak if: empty; **or** no `when`-before-`then`; **or** (`method === "test-run"` and (`len ≤ 40` **or** all content tokens ∈ abstract stoplist)). `applyCriteriaQa` maps weak APs to `{ weakCriterion: true, verificationMethod: manual-ops ? manual-ops : judge }`, passing good APs through unchanged.

### Constraints honored
No FSM change, no migration, no extra LLM calls. Demotion routing bites only when `implement.perCriterionMethod` is also on; standalone, criteria-QA still surfaces the flag. Byte-identical with the switch off (verified by tests).

### Test evidence
- Lint heuristics: empty / short / no-when-then / all-abstract / single-concrete / valid.
- Demotion: weak→judge + `weakCriterion`, `manual-ops` passthrough, good-criterion untouched, purity (no input mutation).
- Config: `criteriaQa` defaults off; accepts override.
- `formatPriorFindings`: byte-identical without the opt; adequacy clause present when on; budget respected under the extended header.
- `npm run check` clean; full unit suite **4711 passed / 0 failed**.

### Adversarial self-review
- **Risk 1 (over-aggressive lint):** heuristic is conservative — (c) only fires when *every* content token is abstract; false-negative preference documented in code.
- **Risk 2 (prompt bloat):** adequacy clause is a fixed short string added only when enabled; the existing oldest-first clamp still governs the whole block (test asserts ≤ budget with omission).