### PR TITLE
fix: /api/pr-queue always 401 (missing auth mount)

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -150,6 +150,7 @@ export async function registerRoutes(
   app.use("/api/traces", requireAuth, requireProject);         // UNCERTAIN — see note above
   app.use("/api/task-groups", requireAuth, requireProject);
   app.use("/api/consilium-loops", requireAuth, requireProject);
+  app.use("/api/pr-queue", requireAuth, requireProject);
   app.use("/api/consilium-reviews", requireAuth, requireProject);
   app.use("/api/lmstudio", requireAuth, requireProject);       // UNCERTAIN — see note above
   app.use("/api/tracker-connections", requireAuth, requireProject);


### PR DESCRIPTION
The `/api/pr-queue` route (from #464) self-checks `req.user` but its path prefix had no `app.use(..., requireAuth, requireProject)` guard — so `req.user` was never populated and every request 401'd, making the PR Queue page non-functional. Added the mount next to `/api/consilium-loops`. One line.