### PR TITLE
fix: Statistics drag/resize and per-workspace attribution

### DIFF
--- a/client/src/pages/Statistics.tsx
+++ b/client/src/pages/Statistics.tsx
@@ -695,6 +695,21 @@ const ResponsiveGridLayout = WidthProvider(Responsive);
 const BREAKPOINTS = { lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 };
 const COLS = { lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 };
 
+// Scoped interaction CSS for the RGL grid. The pure data/config (draggableHandle,
+// isDraggable/isResizable, controlled `layouts`, persistence) is correct in
+// isolation; what an SSR/jsdom harness cannot exercise is real pointer-gesture
+// arbitration. The grid lives inside an `overflow-y-auto` scroll container, so on
+// touch / pen / precision-pointer devices the browser's default `touch-action`
+// lets that scroll container claim a gesture that STARTS on a drag/resize handle
+// (pan) before RGL's DraggableCore/Resizable can act — the widget then "can't be
+// moved or resized". `touch-action: none` on the two handle selectors hands those
+// gestures to RGL instead. The z-index keeps the SE resize corner hit-target above
+// any widget body content (tables/charts) that paints into the same corner.
+const DASHBOARD_GRID_CSS = `
+.stats-dashboard-grid .widget-drag-handle { touch-action: none; }
+.stats-dashboard-grid .react-resizable-handle { touch-action: none; z-index: 3; }
+`;
+
 export default function Statistics() {
   const { data: overview, isLoading: overviewLoading } = useQuery<StatsOverview>({
     queryKey: ["stats-overview"],
@@ -726,6 +741,7 @@ export default function Statistics() {
       </div>
 
       <div className="flex-1 overflow-y-auto p-6">
+        <style>{DASHBOARD_GRID_CSS}</style>
         <ResponsiveGridLayout
           className="stats-dashboard-grid"
           layouts={layouts}

--- a/server/services/task-orchestrator.ts
+++ b/server/services/task-orchestrator.ts
@@ -1,7 +1,7 @@
 import type { IStorage } from "../storage";
 import type { WsManager } from "../ws/manager";
 import type { PipelineController } from "../controller/pipeline-controller";
-import type { Gateway } from "../gateway/index";
+import type { Gateway, GatewayLoggingOptions } from "../gateway/index";
 import type {
   TaskGroupRow,
   TaskRow,
@@ -707,9 +707,18 @@ export class TaskOrchestrator {
     // fix (judge timeout resilience): the judge's largest-context call can hit
     // the wall-clock cap and return 0 tokens; completeDirectLlm adds an optional
     // single bounded retry (default OFF ⇒ byte-identical to the single call above).
-    const { response, retry } = await this.completeDirectLlm(request, {
-      overallTimeoutMs: taskTimeoutMs,
-    });
+    // Source-side workspace attribution (BUG 2 fix): stamp the consilium task-group
+    // id onto llm_requests.run_id. The read side (getLlmStatsByWorkspace) resolves
+    // run_id -> consilium_loops.groupId -> repoPath -> workspace. Before this, the
+    // direct_llm path passed no logging options, so run_id was NULL on every row and
+    // the Per-Workspace Breakdown panel was always empty (all "Unattributed").
+    // Only runId is stamped: workspaceId here would additionally trigger the gateway
+    // budget pre-check + cost-ledger write, which this path intentionally does not do.
+    const { response, retry } = await this.completeDirectLlm(
+      request,
+      { overallTimeoutMs: taskTimeoutMs },
+      { runId: group.id },
+    );
 
     this.tracing.completeLlmSpan(group.id, llmSpanId, {
       response,
@@ -741,12 +750,13 @@ export class TaskOrchestrator {
   private async completeDirectLlm(
     request: GatewayRequest,
     streamOptions: StreamingStageOptions,
+    loggingOptions?: GatewayLoggingOptions,
   ): Promise<{ response: GatewayResponse; retry: RetryNote | null }> {
     const cfg = configLoader.get().pipeline.consiliumLoop.judgeRetry;
 
     let cause: RetryNote["cause"];
     try {
-      const response = await this.gateway.completeStreaming(request, undefined, undefined, streamOptions);
+      const response = await this.gateway.completeStreaming(request, undefined, loggingOptions, streamOptions);
       // Disabled OR a non-empty completion ⇒ today's behaviour, no retry.
       if (!cfg.enabled || !isEmptyCompletion(response)) return { response, retry: null };
       cause = "empty output";
@@ -759,7 +769,7 @@ export class TaskOrchestrator {
     // ── single bounded retry (enabled AND timeout/empty only) ──
     const retriedModel = cfg.fallbackModel ?? request.modelSlug;
     const retryRequest: GatewayRequest = { ...request, modelSlug: retriedModel };
-    const response = await this.gateway.completeStreaming(retryRequest, undefined, undefined, streamOptions);
+    const response = await this.gateway.completeStreaming(retryRequest, undefined, loggingOptions, streamOptions);
     return {
       response,
       retry: { cause, fallbackModel: cfg.fallbackModel ?? null, retriedModel },

--- a/tests/unit/dashboard-layout.test.ts
+++ b/tests/unit/dashboard-layout.test.ts
@@ -136,4 +136,76 @@ describe("dashboard-layout persistence", () => {
     // Subsequent load also yields the default (storage was cleared).
     expect(loadLayout()).toEqual(DEFAULT_LAYOUT);
   });
+
+  // ── Operator acceptance scenario ──────────────────────────────────────────────
+  // "Shrink the Timeline widget (w:12 → w:6), move it to the left column, reload →
+  //  it stays." This is the persistence contract the acceptance test exercises: the
+  //  layout react-grid-layout emits from onLayoutChange is saved verbatim, and a
+  //  reload (loadLayout) must return Timeline at exactly the resized + moved
+  //  geometry — never snapping back to the default full-width top position.
+  describe("operator acceptance: shrink + move Timeline, reload keeps it", () => {
+    // The exact `allLayouts` react-grid-layout hands to saveLayout after the
+    // operator shrinks Timeline to w:6 and drags it to x:0 in the left column,
+    // with by-model pulled up beside it at x:6 — proving two widgets sit side by
+    // side (only possible because Timeline is now half width).
+    const movedLg = [
+      { i: "totals", x: 0, y: 0, w: 12, h: 3, minW: 4, minH: 2 },
+      { i: "timeline", x: 0, y: 3, w: 6, h: 7, minW: 4, minH: 4 },
+      { i: "by-model", x: 6, y: 3, w: 6, h: 7, minW: 4, minH: 3 },
+      { i: "by-workspace", x: 0, y: 10, w: 12, h: 7, minW: 4, minH: 3 },
+      { i: "request-log", x: 0, y: 17, w: 12, h: 10, minW: 5, minH: 5 },
+    ];
+
+    it("persists the shrunk + moved Timeline across a reload (lg breakpoint)", () => {
+      saveLayout({ lg: movedLg });
+
+      const timeline = loadLayout().lg!.find((i) => i.i === "timeline")!;
+      expect(timeline).toBeDefined();
+      // Shrunk to half width and moved into the left column — and it stays.
+      expect(timeline.w).toBe(6);
+      expect(timeline.x).toBe(0);
+      expect(timeline.y).toBe(3);
+      expect(timeline.h).toBe(7);
+      // The shrink limits survive too, so the widget can be re-shrunk after reload.
+      expect(timeline.minW).toBe(4);
+      expect(timeline.minH).toBe(4);
+    });
+
+    it("keeps a second widget beside the shrunk Timeline (side-by-side layout survives)", () => {
+      saveLayout({ lg: movedLg });
+
+      const loaded = loadLayout().lg!;
+      const timeline = loaded.find((i) => i.i === "timeline")!;
+      const byModel = loaded.find((i) => i.i === "by-model")!;
+      // by-model occupies the right half on the same row → they render side by side.
+      expect(timeline.x).toBe(0);
+      expect(byModel.x).toBe(6);
+      expect(byModel.y).toBe(timeline.y);
+      expect(timeline.w + byModel.w).toBe(12);
+    });
+
+    it("persists the shrunk + moved Timeline at a NON-lg breakpoint (md)", () => {
+      // When the dashboard is viewed below 1200px, react-grid-layout emits the
+      // moved layout under the CURRENT breakpoint key (md) alongside lg. reconcile
+      // must preserve the md geometry too — there is no breakpoint-key mismatch
+      // between what RGL emits (md) and what loadLayout reconciles.
+      const movedMd = [
+        { i: "totals", x: 0, y: 0, w: 10, h: 3, minW: 4, minH: 2 },
+        { i: "timeline", x: 0, y: 3, w: 6, h: 7, minW: 4, minH: 4 },
+        { i: "by-model", x: 0, y: 10, w: 10, h: 7, minW: 4, minH: 3 },
+        { i: "by-workspace", x: 0, y: 17, w: 10, h: 7, minW: 4, minH: 3 },
+        { i: "request-log", x: 0, y: 24, w: 10, h: 10, minW: 5, minH: 5 },
+      ];
+      saveLayout({ lg: DEFAULT_LAYOUT.lg!, md: movedMd });
+
+      const reloaded = loadLayout();
+      // The md breakpoint the operator actually interacted with is preserved…
+      const mdTimeline = reloaded.md!.find((i) => i.i === "timeline")!;
+      expect(mdTimeline.w).toBe(6);
+      expect(mdTimeline.x).toBe(0);
+      // …and lg is left untouched (still full-width default).
+      const lgTimeline = reloaded.lg!.find((i) => i.i === "timeline")!;
+      expect(lgTimeline.w).toBe(12);
+    });
+  });
 });

--- a/tests/unit/task-orchestrator-workspace-attribution.test.ts
+++ b/tests/unit/task-orchestrator-workspace-attribution.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Write-side regression for BUG 2 (Per-Workspace Breakdown panel always empty).
+ *
+ * ROOT CAUSE: the consilium `direct_llm` path in TaskOrchestrator called
+ * `gateway.completeStreaming(request, undefined, undefined, streamOptions)` — the
+ * THIRD argument (loggingOptions) was `undefined`, so the gateway logged every
+ * llm_requests row with run_id = NULL. The read side
+ * (getLlmStatsByWorkspace) resolves run_id -> consilium_loops.groupId ->
+ * repoPath -> workspace, so a NULL run_id can NEVER attribute: 100% of real
+ * usage fell into the "Unattributed" bucket and the panel looked empty.
+ *
+ * The existing read-side suite (stats-by-workspace.test.ts) always inserts rows
+ * with `runId: group.id` MANUALLY — it encodes the very assumption the write side
+ * violated, so it could not catch this bug. These tests close that gap by driving
+ * the REAL orchestrator direct_llm path and asserting the gateway is handed
+ * `loggingOptions.runId === group.id`, then proving the full write->read loop
+ * attributes the request to its workspace (NOT Unattributed), counted exactly once.
+ *
+ * Harness mirrors task-orchestrator-judge-retry.test.ts (real startGroup over
+ * MemStorage + a programmable gateway double), extended to capture the
+ * loggingOptions argument and to persist a row like the real gateway would.
+ */
+import { describe, it, expect } from "vitest";
+import { MemStorage } from "../../server/storage.js";
+import { TaskOrchestrator } from "../../server/services/task-orchestrator.js";
+import type { WsManager } from "../../server/ws/manager.js";
+import type { PipelineController } from "../../server/controller/pipeline-controller.js";
+import type { Gateway } from "../../server/gateway/index.js";
+import type { GatewayRequest, GatewayResponse } from "../../shared/types.js";
+import type { InsertLlmRequest } from "../../shared/schema.js";
+
+const VALID_JSON = JSON.stringify({
+  summary: "verdict",
+  output: { verdict: "ship it" },
+  decisions: ["converged"],
+});
+
+/** One recorded physical gateway call: the request + the loggingOptions handed in. */
+interface RecordedCall {
+  request: GatewayRequest;
+  loggingOptions: { runId?: string; workspaceId?: string; teamId?: string } | undefined;
+}
+
+/**
+ * A gateway double that (1) records the loggingOptions of every physical
+ * completeStreaming call and (2) — when `storage` is provided — persists an
+ * llm_requests row EXACTLY as the real gateway.logRequest does: `runId` taken
+ * from the loggingOptions it was handed (`?? null`). This makes the double a
+ * faithful stand-in for the write side so the read side can be exercised.
+ */
+function makeGateway(storage?: MemStorage): { gateway: Gateway; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const completeStreaming = async (
+    request: GatewayRequest,
+    _privacy?: unknown,
+    loggingOptions?: { runId?: string; workspaceId?: string; teamId?: string },
+    _stream?: unknown,
+  ): Promise<GatewayResponse> => {
+    calls.push({ request, loggingOptions });
+    if (storage) {
+      const row: InsertLlmRequest = {
+        runId: loggingOptions?.runId ?? null, // <- the exact field this bug is about
+        stageExecutionId: null,
+        modelSlug: request.modelSlug,
+        provider: "anthropic",
+        messages: [],
+        systemPrompt: null,
+        temperature: null,
+        maxTokens: null,
+        responseContent: VALID_JSON,
+        inputTokens: 100,
+        outputTokens: 40,
+        totalTokens: 140,
+        latencyMs: 10,
+        estimatedCostUsd: 0.02,
+        status: "success",
+        errorMessage: null,
+        teamId: loggingOptions?.teamId ?? null,
+        tags: [],
+      } as InsertLlmRequest;
+      await storage.createLlmRequest(row);
+    }
+    return { content: VALID_JSON, tokensUsed: 140, modelSlug: request.modelSlug, finishReason: "stop" };
+  };
+  const gateway = { complete: completeStreaming, completeStreaming } as unknown as Gateway;
+  return { gateway, calls };
+}
+
+function makeOrchestrator(gateway: Gateway, storage: MemStorage): TaskOrchestrator {
+  const wsManager = { broadcastToRun: () => {} } as unknown as WsManager;
+  const pipelineController = {} as unknown as PipelineController;
+  return new TaskOrchestrator(storage, wsManager, pipelineController, gateway);
+}
+
+/** One direct_llm task standing in for a consilium review/judge call. */
+async function runDirectLlmGroup(orchestrator: TaskOrchestrator, storage: MemStorage) {
+  const { group, tasks } = await orchestrator.createTaskGroup({
+    name: "review", description: "d", input: "review the change",
+    tasks: [{ name: "Reviewer", description: "review", executionMode: "direct_llm", modelSlug: "claude-3-5-sonnet" }],
+  });
+  const { iteration } = await orchestrator.startGroup(group.id);
+  const executions = await storage.getExecutionsByIteration(group.id, iteration.id);
+  const exec = executions.find((e) => e.taskId === tasks[0].id)!;
+  return { group, exec };
+}
+
+describe("TaskOrchestrator direct_llm — workspace attribution (BUG 2 write-side)", () => {
+  it("stamps loggingOptions.runId = group.id on the direct_llm gateway call (once)", async () => {
+    const storage = new MemStorage();
+    const { gateway, calls } = makeGateway();
+    const orchestrator = makeOrchestrator(gateway, storage);
+
+    const { group, exec } = await runDirectLlmGroup(orchestrator, storage);
+
+    expect(exec.status).toBe("completed");
+    // Exactly one physical call (retry is default-OFF) — no double stamp.
+    expect(calls).toHaveLength(1);
+    // The regression: the gateway MUST be handed runId = the task-group id, so the
+    // row it logs is attributable. Before the fix this was `undefined` -> run_id NULL.
+    expect(calls[0].loggingOptions?.runId).toBe(group.id);
+    expect(calls[0].loggingOptions?.runId).not.toBeUndefined();
+  });
+
+  it("end-to-end: the stamped request lands in its workspace bucket, not Unattributed", async () => {
+    const storage = new MemStorage();
+    const { gateway } = makeGateway(storage); // gateway persists the row like production does
+    const orchestrator = makeOrchestrator(gateway, storage);
+
+    // Workspace whose path the consilium loop points at.
+    const ws = await storage.createWorkspace({
+      name: "alpha", type: "local", path: "/repo/alpha", branch: "main",
+    });
+
+    const { group, exec } = await runDirectLlmGroup(orchestrator, storage);
+    expect(exec.status).toBe("completed");
+
+    // The consilium loop that ties this group's runId to the workspace path.
+    await storage.createLoop({ groupId: group.id, repoPath: "/repo/alpha", state: "converged" });
+
+    const stats = await storage.getLlmStatsByWorkspace();
+
+    // Attributed to alpha — NOT Unattributed — and counted exactly once.
+    expect(stats).toHaveLength(1);
+    expect(stats[0]).toMatchObject({
+      workspaceId: ws.id,
+      workspaceName: "alpha",
+      requests: 1,
+      inputTokens: 100,
+      outputTokens: 40,
+    });
+    expect(stats.some((s) => s.workspaceId === null)).toBe(false); // nothing unattributed
+    // Global single-count invariant.
+    expect(stats.reduce((n, s) => n + s.requests, 0)).toBe(1);
+  });
+
+  it("regression proof: WITHOUT the runId stamp the same row would be Unattributed", async () => {
+    // Guards the read-side semantics the bug depended on: a NULL run_id can never
+    // attribute. This is the state the panel was stuck in before the fix.
+    const storage = new MemStorage();
+    const ws = await storage.createWorkspace({ name: "alpha", type: "local", path: "/repo/alpha", branch: "main" });
+    const group = await storage.createTaskGroup({ name: "review", description: "d", input: "i" });
+    await storage.createLoop({ groupId: group.id, repoPath: "/repo/alpha", state: "converged" });
+
+    await storage.createLlmRequest({
+      runId: null, stageExecutionId: null, modelSlug: "claude-3-5-sonnet", provider: "anthropic",
+      messages: [], systemPrompt: null, temperature: null, maxTokens: null, responseContent: "",
+      inputTokens: 100, outputTokens: 40, totalTokens: 140, latencyMs: 10, estimatedCostUsd: 0.02,
+      status: "success", errorMessage: null, teamId: null, tags: [],
+    } as InsertLlmRequest);
+
+    const stats = await storage.getLlmStatsByWorkspace();
+    expect(stats).toHaveLength(1);
+    expect(stats[0].workspaceId).toBeNull();
+    expect(stats[0].workspaceName).toBe("Unattributed");
+    expect(stats.some((s) => s.workspaceId === ws.id)).toBe(false);
+  });
+});


### PR DESCRIPTION
Two operator-reported bugs on the Statistics page (now the home route `/`), fixed together.

## BUG 1 — drag & resize do not work

**Root cause.** The react-grid-layout data/config is correct in isolation. This was verified three ways against the *installed* RGL 2.2.3 (a functional-component rewrite, not the classic class-based lib):

- **Static SSR render** of the exact config produces the correct DOM — `.react-grid-item.react-draggable.react-resizable` positioned via inline transforms, with the `.react-resizable-handle-se` corner handle injected as a **sibling child of `.react-grid-item`** (so `WidgetShell`'s `overflow-hidden`, which clips only its own descendants, does not clip the handle).
- **React-19 jsdom interaction harness** with the exact nested `WidgetShell` DOM: mousedown on the deep header handle engages `DraggableCore` (`.react-draggable-dragging` applies) — proving `draggableHandle=".widget-drag-handle"` matches, `isDraggable`/`isResizable` are honored, and `react-draggable@4.7.0`/`react-resizable@3.2.0` (the RGL org's nodeRef builds) are React-19-safe (no `findDOMNode`).
- **CSS loads**: both `react-grid-layout/css/styles.css` (exports-mapped, `sideEffects:["*.css"]`) and `react-resizable/css/styles.css` resolve and carry full handle positioning; neither is tree-shaken.
- **Controlled `layouts` round-trips**: RGL's `Responsive` re-derives from `propsLayouts` only on deep-inequality and emits complete `allLayouts` (`{...layoutsRef.current, [breakpoint]: newLayout}`); the parent's `setLayouts` + `saveLayout` persists and the Reset button works.

The one failure class no SSR/node/jsdom oracle can exercise is **real pointer-gesture arbitration**. The grid lives inside an `overflow-y-auto` scroll container, so with the browser default `touch-action`, a touch/pen/precision-pointer gesture that *starts on a handle* can be claimed by the scroll container as a pan **before** RGL's `DraggableCore`/`Resizable` acts — experienced exactly as "widgets can't be moved or resized."

**Fix.** Scoped interaction CSS (prefixed `.stats-dashboard-grid`, cannot leak):

```css
.stats-dashboard-grid .widget-drag-handle    { touch-action: none; }
.stats-dashboard-grid .react-resizable-handle { touch-action: none; z-index: 3; }
```

`touch-action: none` hands drag (header) and resize (SE corner) gestures to RGL instead of the scroll container; `z-index: 3` keeps the resize corner's hit-target above widget body content that paints into the same corner. `dashboard-layout.ts` is unchanged (verified correct).

**Honest scope note.** The config was already correct; this is defensive hardening with a concrete mechanism, not a fix for a defect reproducible in the (vite-forbidden) test environment. If drag still fails in the live build after this, the residual cause is environmental and lives in the **app shell** (a higher-`z-index` overlay intercepting `pointer-events` over the grid, or a global `pointer-events`/`touch-action` rule) — outside this PR's stated lane (`Statistics.tsx` + its layout lib).

## BUG 2 — Per-Workspace Breakdown empty despite real usage

**Attribution linkage found.** `llm_requests` has no workspace/loop FK; the only usable key is `run_id`. The read side (`getLlmStatsByWorkspace`) already resolves `run_id -> consilium_loops.groupId -> repoPath -> workspaces.path` with a single-count fold and an Unattributed bucket — it was correct. But the consilium `direct_llm` choke point (`TaskOrchestrator.executeDirectLlm -> completeDirectLlm -> gateway.completeStreaming(request, undefined, **undefined**, streamOptions)`) passed no logging options, so `run_id` was **NULL on every row** and 100% of usage landed in "Unattributed" (matching the verified 93/93 NULL in the dev DB).

**Fix (source-stamp).** A read rewire was impossible (no other populated key). Stamp the task-group id onto `run_id` at the source — `completeDirectLlm` gains an optional `loggingOptions`, forwarded to **both** the initial and bounded-retry `completeStreaming` calls; `executeDirectLlm` passes `{ runId: group.id }`. Only `runId` is stamped (not `workspaceId`, which would newly trigger the gateway budget pre-check + cost-ledger write on this path). The Unattributed bucket is preserved for genuinely context-free calls. **No migration** — `run_id` already exists, it was just unpopulated.

## Tests & evidence

- New `tests/unit/task-orchestrator-workspace-attribution.test.ts` (write-side gap the read-side suite structurally could not catch): the orchestrator hands the gateway `loggingOptions.runId === group.id` **exactly once**; full write→read attributes the request to its workspace (not Unattributed), counted once; a `run_id = NULL` row proves the failure mode maps to Unattributed.
- Extended `tests/unit/dashboard-layout.test.ts` with the operator acceptance scenario: Timeline shrunk to `w:6` + moved to the left column persists across reload at **lg** and **md**, a neighbor stays side-by-side, `minW`/`minH` survive — alongside the retained unknown-key-drop / version-mismatch-reset / reset-clears-storage cases.
- `npm run check` (tsc): clean. Local: `dashboard-layout` + `task-orchestrator-workspace-attribution` + `stats-by-workspace` + `judge-retry` = **22/22**; integration `stats-api` = **16/16**. Full suite / CI (pull_request run authoritative) is the gate; known flakes: providers/antigravity, config-sync-multi-instance.

## Adversarial self-review
- **RGL fix vs reset/versioning:** `dashboard-layout.ts` untouched; body scroll and action buttons (siblings of / outside the handle) untouched; Reset-layout and version-bump/discard paths not regressed (covered by retained tests).
- **Attribution double-count / mis-bucket:** only `runId` stamped, exactly once per direct_llm call (asserted); read side single-count fold unchanged; NULL run_id still maps to Unattributed.

Files: `client/src/pages/Statistics.tsx`, `server/services/task-orchestrator.ts`, `tests/unit/dashboard-layout.test.ts`, `tests/unit/task-orchestrator-workspace-attribution.test.ts`.