### PR TITLE
feat: triggers create consilium loops (retarget off pipelines)

### DIFF
--- a/client/src/components/triggers/TriggerCard.tsx
+++ b/client/src/components/triggers/TriggerCard.tsx
@@ -7,6 +7,7 @@ import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { useEnableTrigger, useDisableTrigger } from "@/hooks/use-triggers";
 import type { PipelineTrigger, TriggerType, ScheduleTriggerConfig, GitHubEventTriggerConfig, FileChangeTriggerConfig } from "@shared/types";
+import { loopTargetSummary } from "./trigger-form-logic";
 
 // ─── Type badge config ────────────────────────────────────────────────────────
 
@@ -60,18 +61,18 @@ function configSummary(trigger: PipelineTrigger): string {
 
 interface TriggerCardProps {
   trigger: PipelineTrigger;
-  pipelineName?: string;
   onEdit: (trigger: PipelineTrigger) => void;
   onDelete: (trigger: PipelineTrigger) => void;
 }
 
-export function TriggerCard({ trigger, pipelineName, onEdit, onDelete }: TriggerCardProps) {
+export function TriggerCard({ trigger, onEdit, onDelete }: TriggerCardProps) {
   const enable = useEnableTrigger();
   const disable = useDisableTrigger();
 
   const meta = TYPE_META[trigger.type];
   const Icon = meta.Icon;
   const isPending = enable.isPending || disable.isPending;
+  const loopTarget = loopTargetSummary(trigger);
 
   function handleToggle(checked: boolean) {
     if (checked) {
@@ -102,9 +103,9 @@ export function TriggerCard({ trigger, pipelineName, onEdit, onDelete }: Trigger
               >
                 {meta.label}
               </Badge>
-              {pipelineName && (
+              {loopTarget && (
                 <span className="text-[10px] text-muted-foreground font-medium truncate">
-                  {pipelineName}
+                  {loopTarget}
                 </span>
               )}
             </div>
@@ -115,6 +116,12 @@ export function TriggerCard({ trigger, pipelineName, onEdit, onDelete }: Trigger
 
             <p className="text-[10px] text-muted-foreground mt-1">
               Last triggered: <span className="font-medium">{lastTriggered}</span>
+              {trigger.suppressedCount > 0 && (
+                <>
+                  {" · "}
+                  <span className="font-medium">{trigger.suppressedCount}</span> suppressed
+                </>
+              )}
             </p>
           </div>
         </div>

--- a/client/src/components/triggers/TriggerForm.tsx
+++ b/client/src/components/triggers/TriggerForm.tsx
@@ -20,31 +20,46 @@ import {
 } from "@/components/ui/select";
 import { useCreateTrigger, useUpdateTrigger } from "@/hooks/use-triggers";
 import { WebhookDetails } from "./WebhookDetails";
-import type {
-  PipelineTrigger,
-  TriggerType,
-  InsertTrigger,
-  ScheduleTriggerConfig,
-  GitHubEventTriggerConfig,
-  FileChangeTriggerConfig,
+import {
+  LOOP_FIRING_TYPES,
+  isTriggerFormValid,
+  buildLoopTemplate,
+  type LoopTemplateState,
+} from "./trigger-form-logic";
+import {
+  CONSILIUM_REVIEW_PRESETS,
+  type PipelineTrigger,
+  type TriggerType,
+  type InsertTrigger,
+  type ConsiliumReviewPreset,
+  type ConsiliumReviewTriggerAction,
+  type ScheduleTriggerConfig,
+  type GitHubEventTriggerConfig,
+  type FileChangeTriggerConfig,
 } from "@shared/types";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface Pipeline {
-  id: string;
+/** A repo the trigger's loop can target — one of the active project's workspaces. */
+export interface TriggerWorkspaceOption {
+  path: string;
   name: string;
 }
 
 interface TriggerFormProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  pipelines: Pipeline[];
+  /** The active project's allowlisted workspaces — the loop target picklist. */
+  workspaces: TriggerWorkspaceOption[];
   /** When provided, the form is in edit mode */
   trigger?: PipelineTrigger;
-  /** Pre-select a pipeline when creating */
-  defaultPipelineId?: string;
 }
+
+const PRESET_LABELS: Record<ConsiliumReviewPreset, string> = {
+  "sdlc-cross-review": "SDLC cross-review",
+  "diff-pr-review": "Diff / PR review",
+  "full-viability": "Full viability",
+};
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -81,7 +96,108 @@ const GITHUB_EVENT_OPTIONS = [
   "delete",
 ] as const;
 
-// ─── Sub-forms ────────────────────────────────────────────────────────────────
+// ─── Loop-template sub-form (schedule + file_change) ────────────────────────────
+
+function LoopTemplateFields({
+  state,
+  workspaces,
+  repoRequired,
+  onChange,
+}: {
+  state: LoopTemplateState;
+  workspaces: TriggerWorkspaceOption[];
+  repoRequired: boolean;
+  onChange: (patch: Partial<LoopTemplateState>) => void;
+}) {
+  return (
+    <fieldset className="space-y-3 rounded-md border border-border p-3">
+      <legend className="px-1 text-xs font-medium">Consilium loop target</legend>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="loop-preset" className="text-xs">
+          Preset <span className="text-destructive">*</span>
+        </Label>
+        <Select
+          value={state.preset}
+          onValueChange={(v) => onChange({ preset: v as ConsiliumReviewPreset })}
+        >
+          <SelectTrigger id="loop-preset" className="h-8 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {CONSILIUM_REVIEW_PRESETS.map((p) => (
+              <SelectItem key={p} value={p} className="text-xs">
+                {PRESET_LABELS[p]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="loop-repo" className="text-xs">
+          Repository{" "}
+          {repoRequired ? (
+            <span className="text-destructive">*</span>
+          ) : (
+            <span className="text-muted-foreground">(defaults to the watched repo)</span>
+          )}
+        </Label>
+        <Select value={state.repoPath} onValueChange={(v) => onChange({ repoPath: v })}>
+          <SelectTrigger id="loop-repo" className="h-8 text-xs">
+            <SelectValue placeholder="Select a workspace" />
+          </SelectTrigger>
+          <SelectContent>
+            {workspaces.map((w) => (
+              <SelectItem key={w.path} value={w.path} className="text-xs">
+                {w.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-[10px] text-muted-foreground">
+          Re-validated against the allowed repo paths when the trigger fires.
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="loop-instruction" className="text-xs">
+          Instruction <span className="text-muted-foreground">(optional)</span>
+        </Label>
+        <Input
+          id="loop-instruction"
+          value={state.engineerInstruction}
+          onChange={(e) => onChange({ engineerInstruction: e.target.value })}
+          placeholder="Review the change: ${event}"
+          className="text-xs h-8"
+        />
+        <p className="text-[10px] text-muted-foreground">
+          Use <code className="font-mono">{"${event}"}</code> to insert a description of the firing event.
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="loop-max-rounds" className="text-xs">
+          Max rounds <span className="text-muted-foreground">(1–6)</span>
+        </Label>
+        <Input
+          id="loop-max-rounds"
+          type="number"
+          min={1}
+          max={6}
+          value={state.maxRounds}
+          onChange={(e) => onChange({ maxRounds: e.target.value })}
+          className="text-xs h-8 w-24"
+        />
+        <p className="text-[10px] text-muted-foreground">
+          Automated fires run review-only (1 round) in this release.
+        </p>
+      </div>
+    </fieldset>
+  );
+}
+
+// ─── Other sub-forms ────────────────────────────────────────────────────────────
 
 function WebhookConfigFields({
   secret,
@@ -91,31 +207,37 @@ function WebhookConfigFields({
   onSecretChange: (v: string) => void;
 }) {
   return (
-    <div className="space-y-1.5">
-      <Label htmlFor="webhook-secret-input" className="text-xs">
-        HMAC Secret <span className="text-muted-foreground">(optional)</span>
-      </Label>
-      <div className="flex gap-2">
-        <Input
-          id="webhook-secret-input"
-          type="password"
-          value={secret}
-          onChange={(e) => onSecretChange(e.target.value)}
-          placeholder="Leave blank to skip signature verification"
-          className="font-mono text-xs h-8"
-          autoComplete="new-password"
-        />
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="h-8 px-3 shrink-0"
-          onClick={() => onSecretChange(generateSecret())}
-          aria-label="Generate random secret"
-        >
-          <RefreshCw className="h-3.5 w-3.5 mr-1" />
-          Generate
-        </Button>
+    <div className="space-y-3">
+      <p className="text-[11px] text-muted-foreground">
+        Webhook and GitHub-event receivers do not yet create loops — the HTTP receiver is
+        coming in a follow-up. The trigger persists so it is ready when the receiver ships.
+      </p>
+      <div className="space-y-1.5">
+        <Label htmlFor="webhook-secret-input" className="text-xs">
+          HMAC Secret <span className="text-muted-foreground">(optional)</span>
+        </Label>
+        <div className="flex gap-2">
+          <Input
+            id="webhook-secret-input"
+            type="password"
+            value={secret}
+            onChange={(e) => onSecretChange(e.target.value)}
+            placeholder="Leave blank to skip signature verification"
+            className="font-mono text-xs h-8"
+            autoComplete="new-password"
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 px-3 shrink-0"
+            onClick={() => onSecretChange(generateSecret())}
+            aria-label="Generate random secret"
+          >
+            <RefreshCw className="h-3.5 w-3.5 mr-1" />
+            Generate
+          </Button>
+        </div>
       </div>
     </div>
   );
@@ -170,6 +292,10 @@ function GitHubConfigFields({
 
   return (
     <div className="space-y-3">
+      <p className="text-[11px] text-muted-foreground">
+        GitHub-event → loop mapping (the HMAC receiver + event fan-out) lands in a follow-up.
+        The trigger persists now so it is ready when the receiver ships.
+      </p>
       <div className="space-y-1.5">
         <Label htmlFor="gh-repo" className="text-xs">
           Repository <span className="text-destructive">*</span>
@@ -265,46 +391,28 @@ function FileChangeConfigFields({
 export function TriggerForm({
   open,
   onOpenChange,
-  pipelines,
+  workspaces,
   trigger,
-  defaultPipelineId,
 }: TriggerFormProps) {
   const isEdit = !!trigger;
   const createTrigger = useCreateTrigger();
   const updateTrigger = useUpdateTrigger();
 
   // ── State ──────────────────────────────────────────────────────────────────
-  const [pipelineId, setPipelineId] = useState(
-    trigger?.pipelineId ?? defaultPipelineId ?? pipelines[0]?.id ?? "",
-  );
-  const [type, setType] = useState<TriggerType>(trigger?.type ?? "webhook");
+  const [type, setType] = useState<TriggerType>(trigger?.type ?? "schedule");
   const [enabled, setEnabled] = useState(trigger?.enabled ?? true);
   const [webhookSecret, setWebhookSecret] = useState("");
-  const [cron, setCron] = useState(
-    type === "schedule"
-      ? (trigger?.config as ScheduleTriggerConfig)?.cron ?? ""
-      : "",
-  );
-  const [ghRepo, setGhRepo] = useState(
-    type === "github_event"
-      ? (trigger?.config as GitHubEventTriggerConfig)?.repository ?? ""
-      : "",
-  );
-  const [ghEvents, setGhEvents] = useState<string[]>(
-    type === "github_event"
-      ? (trigger?.config as GitHubEventTriggerConfig)?.events ?? []
-      : [],
-  );
-  const [watchPath, setWatchPath] = useState(
-    type === "file_change"
-      ? (trigger?.config as FileChangeTriggerConfig)?.watchPath ?? ""
-      : "",
-  );
-  const [filePatterns, setFilePatterns] = useState<string[]>(
-    type === "file_change"
-      ? (trigger?.config as FileChangeTriggerConfig)?.patterns ?? []
-      : [],
-  );
+  const [cron, setCron] = useState("");
+  const [ghRepo, setGhRepo] = useState("");
+  const [ghEvents, setGhEvents] = useState<string[]>([]);
+  const [watchPath, setWatchPath] = useState("");
+  const [filePatterns, setFilePatterns] = useState<string[]>([]);
+  const [template, setTemplate] = useState<LoopTemplateState>({
+    preset: "sdlc-cross-review",
+    repoPath: workspaces[0]?.path ?? "",
+    engineerInstruction: "",
+    maxRounds: "1",
+  });
 
   // Created webhook result (shown after creation)
   const [createdWebhook, setCreatedWebhook] = useState<{
@@ -312,20 +420,17 @@ export function TriggerForm({
     secret: string;
   } | null>(null);
 
-  // Reset when trigger prop changes
+  // Reset when the dialog opens / the edited trigger changes.
   useEffect(() => {
     if (!open) {
       setCreatedWebhook(null);
       return;
     }
-    setPipelineId(trigger?.pipelineId ?? defaultPipelineId ?? pipelines[0]?.id ?? "");
-    setType(trigger?.type ?? "webhook");
+    setType(trigger?.type ?? "schedule");
     setEnabled(trigger?.enabled ?? true);
     setWebhookSecret("");
     setCron(
-      trigger?.type === "schedule"
-        ? (trigger.config as ScheduleTriggerConfig).cron
-        : "",
+      trigger?.type === "schedule" ? (trigger.config as ScheduleTriggerConfig).cron : "",
     );
     setGhRepo(
       trigger?.type === "github_event"
@@ -344,54 +449,63 @@ export function TriggerForm({
     );
     setFilePatterns(
       trigger?.type === "file_change"
-        ? (trigger.config as FileChangeTriggerConfig).patterns
+        ? (trigger.config as FileChangeTriggerConfig).patterns ?? []
         : [],
     );
-  }, [open, trigger, defaultPipelineId, pipelines]);
+    const action =
+      trigger && (trigger.config as { action?: ConsiliumReviewTriggerAction }).action;
+    setTemplate({
+      preset: action?.preset ?? "sdlc-cross-review",
+      repoPath: action?.repoPath ?? workspaces[0]?.path ?? "",
+      engineerInstruction: action?.engineerInstruction ?? "",
+      maxRounds: action?.maxRounds ? String(action.maxRounds) : "1",
+    });
+  }, [open, trigger, workspaces]);
+
+  const showLoopTemplate = LOOP_FIRING_TYPES.has(type);
+  const repoRequired = type === "schedule";
 
   // ── Build config ────────────────────────────────────────────────────────────
-  function buildConfig():
-    | Record<string, never>
-    | ScheduleTriggerConfig
-    | GitHubEventTriggerConfig
-    | FileChangeTriggerConfig {
+  function buildConfig(): Record<string, unknown> {
     switch (type) {
       case "webhook":
         return {};
       case "schedule":
-        return { cron };
+        return { cron, action: buildLoopTemplate(template) };
       case "github_event":
         return { repository: ghRepo, events: ghEvents };
       case "file_change":
-        return { watchPath, patterns: filePatterns };
+        return { watchPath, patterns: filePatterns, action: buildLoopTemplate(template) };
     }
   }
 
   // ── Validation ──────────────────────────────────────────────────────────────
-  function isValid(): boolean {
-    if (!pipelineId) return false;
-    if (type === "schedule") return cron.trim().length > 0;
-    if (type === "github_event")
-      return ghRepo.trim().length > 0 && ghEvents.length > 0;
-    if (type === "file_change") return watchPath.trim().length > 0;
-    return true;
+  function valid(): boolean {
+    return isTriggerFormValid({
+      type,
+      cron,
+      ghRepo,
+      ghEvents,
+      watchPath,
+      preset: template.preset,
+      repoPath: template.repoPath,
+    });
   }
 
   // ── Submit ──────────────────────────────────────────────────────────────────
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!isValid()) return;
+    if (!valid()) return;
 
     if (isEdit && trigger) {
       updateTrigger.mutate(
-        { id: trigger.id, type, config: buildConfig(), enabled },
+        { id: trigger.id, type, config: buildConfig() as never, enabled },
         { onSuccess: () => onOpenChange(false) },
       );
     } else {
       const payload: InsertTrigger & { _plainSecret?: string } = {
-        pipelineId,
         type,
-        config: buildConfig(),
+        config: buildConfig() as never,
         enabled,
         _plainSecret: webhookSecret || undefined,
       };
@@ -438,29 +552,6 @@ export function TriggerForm({
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4" noValidate>
-          {/* Pipeline selector */}
-          <div className="space-y-1.5">
-            <Label htmlFor="pipeline-select" className="text-xs">
-              Pipeline <span className="text-destructive">*</span>
-            </Label>
-            <Select
-              value={pipelineId}
-              onValueChange={setPipelineId}
-              disabled={isEdit}
-            >
-              <SelectTrigger id="pipeline-select" className="h-8 text-xs">
-                <SelectValue placeholder="Select a pipeline" />
-              </SelectTrigger>
-              <SelectContent>
-                {pipelines.map((p) => (
-                  <SelectItem key={p.id} value={p.id} className="text-xs">
-                    {p.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
           {/* Type selector */}
           <div className="space-y-1.5">
             <Label htmlFor="type-select" className="text-xs">
@@ -475,10 +566,10 @@ export function TriggerForm({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="webhook" className="text-xs">Webhook</SelectItem>
                 <SelectItem value="schedule" className="text-xs">Schedule (Cron)</SelectItem>
-                <SelectItem value="github_event" className="text-xs">GitHub Event</SelectItem>
                 <SelectItem value="file_change" className="text-xs">File Change</SelectItem>
+                <SelectItem value="webhook" className="text-xs">Webhook</SelectItem>
+                <SelectItem value="github_event" className="text-xs">GitHub Event</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -514,6 +605,16 @@ export function TriggerForm({
             />
           )}
 
+          {/* Loop template (schedule + file_change) */}
+          {showLoopTemplate && (
+            <LoopTemplateFields
+              state={template}
+              workspaces={workspaces}
+              repoRequired={repoRequired}
+              onChange={(patch) => setTemplate((prev) => ({ ...prev, ...patch }))}
+            />
+          )}
+
           {/* Enabled checkbox */}
           <div className="flex items-center gap-2">
             <Checkbox
@@ -545,7 +646,7 @@ export function TriggerForm({
             <Button
               type="submit"
               size="sm"
-              disabled={isPending || !isValid()}
+              disabled={isPending || !valid()}
             >
               {isPending
                 ? "Saving…"

--- a/client/src/components/triggers/trigger-form-logic.ts
+++ b/client/src/components/triggers/trigger-form-logic.ts
@@ -1,0 +1,87 @@
+/**
+ * trigger-form-logic.ts — pure, node-testable logic for the trigger form + card.
+ *
+ * Extracted from TriggerForm.tsx / TriggerCard.tsx (no JSX / React) so the unit
+ * tests can import it in the node environment (mirrors task-form-logic.ts). All
+ * SECURITY boundaries (repoPath allowlist, untrusted-text sanitization) live
+ * SERVER-SIDE in the review factory — this module only shapes the request.
+ */
+import type {
+  PipelineTrigger,
+  TriggerType,
+  ConsiliumReviewPreset,
+  ConsiliumReviewTriggerAction,
+} from "@shared/types";
+
+/** Trigger types whose firing creates a consilium loop (carry a loop template). */
+export const LOOP_FIRING_TYPES: ReadonlySet<TriggerType> = new Set(["schedule", "file_change"]);
+
+export interface LoopTemplateState {
+  preset: ConsiliumReviewPreset;
+  repoPath: string;
+  engineerInstruction: string;
+  maxRounds: string;
+}
+
+/**
+ * Whether the trigger form is submittable. The pipeline requirement is GONE — a
+ * trigger no longer targets a pipeline. schedule/file_change require a loop template
+ * (a preset and, for schedule, a repoPath since there is no watchPath to derive it
+ * from). webhook/github keep their legacy fields.
+ */
+export function isTriggerFormValid(input: {
+  type: TriggerType;
+  cron: string;
+  ghRepo: string;
+  ghEvents: string[];
+  watchPath: string;
+  preset: string;
+  repoPath: string;
+}): boolean {
+  const { type, cron, ghRepo, ghEvents, watchPath, preset, repoPath } = input;
+  if (type === "schedule") {
+    return cron.trim().length > 0 && preset.length > 0 && repoPath.trim().length > 0;
+  }
+  if (type === "file_change") {
+    return watchPath.trim().length > 0 && preset.length > 0;
+  }
+  if (type === "github_event") {
+    return ghRepo.trim().length > 0 && ghEvents.length > 0;
+  }
+  return true; // webhook
+}
+
+/**
+ * Whether the "Add Trigger" button should be enabled: the project must have at
+ * least one allowlisted workspace to target (replaces the old zero-pipelines gate),
+ * and the subsystem must be configured.
+ */
+export function canAddTrigger(workspaceCount: number, subsystemDisabled: boolean): boolean {
+  return workspaceCount > 0 && !subsystemDisabled;
+}
+
+/** Build the loop-template `action` from the form's template state. */
+export function buildLoopTemplate(state: LoopTemplateState): ConsiliumReviewTriggerAction {
+  const rounds = Number.parseInt(state.maxRounds, 10);
+  const action: ConsiliumReviewTriggerAction = {
+    kind: "consilium_review",
+    preset: state.preset,
+  };
+  if (state.repoPath.trim().length > 0) action.repoPath = state.repoPath.trim();
+  if (state.engineerInstruction.trim().length > 0) {
+    action.engineerInstruction = state.engineerInstruction.trim();
+  }
+  if (Number.isFinite(rounds) && rounds >= 1 && rounds <= 6) action.maxRounds = rounds;
+  return action;
+}
+
+/**
+ * The repo basename + preset the trigger's loop targets, or null when the trigger
+ * carries no loop template (webhook/github). Shown on the trigger card.
+ */
+export function loopTargetSummary(trigger: PipelineTrigger): string | null {
+  const action = (trigger.config as { action?: ConsiliumReviewTriggerAction }).action;
+  if (!action || action.kind !== "consilium_review") return null;
+  const repo = action.repoPath ? action.repoPath.split("/").filter(Boolean).pop() : undefined;
+  return repo ? `${action.preset} → ${repo}` : action.preset;
+}

--- a/client/src/pages/TriggersPage.tsx
+++ b/client/src/pages/TriggersPage.tsx
@@ -1,20 +1,30 @@
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Zap, Plus, Loader2, ZapOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { TriggerCard } from "@/components/triggers/TriggerCard";
-import { TriggerForm } from "@/components/triggers/TriggerForm";
+import { TriggerForm, type TriggerWorkspaceOption } from "@/components/triggers/TriggerForm";
 import { useTriggers, useDeleteTrigger } from "@/hooks/use-triggers";
-import { usePipelines } from "@/hooks/use-pipeline";
+import { apiRequest } from "@/hooks/use-pipeline";
 import type { PipelineTrigger } from "@shared/types";
+import type { WorkspaceRow } from "@shared/schema";
 
-interface Pipeline {
-  id: string;
-  name: string;
+/**
+ * Workspaces for the active project — the loop-target picklist for new triggers,
+ * and the gate for enabling the "Add Trigger" button (a trigger now fires a
+ * consilium loop against one of the project's allowlisted repos, not a pipeline).
+ * Uses the shared apiRequest transport so `x-project-id` is attached.
+ */
+function useWorkspaces() {
+  return useQuery<WorkspaceRow[]>({
+    queryKey: ["/api/workspaces"],
+    queryFn: () => apiRequest("GET", "/api/workspaces") as Promise<WorkspaceRow[]>,
+  });
 }
 
 export default function TriggersPage() {
   const { data: triggers, isLoading: triggersLoading, error } = useTriggers();
-  const { data: pipelinesData } = usePipelines();
+  const { data: workspaceData } = useWorkspaces();
   const deleteTrigger = useDeleteTrigger();
 
   const [formOpen, setFormOpen] = useState(false);
@@ -22,11 +32,10 @@ export default function TriggersPage() {
 
   const subsystemDisabled = (error as (Error & { disabled?: boolean }) | null)?.disabled === true || (error as (Error & { status?: number }) | null)?.status === 503;
   const triggerList: PipelineTrigger[] = Array.isArray(triggers) ? triggers : [];
-  const pipelines: Pipeline[] = Array.isArray(pipelinesData) ? pipelinesData : [];
-
-  function pipelineName(id: string): string {
-    return pipelines.find((p) => p.id === id)?.name ?? id.slice(0, 8);
-  }
+  const workspaces: TriggerWorkspaceOption[] = Array.isArray(workspaceData)
+    ? workspaceData.map((w) => ({ path: w.path, name: w.name }))
+    : [];
+  const hasWorkspaces = workspaces.length > 0;
 
   function handleAdd() {
     setEditingTrigger(undefined);
@@ -50,14 +59,14 @@ export default function TriggersPage() {
         <div>
           <h2 className="text-sm font-semibold">Triggers</h2>
           <p className="text-xs text-muted-foreground">
-            Automate pipeline runs with webhooks, schedules, and events
+            Start consilium loops automatically from schedules and file changes
           </p>
         </div>
         <Button
           size="sm"
           className="h-8 text-xs"
           onClick={handleAdd}
-          disabled={pipelines.length === 0 || subsystemDisabled}
+          disabled={!hasWorkspaces || subsystemDisabled}
         >
           <Plus className="h-3 w-3 mr-2" />
           Add Trigger
@@ -126,14 +135,14 @@ export default function TriggersPage() {
             <Zap className="h-10 w-10 text-muted-foreground/40 mb-4" />
             <p className="text-sm font-medium text-muted-foreground">No triggers yet</p>
             <p className="text-xs text-muted-foreground mt-1 mb-6">
-              Add one to automate your pipeline runs.
+              Add one to start consilium loops automatically.
             </p>
-            <Button size="sm" onClick={handleAdd} disabled={pipelines.length === 0}>
+            <Button size="sm" onClick={handleAdd} disabled={!hasWorkspaces}>
               <Plus className="h-3 w-3 mr-2" /> Add Trigger
             </Button>
-            {pipelines.length === 0 && (
+            {!hasWorkspaces && (
               <p className="text-xs text-muted-foreground mt-3">
-                Create a pipeline first before adding triggers.
+                Register a workspace for this project before adding triggers.
               </p>
             )}
           </div>
@@ -144,7 +153,6 @@ export default function TriggersPage() {
             <TriggerCard
               key={trigger.id}
               trigger={trigger}
-              pipelineName={pipelineName(trigger.pipelineId)}
               onEdit={handleEdit}
               onDelete={handleDelete}
             />
@@ -155,7 +163,7 @@ export default function TriggersPage() {
       <TriggerForm
         open={formOpen}
         onOpenChange={setFormOpen}
-        pipelines={pipelines}
+        workspaces={workspaces}
         trigger={editingTrigger}
       />
     </div>

--- a/migrations/0042_triggers_target_loops.sql
+++ b/migrations/0042_triggers_target_loops.sql
@@ -1,0 +1,45 @@
+-- migration: 0042_triggers_target_loops
+-- T1 retarget of the trigger subsystem off the (deleted) pipeline entity and onto
+-- consilium loops (see docs/design/loop-triggers.md, PR "triggers create consilium
+-- loops"). Three additive, idempotent changes — no data is dropped or rewritten.
+--
+-- 1) triggers.pipeline_id → NULLABLE.
+--    A trigger now fires a CONSILIUM LOOP (loop template in `config`), not a
+--    pipeline run. The pipeline entity left the product surface, so there are ZERO
+--    pipelines and a NOT NULL FK made every new trigger un-createable (the "Add
+--    Trigger" button was permanently disabled). Dropping NOT NULL lets triggers be
+--    created project-scoped with no pipeline. The FK itself is KEPT (nullable) so
+--    pre-existing pipeline-era rows still reference their pipeline.
+--
+-- 2) triggers.suppressed_count → new INT NOT NULL DEFAULT 0.
+--    Policy rail (§4): a fire suppressed by dedup (or a future budget/debounce rail)
+--    increments this instead of blindly creating a second active loop. Surfaced on
+--    the triggers page so silence is diagnosable. Backfills to 0 for existing rows.
+--
+-- 3) consilium_loops.trigger_provenance → new JSONB (nullable).
+--    Provenance (§6): every trigger-fired loop records `{ triggerId, triggerType,
+--    eventDigest, firedAt }` so the launch passport can show which trigger + event
+--    started it. Null ⇒ a human/API-initiated loop (no trigger) — exactly the
+--    pre-feature behavior, so every pre-existing loop keeps working unchanged.
+--    A DEDICATED column (not archetype_params, which the intent→archetype planner's
+--    plain partial updates own) so a provenance write can never race/clobber it —
+--    same reasoning as the applied_skills column (migration 0041).
+--
+-- Idempotent (IF EXISTS / IF NOT EXISTS) so re-applying against a push-managed dev
+-- DB is safe.
+
+ALTER TABLE triggers
+  ALTER COLUMN pipeline_id DROP NOT NULL;
+
+ALTER TABLE triggers
+  ADD COLUMN IF NOT EXISTS suppressed_count INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE consilium_loops
+  ADD COLUMN IF NOT EXISTS trigger_provenance JSONB;
+
+-- Rollback:
+--   ALTER TABLE consilium_loops DROP COLUMN trigger_provenance;
+--   ALTER TABLE triggers DROP COLUMN suppressed_count;
+--   -- pipeline_id NOT NULL cannot be safely restored once null rows exist; first
+--   -- delete/repair any pipeline-less triggers, then:
+--   -- ALTER TABLE triggers ALTER COLUMN pipeline_id SET NOT NULL;

--- a/server/config/loader.ts
+++ b/server/config/loader.ts
@@ -194,6 +194,9 @@ const ENV_MAPPINGS: EnvMapping[] = [
   { envKey: "MULTI_PIPELINE_CONSILIUM_LOOP_MAX_ROUNDS",       configPath: ["pipeline", "consiliumLoop", "maxRounds"],      kind: "number"  },
   { envKey: "MULTI_PIPELINE_CONSILIUM_LOOP_POLL_INTERVAL_MS", configPath: ["pipeline", "consiliumLoop", "pollIntervalMs"], kind: "number"  },
   { envKey: "MULTI_PIPELINE_CONSILIUM_LOOP_MAX_DIFF_BYTES",   configPath: ["pipeline", "consiliumLoop", "maxDiffBytes"],   kind: "number"  },
+
+  // T1 trigger retarget (loop-triggers.md §4.5): schedule→loop firing kill-switch.
+  { envKey: "TRIGGERS_ENABLED",       configPath: ["features", "triggers", "enabled"], kind: "boolean" },
 ];
 
 /**

--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -90,6 +90,21 @@ export const ConfigSchema = z.object({
       enabled: z.boolean().default(false),
       cronSchedule: z.string().default("0 2 * * *"),
     }).default({}),
+    /**
+     * T1 trigger retarget (loop-triggers.md §4.5): the kill-switch for a schedule
+     * trigger's NEW loop-firing behavior. Default FALSE ⇒ a scheduled fire records
+     * `lastTriggeredAt` but launches NO consilium loop — a running server never
+     * silently starts firing loops. Turn on explicitly to activate schedule→loop.
+     *
+     * This gate does NOT touch the pre-existing file_change → consilium-review
+     * binding (the "one live binding" prototype), which stays gated only by
+     * `pipeline.consiliumLoop.enabled`. It also does not affect trigger CRUD — the
+     * "Add Trigger" UI works regardless; only the automated FIRING of loops from a
+     * schedule is gated here.
+     */
+    triggers: z.object({
+      enabled: z.boolean().default(false),
+    }).default({}),
   }).default({}),
   federation: z.object({
     enabled: z.boolean().default(false),

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -328,27 +328,34 @@ export async function registerRoutes(
     // the last-fired timestamp. Both operate cross-project in system context.
     const fireTrigger = async (trigger: import("@shared/schema").TriggerRow, payload: unknown): Promise<void> => {
       await runAsSystem("fire-trigger", async () => {
-        const pipeline = await storage.getPipeline(trigger.pipelineId);
-        if (!pipeline) {
-          // pipelineId is NOT NULL in the schema; a consilium_review action does
-          // not USE the pipeline, but a dangling pipelineId still means a broken
-          // trigger config — keep the historical record-only no-op (no fire).
-          log(`[triggers] Pipeline not found for trigger ${trigger.id}`, "triggers");
+        // T1 RETARGET: a trigger fires a CONSILIUM LOOP (loop template in config),
+        // not a (deleted) pipeline run. pipelineId is now NULLABLE — a loop-template
+        // trigger has none. We NO LONGER gate on a pipeline lookup (that made every
+        // pipeline-less trigger a permanent no-op). ALWAYS record lastTriggeredAt
+        // first — for EVERY trigger type, action or not — so a fire is diagnosable
+        // even when the dispatch below suppresses/skips.
+        await storage.updateTrigger(trigger.id, { lastTriggeredAt: new Date() });
+        log(`[triggers] Fired trigger ${trigger.id} (type ${trigger.type})`, "triggers");
+
+        // T1 KILL-SWITCH (loop-triggers.md §4.5): a SCHEDULE trigger only fires a
+        // loop when `features.triggers.enabled` is on — a running server never
+        // silently starts firing scheduled loops. The pre-existing file_change
+        // binding is NOT gated here (it stays under consiliumLoop.enabled), so the
+        // one live prototype binding is unchanged.
+        if (trigger.type === "schedule" && !appConfigLoader.get().features.triggers.enabled) {
+          log(`[triggers] schedule trigger ${trigger.id} not fired — features.triggers.enabled is off`, "triggers");
           return;
         }
-        // ALWAYS record lastTriggeredAt — for EVERY trigger type, action or not.
-        await storage.updateTrigger(trigger.id, { lastTriggeredAt: new Date() });
-        log(`[triggers] Fired trigger ${trigger.id} for pipeline ${pipeline.id}`, "triggers");
 
-        // ── Action dispatch (file_change triggers only) ─────────────────────────
-        // ABSENT action ⇒ the record-only no-op above (back-compat for webhook /
-        // schedule / github / plain file_change triggers). Present + consilium_review
-        // ⇒ launch via the SAME factory the HTTP route uses. The changed-file path +
-        // watchPath are UNTRUSTED → they reach ONLY objectiveExtra, which the factory
-        // control-strips + clamps. repoPath is re-validated against the fail-closed
-        // allowlist INSIDE the factory. The launch runs under runAsProject so all
-        // rows stay project-scoped. `reviewDeps: null` (kill-switch off) ⇒ skipped.
-        await maybeLaunchConsiliumReview(
+        // ── Loop-template dispatch ───────────────────────────────────────────────
+        // ABSENT action ⇒ record-only no-op (back-compat for webhook / github /
+        // action-less triggers). Present + consilium_review ⇒ launch via the SAME
+        // factory the HTTP route uses. Untrusted payload strings reach ONLY the
+        // factory's sanitized objective seam (engineerInstruction / objectiveExtra);
+        // repoPath is re-validated against the fail-closed allowlist + the project's
+        // workspaces INSIDE the factory. `reviewDeps: null` (kill-switch off) ⇒
+        // skipped. The launch runs under runAsProject so all rows stay project-scoped.
+        const result = await maybeLaunchConsiliumReview(
           {
             reviewDeps: consiliumLoopController
               ? {
@@ -377,6 +384,13 @@ export async function registerRoutes(
           trigger,
           payload,
         );
+
+        // T1 policy rail (§4): a fire suppressed by dedup bumps the trigger's
+        // suppressed counter (surfaced on the triggers page) instead of blindly
+        // creating a second active loop for the same repo.
+        if (result === "skipped-dedup") {
+          await storage.incrementTriggerSuppressed(trigger.id);
+        }
       });
     };
 

--- a/server/routes/triggers.ts
+++ b/server/routes/triggers.ts
@@ -31,7 +31,28 @@ const WebhookConfigSchema = z.object({
   // and the endpoint is auto-derived. Accept no unknown keys.
 }).strict();
 
+// T1 loop template (loop-triggers.md §2): the SHARED "target = a consilium loop"
+// shape carried in the trigger config JSONB. `repoPath` is re-validated against the
+// fail-closed allowlist INSIDE the factory (this schema only shape-checks it).
+// `engineerInstruction` is UNTRUSTED free-text (may embed `${event}`) — the factory
+// control-strips + byte-clamps + fences it (same seam as the human UI endpoint).
+const LoopTemplateActionSchema = z.object({
+  kind: z.literal("consilium_review"),
+  preset: z.enum(CONSILIUM_REVIEW_PRESETS),
+  maxRounds: z.number().int().min(1).max(6).optional(),
+  repoPath: z.string().min(1).max(4096).optional(),
+  engineerInstruction: z.string().max(8000).optional(),
+});
+
+// A SCHEDULE trigger has no watchPath, so its loop template MUST name an explicit
+// repoPath (still allowlist-re-validated in the factory).
+const ScheduleActionSchema = LoopTemplateActionSchema.extend({
+  repoPath: z.string().min(1).max(4096),
+});
+
 // VETO-2 fix: add IANA timezone validation via Intl.DateTimeFormat constructor.
+// T1 RETARGET: a schedule trigger now REQUIRES a loop template (`action`) — its
+// firing creates a consilium loop, not a (deleted) pipeline run.
 const ScheduleConfigSchema = z.object({
   cron: z.string().min(1).max(200),
   timezone: z.string().max(100).optional().refine(
@@ -47,6 +68,7 @@ const ScheduleConfigSchema = z.object({
     { message: "Invalid IANA timezone identifier" }
   ),
   input: z.string().max(100_000).optional(),
+  action: ScheduleActionSchema,
 });
 
 const GitHubConfigSchema = z.object({
@@ -55,26 +77,18 @@ const GitHubConfigSchema = z.object({
   refFilter: z.string().max(500).optional(),
 });
 
-// A file_change trigger MAY carry an embedded action (no schema migration — it
-// lives in the existing config JSONB). Today the only kind is `consilium_review`,
-// which `fireTrigger` dispatches to the review factory. The factory RE-VALIDATES
-// `repoPath` against the fail-closed allowlist, so this schema only shape-checks
-// it (1..4096 chars) — it is NOT the security boundary. Without this field the
-// strict z.object would SILENTLY STRIP `action`, turning the trigger into a
-// permanent no-op; declaring it here makes the action persist.
-const ConsiliumReviewActionSchema = z.object({
-  kind: z.literal("consilium_review"),
-  preset: z.enum(CONSILIUM_REVIEW_PRESETS),
-  maxRounds: z.number().int().min(1).max(6).optional(),
-  repoPath: z.string().min(1).max(4096).optional(),
-});
-
+// A file_change trigger MAY carry an embedded loop template (`action`). The factory
+// RE-VALIDATES `repoPath` against the fail-closed allowlist, so this schema only
+// shape-checks it — it is NOT the security boundary. Without this field the strict
+// z.object would SILENTLY STRIP `action`, turning the trigger into a permanent
+// no-op; declaring it here makes the action persist. Optional here (a file_change
+// trigger may derive repoPath from watchPath); required for schedule (above).
 const FileChangeConfigSchema = z.object({
   watchPath: z.string().min(1).max(4096),
   patterns: z.array(z.string().min(1).max(500)).optional(),
   debounceMs: z.number().int().min(0).max(30_000).optional(),
   input: z.string().max(100_000).optional(),
-  action: ConsiliumReviewActionSchema.optional(),
+  action: LoopTemplateActionSchema.optional(),
 });
 
 type TriggerTypeValue = "webhook" | "schedule" | "github_event" | "file_change";
@@ -151,6 +165,26 @@ async function assertPipelineOwnership(
   return passed && !res.headersSent;
 }
 
+/**
+ * T1: authorize a per-id trigger operation. A LEGACY pipeline trigger is gated on
+ * its pipeline's owner (unchanged). A pipeline-less loop-template trigger has no
+ * pipeline owner to check — but it was already fetched via a PROJECT-SCOPED
+ * `getTrigger` (so it belongs to req.projectId, which requireProject validated the
+ * caller is a member of), and the mutating routes additionally carry
+ * requireRole("maintainer","admin"). So project scope + role are the boundary here.
+ */
+async function assertTriggerAccess(
+  trigger: { pipelineId: string | null },
+  storage: IStorage,
+  req: Request,
+  res: Response,
+): Promise<boolean> {
+  if (trigger.pipelineId) {
+    return assertPipelineOwnership(trigger.pipelineId, storage, req, res);
+  }
+  return true;
+}
+
 // ─── Route registration ───────────────────────────────────────────────────────
 
 export function registerTriggerRoutes(app: Express, triggerService: TriggerService, storage: IStorage): void {
@@ -165,17 +199,63 @@ export function registerTriggerRoutes(app: Express, triggerService: TriggerServi
         return res.json(await triggerService.getTriggers(pipelineId));
       }
 
-      const pipelines = await storage.getPipelines();
-      const allTriggers = await Promise.all(
-        pipelines.map((p) => triggerService.getTriggers(p.id))
-      );
-      return res.json(allTriggers.flat());
+      // T1: return the PROJECT's triggers (project-scoped), including pipeline-less
+      // loop-template triggers. requireProject upstream validated membership and set
+      // the ALS project the query filters by. (The old pipeline-fan-out returned []
+      // once the pipeline entity left the product.)
+      return res.json(await triggerService.getProjectTriggers());
     } catch (e) {
       const cid = correlationId();
       console.error(`[triggers] GET /api/triggers error cid=${cid}`, e);
       return res.status(500).json({ error: "Internal server error", correlationId: cid });
     }
   });
+
+  // POST /api/triggers — PROJECT-SCOPED create (T1 retarget).
+  //
+  // The trigger entity was pipeline-shaped: created under /api/pipelines/:id/triggers
+  // and requiring a pipeline. The pipeline entity left the product, so there were
+  // ZERO pipelines and no trigger could be created (the "Add Trigger" button was
+  // permanently disabled). A trigger now targets a CONSILIUM LOOP (loop template in
+  // `config`) and is scoped to the request's PROJECT (x-project-id → req.projectId,
+  // set by requireProject upstream). `createTrigger` runs inside the request's
+  // project ALS, so `withProjectInsert` stamps projectId; pipelineId is null.
+  //
+  // The factory (invoked when the trigger later FIRES) re-validates repoPath against
+  // the fail-closed allowlist AND the project's own workspaces — this route only
+  // shape-validates. No secret path here (loop-template triggers use no HMAC secret;
+  // webhook/github secrets still flow through the legacy pipeline route).
+  app.post(
+    "/api/triggers",
+    requireRole("maintainer", "admin"),
+    async (req, res) => {
+      try {
+        if (!req.projectId) {
+          return res.status(400).json({ error: "x-project-id header is required" });
+        }
+
+        const body = CreateTriggerSchema.parse(req.body);
+        const validatedConfig = validateTriggerConfig(body.type, body.config);
+
+        const trigger = await triggerService.createTrigger({
+          // T1: no pipeline — projectId is stamped from the request ALS by storage.
+          type: body.type,
+          config: validatedConfig as never,
+          secret: body.secret,
+          enabled: body.enabled,
+        });
+
+        return res.status(201).json(trigger);
+      } catch (e) {
+        if (e instanceof ZodError) {
+          return res.status(400).json({ error: "Validation failed", issues: e.issues });
+        }
+        const cid = correlationId();
+        console.error(`[triggers] POST /api/triggers error cid=${cid}`, e);
+        return res.status(500).json({ error: "Internal server error", correlationId: cid });
+      }
+    },
+  );
 
   // GET /api/pipelines/:pipelineId/triggers
   // VETO-1: resolve pipeline and gate on ownership before returning triggers.
@@ -244,7 +324,7 @@ export function registerTriggerRoutes(app: Express, triggerService: TriggerServi
       const trigger = await triggerService.getTrigger(String(req.params.id));
       if (!trigger) return res.status(404).json({ error: "Trigger not found" });
 
-      const allowed = await assertPipelineOwnership(trigger.pipelineId, storage, req, res);
+      const allowed = await assertTriggerAccess(trigger, storage, req, res);
       if (!allowed) return;
 
       return res.json(trigger);
@@ -268,7 +348,7 @@ export function registerTriggerRoutes(app: Express, triggerService: TriggerServi
         const trigger = await triggerService.getTrigger(String(req.params.id));
         if (!trigger) return res.status(404).json({ error: "Trigger not found" });
 
-        const allowed = await assertPipelineOwnership(trigger.pipelineId, storage, req, res);
+        const allowed = await assertTriggerAccess(trigger, storage, req, res);
         if (!allowed) return;
 
         const body = UpdateTriggerSchema.parse(req.body);
@@ -308,7 +388,7 @@ export function registerTriggerRoutes(app: Express, triggerService: TriggerServi
         const trigger = await triggerService.getTrigger(String(req.params.id));
         if (!trigger) return res.status(404).json({ error: "Trigger not found" });
 
-        const allowed = await assertPipelineOwnership(trigger.pipelineId, storage, req, res);
+        const allowed = await assertTriggerAccess(trigger, storage, req, res);
         if (!allowed) return;
 
         const deleted = await triggerService.deleteTrigger(String(req.params.id));
@@ -335,7 +415,7 @@ export function registerTriggerRoutes(app: Express, triggerService: TriggerServi
         const trigger = await triggerService.getTrigger(String(req.params.id));
         if (!trigger) return res.status(404).json({ error: "Trigger not found" });
 
-        const allowed = await assertPipelineOwnership(trigger.pipelineId, storage, req, res);
+        const allowed = await assertTriggerAccess(trigger, storage, req, res);
         if (!allowed) return;
 
         const updated = await triggerService.enableTrigger(String(req.params.id));
@@ -359,7 +439,7 @@ export function registerTriggerRoutes(app: Express, triggerService: TriggerServi
         const trigger = await triggerService.getTrigger(String(req.params.id));
         if (!trigger) return res.status(404).json({ error: "Trigger not found" });
 
-        const allowed = await assertPipelineOwnership(trigger.pipelineId, storage, req, res);
+        const allowed = await assertTriggerAccess(trigger, storage, req, res);
         if (!allowed) return;
 
         const updated = await triggerService.disableTrigger(String(req.params.id));

--- a/server/services/consilium/review-factory.ts
+++ b/server/services/consilium/review-factory.ts
@@ -68,7 +68,7 @@ import { basename, join } from "path";
 import simpleGit from "simple-git";
 import type { IStorage } from "../../storage.js";
 import type { InsertConsiliumLoop, ConsiliumLoopRow, Skill, AppliedSkillRef } from "@shared/schema";
-import type { ConsiliumReviewPreset } from "@shared/types";
+import type { ConsiliumReviewPreset, TriggerProvenance } from "@shared/types";
 import type { TaskOrchestrator, CreateTaskParam } from "../task-orchestrator.js";
 import type { ConsiliumLoopController } from "./consilium-loop-controller.js";
 import type { AppConfig } from "../../config/schema.js";
@@ -1143,6 +1143,13 @@ export interface CreateConsiliumReviewParams {
    * (full back-compat). SECURITY: only ever passed to git as an arg-array element.
    */
   ref?: string | null;
+  /**
+   * T1 trigger retarget (loop-triggers.md §6): OPTIONAL provenance of the trigger
+   * that fired this loop — `{ triggerId, triggerType, eventDigest, firedAt }`.
+   * Persisted INERT on the loop's `trigger_provenance` for the launch passport;
+   * never enters a prompt/shell. Absent (human/API launch) ⇒ column stays null.
+   */
+  triggerProvenance?: TriggerProvenance;
 }
 
 /** Clamp a caller-supplied round count into the schema's 1..6 window. */
@@ -1304,6 +1311,9 @@ export async function createConsiliumReview(
     engineerInstruction: params.engineerInstruction ?? null,
     // Stage 2: provenance of the applied (+ any dropped) skills; null ⇒ no skills.
     appliedSkills,
+    // T1 trigger retarget (§6): which trigger + event fired this loop (null ⇒ a
+    // human/API launch). INERT audit data for the launch passport.
+    triggerProvenance: params.triggerProvenance ?? null,
     createdBy: params.createdBy,
   } as InsertConsiliumLoop);
 

--- a/server/services/consilium/trigger-dispatch.ts
+++ b/server/services/consilium/trigger-dispatch.ts
@@ -35,6 +35,19 @@
  *       for the same (projectId, resolved repoPath). This guard is TRIGGER-PATH
  *       ONLY — the explicit UI endpoint (POST /api/consilium-reviews) is
  *       human-initiated and intentionally NOT deduped this way.
+ *
+ *       BOUND (T1, accepted): the dedup is a read-then-create check, not a
+ *       transaction/lock, so two TRULY-CONCURRENT fires for the same
+ *       (project, repoPath) that interleave between `getLoops()` and
+ *       `createReview()` can both pass — creating AT MOST 2 active loops (each
+ *       review-only, `maxRounds=1`), never a storm. It is not made race-safe by a
+ *       partial unique index on non-terminal loops per (project, repoPath) BECAUSE
+ *       that would ALSO block the human UI endpoint (intentionally un-deduped) from
+ *       re-reviewing a repo with a review already in flight. The sequential burst
+ *       vector (many spec writes to ONE watched repo, processed serially by the
+ *       debounced watcher) IS caught. Making the concurrent case airtight —
+ *       trigger-path-only advisory lock keyed on repoPath, or the §4 budget/debounce
+ *       rails — is deferred to T1-full (loop-triggers.md §4.2–4.3).
  *   T6. (FIX MED-2 — autonomous coder from fs events) The trigger path FORCES
  *       maxRounds=1 (review-only) regardless of `action.maxRounds`, so an
  *       unattended file-system event can NEVER reach DEVELOPING / the SDLC coder.
@@ -56,17 +69,77 @@
  *     is a CONFIG discipline, accepted as documented.
  */
 import { existsSync, realpathSync } from "fs";
+import { createHash } from "crypto";
 import { dirname, join } from "path";
 import {
   CONSILIUM_LOOP_TERMINAL_STATES,
   type TriggerRow,
   type ConsiliumLoopRow,
 } from "@shared/schema";
-import type { FileChangeTriggerConfig } from "@shared/types";
+import type {
+  ConsiliumReviewTriggerAction,
+  TriggerProvenance,
+} from "@shared/types";
 import type {
   CreateConsiliumReviewDeps,
   CreateConsiliumReviewParams,
 } from "./review-factory.js";
+
+/**
+ * A trigger's loop-template config, narrowed to the two fields the dispatch reads.
+ * Both file_change (has `watchPath`) and schedule (has neither, so `repoPath` on the
+ * action is required) carry an optional `action`. Kept structural (not a specific
+ * config type) so the seam stays type-agnostic across trigger classes.
+ */
+type LoopTemplateConfig = { watchPath?: string; action?: ConsiliumReviewTriggerAction } | null;
+
+/** The literal token operators may embed in an engineerInstruction (§2). */
+const EVENT_TOKEN = "${event}";
+
+/**
+ * A short, human description of the firing event, folded into the review objective
+ * (via engineerInstruction ${event} interpolation OR objectiveExtra). UNTRUSTED
+ * (it embeds fs paths / payload strings) → the factory control-strips + clamps +
+ * fences it, so it is safe to compose here. Never a shell/branch/PR sink.
+ */
+export function describeEvent(trigger: TriggerRow, payload: unknown): string {
+  const filePath = payloadString(payload, "filePath");
+  if (filePath) return `file change at ${filePath}`;
+  const scheduledAt = payloadString(payload, "scheduledAt");
+  if (scheduledAt) return `scheduled run at ${scheduledAt}`;
+  const event = payloadString(payload, "event");
+  if (event) return `${trigger.type} event: ${event}`;
+  return `${trigger.type} trigger fired`;
+}
+
+/**
+ * A stable, short hex digest of the firing payload for provenance (§6). Enough to
+ * correlate a loop to its event without persisting the (untrusted) payload verbatim.
+ * A non-serialisable payload degrades to a digest of the string form.
+ */
+export function eventDigest(payload: unknown): string {
+  let material: string;
+  try {
+    material = JSON.stringify(payload ?? null) ?? String(payload);
+  } catch {
+    material = String(payload);
+  }
+  return createHash("sha256").update(material).digest("hex").slice(0, 16);
+}
+
+/**
+ * Interpolate the `${event}` token in an operator instruction with the event
+ * description. Returns undefined when there is no instruction (so the caller falls
+ * back to objectiveExtra). Split/join replaces EVERY occurrence without invoking
+ * regex-replacement's `$`-pattern semantics on the (untrusted) description.
+ */
+export function interpolateEvent(
+  instruction: string | undefined,
+  eventDescription: string,
+): string | undefined {
+  if (instruction === undefined || instruction.length === 0) return undefined;
+  return instruction.split(EVENT_TOKEN).join(eventDescription);
+}
 
 /** A loop in one of these states never ticks again → does NOT block a new fire. */
 const TERMINAL_LOOP_STATES: ReadonlySet<string> = new Set(CONSILIUM_LOOP_TERMINAL_STATES);
@@ -166,7 +239,7 @@ export async function maybeLaunchConsiliumReview(
   trigger: TriggerRow,
   payload: unknown,
 ): Promise<ConsiliumDispatchResult> {
-  const config = trigger.config as Partial<FileChangeTriggerConfig> | null;
+  const config = trigger.config as LoopTemplateConfig;
   const action = config?.action;
   if (action?.kind !== "consilium_review") return "noop";
 
@@ -189,9 +262,26 @@ export async function maybeLaunchConsiliumReview(
     return "skipped";
   }
 
-  // T1: the UNTRUSTED changed-file path → objectiveExtra only (clamped in factory).
-  const changedFile = payloadString(payload, "filePath");
-  const objectiveExtra = changedFile ? `Trigger: file change at ${changedFile}` : undefined;
+  // T1: the UNTRUSTED event description (embeds fs paths / payload strings) →
+  // fed to the factory ONLY through its sanitized objective seam (control-strip +
+  // byte-clamp + fence). Two mutually-exclusive sinks, in precedence order:
+  //   1. If the operator wrote an engineerInstruction, INTERPOLATE `${event}` into
+  //      it and pass it as `engineerInstruction` (persisted inert + feeds objective).
+  //   2. Otherwise pass the bare description as `objectiveExtra` (legacy file_change
+  //      behavior). The factory prefers engineerInstruction when BOTH are set, so we
+  //      only ever populate one to keep the objective deterministic.
+  const eventDescription = describeEvent(trigger, payload);
+  const engineerInstruction = interpolateEvent(action.engineerInstruction, eventDescription);
+  const objectiveExtra = engineerInstruction ? undefined : eventDescription;
+
+  // §6 provenance: which trigger + event fired the loop (short payload digest, not
+  // the untrusted payload verbatim). Persisted inert for the launch passport.
+  const provenance: TriggerProvenance = {
+    triggerId: trigger.id,
+    triggerType: trigger.type,
+    eventDigest: eventDigest(payload),
+    firedAt: new Date().toISOString(),
+  };
 
   // T5: dedup key — match against the CANONICAL path the factory persists.
   const resolvedRepo = canonicalRepoPath(repoPath);
@@ -236,12 +326,18 @@ export async function maybeLaunchConsiliumReview(
         preset: action.preset,
         // FK FIX: real `users.id` (project owner), NOT the literal "system".
         createdBy,
-        // T6 (FIX MED-2): FORCE review-only on the trigger path. An autonomous
-        // file-event-driven run must NEVER reach DEVELOPING / the SDLC coder, so
-        // we IGNORE `action.maxRounds` here (server-side, not config-trusted).
-        // Multi-round (1..6) reviews are reachable ONLY via the human UI endpoint.
+        // T6 (FIX MED-2): FORCE review-only on EVERY trigger path (file_change AND
+        // schedule). An unattended, automatically-fired run must NEVER reach
+        // DEVELOPING / the SDLC coder, so we IGNORE `action.maxRounds` here
+        // (server-side, not config-trusted). Multi-round (1..6) is reachable ONLY
+        // via the human UI endpoint. The operator's chosen maxRounds is persisted on
+        // the template for a future (T-full) attended path but is inert today.
         maxRounds: 1,
+        // T1: exactly one of these is set (engineerInstruction wins in the factory).
+        engineerInstruction,
         objectiveExtra,
+        // §6: record which trigger + event started the loop.
+        triggerProvenance: provenance,
       });
     });
 

--- a/server/services/trigger-service.ts
+++ b/server/services/trigger-service.ts
@@ -42,6 +42,7 @@ export class TriggerService {
       hasSecret: row.secretEncrypted !== null && row.secretEncrypted !== undefined,
       enabled: row.enabled,
       lastTriggeredAt: row.lastTriggeredAt ?? null,
+      suppressedCount: row.suppressedCount ?? 0,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
     };
@@ -60,6 +61,12 @@ export class TriggerService {
     return rows.map((r) => this.toPublic(r));
   }
 
+  /** T1: all triggers in the current project ALS (pipeline-based AND pipeline-less). */
+  async getProjectTriggers(): Promise<PipelineTrigger[]> {
+    const rows = await this.storage.getProjectTriggers();
+    return rows.map((r) => this.toPublic(r));
+  }
+
   async getTrigger(id: string): Promise<PipelineTrigger | null> {
     const row = await this.storage.getTrigger(id);
     return row ? this.toPublic(row) : null;
@@ -68,7 +75,8 @@ export class TriggerService {
   async createTrigger(data: InsertTrigger): Promise<PipelineTrigger> {
     const secretEncrypted = data.secret ? this.crypto.encrypt(data.secret) : undefined;
     const row = await this.storage.createTrigger({
-      pipelineId: data.pipelineId,
+      // T1: nullable — a loop-template trigger carries no pipeline.
+      pipelineId: data.pipelineId ?? null,
       type: data.type,
       config: data.config,
       secretEncrypted: secretEncrypted ?? null,

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -1301,6 +1301,12 @@ export class PgStorage implements IStorage {
     return db.select().from(triggers).where(withProject(triggers, eq(triggers.pipelineId, pipelineId))).orderBy(triggers.createdAt);
   }
 
+  async getProjectTriggers(): Promise<TriggerRow[]> {
+    // T1: project-scoped list (the ALS project filter only) so pipeline-less,
+    // loop-template triggers are returned alongside any legacy pipeline triggers.
+    return db.select().from(triggers).where(withProject(triggers)).orderBy(triggers.createdAt);
+  }
+
   async getTrigger(id: string): Promise<TriggerRow | undefined> {
     const [row] = await db.select().from(triggers).where(withProject(triggers, eq(triggers.id, id)));
     return row;
@@ -1328,12 +1334,13 @@ export class PgStorage implements IStorage {
   }
 
   async createTrigger(
-    data: Omit<TriggerRow, "id" | "projectId" | "createdAt" | "updatedAt" | "lastTriggeredAt"> & { secretEncrypted?: string | null },
+    data: Omit<TriggerRow, "id" | "projectId" | "createdAt" | "updatedAt" | "lastTriggeredAt" | "suppressedCount"> & { secretEncrypted?: string | null },
   ): Promise<TriggerRow> {
     const [row] = await db
       .insert(triggers)
       .values(withProjectInsert(triggers, {
-        pipelineId: data.pipelineId,
+        // T1: nullable — a loop-template trigger carries no pipeline.
+        pipelineId: data.pipelineId ?? null,
         type: data.type as TriggerRow["type"],
         config: data.config,
         secretEncrypted: data.secretEncrypted ?? null,
@@ -1355,6 +1362,22 @@ export class PgStorage implements IStorage {
 
   async deleteTrigger(id: string): Promise<void> {
     await db.delete(triggers).where(withProject(triggers, eq(triggers.id, id)));
+  }
+
+  /**
+   * T1 policy rail: atomically bump the suppressed-fire counter. Called from
+   * `fireTrigger` (background/system context) when a fire is suppressed by dedup.
+   * The `+ 1` is computed in SQL (no read-modify-write race). Scoped like every
+   * other trigger write; in the system context `withProject` applies no filter.
+   */
+  async incrementTriggerSuppressed(id: string): Promise<void> {
+    await db
+      .update(triggers)
+      .set({
+        suppressedCount: drizzleSql`${triggers.suppressedCount} + 1`,
+        updatedAt: new Date(),
+      })
+      .where(withProject(triggers, eq(triggers.id, id)));
   }
 
   // ─── Traces (Phase 6.5) ────────────────────────────────────────────────────

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -368,14 +368,18 @@ export interface IStorage {
 
   // Triggers (Phase 6.3)
   getTriggers(pipelineId: string): Promise<TriggerRow[]>;
+  /** T1: all triggers in the current project ALS (pipeline-based AND pipeline-less). */
+  getProjectTriggers(): Promise<TriggerRow[]>;
   getTrigger(id: string): Promise<TriggerRow | undefined>;
   getEnabledTriggersByType(type: string): Promise<TriggerRow[]>;
   /** Cross-project query for system/background use: returns ALL enabled triggers of this type
    *  across every project. Must be called within runAsSystem(). See ADR-001 §3.1(d). */
   getAllEnabledTriggersByType(type: string): Promise<TriggerRow[]>;
-  createTrigger(data: Omit<TriggerRow, 'id' | 'projectId' | 'createdAt' | 'updatedAt' | 'lastTriggeredAt'> & { secretEncrypted?: string | null }): Promise<TriggerRow>;
+  createTrigger(data: Omit<TriggerRow, 'id' | 'projectId' | 'createdAt' | 'updatedAt' | 'lastTriggeredAt' | 'suppressedCount'> & { secretEncrypted?: string | null }): Promise<TriggerRow>;
   updateTrigger(id: string, updates: Partial<TriggerRow>): Promise<TriggerRow>;
   deleteTrigger(id: string): Promise<void>;
+  /** T1 policy rail: atomically bump a trigger's suppressed-fire counter (dedup/budget). */
+  incrementTriggerSuppressed(id: string): Promise<void>;
 
   // Practice Cards (Active Knowledge Base)
   createPracticeCard(data: InsertPracticeCard): Promise<PracticeCardRow>;
@@ -1709,6 +1713,7 @@ export class MemStorage implements IStorage {
       engineerInstruction: data.engineerInstruction ?? null,
       // Stage 2: applied-skill provenance (nullable jsonb).
       appliedSkills: data.appliedSkills ?? null,
+      triggerProvenance: data.triggerProvenance ?? null,
       archetype: data.archetype ?? null,
       archetypeSource: data.archetypeSource ?? null,
       archetypeRationale: data.archetypeRationale ?? null,
@@ -1896,6 +1901,11 @@ export class MemStorage implements IStorage {
     return Array.from(this.triggersMap.values()).filter((t) => t.pipelineId === pipelineId);
   }
 
+  async getProjectTriggers(): Promise<TriggerRow[]> {
+    // MemStorage has no project isolation — return all triggers.
+    return Array.from(this.triggersMap.values());
+  }
+
   async getTrigger(id: string): Promise<TriggerRow | undefined> {
     return this.triggersMap.get(id);
   }
@@ -1911,19 +1921,20 @@ export class MemStorage implements IStorage {
   }
 
   async createTrigger(
-    data: Omit<TriggerRow, 'id' | 'projectId' | 'createdAt' | 'updatedAt' | 'lastTriggeredAt'> & { secretEncrypted?: string | null },
+    data: Omit<TriggerRow, 'id' | 'projectId' | 'createdAt' | 'updatedAt' | 'lastTriggeredAt' | 'suppressedCount'> & { secretEncrypted?: string | null },
   ): Promise<TriggerRow> {
     const id = randomUUID();
     const now = new Date();
     const row: TriggerRow = {
       id,
       projectId: null, // MemStorage has no project context; projectId is null in-memory
-      pipelineId: data.pipelineId,
+      pipelineId: data.pipelineId ?? null, // T1: loop-template triggers carry no pipeline
       type: data.type as TriggerRow["type"],
       config: (data.config ?? {}) as TriggerRow["config"],
       secretEncrypted: data.secretEncrypted ?? null,
       enabled: data.enabled ?? true,
       lastTriggeredAt: null,
+      suppressedCount: 0,
       createdAt: now,
       updatedAt: now,
     };
@@ -1941,6 +1952,16 @@ export class MemStorage implements IStorage {
 
   async deleteTrigger(id: string): Promise<void> {
     this.triggersMap.delete(id);
+  }
+
+  async incrementTriggerSuppressed(id: string): Promise<void> {
+    const existing = this.triggersMap.get(id);
+    if (!existing) return;
+    this.triggersMap.set(id, {
+      ...existing,
+      suppressedCount: (existing.suppressedCount ?? 0) + 1,
+      updatedAt: new Date(),
+    });
   }
 
   // ─── Traces (Phase 6.5) ───────────────────────────────────────────────────

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -17,7 +17,7 @@ import {
 import { vector } from "drizzle-orm/pg-core/columns/vector_extension/vector";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
-import type { TriggerConfig, TriggerType, ManagerConfig, ManagerDecision, TraceSpan, SwarmCloneResult, SwarmMerger, SwarmSplitter, SkillVersionConfig, TaskTraceSpan, TrackerProvider, ActionPoint, Archetype, ArchetypeSource, ResearchReport, ExecutionTrace } from "./types.js";
+import type { TriggerConfig, TriggerType, TriggerProvenance, ManagerConfig, ManagerDecision, TraceSpan, SwarmCloneResult, SwarmMerger, SwarmSplitter, SkillVersionConfig, TaskTraceSpan, TrackerProvider, ActionPoint, Archetype, ArchetypeSource, ResearchReport, ExecutionTrace } from "./types.js";
 
 // ─── RBAC ────────────────────────────────────────────
 
@@ -643,14 +643,19 @@ export const triggers = pgTable(
       .default(sql`gen_random_uuid()`),
     // Denormalized from pipelines.projectId for direct query scoping: ADR-001 PR-0c §3.1(e)
     projectId: text("project_id").references(() => projects.id, { onDelete: "cascade" }),
+    // T1 RETARGET (loop-triggers.md): a trigger fires a CONSILIUM LOOP, not a
+    // (deleted) pipeline run. `pipeline_id` is now NULLABLE — new project-scoped
+    // triggers carry no pipeline. Kept (nullable FK) for pre-existing rows.
     pipelineId: varchar("pipeline_id")
-      .notNull()
       .references(() => pipelines.id, { onDelete: "cascade" }),
     type: text("type").notNull().$type<TriggerType>(),
     config: jsonb("config").notNull().default(sql`'{}'::jsonb`).$type<TriggerConfig>(),
     secretEncrypted: text("secret_encrypted"),
     enabled: boolean("enabled").notNull().default(true),
     lastTriggeredAt: timestamp("last_triggered_at"),
+    // T1 policy rail: monotonically-incremented count of fires suppressed by a
+    // policy (dedup today; budget/debounce later). Surfaced on the triggers page.
+    suppressedCount: integer("suppressed_count").notNull().default(0),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
   },
@@ -668,6 +673,7 @@ export const insertTriggerSchema = createInsertSchema(triggers).omit({
   updatedAt: true,
   lastTriggeredAt: true,
   secretEncrypted: true,
+  suppressedCount: true,
 });
 
 export type TriggerRow = typeof triggers.$inferSelect;
@@ -2028,6 +2034,12 @@ export const consiliumLoops = pgTable(
     // `dropped: true` entry was resolved but dropped WHOLE to fit the byte budget
     // (never truncated mid-skill). INERT in storage — display/audit only.
     appliedSkills: jsonb("applied_skills").$type<AppliedSkillRef[]>(),
+    // T1 (loop-triggers.md §6, migration 0042): provenance of the TRIGGER that
+    // fired this loop — `{ triggerId, triggerType, eventDigest, firedAt }`. Null ⇒
+    // a human/API-initiated loop (no trigger). DEDICATED column (not archetype_params,
+    // which the planner's partial updates own — same reasoning as applied_skills).
+    // INERT display/audit data for the launch passport; never a prompt/shell sink.
+    triggerProvenance: jsonb("trigger_provenance").$type<TriggerProvenance>(),
     // Stage 1 (0032): intent→archetype planner output / human override. All
     // nullable; written by a PLAIN partial update (NOT casLoopState) so persisting
     // an archetype on a terminal loop never transitions it.

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1321,7 +1321,15 @@ export interface WebhookTriggerConfig {
 export interface ScheduleTriggerConfig {
   cron: string;      // standard 5-field cron expression, e.g. "0 9 * * 1"
   timezone?: string; // IANA timezone string, defaults to "UTC"
-  input?: string;    // optional pipeline input override for this scheduled run
+  input?: string;    // legacy free-text input (unused by the loop-template retarget)
+  /**
+   * T1 RETARGET (loop-triggers.md §2): a schedule trigger's firing creates a
+   * CONSILIUM LOOP via the same factory the UI/API use — NOT a (deleted) pipeline
+   * run. The loop template is REQUIRED for a schedule trigger to do anything on
+   * fire; `repoPath` is REQUIRED here (there is no watchPath to derive it from) and
+   * is RE-VALIDATED against the fail-closed allowlist inside the factory.
+   */
+  action?: ConsiliumReviewTriggerAction;
 }
 
 export interface GitHubEventTriggerConfig {
@@ -1369,8 +1377,37 @@ export interface ConsiliumReviewTriggerAction {
   kind: "consilium_review";
   preset: ConsiliumReviewPreset;
   maxRounds?: number;
-  /** Target repo; defaults to the watchPath's repo root when omitted. */
+  /**
+   * Target repo (MUST resolve inside the project's allowlisted workspaces).
+   * Defaults to the watchPath's repo root for file_change when omitted; REQUIRED
+   * for schedule (no watchPath to derive from). Re-validated INSIDE the factory.
+   */
   repoPath?: string;
+  /**
+   * T1 (loop-triggers.md §2): OPTIONAL operator "engineer instruction" free-text
+   * steering the review objective. May contain the literal token `${event}`, which
+   * the runtime interpolates with a short, human description of the firing event
+   * (e.g. "file change at <path>" / "scheduled run at <iso>"). UNTRUSTED — the
+   * factory control-strips + byte-clamps + fences it (same seam as the human UI
+   * endpoint's engineerInstruction) before it enters any prompt. Never a shell/
+   * branch/PR sink.
+   */
+  engineerInstruction?: string;
+}
+
+/**
+ * T1 (loop-triggers.md §2, hard-rail §6): provenance recorded on EVERY
+ * trigger-fired consilium loop so the launch passport (#457) can show which
+ * trigger + which event started it. Persisted INERT as jsonb on the loop
+ * (`consilium_loops.trigger_provenance`); display/audit only, never a prompt or
+ * shell sink. `eventDigest` is a short hex hash of the firing payload — enough to
+ * correlate a loop to the event without storing the (untrusted) payload verbatim.
+ */
+export interface TriggerProvenance {
+  triggerId: string;
+  triggerType: TriggerType;
+  eventDigest: string;
+  firedAt: string; // ISO-8601
 }
 
 export type TriggerConfig =
@@ -1382,7 +1419,10 @@ export type TriggerConfig =
 // Public-facing Trigger shape returned from API (no secretEncrypted)
 export interface PipelineTrigger {
   id: string;
-  pipelineId: string;
+  // T1 RETARGET: a trigger now targets a CONSILIUM LOOP (loop template in config),
+  // not a pipeline. `pipelineId` is legacy/nullable — new project-scoped triggers
+  // carry no pipeline. Kept on the shape for back-compat with pre-existing rows.
+  pipelineId: string | null;
   type: TriggerType;
   config: TriggerConfig;
   // webhookUrl is synthesized by the server for webhook and github_event triggers
@@ -1391,12 +1431,16 @@ export interface PipelineTrigger {
   hasSecret: boolean;
   enabled: boolean;
   lastTriggeredAt: Date | null;
+  // T1 policy rail: count of fires suppressed by a policy (dedup/budget). Surfaced
+  // on the triggers page so silence is diagnosable (loop-triggers.md §6).
+  suppressedCount: number;
   createdAt: Date;
   updatedAt: Date;
 }
 
 export interface InsertTrigger {
-  pipelineId: string;
+  // Legacy/nullable — new loop-template triggers are project-scoped, no pipeline.
+  pipelineId?: string | null;
   type: TriggerType;
   config: TriggerConfig;
   // plaintext secret supplied at creation/update — immediately encrypted, never stored raw

--- a/tests/unit/consilium/trigger-dispatch.test.ts
+++ b/tests/unit/consilium/trigger-dispatch.test.ts
@@ -19,6 +19,9 @@ import {
   maybeLaunchConsiliumReview,
   deriveRepoRoot,
   payloadString,
+  describeEvent,
+  eventDigest,
+  interpolateEvent,
   type ConsiliumTriggerDispatchDeps,
 } from "../../../server/services/consilium/trigger-dispatch.js";
 
@@ -31,7 +34,8 @@ function makeTrigger(
   return {
     id: "trig-1",
     projectId: "proj-1",
-    pipelineId: "pipe-1",
+    pipelineId: null, // T1: loop-template triggers carry no pipeline
+    type: "file_change",
     config,
     ...over,
   } as unknown as TriggerRow;
@@ -154,11 +158,15 @@ describe("maybeLaunchConsiliumReview", () => {
     expect(createReview.mock.calls[0][1].repoPath).toBe("/nonexistent/repo/specs");
   });
 
-  it("launches with NO objectiveExtra when the payload has no filePath", async () => {
+  it("carries a fallback event description as objectiveExtra when the payload has no filePath", async () => {
     const { deps, createReview } = makeDeps();
     const trigger = makeTrigger({ watchPath: "/allowed/omnius", patterns: ["**/*.md"], action: CONSILIUM_ACTION });
     await maybeLaunchConsiliumReview(deps, trigger, {});
-    expect(createReview.mock.calls[0][1].objectiveExtra).toBeUndefined();
+    // T1: every trigger fire now composes SOME event context (sanitized in the
+    // factory). With no filePath/scheduledAt the file_change fallback is used.
+    expect(createReview.mock.calls[0][1].objectiveExtra).toBe("file_change trigger fired");
+    // No operator instruction ⇒ engineerInstruction stays undefined (objectiveExtra wins).
+    expect(createReview.mock.calls[0][1].engineerInstruction).toBeUndefined();
   });
 
   it("subsystem disabled (reviewDeps null) → skipped, factory NOT called", async () => {
@@ -257,5 +265,102 @@ describe("maybeLaunchConsiliumReview", () => {
     await maybeLaunchConsiliumReview(deps, trigger, {});
     // ...but the dispatch clamps it to review-only so an fs event never reaches the coder.
     expect(createReview.mock.calls[0][1].maxRounds).toBe(1);
+  });
+
+  // ─── T1: SCHEDULE triggers fire loops (retarget off pipelines) ───────────────
+
+  it("a SCHEDULE trigger with a loop template launches a loop via the SAME factory", async () => {
+    const { deps, createReview, runInProject } = makeDeps();
+    const action: ConsiliumReviewTriggerAction = {
+      kind: "consilium_review",
+      preset: "full-viability",
+      repoPath: "/allowed/omnius",
+    };
+    const trigger = makeTrigger(
+      { cron: "0 9 * * *", action },
+      { type: "schedule" as TriggerRow["type"] },
+    );
+
+    const result = await maybeLaunchConsiliumReview(deps, trigger, {
+      scheduledAt: "2026-07-03T09:00:00.000Z",
+    });
+
+    expect(result).toBe("launched");
+    expect(runInProject).toHaveBeenCalledWith("proj-1", expect.any(Function));
+    const [, params] = createReview.mock.calls[0];
+    expect(params.repoPath).toBe("/allowed/omnius");
+    expect(params.preset).toBe("full-viability");
+    expect(params.maxRounds).toBe(1); // review-only enforced for automated fires
+    // The schedule event description rides the sanitized objective seam.
+    expect(params.objectiveExtra).toBe("scheduled run at 2026-07-03T09:00:00.000Z");
+  });
+
+  // ─── §6: provenance — every trigger-fired loop records its trigger + event ────
+
+  it("passes trigger provenance (id, type, event digest, firedAt) to the factory", async () => {
+    const { deps, createReview } = makeDeps();
+    const trigger = makeTrigger({ watchPath: "/allowed/omnius", patterns: ["**/*.md"], action: CONSILIUM_ACTION });
+    await maybeLaunchConsiliumReview(deps, trigger, { filePath: "/allowed/omnius/x.md", watchPath: "/allowed/omnius" });
+
+    const prov = createReview.mock.calls[0][1].triggerProvenance;
+    expect(prov.triggerId).toBe("trig-1");
+    expect(prov.triggerType).toBe("file_change");
+    expect(prov.eventDigest).toMatch(/^[0-9a-f]{16}$/);
+    expect(typeof prov.firedAt).toBe("string");
+    expect(Number.isNaN(Date.parse(prov.firedAt))).toBe(false);
+  });
+
+  // ─── T1: engineerInstruction with ${event} interpolation ─────────────────────
+
+  it("interpolates ${event} in the operator instruction and passes it as engineerInstruction", async () => {
+    const { deps, createReview } = makeDeps();
+    const action: ConsiliumReviewTriggerAction = {
+      kind: "consilium_review",
+      preset: "sdlc-cross-review",
+      repoPath: "/allowed/omnius",
+      engineerInstruction: "Review the change: ${event}",
+    };
+    const trigger = makeTrigger({ watchPath: "/allowed/omnius/specs", patterns: ["**/*.md"], action });
+
+    await maybeLaunchConsiliumReview(deps, trigger, {
+      filePath: "/allowed/omnius/specs/00-overview.md",
+      watchPath: "/allowed/omnius/specs",
+    });
+
+    const [, params] = createReview.mock.calls[0];
+    expect(params.engineerInstruction).toBe(
+      "Review the change: file change at /allowed/omnius/specs/00-overview.md",
+    );
+    // engineerInstruction wins in the factory ⇒ objectiveExtra is NOT also set.
+    expect(params.objectiveExtra).toBeUndefined();
+  });
+});
+
+// ─── Event helpers (pure) ──────────────────────────────────────────────────────
+
+describe("describeEvent / eventDigest / interpolateEvent", () => {
+  it("describeEvent prefers filePath, then scheduledAt, then event kind, then a fallback", () => {
+    const t = makeTrigger({}, { type: "file_change" as TriggerRow["type"] });
+    expect(describeEvent(t, { filePath: "/a/b.md" })).toBe("file change at /a/b.md");
+    expect(describeEvent(t, { scheduledAt: "2026-07-03T09:00:00Z" })).toBe("scheduled run at 2026-07-03T09:00:00Z");
+    expect(describeEvent(t, { event: "pull_request" })).toBe("file_change event: pull_request");
+    expect(describeEvent(t, {})).toBe("file_change trigger fired");
+  });
+
+  it("eventDigest is a stable 16-hex-char hash of the payload", () => {
+    const a = eventDigest({ filePath: "/a/b.md" });
+    const b = eventDigest({ filePath: "/a/b.md" });
+    const c = eventDigest({ filePath: "/a/c.md" });
+    expect(a).toMatch(/^[0-9a-f]{16}$/);
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+  });
+
+  it("interpolateEvent replaces every ${event}; returns undefined for an empty instruction", () => {
+    expect(interpolateEvent("x ${event} y ${event}", "E")).toBe("x E y E");
+    expect(interpolateEvent(undefined, "E")).toBeUndefined();
+    expect(interpolateEvent("", "E")).toBeUndefined();
+    // No regex `$`-pattern semantics leak from the (untrusted) description.
+    expect(interpolateEvent("see ${event}", "$1 & $&")).toBe("see $1 & $&");
   });
 });

--- a/tests/unit/triggers-ui.test.ts
+++ b/tests/unit/triggers-ui.test.ts
@@ -12,6 +12,12 @@ import type {
   GitHubEventTriggerConfig,
   FileChangeTriggerConfig,
 } from "@shared/types";
+import {
+  isTriggerFormValid,
+  canAddTrigger,
+  buildLoopTemplate,
+  loopTargetSummary,
+} from "../../client/src/components/triggers/trigger-form-logic";
 
 // ─── Helpers duplicated from TriggerCard / TriggerForm ──────────────────────
 // (keeping them in test scope avoids re-exporting implementation details)
@@ -62,10 +68,11 @@ function generateSecret(): string {
 function buildTrigger(overrides: Partial<PipelineTrigger> & { type: TriggerType }): PipelineTrigger {
   return {
     id: "t-001",
-    pipelineId: "p-001",
+    pipelineId: null,
     hasSecret: false,
     enabled: true,
     lastTriggeredAt: null,
+    suppressedCount: 0,
     createdAt: new Date("2026-01-01"),
     updatedAt: new Date("2026-01-01"),
     config: {},
@@ -201,47 +208,110 @@ describe("TriggerCard display helpers", () => {
   });
 });
 
-// ─── TriggerForm validation logic ────────────────────────────────────────────
+// ─── TriggerForm validation logic (T1 retarget — no pipeline requirement) ─────
 
-describe("TriggerForm validation", () => {
-  function isValid(
-    type: TriggerType,
-    pipelineId: string,
-    cron: string,
-    ghRepo: string,
-    ghEvents: string[],
-    watchPath: string,
-  ): boolean {
-    if (!pipelineId) return false;
-    if (type === "schedule") return cron.trim().length > 0;
-    if (type === "github_event") return ghRepo.trim().length > 0 && ghEvents.length > 0;
-    if (type === "file_change") return watchPath.trim().length > 0;
-    return true;
-  }
+describe("isTriggerFormValid", () => {
+  const base = { cron: "", ghRepo: "", ghEvents: [] as string[], watchPath: "", preset: "sdlc-cross-review", repoPath: "" };
 
-  it("webhook type is always valid when pipelineId present", () => {
-    expect(isValid("webhook", "p-001", "", "", [], "")).toBe(true);
+  it("webhook is always valid (no pipeline requirement anymore)", () => {
+    expect(isTriggerFormValid({ ...base, type: "webhook" })).toBe(true);
   });
 
-  it("webhook type is invalid without pipelineId", () => {
-    expect(isValid("webhook", "", "", "", [], "")).toBe(false);
+  it("schedule requires cron AND a preset AND a repoPath (no watchPath to derive from)", () => {
+    expect(isTriggerFormValid({ ...base, type: "schedule", cron: "0 9 * * *", repoPath: "/allowed/omnius" })).toBe(true);
+    expect(isTriggerFormValid({ ...base, type: "schedule", cron: "0 9 * * *", repoPath: "" })).toBe(false); // no repo
+    expect(isTriggerFormValid({ ...base, type: "schedule", cron: "", repoPath: "/allowed/omnius" })).toBe(false); // no cron
+    expect(isTriggerFormValid({ ...base, type: "schedule", cron: "0 9 * * *", repoPath: "/x", preset: "" })).toBe(false); // no preset
   });
 
-  it("schedule type requires non-empty cron", () => {
-    expect(isValid("schedule", "p-001", "0 9 * * *", "", [], "")).toBe(true);
-    expect(isValid("schedule", "p-001", "", "", [], "")).toBe(false);
-    expect(isValid("schedule", "p-001", "   ", "", [], "")).toBe(false);
+  it("file_change requires watchPath AND a preset; repoPath is optional (derived)", () => {
+    expect(isTriggerFormValid({ ...base, type: "file_change", watchPath: "/workspace" })).toBe(true);
+    expect(isTriggerFormValid({ ...base, type: "file_change", watchPath: "" })).toBe(false);
+    expect(isTriggerFormValid({ ...base, type: "file_change", watchPath: "   " })).toBe(false);
   });
 
   it("github_event requires repository and at least one event", () => {
-    expect(isValid("github_event", "p-001", "", "owner/repo", ["push"], "")).toBe(true);
-    expect(isValid("github_event", "p-001", "", "", ["push"], "")).toBe(false);
-    expect(isValid("github_event", "p-001", "", "owner/repo", [], "")).toBe(false);
+    expect(isTriggerFormValid({ ...base, type: "github_event", ghRepo: "owner/repo", ghEvents: ["push"] })).toBe(true);
+    expect(isTriggerFormValid({ ...base, type: "github_event", ghRepo: "", ghEvents: ["push"] })).toBe(false);
+    expect(isTriggerFormValid({ ...base, type: "github_event", ghRepo: "owner/repo", ghEvents: [] })).toBe(false);
+  });
+});
+
+// ─── Add-Trigger button enablement (operator-reported bug) ───────────────────
+
+describe("canAddTrigger", () => {
+  it("enables with at least one workspace and a configured subsystem", () => {
+    expect(canAddTrigger(1, false)).toBe(true);
+    expect(canAddTrigger(3, false)).toBe(true);
   });
 
-  it("file_change requires watchPath", () => {
-    expect(isValid("file_change", "p-001", "", "", [], "/workspace")).toBe(true);
-    expect(isValid("file_change", "p-001", "", "", [], "")).toBe(false);
-    expect(isValid("file_change", "p-001", "", "", [], "   ")).toBe(false);
+  it("stays disabled with zero workspaces (the fix — no longer gated on pipelines)", () => {
+    expect(canAddTrigger(0, false)).toBe(false);
+  });
+
+  it("stays disabled when the subsystem is not configured, regardless of workspaces", () => {
+    expect(canAddTrigger(5, true)).toBe(false);
+  });
+});
+
+// ─── Loop-template construction ──────────────────────────────────────────────
+
+describe("buildLoopTemplate", () => {
+  it("builds a consilium_review action with only the set fields", () => {
+    const action = buildLoopTemplate({
+      preset: "diff-pr-review",
+      repoPath: "  /allowed/omnius  ",
+      engineerInstruction: "  Review ${event}  ",
+      maxRounds: "3",
+    });
+    expect(action).toEqual({
+      kind: "consilium_review",
+      preset: "diff-pr-review",
+      repoPath: "/allowed/omnius",
+      engineerInstruction: "Review ${event}",
+      maxRounds: 3,
+    });
+  });
+
+  it("omits empty repoPath / instruction and out-of-range rounds", () => {
+    const action = buildLoopTemplate({
+      preset: "sdlc-cross-review",
+      repoPath: "",
+      engineerInstruction: "   ",
+      maxRounds: "99",
+    });
+    expect(action).toEqual({ kind: "consilium_review", preset: "sdlc-cross-review" });
+  });
+});
+
+// ─── Loop-target summary (trigger card) ──────────────────────────────────────
+
+describe("loopTargetSummary", () => {
+  it("summarizes preset → repo basename for a loop-template trigger", () => {
+    const trigger = buildTrigger({
+      type: "schedule",
+      config: {
+        cron: "0 9 * * *",
+        action: { kind: "consilium_review", preset: "full-viability", repoPath: "/allowed/omnius" },
+      } as ScheduleTriggerConfig,
+    });
+    expect(loopTargetSummary(trigger)).toBe("full-viability → omnius");
+  });
+
+  it("returns just the preset when no repoPath is set", () => {
+    const trigger = buildTrigger({
+      type: "file_change",
+      config: {
+        watchPath: "/w",
+        patterns: ["**/*.md"],
+        action: { kind: "consilium_review", preset: "sdlc-cross-review" },
+      } as FileChangeTriggerConfig,
+    });
+    expect(loopTargetSummary(trigger)).toBe("sdlc-cross-review");
+  });
+
+  it("returns null for a trigger with no loop template (webhook)", () => {
+    const trigger = buildTrigger({ type: "webhook", config: {} });
+    expect(loopTargetSummary(trigger)).toBeNull();
   });
 });


### PR DESCRIPTION
## Why

The trigger subsystem was **pipeline-shaped**: `triggers.pipeline_id` was a `NOT NULL` FK to the `pipelines` entity, trigger creation required a pipeline, and `TriggersPage` gated the **"Add Trigger"** button on `pipelines.length > 0`. The pipeline entity left the product surface — there are **zero pipelines** — so the button was **permanently disabled** and no trigger could be created (operator-reported). Per `docs/design/loop-triggers.md` (#458), a trigger firing must now create a **consilium loop**, not a pipeline run.

Implements the **Stage T1 minimum**, kill-switched.

## The pipeline → loop retarget

- **Decoupled triggers from pipelines.** `triggers.pipeline_id` is now **nullable**; triggers are **project-scoped**. New project-scoped `POST /api/triggers` (the UI create hook already targeted `/api/triggers`, which had no POST route — so create was doubly broken). `GET /api/triggers` now returns the **project's** triggers instead of fanning out over the (empty) pipeline list.
- **Loop template** replaces pipeline selection in the form + config: `{ preset (sdlc-cross-review | diff-pr-review | full-viability), repoPath (from the project's allowlisted workspaces), engineerInstruction (optional, `${event}` interpolation), maxRounds }`.
- Firing goes through the **same factory** the UI/API use (`createConsiliumReview` / the `POST /api/consilium-reviews` path) — never a pipeline run.

## What fires loops now vs deferred

| Trigger type | T1 behavior |
|---|---|
| **file_change** | Fires a loop (the existing "one live binding" — verified/kept). |
| **schedule** (cron) | **Now fires a loop** (new), gated by the `features.triggers.enabled` kill-switch. |
| **webhook** / **github_event** | Persist inert. Loop mapping + the HMAC HTTP receiver are **deferred to T1-full** (design §3.1); the form shows a "receiver coming" note. |

## Policy rails (design §4)

- **Dedup (real):** before launching, the trigger path skips (`skipped-dedup`, factory **not** called) if a non-terminal loop already exists for the same `(project, repoPath)` — a burst of spec writes can't fan out into unbounded heavy-model disputes. The suppressed fire increments `triggers.suppressed_count` (surfaced on the page).
- **Per-trigger `enabled`** gate (runtimes only bootstrap enabled triggers).
- **Forced review-only** (`maxRounds=1`) for every automated fire — an unattended event can never reach DEVELOPING / the SDLC coder.
- Budget / debounce / cascade remain stubs with TODOs referencing the design.

## Kill-switch

`features.triggers.enabled` (env `TRIGGERS_ENABLED`), **default false**. A scheduled fire records `lastTriggeredAt` but launches **no** loop until explicitly enabled — a running server never silently starts firing loops. The pre-existing `file_change` binding stays under `pipeline.consiliumLoop.enabled` (unchanged).

## Provenance

New `consilium_loops.trigger_provenance` jsonb records `{ triggerId, triggerType, eventDigest, firedAt }`, threaded through the factory, so the launch passport (#457) can show which trigger + event started a loop. Null ⇒ human/API launch (unchanged).

## Migration 0042 (additive, idempotent)

- `triggers.pipeline_id` → `DROP NOT NULL` (FK kept; existing rows unaffected).
- `triggers.suppressed_count INT NOT NULL DEFAULT 0`.
- `consilium_loops.trigger_provenance JSONB` (dedicated column, not `archetype_params`, to avoid the planner's partial-update clobber — same reasoning as 0041).

## Adversarial self-review (independent security pass)

**No CRITICAL/HIGH.** Verified: (1) trigger-storm guardrails hold — schedule kill-switch off by default, dedup, per-trigger enabled, forced review-only; (2) **allowlist escape closed** — `repoPath` is re-validated at fire time against the global fail-closed allowlist **and** the project's own workspaces inside the factory (the create route only shape-checks); (3) **authz sound** — `requireProject` (membership) + project-scoped `getTrigger` (fail-closed) mean no cross-project read/mutate even with nullable pipelineId; (4) **untrusted input** (event payload + `${event}`) reaches only the factory's control-strip + byte-clamp + fence seam (`interpolateEvent` uses split/join, no regex `$`-pattern semantics), never a shell/branch/PR/SQL sink; (5) migration safe/idempotent.

Findings, all handled or documented: **MED-1** dedup TOCTOU — bounded to **at most 2** concurrent loops (never a storm), sequential burst vector already caught; a partial unique index would wrongly also block the intentionally-un-deduped human UI path, so the concurrent-case hardening (advisory lock / budget rails) is documented and deferred to T1-full. LOW: kill-switch covers schedule only (file_change stays under `consiliumLoop.enabled`, documented); project-RBAC replaces the legacy per-pipeline-owner check (consistent with other project-scoped resources).

## Test evidence

- `npx tsc` — clean.
- Targeted unit tests **51 passing** (`tests/unit/consilium/trigger-dispatch.test.ts` + `tests/unit/triggers-ui.test.ts`): trigger creates a loop (factory mocked), **schedule** fires a loop, dedup suppresses a duplicate, disabled trigger doesn't fire, provenance passed to the factory, `${event}` interpolation, button enables with ≥1 workspace, loop-template validation/build.
- Full unit suite **4781/4782** (the one failure is the pre-existing `costs-routes` ordering flake — unrelated to this diff, passes in isolation). Consilium suite **429/429**. `require-project-middleware` integration **38/38**. The `pull_request` CI run is authoritative.

## Files changed

`shared/types.ts`, `shared/schema.ts`, `migrations/0042_triggers_target_loops.sql`, `server/config/{schema,loader}.ts`, `server/services/consilium/{trigger-dispatch,review-factory}.ts`, `server/services/trigger-service.ts`, `server/routes/triggers.ts`, `server/routes.ts`, `server/storage.ts`, `server/storage-pg.ts`, `client/src/pages/TriggersPage.tsx`, `client/src/components/triggers/{TriggerForm,TriggerCard,trigger-form-logic}.tsx?`, tests.

**Do not merge** — Draft for review.