### PR TITLE
feat: PR review queue with duplicate-run detection

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -36,6 +36,7 @@ import ConfigSync from "@/pages/ConfigSync";
 import Activity from "@/pages/Activity";
 import ConsiliumLoopList from "@/pages/ConsiliumLoopList";
 import ConsiliumLoopDetail from "@/pages/ConsiliumLoopDetail";
+import PrReviewQueue from "@/pages/PrReviewQueue";
 import ContourObservability from "@/pages/ContourObservability";
 import CredentialAccess from "@/pages/CredentialAccess";
 
@@ -87,6 +88,9 @@ function ProtectedRouter() {
         )} />
         <Route path="/consilium-loops" component={() => (
           <ErrorBoundary><ConsiliumLoopList /></ErrorBoundary>
+        )} />
+        <Route path="/pr-queue" component={() => (
+          <ErrorBoundary><PrReviewQueue /></ErrorBoundary>
         )} />
         <Route path="/workspaces" component={() => (
           <ErrorBoundary><WorkspaceList /></ErrorBoundary>

--- a/client/src/components/layout/MainLayout.tsx
+++ b/client/src/components/layout/MainLayout.tsx
@@ -15,6 +15,7 @@ import {
   DollarSign,
   Radio,
   Repeat,
+  GitPullRequest,
   KeyRound,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -54,6 +55,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
   const navItems = [
     { icon: Zap, label: "Triggers", href: "/triggers" },
     { icon: Repeat, label: "Consilium Loops", href: "/consilium-loops" },
+    { icon: GitPullRequest, label: "PR Queue", href: "/pr-queue" },
     { icon: FolderGit2, label: "Workspace", href: "/workspaces" },
     // Show "Connections", "Inventory", "Knowledge Base", and "Traces" sub-items
     // when inside a workspace

--- a/client/src/hooks/use-pr-queue.ts
+++ b/client/src/hooks/use-pr-queue.ts
@@ -1,0 +1,36 @@
+/**
+ * use-pr-queue.ts — react-query surface for the PR REVIEW QUEUE (GET /api/pr-queue,
+ * server route in server/routes/consilium-loops.ts).
+ *
+ * The endpoint returns a FLAT, newest-first list of PR-bearing consilium loops
+ * (loops carrying a Draft PR in a state where it's awaiting review). The page
+ * clusters it by repo with the pure `clusterPrQueue` helper (@shared/pr-queue) to
+ * surface DUPLICATE runs — several open Draft PRs against the same repo.
+ *
+ * Light 5s poll so a freshly-developed loop appears without a manual refresh — the
+ * loop FSM advances server-side via the background poller, there is no WS channel.
+ *
+ * SECURITY: this module only fetches + types data. `repoPath`, `prRef`,
+ * `verdictSummary`, and `triggerProvenance` are model/human-authored strings — the
+ * consuming component renders them as INERT React text and opens `prRef` with
+ * rel="noopener noreferrer".
+ */
+import { useQuery } from "@tanstack/react-query";
+import { apiRequest } from "@/hooks/use-pipeline";
+import type { PrQueueItem } from "@shared/pr-queue";
+
+export type { PrQueueItem };
+export type {
+  PrQueueCluster,
+} from "@shared/pr-queue";
+
+const PR_QUEUE_KEY = "/api/pr-queue";
+
+/** The caller's PR-bearing loops (flat, newest first). Light 5s live-state poll. */
+export function usePrQueue() {
+  return useQuery<PrQueueItem[]>({
+    queryKey: [PR_QUEUE_KEY],
+    queryFn: () => apiRequest("GET", PR_QUEUE_KEY),
+    refetchInterval: 5000,
+  });
+}

--- a/client/src/pages/PrReviewQueue.tsx
+++ b/client/src/pages/PrReviewQueue.tsx
@@ -1,0 +1,287 @@
+/**
+ * PrReviewQueue — "what Draft PR is waiting for my review, and which are duplicate
+ * runs?". Lists the PR-bearing consilium loops (server route GET /api/pr-queue),
+ * GROUPED BY REPO into duplicate clusters via the pure `clusterPrQueue` helper.
+ *
+ * Each repo with >1 open loop-PR is a DUPLICATE CLUSTER: the loops are shown
+ * together, newest first, badged "N open PRs for this repo — newest is likely
+ * current". Older loop-PRs on the same repo get a "superseded?" hint (candidates
+ * to close). We NEVER auto-close anything — we surface + link. "Mark handled" is
+ * LOCAL UI state (a dismissed set in this component); it hides an item from the
+ * current view only and resets on reload — no persistence, no schema change.
+ *
+ * STATE-BASED, NOT GITHUB-LIVE: the queue reflects each loop's FSM state, not a
+ * live GitHub PR fetch — a PR merged/closed directly on GitHub can linger here
+ * until the loop's state advances. A one-line note on the page says so.
+ *
+ * SECURITY: every loop-derived string (repoPath, prRef, verdictSummary,
+ * triggerProvenance) is rendered as INERT React text; the PR link uses
+ * rel="noopener noreferrer" and the loop link is an in-app route.
+ */
+import { useMemo, useState } from "react";
+import { useLocation } from "wouter";
+import { formatDistanceToNow } from "date-fns";
+import {
+  GitPullRequest,
+  ExternalLink,
+  Loader2,
+  Layers,
+  Check,
+  RotateCcw,
+} from "lucide-react";
+import { usePrQueue } from "@/hooks/use-pr-queue";
+import { clusterPrQueue, type PrQueueItem, type PrQueueCluster } from "@shared/pr-queue";
+import { LoopStateBadge } from "@/components/consilium/loop-state";
+
+/** Last path segment of a repo path, for a compact heading. */
+function repoBasename(repoPath: string): string {
+  const trimmed = repoPath.replace(/\/+$/, "");
+  return trimmed.split("/").pop() || repoPath;
+}
+
+/** Relative "2h ago"; empty string for missing/unparseable timestamps. */
+function whenLabel(ts: string | null | undefined): string {
+  if (!ts) return "";
+  try {
+    return formatDistanceToNow(new Date(ts), { addSuffix: true });
+  } catch {
+    return "";
+  }
+}
+
+/** Compact "P1·1 P2·2" open-remainder summary; null when nothing is open. */
+function remainderLabel(item: PrQueueItem): string | null {
+  const r = item.openRemainder;
+  if (!r || r.total <= 0) return null;
+  const parts = Object.entries(r.byPriority).map(([tier, n]) => `${tier}·${n}`);
+  return parts.join(" ");
+}
+
+// ─── One PR card ──────────────────────────────────────────────────────────────
+
+function PrCard({
+  item,
+  superseded,
+  onDismiss,
+}: {
+  item: PrQueueItem;
+  /** True when an older loop-PR on the same repo (a close candidate). */
+  superseded: boolean;
+  onDismiss: (loopId: string) => void;
+}) {
+  const [, navigate] = useLocation();
+  const remainder = remainderLabel(item);
+  return (
+    <div
+      data-testid="pr-queue-card"
+      className="rounded-md border bg-card px-3 py-2.5 space-y-2"
+    >
+      <div className="flex items-center gap-3">
+        <LoopStateBadge state={item.state} />
+
+        {/* Round n and archetype — quick disambiguators between same-repo runs. */}
+        <span className="text-xs text-muted-foreground tabular-nums shrink-0">
+          round {item.round}
+        </span>
+        {item.archetype ? (
+          <span className="text-[11px] px-1.5 py-0.5 rounded border border-border text-muted-foreground">
+            {item.archetype}
+          </span>
+        ) : null}
+
+        {superseded ? (
+          <span
+            data-testid="pr-queue-superseded"
+            className="text-[11px] px-1.5 py-0.5 rounded border border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400"
+            title="A newer run for this repo exists — this older PR is a candidate to close."
+          >
+            superseded?
+          </span>
+        ) : null}
+
+        <span
+          className="ml-auto text-[11px] text-muted-foreground whitespace-nowrap"
+          title={new Date(item.createdAt).toLocaleString()}
+        >
+          {whenLabel(item.updatedAt ?? item.createdAt)}
+        </span>
+      </div>
+
+      {/* Verdict / test summary — inert model text, clamped to two lines. */}
+      {item.verdictSummary ? (
+        <p className="text-xs text-muted-foreground line-clamp-2">{item.verdictSummary}</p>
+      ) : null}
+
+      <div className="flex items-center gap-3 text-xs">
+        {remainder ? (
+          <span className="text-muted-foreground">
+            open: <span className="tabular-nums font-medium">{remainder}</span>
+          </span>
+        ) : null}
+        {item.triggerProvenance ? (
+          <span className="text-muted-foreground truncate" title={item.triggerProvenance}>
+            via {item.triggerProvenance}
+          </span>
+        ) : null}
+
+        <div className="ml-auto flex items-center gap-3">
+          <a
+            href={item.prRef}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-primary hover:underline"
+          >
+            <ExternalLink className="h-3 w-3" />
+            PR
+          </a>
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+            onClick={() => navigate(`/consilium-loops/${item.loopId}`)}
+          >
+            Loop
+          </button>
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+            onClick={() => onDismiss(item.loopId)}
+            title="Mark handled — hides this item from the queue until reload (local only)"
+          >
+            <Check className="h-3 w-3" />
+            Mark handled
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── One repo cluster ─────────────────────────────────────────────────────────
+
+function RepoCluster({
+  cluster,
+  onDismiss,
+}: {
+  cluster: PrQueueCluster;
+  onDismiss: (loopId: string) => void;
+}) {
+  const superseded = new Set(cluster.supersededLoopIds);
+  return (
+    <section data-testid="pr-queue-cluster">
+      <div className="flex items-baseline gap-2 mb-2 px-1">
+        <h2 className="text-sm font-semibold truncate" title={cluster.repoPath}>
+          {repoBasename(cluster.repoPath)}
+        </h2>
+        {cluster.duplicate ? (
+          <span
+            data-testid="pr-queue-duplicate-badge"
+            className="inline-flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded-full border border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400 shrink-0"
+            title="Multiple open Draft PRs target this repo — newer runs likely supersede older ones."
+          >
+            <Layers className="h-3 w-3" />
+            {cluster.items.length} open PRs for this repo — newest is likely current
+          </span>
+        ) : (
+          <span className="text-[11px] text-muted-foreground shrink-0">1 open PR</span>
+        )}
+      </div>
+      <div className="space-y-2">
+        {cluster.items.map((item) => (
+          <PrCard
+            key={item.loopId}
+            item={item}
+            superseded={superseded.has(item.loopId)}
+            onDismiss={onDismiss}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function PrReviewQueue() {
+  const { data, isLoading } = usePrQueue();
+  // LOCAL "mark handled" state — dismissed loopIds are hidden until reload. No
+  // persistence (no migration); a lightweight, resettable operator convenience.
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+
+  const items = (Array.isArray(data) ? data : []) as PrQueueItem[];
+  const visible = items.filter((i) => !dismissed.has(i.loopId));
+  const clusters = useMemo(() => clusterPrQueue(visible), [visible]);
+  const duplicateCount = clusters.filter((c) => c.duplicate).length;
+
+  function dismiss(loopId: string) {
+    setDismissed((prev) => {
+      const next = new Set(prev);
+      next.add(loopId);
+      return next;
+    });
+  }
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      <header className="h-16 border-b border-border flex items-center gap-2 px-6 shrink-0">
+        <GitPullRequest className="h-5 w-5 text-primary" />
+        <div className="min-w-0">
+          <h1 className="text-base font-semibold leading-tight">PR Review Queue</h1>
+          <p className="text-[11px] text-muted-foreground">
+            Draft PRs from consilium loops awaiting review · duplicate runs grouped by repo
+          </p>
+        </div>
+        <div className="ml-auto flex items-center gap-3">
+          {dismissed.size > 0 ? (
+            <button
+              type="button"
+              className="inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground"
+              onClick={() => setDismissed(new Set())}
+              title="Restore items you marked handled this session"
+            >
+              <RotateCcw className="h-3 w-3" />
+              Reset handled ({dismissed.size})
+            </button>
+          ) : null}
+          {duplicateCount > 0 ? (
+            <span className="text-[11px] text-amber-600 dark:text-amber-400">
+              {duplicateCount} repo{duplicateCount === 1 ? "" : "s"} with duplicate runs
+            </span>
+          ) : null}
+        </div>
+      </header>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        {/* Honesty note: the queue reflects loop STATE, not live GitHub PR status. */}
+        <p className="text-[11px] text-muted-foreground/80 mb-4">
+          The queue reflects each loop&apos;s state, not live GitHub PR status. A PR
+          merged or closed directly on GitHub may linger here until its loop advances.
+        </p>
+
+        {isLoading && (
+          <div className="flex items-center justify-center py-16 text-muted-foreground text-sm gap-2">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading…
+          </div>
+        )}
+
+        {!isLoading && clusters.length === 0 && (
+          <div className="rounded-lg border border-dashed border-border py-16 text-center">
+            <GitPullRequest className="mx-auto h-8 w-8 text-muted-foreground/50" />
+            <p className="mt-3 text-sm text-muted-foreground">No Draft PRs awaiting review</p>
+            <p className="mt-1 text-xs text-muted-foreground/70">
+              Draft PRs opened by consilium loops appear here, grouped by repo.
+            </p>
+          </div>
+        )}
+
+        {!isLoading && clusters.length > 0 && (
+          <div className="space-y-6">
+            {clusters.map((cluster) => (
+              <RepoCluster key={cluster.repoPath} cluster={cluster} onDismiss={dismiss} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/server/routes/consilium-loops.ts
+++ b/server/routes/consilium-loops.ts
@@ -22,6 +22,7 @@ import type {
 import { ARCHETYPES } from "@shared/types";
 import { CONSILIUM_LOOP_TERMINAL_STATES } from "@shared/schema";
 import { computeOpenRemainder } from "@shared/consilium-remainder";
+import { isPrBearingLoop, type PrQueueItem } from "@shared/pr-queue";
 import type { AppConfig } from "../config/schema.js";
 import { requireRole } from "../auth/middleware.js";
 import { validateBody } from "../middleware/validate.js";
@@ -117,6 +118,64 @@ export function registerConsiliumLoopRoutes(
     const isAdmin = req.user.role === "admin";
     const loops = isAdmin ? await storage.getLoops() : await storage.getLoopsByOwner(req.user.id);
     res.json(loops.map((l) => maskLoop({ ...l }, isAdmin)));
+  });
+
+  // ── PR review queue (owner-scoped, read-only) ───────────────────────────────
+  // Returns the caller's PR-BEARING loops — those carrying a `prRef` in a state
+  // where that Draft PR is genuinely un-merged/awaiting review (see isPrBearingLoop).
+  // FLAT list, newest first; the client clusters by repoPath into duplicate-run
+  // groups (clusterPrQueue). Read-only, no schema change: it mirrors the list
+  // route's owner scoping, then enriches each PR-bearing loop with a compact
+  // verdict summary + open-remainder read from that loop's LATEST round.
+  //
+  // STATE-BASED, NOT GITHUB-LIVE: we do NOT fetch live GitHub PR status — the queue
+  // reflects loop FSM state (a PR merged/closed directly on GitHub can linger until
+  // the loop's state advances). `triggerProvenance` is unset (no trigger→loop link
+  // in the current schema); the field stays on the contract for forward-compat.
+  app.get("/api/pr-queue", async (req: Request, res: Response) => {
+    if (!req.user?.id) return res.status(401).json({ error: "Authentication required" });
+    const isAdmin = req.user.role === "admin";
+    const loops = isAdmin ? await storage.getLoops() : await storage.getLoopsByOwner(req.user.id);
+    // Filter to the small PR-bearing set BEFORE fetching rounds (bounds the N+1).
+    const bearing = loops.filter((l) => isPrBearingLoop(l));
+    const items: PrQueueItem[] = await Promise.all(
+      bearing.map(async (loop) => {
+        // Enrich from the loop's latest round: verdict/test summary + open remainder.
+        // Best-effort — any read failure degrades to the bare loop fields.
+        let verdictSummary: string | null | undefined;
+        let openRemainder: PrQueueItem["openRemainder"];
+        try {
+          const rounds = await storage.getLoopRounds(loop.id);
+          openRemainder = computeOpenRemainder(rounds) ?? null;
+          const latest = rounds.reduce<(typeof rounds)[number] | undefined>(
+            (best, r) => (best && best.round >= r.round ? best : r),
+            undefined,
+          );
+          verdictSummary = clampSummary(latest?.testSummary);
+        } catch {
+          verdictSummary = undefined;
+          openRemainder = undefined;
+        }
+        return {
+          loopId: loop.id,
+          // isPrBearingLoop guarantees a non-empty prRef; assert for the wire type.
+          prRef: loop.prRef as string,
+          repoPath: loop.repoPath,
+          state: loop.state,
+          round: loop.round,
+          archetype: loop.archetype ?? null,
+          createdAt: new Date(loop.createdAt).toISOString(),
+          updatedAt: loop.updatedAt ? new Date(loop.updatedAt).toISOString() : null,
+          verdictSummary,
+          openRemainder,
+          // No trigger→loop provenance link exists in the schema — left unset.
+          triggerProvenance: null,
+        } satisfies PrQueueItem;
+      }),
+    );
+    // Newest first (createdAt desc). The client re-orders within clusters too.
+    items.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    res.json(items);
   });
 
   // ── Detail (+ rounds) ───────────────────────────────────────────────────────
@@ -268,6 +327,23 @@ export function registerConsiliumLoopRoutes(
     if (!loop) return res.status(409).json({ error: "loop is already terminal" });
     res.json(loop);
   });
+}
+
+/** Max chars of a round's testSummary surfaced on the PR queue card (bounds payload). */
+const PR_QUEUE_SUMMARY_MAX = 500;
+
+/**
+ * Clamp a round's `testSummary` for the compact PR-queue card: trims, drops empty
+ * to `undefined` (omitted from the wire), and caps length with an ellipsis. The
+ * value is INERT model/human text — rendered as inert React text by the client.
+ */
+function clampSummary(summary: string | null | undefined): string | undefined {
+  if (typeof summary !== "string") return undefined;
+  const trimmed = summary.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed.length > PR_QUEUE_SUMMARY_MAX
+    ? `${trimmed.slice(0, PR_QUEUE_SUMMARY_MAX)}…`
+    : trimmed;
 }
 
 /**

--- a/shared/pr-queue.ts
+++ b/shared/pr-queue.ts
@@ -1,0 +1,176 @@
+/**
+ * pr-queue.ts — pure, dependency-free helpers for the PR REVIEW QUEUE (design:
+ * "what Draft PR is waiting for my review, and which are duplicate runs?").
+ *
+ * A consilium loop that develops opens a Draft PR and records its URL on
+ * `consilium_loops.pr_ref`. Multiple loops can run against the SAME repoPath over
+ * time, each opening its own Draft PR — so the same repo accrues several open
+ * loop-PRs, newer runs SUPERSEDING older ones. This module holds the two pure
+ * pieces both the server read-route and the client page share:
+ *
+ *   1. `isPrBearingLoop`  — the PR-bearing predicate (a loop worth queueing).
+ *   2. `clusterPrQueue`   — group a flat item list by repo into duplicate CLUSTERS
+ *                           with a newest-first order + supersede hints.
+ *
+ * DELIBERATELY STATE-BASED, NOT GITHUB-LIVE: the queue reflects the loop's FSM
+ * STATE, never a live GitHub PR fetch. `awaiting_merge` is exactly the open-Draft-PR
+ * review gate (merge-approval sends the loop back to `building_context`, so a loop
+ * sitting in `awaiting_merge` genuinely has an un-merged Draft PR). `stopped_cap` /
+ * `escalated` are terminal-with-verdict runs that may carry a Draft PR opened but
+ * never merge-approved. We EXCLUDE `converged` (a converged/merged outcome),
+ * `failed` and `cancelled` (aborted — any PR is abandoned, not "awaiting review").
+ * Because we do not poll GitHub, a PR merged/closed directly on GitHub (bypassing
+ * the merge-approved gate) can still appear until the loop's state advances — the
+ * UI says so.
+ *
+ * SECURITY: pure data shaping. `repoPath`, `prRef`, `verdictSummary`, and
+ * `triggerProvenance` are inert strings here; the rendering layer treats every
+ * model/human-authored field as inert React text and opens `prRef` with
+ * rel="noopener noreferrer".
+ */
+import type { ConsiliumLoopState } from "./schema.js";
+import type { Archetype, OpenRemainder } from "./types.js";
+
+/**
+ * The loop states a Draft PR can be "waiting for review" in. Ordered by review
+ * urgency (the active merge gate first). See the module doc for why the terminal
+ * `converged`/`failed`/`cancelled` states are excluded.
+ */
+export const PR_BEARING_LOOP_STATES = [
+  "awaiting_merge",
+  "developing",
+  "stopped_cap",
+  "escalated",
+] as const satisfies readonly ConsiliumLoopState[];
+
+const PR_BEARING_SET: ReadonlySet<string> = new Set(PR_BEARING_LOOP_STATES);
+
+/** The minimal loop shape the PR-bearing predicate reads (server row OR client item). */
+export interface PrBearingLoopLike {
+  prRef: string | null | undefined;
+  state: ConsiliumLoopState;
+}
+
+/**
+ * True when a loop belongs in the PR review queue: it carries a non-empty `prRef`
+ * AND its state is one where that Draft PR is genuinely un-merged/awaiting review.
+ * Both conditions are required — a `developing` loop has no `prRef` until the
+ * develop→awaiting_merge transition, so the guard filters it out naturally.
+ */
+export function isPrBearingLoop(loop: PrBearingLoopLike): boolean {
+  return (
+    typeof loop.prRef === "string" &&
+    loop.prRef.trim().length > 0 &&
+    PR_BEARING_SET.has(loop.state)
+  );
+}
+
+/**
+ * One PR-bearing loop, shaped for the queue wire (GET /api/pr-queue). A flat list
+ * of these is returned by the server; the client clusters it with
+ * {@link clusterPrQueue}. All timestamps are ISO strings on the wire.
+ */
+export interface PrQueueItem {
+  loopId: string;
+  /** The Draft PR URL/ref (guaranteed non-empty — the route only emits PR-bearing loops). */
+  prRef: string;
+  repoPath: string;
+  state: ConsiliumLoopState;
+  round: number;
+  archetype: Archetype | null;
+  /** Loop creation time, ISO-8601. Drives the newest-first / supersede ordering. */
+  createdAt: string;
+  /** Loop last-update time, ISO-8601 — a better recency signal than createdAt when present. */
+  updatedAt?: string | null;
+  /** Compact verdict/test summary from the loop's latest round (inert text; may be clamped). */
+  verdictSummary?: string | null;
+  /** Count-by-priority of the last round's still-open action points, when non-empty. */
+  openRemainder?: OpenRemainder | null;
+  /**
+   * How this loop was launched (e.g. a file-change trigger), when known. The current
+   * loop schema carries no trigger→loop link, so the server leaves this undefined; the
+   * field is part of the contract for forward-compat and the UI renders it only when present.
+   */
+  triggerProvenance?: string | null;
+}
+
+/**
+ * A duplicate cluster: every queued PR-bearing loop that targets the SAME repo,
+ * newest first. `duplicate` is true when more than one loop-PR is open for the repo
+ * — the "N open PRs for this repo" case. The newest item is the LIKELY-CURRENT one;
+ * the older ones are SUPERSEDE CANDIDATES (surfaced, never auto-closed).
+ */
+export interface PrQueueCluster {
+  /** Normalized (trailing-slash-insensitive) repo path — the exact cluster key. */
+  repoPath: string;
+  /** Items for this repo, newest first (createdAt/updatedAt desc, loopId tie-break). */
+  items: PrQueueItem[];
+  /** True when the repo has more than one open loop-PR (a duplicate-run situation). */
+  duplicate: boolean;
+  /** The newest item's loopId — the run most likely to be the current one. */
+  currentLoopId: string;
+  /** The older items' loopIds — candidates a human may choose to close. */
+  supersededLoopIds: string[];
+}
+
+/**
+ * Trailing-slash-insensitive repo key so `/repo` and `/repo/` cluster together.
+ * We cluster on the FULL path (never the basename): `/a/service` and `/b/service`
+ * are DIFFERENT repos and MUST NOT be merged into one duplicate cluster.
+ */
+export function normalizeRepoPath(p: string): string {
+  return p.replace(/\/+$/, "");
+}
+
+/** Epoch-ms recency: prefer updatedAt, fall back to createdAt; unparseable → 0. */
+function recencyOf(item: PrQueueItem): number {
+  const raw = item.updatedAt ?? item.createdAt;
+  const t = new Date(raw).getTime();
+  return Number.isFinite(t) ? t : 0;
+}
+
+/** Newest first; deterministic loopId tie-break so equal timestamps sort stably. */
+function byNewest(a: PrQueueItem, b: PrQueueItem): number {
+  const d = recencyOf(b) - recencyOf(a);
+  if (d !== 0) return d;
+  return a.loopId < b.loopId ? -1 : a.loopId > b.loopId ? 1 : 0;
+}
+
+/**
+ * Group a flat PR-queue list into per-repo duplicate CLUSTERS.
+ *
+ * Rules:
+ *   • cluster key = normalized full repoPath (different repos never merge);
+ *   • within a cluster, items are newest first (recency, loopId tie-break);
+ *   • `duplicate` = items.length > 1; `currentLoopId` = newest; the rest are
+ *     `supersededLoopIds` (older loop-PRs on the same repo — close candidates);
+ *   • clusters themselves are ordered most-recently-active repo first.
+ *
+ * Pure and total: an empty input yields an empty array; a single item yields one
+ * non-duplicate cluster with no superseded ids.
+ */
+export function clusterPrQueue(items: PrQueueItem[]): PrQueueCluster[] {
+  const byRepo = new Map<string, PrQueueItem[]>();
+  for (const item of items) {
+    const key = normalizeRepoPath(item.repoPath);
+    const arr = byRepo.get(key);
+    if (arr) arr.push(item);
+    else byRepo.set(key, [item]);
+  }
+
+  const clusters: PrQueueCluster[] = [];
+  for (const [repoPath, arr] of byRepo) {
+    const sorted = [...arr].sort(byNewest);
+    clusters.push({
+      repoPath,
+      items: sorted,
+      duplicate: sorted.length > 1,
+      currentLoopId: sorted[0].loopId,
+      supersededLoopIds: sorted.slice(1).map((i) => i.loopId),
+    });
+  }
+
+  // Most-recently-active repo first, so the freshest work floats to the top.
+  clusters.sort((a, b) => recencyOf(b.items[0]) - recencyOf(a.items[0]));
+  return clusters;
+}

--- a/tests/unit/consilium/pr-queue-cluster.test.ts
+++ b/tests/unit/consilium/pr-queue-cluster.test.ts
@@ -1,0 +1,145 @@
+/**
+ * pr-queue-cluster.test.ts — unit coverage for the PURE PR-review-queue helpers
+ * (`shared/pr-queue.ts`): the PR-bearing predicate and the duplicate-cluster
+ * computation the read-route + client page both depend on.
+ *
+ * Covers:
+ *   - isPrBearingLoop: requires BOTH a non-empty prRef AND a PR-bearing state;
+ *     excludes converged/failed/cancelled and empty/whitespace prRefs;
+ *   - clusterPrQueue: groups by FULL normalized repoPath (never basename — two
+ *     different repos sharing a basename stay separate);
+ *   - trailing-slash-insensitive clustering (/repo and /repo/ merge);
+ *   - newest-first ordering within a cluster (updatedAt preferred, loopId tie-break);
+ *   - duplicate flag + currentLoopId/supersededLoopIds supersede hints;
+ *   - clusters ordered most-recently-active repo first;
+ *   - empty + single-item edge cases.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  isPrBearingLoop,
+  clusterPrQueue,
+  normalizeRepoPath,
+  PR_BEARING_LOOP_STATES,
+  type PrQueueItem,
+} from "../../../shared/pr-queue.js";
+import type { ConsiliumLoopState } from "../../../shared/schema.js";
+
+function item(over: Partial<PrQueueItem> & { loopId: string }): PrQueueItem {
+  return {
+    prRef: "https://github.com/o/r/pull/1",
+    repoPath: "/repos/widget",
+    state: "awaiting_merge",
+    round: 1,
+    archetype: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("isPrBearingLoop", () => {
+  it("requires a non-empty prRef", () => {
+    expect(isPrBearingLoop({ prRef: null, state: "awaiting_merge" })).toBe(false);
+    expect(isPrBearingLoop({ prRef: undefined, state: "awaiting_merge" })).toBe(false);
+    expect(isPrBearingLoop({ prRef: "   ", state: "awaiting_merge" })).toBe(false);
+    expect(isPrBearingLoop({ prRef: "https://x/pull/1", state: "awaiting_merge" })).toBe(true);
+  });
+
+  it("accepts exactly the PR-bearing states, rejects merged/aborted/pre-PR states", () => {
+    for (const state of PR_BEARING_LOOP_STATES) {
+      expect(isPrBearingLoop({ prRef: "https://x/pull/1", state })).toBe(true);
+    }
+    const excluded: ConsiliumLoopState[] = [
+      "pending",
+      "building_context",
+      "reviewing",
+      "deciding",
+      "converged", // merged/converged outcome — not "awaiting review"
+      "failed",
+      "cancelled",
+    ];
+    for (const state of excluded) {
+      expect(isPrBearingLoop({ prRef: "https://x/pull/1", state })).toBe(false);
+    }
+  });
+});
+
+describe("normalizeRepoPath", () => {
+  it("strips trailing slashes", () => {
+    expect(normalizeRepoPath("/a/b/")).toBe("/a/b");
+    expect(normalizeRepoPath("/a/b///")).toBe("/a/b");
+    expect(normalizeRepoPath("/a/b")).toBe("/a/b");
+  });
+});
+
+describe("clusterPrQueue", () => {
+  it("returns an empty array for no items", () => {
+    expect(clusterPrQueue([])).toEqual([]);
+  });
+
+  it("makes a single non-duplicate cluster for one item", () => {
+    const clusters = clusterPrQueue([item({ loopId: "a" })]);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].duplicate).toBe(false);
+    expect(clusters[0].currentLoopId).toBe("a");
+    expect(clusters[0].supersededLoopIds).toEqual([]);
+  });
+
+  it("clusters same-repo loops newest-first with supersede hints", () => {
+    const clusters = clusterPrQueue([
+      item({ loopId: "old", createdAt: "2026-01-01T00:00:00.000Z" }),
+      item({ loopId: "new", createdAt: "2026-03-01T00:00:00.000Z" }),
+      item({ loopId: "mid", createdAt: "2026-02-01T00:00:00.000Z" }),
+    ]);
+    expect(clusters).toHaveLength(1);
+    const c = clusters[0];
+    expect(c.duplicate).toBe(true);
+    expect(c.items.map((i) => i.loopId)).toEqual(["new", "mid", "old"]);
+    expect(c.currentLoopId).toBe("new");
+    expect(c.supersededLoopIds).toEqual(["mid", "old"]);
+  });
+
+  it("prefers updatedAt over createdAt for recency ordering", () => {
+    const clusters = clusterPrQueue([
+      item({ loopId: "a", createdAt: "2026-01-01T00:00:00.000Z", updatedAt: "2026-05-01T00:00:00.000Z" }),
+      item({ loopId: "b", createdAt: "2026-04-01T00:00:00.000Z", updatedAt: "2026-04-02T00:00:00.000Z" }),
+    ]);
+    expect(clusters[0].currentLoopId).toBe("a"); // newer by updatedAt despite older createdAt
+  });
+
+  it("does NOT merge different repos that share a basename", () => {
+    const clusters = clusterPrQueue([
+      item({ loopId: "a", repoPath: "/x/service" }),
+      item({ loopId: "b", repoPath: "/y/service" }),
+    ]);
+    expect(clusters).toHaveLength(2);
+    for (const c of clusters) expect(c.duplicate).toBe(false);
+  });
+
+  it("merges the same repo across a trailing slash", () => {
+    const clusters = clusterPrQueue([
+      item({ loopId: "a", repoPath: "/repos/widget" }),
+      item({ loopId: "b", repoPath: "/repos/widget/" }),
+    ]);
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0].duplicate).toBe(true);
+    expect(clusters[0].repoPath).toBe("/repos/widget");
+  });
+
+  it("orders clusters most-recently-active repo first", () => {
+    const clusters = clusterPrQueue([
+      item({ loopId: "stale", repoPath: "/repos/a", createdAt: "2026-01-01T00:00:00.000Z" }),
+      item({ loopId: "fresh", repoPath: "/repos/b", createdAt: "2026-06-01T00:00:00.000Z" }),
+    ]);
+    expect(clusters.map((c) => c.repoPath)).toEqual(["/repos/b", "/repos/a"]);
+  });
+
+  it("breaks equal timestamps deterministically by loopId", () => {
+    const ts = "2026-01-01T00:00:00.000Z";
+    const clusters = clusterPrQueue([
+      item({ loopId: "zzz", createdAt: ts }),
+      item({ loopId: "aaa", createdAt: ts }),
+    ]);
+    expect(clusters[0].items.map((i) => i.loopId)).toEqual(["aaa", "zzz"]);
+    expect(clusters[0].currentLoopId).toBe("aaa");
+  });
+});

--- a/tests/unit/consilium/pr-queue-route.test.ts
+++ b/tests/unit/consilium/pr-queue-route.test.ts
@@ -1,0 +1,180 @@
+/**
+ * pr-queue-route.test.ts — GET /api/pr-queue (read-only PR review queue).
+ *
+ * Wires the REAL `registerConsiliumLoopRoutes` over a fake storage + a requireAuth
+ * stand-in. Asserts:
+ *   - owner scoping: a non-admin reads getLoopsByOwner; an admin reads getLoops;
+ *   - 401 when unauthenticated;
+ *   - only PR-bearing loops are returned (non-empty prRef AND a PR-bearing state) —
+ *     converged/failed/no-prRef loops are filtered out;
+ *   - each item is shaped per the wire contract (loopId/prRef/repoPath/state/round/
+ *     archetype/createdAt) and enriched with verdictSummary (clamped) + openRemainder
+ *     from the loop's LATEST round;
+ *   - the flat list is newest-first;
+ *   - the returned flat list, fed through the SAME `clusterPrQueue` the client uses,
+ *     produces the expected per-repo duplicate clusters.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import type { AppConfig } from "../../../server/config/schema.js";
+import type { IStorage } from "../../../server/storage.js";
+import type { ConsiliumLoopController } from "../../../server/services/consilium/consilium-loop-controller.js";
+import { registerConsiliumLoopRoutes } from "../../../server/routes/consilium-loops.js";
+import { clusterPrQueue, type PrQueueItem } from "../../../shared/pr-queue.js";
+
+const OWNER = "user-1";
+const config = () => ({ pipeline: { consiliumLoop: {} } }) as unknown as AppConfig;
+
+// A representative loop row (only the fields the route reads). `updatedAt` tracks
+// `createdAt` unless explicitly overridden (recency prefers updatedAt).
+function loop(over: Record<string, unknown>): Record<string, unknown> {
+  const base = {
+    id: "loop-x",
+    groupId: "grp-1",
+    state: "awaiting_merge",
+    round: 1,
+    repoPath: "/repos/widget",
+    prRef: "https://github.com/o/widget/pull/1",
+    archetype: null,
+    createdBy: OWNER,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    ...over,
+  };
+  return { updatedAt: base.createdAt, ...base };
+}
+
+function makeApp(opts: {
+  loops?: Record<string, unknown>[];
+  roundsByLoop?: Record<string, unknown[]>;
+  user?: { id: string; role?: string };
+} = {}) {
+  const { loops = [], roundsByLoop = {} } = opts;
+  const user = "user" in opts ? opts.user : { id: OWNER };
+
+  const getLoopsByOwner = vi.fn(async (ownerId: string) =>
+    loops.filter((l) => l.createdBy === ownerId),
+  );
+  const getLoops = vi.fn(async () => loops);
+  const getLoopRounds = vi.fn(async (loopId: string) => roundsByLoop[loopId] ?? []);
+
+  const storage = {
+    getLoopsByOwner,
+    getLoops,
+    getLoopRounds,
+  } as unknown as IStorage;
+
+  const controller = {} as unknown as ConsiliumLoopController;
+
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (user) (req as unknown as { user: typeof user }).user = user;
+    next();
+  });
+  registerConsiliumLoopRoutes(app, storage, controller, config);
+  return { app, getLoopsByOwner, getLoops, getLoopRounds };
+}
+
+describe("GET /api/pr-queue", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("401 when unauthenticated", async () => {
+    const { app } = makeApp({ user: undefined as never });
+    const res = await request(app).get("/api/pr-queue");
+    expect(res.status).toBe(401);
+  });
+
+  it("owner reads getLoopsByOwner (not the admin-wide getLoops)", async () => {
+    const { app, getLoopsByOwner, getLoops } = makeApp({
+      loops: [loop({ id: "a" })],
+    });
+    const res = await request(app).get("/api/pr-queue");
+    expect(res.status).toBe(200);
+    expect(getLoopsByOwner).toHaveBeenCalledWith(OWNER);
+    expect(getLoops).not.toHaveBeenCalled();
+  });
+
+  it("admin reads the wide getLoops", async () => {
+    const { app, getLoops } = makeApp({
+      loops: [loop({ id: "a" })],
+      user: { id: "admin-x", role: "admin" },
+    });
+    await request(app).get("/api/pr-queue");
+    expect(getLoops).toHaveBeenCalled();
+  });
+
+  it("returns only PR-bearing loops (filters no-prRef / converged / failed)", async () => {
+    const { app } = makeApp({
+      loops: [
+        loop({ id: "keep-awaiting", state: "awaiting_merge" }),
+        loop({ id: "keep-stopped", state: "stopped_cap" }),
+        loop({ id: "drop-no-pr", prRef: null }),
+        loop({ id: "drop-converged", state: "converged" }),
+        loop({ id: "drop-failed", state: "failed" }),
+        loop({ id: "drop-reviewing", state: "reviewing", prRef: null }),
+      ],
+    });
+    const res = await request(app).get("/api/pr-queue");
+    expect(res.status).toBe(200);
+    const ids = (res.body as PrQueueItem[]).map((i) => i.loopId).sort();
+    expect(ids).toEqual(["keep-awaiting", "keep-stopped"]);
+  });
+
+  it("shapes each item and enriches verdictSummary + openRemainder from the LATEST round", async () => {
+    const { app } = makeApp({
+      loops: [loop({ id: "a", round: 2, archetype: "repo-assessment" })],
+      roundsByLoop: {
+        a: [
+          { round: 1, openActionPoints: [{ title: "old", priority: "P0" }], testSummary: "round1" },
+          {
+            round: 2,
+            openActionPoints: [{ title: "x", priority: "P1" }, { title: "y", priority: "P2" }],
+            testSummary: "  final verdict  ",
+          },
+        ],
+      },
+    });
+    const res = await request(app).get("/api/pr-queue");
+    const [it] = res.body as PrQueueItem[];
+    expect(it.loopId).toBe("a");
+    expect(it.prRef).toBe("https://github.com/o/widget/pull/1");
+    expect(it.repoPath).toBe("/repos/widget");
+    expect(it.state).toBe("awaiting_merge");
+    expect(it.round).toBe(2);
+    expect(it.archetype).toBe("repo-assessment");
+    expect(typeof it.createdAt).toBe("string");
+    expect(it.verdictSummary).toBe("final verdict"); // trimmed, from the highest round
+    expect(it.openRemainder).toEqual({ total: 2, byPriority: { P1: 1, P2: 1 } });
+    expect(it.triggerProvenance).toBeNull(); // no trigger→loop link in schema
+  });
+
+  it("orders the flat list newest-first", async () => {
+    const { app } = makeApp({
+      loops: [
+        loop({ id: "old", repoPath: "/repos/a", createdAt: "2026-01-01T00:00:00.000Z" }),
+        loop({ id: "new", repoPath: "/repos/b", createdAt: "2026-06-01T00:00:00.000Z" }),
+      ],
+    });
+    const res = await request(app).get("/api/pr-queue");
+    expect((res.body as PrQueueItem[]).map((i) => i.loopId)).toEqual(["new", "old"]);
+  });
+
+  it("the returned list clusters into per-repo duplicate groups", async () => {
+    const { app } = makeApp({
+      loops: [
+        loop({ id: "w1", repoPath: "/repos/widget", createdAt: "2026-01-01T00:00:00.000Z" }),
+        loop({ id: "w2", repoPath: "/repos/widget/", createdAt: "2026-02-01T00:00:00.000Z" }),
+        loop({ id: "solo", repoPath: "/repos/other", createdAt: "2026-03-01T00:00:00.000Z" }),
+      ],
+    });
+    const res = await request(app).get("/api/pr-queue");
+    const clusters = clusterPrQueue(res.body as PrQueueItem[]);
+    const widget = clusters.find((c) => c.repoPath === "/repos/widget");
+    const other = clusters.find((c) => c.repoPath === "/repos/other");
+    expect(widget?.duplicate).toBe(true);
+    expect(widget?.currentLoopId).toBe("w2"); // newest
+    expect(widget?.supersededLoopIds).toEqual(["w1"]);
+    expect(other?.duplicate).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

A read-only **PR Review Queue** page that answers "what Draft PR is waiting for my review, and which are duplicate runs?". Consilium loops that develop open a Draft PR (recorded on `consilium_loops.pr_ref`); multiple loops can run against the **same repo** over time, each opening its own Draft PR. This page lists those PRs and clusters them by repo so duplicates from different loop runs are surfaced together.

## Route shape — `GET /api/pr-queue`

Owner-scoped (admins see all, mirroring the loops list route), **read-only, no schema change**. Returns a **flat, newest-first** list of PR-bearing loops; the client clusters it. Each item:

```ts
{
  loopId: string,
  prRef: string,            // guaranteed non-empty (only PR-bearing loops emitted)
  repoPath: string,
  state: ConsiliumLoopState,
  round: number,
  archetype: Archetype | null,
  createdAt: string,        // ISO
  updatedAt?: string | null,
  verdictSummary?: string | null,   // latest round's testSummary, trimmed + clamped to 500 chars
  openRemainder?: OpenRemainder | null,  // count-by-priority of last round's still-open APs
  triggerProvenance?: string | null     // reserved; no trigger→loop link in schema → always null
}
```

**Grouping decision:** server returns **flat**, the client groups via the shared pure helper `clusterPrQueue` — keeps the server dead-simple and puts the testable cluster logic in one place used by both sides.

## PR-bearing rule (which loops appear)

A loop is queued when it has a **non-empty `prRef`** AND its state is one where that Draft PR is genuinely un-merged/awaiting review: **`awaiting_merge`** (the merge gate — merge-approval sends the loop back to `building_context`, so a loop sitting here truly has an open Draft PR), **`developing`**, **`stopped_cap`**, **`escalated`**. Excluded: `converged` (merged/converged outcome), `failed`/`cancelled` (aborted), and the pre-PR review states.

## Duplicate-cluster rule

`clusterPrQueue(items)` groups by the **full normalized repoPath** (trailing-slash-insensitive; **never** basename — `/a/service` and `/b/service` stay separate). Within a cluster: **newest first** (prefer `updatedAt`, fall back to `createdAt`, deterministic `loopId` tie-break). A repo with `>1` open loop-PR is a **duplicate cluster** badged *"N open PRs for this repo — newest is likely current"*; the newest is `currentLoopId`, the older ones are `supersededLoopIds` and get a *"superseded?"* hint (close **candidates** — nothing is auto-closed).

## Local vs persisted

- **Local UI state only:** "Mark handled" (hides an item until reload) and the session reset. No persisted `dismissed` flag → **no migration**.
- **Persisted:** nothing new. Read-side only; no FSM/schema change.

## Adversarial notes

- **State-based, not GitHub-live:** the queue reflects each loop's FSM state, not a live GitHub PR fetch. A PR merged/closed directly on GitHub can linger until the loop's state advances — the page says so in a one-line note.
- **No cross-repo mis-clustering:** clustering keys on the full path, verified by a test with two repos sharing a basename.
- **Nav:** this branch owns the nav change ("PR Queue" near Consilium Loops); the parallel triggers team was told not to touch nav.

## Test evidence

- `tests/unit/consilium/pr-queue-cluster.test.ts` — pure predicate + cluster helper (PR-bearing states, slash-insensitive grouping, basename non-merge, newest-first + supersede hints, ordering, tie-break, empty/single edges).
- `tests/unit/consilium/pr-queue-route.test.ts` — route auth/owner-scoping, PR-bearing filter, item shape + latest-round enrichment, newest-first, end-to-end clustering of the returned list.
- `npx tsc` clean; full unit suite green locally: **246 files / 4787 tests passed**. (Known flakes: providers/antigravity, config-sync-multi-instance — the `pull_request` CI run is authoritative.)

Do not merge — draft for review.
