### PR TITLE
feat: record and surface the cancellation reason on loops

### DIFF
--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -699,13 +699,19 @@ function ResultPanel({
         <CardTitle className="text-sm">Result</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        {/* Last-round error — the most important signal when a round degraded. */}
+        {/* Terminal explanation from `loop.error`. For a CANCELLED loop this is the
+            composed "Cancelled by <actor> at <ISO> — <reason>" note (who/when/why),
+            NOT a failure — so it reads as "Cancellation". For every other state it
+            is the last-round degradation signal. Same amber (neutral, not red)
+            treatment either way; the text is INERT loop/user-authored content. */}
         {loop.error && (
           <div className="flex items-start gap-2 rounded-md border border-amber-500/50 bg-amber-500/10 p-3 text-sm">
             <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
             <div className="min-w-0">
-              <p className="font-medium text-amber-700 dark:text-amber-300">Last round error</p>
-              {/* INERT loop-authored error text */}
+              <p className="font-medium text-amber-700 dark:text-amber-300">
+                {loop.state === "cancelled" ? "Cancellation" : "Last round error"}
+              </p>
+              {/* INERT loop/user-authored text */}
               <p className="text-amber-700/90 dark:text-amber-300/90 break-words">{loop.error}</p>
             </div>
           </div>

--- a/server/routes/consilium-loops.ts
+++ b/server/routes/consilium-loops.ts
@@ -45,6 +45,35 @@ const CreateLoopSchema = z.object({
 });
 
 // Stage 1 (§6): the human archetype OVERRIDE body — enum-clamped (no model call).
+/** Max stored cancellation reason (truncated, not rejected — see `sanitizeReason`). */
+const MAX_CANCEL_REASON = 500;
+
+/**
+ * Cancel body is OPTIONAL — an auto-cancel is a POST with no/empty body. A
+ * present `reason` is untrusted free text, sanitized downstream; a non-string
+ * `reason` is a 400. `.passthrough()` is deliberately NOT used.
+ */
+const CancelLoopSchema = z.object({
+  reason: z.string().optional(),
+});
+
+/**
+ * Sanitize an untrusted cancellation reason: control-strip (C0/DEL/C1),
+ * collapse whitespace, trim, then CLAMP (not reject) to {@link MAX_CANCEL_REASON}.
+ * Returns undefined for a non-string or empty-after-strip input so the composed
+ * explanation falls back to the actor+timestamp form (never blank).
+ */
+function sanitizeReason(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const cleaned = raw
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001F\u007F-\u009F]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, MAX_CANCEL_REASON);
+  return cleaned.length ? cleaned : undefined;
+}
+
 const ArchetypeOverrideSchema = z.object({
   archetype: z.enum(ARCHETYPES),
 });
@@ -261,10 +290,25 @@ export function registerConsiliumLoopRoutes(
   );
 
   // ── Cancel (any non-terminal → CANCELLED) ───────────────────────────────────
+  // Body is OPTIONAL: `{ reason?: string }` (untrusted → sanitized + clamped).
+  // The acting user is resolved from the authorized session (never client-set),
+  // so the recorded terminal explanation names a real actor, never "system"
+  // unless truly unresolvable.
   app.post("/api/consilium-loops/:id/cancel", async (req: Request, res: Response) => {
     const auth = await authorizeConsiliumLoop(req, res, storage, String(req.params.id));
     if (!auth) return;
-    const loop = await controller.cancel(auth.loop.id);
+    // Tolerate a missing/empty body (auto-cancel POSTs carry none); only a
+    // present-but-wrong-typed `reason` is a 400.
+    const parsed = CancelLoopSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: "Validation failed",
+        issues: parsed.error.issues.map((i) => ({ path: i.path, message: i.message })),
+      });
+    }
+    const reason = sanitizeReason(parsed.data.reason);
+    const actor = req.user?.name?.trim() || req.user?.email || req.user?.id || undefined;
+    const loop = await controller.cancel(auth.loop.id, { reason, actor });
     if (!loop) return res.status(409).json({ error: "loop is already terminal" });
     res.json(loop);
   });

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -80,7 +80,11 @@ export type LoopEvent =
   // DEVELOPING (injected ONLY by `controller.develop`, NEVER by `deriveEvent` —
   // the poller must never emit it). Round-preserving + CAS-guarded.
   | { kind: "develop_requested" }
-  | { kind: "cancel" };
+  // A cancel MAY carry a human-supplied `reason` and the resolved `actor` label
+  // (both already clamped + control-stripped at the route — untrusted). Absent on
+  // an auto-cancel (an API POST with no body); the reducer still records a
+  // never-blank terminal explanation. See `composeCancelExplanation`.
+  | { kind: "cancel"; reason?: string; actor?: string };
 
 /** A single FSM transition: CAS `from → to`, plus optional column updates. */
 export interface LoopTransition {
@@ -422,15 +426,41 @@ export function isAntiStall(series: number[], round: number): boolean {
 }
 
 /**
+ * Compose the terminal explanation persisted to `consilium_loops.error` when a
+ * loop is CANCELLED. NEVER blank: `actor` falls back to "system" (auto-cancel /
+ * unresolvable user), `reason` is optional. `reason` is expected already
+ * clamped + control-stripped at the route (untrusted); the extra trim here is a
+ * defensive belt on any non-route caller. Pure — the ISO timestamp is passed in
+ * so the reducer stays deterministic under a fixed `at`.
+ *
+ * Shape: `Cancelled by <actor> at <ISO>[ — <reason>]`.
+ */
+export function composeCancelExplanation(at: Date, actor?: string, reason?: string): string {
+  const who = actor && actor.trim() ? actor.trim() : "system";
+  const base = `Cancelled by ${who} at ${at.toISOString()}`;
+  const r = reason?.trim();
+  return r ? `${base} — ${r}` : base;
+}
+
+/**
  * PURE reducer (design §3 table). Given the current persisted `state` and an
  * `event`, return the single transition to commit, or `null` for a no-op.
  * No storage, no I/O, no `any` — the whole table is unit-testable in isolation.
  */
 export function reduce(state: ConsiliumLoopState, event: LoopEvent): LoopTransition | null {
-  // `cancel` from any non-terminal state → CANCELLED (design §3 last row).
+  // `cancel` from any non-terminal state → CANCELLED (design §3 last row). Same
+  // target/extra shape as before (NO FSM state-table change) plus the `error`
+  // column reused as a terminal explanation so the UI never shows a bare
+  // "cancelled" with no who/when/why. `error` here is a cancellation note, NOT a
+  // failure — no counter/filter keys off `error != null`; they gate on `state`.
   if (event.kind === "cancel") {
     if (isTerminal(state)) return null;
-    return { from: state, to: "cancelled", extra: { completedAt: new Date() } };
+    const at = new Date();
+    return {
+      from: state,
+      to: "cancelled",
+      extra: { completedAt: at, error: composeCancelExplanation(at, event.actor, event.reason) },
+    };
   }
 
   // HUMAN re-open: an authorized `develop_requested` promotes a VERDICT-terminal
@@ -991,11 +1021,22 @@ export class ConsiliumLoopController {
     return extractActionPoints(judgeOutput);
   }
 
-  /** Cancel + cascade-cancel the child group; terminal. */
-  async cancel(loopId: string): Promise<ConsiliumLoopRow | null> {
+  /**
+   * Cancel + cascade-cancel the child group; terminal. `opts.reason` +
+   * `opts.actor` (both route-sanitized) are threaded into the reducer so the
+   * `error` column carries a never-blank terminal explanation (who/when/why).
+   */
+  async cancel(
+    loopId: string,
+    opts?: { reason?: string; actor?: string },
+  ): Promise<ConsiliumLoopRow | null> {
     const loop = await this.storage.getLoop(loopId);
     if (!loop || isTerminal(loop.state)) return null;
-    const transition = reduce(loop.state, { kind: "cancel" });
+    const transition = reduce(loop.state, {
+      kind: "cancel",
+      reason: opts?.reason,
+      actor: opts?.actor,
+    });
     if (!transition) return null;
     await this.deps.taskOrchestrator.cancelGroup(loop.groupId).catch(() => undefined);
     this.sdlcRuns.delete(loopId); // H-2: drop any in-flight SDLC handle (terminal).

--- a/tests/integration/consilium/loop-routes.test.ts
+++ b/tests/integration/consilium/loop-routes.test.ts
@@ -226,6 +226,30 @@ describe("consilium-loop routes", () => {
     expect(res.body.state).toBe("cancelled");
   });
 
+  it("cancel with a reason records a self-explanatory `error` (who + when + why)", async () => {
+    const created = await post("/api/consilium-loops", { groupId: ctx.group.id, repoPath: REPO_ROOT });
+    const id = created.body.id;
+    ctx.setUser(OWNER_USER); // name "Owner"
+    const res = await post(`/api/consilium-loops/${id}/cancel`, { reason: "superseded by a newer loop" });
+    expect(res.status).toBe(200);
+    expect(res.body.state).toBe("cancelled");
+    expect(res.body.error).toMatch(/^Cancelled by Owner at .+ — superseded by a newer loop$/);
+    // Persisted (not just echoed): a fresh GET carries the same explanation.
+    ctx.setUser(OWNER_USER);
+    const got = await get(`/api/consilium-loops/${id}`);
+    expect(got.body.error).toBe(res.body.error);
+  });
+
+  it("cancel with NO body still records actor + timestamp — `error` is never blank", async () => {
+    const created = await post("/api/consilium-loops", { groupId: ctx.group.id, repoPath: REPO_ROOT });
+    const id = created.body.id;
+    ctx.setUser(OWNER_USER);
+    const res = await post(`/api/consilium-loops/${id}/cancel`);
+    expect(res.status).toBe(200);
+    expect(res.body.error).toMatch(/^Cancelled by Owner at .+Z$/);
+    expect(res.body.error).not.toContain("—");
+  });
+
   it("list is owner-scoped: OTHER_USER sees none of OWNER's loops", async () => {
     await post("/api/consilium-loops", { groupId: ctx.group.id, repoPath: REPO_ROOT });
     ctx.setUser(OTHER_USER);

--- a/tests/unit/consilium/consilium-loops-develop-route.test.ts
+++ b/tests/unit/consilium/consilium-loops-develop-route.test.ts
@@ -44,7 +44,7 @@ function makeApp(opts: {
   devProgress?: unknown;
   loop?: Record<string, unknown>;
   rounds?: unknown[];
-  user?: { id: string; role?: string };
+  user?: { id: string; role?: string; name?: string; email?: string };
 } = {}) {
   const {
     developResult = { ok: true, loop: { ...DEVELOPING_LOOP } as never },
@@ -60,6 +60,13 @@ function makeApp(opts: {
   const controller = {
     develop: vi.fn(async () => developResult),
     getDevProgress: vi.fn(() => devProgress),
+    // Cancel echoes back a cancelled loop; tests assert the ARGS the route passes
+    // (sanitized reason + session-resolved actor), not controller internals.
+    cancel: vi.fn(async (_id: string, _opts?: { reason?: string; actor?: string }) => ({
+      ...DEVELOPING_LOOP,
+      state: "cancelled",
+      error: "recorded",
+    })),
   } as unknown as ConsiliumLoopController;
 
   const storage = {
@@ -199,5 +206,79 @@ describe("removed standalone execute-sdlc surface", () => {
     const { app } = makeApp();
     const res = await request(app).post(`/api/task-groups/grp-1/execute-sdlc`).send({});
     expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/consilium-loops/:id/cancel — reason + actor threading", () => {
+  beforeEach(() => vi.clearAllMocks());
+  type CancelFn = ReturnType<typeof vi.fn>;
+
+  it("passes a sanitized reason + session-resolved actor (name preferred) to controller.cancel", async () => {
+    const { app, controller } = makeApp({ user: { id: OWNER, name: "Ada Lovelace", email: "ada@x.io" } });
+    const res = await request(app)
+      .post(`/api/consilium-loops/${LOOP_ID}/cancel`)
+      .send({ reason: "  superseded\tby #42  " });
+    expect(res.status).toBe(200);
+    expect(res.body.state).toBe("cancelled");
+    expect(controller.cancel as CancelFn).toHaveBeenCalledWith(LOOP_ID, {
+      reason: "superseded by #42", // control-stripped + whitespace-collapsed + trimmed
+      actor: "Ada Lovelace", // name wins over email/id
+    });
+  });
+
+  it("no body (auto-cancel) → controller.cancel called with reason undefined, actor from id", async () => {
+    const { app, controller } = makeApp({ user: { id: OWNER } }); // no name/email
+    const res = await request(app).post(`/api/consilium-loops/${LOOP_ID}/cancel`).send();
+    expect(res.status).toBe(200);
+    expect(controller.cancel as CancelFn).toHaveBeenCalledWith(LOOP_ID, {
+      reason: undefined,
+      actor: OWNER,
+    });
+  });
+
+  it("clamps an over-long reason to <= 500 chars (truncate, not reject)", async () => {
+    const { app, controller } = makeApp({ user: { id: OWNER, email: "ops@x.io" } });
+    const res = await request(app)
+      .post(`/api/consilium-loops/${LOOP_ID}/cancel`)
+      .send({ reason: "x".repeat(2000) });
+    expect(res.status).toBe(200);
+    const arg = (controller.cancel as CancelFn).mock.calls[0][1] as { reason?: string; actor?: string };
+    expect(arg.reason?.length).toBe(500);
+    expect(arg.actor).toBe("ops@x.io"); // email fallback when no name
+  });
+
+  it("a whitespace-only reason collapses to undefined (never a blank reason tail)", async () => {
+    const { app, controller } = makeApp();
+    const res = await request(app)
+      .post(`/api/consilium-loops/${LOOP_ID}/cancel`)
+      .send({ reason: "   \n\t  " });
+    expect(res.status).toBe(200);
+    const arg = (controller.cancel as CancelFn).mock.calls[0][1] as { reason?: string };
+    expect(arg.reason).toBeUndefined();
+  });
+
+  it("a non-string reason → 400 (validation), controller.cancel NOT called", async () => {
+    const { app, controller } = makeApp();
+    const res = await request(app)
+      .post(`/api/consilium-loops/${LOOP_ID}/cancel`)
+      .send({ reason: 123 });
+    expect(res.status).toBe(400);
+    expect(controller.cancel as CancelFn).not.toHaveBeenCalled();
+  });
+
+  it("a foreign loop → 404, controller.cancel NOT called (no existence oracle)", async () => {
+    const { app, controller } = makeApp({ user: { id: "intruder" } });
+    const res = await request(app)
+      .post(`/api/consilium-loops/${LOOP_ID}/cancel`)
+      .send({ reason: "nope" });
+    expect(res.status).toBe(404);
+    expect(controller.cancel as CancelFn).not.toHaveBeenCalled();
+  });
+
+  it("controller reports already-terminal (null) → 409", async () => {
+    const { app, controller } = makeApp();
+    (controller.cancel as CancelFn).mockResolvedValueOnce(null);
+    const res = await request(app).post(`/api/consilium-loops/${LOOP_ID}/cancel`).send();
+    expect(res.status).toBe(409);
   });
 });

--- a/tests/unit/consilium/loop-fsm.test.ts
+++ b/tests/unit/consilium/loop-fsm.test.ts
@@ -10,6 +10,7 @@ import {
   reduce,
   isAntiStall,
   pickJudgeOutput,
+  composeCancelExplanation,
   ConsiliumLoopController,
   MAX_CONCURRENT_DEV_HANDOFFS,
   SDLC_DEV_REDRIVE_GRACE_MS,
@@ -78,6 +79,60 @@ describe("reduce — design §3 transition table", () => {
   it("DECIDING: decreasing open_p0 does NOT escalate", () => {
     const t = reduce("deciding", { kind: "decided", verdict: verdict(false, 1), priorOpenP0: [3, 2, 1] });
     expect(t?.to).toBe("developing");
+  });
+});
+
+// ─── Cancel explanation: reason + actor carried into the `error` column ───────
+
+describe("reduce — cancel carries reason + actor into error", () => {
+  const ISO_RE = /^Cancelled by .+ at \d{4}-\d{2}-\d{2}T[\d:.]+Z/;
+
+  it("cancel with reason + actor → composed `error` (who/when — why) + completedAt", () => {
+    const t = reduce("reviewing", { kind: "cancel", actor: "Ada Lovelace", reason: "superseded by #42" });
+    expect(t?.to).toBe("cancelled");
+    const err = t?.extra?.error as string;
+    expect(err).toMatch(ISO_RE);
+    expect(err).toContain("Cancelled by Ada Lovelace at ");
+    expect(err).toContain(" — superseded by #42");
+    // completedAt and the error timestamp are the SAME instant.
+    expect(t?.extra?.completedAt).toBeInstanceOf(Date);
+    expect(err).toContain((t?.extra?.completedAt as Date).toISOString());
+  });
+
+  it("cancel WITHOUT reason → still records actor + timestamp (never blank, no trailing dash)", () => {
+    const t = reduce("developing", { kind: "cancel", actor: "ops@team" });
+    const err = t?.extra?.error as string;
+    expect(err).toBe(`Cancelled by ops@team at ${(t?.extra?.completedAt as Date).toISOString()}`);
+    expect(err).not.toContain("—");
+  });
+
+  it("cancel with NEITHER reason NOR actor (auto-cancel) → 'Cancelled by system at <ISO>'", () => {
+    const t = reduce("awaiting_merge", { kind: "cancel" });
+    const err = t?.extra?.error as string;
+    expect(err).toMatch(/^Cancelled by system at /);
+    expect(err).toContain((t?.extra?.completedAt as Date).toISOString());
+  });
+
+  it("blank/whitespace actor or reason falls back cleanly (never blank actor, no empty reason tail)", () => {
+    const t = reduce("reviewing", { kind: "cancel", actor: "   ", reason: "   " });
+    const err = t?.extra?.error as string;
+    expect(err).toMatch(/^Cancelled by system at /);
+    expect(err).not.toContain("—");
+  });
+});
+
+describe("composeCancelExplanation — pure formatter", () => {
+  const at = new Date("2026-07-03T12:00:00.000Z");
+  it("actor + reason", () => {
+    expect(composeCancelExplanation(at, "Grace", "dup")).toBe(
+      "Cancelled by Grace at 2026-07-03T12:00:00.000Z — dup",
+    );
+  });
+  it("actor only", () => {
+    expect(composeCancelExplanation(at, "Grace")).toBe("Cancelled by Grace at 2026-07-03T12:00:00.000Z");
+  });
+  it("neither → system, never blank", () => {
+    expect(composeCancelExplanation(at)).toBe("Cancelled by system at 2026-07-03T12:00:00.000Z");
   });
 });
 
@@ -986,5 +1041,62 @@ describe("controller.develop — R1 cap atomicity under a concurrent burst", () 
     const retry = await controller.develop(busyId!);
     expect(retry.ok).toBe(true); // a freed slot is immediately reusable
     expect(runSdlc).toHaveBeenCalledTimes(MAX_CONCURRENT_DEV_HANDOFFS + 1);
+  });
+});
+
+// ─── controller.cancel — reason + actor persisted to `error` via the CAS ──────
+
+describe("controller.cancel — records terminal explanation", () => {
+  const mkController = (
+    storage: ReturnType<typeof makeFakeStorage>["storage"],
+    cancelGroup = vi.fn(async () => undefined),
+  ) =>
+    new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: { startGroup: vi.fn(), startGroupAsync: vi.fn(), createTaskGroup: vi.fn(), cancelGroup } as never,
+      config: fakeConfig,
+    });
+
+  it("cancel(loopId, { reason, actor }) writes composed `error` + cascades group cancel", async () => {
+    const loop = makeLoop({ state: "reviewing", currentIterationNumber: 1 });
+    const { storage, cas, get } = makeFakeStorage(loop);
+    const cancelGroup = vi.fn(async () => undefined);
+    const res = await mkController(storage, cancelGroup).cancel(loop.id, {
+      reason: "superseded by newer loop",
+      actor: "Ada",
+    });
+    expect(res?.state).toBe("cancelled");
+    expect(cancelGroup).toHaveBeenCalledWith(loop.groupId);
+    // The CAS carried the error + completedAt in its extra.
+    const casExtra = cas.mock.calls.at(-1)?.[3] as { error?: string; completedAt?: Date };
+    expect(casExtra.error).toContain("Cancelled by Ada at ");
+    expect(casExtra.error).toContain(" — superseded by newer loop");
+    expect(get().error).toBe(casExtra.error);
+    expect(get().completedAt).toBeInstanceOf(Date);
+  });
+
+  it("cancel WITHOUT reason still records actor + timestamp — `error` is never blank", async () => {
+    const loop = makeLoop({ state: "developing", devGroupId: "dg1" });
+    const { storage, get } = makeFakeStorage(loop);
+    const res = await mkController(storage).cancel(loop.id, { actor: "ops@team" });
+    expect(res?.state).toBe("cancelled");
+    expect(get().error).toBe(`Cancelled by ops@team at ${(get().completedAt as Date).toISOString()}`);
+    expect(get().error).toBeTruthy();
+  });
+
+  it("cancel with no opts (auto-cancel) → 'Cancelled by system at <ISO>', never blank", async () => {
+    const loop = makeLoop({ state: "awaiting_merge" });
+    const { storage, get } = makeFakeStorage(loop);
+    const res = await mkController(storage).cancel(loop.id);
+    expect(res?.state).toBe("cancelled");
+    expect(get().error).toMatch(/^Cancelled by system at /);
+  });
+
+  it("cancel on an already-terminal loop is a no-op (no error overwrite)", async () => {
+    const loop = makeLoop({ state: "converged", error: null, completedAt: new Date() });
+    const { storage, cas } = makeFakeStorage(loop);
+    const res = await mkController(storage).cancel(loop.id, { actor: "Ada", reason: "late" });
+    expect(res).toBeNull();
+    expect(cas).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## The gap

A cancelled consilium loop was silent about *why*: `reduce()`'s cancel branch set only `{ to: "cancelled", extra: { completedAt } }` — no reason, no actor. The `cancel()` method and `POST /api/consilium-loops/:id/cancel` route took no reason, so the row's `error` was empty and `ConsiliumLoopDetail` rendered a bare "cancelled". Auto-cancels (an API POST with no body) were equally opaque. Who cancelled it, when, and why were all invisible.

## The change

Make cancellation self-explanatory end to end, reusing the **existing** terminal-state `consilium_loops.error` text column.

1. **Route** — `POST /:id/cancel` now accepts an OPTIONAL JSON body `{ reason?: string }`. The reason is untrusted, so it is control-stripped (C0/DEL/C1), whitespace-collapsed, trimmed, and **clamped** (truncated, not rejected) to 500 chars; a whitespace-only reason collapses to none. The acting user is resolved from the authorized session (`name` > `email` > `id`) — never client-supplied. A missing/empty body is tolerated (auto-cancel); only a present-but-non-string `reason` is a 400.
2. **Controller** — `cancel()` and the `reduce` cancel branch carry an optional `reason` + `actor` and compose a never-blank terminal explanation: `Cancelled by <actor> at <ISO>[ — <reason>]`. With no actor resolvable it falls back to `system`. `completedAt` is preserved.
3. **UI** — `ConsiliumLoopDetail` already surfaces `loop.error` in an amber (neutral, not red) callout for a degraded round; a cancelled loop now reuses that exact treatment, labelled **"Cancellation"** instead of "Last round error".

## Why reuse `error` (no new column, no migration)

A parallel branch touches `consilium-loop-controller.ts` and the loop row for trigger provenance. To avoid collision this change adds **no DB column and no migration** — it reuses the existing `error` terminal-explanation field and keeps the FSM state-table unchanged (same `cancelled` target; only the `extra` columns differ). The controller diff is scoped to the `cancel` event/branch, the `cancel()` method, the cancel route, and the UI render.

## Adversarial review

- **Reason is untrusted** → clamped + control-stripped at the route boundary; the pure composer defensively trims too.
- **Overloading `error` must not make a cancelled loop read as a failure.** Swept the codebase: no counter/filter keys off `error != null`. Failure styling (`w.status === "failed"`) and every other terminal decision gate on `state`, not error presence. The stats surface does not aggregate loop `error`. The only effect of a now-populated `error` on a cancelled loop is the intended detail-panel callout.

## Test evidence (tsc + vitest)

- `tsc` clean.
- Unit `loop-fsm.test.ts`: reduce cancel branch carries reason+actor into `error`; without reason still records actor+timestamp (never blank, no trailing dash); auto-cancel → `Cancelled by system at <ISO>`; blank/whitespace inputs fall back cleanly; pure `composeCancelExplanation` formatter; `controller.cancel` persists the composed `error` via the CAS + cascades group cancel; terminal loop is a no-op (no overwrite).
- Unit `consilium-loops-develop-route.test.ts`: route passes a sanitized reason + session-resolved actor (name preferred); no body → reason undefined + actor from id; over-long reason clamped to 500; whitespace-only reason → undefined; non-string reason → 400 (cancel not called); foreign loop → 404; null return → 409.
- Integration `loop-routes.test.ts`: cancel with a reason records + **persists** (verified via a fresh GET) `Cancelled by Owner at <ISO> — <reason>`; cancel with no body records actor+timestamp, never blank.
- Full unit project green (244 files / 4787 tests); consilium integration green (13 tests).

Draft — not for merge.