### PR TITLE
fix: run the intent planner before auto-develop

### DIFF
--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -1529,10 +1529,71 @@ export class ConsiliumLoopController {
     viaCommand = false,
   ): Promise<Record<string, unknown>> {
     await this.recordRound(loop, verdict);
-    this.dispatchSdlc(loop, verdict, viaCommand);
+    // Finding #8 (live loop 83190a0e): the SKILLED implement path keys ENTIRELY off
+    // `loop.archetype` — the archetype skill set (test-author/coder), Stage-B
+    // per-criterion methods, and Stage-C criteria QA all resolve to the default /
+    // unskilled path when it is null. The planner was previously reachable ONLY via
+    // the manual POST /:id/plan, so the AUTOMATIC deciding->developing transition (and
+    // a human POST /:id/develop from a verdict-terminal state) dispatched with
+    // archetype=null and silently ran the legacy single-coder path. Run the planner
+    // FIRST here — the ONE seam ALL three dispatch paths (auto-tick, /develop, redrive)
+    // funnel through — so the archetype is decided before `dispatchSdlc` reads it. The
+    // returned loop carries the freshly-persisted archetype/params; fail-soft leaves it
+    // untouched (see `ensureArchetypePlanned`).
+    const devLoop = await this.ensureArchetypePlanned(loop);
+    this.dispatchSdlc(devLoop, verdict, viaCommand);
     // Persist openP0 + bump updatedAt so the freshly-entered developing loop reads
     // as in-flight (within grace), not stranded. devGroupId stays null (marker).
     return { openP0: verdict.openP0 };
+  }
+
+  /**
+   * Finding #8 fix — run the intent planner before dispatch when the develop path is
+   * reached with NO archetype and the planner is enabled, so the auto-develop path is
+   * SKILLED (archetype skill set + Stage-B/C routing), not just the manual POST /plan.
+   *
+   * Reuses the PUBLIC {@link plan} verbatim (it has NO state guard to weaken — it writes
+   * the archetype columns via a PLAIN partial `updateLoopArchetypeIfNotOverridden`, so
+   * calling it from `developing` never re-transitions the loop). That inherits ALL of
+   * plan()'s contract — idempotent, OVERRIDE-safe (a human `override` is never clobbered),
+   * TOCTOU-guarded, and the SAME Stage-B `normalizeActionPointMethods` + Stage-C
+   * `applyCriteriaQa` persist. `archetypeSource` stays "proposed".
+   *
+   * Guards / safety:
+   *   - `archetype != null` (incl. any pre-develop engineer override, which is always
+   *     non-null) SKIPS planning entirely — the override / prior proposal is honoured.
+   *   - Double-planning race (adversarial risk 1): the tick / develop() single-flight
+   *     lock (`inFlight`) already serializes this per loop, and plan() is a no-op once
+   *     the archetype is set — so a crash-recovery redrive re-reads it non-null and skips.
+   *   - Added latency (adversarial risk 2): one extra LLM call before dispatch. Accepted;
+   *     the AUTONOMOUS path is deliberately NOT gated by the R1 human-dev cap.
+   *   - FAIL-SOFT: planner disabled / no gateway / model error / unparseable reply leaves
+   *     the archetype null and returns the loop UNCHANGED, so dispatch proceeds on today's
+   *     unskilled fallback — WITH a visible note (this file's `this.log` fail-soft
+   *     convention) so the operator can see "planner failed, ran unskilled".
+   */
+  private async ensureArchetypePlanned(loop: ConsiliumLoopRow): Promise<ConsiliumLoopRow> {
+    const cfg = this.loopConfig();
+    // No planning when an archetype is already decided (override or prior proposal), the
+    // kill-switch is off, or no gateway is wired ⇒ byte-identical to today's behavior.
+    // `planner` is optional-chained (a hand-built test config may omit the whole block ⇒
+    // treated as disabled), matching the rest of this file's config-access discipline.
+    if (loop.archetype != null || !cfg.planner?.enabled || !this.deps.gateway) return loop;
+    const planned = await this.plan(loop.id);
+    if (planned.ok && planned.archetype != null) {
+      this.log(
+        loop.id,
+        `auto-plan before develop: archetype=${planned.archetype} (source=${planned.loop.archetypeSource ?? "proposed"})`,
+      );
+      return planned.loop;
+    }
+    // FAIL-SOFT: archetype stays null → dispatch proceeds UNSKILLED, but the operator sees
+    // WHY (same fail-soft convention as the research-preflight / plan() fail-softs).
+    const why = planned.ok
+      ? "planner produced no archetype (model error / unparseable reply)"
+      : `planner unavailable (${planned.code})`;
+    this.log(loop.id, `auto-plan before develop: ${why} — dispatching on UNSKILLED fallback (archetype=null)`);
+    return loop;
   }
 
   /**

--- a/tests/unit/consilium/loop-autoplan-develop.test.ts
+++ b/tests/unit/consilium/loop-autoplan-develop.test.ts
@@ -1,0 +1,333 @@
+/**
+ * loop-autoplan-develop.test.ts — finding #8: the intent planner must run BEFORE the
+ * develop dispatch so the AUTOMATIC deciding→developing transition (and a human
+ * POST /:id/develop from a verdict-terminal state) engages the SKILLED implement path
+ * instead of the legacy unskilled single-coder path.
+ *
+ * Live evidence: loop 83190a0e (maxRounds=2) auto-entered `developing` with
+ * archetype=None/source=None — the planner was reachable ONLY via the manual
+ * POST /:id/plan, so any maxRounds>1 loop that auto-developed skipped it entirely.
+ *
+ * We drive the REAL controller (fake storage + injected `readIterationVerdict`,
+ * `readRepoHead`, `runSdlc`, and a fake planner gateway) and assert what the SDLC
+ * executor seam (`runSdlc`) receives — its `archetype` input is exactly what
+ * `selectSkillSet` keys off inside the executor.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { ConsiliumLoopController } from "../../../server/services/consilium/consilium-loop-controller.js";
+import type { PlannerGateway } from "../../../server/services/consilium/consilium-loop-controller.js";
+import type { ConsiliumLoopRow, ConsiliumLoopState } from "@shared/schema";
+import type { ConvergenceVerdict } from "@shared/types";
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+const JUDGE_WITH_APS = {
+  verdict: "needs work",
+  action_points: [
+    { title: "DEV AP1", priority: "P0", acceptanceCriterion: "When built, then green CI" },
+    { title: "DEV AP2", priority: "P2" },
+  ],
+};
+
+const verdict = (openP0: number): ConvergenceVerdict => ({
+  converged: false,
+  openP0,
+  openActionPoints: Array.from({ length: openP0 }, (_, i) => ({ title: `ap${i}`, priority: "P0" })),
+});
+
+function makeLoop(over: Partial<ConsiliumLoopRow>): ConsiliumLoopRow {
+  return {
+    id: "loop-1",
+    projectId: "proj1",
+    groupId: "grp1",
+    state: "deciding",
+    round: 2,
+    maxRounds: 6,
+    repoPath: process.cwd(),
+    lastReviewedCommit: null,
+    reviewRef: null,
+    engineerInstruction: null,
+    archetype: null,
+    archetypeSource: null,
+    archetypeRationale: null,
+    archetypeParams: null,
+    archetypeDecidedAt: null,
+    currentIterationNumber: 2,
+    devGroupId: null,
+    prRef: null,
+    headCommitAtReview: null,
+    openP0: null,
+    error: null,
+    createdBy: "user1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    completedAt: null,
+    ...over,
+  } as ConsiliumLoopRow;
+}
+
+/** Fake storage — mutable `current` row, generic CAS, and the planner write. */
+function fakeStorage(loop: ConsiliumLoopRow, over: { activeLoop?: unknown } = {}) {
+  let current = loop;
+  const updateLoopArchetypeIfNotOverridden = vi.fn(async (_id: string, extra?: Record<string, unknown>) => {
+    if (current.archetypeSource === "override") return undefined;
+    current = { ...current, ...(extra ?? {}) };
+    return current;
+  });
+  const storage = {
+    getLoop: vi.fn(async () => current),
+    getLoops: vi.fn(async () => [current]),
+    getLoopRounds: vi.fn(async () => []),
+    getActiveLoopByGroup: vi.fn(async () => over.activeLoop ?? null),
+    getWorkspaces: vi.fn(async () => [{ path: process.cwd() }]),
+    casLoopState: vi.fn(async (id: string, expected: ConsiliumLoopState, next: ConsiliumLoopState, extra?: Record<string, unknown>) => {
+      if (id !== current.id || current.state !== expected) return undefined;
+      current = { ...current, ...(extra ?? {}), state: next };
+      return current;
+    }),
+    claimRedrive: vi.fn(async () => undefined),
+    appendLoopRound: vi.fn(async () => ({})),
+    updateLoopRoundActionPoints: vi.fn(async () => undefined),
+    updateLoopRoundTestSummary: vi.fn(async () => undefined),
+    updateLoop: vi.fn(async (_id: string, extra?: Record<string, unknown>) => {
+      current = { ...current, ...(extra ?? {}) };
+      return current;
+    }),
+    updateLoopArchetypeIfNotOverridden,
+    getTaskGroup: vi.fn(async () => ({ id: current.groupId, input: "objective" })),
+    updateTaskGroup: vi.fn(async () => ({})),
+    getIteration: vi.fn(async () => ({ id: "it1", iterationNumber: 2, status: "completed" })),
+    getExecutionsByIteration: vi.fn(async () => [{ output: JUDGE_WITH_APS }]),
+  };
+  return { storage, updateLoopArchetypeIfNotOverridden, get: () => current };
+}
+
+interface CfgOpts {
+  plannerEnabled?: boolean;
+  model?: string;
+}
+const makeConfig =
+  (opts: CfgOpts = {}) =>
+  () =>
+    ({
+      features: { sandbox: { enabled: false } },
+      providers: {},
+      pipeline: {
+        taskGroups: { taskTimeoutMs: 600000 },
+        consiliumLoop: {
+          enabled: true,
+          maxRounds: 6,
+          pollIntervalMs: 5000,
+          maxDiffBytes: 200000,
+          allowedRepoPaths: [process.cwd()],
+          sdlcTimeoutMs: 1200000,
+          planner: {
+            enabled: opts.plannerEnabled ?? true,
+            model: opts.model ?? "claude-sonnet",
+            criteriaQa: { enabled: false },
+          },
+          implement: {
+            enabled: true,
+            verification: { enabled: false },
+            trustedRepoAck: false,
+            maxFixIterations: 3,
+            testCommand: null,
+            testRunTimeoutMs: 300000,
+            lintCommand: null,
+            perCriterionMethod: { enabled: false, judgeModel: "claude-sonnet" },
+            finalVerification: { enabled: false, maxFinalFixIterations: 1 },
+            research: { enabled: false },
+          },
+        },
+      },
+    }) as never;
+
+function fakeGateway(content: string | (() => never)): { gateway: PlannerGateway; spy: ReturnType<typeof vi.fn> } {
+  const spy = vi.fn(async () => {
+    if (typeof content === "function") return content();
+    return { content };
+  });
+  return { gateway: { completeStreaming: spy } as unknown as PlannerGateway, spy };
+}
+
+function makeController(opts: {
+  storage: unknown;
+  gateway?: PlannerGateway;
+  runSdlc: ReturnType<typeof vi.fn>;
+  cfg?: CfgOpts;
+}) {
+  return new ConsiliumLoopController({
+    storage: opts.storage as never,
+    taskOrchestrator: { startGroup: vi.fn(), startGroupAsync: vi.fn(), createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
+    config: makeConfig(opts.cfg),
+    readIterationVerdict: async () => verdict(2),
+    readRepoHead: async () => "headsha",
+    runSdlc: opts.runSdlc as never,
+    gateway: opts.gateway,
+  });
+}
+
+const PROPOSAL = JSON.stringify({ archetype: "infra", rationale: "needs terraform + k8s", params: { cloud: "aws" } });
+
+// ─── Auto-transition (deciding→developing via tick) ──────────────────────────
+
+describe("finding #8 — the AUTOMATIC deciding→developing path plans before dispatch", () => {
+  it("runs the planner FIRST, then dispatches the SKILLED coder (runSdlc gets the archetype)", async () => {
+    const loop = makeLoop({ state: "deciding", archetype: null });
+    const { storage, updateLoopArchetypeIfNotOverridden } = fakeStorage(loop);
+    const { gateway, spy } = fakeGateway(PROPOSAL);
+    const runSdlc = vi.fn(async () => ({ prRef: "https://github.com/x/y/pull/1", headCommit: "abc" }));
+    const controller = makeController({ storage, gateway, runSdlc });
+
+    await controller.tick(loop.id); // deciding → developing → plan → dispatch
+    await flush(); // let the fire-and-forget closeout settle
+
+    // The planner ran once on the configured planner model…
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect((spy.mock.calls[0][0] as { modelSlug: string }).modelSlug).toBe("claude-sonnet");
+    // …the archetype was persisted proposed…
+    expect(updateLoopArchetypeIfNotOverridden).toHaveBeenCalledTimes(1);
+    const wrote = updateLoopArchetypeIfNotOverridden.mock.calls[0][1] as Record<string, unknown>;
+    expect(wrote.archetype).toBe("infra");
+    expect(wrote.archetypeSource).toBe("proposed");
+    // …and the SDLC executor received it (this is what selectSkillSet keys off).
+    expect(runSdlc).toHaveBeenCalledTimes(1);
+    expect(runSdlc.mock.calls[0][0].archetype).toBe("infra");
+    expect(runSdlc.mock.calls[0][0].archetypeParams).toEqual({ cloud: "aws" });
+  });
+
+  it("FAIL-SOFT: an unparseable planner reply → UNSKILLED dispatch (archetype null) + a visible note", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const loop = makeLoop({ state: "deciding", archetype: null });
+    const { storage, updateLoopArchetypeIfNotOverridden } = fakeStorage(loop);
+    const { gateway, spy } = fakeGateway("I reckon this one is infra, honestly.");
+    const runSdlc = vi.fn(async () => ({ prRef: null, headCommit: "" }));
+    const controller = makeController({ storage, gateway, runSdlc });
+
+    await controller.tick(loop.id);
+    await flush();
+
+    expect(spy).toHaveBeenCalledTimes(1); // planner ran…
+    expect(updateLoopArchetypeIfNotOverridden).not.toHaveBeenCalled(); // …but wrote nothing
+    expect(runSdlc).toHaveBeenCalledTimes(1);
+    expect(runSdlc.mock.calls[0][0].archetype).toBeNull(); // UNSKILLED fallback
+    // The operator can SEE the fallback (research-preflight fail-soft convention).
+    expect(log.mock.calls.some((c) => String(c[0]).includes("UNSKILLED fallback"))).toBe(true);
+    log.mockRestore();
+  });
+
+  it("FAIL-SOFT: a planner gateway ERROR does not throw and dispatches UNSKILLED", async () => {
+    const loop = makeLoop({ state: "deciding", archetype: null });
+    const { storage, updateLoopArchetypeIfNotOverridden } = fakeStorage(loop);
+    const { gateway } = fakeGateway(() => {
+      throw new Error("boom");
+    });
+    const runSdlc = vi.fn(async () => ({ prRef: null, headCommit: "" }));
+    const controller = makeController({ storage, gateway, runSdlc });
+
+    await controller.tick(loop.id);
+    await flush();
+
+    expect(updateLoopArchetypeIfNotOverridden).not.toHaveBeenCalled();
+    expect(runSdlc).toHaveBeenCalledTimes(1);
+    expect(runSdlc.mock.calls[0][0].archetype).toBeNull();
+  });
+
+  it("OVERRIDE respected: a pre-develop engineer override is NEVER re-planned or clobbered", async () => {
+    const loop = makeLoop({ state: "deciding", archetype: "infra", archetypeSource: "override" });
+    const { storage, updateLoopArchetypeIfNotOverridden } = fakeStorage(loop);
+    const { gateway, spy } = fakeGateway(JSON.stringify({ archetype: "research", rationale: "x" }));
+    const runSdlc = vi.fn(async () => ({ prRef: null, headCommit: "" }));
+    const controller = makeController({ storage, gateway, runSdlc });
+
+    await controller.tick(loop.id);
+    await flush();
+
+    expect(spy).not.toHaveBeenCalled(); // planner SKIPPED (archetype already decided)
+    expect(updateLoopArchetypeIfNotOverridden).not.toHaveBeenCalled();
+    expect(runSdlc.mock.calls[0][0].archetype).toBe("infra"); // the override drives dispatch
+  });
+
+  it("IDEMPOTENT: a prior 'proposed' archetype (e.g. after a crash-redrive) is not re-planned", async () => {
+    const loop = makeLoop({ state: "deciding", archetype: "infra", archetypeSource: "proposed" });
+    const { storage, updateLoopArchetypeIfNotOverridden } = fakeStorage(loop);
+    const { gateway, spy } = fakeGateway(PROPOSAL);
+    const runSdlc = vi.fn(async () => ({ prRef: null, headCommit: "" }));
+    const controller = makeController({ storage, gateway, runSdlc });
+
+    await controller.tick(loop.id);
+    await flush();
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(updateLoopArchetypeIfNotOverridden).not.toHaveBeenCalled();
+    expect(runSdlc.mock.calls[0][0].archetype).toBe("infra");
+  });
+
+  it("planner.enabled=false ⇒ BYTE-IDENTICAL to today: no planner call, UNSKILLED dispatch, no note", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const loop = makeLoop({ state: "deciding", archetype: null });
+    const { storage, updateLoopArchetypeIfNotOverridden } = fakeStorage(loop);
+    const { gateway, spy } = fakeGateway(PROPOSAL);
+    const runSdlc = vi.fn(async () => ({ prRef: null, headCommit: "" }));
+    const controller = makeController({ storage, gateway, runSdlc, cfg: { plannerEnabled: false } });
+
+    await controller.tick(loop.id);
+    await flush();
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(updateLoopArchetypeIfNotOverridden).not.toHaveBeenCalled();
+    expect(runSdlc.mock.calls[0][0].archetype).toBeNull();
+    // No auto-plan note is emitted when the kill-switch is off (path untouched).
+    expect(log.mock.calls.some((c) => String(c[0]).includes("auto-plan before develop"))).toBe(false);
+    log.mockRestore();
+  });
+
+  it("planner enabled but NO gateway wired ⇒ UNSKILLED dispatch (planner treated as disabled)", async () => {
+    const loop = makeLoop({ state: "deciding", archetype: null });
+    const { storage, updateLoopArchetypeIfNotOverridden } = fakeStorage(loop);
+    const runSdlc = vi.fn(async () => ({ prRef: null, headCommit: "" }));
+    const controller = makeController({ storage, gateway: undefined, runSdlc });
+
+    await controller.tick(loop.id);
+    await flush();
+
+    expect(updateLoopArchetypeIfNotOverridden).not.toHaveBeenCalled();
+    expect(runSdlc.mock.calls[0][0].archetype).toBeNull();
+  });
+});
+
+// ─── Manual POST /:id/develop (verdict-terminal → developing) ────────────────
+
+describe("finding #8 — the manual develop() path from a terminal state ALSO plans first", () => {
+  it("a human re-open of a CONVERGED loop with null archetype runs the planner, then dispatches SKILLED", async () => {
+    const loop = makeLoop({ state: "converged", archetype: null });
+    const { storage, updateLoopArchetypeIfNotOverridden } = fakeStorage(loop);
+    const { gateway, spy } = fakeGateway(PROPOSAL);
+    const runSdlc = vi.fn(async () => ({ prRef: "https://github.com/x/y/pull/9", headCommit: "abc" }));
+    const controller = makeController({ storage, gateway, runSdlc });
+
+    const res = await controller.develop(loop.id);
+    await flush();
+
+    expect(res.ok).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1); // planner ran on the manual path too
+    expect(updateLoopArchetypeIfNotOverridden).toHaveBeenCalledTimes(1);
+    expect(runSdlc).toHaveBeenCalledTimes(1);
+    expect(runSdlc.mock.calls[0][0].archetype).toBe("infra");
+  });
+
+  it("a human re-open with a pre-set override dispatches on the override — no planner call", async () => {
+    const loop = makeLoop({ state: "converged", archetype: "infra", archetypeSource: "override" });
+    const { storage } = fakeStorage(loop);
+    const { gateway, spy } = fakeGateway(JSON.stringify({ archetype: "research", rationale: "x" }));
+    const runSdlc = vi.fn(async () => ({ prRef: null, headCommit: "" }));
+    const controller = makeController({ storage, gateway, runSdlc });
+
+    const res = await controller.develop(loop.id);
+    await flush();
+
+    expect(res.ok).toBe(true);
+    expect(spy).not.toHaveBeenCalled();
+    expect(runSdlc.mock.calls[0][0].archetype).toBe("infra");
+  });
+});


### PR DESCRIPTION
## Problem (finding #8, from a live full run)

The loop FSM's **automatic** `deciding → developing` transition dispatched the SDLC with `archetype=null`, silently bypassing the intent planner — and with it the **entire skilled pipeline**. The archetype skill set (test-author/coder), Stage-B per-criterion methods, and Stage-C criteria QA all key off the planner having run, so any `maxRounds>1` loop that auto-developed ran the legacy **unskilled single-coder** path. The planner was previously reachable **only** via the manual `POST /:id/plan`.

**Live evidence:** loop `83190a0e` (`maxRounds=2`) auto-entered `developing` with `archetype=None / source=None`; `devProgress` showed a bare coder with no test-author step and no per-criterion methods.

## The seam

All three dispatch paths funnel through **one** method — `ConsiliumLoopController.startDevHandoff`:

| Path | Call site |
|------|-----------|
| Autonomous `deciding→developing` | `runSideEffect` → `startDevHandoff(loop, verdict)` |
| Human `POST /:id/develop` (terminal re-open) | `develop()` → `startDevHandoff(won, verdict, true)` |
| Crash-recovery redrive | `redriveStranded(developing)` → `startDevHandoff(claimed, verdict)` |

`dispatchSdlc` (which reads `loop.archetype`) is called **only** from `startDevHandoff`, so fixing it there covers every path in one place.

## The fix (minimal, side-effect ordering only — no FSM/reducer/state-table change, no migration)

New private `ensureArchetypePlanned(loop)` runs **before** `dispatchSdlc`: when the loop reaches develop with `archetype == null` **and** `planner.enabled` **and** a gateway is wired, it runs the planner first, then dispatches on the returned skilled loop.

It reuses the **public `plan()` verbatim** — `plan()` has no state guard to weaken (adversarial risk 3 avoided by construction): it writes the archetype columns via a **plain partial** `updateLoopArchetypeIfNotOverridden`, so calling it from `developing` never re-transitions the loop. This inherits all of `plan()`'s contract:
- **Idempotent** — a set archetype (proposed or override) is a no-op; a crash redrive re-reads it non-null and skips.
- **Override-safe** — a human `override` (always non-null) is never re-planned or clobbered; `archetypeSource` stays `"proposed"` on a fresh proposal.
- **TOCTOU-guarded** + Stage-B `normalizeActionPointMethods` / Stage-C `applyCriteriaQa` persist, exactly as `plan()` does today.

## Fail-soft (preserved)

A disabled planner / missing gateway / model error / unparseable reply leaves `archetype` null → dispatch proceeds on today's **unskilled fallback** WITH a **visible note** (this file's `this.log` fail-soft convention, same style as the research-preflight guard) so the operator can see "planner failed, ran unskilled".

## Adversarial self-review

1. **Double-planning race** — the per-loop in-process single-flight lock (`inFlight`, held across both `tick` and `develop`) serializes planning; `plan()` is a no-op once the archetype is set, and its write is source-conditional (CAS discipline intact).
2. **Added planner latency delaying dispatch** — one extra LLM call before dispatch. Accepted; the autonomous path is deliberately **not** gated by the R1 human-dev concurrency cap.
3. **Weakening the public `/plan` route guards** — not done. `plan()` is reused unchanged; no guard relaxed.

## Tests

New `tests/unit/consilium/loop-autoplan-develop.test.ts` (9 cases) drives the real controller with a fake planner gateway + injected `runSdlc`, asserting what the executor seam receives (`runSdlc(...).archetype` = what `selectSkillSet` keys off):

- auto-transition → planner runs → **skilled** dispatch (`runSdlc` gets `archetype`, params threaded);
- planner unparseable / gateway error → **unskilled** dispatch (`archetype: null`) + visible note;
- pre-develop override → planner **skipped**, dispatch on the override;
- prior `proposed` archetype (crash-redrive case) → **not** re-planned;
- `planner.enabled=false` and no-gateway → **byte-identical** to today (no planner call, no note);
- manual `develop()` from a `converged` loop → planner runs, then skilled dispatch (+ override respected).

Verification:
- `tsc --noEmit` clean.
- Targeted consilium + sdlc unit suites: **544 passed**.
- Full unit project: 4732 passed; the only failure is `federation-transport.test.ts` (a bidirectional-messaging timing flake — passes in isolation, failure count varied run-to-run, outside this change's zone). Known flakes `providers/antigravity` and `config-sync-multi-instance` per repo protocol; **the pull_request CI run is authoritative.**

Files changed:
- `server/services/consilium/consilium-loop-controller.ts`
- `tests/unit/consilium/loop-autoplan-develop.test.ts` (new)