### PR TITLE
feat: skills extend the loop's engineer instruction

### DIFF
--- a/client/src/components/consilium/new-review-dialog.tsx
+++ b/client/src/components/consilium/new-review-dialog.tsx
@@ -3,9 +3,11 @@
  * for ConsiliumLoopList. Mirrors ProjectSelector's create-dialog pattern (the
  * shared Dialog primitive + a controlled form + a toast on settle).
  *
- * It POSTs `{ repoPath, preset, maxRounds?, baselineCommit?, ref?, engineerInstruction? }` to
- * `/api/consilium-reviews` via the shared apiRequest transport (carries auth +
- * `x-project-id`, same as every project-scoped call).
+ * It POSTs `{ repoPath, preset, maxRounds?, baselineCommit?, ref?, engineerInstruction?,
+ * skillIds? }` to `/api/consilium-reviews` via the shared apiRequest transport
+ * (carries auth + `x-project-id`, same as every project-scoped call). The optional
+ * `skillIds` are operator-selected skills whose directives the server appends to the
+ * engineer instruction (fenced-as-data, byte-budgeted).
  *
  * REPO SELECTION: instead of free-typing a path that may not be allowlisted, the
  * user PICKS from the active project's workspaces (passed in by the page, which
@@ -64,7 +66,9 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import { apiRequest } from "@/hooks/use-pipeline";
+import { useSkills } from "@/hooks/use-skills";
 import { useToast } from "@/hooks/use-toast";
 
 /** The presets the backend accepts, with human labels (default first). */
@@ -81,6 +85,15 @@ type Preset = (typeof PRESETS)[number]["value"];
  * `error` text verbatim).
  */
 const MAX_INSTRUCTION_LEN = 8000;
+
+/** Max skills that may extend one review's instruction (mirrors the server bound). */
+const MAX_REVIEW_SKILLS = 5;
+
+/** The first line of a skill's description — a compact one-line hint in the picker. */
+function firstLine(text: string | null | undefined): string {
+  const line = (text ?? "").split("\n")[0]?.trim() ?? "";
+  return line;
+}
 
 /**
  * The slice of a workspace this dialog needs — a human `name`, a repo `path`, the
@@ -162,10 +175,30 @@ export function NewConsiliumReviewDialog({
   // Optional free-text instruction (tone / requirements for the evaluation). Sent
   // as `engineerInstruction` only when non-empty; the server fences it as data.
   const [engineerInstruction, setEngineerInstruction] = useState("");
+  // Optional operator-selected skills whose directives extend the instruction. Sent
+  // as `skillIds` (order = priority) only when non-empty; capped at MAX_REVIEW_SKILLS.
+  const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [, navigate] = useLocation();
   const qc = useQueryClient();
   const { toast } = useToast();
+
+  // The active project's non-builtin skills (project-scoped via apiRequest's
+  // x-project-id). Powers the optional multi-select below; absent/empty ⇒ the
+  // section is hidden entirely (never a dead control).
+  const skillsQuery = useSkills({ isBuiltin: false });
+  const availableSkills = skillsQuery.data ?? [];
+  const atSkillCap = selectedSkillIds.length >= MAX_REVIEW_SKILLS;
+
+  // Toggle a skill in/out of the selection, enforcing the cap on add. Selection
+  // order is preserved (it is the priority order the server drops from, last-first).
+  const toggleSkill = (id: string) => {
+    setSelectedSkillIds((cur) => {
+      if (cur.includes(id)) return cur.filter((s) => s !== id);
+      if (cur.length >= MAX_REVIEW_SKILLS) return cur;
+      return [...cur, id];
+    });
+  };
 
   // Whether to show the free-text REPO input: no workspaces to pick from, or the
   // user explicitly opted into a custom path.
@@ -265,6 +298,7 @@ export function NewConsiliumReviewDialog({
       baselineCommit?: string;
       ref?: string;
       engineerInstruction?: string;
+      skillIds?: string[];
     } = { repoPath: path, preset };
 
     const rounds = Number(maxRounds);
@@ -288,6 +322,10 @@ export function NewConsiliumReviewDialog({
     // the soft counter, not silent loss, signals an over-limit value.
     const instruction = engineerInstruction.trim();
     if (instruction) body.engineerInstruction = instruction;
+    // Skills → `skillIds` (order = priority). Send only when some are selected; the
+    // server resolves them project-scoped and appends their directives to the
+    // instruction under a byte budget (dropping whole skills if it must).
+    if (selectedSkillIds.length > 0) body.skillIds = selectedSkillIds;
 
     try {
       setSubmitting(true);
@@ -500,6 +538,67 @@ export function NewConsiliumReviewDialog({
               </p>
             )}
           </div>
+
+          {/* Optional SKILLS — each selected skill's directive is appended to the
+              engineer instruction (server-side, fenced-as-data, byte-budgeted). Hidden
+              when the project has no skills, so it is never an empty dead control. */}
+          {availableSkills.length > 0 && (
+            <div className="space-y-2">
+              <div className="flex items-baseline justify-between gap-2">
+                <Label>
+                  Skills{" "}
+                  <span className="text-muted-foreground">(extend the instruction)</span>
+                </Label>
+                <span
+                  className="text-xs tabular-nums text-muted-foreground"
+                  data-testid="new-review-skills-counter"
+                >
+                  {selectedSkillIds.length}/{MAX_REVIEW_SKILLS}
+                </span>
+              </div>
+              <div
+                className="max-h-40 space-y-1 overflow-y-auto rounded border p-2"
+                data-testid="new-review-skills"
+              >
+                {availableSkills.map((skill) => {
+                  const checked = selectedSkillIds.includes(skill.id);
+                  const disabled = !checked && atSkillCap;
+                  const hint = firstLine(skill.description);
+                  return (
+                    <label
+                      key={skill.id}
+                      className={
+                        "flex items-start gap-2 rounded p-1.5 text-sm " +
+                        (disabled
+                          ? "cursor-not-allowed opacity-50"
+                          : "cursor-pointer hover:bg-muted/50")
+                      }
+                    >
+                      <Checkbox
+                        checked={checked}
+                        disabled={disabled}
+                        onCheckedChange={() => toggleSkill(skill.id)}
+                        data-testid={`new-review-skill-${skill.id}`}
+                        className="mt-0.5"
+                      />
+                      <span className="min-w-0">
+                        <span className="font-medium">{skill.name}</span>
+                        {hint && (
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {hint}
+                          </span>
+                        )}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Each selected skill's directive is appended to the instruction above,
+                in the order picked. At most {MAX_REVIEW_SKILLS}.
+              </p>
+            </div>
+          )}
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={() => setOpen(false)}>

--- a/client/src/hooks/use-consilium-loops.ts
+++ b/client/src/hooks/use-consilium-loops.ts
@@ -18,6 +18,7 @@ import type {
   ConsiliumLoopState,
   ConsiliumLoopRow,
   ConsiliumLoopRoundRow,
+  AppliedSkillRef,
 } from "@shared/schema";
 import type {
   Archetype,
@@ -227,6 +228,13 @@ export type ConsiliumLoopDetail = ConsiliumLoopListItem & {
   archetypeParams?: Record<string, string> | null;
   /** The optional human instruction captured at review creation (INERT text). */
   engineerInstruction?: string | null;
+  /**
+   * Stage 2 (skills extend the instruction): provenance of the operator skills whose
+   * directives extended the engineer instruction at launch. Each entry carries the
+   * skill `id` + `name`; a `dropped: true` entry was resolved but dropped WHOLE to
+   * fit the byte budget (never truncated mid-skill). Absent/null ⇒ no skills applied.
+   */
+  appliedSkills?: AppliedSkillRef[] | null;
   /**
    * Observability (GAP 2): the computed role→model/tool composition + verification
    * config. Server-derived, read-only, secret-free. Absent on a pre-composition

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -1605,6 +1605,41 @@ function LaunchPassportCard({ loop }: { loop: ConsiliumLoopDetailRow }) {
             </p>
           </div>
         ) : null}
+        {/* Stage 2 — the operator SKILLS whose directives extended the instruction.
+            Applied skills render as solid badges; any skill DROPPED WHOLE to fit the
+            byte budget renders muted with a note (it never truncated mid-skill). */}
+        {loop.appliedSkills && loop.appliedSkills.length > 0 ? (
+          <div className="space-y-1.5">
+            <p className="flex items-center gap-1.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+              <Wrench className="h-3 w-3" aria-hidden="true" />
+              Applied skills
+            </p>
+            <div className="flex flex-wrap gap-1.5" data-testid="passport-applied-skills">
+              {loop.appliedSkills.map((s) =>
+                s.dropped ? (
+                  <Badge
+                    key={s.id}
+                    variant="outline"
+                    className="text-[11px] text-muted-foreground line-through"
+                    title="Dropped to fit the instruction size budget — not applied"
+                  >
+                    {s.name}
+                  </Badge>
+                ) : (
+                  <Badge key={s.id} variant="secondary" className="text-[11px]">
+                    {s.name}
+                  </Badge>
+                ),
+              )}
+            </div>
+            {loop.appliedSkills.some((s) => s.dropped) ? (
+              <p className="text-[11px] text-muted-foreground">
+                Struck-through skills were dropped whole to fit the instruction size
+                budget (never truncated mid-skill).
+              </p>
+            ) : null}
+          </div>
+        ) : null}
       </CardContent>
     </Card>
   );

--- a/migrations/0041_consilium_loops_applied_skills.sql
+++ b/migrations/0041_consilium_loops_applied_skills.sql
@@ -1,0 +1,28 @@
+-- migration: 0041_consilium_loops_applied_skills
+-- Adds a nullable `applied_skills` jsonb column to consilium_loops for the Stage 2
+-- feature "skills extend the loop's engineer instruction".
+--
+-- When the "New consilium review" route is given `skillIds`, the factory resolves
+-- each (PROJECT-SCOPED) skills-table row and APPENDS its directives to the human
+-- engineer instruction (fenced-as-data, byte-clamped so nothing truncates mid-skill).
+-- This column records WHICH skills shaped the launch, as an ordered array of
+-- `{ id, name, dropped? }`:
+--   - an entry WITHOUT `dropped` was applied in full;
+--   - an entry WITH `dropped: true` was resolved but DROPPED WHOLE (lowest-priority
+--     -last) to keep the combined instruction under the byte budget.
+-- It is INERT display/audit data (the launch passport lists it); never a shell/
+-- branch/PR sink.
+--
+-- We add a DEDICATED column (rather than riding archetype_params) because that
+-- jsonb is owned by the intent→archetype planner's plain partial updates and a
+-- skill write must never race/clobber it. Nullable; no backfill — null means "no
+-- skills applied", which is exactly the pre-feature behavior, so every pre-existing
+-- loop keeps working unchanged (full back-compat).
+--
+-- Idempotent (IF NOT EXISTS) so re-applying against a push-managed dev DB is safe.
+
+ALTER TABLE consilium_loops
+  ADD COLUMN IF NOT EXISTS applied_skills JSONB;
+
+-- Rollback:
+--   ALTER TABLE consilium_loops DROP COLUMN applied_skills;

--- a/server/routes/consilium-reviews.ts
+++ b/server/routes/consilium-reviews.ts
@@ -42,6 +42,11 @@ const CreateReviewSchema = z.object({
   // factory's OBJECTIVE_EXTRA_MAX_BYTES (8000) so a too-long body is a clean 400
   // here rather than a silent truncation downstream.
   engineerInstruction: z.string().max(8000).optional(),
+  // Stage 2 (skills extend the instruction): OPTIONAL operator-selected skill ids
+  // whose directives are APPENDED to the engineerInstruction. Bounded to 5 (>5 is a
+  // clean 400 here) and each id length-clamped. The factory resolves them
+  // PROJECT-SCOPED — a foreign/unknown id is a 400 naming the offending id.
+  skillIds: z.array(z.string().min(1).max(200)).max(5).optional(),
 });
 
 export function registerConsiliumReviewRoutes(app: Express, deps: CreateConsiliumReviewDeps): void {
@@ -64,6 +69,8 @@ export function registerConsiliumReviewRoutes(app: Express, deps: CreateConsiliu
           ref: body.ref,
           // Stage 1 (§5): threads to the factory objectiveExtra (sanitized) + persists.
           engineerInstruction: body.engineerInstruction,
+          // Stage 2: operator skill ids — resolved + appended by the factory.
+          skillIds: body.skillIds,
         });
         return res.status(201).json(loop);
       } catch (err) {
@@ -73,6 +80,13 @@ export function registerConsiliumReviewRoutes(app: Express, deps: CreateConsiliu
         // an opaque "invalid" (the path is the user's own input, not an fs leak).
         if (/baselineCommit/i.test(message)) {
           return res.status(400).json({ error: "baselineCommit must be a 7–64 char hex commit SHA" });
+        }
+        // Stage 2: an unknown/foreign skill id (the factory resolves skills
+        // PROJECT-SCOPED). Surface the factory message VERBATIM — it names the
+        // offending id (the caller's own input, not an fs leak) so the failure is
+        // actionable ("skill \"<id>\" was not found in this project").
+        if (message.includes("[skill-not-found]")) {
+          return res.status(400).json({ error: message.replace("[skill-not-found] ", "") });
         }
         // The factory STRICT-validates the optional branch/ref (ref-validator.ts)
         // and throws INVALID_REF_MESSAGE on a bad one — surface a clear 400 (the

--- a/server/services/consilium/review-factory.ts
+++ b/server/services/consilium/review-factory.ts
@@ -67,7 +67,7 @@ import { readdirSync, readFileSync, statSync, type Dirent } from "fs";
 import { basename, join } from "path";
 import simpleGit from "simple-git";
 import type { IStorage } from "../../storage.js";
-import type { InsertConsiliumLoop, ConsiliumLoopRow } from "@shared/schema";
+import type { InsertConsiliumLoop, ConsiliumLoopRow, Skill, AppliedSkillRef } from "@shared/schema";
 import type { ConsiliumReviewPreset } from "@shared/types";
 import type { TaskOrchestrator, CreateTaskParam } from "../task-orchestrator.js";
 import type { ConsiliumLoopController } from "./consilium-loop-controller.js";
@@ -82,6 +82,21 @@ import { validateReviewRef } from "./ref-validator.js";
 const INPUT_CAP_BYTES = 50_000;
 /** Hard byte cap on UNTRUSTED caller text (a changed-file path or a diff blob). */
 const OBJECTIVE_EXTRA_MAX_BYTES = 8_000;
+/**
+ * Byte cap on the COMBINED engineer-instruction + appended skill directives
+ * (Stage 2 — skills extend the loop's engineer instruction).
+ *
+ * DELIBERATELY tied to `OBJECTIVE_EXTRA_MAX_BYTES`: the combined text is fed to the
+ * dispute through the SAME `objectiveExtra` seam, which `untrustedExtraBlock`
+ * clamps to `OBJECTIVE_EXTRA_MAX_BYTES`. If the combined text exceeded that clamp,
+ * the downstream clamp would slice it — potentially MID-SKILL — with no record of
+ * what was lost. So we keep the combined budget == the downstream clamp and, when
+ * the budget is tight, drop WHOLE skills (lowest-priority-last) here instead, which
+ * is auditable (recorded on the loop) and never truncates a skill mid-block.
+ */
+const COMBINED_INSTRUCTION_MAX_BYTES = OBJECTIVE_EXTRA_MAX_BYTES;
+/** Max number of skills a single review may layer onto its engineer instruction. */
+export const MAX_REVIEW_SKILLS = 5;
 /** Single-line clamp for the (server-derived) repo basename in the group name. */
 const GROUP_NAME_BASENAME_MAX = 120;
 /** Review-only default: one round, no DEV handoff (overridable per call). */
@@ -307,6 +322,137 @@ function untrustedExtraBlock(objectiveExtra: string | undefined): string {
     fence +
     note
   );
+}
+
+// ─── Skill-directive composition (Stage 2 — skills extend the instruction) ───
+
+/** One resolved skill's contribution to the instruction extension. */
+export interface SkillDirective {
+  /** The skills-table row id (for provenance). */
+  id: string;
+  /** The skill name (rendered as the directive sub-heading + provenance label). */
+  name: string;
+  /** The directive body: the skill's systemPromptOverride, else its description. */
+  text: string;
+}
+
+/** The result of composing an engineer instruction with skill directives. */
+export interface ComposedInstruction {
+  /**
+   * The combined text (engineer instruction + appended skill directives), clamped
+   * to fit `COMBINED_INSTRUCTION_MAX_BYTES`. `undefined` ⇒ nothing to feed (no
+   * instruction and no applied skills). When `skills` was empty this is the
+   * ORIGINAL instruction, byte-for-byte (no-skill loops are unchanged).
+   */
+  combined: string | undefined;
+  /** Skills whose FULL directive block was included, in priority order. */
+  appliedSkills: AppliedSkillRef[];
+  /** Skills DROPPED WHOLE (lowest-priority-last) to fit the byte budget. */
+  droppedSkills: AppliedSkillRef[];
+}
+
+/** Header that separates the human instruction from the appended skill directives. */
+const SKILL_DIRECTIVES_HEADER = "## Skill directives";
+
+/**
+ * Append operator-selected SKILL directives to the (optional) human engineer
+ * instruction, under a hard byte budget. PURE (no I/O) so the byte-clamp / drop
+ * logic is unit-testable in isolation.
+ *
+ * Format (delimited so a reviewer/model sees exactly what each skill contributed):
+ *
+ *   <engineer instruction>
+ *
+ *   ## Skill directives
+ *
+ *   ### <skill name>
+ *   <skill text>
+ *
+ *   ### <next skill name>
+ *   <next skill text>
+ *
+ * Budget: the WHOLE combined string is kept <= `maxBytes`
+ * (`COMBINED_INSTRUCTION_MAX_BYTES`, itself == the downstream `untrustedExtraBlock`
+ * clamp) so nothing is truncated MID-SKILL further down the pipe. When the budget
+ * is tight we DROP WHOLE skills, lowest-priority-last: skills are processed in the
+ * given order (highest priority first) and, the moment one does not fit, it AND
+ * every skill after it are dropped — a strict prefix keeps, suffix drops. The
+ * instruction itself is always kept (it already passed the route's own length cap).
+ *
+ * Back-compat: an EMPTY `skills` list returns the original instruction unchanged
+ * (byte-identical), so loops launched WITHOUT skills produce the exact same
+ * objective as before. If skills were supplied but NONE fit (a maxed-out
+ * instruction), we return the instruction unchanged too (never a dangling header).
+ */
+export function composeInstructionWithSkills(
+  engineerInstruction: string | undefined,
+  skills: SkillDirective[],
+  maxBytes: number = COMBINED_INSTRUCTION_MAX_BYTES,
+): ComposedInstruction {
+  // No skills ⇒ byte-identical to the pre-skills behavior (critical for the
+  // no-regression guarantee on instruction-only loops).
+  if (skills.length === 0) {
+    return { combined: engineerInstruction, appliedSkills: [], droppedSkills: [] };
+  }
+
+  const base = engineerInstruction ?? "";
+  const headerPart = (base.length > 0 ? "\n\n" : "") + SKILL_DIRECTIVES_HEADER;
+  let used = Buffer.byteLength(base + headerPart, "utf8");
+
+  const appliedSkills: AppliedSkillRef[] = [];
+  const droppedSkills: AppliedSkillRef[] = [];
+  let blocks = "";
+  let stopped = false;
+
+  for (const skill of skills) {
+    const text = (skill.text ?? "").trim();
+    const block = `\n\n### ${skill.name}\n${text}`;
+    const blockBytes = Buffer.byteLength(block, "utf8");
+    // Strict priority: once a skill overflows the budget, it AND every lower-
+    // priority skill after it are dropped WHOLE (never partially embedded).
+    if (!stopped && used + blockBytes <= maxBytes) {
+      blocks += block;
+      used += blockBytes;
+      appliedSkills.push({ id: skill.id, name: skill.name });
+    } else {
+      stopped = true;
+      droppedSkills.push({ id: skill.id, name: skill.name, dropped: true });
+    }
+  }
+
+  // Nothing fit (e.g. a budget-filling instruction) ⇒ keep the instruction as-is
+  // rather than emitting a header with no directives under it.
+  if (appliedSkills.length === 0) {
+    return { combined: engineerInstruction, appliedSkills: [], droppedSkills };
+  }
+
+  return { combined: base + headerPart + blocks, appliedSkills, droppedSkills };
+}
+
+/**
+ * Resolve the caller-supplied `skillIds` into ordered {@link SkillDirective}s using
+ * the PROJECT-SCOPED storage (`storage.getSkill` filters by the caller's ALS
+ * project, so a skill id belonging to ANOTHER project resolves to `undefined` and
+ * is rejected — no cross-tenant leak). An unknown/foreign id THROWS with the
+ * offending id (the route maps it to a 400). Preserves the caller's order (== skill
+ * priority for the drop-whole-skill budgeting).
+ */
+async function resolveSkillDirectives(
+  storage: IStorage,
+  skillIds: readonly string[],
+): Promise<SkillDirective[]> {
+  const directives: SkillDirective[] = [];
+  for (const id of skillIds) {
+    const row: Skill | undefined = await storage.getSkill(id);
+    if (!row) {
+      // The id is the caller's own input (not an fs path) — safe to echo so the
+      // route can surface an actionable 400 naming the offending id.
+      throw new Error(`[skill-not-found] skill "${id}" was not found in this project`);
+    }
+    const text = (row.systemPromptOverride ?? "").trim() || (row.description ?? "").trim();
+    directives.push({ id: row.id, name: row.name, text });
+  }
+  return directives;
 }
 
 // ─── Spec-set embedding (full-viability) ────────────────────────────────────
@@ -981,6 +1127,16 @@ export interface CreateConsiliumReviewParams {
    */
   engineerInstruction?: string;
   /**
+   * Stage 2 (skills extend the instruction): OPTIONAL operator-selected skill ids
+   * (<= MAX_REVIEW_SKILLS). Each is resolved PROJECT-SCOPED (`storage.getSkill`
+   * under the caller's ALS — a foreign id throws, no cross-tenant leak) and its
+   * directive (systemPromptOverride, else description) is APPENDED to
+   * `engineerInstruction` under a byte budget (whole skills dropped, never
+   * truncated mid-skill). The applied/dropped provenance is persisted on the loop's
+   * `appliedSkills`. Absent/empty ⇒ objective is byte-identical to a no-skills loop.
+   */
+  skillIds?: string[];
+  /**
    * BRANCH-targeted review: an optional git ref (branch name / revision) the
    * review targets. STRICT-validated here (ref-validator.ts) before it reaches
    * git; persisted as the loop's `reviewRef`. Absent/null ⇒ working-tree HEAD
@@ -1087,11 +1243,28 @@ export async function createConsiliumReview(
   const reviewRef =
     params.ref === undefined || params.ref === null ? null : validateReviewRef(params.ref);
 
-  // Stage 1 (§5): the human "engineer instruction" feeds the dispute via the SAME
-  // sanitized `objectiveExtra` seam. Precedence: an explicit engineerInstruction
-  // (human route) wins over objectiveExtra (file-change trigger); only one is set in
-  // practice. Both untrusted ⇒ control-stripped + byte-clamped + fenced (S2).
-  const objectiveExtra = params.engineerInstruction ?? params.objectiveExtra;
+  // Stage 2 (skills extend the instruction): resolve the OPTIONAL operator skill
+  // ids PROJECT-SCOPED (a foreign/unknown id throws here → 400, before any
+  // persistence) and APPEND their directives to the engineer instruction under a
+  // byte budget (whole skills dropped lowest-priority-last; never truncated
+  // mid-skill). `appliedSkills` (applied + dropped provenance) is persisted on the
+  // loop; the COMBINED text rides the SAME untrusted `objectiveExtra` seam so it
+  // gets the identical control-strip + byte-clamp + fence the raw instruction gets.
+  // Empty/absent skillIds ⇒ composed === the original instruction (byte-identical).
+  const skillIds = params.skillIds ?? [];
+  const composed = composeInstructionWithSkills(
+    params.engineerInstruction,
+    skillIds.length > 0 ? await resolveSkillDirectives(storage, skillIds) : [],
+  );
+  const appliedSkills: AppliedSkillRef[] | null =
+    skillIds.length > 0 ? [...composed.appliedSkills, ...composed.droppedSkills] : null;
+
+  // The human "engineer instruction" (now possibly skill-extended) feeds the
+  // dispute via the SAME sanitized `objectiveExtra` seam. Precedence: an explicit
+  // (skill-extended) engineerInstruction (human route) wins over objectiveExtra
+  // (file-change trigger); only one is set in practice. Both untrusted ⇒
+  // control-stripped + byte-clamped + fenced (S2).
+  const objectiveExtra = composed.combined ?? params.objectiveExtra;
 
   // S2: WITH a ref, read repo content AT THE REF via git (no working tree);
   // otherwise the filesystem read. The diff side resolves the ref in diff-context.
@@ -1125,8 +1298,12 @@ export async function createConsiliumReview(
     lastReviewedCommit: baseline,
     // BRANCH-targeted review: the chosen ref (null ⇒ working-tree HEAD).
     reviewRef,
-    // Stage 1 (§5): persist the human engineer instruction INERT for the planner.
+    // Stage 1 (§5): persist the RAW human engineer instruction INERT for the
+    // planner (the skill-extended COMBINED text only feeds the objective — the
+    // planner reads the operator's own words, unmixed with skill directives).
     engineerInstruction: params.engineerInstruction ?? null,
+    // Stage 2: provenance of the applied (+ any dropped) skills; null ⇒ no skills.
+    appliedSkills,
     createdBy: params.createdBy,
   } as InsertConsiliumLoop);
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1642,6 +1642,8 @@ export class MemStorage implements IStorage {
       reviewRef: data.reviewRef ?? null,
       // Stage 1: engineer instruction + archetype planner columns (all nullable).
       engineerInstruction: data.engineerInstruction ?? null,
+      // Stage 2: applied-skill provenance (nullable jsonb).
+      appliedSkills: data.appliedSkills ?? null,
       archetype: data.archetype ?? null,
       archetypeSource: data.archetypeSource ?? null,
       archetypeRationale: data.archetypeRationale ?? null,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1977,6 +1977,25 @@ export const CONSILIUM_LOOP_TERMINAL_STATES = [
   "cancelled",
 ] as const satisfies readonly ConsiliumLoopState[];
 
+/**
+ * Provenance of ONE operator-selected skill whose directives extended a consilium
+ * loop's engineer instruction (Stage 2 — skills extend the loop's engineer
+ * instruction). Recorded on `consilium_loops.applied_skills` at launch so the
+ * launch passport can show exactly which skills shaped the dispute.
+ *
+ * `dropped: true` marks a skill that WAS resolved (a real, project-scoped row) but
+ * was DROPPED WHOLE — lowest-priority-last — to keep the combined instruction under
+ * the byte budget. It never means "truncated mid-skill" (that never happens): a
+ * skill is either applied in full or dropped in full.
+ */
+export interface AppliedSkillRef {
+  /** The skills-table row id that was selected. */
+  id: string;
+  /** The skill name captured at launch (for a stable label even if the row changes). */
+  name: string;
+  /** True when the skill was dropped WHOLE to fit the byte budget (not applied). */
+  dropped?: boolean;
+}
 
 export const consiliumLoops = pgTable(
   "consilium_loops",
@@ -2002,6 +2021,13 @@ export const consiliumLoops = pgTable(
     // the dispute objective (factory objectiveExtra) AND the planner. UNTRUSTED:
     // fenced-as-data in prompts, inert in storage; never a shell/branch/PR sink.
     engineerInstruction: text("engineer_instruction"),
+    // Stage 2 (0041): provenance of the operator-selected SKILLS whose directives
+    // extended `engineer_instruction` (see review-factory composeInstructionWithSkills).
+    // Nullable jsonb; null ⇒ no skills applied (the objective is byte-identical to the
+    // pre-skills behavior). Each entry carries the skill id + name at launch; a
+    // `dropped: true` entry was resolved but dropped WHOLE to fit the byte budget
+    // (never truncated mid-skill). INERT in storage — display/audit only.
+    appliedSkills: jsonb("applied_skills").$type<AppliedSkillRef[]>(),
     // Stage 1 (0032): intent→archetype planner output / human override. All
     // nullable; written by a PLAIN partial update (NOT casLoopState) so persisting
     // an archetype on a terminal loop never transitions it.

--- a/tests/unit/consilium/consilium-reviews-route.test.ts
+++ b/tests/unit/consilium/consilium-reviews-route.test.ts
@@ -122,3 +122,46 @@ describe("POST /api/consilium-reviews — BRANCH-targeted ref wiring", () => {
     expect((mockedCreate.mock.calls[0][1] as { ref?: string }).ref).toBeUndefined();
   });
 });
+
+
+describe("POST /api/consilium-reviews — Stage 2 skillIds wiring", () => {
+  beforeEach(() => mockedCreate.mockReset());
+
+  it("passes VALID skillIds through to the factory (order preserved) and returns 201", async () => {
+    mockedCreate.mockResolvedValueOnce({ id: "loop-sk", status: "PENDING" } as never);
+    const res = await request(makeApp())
+      .post("/api/consilium-reviews")
+      .send({ ...VALID_BODY, skillIds: ["sk-1", "sk-2"] });
+    expect(res.status).toBe(201);
+    expect(mockedCreate.mock.calls[0][1]).toMatchObject({ skillIds: ["sk-1", "sk-2"] });
+  });
+
+  it("REJECTS more than 5 skillIds with 400 BEFORE the factory is called (zod .max(5))", async () => {
+    const res = await request(makeApp())
+      .post("/api/consilium-reviews")
+      .send({ ...VALID_BODY, skillIds: ["a", "b", "c", "d", "e", "f"] });
+    expect(res.status).toBe(400);
+    expect(mockedCreate).not.toHaveBeenCalled();
+  });
+
+  it("maps an unknown/foreign skill id to a 400 naming the offending id", async () => {
+    mockedCreate.mockRejectedValueOnce(
+      new Error('[skill-not-found] skill "sk-FOREIGN" was not found in this project'),
+    );
+    const res = await request(makeApp())
+      .post("/api/consilium-reviews")
+      .send({ ...VALID_BODY, skillIds: ["sk-FOREIGN"] });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/sk-FOREIGN/);
+    expect(res.body.error).toMatch(/was not found in this project/);
+    // The internal tag prefix is stripped from the surfaced message.
+    expect(res.body.error).not.toMatch(/\[skill-not-found\]/);
+  });
+
+  it("absent skillIds is back-compat (factory called with skillIds === undefined)", async () => {
+    mockedCreate.mockResolvedValueOnce({ id: "loop-1", status: "PENDING" } as never);
+    const res = await request(makeApp()).post("/api/consilium-reviews").send(VALID_BODY);
+    expect(res.status).toBe(201);
+    expect((mockedCreate.mock.calls[0][1] as { skillIds?: string[] }).skillIds).toBeUndefined();
+  });
+});

--- a/tests/unit/consilium/review-factory.test.ts
+++ b/tests/unit/consilium/review-factory.test.ts
@@ -22,11 +22,13 @@ import {
   buildCrossReviewTasks,
   composeObjective,
   composeObjectiveAtRef,
+  composeInstructionWithSkills,
   createConsiliumReview,
   PRESET_PANELS,
   DEFAULT_REVIEW_MAX_ROUNDS,
   type CreateConsiliumReviewDeps,
   type SpecGitClient,
+  type SkillDirective,
 } from "../../../server/services/consilium/review-factory.js";
 
 // ─── 1. The 5-task DAG ────────────────────────────────────────────────────────
@@ -228,7 +230,14 @@ describe("createConsiliumReview — allowlist gate, baseline threading, rounds",
   // workspacePaths defaults to the allowlist roots so a repo that is globally
   // allowlisted is ALSO a project workspace unless a test deliberately diverges
   // them (MED-3 intersects the two boundaries).
-  function makeDeps(allowedRepoPaths: string[], workspacePaths: string[] = allowedRepoPaths) {
+  function makeDeps(
+    allowedRepoPaths: string[],
+    workspacePaths: string[] = allowedRepoPaths,
+    // Stage 2: the PROJECT-SCOPED skills the factory can resolve. `getSkill(id)`
+    // returns the matching row or undefined (a foreign/unknown id — the production
+    // withProject scoping makes a cross-project id resolve to undefined too).
+    skills: Array<{ id: string; name: string; systemPromptOverride?: string; description?: string }> = [],
+  ) {
     const createTaskGroup = vi.fn().mockResolvedValue({ group: { id: "g1" }, tasks: [] });
     const createLoop = vi
       .fn()
@@ -239,13 +248,15 @@ describe("createConsiliumReview — allowlist gate, baseline threading, rounds",
     const getWorkspaces = vi
       .fn()
       .mockResolvedValue(workspacePaths.map((p, i) => ({ id: `ws${i}`, name: `ws${i}`, path: p })));
+    const skillsById = new Map(skills.map((s) => [s.id, s]));
+    const getSkill = vi.fn(async (id: string) => skillsById.get(id));
     const deps = {
-      storage: { createLoop, getWorkspaces },
+      storage: { createLoop, getWorkspaces, getSkill },
       orchestrator: { createTaskGroup },
       controller: { start },
       config: () => ({ pipeline: { consiliumLoop: { allowedRepoPaths } } }),
     } as unknown as CreateConsiliumReviewDeps;
-    return { deps, createTaskGroup, createLoop, start, getWorkspaces };
+    return { deps, createTaskGroup, createLoop, start, getWorkspaces, getSkill };
   }
 
   it("REJECTS a repoPath outside the allowlist (S1, fail-closed, never trusts the caller)", async () => {
@@ -446,6 +457,96 @@ describe("createConsiliumReview — allowlist gate, baseline threading, rounds",
     expect(createLoop).toHaveBeenCalledTimes(2);
     // The factory deps don't even expose getLoops — proof the factory does no dedup read.
     expect((deps.storage as unknown as Record<string, unknown>).getLoops).toBeUndefined();
+  });
+
+  // ─── Stage 2: skills extend the engineer instruction ────────────────────────
+
+  it("resolves skillIds PROJECT-SCOPED, appends their directives to the objective (fenced), and persists provenance", async () => {
+    const { deps, createTaskGroup, createLoop, getSkill } = makeDeps([allowed], [allowed], [
+      { id: "sk-1", name: "security-first", systemPromptOverride: "Weight every auth boundary as P0." },
+      { id: "sk-2", name: "tests-required", description: "Require a failing test for each finding." },
+    ]);
+    await createConsiliumReview(deps, {
+      projectId: "p1",
+      repoPath: allowed,
+      preset: "sdlc-cross-review",
+      createdBy: "u1",
+      engineerInstruction: "Focus on the auth refactor.",
+      skillIds: ["sk-1", "sk-2"],
+    });
+    // Resolved via the project-scoped getSkill (not a global read).
+    expect(getSkill).toHaveBeenCalledWith("sk-1");
+    expect(getSkill).toHaveBeenCalledWith("sk-2");
+
+    // The combined text rides the UNTRUSTED-extra seam into the objective: the
+    // instruction, the delimiter, both skill names, and both directive bodies.
+    const objective = createTaskGroup.mock.calls[0][0].input as string;
+    expect(objective).toContain("UNTRUSTED");
+    expect(objective).toContain("Focus on the auth refactor.");
+    expect(objective).toContain("## Skill directives");
+    expect(objective).toContain("### security-first");
+    expect(objective).toContain("Weight every auth boundary as P0.");
+    expect(objective).toContain("### tests-required");
+    // sk-2 has no override → falls back to its description.
+    expect(objective).toContain("Require a failing test for each finding.");
+
+    // Provenance persisted on the loop (order preserved, none dropped).
+    const loopArg = createLoop.mock.calls[0][0];
+    expect(loopArg.appliedSkills).toEqual([
+      { id: "sk-1", name: "security-first" },
+      { id: "sk-2", name: "tests-required" },
+    ]);
+    // The RAW instruction (unmixed with skill directives) is what the planner reads.
+    expect(loopArg.engineerInstruction).toBe("Focus on the auth refactor.");
+  });
+
+  it("REJECTS an unknown/foreign skill id (naming it) BEFORE any persistence", async () => {
+    const { deps, createTaskGroup, createLoop } = makeDeps([allowed], [allowed], [
+      { id: "sk-1", name: "security-first", systemPromptOverride: "x" },
+    ]);
+    await expect(
+      createConsiliumReview(deps, {
+        projectId: "p1",
+        repoPath: allowed,
+        preset: "sdlc-cross-review",
+        createdBy: "u1",
+        skillIds: ["sk-1", "sk-FOREIGN"],
+      }),
+    ).rejects.toThrow(/\[skill-not-found\].*sk-FOREIGN/);
+    expect(createTaskGroup).not.toHaveBeenCalled();
+    expect(createLoop).not.toHaveBeenCalled();
+  });
+
+  it("no skillIds ⇒ appliedSkills null AND the objective is byte-identical to a no-skills loop (no regression)", async () => {
+    const instruction = "Focus on the auth refactor.";
+    // With skills available but NOT selected, and again with a plain instruction:
+    // both must produce the exact same objective bytes.
+    const a = makeDeps([allowed], [allowed], [
+      { id: "sk-1", name: "security-first", systemPromptOverride: "x" },
+    ]);
+    await createConsiliumReview(a.deps, {
+      projectId: "p1",
+      repoPath: allowed,
+      preset: "sdlc-cross-review",
+      createdBy: "u1",
+      engineerInstruction: instruction,
+    });
+    expect(a.createLoop.mock.calls[0][0].appliedSkills).toBeNull();
+    const withoutSkillsObjective = a.createTaskGroup.mock.calls[0][0].input as string;
+
+    const b = makeDeps([allowed], [allowed]);
+    await createConsiliumReview(b.deps, {
+      projectId: "p1",
+      repoPath: allowed,
+      preset: "sdlc-cross-review",
+      createdBy: "u1",
+      engineerInstruction: instruction,
+      skillIds: [],
+    });
+    const emptySkillIdsObjective = b.createTaskGroup.mock.calls[0][0].input as string;
+    // Byte-identical: an absent/empty skill list changes nothing.
+    expect(emptySkillIdsObjective).toBe(withoutSkillsObjective);
+    expect(b.createLoop.mock.calls[0][0].appliedSkills).toBeNull();
   });
 });
 
@@ -799,5 +900,86 @@ describe("composeObjectiveAtRef — sdlc-cross-review digest reads AT the ref (g
     expect(obj).toMatch(/Consilium diff \/ PR review/);
     expect(obj).not.toMatch(/Repository digest/);
     expect(raw).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Stage 2: composeInstructionWithSkills — pure composition + byte-budget ────
+
+describe("composeInstructionWithSkills — delimiter, byte clamp, drop-whole-skill", () => {
+  const sk = (id: string, name: string, text: string): SkillDirective => ({ id, name, text });
+
+  it("empty skills list returns the instruction UNCHANGED (byte-identical back-compat)", () => {
+    const r = composeInstructionWithSkills("do the thing", []);
+    expect(r.combined).toBe("do the thing");
+    expect(r.appliedSkills).toEqual([]);
+    expect(r.droppedSkills).toEqual([]);
+    // undefined instruction + no skills ⇒ undefined (nothing to feed).
+    expect(composeInstructionWithSkills(undefined, []).combined).toBeUndefined();
+  });
+
+  it("appends skill directives under a clear delimiter, in priority order", () => {
+    const r = composeInstructionWithSkills("base instruction", [
+      sk("a", "alpha", "alpha body"),
+      sk("b", "beta", "beta body"),
+    ]);
+    expect(r.combined).toBe(
+      "base instruction\n\n## Skill directives\n\n### alpha\nalpha body\n\n### beta\nbeta body",
+    );
+    expect(r.appliedSkills).toEqual([
+      { id: "a", name: "alpha" },
+      { id: "b", name: "beta" },
+    ]);
+    expect(r.droppedSkills).toEqual([]);
+  });
+
+  it("with no instruction, the header leads (no dangling blank line)", () => {
+    const r = composeInstructionWithSkills(undefined, [sk("a", "alpha", "alpha body")]);
+    expect(r.combined).toBe("## Skill directives\n\n### alpha\nalpha body");
+  });
+
+  it("DROPS WHOLE skills lowest-priority-last to fit the byte budget (never truncates mid-skill)", () => {
+    // A tiny budget that fits the instruction + header + the FIRST skill only.
+    const first = sk("a", "alpha", "A".repeat(40));
+    const second = sk("b", "beta", "B".repeat(40));
+    const third = sk("c", "gamma", "C".repeat(40));
+    const base = "base";
+    const headerBytes = Buffer.byteLength("base\n\n## Skill directives", "utf8");
+    const firstBlockBytes = Buffer.byteLength("\n\n### alpha\n" + "A".repeat(40), "utf8");
+    // Budget = exactly instruction + header + first skill (second/third can't fit).
+    const budget = headerBytes + firstBlockBytes;
+
+    const r = composeInstructionWithSkills(base, [first, second, third], budget);
+    expect(r.appliedSkills).toEqual([{ id: "a", name: "alpha" }]);
+    expect(r.droppedSkills).toEqual([
+      { id: "b", name: "beta", dropped: true },
+      { id: "c", name: "gamma", dropped: true },
+    ]);
+    // The combined never exceeds the budget and contains ONLY whole skills.
+    expect(Buffer.byteLength(r.combined ?? "", "utf8")).toBeLessThanOrEqual(budget);
+    expect(r.combined).toContain("### alpha");
+    expect(r.combined).not.toContain("### beta");
+    expect(r.combined).not.toContain("### gamma");
+    // The applied skill's body is present IN FULL (not sliced).
+    expect(r.combined).toContain("A".repeat(40));
+  });
+
+  it("strict priority: once a skill overflows, it AND all lower-priority skills drop (no greedy backfill)", () => {
+    // A HUGE second skill that cannot fit, then a tiny third that WOULD fit greedily
+    // — but strict priority drops both once the second overflows.
+    const first = sk("a", "alpha", "a");
+    const huge = sk("b", "beta", "B".repeat(10_000));
+    const tiny = sk("c", "gamma", "c");
+    const r = composeInstructionWithSkills("base", [first, huge, tiny], 200);
+    expect(r.appliedSkills.map((s) => s.id)).toEqual(["a"]);
+    expect(r.droppedSkills.map((s) => s.id)).toEqual(["b", "c"]);
+  });
+
+  it("a budget-filling instruction drops ALL skills and keeps the instruction unchanged (no dangling header)", () => {
+    const big = "X".repeat(300);
+    const r = composeInstructionWithSkills(big, [sk("a", "alpha", "alpha body")], 100);
+    expect(r.combined).toBe(big);
+    expect(r.appliedSkills).toEqual([]);
+    expect(r.droppedSkills).toEqual([{ id: "a", name: "alpha", dropped: true }]);
+    expect(r.combined).not.toContain("## Skill directives");
   });
 });


### PR DESCRIPTION
## What

Operators can now layer **project-scoped SKILLS** onto a consilium review's engineer instruction. Each selected skill's directive is appended to the free-text instruction, fenced-as-data, before the dispute runs.

## Composition rules

`POST /api/consilium-reviews` accepts an optional `skillIds: string[]` (max 5, enforced by zod → 400 on overflow). The review-factory:

1. Resolves each id via `storage.getSkill(id)` — **PROJECT-SCOPED** under the caller's ALS (`withProject`), so an id belonging to another project resolves to `undefined` and is rejected with a `400` **naming the offending id**. No cross-tenant leak.
2. For each resolved skill, takes its `systemPromptOverride` (falling back to `description`) as the directive body.
3. Appends the directives to the engineer instruction under a delimited block, in the order picked (= priority):

   ```
   <engineer instruction>

   ## Skill directives

   ### <skill name>
   <skill text>
   ```

The combined text rides the **same** untrusted `objectiveExtra` seam as the raw instruction, so it inherits the identical `untrustedExtraBlock` sanitation: control-strip + byte-clamp + strictly-longer backtick fence (structural-breakout defence). Skill text is operator-authored (same trust as the instruction) but still treated as data.

## Clamp policy (no silent mid-skill truncation)

The downstream `untrustedExtraBlock` clamps the extra to `OBJECTIVE_EXTRA_MAX_BYTES` (8000). The combined-instruction budget (`COMBINED_INSTRUCTION_MAX_BYTES`) is **deliberately pinned to that same value** so the downstream clamp is a no-op and can never slice a skill mid-block. When the budget is tight, `composeInstructionWithSkills` drops **WHOLE skills, lowest-priority-last** (strict prefix-keeps / suffix-drops — no greedy backfill). A budget-filling instruction drops all skills and keeps the instruction byte-identical (no dangling header). Verified end-to-end: the objective's spec/digest budget already reserves room for the extra block, so the final 50k `INPUT_CAP_BYTES` clamp is also a no-op on it.

## Provenance

A new **nullable** `consilium_loops.applied_skills` jsonb column (migration `0041`, additive, idempotent `IF NOT EXISTS`, no backfill) records the applied (+ any dropped) skills as `{ id, name, dropped? }[]`. Chose a dedicated column over riding `archetype_params` because that jsonb is owned by the archetype planner's partial updates and must not race a skill write. The launch passport card (#457) lists applied skills (dropped ones struck-through with a note). The raw `engineer_instruction` column is unchanged — the planner reads the operator's words unmixed with directives.

## UI

`new-review-dialog` gains a capped (≤5) multi-select of the project's non-builtin skills (name + first line of description), hidden entirely when the project has no skills. English strings throughout.

## Back-compat (adversarially checked)

- **Absent/empty `skillIds`** ⇒ `appliedSkills` null and the objective is **byte-identical** to a pre-skills loop (short-circuit before any composition). Covered by a test asserting the two objectives are `===`.
- **Silent mid-skill truncation** — prevented by the pinned budget + drop-whole-skill logic; covered by a test asserting only whole skills survive and the applied body is present in full.
- **Cross-project skill leak** — prevented by the project-scoped `getSkill`; unknown/foreign id throws and 400s.

## Test evidence

- `tsc` clean.
- Full **unit suite: 4737 passed / 241 files** (`vitest run --project unit`).
- New coverage: pure `composeInstructionWithSkills` (delimiter, byte clamp, drop-whole-skill strict priority, byte-identical back-compat), factory threading (resolve + fence + persist + unknown-id reject + no-skills byte-identity), route validation (skillIds passthrough, >5 → 400, unknown id → 400 naming it, absent → back-compat).

Integration tests / known flakes (providers-antigravity, config-sync-multi-instance) defer to the authoritative `pull_request` CI run.