### PR TITLE
feat: configurable Statistics dashboard, per-workspace breakdown, drop pipeline-runs stat

### DIFF
--- a/client/src/lib/dashboard-layout.ts
+++ b/client/src/lib/dashboard-layout.ts
@@ -1,0 +1,214 @@
+// ─── Dashboard layout persistence (localStorage, versioned) ────────────────────
+//
+// The Statistics dashboard is a Grafana-like grid of repositionable/resizable
+// widgets powered by react-grid-layout. This module owns the *versioned* schema
+// used to persist the per-browser layout in localStorage, plus the reconciliation
+// logic that keeps a stored layout safe to apply even when the set of widgets has
+// changed since it was written (widget added, removed, or renamed).
+//
+// Design guarantees:
+//   1. Version mismatch  → stored layout is discarded, DEFAULT_LAYOUT is used.
+//   2. Unknown widget key → dropped from the applied layout (never crashes).
+//   3. Missing widget     → filled in from its default position.
+//   4. Same-version, complete layout → round-trips unchanged.
+
+import type { Layout, LayoutItem, ResponsiveLayouts } from "react-grid-layout/legacy";
+
+// Bump whenever the DEFAULT_LAYOUT shape or widget set changes incompatibly.
+export const LAYOUT_VERSION = 1;
+
+const STORAGE_KEY = "stats-dashboard-layout:v1";
+
+// ─── Widget registry ──────────────────────────────────────────────────────────
+// The canonical list of widget keys currently rendered on the dashboard. A layout
+// entry whose `i` is not in this set is considered stale/unknown and is dropped.
+export type WidgetKey =
+  | "totals"
+  | "timeline"
+  | "by-model"
+  | "by-workspace"
+  | "request-log";
+
+export const WIDGET_KEYS: readonly WidgetKey[] = [
+  "totals",
+  "timeline",
+  "by-model",
+  "by-workspace",
+  "request-log",
+];
+
+function isKnownWidget(key: string): key is WidgetKey {
+  return (WIDGET_KEYS as readonly string[]).includes(key);
+}
+
+// ─── Default layout ─────────────────────────────────────────────────────────────
+// Only the `lg` breakpoint is defined explicitly; react-grid-layout's Responsive
+// component derives the other breakpoints from it. The vertical stacking mirrors
+// the pre-dashboard page order: Totals → Timeline → Per-Model → Per-Workspace →
+// Request Log. Grid is 12 columns at `lg`.
+//
+// minW=4 on Timeline (and the tables) means a widget can be shrunk to a third of
+// the width and moved into a left column — i.e. the operator can shrink Timeline
+// to ~half width (w6) and drag it to x:0, placing another widget beside it.
+export const DEFAULT_LAYOUT: ResponsiveLayouts = {
+  lg: [
+    { i: "totals", x: 0, y: 0, w: 12, h: 3, minW: 4, minH: 2 },
+    { i: "timeline", x: 0, y: 3, w: 12, h: 7, minW: 4, minH: 4 },
+    { i: "by-model", x: 0, y: 10, w: 12, h: 7, minW: 4, minH: 3 },
+    { i: "by-workspace", x: 0, y: 17, w: 12, h: 7, minW: 4, minH: 3 },
+    { i: "request-log", x: 0, y: 24, w: 12, h: 10, minW: 5, minH: 5 },
+  ],
+};
+
+interface StoredLayout {
+  version: number;
+  layouts: ResponsiveLayouts;
+}
+
+// ─── Storage access (SSR/Node/private-mode safe) ───────────────────────────────
+function getStorage(): Storage | undefined {
+  try {
+    if (typeof localStorage !== "undefined") return localStorage;
+  } catch {
+    // Access can throw in some privacy modes — treat as "no storage".
+  }
+  return undefined;
+}
+
+function cloneLayouts(layouts: ResponsiveLayouts): ResponsiveLayouts {
+  return JSON.parse(JSON.stringify(layouts)) as ResponsiveLayouts;
+}
+
+function defaultLayouts(): ResponsiveLayouts {
+  return cloneLayouts(DEFAULT_LAYOUT);
+}
+
+// ─── Type guards for untrusted stored data ─────────────────────────────────────
+function isStoredLayout(value: unknown): value is StoredLayout {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.version === "number" &&
+    typeof obj.layouts === "object" &&
+    obj.layouts !== null
+  );
+}
+
+function isLayoutItem(value: unknown): value is LayoutItem {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.i === "string" &&
+    typeof obj.x === "number" &&
+    typeof obj.y === "number" &&
+    typeof obj.w === "number" &&
+    typeof obj.h === "number"
+  );
+}
+
+function findDefaultItem(
+  key: WidgetKey,
+  breakpointDefaults: Layout,
+): LayoutItem | undefined {
+  return (
+    breakpointDefaults.find((item) => item.i === key) ??
+    DEFAULT_LAYOUT.lg?.find((item) => item.i === key)
+  );
+}
+
+// Reconcile a single breakpoint's items: drop unknown keys, dedupe, preserve the
+// stored order of known items, then append any missing current widgets from their
+// default positions. Never throws.
+function reconcileBreakpoint(items: Layout, breakpointDefaults: Layout): Layout {
+  const knownByKey = new Map<string, LayoutItem>();
+  for (const item of items) {
+    if (isKnownWidget(item.i)) knownByKey.set(item.i, item); // last wins on dup
+  }
+
+  const result: LayoutItem[] = [];
+  const seen = new Set<string>();
+
+  // Preserve first-appearance order of known items.
+  for (const item of items) {
+    if (isKnownWidget(item.i) && !seen.has(item.i)) {
+      result.push(knownByKey.get(item.i)!);
+      seen.add(item.i);
+    }
+  }
+
+  // Ensure every current widget has an entry.
+  for (const key of WIDGET_KEYS) {
+    if (!seen.has(key)) {
+      const fallback = findDefaultItem(key, breakpointDefaults);
+      if (fallback) {
+        result.push(fallback);
+        seen.add(key);
+      }
+    }
+  }
+
+  return result;
+}
+
+function reconcile(stored: ResponsiveLayouts): ResponsiveLayouts {
+  const breakpoints = new Set<string>(Object.keys(stored));
+  breakpoints.add("lg"); // `lg` must always exist so Responsive can derive others.
+
+  const out: Record<string, Layout> = {};
+  for (const bp of breakpoints) {
+    const raw = stored[bp];
+    const items: Layout = Array.isArray(raw) ? raw.filter(isLayoutItem) : [];
+    const breakpointDefaults = DEFAULT_LAYOUT[bp] ?? DEFAULT_LAYOUT.lg ?? [];
+    out[bp] = reconcileBreakpoint(items, breakpointDefaults);
+  }
+  return out;
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────────
+
+/**
+ * Load the persisted layout, falling back to (a clone of) DEFAULT_LAYOUT on any of:
+ * missing storage, unparseable JSON, wrong shape, or version mismatch. A valid
+ * same-version layout is reconciled against the current widget set so stale keys
+ * are dropped and missing widgets are backfilled — it never crashes the page.
+ */
+export function loadLayout(): ResponsiveLayouts {
+  const storage = getStorage();
+  const raw = storage?.getItem(STORAGE_KEY);
+  if (!raw) return defaultLayouts();
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return defaultLayouts();
+  }
+
+  if (!isStoredLayout(parsed)) return defaultLayouts();
+  if (parsed.version !== LAYOUT_VERSION) return defaultLayouts();
+
+  return reconcile(parsed.layouts);
+}
+
+/** Persist the given layouts under the current schema version. Best-effort. */
+export function saveLayout(layouts: ResponsiveLayouts): void {
+  const storage = getStorage();
+  if (!storage) return;
+  const payload: StoredLayout = { version: LAYOUT_VERSION, layouts };
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // Quota/serialization failures are non-fatal for a per-browser convenience.
+  }
+}
+
+/** Clear the persisted layout and return a fresh clone of the default. */
+export function resetLayout(): ResponsiveLayouts {
+  const storage = getStorage();
+  try {
+    storage?.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+  return defaultLayouts();
+}

--- a/client/src/pages/Statistics.tsx
+++ b/client/src/pages/Statistics.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import {
@@ -10,8 +10,25 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from "recharts";
-import { Download, ChevronDown, ChevronRight } from "lucide-react";
+import {
+  Responsive,
+  WidthProvider,
+  type Layout,
+  type ResponsiveLayouts,
+} from "react-grid-layout/legacy";
+import { Download, ChevronDown, ChevronRight, GripVertical, RotateCcw } from "lucide-react";
 import { cn } from "@/lib/utils";
+import {
+  loadLayout,
+  saveLayout,
+  resetLayout,
+} from "@/lib/dashboard-layout";
+
+// react-grid-layout ships its own scoped CSS (targets `.react-grid-item` /
+// `.react-resizable-handle` — it does NOT restyle our `.rounded-lg border ...`
+// cards). react-resizable provides the resize-handle styles.
+import "react-grid-layout/css/styles.css";
+import "react-resizable/css/styles.css";
 
 // ─── API types ───────────────────────────────────────────────────────────────
 
@@ -19,7 +36,6 @@ interface StatsOverview {
   totalRequests: number;
   totalTokens: { input: number; output: number; total: number };
   totalCostUsd: number;
-  totalRuns: number;
 }
 
 interface ModelStat {
@@ -31,6 +47,15 @@ interface ModelStat {
   costUsd: number;
   avgLatencyMs: number;
   errorRate: number;
+}
+
+interface WorkspaceStat {
+  workspaceId: string | null;
+  workspaceName: string;
+  requests: number;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
 }
 
 interface TimelinePoint {
@@ -98,28 +123,79 @@ function fmtDate(iso: string | null) {
   return d.toLocaleString();
 }
 
-// ─── Summary Cards ───────────────────────────────────────────────────────────
+// ─── Widget shell (drag handle lives on the header only) ───────────────────────
+//
+// The whole card is the react-grid-layout grid item, but ONLY the `.widget-drag-handle`
+// element (grip + title) initiates a drag — RGL's `draggableHandle` prop points at it.
+// Action controls (granularity/metric buttons, CSV/JSON export) are rendered as siblings
+// of the handle (never inside it), so they stay clickable. The body is independently
+// scrollable so inner tables / text selection / sorting keep working while the widget
+// has a fixed grid height.
 
-function SummaryCards({ overview }: { overview: StatsOverview }) {
+function WidgetShell({
+  title,
+  actions,
+  children,
+}: {
+  title: string;
+  actions?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="h-full flex flex-col rounded-lg border border-border bg-card overflow-hidden">
+      <div className="flex items-center justify-between gap-2 px-4 pt-3 pb-2 shrink-0 border-b border-border/50">
+        <div
+          className="widget-drag-handle flex items-center gap-1.5 cursor-move select-none min-w-0"
+          title="Drag to move"
+        >
+          <GripVertical className="h-4 w-4 text-muted-foreground shrink-0" />
+          <p className="text-sm font-medium truncate">{title}</p>
+        </div>
+        {actions ? <div className="flex gap-2 flex-wrap justify-end">{actions}</div> : null}
+      </div>
+      <div className="flex-1 min-h-0 overflow-auto p-4">{children}</div>
+    </div>
+  );
+}
+
+// ─── Totals widget (formerly SummaryCards) ─────────────────────────────────────
+
+function TotalsWidget({
+  overview,
+  loading,
+}: {
+  overview: StatsOverview | undefined;
+  loading: boolean;
+}) {
+  if (loading || !overview) {
+    return (
+      <WidgetShell title="Totals">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="rounded-lg border border-border bg-background/40 p-4 animate-pulse h-20" />
+          ))}
+        </div>
+      </WidgetShell>
+    );
+  }
+
   const cards = [
     { label: "Total Requests", value: fmt(overview.totalRequests) },
     { label: "Total Tokens", value: fmt(overview.totalTokens.total) },
-    { label: "Pipeline Runs", value: fmt(overview.totalRuns) },
     { label: "Estimated Cost", value: fmtCost(overview.totalCostUsd) },
   ];
 
   return (
-    <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-      {cards.map((c) => (
-        <div
-          key={c.label}
-          className="rounded-lg border border-border bg-card p-4"
-        >
-          <p className="text-xs text-muted-foreground">{c.label}</p>
-          <p className="text-2xl font-semibold mt-1">{c.value}</p>
-        </div>
-      ))}
-    </div>
+    <WidgetShell title="Totals">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        {cards.map((c) => (
+          <div key={c.label} className="rounded-lg border border-border bg-background/40 p-4">
+            <p className="text-xs text-muted-foreground">{c.label}</p>
+            <p className="text-2xl font-semibold mt-1">{c.value}</p>
+          </div>
+        ))}
+      </div>
+    </WidgetShell>
   );
 }
 
@@ -143,56 +219,55 @@ function TimelineChart() {
     costUsd: "Cost ($)",
   };
 
-  return (
-    <div className="rounded-lg border border-border bg-card p-4 space-y-3">
-      <div className="flex items-center justify-between flex-wrap gap-2">
-        <p className="text-sm font-medium">Timeline</p>
-        <div className="flex gap-2 flex-wrap">
-          <div className="flex gap-1">
-            {(["day", "week"] as Granularity[]).map((g) => (
-              <button
-                key={g}
-                onClick={() => setGranularity(g)}
-                className={cn(
-                  "text-xs px-2 py-1 rounded border transition-colors",
-                  granularity === g
-                    ? "bg-primary text-primary-foreground border-primary"
-                    : "border-border text-muted-foreground hover:border-primary/50",
-                )}
-              >
-                {g.charAt(0).toUpperCase() + g.slice(1)}
-              </button>
-            ))}
-          </div>
-          <div className="flex gap-1">
-            {(Object.keys(metricLabels) as ChartMetric[]).map((m) => (
-              <button
-                key={m}
-                onClick={() => setMetric(m)}
-                className={cn(
-                  "text-xs px-2 py-1 rounded border transition-colors",
-                  metric === m
-                    ? "bg-primary text-primary-foreground border-primary"
-                    : "border-border text-muted-foreground hover:border-primary/50",
-                )}
-              >
-                {metricLabels[m]}
-              </button>
-            ))}
-          </div>
-        </div>
+  const actions = (
+    <>
+      <div className="flex gap-1">
+        {(["day", "week"] as Granularity[]).map((g) => (
+          <button
+            key={g}
+            onClick={() => setGranularity(g)}
+            className={cn(
+              "text-xs px-2 py-1 rounded border transition-colors",
+              granularity === g
+                ? "bg-primary text-primary-foreground border-primary"
+                : "border-border text-muted-foreground hover:border-primary/50",
+            )}
+          >
+            {g.charAt(0).toUpperCase() + g.slice(1)}
+          </button>
+        ))}
       </div>
+      <div className="flex gap-1">
+        {(Object.keys(metricLabels) as ChartMetric[]).map((m) => (
+          <button
+            key={m}
+            onClick={() => setMetric(m)}
+            className={cn(
+              "text-xs px-2 py-1 rounded border transition-colors",
+              metric === m
+                ? "bg-primary text-primary-foreground border-primary"
+                : "border-border text-muted-foreground hover:border-primary/50",
+            )}
+          >
+            {metricLabels[m]}
+          </button>
+        ))}
+      </div>
+    </>
+  );
 
+  return (
+    <WidgetShell title="Timeline" actions={actions}>
       {isLoading ? (
-        <div className="h-48 flex items-center justify-center text-xs text-muted-foreground">
+        <div className="h-full min-h-40 flex items-center justify-center text-xs text-muted-foreground">
           Loading...
         </div>
       ) : !data || data.length === 0 ? (
-        <div className="h-48 flex items-center justify-center text-xs text-muted-foreground">
-          No data yet — run a pipeline to generate statistics.
+        <div className="h-full min-h-40 flex items-center justify-center text-xs text-muted-foreground">
+          No data yet.
         </div>
       ) : (
-        <ResponsiveContainer width="100%" height={200}>
+        <ResponsiveContainer width="100%" height="100%" minHeight={160}>
           <AreaChart data={data} margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>
             <defs>
               <linearGradient id="areaGrad" x1="0" y1="0" x2="0" y2="1">
@@ -223,7 +298,7 @@ function TimelineChart() {
           </AreaChart>
         </ResponsiveContainer>
       )}
-    </div>
+    </WidgetShell>
   );
 }
 
@@ -261,19 +336,11 @@ function ModelTable() {
     { label: "Error Rate", key: "errorRate", fmt: (v) => `${(v * 100).toFixed(1)}%` },
   ];
 
-  if (isLoading) {
-    return (
-      <div className="rounded-lg border border-border bg-card p-4">
-        <p className="text-sm font-medium mb-3">Per-Model Breakdown</p>
-        <p className="text-xs text-muted-foreground">Loading...</p>
-      </div>
-    );
-  }
-
   return (
-    <div className="rounded-lg border border-border bg-card p-4 space-y-3">
-      <p className="text-sm font-medium">Per-Model Breakdown</p>
-      {sorted.length === 0 ? (
+    <WidgetShell title="Per-Model Breakdown">
+      {isLoading ? (
+        <p className="text-xs text-muted-foreground">Loading...</p>
+      ) : sorted.length === 0 ? (
         <p className="text-xs text-muted-foreground">No data yet.</p>
       ) : (
         <div className="overflow-x-auto">
@@ -307,7 +374,103 @@ function ModelTable() {
           </table>
         </div>
       )}
-    </div>
+    </WidgetShell>
+  );
+}
+
+// ─── Workspace Breakdown Table ─────────────────────────────────────────────────
+
+type WorkspaceSortKey = "requests" | "tokens" | "costUsd" | "workspaceName";
+
+function WorkspaceTable() {
+  const { data, isLoading } = useQuery<WorkspaceStat[]>({
+    queryKey: ["stats-by-workspace"],
+    queryFn: () => fetchJson("/api/stats/by-workspace"),
+  });
+
+  const [sortKey, setSortKey] = useState<WorkspaceSortKey>("requests");
+  const [sortAsc, setSortAsc] = useState(false);
+
+  const toggleSort = (key: WorkspaceSortKey) => {
+    if (sortKey === key) setSortAsc(!sortAsc);
+    else { setSortKey(key); setSortAsc(false); }
+  };
+
+  const valueFor = (row: WorkspaceStat, key: WorkspaceSortKey): number | string => {
+    switch (key) {
+      case "workspaceName":
+        return row.workspaceName;
+      case "tokens":
+        return row.inputTokens + row.outputTokens;
+      case "requests":
+        return row.requests;
+      case "costUsd":
+        return row.costUsd;
+    }
+  };
+
+  const sorted = [...(data ?? [])].sort((a, b) => {
+    const av = valueFor(a, sortKey);
+    const bv = valueFor(b, sortKey);
+    if (typeof av === "string" || typeof bv === "string") {
+      const cmp = String(av).localeCompare(String(bv));
+      return sortAsc ? cmp : -cmp;
+    }
+    return sortAsc ? av - bv : bv - av;
+  });
+
+  const cols: { label: string; key: WorkspaceSortKey }[] = [
+    { label: "Workspace", key: "workspaceName" },
+    { label: "Requests", key: "requests" },
+    { label: "Tokens", key: "tokens" },
+    { label: "Cost", key: "costUsd" },
+  ];
+
+  return (
+    <WidgetShell title="Per-Workspace Breakdown">
+      {isLoading ? (
+        <p className="text-xs text-muted-foreground">Loading...</p>
+      ) : sorted.length === 0 ? (
+        <p className="text-xs text-muted-foreground">No data yet.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-border">
+                {cols.map((c) => (
+                  <th
+                    key={c.key}
+                    className="text-left pb-2 pr-4 text-muted-foreground font-medium cursor-pointer hover:text-foreground whitespace-nowrap"
+                    onClick={() => toggleSort(c.key)}
+                  >
+                    {c.label} {sortKey === c.key ? (sortAsc ? "▲" : "▼") : ""}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((row) => (
+                <tr
+                  key={row.workspaceId ?? "__unattributed__"}
+                  className="border-b border-border/50 hover:bg-muted/30"
+                >
+                  <td className="py-2 pr-4">
+                    {row.workspaceId === null ? (
+                      <span className="text-muted-foreground italic">{row.workspaceName}</span>
+                    ) : (
+                      row.workspaceName
+                    )}
+                  </td>
+                  <td className="py-2 pr-4">{fmt(row.requests)}</td>
+                  <td className="py-2 pr-4">{fmt(row.inputTokens + row.outputTokens)}</td>
+                  <td className="py-2 pr-4">{fmtCost(row.costUsd)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </WidgetShell>
   );
 }
 
@@ -368,161 +531,169 @@ function RequestLog() {
     URL.revokeObjectURL(url);
   }
 
+  const actions = (
+    <>
+      <button
+        onClick={() => handleExport("csv")}
+        className="flex items-center gap-1 text-xs px-2 py-1 rounded border border-border hover:border-primary/50 text-muted-foreground"
+      >
+        <Download className="h-3 w-3" /> CSV
+      </button>
+      <button
+        onClick={() => handleExport("json")}
+        className="flex items-center gap-1 text-xs px-2 py-1 rounded border border-border hover:border-primary/50 text-muted-foreground"
+      >
+        <Download className="h-3 w-3" /> JSON
+      </button>
+    </>
+  );
+
   return (
-    <div className="rounded-lg border border-border bg-card p-4 space-y-3">
-      <div className="flex items-center justify-between flex-wrap gap-2">
-        <p className="text-sm font-medium">Request Log</p>
-        <div className="flex gap-2">
-          <button
-            onClick={() => handleExport("csv")}
-            className="flex items-center gap-1 text-xs px-2 py-1 rounded border border-border hover:border-primary/50 text-muted-foreground"
+    <WidgetShell title="Request Log" actions={actions}>
+      <div className="space-y-3">
+        {/* Filters */}
+        <div className="flex gap-2 flex-wrap">
+          <input
+            type="text"
+            placeholder="Filter by model..."
+            value={modelFilter}
+            onChange={(e) => { setModelFilter(e.target.value); setPage(1); }}
+            className="text-xs px-2 py-1 rounded border border-border bg-background text-foreground placeholder:text-muted-foreground"
+          />
+          <input
+            type="text"
+            placeholder="Filter by provider..."
+            value={providerFilter}
+            onChange={(e) => { setProviderFilter(e.target.value); setPage(1); }}
+            className="text-xs px-2 py-1 rounded border border-border bg-background text-foreground placeholder:text-muted-foreground"
+          />
+          <select
+            value={statusFilter}
+            onChange={(e) => { setStatusFilter(e.target.value); setPage(1); }}
+            className="text-xs px-2 py-1 rounded border border-border bg-background text-foreground"
           >
-            <Download className="h-3 w-3" /> CSV
-          </button>
-          <button
-            onClick={() => handleExport("json")}
-            className="flex items-center gap-1 text-xs px-2 py-1 rounded border border-border hover:border-primary/50 text-muted-foreground"
-          >
-            <Download className="h-3 w-3" /> JSON
-          </button>
+            <option value="">All statuses</option>
+            <option value="success">Success</option>
+            <option value="error">Error</option>
+          </select>
         </div>
-      </div>
 
-      {/* Filters */}
-      <div className="flex gap-2 flex-wrap">
-        <input
-          type="text"
-          placeholder="Filter by model..."
-          value={modelFilter}
-          onChange={(e) => { setModelFilter(e.target.value); setPage(1); }}
-          className="text-xs px-2 py-1 rounded border border-border bg-background text-foreground placeholder:text-muted-foreground"
-        />
-        <input
-          type="text"
-          placeholder="Filter by provider..."
-          value={providerFilter}
-          onChange={(e) => { setProviderFilter(e.target.value); setPage(1); }}
-          className="text-xs px-2 py-1 rounded border border-border bg-background text-foreground placeholder:text-muted-foreground"
-        />
-        <select
-          value={statusFilter}
-          onChange={(e) => { setStatusFilter(e.target.value); setPage(1); }}
-          className="text-xs px-2 py-1 rounded border border-border bg-background text-foreground"
-        >
-          <option value="">All statuses</option>
-          <option value="success">Success</option>
-          <option value="error">Error</option>
-        </select>
-      </div>
-
-      {isLoading ? (
-        <p className="text-xs text-muted-foreground">Loading...</p>
-      ) : !data || data.rows.length === 0 ? (
-        <p className="text-xs text-muted-foreground">No requests found.</p>
-      ) : (
-        <>
-          <div className="overflow-x-auto">
-            <table className="w-full text-xs">
-              <thead>
-                <tr className="border-b border-border">
-                  {["Time", "Model", "Team", "In Tok", "Out Tok", "Cost", "Latency", "Status"].map((h) => (
-                    <th key={h} className="text-left pb-2 pr-3 text-muted-foreground font-medium whitespace-nowrap">
-                      {h}
-                    </th>
-                  ))}
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                {data.rows.map((row) => (
-                  <>
-                    <tr
-                      key={row.id}
-                      className="border-b border-border/50 hover:bg-muted/30 cursor-pointer"
-                      onClick={() => setExpandedId(expandedId === row.id ? null : row.id)}
-                    >
-                      <td className="py-1.5 pr-3 text-muted-foreground whitespace-nowrap">
-                        {fmtDate(row.createdAt).slice(0, 16)}
-                      </td>
-                      <td className="py-1.5 pr-3 font-mono truncate max-w-[150px]">{row.modelSlug}</td>
-                      <td className="py-1.5 pr-3 text-muted-foreground">{row.teamId ?? "—"}</td>
-                      <td className="py-1.5 pr-3">{fmt(row.inputTokens)}</td>
-                      <td className="py-1.5 pr-3">{fmt(row.outputTokens)}</td>
-                      <td className="py-1.5 pr-3">{row.estimatedCostUsd ? fmtCost(row.estimatedCostUsd) : "—"}</td>
-                      <td className="py-1.5 pr-3">{row.latencyMs}ms</td>
-                      <td className="py-1.5 pr-3">
-                        <span className={cn(
-                          "px-1.5 py-0.5 rounded text-[10px] font-medium",
-                          row.status === "success"
-                            ? "bg-green-500/10 text-green-500"
-                            : "bg-red-500/10 text-red-500",
-                        )}>
-                          {row.status}
-                        </span>
-                      </td>
-                      <td className="py-1.5">
-                        {expandedId === row.id
-                          ? <ChevronDown className="h-3 w-3 text-muted-foreground" />
-                          : <ChevronRight className="h-3 w-3 text-muted-foreground" />
-                        }
-                      </td>
-                    </tr>
-                    {expandedId === row.id && detail && (
-                      <tr key={`${row.id}-detail`} className="border-b border-border/50">
-                        <td colSpan={9} className="pb-3 pr-3">
-                          <div className="rounded-md border border-border bg-muted/20 p-3 space-y-2 text-xs">
-                            <div>
-                              <p className="text-muted-foreground font-medium mb-1">Messages</p>
-                              <pre className="text-[11px] whitespace-pre-wrap font-mono max-h-40 overflow-y-auto">
-                                {JSON.stringify(detail.messages, null, 2)}
-                              </pre>
-                            </div>
-                            {detail.responseContent && (
-                              <div>
-                                <p className="text-muted-foreground font-medium mb-1">Response</p>
-                                <pre className="text-[11px] whitespace-pre-wrap font-mono max-h-40 overflow-y-auto">
-                                  {detail.responseContent}
-                                </pre>
-                              </div>
-                            )}
-                          </div>
+        {isLoading ? (
+          <p className="text-xs text-muted-foreground">Loading...</p>
+        ) : !data || data.rows.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No requests found.</p>
+        ) : (
+          <>
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="border-b border-border">
+                    {["Time", "Model", "Team", "In Tok", "Out Tok", "Cost", "Latency", "Status"].map((h) => (
+                      <th key={h} className="text-left pb-2 pr-3 text-muted-foreground font-medium whitespace-nowrap">
+                        {h}
+                      </th>
+                    ))}
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.rows.map((row) => (
+                    <>
+                      <tr
+                        key={row.id}
+                        className="border-b border-border/50 hover:bg-muted/30 cursor-pointer"
+                        onClick={() => setExpandedId(expandedId === row.id ? null : row.id)}
+                      >
+                        <td className="py-1.5 pr-3 text-muted-foreground whitespace-nowrap">
+                          {fmtDate(row.createdAt).slice(0, 16)}
+                        </td>
+                        <td className="py-1.5 pr-3 font-mono truncate max-w-[150px]">{row.modelSlug}</td>
+                        <td className="py-1.5 pr-3 text-muted-foreground">{row.teamId ?? "—"}</td>
+                        <td className="py-1.5 pr-3">{fmt(row.inputTokens)}</td>
+                        <td className="py-1.5 pr-3">{fmt(row.outputTokens)}</td>
+                        <td className="py-1.5 pr-3">{row.estimatedCostUsd ? fmtCost(row.estimatedCostUsd) : "—"}</td>
+                        <td className="py-1.5 pr-3">{row.latencyMs}ms</td>
+                        <td className="py-1.5 pr-3">
+                          <span className={cn(
+                            "px-1.5 py-0.5 rounded text-[10px] font-medium",
+                            row.status === "success"
+                              ? "bg-green-500/10 text-green-500"
+                              : "bg-red-500/10 text-red-500",
+                          )}>
+                            {row.status}
+                          </span>
+                        </td>
+                        <td className="py-1.5">
+                          {expandedId === row.id
+                            ? <ChevronDown className="h-3 w-3 text-muted-foreground" />
+                            : <ChevronRight className="h-3 w-3 text-muted-foreground" />
+                          }
                         </td>
                       </tr>
-                    )}
-                  </>
-                ))}
-              </tbody>
-            </table>
-          </div>
-
-          {/* Pagination */}
-          <div className="flex items-center justify-between text-xs text-muted-foreground">
-            <span>{data.total} total</span>
-            <div className="flex gap-2 items-center">
-              <button
-                onClick={() => setPage((p) => Math.max(1, p - 1))}
-                disabled={page <= 1}
-                className="px-2 py-1 rounded border border-border disabled:opacity-40 hover:border-primary/50"
-              >
-                Prev
-              </button>
-              <span>{page} / {totalPages}</span>
-              <button
-                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-                disabled={page >= totalPages}
-                className="px-2 py-1 rounded border border-border disabled:opacity-40 hover:border-primary/50"
-              >
-                Next
-              </button>
+                      {expandedId === row.id && detail && (
+                        <tr key={`${row.id}-detail`} className="border-b border-border/50">
+                          <td colSpan={9} className="pb-3 pr-3">
+                            <div className="rounded-md border border-border bg-muted/20 p-3 space-y-2 text-xs">
+                              <div>
+                                <p className="text-muted-foreground font-medium mb-1">Messages</p>
+                                <pre className="text-[11px] whitespace-pre-wrap font-mono max-h-40 overflow-y-auto">
+                                  {JSON.stringify(detail.messages, null, 2)}
+                                </pre>
+                              </div>
+                              {detail.responseContent && (
+                                <div>
+                                  <p className="text-muted-foreground font-medium mb-1">Response</p>
+                                  <pre className="text-[11px] whitespace-pre-wrap font-mono max-h-40 overflow-y-auto">
+                                    {detail.responseContent}
+                                  </pre>
+                                </div>
+                              )}
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </>
+                  ))}
+                </tbody>
+              </table>
             </div>
-          </div>
-        </>
-      )}
-    </div>
+
+            {/* Pagination */}
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>{data.total} total</span>
+              <div className="flex gap-2 items-center">
+                <button
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={page <= 1}
+                  className="px-2 py-1 rounded border border-border disabled:opacity-40 hover:border-primary/50"
+                >
+                  Prev
+                </button>
+                <span>{page} / {totalPages}</span>
+                <button
+                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                  disabled={page >= totalPages}
+                  className="px-2 py-1 rounded border border-border disabled:opacity-40 hover:border-primary/50"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </WidgetShell>
   );
 }
 
 // ─── Page ─────────────────────────────────────────────────────────────────────
+
+// Classic WidthProvider(Responsive) composition from the `legacy` entry point:
+// auto-measures container width and supplies responsive breakpoints.
+const ResponsiveGridLayout = WidthProvider(Responsive);
+
+const BREAKPOINTS = { lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 };
+const COLS = { lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 };
 
 export default function Statistics() {
   const { data: overview, isLoading: overviewLoading } = useQuery<StatsOverview>({
@@ -530,26 +701,61 @@ export default function Statistics() {
     queryFn: () => fetchJson("/api/stats/overview"),
   });
 
+  const [layouts, setLayouts] = useState<ResponsiveLayouts>(() => loadLayout());
+
+  const handleLayoutChange = (_current: Layout, allLayouts: ResponsiveLayouts) => {
+    setLayouts(allLayouts);
+    saveLayout(allLayouts);
+  };
+
+  const handleReset = () => {
+    setLayouts(resetLayout());
+  };
+
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
-      <div className="h-16 border-b border-border flex items-center px-6 shrink-0">
+      <div className="h-16 border-b border-border flex items-center justify-between px-6 shrink-0">
         <h1 className="text-base font-semibold">Statistics</h1>
+        <button
+          onClick={handleReset}
+          className="flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded border border-border text-muted-foreground hover:border-primary/50 hover:text-foreground transition-colors"
+          title="Restore the default dashboard layout"
+        >
+          <RotateCcw className="h-3.5 w-3.5" /> Reset layout
+        </button>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-6 space-y-6">
-        {overviewLoading || !overview ? (
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <div key={i} className="rounded-lg border border-border bg-card p-4 animate-pulse h-20" />
-            ))}
+      <div className="flex-1 overflow-y-auto p-6">
+        <ResponsiveGridLayout
+          className="stats-dashboard-grid"
+          layouts={layouts}
+          breakpoints={BREAKPOINTS}
+          cols={COLS}
+          rowHeight={40}
+          margin={[16, 16]}
+          containerPadding={[0, 0]}
+          draggableHandle=".widget-drag-handle"
+          isDraggable
+          isResizable
+          useCSSTransforms
+          onLayoutChange={handleLayoutChange}
+        >
+          <div key="totals">
+            <TotalsWidget overview={overview} loading={overviewLoading} />
           </div>
-        ) : (
-          <SummaryCards overview={overview} />
-        )}
-
-        <TimelineChart />
-        <ModelTable />
-        <RequestLog />
+          <div key="timeline">
+            <TimelineChart />
+          </div>
+          <div key="by-model">
+            <ModelTable />
+          </div>
+          <div key="by-workspace">
+            <WorkspaceTable />
+          </div>
+          <div key="request-log">
+            <RequestLog />
+          </div>
+        </ResponsiveGridLayout>
       </div>
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "react": "^19.2.0",
         "react-day-picker": "^9.11.1",
         "react-dom": "^19.2.0",
+        "react-grid-layout": "2.2.3",
         "react-hook-form": "^7.66.0",
         "react-resizable-panels": "^2.1.9",
         "reactflow": "^11.11.4",
@@ -8961,6 +8962,44 @@
         "react": "^19.2.3"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.7.0.tgz",
+      "integrity": "sha512-kTpANmKWVnFXiZ76Ag2ZowiFStuBYnJ606PI1TbUsOg29/400/JNIxI9+CuenhiAqFuXWJffz6F4UI3R51kUug==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-grid-layout": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-2.2.3.tgz",
+      "integrity": "sha512-OAEJHBxmfuxQfVtZwRzmsokijGlBgzYIJ7MUlLk/VSa43SaGzu15w5D0P2RDrfX5EvP9POMbL6bFrai/huDzbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "fast-equals": "^4.0.3",
+        "prop-types": "^15.8.1",
+        "react-draggable": "^4.4.6",
+        "react-resizable": "^3.1.3",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-grid-layout/node_modules/fast-equals": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
+      "license": "MIT"
+    },
     "node_modules/react-hook-form": {
       "version": "7.71.1",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
@@ -9038,6 +9077,20 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-resizable": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.2.0.tgz",
+      "integrity": "sha512-3NKQ0SLZV7rs3LQHeXlOzDSRQfFrkX6TVet77/Qk03zqiZyee37b7N8/gwDJAA8UUjRz7PdWCCy49hcso45SMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "15.x",
+        "react-draggable": "^4.5.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3",
+        "react-dom": ">= 16.3"
       }
     },
     "node_modules/react-resizable-panels": {
@@ -9227,6 +9280,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "react": "^19.2.0",
     "react-day-picker": "^9.11.1",
     "react-dom": "^19.2.0",
+    "react-grid-layout": "2.2.3",
     "react-hook-form": "^7.66.0",
     "react-resizable-panels": "^2.1.9",
     "reactflow": "^11.11.4",

--- a/server/routes/stats.ts
+++ b/server/routes/stats.ts
@@ -40,10 +40,10 @@ export function registerStatsRoutes(app: Express, storage: IStorage): void {
   // GET /api/stats/overview
   app.get("/api/stats/overview", async (_req, res) => {
     try {
-      const [llmStats, allRuns] = await Promise.all([
-        storage.getLlmRequestStats(),
-        storage.getPipelineRuns(),
-      ]);
+      // Pipeline runs were removed from the overview: pipeline_runs is 0 all-time
+      // on this platform and the entity left the primary UI, so we no longer scan
+      // that table here (it was a wasted full-table read). Only LLM aggregates.
+      const llmStats = await storage.getLlmRequestStats();
       res.json({
         totalRequests: llmStats.totalRequests,
         totalTokens: {
@@ -52,7 +52,6 @@ export function registerStatsRoutes(app: Express, storage: IStorage): void {
           total: llmStats.totalInputTokens + llmStats.totalOutputTokens,
         },
         totalCostUsd: llmStats.totalCostUsd,
-        totalRuns: allRuns.length,
       });
     } catch (err) {
       console.error("/api/stats/overview error:", err);
@@ -89,6 +88,17 @@ export function registerStatsRoutes(app: Express, storage: IStorage): void {
       res.json(stats);
     } catch (err) {
       console.error("/api/stats/by-team error:", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  // GET /api/stats/by-workspace — tokens/cost/requests attributed per workspace
+  app.get("/api/stats/by-workspace", async (_req, res) => {
+    try {
+      const stats = await storage.getLlmStatsByWorkspace();
+      res.json(stats);
+    } catch (err) {
+      console.error("/api/stats/by-workspace error:", err);
       res.status(500).json({ error: "Internal server error" });
     }
   });

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -2,7 +2,7 @@ import { eq, desc, and, or, ilike, lt, ne, gte, lte, asc, isNull, inArray, sql a
 import type { SQL } from "drizzle-orm";
 import { db, withProject, withProjectList, withProjectInsert, withProjectOrGlobal } from "./db";
 import { unscopedSystemQuery, getProjectId } from "./context";
-import type { IStorage, PracticeCardFilters, LlmRequestFilters, LlmRequestStats, LlmStatsByModel, LlmStatsByProvider, LlmStatsByTeam, LlmTimelinePoint, RunHistoryQuery, PipelineRunHistoryRow, TaskGroupHistoryRow } from "./storage";
+import type { IStorage, PracticeCardFilters, LlmRequestFilters, LlmRequestStats, LlmStatsByModel, LlmStatsByProvider, LlmStatsByTeam, LlmStatsByWorkspace, LlmTimelinePoint, RunHistoryQuery, PipelineRunHistoryRow, TaskGroupHistoryRow } from "./storage";
 import {
   TASK_GROUP_V2_MAX_LIMIT,
   IterationConflictError,
@@ -608,6 +608,76 @@ export class PgStorage implements IStorage {
         outputTokens: r.outputTokens,
         costUsd: r.costUsd,
       }));
+  }
+
+  async getLlmStatsByWorkspace(): Promise<LlmStatsByWorkspace[]> {
+    // Read-side workspace attribution. See MemStorage.getLlmStatsByWorkspace for the
+    // full rationale. Chosen join: llm_requests.runId (= task_groups.id in the
+    // consilium path) -> consilium_loops.groupId -> repoPath -> workspaces.path.
+    //
+    // Single-count guard: rather than JOIN requests to the (potentially many)
+    // consilium_loops / tasks rows of a group -- which fans out and double-counts
+    // tokens/cost -- we (1) aggregate requests grouped by runId (each request lands
+    // in exactly ONE runId bucket, project-scoped), then (2) resolve each runId to a
+    // SINGLE workspace and fold. No request-to-loop join exists, so no fan-out.
+
+    // 1. Per-runId aggregation, project-scoped exactly like every other stat.
+    const reqRows = await db
+      .select({
+        runId: llmRequests.runId,
+        requests: drizzleSql<number>`count(*)::int`,
+        inputTokens: drizzleSql<number>`coalesce(sum(input_tokens), 0)::int`,
+        outputTokens: drizzleSql<number>`coalesce(sum(output_tokens), 0)::int`,
+        costUsd: drizzleSql<number>`coalesce(sum(estimated_cost_usd), 0)::float`,
+      })
+      .from(llmRequests)
+      .where(withProject(llmRequests))
+      .groupBy(llmRequests.runId);
+
+    // 2a. path -> workspace (deterministic: lowest id wins on a duplicate path).
+    const wsRows = await db
+      .select({ id: workspaces.id, name: workspaces.name, path: workspaces.path })
+      .from(workspaces)
+      .where(withProject(workspaces));
+    const wsByPath = new Map<string, { id: string; name: string }>();
+    for (const w of [...wsRows].sort((a, b) => a.id.localeCompare(b.id))) {
+      if (!wsByPath.has(w.path)) wsByPath.set(w.path, w);
+    }
+
+    // 2b. group -> one workspace: the newest resolving loop wins.
+    const loopRows = await db
+      .select({ groupId: consiliumLoops.groupId, repoPath: consiliumLoops.repoPath })
+      .from(consiliumLoops)
+      .where(withProject(consiliumLoops))
+      .orderBy(desc(consiliumLoops.createdAt), desc(consiliumLoops.id));
+    const groupToWs = new Map<string, { id: string; name: string }>();
+    for (const loop of loopRows) {
+      if (groupToWs.has(loop.groupId)) continue;
+      const w = wsByPath.get(loop.repoPath);
+      if (w) groupToWs.set(loop.groupId, w);
+    }
+
+    // 3. Fold each runId bucket into its single workspace (or Unattributed).
+    const UNATTRIBUTED = "\u0000unattributed";
+    const out = new Map<string, LlmStatsByWorkspace>();
+    for (const r of reqRows) {
+      const ws = r.runId ? groupToWs.get(r.runId) : undefined;
+      const key = ws ? ws.id : UNATTRIBUTED;
+      const existing = out.get(key) ?? {
+        workspaceId: ws ? ws.id : null,
+        workspaceName: ws ? ws.name : "Unattributed",
+        requests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        costUsd: 0,
+      };
+      existing.requests += r.requests;
+      existing.inputTokens += r.inputTokens;
+      existing.outputTokens += r.outputTokens;
+      existing.costUsd += r.costUsd;
+      out.set(key, existing);
+    }
+    return Array.from(out.values());
   }
 
   async getLlmTimeline(from: Date, to: Date, granularity: 'day' | 'week'): Promise<LlmTimelinePoint[]> {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -129,6 +129,15 @@ export interface LlmStatsByTeam {
   costUsd: number;
 }
 
+export interface LlmStatsByWorkspace {
+  workspaceId: string | null;
+  workspaceName: string;
+  requests: number;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+}
+
 export interface LlmTimelinePoint {
   date: string;
   requests: number;
@@ -305,6 +314,7 @@ export interface IStorage {
   getLlmStatsByModel(): Promise<LlmStatsByModel[]>;
   getLlmStatsByProvider(): Promise<LlmStatsByProvider[]>;
   getLlmStatsByTeam(): Promise<LlmStatsByTeam[]>;
+  getLlmStatsByWorkspace(): Promise<LlmStatsByWorkspace[]>;
   getLlmTimeline(from: Date, to: Date, granularity: 'day' | 'week'): Promise<LlmTimelinePoint[]>;
 
   // Memories
@@ -1185,6 +1195,61 @@ export class MemStorage implements IStorage {
       const key = r.teamId!;
       const existing = map.get(key) ?? {
         teamId: key,
+        requests: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        costUsd: 0,
+      };
+      existing.requests++;
+      existing.inputTokens += r.inputTokens ?? 0;
+      existing.outputTokens += r.outputTokens ?? 0;
+      existing.costUsd += r.estimatedCostUsd ?? 0;
+      map.set(key, existing);
+    }
+    return Array.from(map.values());
+  }
+
+  async getLlmStatsByWorkspace(): Promise<LlmStatsByWorkspace[]> {
+    // Attribution (read-side only): llm_requests.runId holds a task_groups.id in
+    // the consilium path (the gateway is called with runId = group.id). We resolve
+    // a group -> workspace via consilium_loops.groupId -> repoPath -> workspaces.path.
+    //
+    // Single-count guard: a group may own MANY consilium_loops rows (terminal loops
+    // accumulate across re-runs) and MANY tasks. We therefore build a runId ->
+    // single-workspace map FIRST (one deterministic workspace per group), then fold
+    // each request into exactly one bucket. There is no request-to-loop fan-out
+    // join, so a request's tokens/cost are summed exactly once.
+
+    // path -> workspace (deterministic: lowest id wins on a duplicate path).
+    const wsByPath = new Map<string, WorkspaceRow>();
+    for (const w of Array.from(this.workspacesMap.values()).sort((a, b) => a.id.localeCompare(b.id))) {
+      if (!wsByPath.has(w.path)) wsByPath.set(w.path, w);
+    }
+
+    // group -> one workspace: the newest loop (createdAt desc, id desc) whose
+    // repoPath resolves wins; older loops of the same group never override it.
+    const loops = Array.from(this.consiliumLoopsMap.values()).sort((a, b) => {
+      const ta = a.createdAt?.getTime() ?? 0;
+      const tb = b.createdAt?.getTime() ?? 0;
+      if (ta !== tb) return tb - ta;
+      return b.id.localeCompare(a.id);
+    });
+    const groupToWs = new Map<string, WorkspaceRow>();
+    for (const loop of loops) {
+      if (groupToWs.has(loop.groupId)) continue;
+      const w = wsByPath.get(loop.repoPath);
+      if (w) groupToWs.set(loop.groupId, w);
+    }
+
+    // Fold each request into exactly one workspace (or the Unattributed bucket).
+    const UNATTRIBUTED = "\u0000unattributed";
+    const map = new Map<string, LlmStatsByWorkspace>();
+    for (const r of this.llmRequestsMap.values()) {
+      const ws = r.runId ? groupToWs.get(r.runId) : undefined;
+      const key = ws ? ws.id : UNATTRIBUTED;
+      const existing = map.get(key) ?? {
+        workspaceId: ws ? ws.id : null,
+        workspaceName: ws ? ws.name : "Unattributed",
         requests: 0,
         inputTokens: 0,
         outputTokens: 0,

--- a/tests/e2e/statistics.spec.ts
+++ b/tests/e2e/statistics.spec.ts
@@ -65,11 +65,11 @@ test.describe("Statistics", () => {
       totalRequests: number;
       totalTokens: { input: number; output: number; total: number };
       totalCostUsd: number;
-      totalRuns: number;
     };
     expect(typeof body.totalRequests).toBe("number");
     expect(typeof body.totalCostUsd).toBe("number");
-    expect(typeof body.totalRuns).toBe("number");
+    // Pipeline Runs was removed from the overview response.
+    expect(body).not.toHaveProperty("totalRuns");
     expect(typeof body.totalTokens.total).toBe("number");
   });
 
@@ -80,12 +80,10 @@ test.describe("Statistics", () => {
       totalRequests: number;
       totalTokens: { input: number; output: number; total: number };
       totalCostUsd: number;
-      totalRuns: number;
     };
 
     expect(body.totalRequests).toBeGreaterThanOrEqual(0);
     expect(body.totalCostUsd).toBeGreaterThanOrEqual(0);
-    expect(body.totalRuns).toBeGreaterThanOrEqual(0);
     expect(body.totalTokens.input).toBeGreaterThanOrEqual(0);
     expect(body.totalTokens.output).toBeGreaterThanOrEqual(0);
   });
@@ -157,6 +155,15 @@ test.describe("Statistics", () => {
   test("GET /api/stats/by-team returns array", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
     const res = await page.request.get(`${baseURL}/api/stats/by-team`);
+    expect(res.status()).toBe(200);
+
+    const body = await res.json() as unknown[];
+    expect(Array.isArray(body)).toBe(true);
+  });
+
+  test("GET /api/stats/by-workspace returns array", async ({ page }, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
+    const res = await page.request.get(`${baseURL}/api/stats/by-workspace`);
     expect(res.status()).toBe(200);
 
     const body = await res.json() as unknown[];

--- a/tests/integration/stats-api.test.ts
+++ b/tests/integration/stats-api.test.ts
@@ -98,6 +98,8 @@ describe("Stats API", () => {
           total: 230,
         }),
       });
+      // Pipeline Runs was removed from the overview response shape.
+      expect(res.body).not.toHaveProperty("totalRuns");
     });
   });
 
@@ -127,6 +129,20 @@ describe("Stats API", () => {
       expect(Array.isArray(res.body)).toBe(true);
       const teams = res.body.map((r: { teamId: string }) => r.teamId);
       expect(teams).toContain("planning");
+    });
+  });
+
+  describe("GET /api/stats/by-workspace", () => {
+    it("returns an array (unattributed bucket for un-linked requests)", async () => {
+      // The two seeded requests (run-1, run-2) map to no consilium loop, so they
+      // fall into the explicit Unattributed bucket rather than being dropped.
+      const res = await request(app).get("/api/stats/by-workspace");
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      const unattr = res.body.find((r: { workspaceId: string | null }) => r.workspaceId === null);
+      expect(unattr).toBeDefined();
+      expect(unattr.workspaceName).toBe("Unattributed");
+      expect(unattr.requests).toBe(2);
     });
   });
 

--- a/tests/unit/dashboard-layout.test.ts
+++ b/tests/unit/dashboard-layout.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_LAYOUT,
+  LAYOUT_VERSION,
+  loadLayout,
+  resetLayout,
+  saveLayout,
+} from "@/lib/dashboard-layout";
+
+// ─── In-memory localStorage stub (node environment, no jsdom) ───────────────────
+class MemoryStorage {
+  private store = new Map<string, string>();
+  get length() {
+    return this.store.size;
+  }
+  clear() {
+    this.store.clear();
+  }
+  getItem(key: string) {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+  setItem(key: string, value: string) {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string) {
+    this.store.delete(key);
+  }
+  key(index: number) {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+}
+
+const STORAGE_KEY = "stats-dashboard-layout:v1";
+
+function seed(payload: unknown) {
+  (globalThis.localStorage as Storage).setItem(STORAGE_KEY, JSON.stringify(payload));
+}
+
+beforeEach(() => {
+  // Fresh storage per test.
+  (globalThis as unknown as { localStorage: Storage }).localStorage =
+    new MemoryStorage() as unknown as Storage;
+});
+
+describe("dashboard-layout persistence", () => {
+  it("returns the default layout when nothing is stored", () => {
+    expect(loadLayout()).toEqual(DEFAULT_LAYOUT);
+  });
+
+  it("discards a stored layout whose version does not match (falls back to default)", () => {
+    seed({
+      version: LAYOUT_VERSION + 99,
+      layouts: {
+        lg: [{ i: "timeline", x: 6, y: 0, w: 6, h: 4 }],
+      },
+    });
+    expect(loadLayout()).toEqual(DEFAULT_LAYOUT);
+  });
+
+  it("drops unknown/stale widget keys from a same-version layout without throwing", () => {
+    seed({
+      version: LAYOUT_VERSION,
+      layouts: {
+        lg: [
+          { i: "totals", x: 0, y: 0, w: 12, h: 3 },
+          { i: "timeline", x: 0, y: 3, w: 12, h: 7 },
+          { i: "by-model", x: 0, y: 10, w: 12, h: 7 },
+          { i: "by-workspace", x: 0, y: 17, w: 12, h: 7 },
+          { i: "request-log", x: 0, y: 24, w: 12, h: 10 },
+          // stale key from a previous app version — must be dropped:
+          { i: "legacy-pipeline-runs", x: 0, y: 40, w: 12, h: 4 },
+        ],
+      },
+    });
+
+    let result: ReturnType<typeof loadLayout>;
+    expect(() => {
+      result = loadLayout();
+    }).not.toThrow();
+
+    const keys = result!.lg!.map((item) => item.i);
+    expect(keys).not.toContain("legacy-pipeline-runs");
+    expect(keys.sort()).toEqual(
+      ["by-model", "by-workspace", "request-log", "timeline", "totals"].sort(),
+    );
+  });
+
+  it("backfills a current widget that is missing from the stored layout", () => {
+    seed({
+      version: LAYOUT_VERSION,
+      layouts: {
+        lg: [
+          { i: "totals", x: 0, y: 0, w: 12, h: 3 },
+          { i: "timeline", x: 0, y: 3, w: 12, h: 7 },
+          { i: "by-model", x: 0, y: 10, w: 12, h: 7 },
+          // "by-workspace" intentionally missing
+          { i: "request-log", x: 0, y: 24, w: 12, h: 10 },
+        ],
+      },
+    });
+
+    const result = loadLayout();
+    const workspace = result.lg!.find((item) => item.i === "by-workspace");
+    const defaultWorkspace = DEFAULT_LAYOUT.lg!.find(
+      (item) => item.i === "by-workspace",
+    );
+
+    expect(workspace).toBeDefined();
+    // Backfilled from its default position.
+    expect(workspace).toEqual(defaultWorkspace);
+    // All five widgets are present.
+    expect(result.lg!.map((i) => i.i).sort()).toEqual(
+      ["by-model", "by-workspace", "request-log", "timeline", "totals"].sort(),
+    );
+  });
+
+  it("round-trips a valid same-version layout unchanged", () => {
+    const custom = {
+      lg: [
+        { i: "totals", x: 0, y: 0, w: 12, h: 3, minW: 4, minH: 2 },
+        { i: "timeline", x: 0, y: 3, w: 6, h: 7, minW: 4, minH: 4 },
+        { i: "by-model", x: 6, y: 3, w: 6, h: 7, minW: 4, minH: 3 },
+        { i: "by-workspace", x: 0, y: 10, w: 6, h: 7, minW: 4, minH: 3 },
+        { i: "request-log", x: 0, y: 17, w: 12, h: 10, minW: 5, minH: 5 },
+      ],
+    };
+
+    saveLayout(custom);
+    expect(loadLayout()).toEqual(custom);
+  });
+
+  it("resetLayout clears storage and returns the default", () => {
+    saveLayout({ lg: [{ i: "timeline", x: 0, y: 0, w: 6, h: 5 }] });
+    const afterReset = resetLayout();
+    expect(afterReset).toEqual(DEFAULT_LAYOUT);
+    // Subsequent load also yields the default (storage was cleared).
+    expect(loadLayout()).toEqual(DEFAULT_LAYOUT);
+  });
+});

--- a/tests/unit/stats-by-workspace.test.ts
+++ b/tests/unit/stats-by-workspace.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for MemStorage.getLlmStatsByWorkspace() — the per-workspace LLM
+ * aggregation (tokens / cost / requests attributed to a WORKSPACE).
+ *
+ * Attribution join under test:
+ *   llm_requests.runId  ==  task_groups.id   (the gateway records runId = group.id
+ *                                             in the consilium/task-group path)
+ *   consilium_loops.groupId == that group.id
+ *   consilium_loops.repoPath == workspaces.path   -> resolves the workspace.
+ *
+ * Correctness properties asserted:
+ *   (a) attribution — a request whose runId maps through a loop lands on that
+ *       loop's workspace;
+ *   (b) unattributed bucket — a request with a null runId, or a runId that maps
+ *       to no workspace, lands in { workspaceId: null, workspaceName: "Unattributed" };
+ *   (c) NO double-counting — a group owning MULTIPLE consilium_loops rows AND
+ *       MULTIPLE tasks has its single request counted exactly once (a naive
+ *       fan-out join would multiply its tokens/cost by loops x tasks).
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { MemStorage } from "../../server/storage.js";
+import type { InsertLlmRequest } from "../../shared/schema.js";
+
+/** Minimal, valid llm_request payload; caller overrides what matters. */
+function llmReq(overrides: Partial<InsertLlmRequest>): InsertLlmRequest {
+  return {
+    runId: null,
+    stageExecutionId: null,
+    modelSlug: "claude-3-5-sonnet",
+    provider: "anthropic",
+    messages: [],
+    systemPrompt: null,
+    temperature: null,
+    maxTokens: null,
+    responseContent: "",
+    inputTokens: 10,
+    outputTokens: 5,
+    totalTokens: 15,
+    latencyMs: 100,
+    estimatedCostUsd: 0.001,
+    status: "success",
+    errorMessage: null,
+    teamId: null,
+    tags: [],
+    ...overrides,
+  } as InsertLlmRequest;
+}
+
+describe("MemStorage.getLlmStatsByWorkspace()", () => {
+  let storage: MemStorage;
+
+  beforeEach(() => {
+    storage = new MemStorage();
+  });
+
+  it("(a) attributes a request to the workspace resolved via its consilium loop", async () => {
+    const ws = await storage.createWorkspace({
+      name: "alpha", type: "local", path: "/repo/alpha", branch: "main",
+    });
+    const group = await storage.createTaskGroup({
+      name: "review-alpha", description: "d", input: "i",
+    });
+    await storage.createLoop({
+      groupId: group.id, repoPath: "/repo/alpha", state: "converged",
+    });
+
+    await storage.createLlmRequest(llmReq({ runId: group.id, inputTokens: 100, outputTokens: 40, estimatedCostUsd: 0.02 }));
+
+    const stats = await storage.getLlmStatsByWorkspace();
+    expect(stats).toHaveLength(1);
+    expect(stats[0]).toMatchObject({
+      workspaceId: ws.id,
+      workspaceName: "alpha",
+      requests: 1,
+      inputTokens: 100,
+      outputTokens: 40,
+      costUsd: 0.02,
+    });
+  });
+
+  it("(b) buckets null-runId and unmatched-runId requests as Unattributed", async () => {
+    // A request with no runId at all.
+    await storage.createLlmRequest(llmReq({ runId: null, inputTokens: 7, outputTokens: 3, estimatedCostUsd: 0.005 }));
+    // A request whose runId maps to no loop/workspace.
+    await storage.createLlmRequest(llmReq({ runId: "ghost-group", inputTokens: 8, outputTokens: 2, estimatedCostUsd: 0.004 }));
+
+    const stats = await storage.getLlmStatsByWorkspace();
+    expect(stats).toHaveLength(1);
+    expect(stats[0]).toMatchObject({
+      workspaceId: null,
+      workspaceName: "Unattributed",
+      requests: 2,
+      inputTokens: 15,
+      outputTokens: 5,
+    });
+    expect(stats[0].costUsd).toBeCloseTo(0.009, 10);
+  });
+
+  it("(c) counts a request ONCE for a group with 2 consilium loops and 2 tasks", async () => {
+    const ws = await storage.createWorkspace({
+      name: "beta", type: "local", path: "/repo/beta", branch: "main",
+    });
+    // Two OTHER workspaces the fan-out could wrongly attribute to via tasks.
+    const wsX = await storage.createWorkspace({ name: "x", type: "local", path: "/repo/x", branch: "main" });
+    const wsY = await storage.createWorkspace({ name: "y", type: "local", path: "/repo/y", branch: "main" });
+
+    const group = await storage.createTaskGroup({ name: "review-beta", description: "d", input: "i" });
+
+    // TWO terminal consilium loops on the SAME group (terminal loops accumulate
+    // across re-runs; only NON-terminal loops are unique-per-group). Both point at
+    // the same repo, so the resolved workspace is unambiguous regardless of which
+    // loop wins the deterministic pick.
+    await storage.createLoop({ groupId: group.id, repoPath: "/repo/beta", state: "converged" });
+    await storage.createLoop({ groupId: group.id, repoPath: "/repo/beta", state: "failed" });
+
+    // TWO tasks on the group, carrying DIFFERENT workspaceIds — a naive join on
+    // tasks would fan out and double-count. Our chosen join ignores tasks, so these
+    // must have zero effect.
+    await storage.createTask({ groupId: group.id, name: "t1", description: "d", workspaceId: wsX.id });
+    await storage.createTask({ groupId: group.id, name: "t2", description: "d", workspaceId: wsY.id });
+
+    // ONE request for the group.
+    await storage.createLlmRequest(llmReq({ runId: group.id, inputTokens: 100, outputTokens: 50, estimatedCostUsd: 0.01 }));
+
+    const stats = await storage.getLlmStatsByWorkspace();
+
+    // Only the beta workspace bucket exists — X and Y (task workspaces) must NOT appear.
+    expect(stats).toHaveLength(1);
+    const beta = stats.find((s) => s.workspaceId === ws.id);
+    expect(beta).toBeDefined();
+    expect(beta).toMatchObject({
+      workspaceName: "beta",
+      requests: 1,        // counted once, NOT 2 loops x 2 tasks = 4
+      inputTokens: 100,   // summed once
+      outputTokens: 50,
+      costUsd: 0.01,
+    });
+    expect(stats.some((s) => s.workspaceId === wsX.id)).toBe(false);
+    expect(stats.some((s) => s.workspaceId === wsY.id)).toBe(false);
+
+    // Global invariant: total requests across all buckets == total requests recorded.
+    const totalBucketed = stats.reduce((n, s) => n + s.requests, 0);
+    expect(totalBucketed).toBe(1);
+  });
+
+  it("mixes attributed and unattributed requests without cross-contamination", async () => {
+    const ws = await storage.createWorkspace({ name: "gamma", type: "local", path: "/repo/gamma", branch: "main" });
+    const group = await storage.createTaskGroup({ name: "review-gamma", description: "d", input: "i" });
+    await storage.createLoop({ groupId: group.id, repoPath: "/repo/gamma", state: "converged" });
+
+    await storage.createLlmRequest(llmReq({ runId: group.id, inputTokens: 10, outputTokens: 10, estimatedCostUsd: 0.001 }));
+    await storage.createLlmRequest(llmReq({ runId: group.id, inputTokens: 20, outputTokens: 20, estimatedCostUsd: 0.002 }));
+    await storage.createLlmRequest(llmReq({ runId: null, inputTokens: 5, outputTokens: 5, estimatedCostUsd: 0.003 }));
+
+    const stats = await storage.getLlmStatsByWorkspace();
+    const gamma = stats.find((s) => s.workspaceId === ws.id);
+    const unattr = stats.find((s) => s.workspaceId === null);
+
+    expect(gamma).toMatchObject({ requests: 2, inputTokens: 30, outputTokens: 30, costUsd: 0.003 });
+    expect(unattr).toMatchObject({ workspaceName: "Unattributed", requests: 1, inputTokens: 5, outputTokens: 5 });
+    // Every recorded request is accounted for exactly once.
+    expect(stats.reduce((n, s) => n + s.requests, 0)).toBe(3);
+  });
+});


### PR DESCRIPTION
## What & why

The Statistics page is now the **home page (`/`)**. This PR turns it into a Grafana-like configurable dashboard, drops a dead stat, and adds a per-workspace breakdown. Read-side only — **no FSM/schema/migration changes**.

### 1. Drop the "Pipeline Runs" stat
Pipelines never ran on this platform (`pipeline_runs = 0` all-time) and the entity left the primary UI.
- **Client**: removed the "Pipeline Runs" summary card (Totals is now 3 cards) and `totalRuns` from the `StatsOverview` interface; neutralized pipeline-referencing copy (Timeline empty state → "No data yet.").
- **Server**: `GET /api/stats/overview` no longer calls `storage.getPipelineRuns()` (a wasted full-table scan) and no longer returns `totalRuns`. `getPipelineRuns()` itself is untouched (still used elsewhere).

### 2. Grafana-like configurable blocks
Each widget — **Totals, Timeline, Per-Model, Per-Workspace, Request Log** — is a repositionable + resizable grid block.
- **Dependency decision**: `react-grid-layout` was absent; added **pinned to exactly `2.2.3`** (latest stable). Chosen because its peer range is `react >= 16.3` (React-19-safe), it **bundles its own TS types** (no `@types` needed), and its deps `react-draggable@^4.4.6` / `react-resizable@^3.1.3` are ref-based — no `findDOMNode` (which React 19 removed). We use the `react-grid-layout/legacy` subpath (`WidthProvider(Responsive)`) for the classic auto-measuring responsive HOC.
- **Default layout** mirrors today's vertical stack (Totals → Timeline → Per-Model → Per-Workspace → Request Log) on a 12-col grid.
- **Drag handle on the widget header only** (`draggableHandle=".widget-drag-handle"` + a grip affordance) so inner scrolling, text selection, table sorting, filters, pagination and CSV/JSON export stay fully clickable (header actions and body controls are rendered as siblings of the handle, not inside it).
- **Resize** enabled; **"Reset layout"** button in the page header.
- **Layout persists per browser in localStorage** (no server persistence in this PR), via a **versioned** helper (`client/src/lib/dashboard-layout.ts`, `LAYOUT_VERSION`): a version mismatch or unparseable/wrong-shape value falls back to the default; a valid same-version layout is **reconciled** against the current widget set — **unknown/stale widget keys are dropped** and **missing widgets are backfilled** from their defaults, so a future widget rename can never crash the page on a stale value.
- **Operator example works**: Timeline has `minW=4`, so it can be shrunk to ~half width and dragged into a left column with another widget beside it.

### 3. Per-Workspace Breakdown widget
New table analogous to Per-Model, served by **`GET /api/stats/by-workspace`** (mirrors `by-model`). Columns: Workspace / Requests / Tokens / Cost.

**Attribution join chosen** (cheapest reliable, verified in code):
`llm_requests.runId` → `consilium_loops.groupId` → `consilium_loops.repoPath` → `workspaces.path`.
- In the consilium/task path the gateway logs `runId = task_groups.id` (`server/gateway/index.ts` ← `task-orchestrator.ts`), and `consilium_loops.groupId` equals that group id, with `repoPath` (NOT NULL) resolved to a workspace by path (the existing "workspace-bind"). The `tasks.workspaceId` path was rejected: it's nullable and only set on the *separate* DEV-handoff group, so it would leave most requests unattributed.
- **No double-counting**: a group can have many `consilium_loops`/`tasks` rows. We never JOIN requests to loops. Instead we (1) aggregate requests **grouped by `runId`** (each request lands in exactly one bucket, project-scoped), then (2) resolve each `runId` to a **single** workspace (newest resolving loop wins) and fold — fan-out is structurally impossible.
- **Unattributed bucket**: requests with null or unresolved `runId` are surfaced as an explicit `{ workspaceId: null, workspaceName: "Unattributed" }` row (never silently dropped), emitted only when non-empty.

Implemented in both `MemStorage` and `PgStorage` (the latter preserves the `withProject()` tenant-scoping used by every other stat).

## Adversarial self-review
- **Risk 1 (RGL CSS bleeding into existing cards)**: RGL CSS targets only its own `.react-grid-item`/`.react-resizable-handle` classes; existing `rounded-lg border bg-card` visuals are untouched; body uses `overflow-auto` so inner `overflow-x-auto` tables aren't clipped by RGL's absolute positioning.
- **Risk 2 (stale localStorage crashing after a widget rename)**: versioned schema + reconciliation (drop-unknown, backfill-missing) with a unit test covering version mismatch, unknown keys, and missing widgets.
- **Risk 3 (per-workspace double-counting)**: aggregate-by-runId-then-map guarantees each `llm_request` is counted exactly once; asserted by a test with a group carrying 2 loops + 2 tasks.

## Test evidence
- `npx tsc` → exit **0** (client gate).
- Unit project: **243 files / 4734 tests passed** (includes new `tests/unit/stats-by-workspace.test.ts` — attribution + unattributed + single-count; and `tests/unit/dashboard-layout.test.ts` — 6 cases for versioned schema/reconciliation).
- Integration: **55 files / 867 passed / 5 skipped** (`tests/integration/stats-api.test.ts` updated: by-workspace unattributed bucket + overview `not.toHaveProperty("totalRuns")`).
- Known-flaky suites (providers/antigravity, config-sync-multi-instance) passed this run.

Rebased onto latest `main` (upstream advanced during the work; zero file overlap).

**Draft — do not merge.**
