### PR TITLE
feat: commit-count build version in health and sidebar

### DIFF
--- a/client/src/components/layout/MainLayout.tsx
+++ b/client/src/components/layout/MainLayout.tsx
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/hooks/use-auth";
+import { useQuery } from "@tanstack/react-query";
 import type { UserRole } from "@shared/types";
 import { PeerStatusBadge } from "@/components/config-sync/PeerStatusBadge";
 import { ProjectSelector } from "@/components/ProjectSelector";
@@ -37,6 +38,14 @@ const ROLE_BADGE: Record<UserRole, { label: string; className: string }> = {
 export default function MainLayout({ children }: MainLayoutProps) {
   const [location, navigate] = useLocation();
   const { user, logout } = useAuth();
+  // Build identity from /api/health (public): version = 1.0.<commit count>, plus short sha.
+  const { data: health } = useQuery<{ version?: string; commit?: string | null }>({
+    queryKey: ["/api/health"],
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+  });
+  const version = health?.version && health.version !== "unknown" ? health.version : null;
+  const commit = health?.commit ?? null;
 
   // Detect if we're inside a workspace so we can show the connections sub-item
   const workspaceMatch = location.match(/^\/workspaces\/([^/]+)/);
@@ -183,6 +192,12 @@ export default function MainLayout({ children }: MainLayoutProps) {
           </button>
           <div className="px-3 py-2 text-xs text-muted-foreground flex flex-col gap-1">
             <span className="font-mono text-[10px] uppercase tracking-wider">Status: Air-gapped</span>
+            {version && (
+              <span className="font-mono text-[10px] uppercase tracking-wider">
+                Build: v{version}
+                {commit ? ` · ${commit}` : ""}
+              </span>
+            )}
             <span className="font-mono text-[10px] uppercase tracking-wider text-emerald-500">
               Telemetry: Disabled
             </span>

--- a/server/build-info.ts
+++ b/server/build-info.ts
@@ -1,0 +1,47 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Build identity, computed ONCE at boot from the git checkout the server runs
+ * from. The version number is simply the commit count on HEAD ("count versions
+ * by commit"), paired with the short sha for exact provenance.
+ *
+ * Fail-soft: outside a git checkout (or with git missing) every field is null
+ * and callers fall back to the static package version. Never throws, never
+ * blocks boot (callers await a cached promise).
+ */
+export interface BuildInfo {
+  /** e.g. "1.0.1234" — 1.0.<commit count on HEAD>. */
+  version: string | null;
+  /** Short commit sha, e.g. "67d2365b". */
+  commit: string | null;
+  /** Total commits on HEAD. */
+  commitCount: number | null;
+}
+
+let cached: Promise<BuildInfo> | null = null;
+
+async function compute(): Promise<BuildInfo> {
+  try {
+    const [count, sha] = await Promise.all([
+      execFileAsync("git", ["rev-list", "--count", "HEAD"], { timeout: 5_000 }),
+      execFileAsync("git", ["rev-parse", "--short", "HEAD"], { timeout: 5_000 }),
+    ]);
+    const commitCount = Number.parseInt(count.stdout.trim(), 10);
+    const commit = sha.stdout.trim();
+    if (!Number.isFinite(commitCount) || !/^[0-9a-f]{4,40}$/.test(commit)) {
+      return { version: null, commit: null, commitCount: null };
+    }
+    return { version: `1.0.${commitCount}`, commit, commitCount };
+  } catch {
+    return { version: null, commit: null, commitCount: null };
+  }
+}
+
+/** Cached-forever build info (the checkout does not change under a running server). */
+export function getBuildInfo(): Promise<BuildInfo> {
+  cached ??= compute();
+  return cached;
+}

--- a/server/routes/health.ts
+++ b/server/routes/health.ts
@@ -3,6 +3,7 @@ import { pool } from "../db";
 import { configLoader } from "../config/loader";
 import { authService } from "../auth/service";
 import { getFederationManager } from "../federation/manager-state";
+import { getBuildInfo } from "../build-info";
 
 /**
  * GET /api/health
@@ -113,10 +114,13 @@ export function registerHealthRoutes(app: Express): void {
       peerCount: fm ? fm.getPeers().length : 0,
     };
 
+    const build = await getBuildInfo();
+
     // Full response for authenticated users
     const body = {
       status: overallStatus,
-      version: process.env.npm_package_version ?? "unknown",
+      version: build.version ?? process.env.npm_package_version ?? "unknown",
+      commit: build.commit,
       uptime: Math.floor(process.uptime()),
       db: dbStatus,
       providers: {


### PR DESCRIPTION
Operator ask: versioning next to "Status: Air-gapped", counted by commit.

- `server/build-info.ts`: computed once at boot — `version = 1.0.<git rev-list --count HEAD>` + short sha; fail-soft nulls outside a checkout (health falls back to the package version).
- `/api/health` now carries the git-derived `version` + `commit`.
- Sidebar footer renders `Build: v1.0.NNNN · sha` under the Air-gapped status.

tsc clean.