### PR TITLE
feat: configurable SDLC coder model

### DIFF
--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -416,6 +416,35 @@ export const ConfigSchema = z.object({
          *  `consiliumLoop.enabled` (the loop only runs at all when that is true). */
         enabled: z.boolean().default(false),
         /**
+         * OPTIONAL operator-pinned model for the agentic SDLC coder (the local
+         * `claude` CLI that implements action points). Absent (default) ⇒ the coder
+         * spawns with NO `--model` flag and uses the CLI's OWN default model —
+         * byte-for-byte today's behavior. When SET, EVERY coder invocation of a
+         * round (initial per-AP coder, verify→fix iterations, final-state fix coder)
+         * adds `--model <slug>`.
+         *
+         * SECURITY (fail-closed at load): the coder passes this as a SEPARATE argv
+         * element (arg-array, no shell), but it is STILL constrained to a safe slug
+         * so a config value can never be flag-like, whitespaced, or a shell
+         * metacharacter — it can ONLY ever be a model id. The task specified
+         * `^[a-zA-Z0-9._-]+$`; this is tightened to require an alphanumeric FIRST
+         * char (a strict subset) so a value can never even look like a flag
+         * (`-p`, `--dangerously-...`). A value that fails ABORTS config load rather
+         * than silently defaulting; the argv seam (`buildCoderArgs`) re-validates
+         * with the SAME slug as an independent second layer. min(1) rejects empty.
+         * NOTE: this is a claude-CLI model slug (e.g. "sonnet"); the coder path is
+         * claude-CLI-specific — see the PR for why the Gemini/Antigravity CLI cannot
+         * serve as an agentic coder today.
+         */
+        coderModel: z
+          .string()
+          .min(1)
+          .regex(
+            /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/,
+            "coderModel must be a safe model slug (alphanumeric start; [A-Za-z0-9._-])",
+          )
+          .optional(),
+        /**
          * Stage 2b (design §3.C/§5/§10-2b): the per-criterion SANDBOXED VERIFICATION
          * + bounded code→test→fix loop — the ONLY surface that EXECUTES repo code (the
          * test command) in the isolated worktree. It has its OWN kill-switch, default

--- a/server/services/consilium/composition.ts
+++ b/server/services/consilium/composition.ts
@@ -130,14 +130,17 @@ export function buildLoopComposition(
   };
 
   // The SDLC coder runs through the Anthropic provider: "cli" mode = the local
-  // `claude` CLI (Opus, subscription-backed, 0 API tokens); "api" = the billed
-  // Anthropic API. Only the MODE and the resulting tool NAME are exposed — never
-  // the apiKey.
+  // `claude` CLI (subscription-backed, 0 API tokens); "api" = the billed Anthropic
+  // API. Only the MODE, the resulting tool NAME, and the (operator-pinned) model
+  // slug are exposed — never the apiKey. When the operator pins
+  // `implement.coderModel` it is surfaced VERBATIM (the coder spawns `--model
+  // <slug>`); absent ⇒ the coder runs on the CLI's OWN default (cli mode shows the
+  // known default slug, api mode has no slug).
   const cliMode = config.providers.anthropic.mode === "cli";
   const coder: CompositionRole = {
     role: "coder",
     label: "SDLC coder",
-    model: cliMode ? "claude-opus" : null,
+    model: impl.coderModel ?? (cliMode ? "claude-opus" : null),
     tool: cliMode ? "claude CLI (local)" : "Anthropic API",
   };
 

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -1418,6 +1418,9 @@ export class ConsiliumLoopController {
       // Per-action-point coder timeout (configurable). The executor runs the
       // coder once per action point sequentially; this bounds a SINGLE run.
       coderTimeoutMs: cfg.sdlcTimeoutMs,
+      // Operator-pinned coder model (optional). Absent ⇒ the CLI's default model.
+      // Threaded once at the executor's runCoder seam into every coder invocation.
+      coderModel: cfg.implement.coderModel,
       // Stage 2a archetype-branched skilled coder (null archetype ⇒ default step set).
       archetype: loop.archetype ?? null,
       archetypeParams: loop.archetypeParams ?? null,

--- a/server/services/sdlc/coder.ts
+++ b/server/services/sdlc/coder.ts
@@ -72,6 +72,30 @@ const ERROR_MAX = 300;
 export const ALLOWED_TOOLS = ["Edit", "Write", "Read"] as const;
 
 /**
+ * Safe shape for the OPTIONAL operator-pinned coder model slug (config
+ * `pipeline.consiliumLoop.implement.coderModel`). A pinned model reaches the
+ * `claude` CLI as a SEPARATE argv element (`--model <slug>`, arg-array, no shell),
+ * so it can never be word-split into extra flags — but we STILL constrain it so a
+ * config value can never carry whitespace or a shell metacharacter: it can ONLY
+ * ever be a model id.
+ *
+ * The task specified `^[a-zA-Z0-9._-]+$`; we TIGHTEN it to the strict subset below
+ * — the FIRST character must be alphanumeric, so a value can never even LOOK like a
+ * flag (`-p`, `--dangerously-skip-permissions`) regardless of how the CLI's arg
+ * parser treats a leading-dash option value. Every value this accepts the specified
+ * regex also accepts (strict subset), so it stays within the required slug shape
+ * while closing the leading-`-` flag-injection vector the adversarial review flags.
+ * Enforced at BOTH the config schema (fail-closed at load) AND here at the argv seam
+ * (defense-in-depth — an invalid value is dropped, degrading to the CLI default).
+ */
+export const CODER_MODEL_SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+
+/** True iff `model` is a safe model slug (see {@link CODER_MODEL_SLUG_RE}). */
+export function isValidCoderModel(model: string): boolean {
+  return CODER_MODEL_SLUG_RE.test(model);
+}
+
+/**
  * H-1 — the coder spawns under a COMPLETE, ALLOWLISTED env (not the inherited
  * `process.env`). Only these keys are forwarded: PATH/HOME + locale so the OS can
  * resolve + run the `claude` binary, and the claude CLI's OWN auth/config vars so
@@ -151,6 +175,14 @@ export interface CoderOptions {
    * ⇒ the legacy prompt verbatim (no regression).
    */
   systemPrompt?: string;
+  /**
+   * OPTIONAL operator-pinned model slug for the coder's `claude` CLI invocation
+   * (config `pipeline.consiliumLoop.implement.coderModel`). When set AND a safe
+   * slug, `buildCoderArgs` adds `--model <slug>`; absent (or invalid) ⇒ the CLI's
+   * OWN default model — byte-for-byte today's invocation. Validated against
+   * {@link CODER_MODEL_SLUG_RE} at the argv seam so config can never inject a flag.
+   */
+  model?: string;
 }
 
 function clamp(value: string, max: number): string {
@@ -213,18 +245,29 @@ export function buildCoderPrompt(
  * NARROW the surface — a value outside the baseline (e.g. `Bash`) is dropped, and a
  * wholly-empty result degrades to the baseline (fail-safe; never a widening). A
  * strict subset (read-only ⇒ ["Read"]) is honored exactly.
+ *
+ * `model` is the OPTIONAL operator-pinned coder model (config
+ * `implement.coderModel`). When present AND a safe slug it is emitted as
+ * `--model <slug>` (a SEPARATE argv element — no shell); absent OR invalid ⇒ NO
+ * `--model` flag, so the CLI uses its own default and the arg array is BYTE-FOR-BYTE
+ * the legacy invocation (no regression). The slug filter is the argv-seam half of
+ * the two-layer guard (the config schema rejects a bad slug at load) — a config
+ * value can NEVER inject an extra flag.
  */
 export function buildCoderArgs(
   worktreeDir: string,
   allowedTools: readonly string[] = ALLOWED_TOOLS,
+  model?: string,
 ): string[] {
   const ceiling = ALLOWED_TOOLS as readonly string[];
   const scoped = allowedTools.filter((t) => ceiling.includes(t));
   const tools = scoped.length > 0 ? scoped : [...ALLOWED_TOOLS];
+  const modelArgs = model && isValidCoderModel(model) ? ["--model", model] : [];
   return [
     "-p",
     "--output-format",
     "json",
+    ...modelArgs,
     "--permission-mode",
     "acceptEdits",
     "--allowedTools",
@@ -263,7 +306,7 @@ export class SdlcCoder {
     // Stage 2a: a SkilledStep MAY scope the tool surface (NARROW only) + prepend a
     // role prompt. Both default to the legacy values ⇒ the unskilled path is byte-
     // for-byte identical.
-    const args = buildCoderArgs(worktreeDir, options.allowedTools);
+    const args = buildCoderArgs(worktreeDir, options.allowedTools, options.model);
     const prompt = buildCoderPrompt(actionPoints, { systemPrompt: options.systemPrompt });
     const { stdout } = await this.limiter.run(() =>
       spawnCli({

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -289,6 +289,17 @@ export interface SdlcHandoffRequest {
   /** Hard timeout PER action-point coder run (ms). Defaults to the coder default. */
   coderTimeoutMs?: number;
   /**
+   * OPTIONAL operator-pinned model slug for the agentic coder's `claude` CLI
+   * (config `pipeline.consiliumLoop.implement.coderModel`). Threaded ONCE at the
+   * `runCoder` seam into EVERY coder invocation of the round — the initial per-AP
+   * coder (skilled + unskilled), the verify→fix iterations, AND the final-state
+   * fix coder — so all call sites carry the same model. Absent ⇒ the CLI's own
+   * default model (byte-for-byte today's invocation, no regression). Constrained to
+   * a safe slug (`CODER_MODEL_SLUG_RE`) at BOTH config load AND the argv seam so it
+   * can never inject a flag.
+   */
+  coderModel?: string;
+  /**
    * Stage 2a: the loop's Stage-1 archetype. Drives the SKILLED step selection
    * (`selectSkillSet`). null/absent ⇒ NO steps ⇒ today's single unskilled coder
    * per action point (byte-for-byte unchanged — NO regression).
@@ -840,7 +851,16 @@ export async function runSdlcHandoff(
   const createWorktree = deps.createWorktree ?? createSdlcWorktree;
   const removeWorktree = deps.removeWorktree ?? removeSdlcWorktree;
   const resolveDefault = deps.resolveDefaultBranchFn ?? resolveDefaultBranch;
-  const runCoder = deps.runCoder ?? ((dir, aps, opts) => sharedCoder.run(dir, aps, opts));
+  // Thread the operator-pinned coder model ONCE here at the seam. Every call site
+  // (initial skilled + unskilled coder, verify→fix iterations, final-state fix
+  // coder) goes through this single `runCoder`, so folding `model` into the opts
+  // here carries it to ALL of them — including an injected (test) coder, so the
+  // threading is observable. When `req.coderModel` is ABSENT the opts object is
+  // passed through UNTOUCHED ⇒ no `model` key ⇒ no `--model` flag ⇒ byte-for-byte
+  // today's invocation (no regression).
+  const baseCoder = deps.runCoder ?? ((dir, aps, opts) => sharedCoder.run(dir, aps, opts));
+  const runCoder: NonNullable<SdlcExecutorDeps["runCoder"]> = (dir, aps, opts) =>
+    baseCoder(dir, aps, req.coderModel ? { ...opts, model: req.coderModel } : opts);
   const push = deps.push ?? pushBranch;
   const openPr = deps.openPr ?? openDraftPr;
   const progress = makeProgressTracker(onProgress, req.actionPoints);

--- a/tests/unit/consilium/composition.test.ts
+++ b/tests/unit/consilium/composition.test.ts
@@ -93,6 +93,21 @@ describe("buildLoopComposition — config → flags & models", () => {
     expect(api.coder.model).toBeNull();
   });
 
+  it("surfaces the operator-pinned implement.coderModel on the coder role (over the CLI default)", () => {
+    const pinned = buildLoopComposition(
+      null,
+      ConfigSchema.parse({
+        pipeline: { consiliumLoop: { implement: { coderModel: "sonnet" } } },
+      }),
+    );
+    // When pinned, the coder role reports the configured slug (not the CLI default).
+    expect(pinned.coder.model).toBe("sonnet");
+    expect(pinned.coder.tool).toBe("claude CLI (local)");
+
+    // Absent ⇒ falls back to the CLI default representation (unchanged behavior).
+    expect(buildLoopComposition(null, baseConfig()).coder.model).toBe("claude-opus");
+  });
+
   it("threads verification flags, commands, timeouts, planner + judge-retry from config", () => {
     const config = ConfigSchema.parse({
       pipeline: {

--- a/tests/unit/consilium/consilium-config.test.ts
+++ b/tests/unit/consilium/consilium-config.test.ts
@@ -123,6 +123,39 @@ describe("pipeline.consiliumLoop schema", () => {
     expect(parseLoop({ implement: { testRunTimeoutMs: "abc" } }).success).toBe(false);
   });
 
+  it("coderModel: absent by default (⇒ CLI default model, byte-for-byte today's coder)", () => {
+    const res = ConfigSchema.safeParse({});
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    expect(res.data.pipeline.consiliumLoop.implement.coderModel).toBeUndefined();
+  });
+
+  it("coderModel: accepts a valid model slug (sonnet / gemini-pro / dotted)", () => {
+    for (const slug of ["sonnet", "gemini-pro", "claude-3.5-sonnet", "opus"]) {
+      const res = parseLoop({ implement: { coderModel: slug } });
+      expect(res.success).toBe(true);
+      if (res.success) {
+        expect(res.data.pipeline.consiliumLoop.implement.coderModel).toBe(slug);
+      }
+    }
+  });
+
+  it("coderModel: SECURITY — rejects an injection / flag-like / whitespaced value at load (fail-closed)", () => {
+    for (const evil of [
+      "",
+      "--dangerously-skip-permissions",
+      "-p",
+      "sonnet --dangerously-skip-permissions",
+      "sonnet; rm -rf /",
+      "sonnet\n--verbose",
+      "$(whoami)",
+      "a b",
+      "a/b",
+    ]) {
+      expect(parseLoop({ implement: { coderModel: evil } }).success).toBe(false);
+    }
+  });
+
   it("Stage 2b: trustedRepoAck defaults to false (fail-closed enable-gate)", () => {
     const res = ConfigSchema.safeParse({});
     expect(res.success).toBe(true);

--- a/tests/unit/sdlc/coder.test.ts
+++ b/tests/unit/sdlc/coder.test.ts
@@ -18,6 +18,7 @@ import {
   buildCoderPrompt,
   parseCoderOutput,
   sanitizedCoderEnv,
+  isValidCoderModel,
   ALLOWED_TOOLS,
   CODER_ENV_ALLOWLIST,
 } from "../../../server/services/sdlc/coder.js";
@@ -48,6 +49,83 @@ describe("buildCoderArgs — exact agentic arg array (DRY security check)", () =
     expect(args).not.toContain("Bash"); // C-1: a Bash child escapes --add-dir/cwd
     expect(args[args.indexOf("--add-dir") + 1]).toBe(WT); // confinement dir
     expect(ALLOWED_TOOLS).toEqual(["Edit", "Write", "Read"]);
+  });
+});
+
+describe("buildCoderArgs — operator-pinned --model threading (configurable coder model)", () => {
+  it("adds `--model <slug>` (as a SEPARATE argv element) when a valid model is set", () => {
+    const args = buildCoderArgs(WT, [...ALLOWED_TOOLS], "sonnet");
+    const i = args.indexOf("--model");
+    expect(i).toBeGreaterThanOrEqual(0);
+    expect(args[i + 1]).toBe("sonnet"); // the slug is its OWN element (no shell word-split)
+    // The confinement + allowlist construction is otherwise unchanged.
+    expect(args[args.indexOf("--add-dir") + 1]).toBe(WT);
+    const tools = args.slice(args.indexOf("--allowedTools") + 1, args.indexOf("--add-dir"));
+    expect(tools).toEqual(["Edit", "Write", "Read"]);
+  });
+
+  it("threads gemini-style dotted slugs verbatim (e.g. gemini-pro / claude-3.5)", () => {
+    expect(buildCoderArgs(WT, [...ALLOWED_TOOLS], "gemini-pro")).toContain("gemini-pro");
+    const args = buildCoderArgs(WT, [...ALLOWED_TOOLS], "claude-3.5-sonnet");
+    expect(args[args.indexOf("--model") + 1]).toBe("claude-3.5-sonnet");
+  });
+
+  it("absent model ⇒ NO --model flag ⇒ BYTE-FOR-BYTE the legacy arg array (no regression)", () => {
+    const legacy = [
+      "-p", "--output-format", "json",
+      "--permission-mode", "acceptEdits",
+      "--allowedTools", "Edit", "Write", "Read",
+      "--add-dir", WT,
+    ];
+    expect(buildCoderArgs(WT)).toEqual(legacy);
+    expect(buildCoderArgs(WT, [...ALLOWED_TOOLS])).toEqual(legacy);
+    expect(buildCoderArgs(WT, [...ALLOWED_TOOLS], undefined)).toEqual(legacy);
+    expect(buildCoderArgs(WT, [...ALLOWED_TOOLS], "")).toEqual(legacy); // empty ⇒ dropped
+  });
+
+  it("SECURITY: a flag-like / injection model value is DROPPED (never emits --model, never the value)", () => {
+    // A value crafted to look like an extra CLI flag or to carry shell/space chars.
+    for (const evil of [
+      "--dangerously-skip-permissions",
+      "sonnet --dangerously-skip-permissions",
+      "sonnet; rm -rf /",
+      "sonnet\n--verbose",
+      "$(whoami)",
+      "a b",
+      "../etc/passwd/../..",
+    ]) {
+      const args = buildCoderArgs(WT, [...ALLOWED_TOOLS], evil);
+      expect(args).not.toContain("--model"); // the flag itself is not emitted
+      expect(args).not.toContain(evil); // and neither is the raw value
+      // The invocation degrades to the safe legacy shape (confinement intact).
+      expect(args[args.indexOf("--add-dir") + 1]).toBe(WT);
+      expect(args).not.toContain("--dangerously-skip-permissions");
+    }
+  });
+});
+
+describe("isValidCoderModel — safe model-slug guard (^[a-zA-Z0-9._-]+$)", () => {
+  it("accepts real model slugs", () => {
+    for (const ok of ["sonnet", "gemini-pro", "claude-3.5-sonnet", "opus", "gpt-4o", "a", "model_1.2-x"]) {
+      expect(isValidCoderModel(ok)).toBe(true);
+    }
+  });
+
+  it("rejects empty, flag-like, whitespace, and shell-metachar values", () => {
+    for (const bad of [
+      "",
+      "-p",
+      "--model",
+      "a b",
+      "sonnet;rm",
+      "sonnet\n",
+      "$(x)",
+      "a|b",
+      "a/b",
+      "a`b`",
+    ]) {
+      expect(isValidCoderModel(bad)).toBe(false);
+    }
   });
 });
 

--- a/tests/unit/sdlc/skilled-coder.test.ts
+++ b/tests/unit/sdlc/skilled-coder.test.ts
@@ -225,3 +225,46 @@ describe("runSdlcHandoff — archetype → SKILLED steps wiring", () => {
     expect(res.prRef).toBe("https://github.com/x/y/pull/9");
   });
 });
+
+describe("runSdlcHandoff — operator-pinned coderModel threaded ONCE at the seam", () => {
+  it("threads req.coderModel into EVERY coder invocation of the UNSKILLED path", async () => {
+    const deps = makeDeps({ getSkills: vi.fn(async () => [] as Skill[]) });
+    await runSdlcHandoff(
+      baseReq({ archetype: null, coderTimeoutMs: 999, coderModel: "sonnet" }),
+      deps as never,
+    );
+    const calls = (deps.runCoder as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(APS.length); // one coder per AP — UNCHANGED count
+    for (const call of calls) {
+      // Every call carries the model AND preserves the existing opts (timeoutMs).
+      expect(call[2]).toEqual({ timeoutMs: 999, model: "sonnet" });
+    }
+  });
+
+  it("threads req.coderModel into ALL of the SKILLED multi-step invocations (shared seam)", async () => {
+    const deps = makeDeps({ getSkills: vi.fn(async () => [] as Skill[]) });
+    await runSdlcHandoff(
+      baseReq({ archetype: "repo-assessment", coderModel: "gemini-pro" }),
+      deps as never,
+    );
+    const calls = (deps.runCoder as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(2 * APS.length); // test-author → coder, per AP
+    // Every invocation — test-author AND implementer, every AP — carries the model,
+    // while the per-step allowedTools/systemPrompt are still set as before.
+    for (const call of calls) {
+      expect(call[2].model).toBe("gemini-pro");
+      expect(call[2].allowedTools).toEqual([...ALLOWED_TOOLS]);
+      expect(typeof call[2].systemPrompt).toBe("string");
+    }
+  });
+
+  it("ABSENT coderModel ⇒ opts carry NO model key (byte-for-byte today's invocation)", async () => {
+    const deps = makeDeps({ getSkills: vi.fn(async () => [] as Skill[]) });
+    await runSdlcHandoff(baseReq({ archetype: null, coderTimeoutMs: 999 }), deps as never);
+    const calls = (deps.runCoder as ReturnType<typeof vi.fn>).mock.calls;
+    for (const call of calls) {
+      expect(call[2]).toEqual({ timeoutMs: 999 });
+      expect("model" in call[2]).toBe(false); // no model key was folded in
+    }
+  });
+});


### PR DESCRIPTION
## What

Make the SDLC agentic coder's model an **operator decision** instead of the silent `claude` CLI default. New optional config `pipeline.consiliumLoop.implement.coderModel`. When set, every claude-CLI coder invocation of a round spawns with `--model <slug>`. When **absent, behavior is byte-for-byte unchanged** (no `--model` flag → CLI default model).

## The seam

The executor exposes a single `runCoder` used by **all** coder call sites of a round:
- initial per-AP coder — skilled path (`executor.ts` ~L1091) and unskilled path (~L1119)
- verify→fix iterations (`runVerifyFixLoop`, ~L1406, via `io.runCoder`)
- final-state fix coder (`runFinalVerification`, ~L1527, via the same wrapped `runCoder`)

`req.coderModel` is folded into the opts **once**, at the `runCoder` wrapper (`executor.ts` ~L843):

```ts
const baseCoder = deps.runCoder ?? ((dir, aps, opts) => sharedCoder.run(dir, aps, opts));
const runCoder = (dir, aps, opts) =>
  baseCoder(dir, aps, req.coderModel ? { ...opts, model: req.coderModel } : opts);
```

So threading happens in exactly one place and reaches all three fix/coder call sites transitively. When `coderModel` is absent the opts object is passed through **untouched** (no `model` key), preserving the existing byte-for-byte invocation. `CoderOptions.model` → `SdlcCoder.run` → `buildCoderArgs`, which emits `["--model", slug]` as **separate argv elements** (arg-array, no shell).

Flow: `schema.implement.coderModel` → controller builds `SdlcHandoffRequest.coderModel` → executor seam → `buildCoderArgs`.

## Security — flag injection (adversarial review)

The value is passed as a separate argv element (no shell, no word-split), but it is **still** constrained to a safe slug at **two independent layers**:

1. **Config load (fail-closed)** — `z.string().min(1).regex(...)`; an invalid value **aborts config load** rather than silently defaulting.
2. **Argv seam (defense-in-depth)** — `buildCoderArgs` re-validates via `isValidCoderModel`; an invalid/empty value is **dropped**, degrading to the CLI default (never emits `--model`, never emits the raw value).

**Regex hardening:** the ticket specified `^[a-zA-Z0-9._-]+$`, but that regex *accepts* `--dangerously-skip-permissions` and `-p` (all chars are in the class). I tightened it to the strict subset `^[a-zA-Z0-9][a-zA-Z0-9._-]*$` — the first char must be alphanumeric, so a value can never even *look* like a flag regardless of how the CLI arg-parser treats a leading-dash option argument. Every value the tightened regex accepts, the specified regex also accepts (strict subset), so it stays within the required slug shape while closing the leading-`-` flag-injection vector.

## Composition

`server/services/consilium/composition.ts` `coder` role now surfaces `impl.coderModel ?? (cliMode ? "claude-opus" : null)` — the configured slug when pinned, the CLI default representation when absent (existing behavior preserved).

## Gemini parity verdict — deferred, documented (no blind build)

Investigated the Antigravity/Gemini CLI (`server/gateway/providers/antigravity-cli.ts`, `gemini.ts`) as an alternative agentic coder. **No parity — `coderProvider` wiring NOT added.** Reasons:

- The `agy` CLI contract is `agy --print=<prompt> --model=<model>` — a **single-shot text completion**: "runs a single prompt non-interactively and prints the response to stdout, then exits."
- It has **no equivalent** to the claude-CLI agentic-coder primitives the SDLC coder's entire security model depends on: `--permission-mode acceptEdits` (auto-approve edits only), `--allowedTools Edit Write Read` (scoped file tools, no Bash), `--add-dir <worktree>` (filesystem confinement).
- Output is **free-form text**, not the `--output-format json` structured result the coder parses.
- The provider's own header notes agentic file-editing would require the interactive/ACP transport, which is not wired.

**What's missing for parity:** an agentic file-editing headless mode on `agy` with (a) tool restriction to file ops, (b) auto-approve-edits confined to a directory, and (c) structured/JSON result output. Until that exists, adding `coderProvider: "gemini"` would mean rebuilding the entire confinement layer (permission model + tool allowlist + worktree sandbox) that claude provides natively — not a small change. Delivered claude-model-selection only, per the ticket's "do not force it."

## Tests (local: `tsc` clean; full `unit` project green — 4737 passed / 0 failed)

- `tests/unit/sdlc/coder.test.ts` — `--model` emitted (separate argv element) when set incl. `gemini-pro`/dotted slugs; **absent ⇒ byte-for-byte legacy arg array**; injection/flag-like/whitespace/shell-metachar values **dropped**; `isValidCoderModel` slug guard accept/reject table.
- `tests/unit/sdlc/skilled-coder.test.ts` — `coderModel` threaded into **every** invocation of both the unskilled (1/AP) and skilled (test-author→coder, 2/AP) paths via the shared seam; absent ⇒ no `model` key.
- `tests/unit/consilium/consilium-config.test.ts` — schema default undefined; accepts valid slugs; **rejects injection at load (fail-closed)**.
- `tests/unit/consilium/composition.test.ts` — coder role surfaces the pinned model over the CLI default.

Known flakes noted in the ticket (`providers/antigravity`, `config-sync-multi-instance`) also passed locally; the `pull_request` CI run is authoritative.

## Not merged — Draft.
