### PR TITLE
feat: loop launch passport, composition card, and live review visibility

### DIFF
--- a/client/src/hooks/use-consilium-loops.ts
+++ b/client/src/hooks/use-consilium-loops.ts
@@ -153,6 +153,50 @@ export type ConsiliumLoopRoundDetail = ConsiliumLoopRoundRow & {
   executionTrace?: ExecutionTrace | null;
 };
 
+// ─── Composition (Observability GAP 2 — the "who does what" of a round) ───────
+//
+// The computed `composition` block surfaced on the loop GET: WHICH models/tools
+// fill each role. It mirrors the server-side `LoopComposition` (server/services/
+// consilium/composition.ts) — kept as a client-side interface (the canonical
+// shape has no @shared home). Every value is a NAME or a BOOLEAN — the server
+// allowlists them explicitly and NEVER exposes a secret. Absent on old backends
+// (or a degraded read), so the UI treats its presence as the only render signal.
+
+/** One role → the model/tool that fills it. */
+export interface CompositionRole {
+  role: string;
+  label: string;
+  model: string | null;
+  tool?: string | null;
+  enabled?: boolean;
+}
+
+/** The active verification config — names + booleans only. */
+export interface CompositionVerification {
+  implementEnabled: boolean;
+  perCriterionMethodEnabled: boolean;
+  verificationEnabled: boolean;
+  effectiveVerificationEnabled: boolean;
+  finalVerificationEnabled: boolean;
+  testCommand: string | null;
+  lintCommand: string | null;
+  testRunTimeoutMs: number;
+  sdlcTimeoutMs: number;
+  maxFixIterations: number;
+}
+
+/** The computed composition block (declared from the preset panel + config). */
+export interface LoopComposition {
+  preset: string | null;
+  debaters: CompositionRole[];
+  judge: CompositionRole;
+  judgeRetry: { enabled: boolean; fallbackModel: string | null };
+  planner: CompositionRole;
+  coder: CompositionRole;
+  verifier: CompositionRole;
+  verification: CompositionVerification;
+}
+
 /**
  * The detail endpoint returns the loop fields spread WITH a `rounds` array and,
  * while the loop is `developing`, an optional `devProgress` snapshot.
@@ -183,6 +227,12 @@ export type ConsiliumLoopDetail = ConsiliumLoopListItem & {
   archetypeParams?: Record<string, string> | null;
   /** The optional human instruction captured at review creation (INERT text). */
   engineerInstruction?: string | null;
+  /**
+   * Observability (GAP 2): the computed role→model/tool composition + verification
+   * config. Server-derived, read-only, secret-free. Absent on a pre-composition
+   * backend or a degraded read — consumers render it defensively.
+   */
+  composition?: LoopComposition | null;
 };
 
 export type { ConsiliumLoopState, ConsiliumLoopRow, ConsiliumLoopRoundRow };

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -43,6 +43,13 @@ import {
   ShieldAlert,
   BookOpen,
   Gavel,
+  Rocket,
+  Users,
+  Cpu,
+  Wrench,
+  FlaskConical,
+  GitBranch,
+  Radio,
 } from "lucide-react";
 import {
   useConsiliumLoop,
@@ -69,6 +76,8 @@ import {
   type ExecutionWorkerStatus,
   type ExecutionSkillCapability,
   type ExecutionCriterionMethod,
+  type LoopComposition,
+  type CompositionRole,
 } from "@/hooks/use-consilium-loops";
 import { useAuth } from "@/hooks/use-auth";
 import { useToast } from "@/hooks/use-toast";
@@ -1510,6 +1519,310 @@ function PlannedArchetypeCard({
 
 // ─── Page ───────────────────────────────────────────────────────────────────
 
+// ─── GAP 1: Launch passport ──────────────────────────────────────────────────
+//
+// HOW this loop was launched, consolidated into one card: the review preset
+// (server-recovered from the group name, via `composition`), createdAt/createdBy,
+// the target repoPath + reviewRef, the round budget, and the optional human
+// engineer instruction. Fields the loop already carried were scattered across
+// "Key facts"; this makes the launch context first-class + legible.
+//
+// SECURITY: `engineerInstruction` is UNTRUSTED human text — rendered as INERT
+// React text (never dangerouslySetInnerHTML). `createdBy` is server-masked for a
+// non-admin (absent ⇒ "hidden").
+
+function fmtRelative(raw: string | Date | null | undefined): { rel: string; abs: string } | null {
+  if (!raw) return null;
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return null;
+  return { rel: formatDistanceToNow(d, { addSuffix: true }), abs: d.toLocaleString() };
+}
+
+function LaunchPassportCard({ loop }: { loop: ConsiliumLoopDetailRow }) {
+  const created = fmtRelative(loop.createdAt);
+  const preset = loop.composition?.preset ?? null;
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-sm">
+          <Rocket className="h-4 w-4 text-primary" aria-hidden="true" />
+          Launch
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <dl className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+          <Fact label="Preset">
+            {preset ? (
+              <span className="font-mono text-xs">{preset}</span>
+            ) : (
+              <span className="text-muted-foreground">—</span>
+            )}
+          </Fact>
+          <Fact label="Max rounds">
+            <span className="tabular-nums">{loop.maxRounds}</span>
+          </Fact>
+          <Fact label="Created">
+            {created ? (
+              <span className="text-xs text-muted-foreground" title={created.abs}>
+                {created.rel}
+              </span>
+            ) : (
+              <span className="text-muted-foreground">—</span>
+            )}
+          </Fact>
+          <Fact label="Created by">
+            {loop.createdBy ? (
+              <span className="font-mono text-xs">{loop.createdBy}</span>
+            ) : (
+              <span className="text-xs text-muted-foreground">hidden</span>
+            )}
+          </Fact>
+          <Fact label="Review ref">
+            {loop.reviewRef ? (
+              <span className="inline-flex items-center gap-1 font-mono text-xs">
+                <GitBranch className="h-3 w-3 text-muted-foreground" aria-hidden="true" />
+                {loop.reviewRef}
+              </span>
+            ) : (
+              <span className="text-xs text-muted-foreground">working-tree HEAD</span>
+            )}
+          </Fact>
+          <Fact label="Repo">
+            <span className="font-mono text-xs break-all" title={loop.repoPath}>
+              {loop.repoPath}
+            </span>
+          </Fact>
+        </dl>
+        {/* Optional human steering captured at launch — INERT, fenced-as-text. */}
+        {loop.engineerInstruction ? (
+          <div className="space-y-1">
+            <p className="flex items-center gap-1.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+              <FileText className="h-3 w-3" aria-hidden="true" />
+              Engineer instruction
+            </p>
+            <p className="whitespace-pre-wrap break-words rounded bg-muted/50 p-2 text-xs">
+              {loop.engineerInstruction}
+            </p>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── GAP 2: Composition ──────────────────────────────────────────────────────
+//
+// WHICH model/tool fills each role of a round — the dispute debaters + judge, the
+// intent planner, the judge-timeout fallback, the SDLC coder, and the Stage-B
+// verifier — plus the active verification config. All server-DECLARED (from the
+// preset panel + config); the models that ACTUALLY ran surface per-participant in
+// each round's Dispute + the live "Current round" section (which read the real
+// execution rows), so this card is labelled to avoid preset-vs-actual drift.
+//
+// SECURITY: every value is a NAME or a BOOLEAN the server allowlisted — no secret
+// reaches the client. Rendered as INERT text; the card has no links.
+
+/** ms → a compact human duration (e.g. "20 min", "5 min", "45s"). */
+function msLabel(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return "—";
+  if (ms >= 60_000) {
+    const min = ms / 60_000;
+    return `${Number.isInteger(min) ? min : min.toFixed(1)} min`;
+  }
+  return `${Math.round(ms / 1000)}s`;
+}
+
+function EnabledPill({ on, label }: { on: boolean; label?: string }) {
+  return (
+    <Badge
+      className={
+        on
+          ? "bg-green-600 text-white gap-1"
+          : "bg-muted text-muted-foreground gap-1"
+      }
+    >
+      {on ? <Check className="h-3 w-3" /> : <X className="h-3 w-3" />}
+      {label ?? (on ? "on" : "off")}
+    </Badge>
+  );
+}
+
+function RoleRow({
+  icon,
+  role,
+  detail,
+}: {
+  icon: React.ReactNode;
+  role: CompositionRole;
+  detail?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2 border-b border-border/40 py-1.5 last:border-b-0">
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="text-muted-foreground">{icon}</span>
+        <span className="truncate text-sm">{role.label}</span>
+        {role.enabled === false ? (
+          <Badge className="bg-muted text-muted-foreground text-[10px]">disabled</Badge>
+        ) : null}
+      </div>
+      <div className="flex shrink-0 items-center gap-2 text-right">
+        {detail}
+        {role.tool ? (
+          <span className="text-[11px] text-muted-foreground">{role.tool}</span>
+        ) : null}
+        {role.model ? (
+          <span className="font-mono text-xs">{role.model}</span>
+        ) : !role.tool ? (
+          <span className="text-xs text-muted-foreground">—</span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function CompositionCard({ composition }: { composition: LoopComposition }) {
+  const v = composition.verification;
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-sm">
+          <Cpu className="h-4 w-4 text-primary" aria-hidden="true" />
+          Composition
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-[11px] text-muted-foreground/80">
+          Declared from the review preset + config. The models that actually ran
+          appear per-participant in each round&rsquo;s Dispute (and the live Current
+          round) below.
+        </p>
+
+        {/* Dispute panel + downstream roles → model/tool. */}
+        <div className="rounded-md border px-3">
+          {composition.debaters.map((d, i) => (
+            <RoleRow
+              key={`debater-${i}`}
+              icon={<Users className="h-3.5 w-3.5" />}
+              role={{ ...d, label: `Debater · ${d.label}` }}
+            />
+          ))}
+          <RoleRow icon={<Gavel className="h-3.5 w-3.5" />} role={composition.judge} />
+          <RoleRow
+            icon={<Sparkles className="h-3.5 w-3.5" />}
+            role={composition.planner}
+          />
+          <RoleRow icon={<Wrench className="h-3.5 w-3.5" />} role={composition.coder} />
+          <RoleRow
+            icon={<FlaskConical className="h-3.5 w-3.5" />}
+            role={composition.verifier}
+          />
+          {/* Judge-timeout resilience: a single bounded retry + optional fallback. */}
+          <div className="flex items-center justify-between gap-2 py-1.5">
+            <div className="flex items-center gap-2">
+              <RefreshCw className="h-3.5 w-3.5 text-muted-foreground" />
+              <span className="text-sm">Judge retry</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <EnabledPill on={composition.judgeRetry.enabled} />
+              {composition.judgeRetry.fallbackModel ? (
+                <span className="font-mono text-xs">
+                  {composition.judgeRetry.fallbackModel}
+                </span>
+              ) : (
+                <span className="text-xs text-muted-foreground">same model</span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Active verification config — flags + commands + timeouts (no secrets). */}
+        <div className="space-y-2">
+          <p className="flex items-center gap-1.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+            <FlaskConical className="h-3 w-3" aria-hidden="true" />
+            Verification config
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <EnabledPill on={v.implementEnabled} label={`skilled implement ${v.implementEnabled ? "on" : "off"}`} />
+            <EnabledPill on={v.perCriterionMethodEnabled} label={`per-criterion ${v.perCriterionMethodEnabled ? "on" : "off"}`} />
+            <EnabledPill on={v.effectiveVerificationEnabled} label={`test-run ${v.effectiveVerificationEnabled ? "on" : "off"}`} />
+            <EnabledPill on={v.finalVerificationEnabled} label={`final verify ${v.finalVerificationEnabled ? "on" : "off"}`} />
+          </div>
+          {/* Surface intent-vs-effective when the operator asked for verification
+              but the sandbox/trusted-repo gate withheld it (degrades to Stage-2a). */}
+          {v.verificationEnabled && !v.effectiveVerificationEnabled ? (
+            <p className="inline-flex items-center gap-1 text-[11px] text-amber-600 dark:text-amber-400">
+              <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+              verification requested but gated off (no sandbox / trusted-repo ack) — no test runs
+            </p>
+          ) : null}
+          <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs sm:grid-cols-4">
+            <div>
+              <dt className="text-muted-foreground">Test command</dt>
+              <dd className="font-mono break-all">{v.testCommand ?? "auto-detect"}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">Lint command</dt>
+              <dd className="font-mono break-all">{v.lintCommand ?? "—"}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">Test timeout</dt>
+              <dd className="tabular-nums">{msLabel(v.testRunTimeoutMs)}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">SDLC / AP timeout</dt>
+              <dd className="tabular-nums">{msLabel(v.sdlcTimeoutMs)}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground">Max fix iterations</dt>
+              <dd className="tabular-nums">{v.maxFixIterations}</dd>
+            </div>
+          </dl>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── GAP 3: live "Current round" (the REVIEWING phase is no longer a black box) ─
+//
+// consilium_loop_rounds rows are written at DECIDE time, so while round N is being
+// disputed there is NO round row yet → the per-round Dispute (below) can't render,
+// exactly when the operator is watching. The loop row DOES carry the in-flight
+// iteration (`currentIterationNumber`) the instant it enters REVIEWING, so we point
+// the SAME IterationDetailView (#451) at it: per-participant execution cards with
+// status / model / elapsed / expandable output as they land.
+//
+// Mounted ONLY while `reviewing`/`deciding` (so it unmounts — and stops polling —
+// the moment the round settles into a row); IterationDetailView fetches lazily and
+// polls on its own 3s cadence, so this adds no new polling machinery.
+const LIVE_ROUND_STATES: ReadonlySet<ConsiliumLoopState> = new Set<ConsiliumLoopState>([
+  "reviewing",
+  "deciding",
+]);
+
+function LiveCurrentRound({ loop }: { loop: ConsiliumLoopDetailRow }) {
+  if (!LIVE_ROUND_STATES.has(loop.state)) return null;
+  const iter = loop.currentIterationNumber;
+  if (iter == null || !loop.groupId) return null;
+  return (
+    <Card className="border-blue-500/40">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-sm">
+          <Radio className="h-4 w-4 animate-pulse text-blue-500" aria-hidden="true" />
+          Current round (live) — {loop.state === "reviewing" ? "reviewing" : "deciding"}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <p className="text-[11px] text-muted-foreground/80">
+          The dispute for round {loop.round || 1} is running (iteration #{iter}). Cards
+          update as each participant completes.
+        </p>
+        <IterationDetailView groupId={loop.groupId} iterationNumber={iter} />
+      </CardContent>
+    </Card>
+  );
+}
+
 export default function ConsiliumLoopDetail() {
   const params = useParams<{ id: string }>();
   const id = params.id;
@@ -1752,6 +2065,9 @@ export default function ConsiliumLoopDetail() {
           />
         )}
 
+        {/* GAP 1 — Launch passport: HOW this loop was launched, consolidated. */}
+        <LaunchPassportCard loop={loop} />
+
         {/* FSM progress */}
         <Card>
           <CardHeader className="pb-3">
@@ -1767,6 +2083,11 @@ export default function ConsiliumLoopDetail() {
             )}
           </CardContent>
         </Card>
+
+        {/* GAP 3 — live "Current round": the in-flight dispute during
+            reviewing/deciding, before any round row exists. Self-gates (renders
+            nothing outside those states) and unmounts to stop polling. */}
+        <LiveCurrentRound loop={loop} />
 
         {/* Key facts */}
         <Card>
@@ -1825,6 +2146,11 @@ export default function ConsiliumLoopDetail() {
             </dl>
           </CardContent>
         </Card>
+
+        {/* GAP 2 — Composition: WHICH model/tool fills each role + the active
+            verification config. Server-derived, read-only, secret-free; absent on
+            a pre-composition backend or a degraded read, so render defensively. */}
+        {loop.composition ? <CompositionCard composition={loop.composition} /> : null}
 
         {/* Rounds */}
         <Card>

--- a/server/routes/consilium-loops.ts
+++ b/server/routes/consilium-loops.ts
@@ -28,6 +28,11 @@ import { validateBody } from "../middleware/validate.js";
 import { authorizeConsiliumLoop } from "./authorize-consilium-loop.js";
 import { isVisible } from "./authorize-run.js";
 import { assertAllowedRepoPath } from "../services/consilium/repo-allowlist.js";
+import {
+  buildLoopComposition,
+  parseConsiliumPreset,
+  type LoopComposition,
+} from "../services/consilium/composition.js";
 
 const SHA_RE = /^[0-9a-f]{7,64}$/;
 
@@ -137,7 +142,32 @@ export function registerConsiliumLoopRoutes(
     // Stage 1: the new loop columns (engineerInstruction, archetype, archetypeSource,
     // archetypeRationale, archetypeParams, archetypeDecidedAt) ride the maskLoop
     // spread of `auth.loop` automatically — no per-field allowlist to keep in sync.
-    res.json({ ...maskLoop({ ...auth.loop }, !!isAdmin), rounds, devProgress, openRemainder });
+    //
+    // Observability (GAP 2): the computed `composition` — WHICH models/tools fill
+    // each role (debaters + judge from the review-factory preset panel, planner,
+    // judge-retry fallback, SDLC coder, Stage-B verifier) + the active verification
+    // config. Read-only, additive, and a strict NAME/BOOLEAN allowlist (never a
+    // secret — see composition.ts). The preset is recovered from the group NAME;
+    // the whole block is best-effort: any read failure (or a partial config) omits
+    // it rather than breaking the GET (parity with `devProgress`).
+    let composition: LoopComposition | undefined;
+    try {
+      const group =
+        typeof storage.getTaskGroup === "function"
+          ? await storage.getTaskGroup(auth.loop.groupId)
+          : undefined;
+      const preset = parseConsiliumPreset(group?.name);
+      composition = buildLoopComposition(preset, config());
+    } catch {
+      composition = undefined;
+    }
+    res.json({
+      ...maskLoop({ ...auth.loop }, !!isAdmin),
+      rounds,
+      devProgress,
+      openRemainder,
+      composition,
+    });
   });
 
   // ── Start (PENDING → BUILDING_CONTEXT) ──────────────────────────────────────

--- a/server/services/consilium/composition.ts
+++ b/server/services/consilium/composition.ts
@@ -1,0 +1,177 @@
+/**
+ * composition.ts — the read-only, computed "who does what" of a consilium loop
+ * (Observability GAP 2). It answers a question the loop row alone cannot: WHICH
+ * models/tools fill each role of a round — the dispute debaters + judge (from the
+ * review-factory preset panel), the intent planner, the judge-timeout fallback,
+ * the SDLC coder (provider/CLI), the Stage-B per-criterion verifier, and the
+ * active verification config (commands/timeouts/gates).
+ *
+ * It is ADDITIVE and READ-ONLY: surfaced as the `composition` block on
+ * GET /api/consilium-loops/:id and rendered as the "Composition" card. Nothing
+ * downstream branches on it.
+ *
+ * SECURITY (the ONLY hard rule here): this is a **strict allowlist** of NAMES and
+ * BOOLEANS. It reads model slugs (server constants), kill-switch flags, timeouts,
+ * and operator-configured test/lint COMMANDS — the same names already surfaced in
+ * PR bodies / round `testSummary`. It NEVER reads a secret: no `apiKey`, no
+ * `encryption.key`, no `clusterSecret`, no token. Do not spread config; every
+ * field below is picked explicitly by name so a future secret added to the config
+ * schema can never leak through here.
+ */
+import type { AppConfig } from "../../config/schema.js";
+import { effectiveVerificationEnabled } from "../../config/schema.js";
+import { PRESET_PANELS, type ConsiliumPanel } from "./review-factory.js";
+import { CONSILIUM_REVIEW_PRESETS, type ConsiliumReviewPreset } from "@shared/types";
+
+/** One role in the round → the model/tool that fills it. */
+export interface CompositionRole {
+  /** Machine role key ("debater" | "judge" | "planner" | "coder" | "verifier"). */
+  readonly role: string;
+  /** Human display label (e.g. "Opus", "Judge", "SDLC coder"). */
+  readonly label: string;
+  /** Catalog model slug, or null when the role runs on a tool rather than a slug. */
+  readonly model: string | null;
+  /** The tool/provider a role runs through (e.g. "claude CLI (local)"), when applicable. */
+  readonly tool?: string | null;
+  /** For a gated role: whether the kill-switch that arms it is on. */
+  readonly enabled?: boolean;
+}
+
+/** The active verification config — names + booleans only (no secrets). */
+export interface CompositionVerification {
+  readonly implementEnabled: boolean;
+  readonly perCriterionMethodEnabled: boolean;
+  readonly verificationEnabled: boolean;
+  /** The gated truth (verification.enabled AND sandbox/trusted-repo ack). */
+  readonly effectiveVerificationEnabled: boolean;
+  readonly finalVerificationEnabled: boolean;
+  readonly testCommand: string | null;
+  readonly lintCommand: string | null;
+  readonly testRunTimeoutMs: number;
+  readonly sdlcTimeoutMs: number;
+  readonly maxFixIterations: number;
+}
+
+/** The computed composition block surfaced on the loop GET. */
+export interface LoopComposition {
+  /** The review preset (recovered from the group name), or null when unknown. */
+  readonly preset: ConsiliumReviewPreset | null;
+  /** The cross-review dispute participants (one per panel seat). */
+  readonly debaters: CompositionRole[];
+  /** The synthesizing judge. */
+  readonly judge: CompositionRole;
+  /** Judge-timeout resilience: bounded single-retry + optional fallback model. */
+  readonly judgeRetry: { readonly enabled: boolean; readonly fallbackModel: string | null };
+  /** The intent→archetype planner. */
+  readonly planner: CompositionRole;
+  /** The SDLC coder (provider/CLI that implements action points). */
+  readonly coder: CompositionRole;
+  /** The Stage-B `judge`-method per-criterion verifier. */
+  readonly verifier: CompositionRole;
+  /** The active verification config. */
+  readonly verification: CompositionVerification;
+}
+
+const GROUP_NAME_PRESET_RE = /^\[consilium-review:([a-z0-9-]+)\]/i;
+
+/**
+ * Recover the review preset from a consilium group's NAME (the factory names the
+ * group `[consilium-review:<preset>] <repo>`). Returns null for a name that does
+ * not match or names an unknown preset — the caller renders the panel from the
+ * default (all presets share the proven 2-model panel today) and simply omits the
+ * preset label. Pure + defensive: never throws on a malformed/absent name.
+ */
+export function parseConsiliumPreset(
+  groupName: string | null | undefined,
+): ConsiliumReviewPreset | null {
+  if (!groupName) return null;
+  const m = GROUP_NAME_PRESET_RE.exec(groupName);
+  const candidate = m?.[1];
+  if (!candidate) return null;
+  return (CONSILIUM_REVIEW_PRESETS as readonly string[]).includes(candidate)
+    ? (candidate as ConsiliumReviewPreset)
+    : null;
+}
+
+/**
+ * Build the loop's composition from the (recovered) preset + the parsed config.
+ * PURE — no I/O, no side effects. The panel is the preset's panel when known, else
+ * the canonical cross-review panel (every preset shares it today, so a null preset
+ * still yields the correct debaters/judge). Every config read is an explicit,
+ * name-by-name allowlist pick — see the file header security note.
+ */
+export function buildLoopComposition(
+  preset: ConsiliumReviewPreset | null,
+  config: AppConfig,
+): LoopComposition {
+  const panel: ConsiliumPanel =
+    (preset && PRESET_PANELS[preset]) || PRESET_PANELS["sdlc-cross-review"];
+
+  const loopCfg = config.pipeline.consiliumLoop;
+  const impl = loopCfg.implement;
+
+  const debaters: CompositionRole[] = panel.reviewers.map((r) => ({
+    role: "debater",
+    label: r.name,
+    model: r.modelSlug,
+  }));
+
+  const judge: CompositionRole = {
+    role: "judge",
+    label: "Judge",
+    model: panel.judgeModelSlug,
+  };
+
+  const planner: CompositionRole = {
+    role: "planner",
+    label: "Intent planner",
+    model: loopCfg.planner.model,
+    enabled: loopCfg.planner.enabled,
+  };
+
+  // The SDLC coder runs through the Anthropic provider: "cli" mode = the local
+  // `claude` CLI (Opus, subscription-backed, 0 API tokens); "api" = the billed
+  // Anthropic API. Only the MODE and the resulting tool NAME are exposed — never
+  // the apiKey.
+  const cliMode = config.providers.anthropic.mode === "cli";
+  const coder: CompositionRole = {
+    role: "coder",
+    label: "SDLC coder",
+    model: cliMode ? "claude-opus" : null,
+    tool: cliMode ? "claude CLI (local)" : "Anthropic API",
+  };
+
+  const verifier: CompositionRole = {
+    role: "verifier",
+    label: "Stage-B verifier",
+    model: impl.perCriterionMethod.judgeModel,
+    enabled: impl.perCriterionMethod.enabled,
+  };
+
+  const verification: CompositionVerification = {
+    implementEnabled: impl.enabled,
+    perCriterionMethodEnabled: impl.perCriterionMethod.enabled,
+    verificationEnabled: impl.verification.enabled,
+    effectiveVerificationEnabled: effectiveVerificationEnabled(config),
+    finalVerificationEnabled: impl.finalVerification.enabled,
+    testCommand: impl.testCommand,
+    lintCommand: impl.lintCommand,
+    testRunTimeoutMs: impl.testRunTimeoutMs,
+    sdlcTimeoutMs: loopCfg.sdlcTimeoutMs,
+    maxFixIterations: impl.maxFixIterations,
+  };
+
+  return {
+    preset,
+    debaters,
+    judge,
+    judgeRetry: {
+      enabled: loopCfg.judgeRetry.enabled,
+      fallbackModel: loopCfg.judgeRetry.fallbackModel ?? null,
+    },
+    planner,
+    coder,
+    verifier,
+    verification,
+  };
+}

--- a/tests/unit/consilium/composition.test.ts
+++ b/tests/unit/consilium/composition.test.ts
@@ -1,0 +1,256 @@
+/**
+ * composition.test.ts — the read-only, computed "who does what" of a consilium
+ * loop (Observability GAP 2). Covers the PURE helpers
+ * (`parseConsiliumPreset` + `buildLoopComposition`) and the GET route SHAPE.
+ *
+ * The load-bearing property is SECURITY: the composition is a strict NAME/BOOLEAN
+ * allowlist and must NEVER carry a secret (apiKey / encryption key / token), even
+ * when those are populated in the config it reads. That is asserted directly by
+ * planting secrets into the config and proving they do not surface.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import {
+  buildLoopComposition,
+  parseConsiliumPreset,
+} from "../../../server/services/consilium/composition.js";
+import { ConfigSchema, type AppConfig } from "../../../server/config/schema.js";
+import type { IStorage } from "../../../server/storage.js";
+import type { ConsiliumLoopController } from "../../../server/services/consilium/consilium-loop-controller.js";
+import { registerConsiliumLoopRoutes } from "../../../server/routes/consilium-loops.js";
+
+const baseConfig = (): AppConfig => ConfigSchema.parse({});
+
+// ─── parseConsiliumPreset — recover the preset from the group NAME ────────────
+
+describe("parseConsiliumPreset", () => {
+  it("recovers each known preset from the factory group-name prefix", () => {
+    expect(parseConsiliumPreset("[consilium-review:sdlc-cross-review] widget")).toBe(
+      "sdlc-cross-review",
+    );
+    expect(parseConsiliumPreset("[consilium-review:diff-pr-review] some/repo")).toBe(
+      "diff-pr-review",
+    );
+    expect(parseConsiliumPreset("[consilium-review:full-viability]")).toBe(
+      "full-viability",
+    );
+  });
+
+  it("returns null for an unknown preset, a non-matching name, or an absent name", () => {
+    expect(parseConsiliumPreset("[consilium-review:not-a-preset] x")).toBeNull();
+    expect(parseConsiliumPreset("just a plain group name")).toBeNull();
+    expect(parseConsiliumPreset("")).toBeNull();
+    expect(parseConsiliumPreset(null)).toBeNull();
+    expect(parseConsiliumPreset(undefined)).toBeNull();
+  });
+});
+
+// ─── buildLoopComposition — preset → roles/panel ─────────────────────────────
+
+describe("buildLoopComposition — preset → panel roles", () => {
+  it("maps the cross-review panel to debaters (Opus + Gemini) and an Opus judge", () => {
+    const c = buildLoopComposition("sdlc-cross-review", baseConfig());
+    expect(c.preset).toBe("sdlc-cross-review");
+    expect(c.debaters).toHaveLength(2);
+    expect(c.debaters.map((d) => d.label)).toEqual(["Opus", "Gemini"]);
+    expect(c.debaters.map((d) => d.model)).toEqual(["claude-opus", "gemini-3-1-pro-high"]);
+    expect(c.debaters.every((d) => d.role === "debater")).toBe(true);
+    expect(c.judge.role).toBe("judge");
+    expect(c.judge.model).toBe("claude-opus");
+  });
+
+  it("falls back to the canonical panel (and a null preset) for an unknown/absent preset", () => {
+    const c = buildLoopComposition(null, baseConfig());
+    // Every preset shares the 2-model panel today, so a null preset still yields
+    // the correct debaters/judge — only the preset LABEL is omitted.
+    expect(c.preset).toBeNull();
+    expect(c.debaters.map((d) => d.model)).toEqual(["claude-opus", "gemini-3-1-pro-high"]);
+    expect(c.judge.model).toBe("claude-opus");
+  });
+
+  it("exposes the downstream roles: planner, coder, verifier", () => {
+    const c = buildLoopComposition("diff-pr-review", baseConfig());
+    expect(c.planner.role).toBe("planner");
+    expect(c.coder.role).toBe("coder");
+    expect(c.verifier.role).toBe("verifier");
+  });
+});
+
+// ─── buildLoopComposition — config → flags/models ────────────────────────────
+
+describe("buildLoopComposition — config → flags & models", () => {
+  it("reflects the SDLC coder mode: cli → local CLI (claude-opus), api → Anthropic API (no slug)", () => {
+    const cli = buildLoopComposition(null, baseConfig()); // mode defaults to "cli"
+    expect(cli.coder.tool).toBe("claude CLI (local)");
+    expect(cli.coder.model).toBe("claude-opus");
+
+    const api = buildLoopComposition(
+      null,
+      ConfigSchema.parse({ providers: { anthropic: { mode: "api" } } }),
+    );
+    expect(api.coder.tool).toBe("Anthropic API");
+    expect(api.coder.model).toBeNull();
+  });
+
+  it("threads verification flags, commands, timeouts, planner + judge-retry from config", () => {
+    const config = ConfigSchema.parse({
+      pipeline: {
+        consiliumLoop: {
+          sdlcTimeoutMs: 900_000,
+          planner: { enabled: true, model: "claude-sonnet" },
+          judgeRetry: { enabled: true, fallbackModel: "gemini-3-1-pro-high" },
+          implement: {
+            enabled: true,
+            testCommand: "npm test",
+            lintCommand: "npm run lint",
+            maxFixIterations: 5,
+            testRunTimeoutMs: 600_000,
+            verification: { enabled: true },
+            trustedRepoAck: true,
+            finalVerification: { enabled: true },
+            perCriterionMethod: { enabled: true, judgeModel: "claude-opus" },
+          },
+        },
+      },
+    });
+    const c = buildLoopComposition("full-viability", config);
+    expect(c.verification.implementEnabled).toBe(true);
+    expect(c.verification.perCriterionMethodEnabled).toBe(true);
+    expect(c.verification.verificationEnabled).toBe(true);
+    // verification.enabled AND trustedRepoAck ⇒ gate satisfied.
+    expect(c.verification.effectiveVerificationEnabled).toBe(true);
+    expect(c.verification.finalVerificationEnabled).toBe(true);
+    expect(c.verification.testCommand).toBe("npm test");
+    expect(c.verification.lintCommand).toBe("npm run lint");
+    expect(c.verification.testRunTimeoutMs).toBe(600_000);
+    expect(c.verification.sdlcTimeoutMs).toBe(900_000);
+    expect(c.verification.maxFixIterations).toBe(5);
+    expect(c.judgeRetry).toEqual({ enabled: true, fallbackModel: "gemini-3-1-pro-high" });
+    expect(c.planner.model).toBe("claude-sonnet");
+    expect(c.verifier.model).toBe("claude-opus");
+    expect(c.verifier.enabled).toBe(true);
+  });
+
+  it("reports verification requested-but-gated-off (no sandbox / no trusted-repo ack)", () => {
+    const config = ConfigSchema.parse({
+      pipeline: {
+        consiliumLoop: { implement: { verification: { enabled: true } } },
+      },
+    });
+    const c = buildLoopComposition(null, config);
+    expect(c.verification.verificationEnabled).toBe(true);
+    // Requested but the sandbox/trusted-repo gate withholds it → degrades to 2a.
+    expect(c.verification.effectiveVerificationEnabled).toBe(false);
+  });
+});
+
+// ─── SECURITY: strict NAME/BOOLEAN allowlist — a secret can NEVER surface ─────
+
+describe("buildLoopComposition — secret allowlist (never leaks a secret)", () => {
+  const SECRETS = {
+    anthropic: "sk-ant-SECRET-DO-NOT-LEAK",
+    google: "GOOGLE-SECRET-DO-NOT-LEAK",
+    xai: "XAI-SECRET-DO-NOT-LEAK",
+    tavily: "TAVILY-SECRET-DO-NOT-LEAK",
+  };
+
+  const config = ConfigSchema.parse({
+    providers: {
+      anthropic: { mode: "api", apiKey: SECRETS.anthropic },
+      google: { apiKey: SECRETS.google },
+      xai: { apiKey: SECRETS.xai },
+      tavily: { apiKey: SECRETS.tavily },
+    },
+  });
+
+  it("carries none of the planted secret VALUES anywhere in the composition", () => {
+    const serialized = JSON.stringify(buildLoopComposition("sdlc-cross-review", config));
+    for (const secret of Object.values(SECRETS)) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+
+  it("exposes no secret-NAMED key (apiKey / secret / token / password / key) at any depth", () => {
+    const c = buildLoopComposition("sdlc-cross-review", config);
+    const secretKey = /api[-_]?key|secret|token|password|(^|[^a-z])key([^a-z]|$)/i;
+    const walk = (node: unknown, path: string): void => {
+      if (node == null || typeof node !== "object") return;
+      for (const [k, v] of Object.entries(node)) {
+        expect(
+          secretKey.test(k),
+          `secret-named key "${k}" found at ${path}`,
+        ).toBe(false);
+        walk(v, `${path}.${k}`);
+      }
+    };
+    walk(c, "composition");
+  });
+});
+
+// ─── Route shape — GET /api/consilium-loops/:id merges `composition` ──────────
+
+const LOOP_ID = "loop-1";
+const OWNER = "user-1";
+const LOOP = {
+  id: LOOP_ID,
+  groupId: "grp-1",
+  state: "reviewing",
+  round: 1,
+  createdBy: OWNER,
+  repoPath: "/repos/widget",
+};
+
+function makeApp(opts: { groupName?: string; hasGetTaskGroup?: boolean } = {}) {
+  const { groupName = "[consilium-review:diff-pr-review] widget", hasGetTaskGroup = true } = opts;
+  const controller = {
+    getDevProgress: vi.fn(() => undefined),
+  } as unknown as ConsiliumLoopController;
+
+  const storage = {
+    getLoop: vi.fn(async () => ({ ...LOOP })),
+    getLoopRounds: vi.fn(async () => []),
+    ...(hasGetTaskGroup
+      ? { getTaskGroup: vi.fn(async () => ({ id: "grp-1", name: groupName })) }
+      : {}),
+  } as unknown as IStorage;
+
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as unknown as { user: { id: string } }).user = { id: OWNER };
+    next();
+  });
+  registerConsiliumLoopRoutes(app, storage, controller, () => baseConfig());
+  return app;
+}
+
+describe("GET /api/consilium-loops/:id — composition merge (route shape)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("merges a composition block with the preset recovered from the group name", async () => {
+    const res = await request(makeApp()).get(`/api/consilium-loops/${LOOP_ID}`);
+    expect(res.status).toBe(200);
+    expect(res.body.composition).toBeDefined();
+    expect(res.body.composition.preset).toBe("diff-pr-review");
+    expect(res.body.composition.debaters).toHaveLength(2);
+    expect(res.body.composition.judge.model).toBe("claude-opus");
+    expect(res.body.composition.verification).toBeDefined();
+  });
+
+  it("still returns a (null-preset) composition when storage lacks getTaskGroup", async () => {
+    const res = await request(makeApp({ hasGetTaskGroup: false })).get(
+      `/api/consilium-loops/${LOOP_ID}`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.composition).toBeDefined();
+    expect(res.body.composition.preset).toBeNull();
+    expect(res.body.composition.debaters).toHaveLength(2);
+  });
+
+  it("never serializes a secret-named key in the route response composition", async () => {
+    const res = await request(makeApp()).get(`/api/consilium-loops/${LOOP_ID}`);
+    const serialized = JSON.stringify(res.body.composition);
+    expect(serialized).not.toMatch(/apiKey|"key"|password|token/i);
+  });
+});


### PR DESCRIPTION
## What

Closes three black-box gaps on the consilium loop detail page (`ConsiliumLoopDetail.tsx`), per `docs/design/loop-consolidation.md` §8. All server work is **additive, read-side only** — no FSM/schema/migration change.

### 1. Launch passport card (GAP 1)
Consolidates *how* the loop was launched into one card: preset (server-recovered from the group name), `createdBy`/`createdAt` (createdBy server-masked for non-admins), `repoPath`, `reviewRef`, `maxRounds`, and the optional `engineerInstruction` (untrusted human text, rendered INERT).

### 2. Composition card + server block (GAP 2)
A computed `composition` block on `GET /api/consilium-loops/:id` answering "which model/tool fills each role":

```jsonc
{
  "preset": "diff-pr-review" | null,           // recovered from the group name
  "debaters": [ { "role": "debater", "label": "Opus",   "model": "claude-opus" },
                { "role": "debater", "label": "Gemini", "model": "gemini-3-1-pro-high" } ],
  "judge":    { "role": "judge",    "label": "Judge",         "model": "claude-opus" },
  "judgeRetry": { "enabled": bool, "fallbackModel": string | null },
  "planner":  { "role": "planner",  "label": "Intent planner", "model": "…", "enabled": bool },
  "coder":    { "role": "coder",    "label": "SDLC coder", "model": "claude-opus" | null,
                "tool": "claude CLI (local)" | "Anthropic API" },
  "verifier": { "role": "verifier", "label": "Stage-B verifier", "model": "…", "enabled": bool },
  "verification": {
    "implementEnabled": bool, "perCriterionMethodEnabled": bool,
    "verificationEnabled": bool, "effectiveVerificationEnabled": bool,
    "finalVerificationEnabled": bool,
    "testCommand": string | null, "lintCommand": string | null,
    "testRunTimeoutMs": number, "sdlcTimeoutMs": number, "maxFixIterations": number
  }
}
```

**Security:** strict NAME/BOOLEAN allowlist — every config read is an explicit name-by-name pick (never a spread), so a future secret added to the config schema can never leak. No `apiKey`/`token`/`encryption`/key ever surfaces. The block is `undefined` on any read failure or partial config (parity with `devProgress`). Values are **declared** (from preset + config) and labeled as such in the card; the models that *actually ran* surface per-participant in each round's Dispute and the live section below — avoiding declared-vs-observed drift.

### 3. Live current-round section (GAP 3)
`consilium_loop_rounds` rows are written at *decide* time, so the reviewing phase was blank before a round row existed. Reuses `IterationDetailView` (#451) pointed at the loop's in-flight `currentIterationNumber`. Mounts **only** in `reviewing`/`deciding` and unmounts otherwise, so it uses the existing 3s poll cadence and adds no new polling — and stops the moment the round settles.

> GAP 4 (lifecycle stepper) was already implemented as `FsmStepper` on `main`; no change needed.

## Salvaged vs redone
The previous team's worktree was **mostly sound and fully salvaged** — `composition.ts`, the route wiring, the client hook types, and the three card *component definitions* all typechecked cleanly. What was missing (team died "inserting components before the main export"): **the components were defined but never rendered**. Redone: wired all three cards into the render tree at logical positions, and added the test suite. Nothing was thrown away.

## Tests
- `tests/unit/consilium/composition.test.ts` (new, 13 tests): `parseConsiliumPreset` recovery, preset→panel roles, config→flags/models, **secret-allowlist** (planted apiKeys + secret-named-key walk), and GET route shape.
- `tsc --noEmit`: clean.
- Full unit suite: **4724 passed** (241 files).

## Adversarial self-review
- **Secret leakage:** explicit allowlist + direct tests (planted secret values absent; no secret-named key at any depth).
- **API hammering:** live section self-gates to reviewing/deciding and unmounts otherwise; reuses IterationDetailView's existing poll — no new machinery.
- **Declared-vs-observed drift:** composition is labeled DECLARED; observed models live in the dispute + live cards.
