### PR TITLE
feat: reconcile PR-queue with live GitHub PR status

### DIFF
--- a/client/src/hooks/use-pr-queue.ts
+++ b/client/src/hooks/use-pr-queue.ts
@@ -3,9 +3,12 @@
  * server route in server/routes/consilium-loops.ts).
  *
  * The endpoint returns a FLAT, newest-first list of PR-bearing consilium loops
- * (loops carrying a Draft PR in a state where it's awaiting review). The page
- * clusters it by repo with the pure `clusterPrQueue` helper (@shared/pr-queue) to
- * surface DUPLICATE runs — several open Draft PRs against the same repo.
+ * (loops carrying a Draft PR in a state where it's awaiting review), each reconciled
+ * server-side with its LIVE GitHub PR status (`githubStatus`: OPEN/DRAFT/MERGED/
+ * CLOSED/unknown — best-effort, "unknown" when GitHub is unreachable/unauthed). The
+ * page clusters it by repo with the pure `clusterPrQueue` helper (@shared/pr-queue)
+ * to surface DUPLICATE runs, and moves MERGED/CLOSED items to a collapsed "resolved"
+ * section (the loop state is stale relative to GitHub).
  *
  * Light 5s poll so a freshly-developed loop appears without a manual refresh — the
  * loop FSM advances server-side via the background poller, there is no WS channel.
@@ -22,6 +25,7 @@ import type { PrQueueItem } from "@shared/pr-queue";
 export type { PrQueueItem };
 export type {
   PrQueueCluster,
+  GithubPrStatus,
 } from "@shared/pr-queue";
 
 const PR_QUEUE_KEY = "/api/pr-queue";

--- a/client/src/pages/PrReviewQueue.tsx
+++ b/client/src/pages/PrReviewQueue.tsx
@@ -10,9 +10,13 @@
  * LOCAL UI state (a dismissed set in this component); it hides an item from the
  * current view only and resets on reload — no persistence, no schema change.
  *
- * STATE-BASED, NOT GITHUB-LIVE: the queue reflects each loop's FSM state, not a
- * live GitHub PR fetch — a PR merged/closed directly on GitHub can linger here
- * until the loop's state advances. A one-line note on the page says so.
+ * GITHUB-RECONCILED: each item carries a server-fetched `githubStatus`
+ * (OPEN/DRAFT/MERGED/CLOSED/unknown). Items whose PR is MERGED or CLOSED are moved
+ * out of the active list into a collapsed "Resolved on GitHub — loop state stale"
+ * section (de-emphasized, never hidden — a non-terminal loop over a done PR is itself
+ * worth surfacing). Within a duplicate cluster the live-OPEN PR is elected current
+ * over a newer merged/closed one. `githubStatus:"unknown"` (no auth / GitHub
+ * unreachable) is treated as ACTIVE — we only demote a PR we positively know is done.
  *
  * SECURITY: every loop-derived string (repoPath, prRef, verdictSummary,
  * triggerProvenance) is rendered as INERT React text; the PR link uses
@@ -23,14 +27,22 @@ import { useLocation } from "wouter";
 import { formatDistanceToNow } from "date-fns";
 import {
   GitPullRequest,
+  GitMerge,
   ExternalLink,
   Loader2,
   Layers,
   Check,
   RotateCcw,
+  ChevronRight,
 } from "lucide-react";
 import { usePrQueue } from "@/hooks/use-pr-queue";
-import { clusterPrQueue, type PrQueueItem, type PrQueueCluster } from "@shared/pr-queue";
+import {
+  clusterPrQueue,
+  isResolvedGithubStatus,
+  type PrQueueItem,
+  type PrQueueCluster,
+  type GithubPrStatus,
+} from "@shared/pr-queue";
 import { LoopStateBadge } from "@/components/consilium/loop-state";
 
 /** Last path segment of a repo path, for a compact heading. */
@@ -47,6 +59,51 @@ function whenLabel(ts: string | null | undefined): string {
   } catch {
     return "";
   }
+}
+
+/** Visual style per live GitHub PR status. `unknown`/undefined renders nothing. */
+const GITHUB_STATUS_STYLE: Record<GithubPrStatus, { label: string; className: string; title: string }> = {
+  OPEN: {
+    label: "GitHub: open",
+    className: "border-emerald-500/40 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+    title: "The PR is open on GitHub — loop state is consistent.",
+  },
+  DRAFT: {
+    label: "GitHub: draft",
+    className: "border-sky-500/40 bg-sky-500/10 text-sky-600 dark:text-sky-400",
+    title: "The PR is still a Draft on GitHub.",
+  },
+  MERGED: {
+    label: "GitHub: merged",
+    className: "border-violet-500/40 bg-violet-500/10 text-violet-600 dark:text-violet-400",
+    title: "The PR is already MERGED on GitHub — this loop's non-terminal state is stale.",
+  },
+  CLOSED: {
+    label: "GitHub: closed",
+    className: "border-rose-500/40 bg-rose-500/10 text-rose-600 dark:text-rose-400",
+    title: "The PR was CLOSED on GitHub without merging — this loop's state is stale.",
+  },
+  unknown: {
+    label: "GitHub: unknown",
+    className: "border-border bg-muted/40 text-muted-foreground",
+    title: "Live GitHub status could not be determined (no server-side auth or GitHub unreachable).",
+  },
+};
+
+/** Live GitHub PR status pill. Omitted entirely for a missing status (older wire). */
+function GithubStatusBadge({ status }: { status: GithubPrStatus | null | undefined }) {
+  if (!status) return null;
+  const s = GITHUB_STATUS_STYLE[status];
+  return (
+    <span
+      data-testid="pr-queue-github-status"
+      data-status={status}
+      className={`text-[11px] px-1.5 py-0.5 rounded border ${s.className}`}
+      title={s.title}
+    >
+      {s.label}
+    </span>
+  );
 }
 
 /** Compact "P1·1 P2·2" open-remainder summary; null when nothing is open. */
@@ -76,8 +133,9 @@ function PrCard({
       data-testid="pr-queue-card"
       className="rounded-md border bg-card px-3 py-2.5 space-y-2"
     >
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-3 flex-wrap">
         <LoopStateBadge state={item.state} />
+        <GithubStatusBadge status={item.githubStatus} />
 
         {/* Round n and archetype — quick disambiguators between same-repo runs. */}
         <span className="text-xs text-muted-foreground tabular-nums shrink-0">
@@ -161,13 +219,19 @@ function PrCard({
 function RepoCluster({
   cluster,
   onDismiss,
+  dimmed = false,
 }: {
   cluster: PrQueueCluster;
   onDismiss: (loopId: string) => void;
+  /** Resolved-on-GitHub section: de-emphasize the whole cluster (stale loop state). */
+  dimmed?: boolean;
 }) {
   const superseded = new Set(cluster.supersededLoopIds);
   return (
-    <section data-testid="pr-queue-cluster">
+    <section
+      data-testid="pr-queue-cluster"
+      className={dimmed ? "opacity-60" : undefined}
+    >
       <div className="flex items-baseline gap-2 mb-2 px-1">
         <h2 className="text-sm font-semibold truncate" title={cluster.repoPath}>
           {repoBasename(cluster.repoPath)}
@@ -209,7 +273,20 @@ export default function PrReviewQueue() {
 
   const items = (Array.isArray(data) ? data : []) as PrQueueItem[];
   const visible = items.filter((i) => !dismissed.has(i.loopId));
-  const clusters = useMemo(() => clusterPrQueue(visible), [visible]);
+
+  // Split on LIVE GitHub status: MERGED/CLOSED PRs are "resolved" — their loop is in a
+  // stale non-terminal state, so they leave the active list for a collapsed section.
+  // `unknown`/OPEN/DRAFT stay ACTIVE (we only demote a PR we positively know is done).
+  const { activeClusters, resolvedClusters, resolvedCount } = useMemo(() => {
+    const active = visible.filter((i) => !isResolvedGithubStatus(i.githubStatus));
+    const resolved = visible.filter((i) => isResolvedGithubStatus(i.githubStatus));
+    return {
+      activeClusters: clusterPrQueue(active),
+      resolvedClusters: clusterPrQueue(resolved),
+      resolvedCount: resolved.length,
+    };
+  }, [visible]);
+  const clusters = activeClusters;
   const duplicateCount = clusters.filter((c) => c.duplicate).length;
 
   function dismiss(loopId: string) {
@@ -251,10 +328,12 @@ export default function PrReviewQueue() {
       </header>
 
       <div className="flex-1 overflow-y-auto p-6">
-        {/* Honesty note: the queue reflects loop STATE, not live GitHub PR status. */}
+        {/* Honesty note: status is reconciled with GitHub, best-effort. */}
         <p className="text-[11px] text-muted-foreground/80 mb-4">
-          The queue reflects each loop&apos;s state, not live GitHub PR status. A PR
-          merged or closed directly on GitHub may linger here until its loop advances.
+          Each item is reconciled with its live GitHub PR status. Merged or closed PRs
+          move to the &ldquo;Resolved on GitHub&rdquo; section below (the loop state is
+          stale). When GitHub can&apos;t be reached the status reads
+          &ldquo;unknown&rdquo; and the item stays in the active list.
         </p>
 
         {isLoading && (
@@ -264,7 +343,7 @@ export default function PrReviewQueue() {
           </div>
         )}
 
-        {!isLoading && clusters.length === 0 && (
+        {!isLoading && clusters.length === 0 && resolvedCount === 0 && (
           <div className="rounded-lg border border-dashed border-border py-16 text-center">
             <GitPullRequest className="mx-auto h-8 w-8 text-muted-foreground/50" />
             <p className="mt-3 text-sm text-muted-foreground">No Draft PRs awaiting review</p>
@@ -280,6 +359,28 @@ export default function PrReviewQueue() {
               <RepoCluster key={cluster.repoPath} cluster={cluster} onDismiss={dismiss} />
             ))}
           </div>
+        )}
+
+        {/* Resolved on GitHub — merged/closed PRs whose loop is still non-terminal.
+            Collapsed by default, de-emphasized, but SURFACED (the stale state matters). */}
+        {!isLoading && resolvedCount > 0 && (
+          <details data-testid="pr-queue-resolved" className="mt-8 group">
+            <summary className="flex items-center gap-2 cursor-pointer select-none text-xs text-muted-foreground hover:text-foreground">
+              <ChevronRight className="h-3.5 w-3.5 transition-transform group-open:rotate-90" />
+              <GitMerge className="h-3.5 w-3.5" />
+              Already merged/closed on GitHub — loop state stale ({resolvedCount})
+            </summary>
+            <div className="mt-4 space-y-6">
+              {resolvedClusters.map((cluster) => (
+                <RepoCluster
+                  key={cluster.repoPath}
+                  cluster={cluster}
+                  onDismiss={dismiss}
+                  dimmed
+                />
+              ))}
+            </div>
+          </details>
         )}
       </div>
     </div>

--- a/server/routes/consilium-loops.ts
+++ b/server/routes/consilium-loops.ts
@@ -23,6 +23,7 @@ import { ARCHETYPES } from "@shared/types";
 import { CONSILIUM_LOOP_TERMINAL_STATES } from "@shared/schema";
 import { computeOpenRemainder } from "@shared/consilium-remainder";
 import { isPrBearingLoop, type PrQueueItem } from "@shared/pr-queue";
+import { githubStatusCache } from "../services/github-status.js";
 import type { AppConfig } from "../config/schema.js";
 import { requireRole } from "../auth/middleware.js";
 import { validateBody } from "../middleware/validate.js";
@@ -157,10 +158,14 @@ export function registerConsiliumLoopRoutes(
   // route's owner scoping, then enriches each PR-bearing loop with a compact
   // verdict summary + open-remainder read from that loop's LATEST round.
   //
-  // STATE-BASED, NOT GITHUB-LIVE: we do NOT fetch live GitHub PR status — the queue
-  // reflects loop FSM state (a PR merged/closed directly on GitHub can linger until
-  // the loop's state advances). `triggerProvenance` is unset (no trigger→loop link
-  // in the current schema); the field stays on the contract for forward-compat.
+  // GITHUB-RECONCILED (read-only): after building the state-based list, each item's
+  // `prRef` is reconciled against the LIVE GitHub PR (OPEN/DRAFT/MERGED/CLOSED) via a
+  // short-TTL cache over `gh` (server-side auth = GH_TOKEN/GITHUB_TOKEN, same path as
+  // pr-wrapper). This is BEST-EFFORT and BUDGETED: if GitHub is unreachable, rate-
+  // limited, unauthenticated, or slow, every item degrades to `githubStatus:"unknown"`
+  // and the route still returns promptly — GitHub can never take the queue down. No
+  // FSM transition happens here; MERGED/CLOSED merely SURFACE a stale loop state.
+  // `triggerProvenance` is unset (no trigger→loop link in the current schema).
   app.get("/api/pr-queue", async (req: Request, res: Response) => {
     if (!req.user?.id) return res.status(401).json({ error: "Authentication required" });
     const isAdmin = req.user.role === "admin";
@@ -207,6 +212,26 @@ export function registerConsiliumLoopRoutes(
     );
     // Newest first (createdAt desc). The client re-orders within clusters too.
     items.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+
+    // Reconcile with LIVE GitHub PR status — best-effort, hard-budgeted. The cache
+    // dedups by prRef (60s TTL) so N poll cycles + duplicate refs collapse to one
+    // `gh` call per ref. We race the whole batch against a wall-clock budget: if
+    // GitHub stalls past it, items keep `githubStatus:"unknown"` and we ship anyway.
+    // Any throw degrades identically — the route never fails on GitHub.
+    try {
+      const statuses = await withBudget(
+        githubStatusCache.getMany(items.map((i) => i.prRef)),
+        PR_QUEUE_GITHUB_BUDGET_MS,
+      );
+      if (statuses) {
+        for (const item of items) item.githubStatus = statuses.get(item.prRef) ?? "unknown";
+      } else {
+        for (const item of items) item.githubStatus = "unknown"; // budget elapsed.
+      }
+    } catch {
+      for (const item of items) item.githubStatus = "unknown";
+    }
+
     res.json(items);
   });
 
@@ -373,6 +398,35 @@ export function registerConsiliumLoopRoutes(
     const loop = await controller.cancel(auth.loop.id, { reason, actor });
     if (!loop) return res.status(409).json({ error: "loop is already terminal" });
     res.json(loop);
+  });
+}
+
+/**
+ * Wall-clock budget for the whole live-GitHub reconciliation of a /api/pr-queue
+ * response. Past it we ship the state-based list with `githubStatus:"unknown"` — the
+ * queue must never block on GitHub being reachable/fast (per-`gh`-call timeout is a
+ * separate, longer bound; this caps the batch as seen by the request).
+ */
+const PR_QUEUE_GITHUB_BUDGET_MS = 8_000;
+
+/**
+ * Resolve `p` within `ms`, or `null` if the budget elapses first (the pending work
+ * still settles in the background — its result lands in the cache for the next poll).
+ * Never rejects: a rejection of `p` also resolves to `null` so the caller degrades.
+ */
+function withBudget<T>(p: Promise<T>, ms: number): Promise<T | null> {
+  return new Promise<T | null>((resolve) => {
+    const timer = setTimeout(() => resolve(null), ms);
+    p.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      () => {
+        clearTimeout(timer);
+        resolve(null);
+      },
+    );
   });
 }
 

--- a/server/services/github-status.ts
+++ b/server/services/github-status.ts
@@ -1,0 +1,225 @@
+/**
+ * github-status.ts — LIVE GitHub PR status for the PR REVIEW QUEUE.
+ *
+ * The queue's `prRef` is written by `pr-wrapper.ts` (a real GitHub Draft-PR URL).
+ * That module already establishes the ONE GitHub auth path in this server: the
+ * local `gh` CLI, run under a SANITIZED env that keeps only the intended token var
+ * (`GH_TOKEN`/`GITHUB_TOKEN`) and strips every inherited `GH_*` so a poisoned
+ * ambient env cannot redirect `gh` to an attacker host and exfiltrate the token
+ * (pr-wrapper H-7b). This service reuses that exact discipline to READ a PR's state.
+ *
+ * Contract (never-throw, fail-open):
+ *   - `fetchPrStatus(prRef)` maps `gh pr view <url> --json state,isDraft` to a
+ *     {@link GithubPrStatus}. A ref that is not a recognizable GitHub PR URL, a
+ *     missing/unauthenticated `gh`, a timeout, a rate-limit, or a parse error ALL
+ *     degrade to `"unknown"`. It NEVER throws and NEVER blocks indefinitely.
+ *   - A short-TTL cache (default 60s) with in-flight de-duplication bounds GitHub
+ *     traffic: repeated polls and duplicate refs within a request collapse to ONE
+ *     `gh` call per ref per TTL window (defends N+1 + rate limits). The cache is
+ *     size-bounded (LRU-ish eviction of the oldest inserted entry) so it cannot grow
+ *     unbounded from many distinct refs.
+ *   - `getMany` fetches a set of refs with BOUNDED concurrency.
+ *
+ * SECURITY:
+ *   - No server-side GitHub auth is REQUIRED: without a token `gh` fails and we
+ *     return `"unknown"`. Live status simply needs `GH_TOKEN`/`GITHUB_TOKEN` (or a
+ *     `gh auth login` identity) present for the server process.
+ *   - The token is NEVER read, logged, or returned here — only handed to `gh` via
+ *     the sanitized env. Error strings are path-scrubbed before they surface.
+ *   - `prRef` is validated to the canonical `https://github.com/<o>/<r>/pull/<n>`
+ *     shape and RECONSTRUCTED from its captures before reaching `gh` — nothing
+ *     free-form (and nothing leading-dash) can be interpreted as a flag.
+ */
+import { execFile } from "child_process";
+import { promisify } from "util";
+import type { GithubPrStatus } from "@shared/pr-queue";
+
+/** Minimal `gh`-runner surface (unit tests inject a fake — no real `gh`/network). */
+export type ExecFileFn = (
+  file: string,
+  args: string[],
+  options?: { timeout?: number; env?: NodeJS.ProcessEnv },
+) => Promise<{ stdout: string; stderr: string }>;
+
+const execFileAsync: ExecFileFn = promisify(execFile);
+
+/** Canonical GitHub PR URL. Captures owner, repo, number; ignores any trailing bits. */
+const PR_URL_RE = /^https:\/\/github\.com\/([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)\/pull\/([0-9]+)(?:[/#?].*)?$/;
+
+/** The single token var this server intends to expose to `gh` (parity w/ pr-wrapper). */
+const KEEP_TOKEN_VARS = ["GH_TOKEN", "GITHUB_TOKEN"] as const;
+
+/** Per-`gh`-call wall-clock budget — the route must never hang on a slow GitHub. */
+const GH_TIMEOUT_MS = 15_000;
+
+/**
+ * Sanitized env (pr-wrapper H-7b parity): drop every inherited `GH_*`, then re-add
+ * only the intended token var(s). A poisoned ambient env can no longer redirect `gh`
+ * to an attacker host and leak the token.
+ */
+function sanitizedEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (k.startsWith("GH_")) continue;
+    env[k] = v;
+  }
+  for (const tokenVar of KEEP_TOKEN_VARS) {
+    if (process.env[tokenVar]) env[tokenVar] = process.env[tokenVar];
+  }
+  return env;
+}
+
+/** Reconstruct the canonical PR URL from a validated ref, or `null` if unrecognized. */
+export function canonicalPrUrl(prRef: string): string | null {
+  const m = PR_URL_RE.exec(prRef.trim());
+  if (!m) return null;
+  return `https://github.com/${m[1]}/${m[2]}/pull/${m[3]}`;
+}
+
+/** Map `gh`'s `{ state, isDraft }` to our status; anything unexpected → `"unknown"`. */
+function mapGhView(raw: unknown): GithubPrStatus {
+  if (!raw || typeof raw !== "object") return "unknown";
+  const { state, isDraft } = raw as { state?: unknown; isDraft?: unknown };
+  const s = typeof state === "string" ? state.toUpperCase() : "";
+  if (s === "MERGED") return "MERGED";
+  if (s === "CLOSED") return "CLOSED";
+  if (s === "OPEN") return isDraft === true ? "DRAFT" : "OPEN";
+  return "unknown";
+}
+
+/**
+ * Fetch LIVE status for one `prRef` (uncached). Never throws; every failure path
+ * (unrecognized ref, `gh` missing/unauth/timeout/rate-limit, bad JSON) → `"unknown"`.
+ */
+export async function fetchPrStatus(
+  prRef: string,
+  run: ExecFileFn = execFileAsync,
+): Promise<GithubPrStatus> {
+  const url = canonicalPrUrl(prRef);
+  if (!url) return "unknown"; // not a GitHub PR URL — nothing to reconcile.
+  try {
+    const { stdout } = await run(
+      "gh",
+      ["pr", "view", url, "--json", "state,isDraft"],
+      { timeout: GH_TIMEOUT_MS, env: sanitizedEnv() },
+    );
+    return mapGhView(JSON.parse(stdout || "null"));
+  } catch {
+    // gh absent / unauthenticated / rate-limited / timed out / non-JSON → fail open.
+    return "unknown";
+  }
+}
+
+// ─── TTL + in-flight-dedup + bounded cache ───────────────────────────────────────
+
+interface CacheEntry {
+  status: GithubPrStatus;
+  expiresAt: number;
+}
+
+export interface GithubStatusCache {
+  /** Cached live status for one ref (fetch on miss/expiry; dedup concurrent misses). */
+  get(prRef: string, run?: ExecFileFn): Promise<GithubPrStatus>;
+  /** Cached live status for many refs with bounded concurrency; unique refs only. */
+  getMany(prRefs: string[], run?: ExecFileFn): Promise<Map<string, GithubPrStatus>>;
+  clear(): void;
+  size(): number;
+}
+
+export interface GithubStatusCacheOptions {
+  /** Freshness window per ref. Default 60s — short enough to catch a merge quickly. */
+  ttlMs?: number;
+  /** Hard cap on resolved entries; oldest-inserted evicted past it. Default 1000. */
+  maxEntries?: number;
+  /** Max concurrent `gh` calls in `getMany`. Default 6 — bounds the burst. */
+  concurrency?: number;
+  /** Injectable clock (tests). Default `Date.now`. */
+  now?: () => number;
+}
+
+/**
+ * Build an isolated status cache. The route uses the module singleton
+ * {@link githubStatusCache}; tests construct their own instance so state never
+ * leaks between cases.
+ */
+export function createGithubStatusCache(
+  opts: GithubStatusCacheOptions = {},
+): GithubStatusCache {
+  const ttlMs = opts.ttlMs ?? 60_000;
+  const maxEntries = opts.maxEntries ?? 1000;
+  const concurrency = Math.max(1, opts.concurrency ?? 6);
+  const now = opts.now ?? Date.now;
+
+  const entries = new Map<string, CacheEntry>();
+  const inflight = new Map<string, Promise<GithubPrStatus>>();
+
+  /** Evict expired first, then oldest-inserted, until under the size cap. */
+  function evictIfNeeded(): void {
+    if (entries.size <= maxEntries) return;
+    const t = now();
+    for (const [k, e] of entries) {
+      if (e.expiresAt <= t) entries.delete(k);
+    }
+    while (entries.size > maxEntries) {
+      const oldest = entries.keys().next().value;
+      if (oldest === undefined) break;
+      entries.delete(oldest);
+    }
+  }
+
+  async function get(prRef: string, run?: ExecFileFn): Promise<GithubPrStatus> {
+    const t = now();
+    const hit = entries.get(prRef);
+    if (hit && hit.expiresAt > t) return hit.status;
+
+    // Collapse a concurrent stampede for the same ref into a single `gh` call.
+    const existing = inflight.get(prRef);
+    if (existing) return existing;
+
+    const p = fetchPrStatus(prRef, run)
+      .then((status) => {
+        entries.set(prRef, { status, expiresAt: now() + ttlMs });
+        evictIfNeeded();
+        return status;
+      })
+      .finally(() => {
+        inflight.delete(prRef);
+      });
+    inflight.set(prRef, p);
+    return p;
+  }
+
+  async function getMany(
+    prRefs: string[],
+    run?: ExecFileFn,
+  ): Promise<Map<string, GithubPrStatus>> {
+    const unique = [...new Set(prRefs)];
+    const out = new Map<string, GithubPrStatus>();
+    let i = 0;
+    async function worker(): Promise<void> {
+      while (i < unique.length) {
+        const ref = unique[i++];
+        out.set(ref, await get(ref, run));
+      }
+    }
+    const workers = Array.from(
+      { length: Math.min(concurrency, unique.length) },
+      () => worker(),
+    );
+    await Promise.all(workers);
+    return out;
+  }
+
+  return {
+    get,
+    getMany,
+    clear: () => {
+      entries.clear();
+      inflight.clear();
+    },
+    size: () => entries.size,
+  };
+}
+
+/** Process-wide singleton the route uses (60s TTL, bounded). */
+export const githubStatusCache = createGithubStatusCache();

--- a/shared/pr-queue.ts
+++ b/shared/pr-queue.ts
@@ -66,6 +66,32 @@ export function isPrBearingLoop(loop: PrBearingLoopLike): boolean {
 }
 
 /**
+ * LIVE GitHub PR status for a queued item's `prRef`, reconciled server-side against
+ * the actual PR (not the loop FSM). `unknown` is the fail-open value: no server-side
+ * GitHub auth, `gh` unreachable/rate-limited/timed-out, or a `prRef` that is not a
+ * recognizable GitHub PR URL. The route NEVER blocks on GitHub — it degrades to
+ * `unknown` rather than failing, so an outage can never take the queue down.
+ *
+ *   OPEN    — PR is open and ready (loop state is consistent).
+ *   DRAFT   — PR is open but still a Draft.
+ *   MERGED  — PR already merged on GitHub; a non-terminal loop state is now STALE.
+ *   CLOSED  — PR closed without merge; a non-terminal loop state is now STALE.
+ *   unknown — could not be determined (see above) — treated as ACTIVE, never resolved.
+ */
+export type GithubPrStatus = "OPEN" | "DRAFT" | "MERGED" | "CLOSED" | "unknown";
+
+/**
+ * A GitHub PR is "resolved" (merged or closed) — i.e. the loop's non-terminal state
+ * is stale relative to GitHub. `unknown`/`OPEN`/`DRAFT`/undefined are ACTIVE: we only
+ * de-emphasize a PR we positively know is done, never one we merely failed to fetch.
+ */
+export function isResolvedGithubStatus(
+  status: GithubPrStatus | null | undefined,
+): boolean {
+  return status === "MERGED" || status === "CLOSED";
+}
+
+/**
  * One PR-bearing loop, shaped for the queue wire (GET /api/pr-queue). A flat list
  * of these is returned by the server; the client clusters it with
  * {@link clusterPrQueue}. All timestamps are ISO strings on the wire.
@@ -92,6 +118,14 @@ export interface PrQueueItem {
    * field is part of the contract for forward-compat and the UI renders it only when present.
    */
   triggerProvenance?: string | null;
+  /**
+   * LIVE GitHub PR status reconciled server-side from `prRef` (see {@link GithubPrStatus}).
+   * `"unknown"` when GitHub could not be reached / no auth / unrecognized ref; the field
+   * may be absent on wires that predate reconciliation (older server) — the client treats
+   * a missing value the same as `"unknown"` (active). MERGED/CLOSED items move to the
+   * collapsed "resolved" section: the loop state is stale but still worth surfacing.
+   */
+  githubStatus?: GithubPrStatus | null;
 }
 
 /**
@@ -129,8 +163,25 @@ function recencyOf(item: PrQueueItem): number {
   return Number.isFinite(t) ? t : 0;
 }
 
-/** Newest first; deterministic loopId tie-break so equal timestamps sort stably. */
+/**
+ * Cluster sort rank: an ACTIVE PR (OPEN/DRAFT/unknown/unset) outranks a RESOLVED
+ * one (MERGED/CLOSED). Lower is "more current". This is what makes a duplicate
+ * cluster elect the live-OPEN PR as `currentLoopId` even when a merged/closed run
+ * is newer — a stale-but-recent merged PR must not shadow the actual open review.
+ */
+function livenessRank(item: PrQueueItem): number {
+  return isResolvedGithubStatus(item.githubStatus) ? 1 : 0;
+}
+
+/**
+ * Current-first ordering within a cluster: live/active before resolved, then newest
+ * first, then a deterministic loopId tie-break so equal timestamps sort stably.
+ * With no `githubStatus` populated every item ranks ACTIVE, so this reduces exactly
+ * to the prior newest-first behavior (backward compatible).
+ */
 function byNewest(a: PrQueueItem, b: PrQueueItem): number {
+  const rank = livenessRank(a) - livenessRank(b);
+  if (rank !== 0) return rank;
   const d = recencyOf(b) - recencyOf(a);
   if (d !== 0) return d;
   return a.loopId < b.loopId ? -1 : a.loopId > b.loopId ? 1 : 0;

--- a/tests/unit/consilium/github-status.test.ts
+++ b/tests/unit/consilium/github-status.test.ts
@@ -1,0 +1,152 @@
+/**
+ * github-status.test.ts — LIVE GitHub PR status service (server/services/github-status.ts).
+ *
+ * Injects a FAKE execFile — no real `gh`, no network. Covers:
+ *   - fetchPrStatus maps gh `{state,isDraft}` → OPEN/DRAFT/MERGED/CLOSED;
+ *   - graceful degrade to "unknown": unrecognized ref (no gh call), gh throw
+ *     (missing/unauth/rate-limit/timeout), non-JSON stdout;
+ *   - canonicalPrUrl validates + reconstructs the URL (no free-form/leading-dash
+ *     value reaches gh) — and the gh argv uses that canonical URL;
+ *   - the TTL cache: a hit inside the window makes ZERO extra gh calls; expiry
+ *     refetches (injected clock);
+ *   - in-flight de-duplication: concurrent gets for one ref → ONE gh call;
+ *   - getMany dedups duplicate refs and bounds work to one call per unique ref;
+ *   - size bound: the cache never exceeds maxEntries (oldest evicted).
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  fetchPrStatus,
+  canonicalPrUrl,
+  createGithubStatusCache,
+  type ExecFileFn,
+} from "../../../server/services/github-status.js";
+
+const PR = "https://github.com/acme/widget/pull/42";
+
+/** A fake gh runner returning a fixed `gh pr view --json` payload; counts calls. */
+function fakeGh(payload: unknown): { run: ExecFileFn; calls: () => number; argv: string[][] } {
+  const argv: string[][] = [];
+  const run: ExecFileFn = vi.fn(async (_file: string, args: string[]) => {
+    argv.push(args);
+    return { stdout: JSON.stringify(payload), stderr: "" };
+  });
+  return { run, calls: () => (run as unknown as { mock: { calls: unknown[] } }).mock.calls.length, argv };
+}
+
+describe("canonicalPrUrl", () => {
+  it("accepts a canonical GitHub PR URL and reconstructs it", () => {
+    expect(canonicalPrUrl(PR)).toBe(PR);
+    expect(canonicalPrUrl(`${PR}/files`)).toBe(PR); // trailing path stripped
+    expect(canonicalPrUrl(`${PR}#discussion`)).toBe(PR);
+    expect(canonicalPrUrl(`  ${PR}  `)).toBe(PR); // trimmed
+  });
+
+  it("rejects non-PR / non-GitHub / leading-dash refs → null", () => {
+    expect(canonicalPrUrl("")).toBeNull();
+    expect(canonicalPrUrl("-F/etc/passwd")).toBeNull();
+    expect(canonicalPrUrl("https://evil.example.com/acme/widget/pull/1")).toBeNull();
+    expect(canonicalPrUrl("https://github.com/acme/widget/issues/1")).toBeNull();
+    expect(canonicalPrUrl("https://github.com/acme/widget/pull/notanumber")).toBeNull();
+  });
+});
+
+describe("fetchPrStatus", () => {
+  it("maps OPEN + isDraft:false → OPEN and calls gh with the canonical URL", async () => {
+    const gh = fakeGh({ state: "OPEN", isDraft: false });
+    expect(await fetchPrStatus(PR, gh.run)).toBe("OPEN");
+    expect(gh.argv[0]).toEqual(["pr", "view", PR, "--json", "state,isDraft"]);
+  });
+
+  it("maps OPEN + isDraft:true → DRAFT", async () => {
+    const gh = fakeGh({ state: "OPEN", isDraft: true });
+    expect(await fetchPrStatus(PR, gh.run)).toBe("DRAFT");
+  });
+
+  it("maps MERGED → MERGED and CLOSED → CLOSED", async () => {
+    expect(await fetchPrStatus(PR, fakeGh({ state: "MERGED", isDraft: false }).run)).toBe("MERGED");
+    expect(await fetchPrStatus(PR, fakeGh({ state: "CLOSED", isDraft: false }).run)).toBe("CLOSED");
+  });
+
+  it("degrades to unknown for an unrecognized ref WITHOUT calling gh", async () => {
+    const gh = fakeGh({ state: "OPEN", isDraft: false });
+    expect(await fetchPrStatus("not-a-url", gh.run)).toBe("unknown");
+    expect(gh.calls()).toBe(0);
+  });
+
+  it("degrades to unknown when gh throws (missing/unauth/rate-limit/timeout)", async () => {
+    const run: ExecFileFn = vi.fn(async () => {
+      throw new Error("gh: not authenticated / API rate limit exceeded");
+    });
+    expect(await fetchPrStatus(PR, run)).toBe("unknown");
+  });
+
+  it("degrades to unknown on non-JSON stdout or unexpected shape", async () => {
+    const bad: ExecFileFn = vi.fn(async () => ({ stdout: "<!DOCTYPE html>", stderr: "" }));
+    expect(await fetchPrStatus(PR, bad)).toBe("unknown");
+    expect(await fetchPrStatus(PR, fakeGh({ state: "WEIRD" }).run)).toBe("unknown");
+  });
+});
+
+describe("createGithubStatusCache", () => {
+  it("serves a cached hit inside the TTL with ZERO extra gh calls", async () => {
+    const gh = fakeGh({ state: "OPEN", isDraft: false });
+    let t = 1000;
+    const cache = createGithubStatusCache({ ttlMs: 60_000, now: () => t });
+    expect(await cache.get(PR, gh.run)).toBe("OPEN");
+    t = 30_000; // within TTL
+    expect(await cache.get(PR, gh.run)).toBe("OPEN");
+    expect(gh.calls()).toBe(1);
+  });
+
+  it("refetches after the TTL expires", async () => {
+    let payload: { state: string; isDraft: boolean } = { state: "OPEN", isDraft: true };
+    let calls = 0;
+    const run: ExecFileFn = vi.fn(async () => {
+      calls++;
+      return { stdout: JSON.stringify(payload), stderr: "" };
+    });
+    let t = 0;
+    const cache = createGithubStatusCache({ ttlMs: 60_000, now: () => t });
+    expect(await cache.get(PR, run)).toBe("DRAFT");
+    payload = { state: "MERGED", isDraft: false };
+    t = 60_001; // past TTL
+    expect(await cache.get(PR, run)).toBe("MERGED");
+    expect(calls).toBe(2);
+  });
+
+  it("de-duplicates concurrent misses for the same ref into ONE gh call", async () => {
+    let calls = 0;
+    const run: ExecFileFn = vi.fn(async () => {
+      calls++;
+      await new Promise((r) => setTimeout(r, 5));
+      return { stdout: JSON.stringify({ state: "OPEN", isDraft: false }), stderr: "" };
+    });
+    const cache = createGithubStatusCache();
+    const [a, b, c] = await Promise.all([
+      cache.get(PR, run),
+      cache.get(PR, run),
+      cache.get(PR, run),
+    ]);
+    expect([a, b, c]).toEqual(["OPEN", "OPEN", "OPEN"]);
+    expect(calls).toBe(1);
+  });
+
+  it("getMany dedups duplicate refs → one call per UNIQUE ref", async () => {
+    const gh = fakeGh({ state: "OPEN", isDraft: false });
+    const cache = createGithubStatusCache();
+    const other = "https://github.com/acme/widget/pull/99";
+    const map = await cache.getMany([PR, PR, other, PR], gh.run);
+    expect(map.get(PR)).toBe("OPEN");
+    expect(map.get(other)).toBe("OPEN");
+    expect(gh.calls()).toBe(2); // PR + other, not 4
+  });
+
+  it("bounds the cache size (oldest evicted past maxEntries)", async () => {
+    const gh = fakeGh({ state: "OPEN", isDraft: false });
+    const cache = createGithubStatusCache({ maxEntries: 3, ttlMs: 60_000, now: () => 1 });
+    for (let n = 0; n < 10; n++) {
+      await cache.get(`https://github.com/acme/widget/pull/${n}`, gh.run);
+    }
+    expect(cache.size()).toBeLessThanOrEqual(3);
+  });
+});

--- a/tests/unit/consilium/pr-queue-cluster.test.ts
+++ b/tests/unit/consilium/pr-queue-cluster.test.ts
@@ -17,6 +17,7 @@
 import { describe, it, expect } from "vitest";
 import {
   isPrBearingLoop,
+  isResolvedGithubStatus,
   clusterPrQueue,
   normalizeRepoPath,
   PR_BEARING_LOOP_STATES,
@@ -141,5 +142,50 @@ describe("clusterPrQueue", () => {
     ]);
     expect(clusters[0].items.map((i) => i.loopId)).toEqual(["aaa", "zzz"]);
     expect(clusters[0].currentLoopId).toBe("aaa");
+  });
+
+  it("elects the live-OPEN PR as current over a NEWER merged/closed run", () => {
+    const clusters = clusterPrQueue([
+      // Newer by time, but MERGED on GitHub — must not be current.
+      item({ loopId: "merged-new", createdAt: "2026-03-01T00:00:00.000Z", githubStatus: "MERGED" }),
+      // Older, but the live-OPEN PR — this is the real current review.
+      item({ loopId: "open-old", createdAt: "2026-01-01T00:00:00.000Z", githubStatus: "OPEN" }),
+    ]);
+    expect(clusters).toHaveLength(1);
+    const c = clusters[0];
+    expect(c.currentLoopId).toBe("open-old");
+    expect(c.items.map((i) => i.loopId)).toEqual(["open-old", "merged-new"]);
+    expect(c.supersededLoopIds).toEqual(["merged-new"]);
+  });
+
+  it("treats unknown/DRAFT as ACTIVE (not resolved) so a newer one stays current", () => {
+    const clusters = clusterPrQueue([
+      item({ loopId: "unknown-new", createdAt: "2026-03-01T00:00:00.000Z", githubStatus: "unknown" }),
+      item({ loopId: "draft-old", createdAt: "2026-01-01T00:00:00.000Z", githubStatus: "DRAFT" }),
+    ]);
+    // Both active → pure recency: the newer one is current.
+    expect(clusters[0].currentLoopId).toBe("unknown-new");
+  });
+
+  it("is backward compatible: no githubStatus reduces to newest-first", () => {
+    const clusters = clusterPrQueue([
+      item({ loopId: "old", createdAt: "2026-01-01T00:00:00.000Z" }),
+      item({ loopId: "new", createdAt: "2026-03-01T00:00:00.000Z" }),
+    ]);
+    expect(clusters[0].currentLoopId).toBe("new");
+  });
+});
+
+describe("isResolvedGithubStatus", () => {
+  it("is true only for MERGED/CLOSED", () => {
+    expect(isResolvedGithubStatus("MERGED")).toBe(true);
+    expect(isResolvedGithubStatus("CLOSED")).toBe(true);
+  });
+  it("is false for OPEN/DRAFT/unknown/null/undefined (active)", () => {
+    expect(isResolvedGithubStatus("OPEN")).toBe(false);
+    expect(isResolvedGithubStatus("DRAFT")).toBe(false);
+    expect(isResolvedGithubStatus("unknown")).toBe(false);
+    expect(isResolvedGithubStatus(null)).toBe(false);
+    expect(isResolvedGithubStatus(undefined)).toBe(false);
   });
 });

--- a/tests/unit/consilium/pr-queue-route.test.ts
+++ b/tests/unit/consilium/pr-queue-route.test.ts
@@ -20,6 +20,15 @@ import request from "supertest";
 import type { AppConfig } from "../../../server/config/schema.js";
 import type { IStorage } from "../../../server/storage.js";
 import type { ConsiliumLoopController } from "../../../server/services/consilium/consilium-loop-controller.js";
+import type { GithubPrStatus } from "../../../shared/pr-queue.js";
+
+// Mock the LIVE-GitHub cache so the route never spawns a real `gh` — every case
+// controls the reconciled status (or its failure) via `getManyMock`.
+const { getManyMock } = vi.hoisted(() => ({ getManyMock: vi.fn() }));
+vi.mock("../../../server/services/github-status.js", () => ({
+  githubStatusCache: { getMany: getManyMock },
+}));
+
 import { registerConsiliumLoopRoutes } from "../../../server/routes/consilium-loops.js";
 import { clusterPrQueue, type PrQueueItem } from "../../../shared/pr-queue.js";
 
@@ -77,7 +86,13 @@ function makeApp(opts: {
 }
 
 describe("GET /api/pr-queue", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: reconciliation returns "unknown" for every ref (hermetic, no `gh`).
+    getManyMock.mockImplementation(async (refs: string[]) =>
+      new Map<string, GithubPrStatus>(refs.map((r) => [r, "unknown"])),
+    );
+  });
 
   it("401 when unauthenticated", async () => {
     const { app } = makeApp({ user: undefined as never });
@@ -176,5 +191,43 @@ describe("GET /api/pr-queue", () => {
     expect(widget?.currentLoopId).toBe("w2"); // newest
     expect(widget?.supersededLoopIds).toEqual(["w1"]);
     expect(other?.duplicate).toBe(false);
+  });
+
+  it("enriches each item with the reconciled live GitHub status", async () => {
+    const { app } = makeApp({
+      loops: [
+        loop({ id: "a", prRef: "https://github.com/o/widget/pull/1" }),
+        loop({ id: "b", prRef: "https://github.com/o/widget/pull/2", state: "stopped_cap" }),
+      ],
+    });
+    getManyMock.mockImplementation(async () =>
+      new Map<string, GithubPrStatus>([
+        ["https://github.com/o/widget/pull/1", "OPEN"],
+        ["https://github.com/o/widget/pull/2", "MERGED"],
+      ]),
+    );
+    const res = await request(app).get("/api/pr-queue");
+    const byId = Object.fromEntries((res.body as PrQueueItem[]).map((i) => [i.loopId, i.githubStatus]));
+    expect(byId).toEqual({ a: "OPEN", b: "MERGED" });
+    // Reconciliation is called with exactly the queued prRefs.
+    expect(getManyMock).toHaveBeenCalledWith([
+      "https://github.com/o/widget/pull/1",
+      "https://github.com/o/widget/pull/2",
+    ]);
+  });
+
+  it("degrades every item to 'unknown' when reconciliation REJECTS (GitHub down)", async () => {
+    const { app } = makeApp({ loops: [loop({ id: "a" }), loop({ id: "b", prRef: "https://github.com/o/widget/pull/2" })] });
+    getManyMock.mockRejectedValue(new Error("gh: API rate limit exceeded"));
+    const res = await request(app).get("/api/pr-queue");
+    expect(res.status).toBe(200); // the queue is NEVER taken down by GitHub
+    for (const it of res.body as PrQueueItem[]) expect(it.githubStatus).toBe("unknown");
+  });
+
+  it("defaults a ref missing from the reconciliation map to 'unknown'", async () => {
+    const { app } = makeApp({ loops: [loop({ id: "a" })] });
+    getManyMock.mockImplementation(async () => new Map<string, GithubPrStatus>()); // empty
+    const res = await request(app).get("/api/pr-queue");
+    expect((res.body as PrQueueItem[])[0].githubStatus).toBe("unknown");
   });
 });


### PR DESCRIPTION
## Problem

The PR review queue reflected **loop FSM state only**. A loop stuck at `awaiting_merge` kept showing a PR that was already merged/closed on GitHub (observed: Omniscience#351 shown as `awaiting_merge` though merged). The queue and GitHub disagreed and there was no reconciliation.

## What this does (read-side only — no FSM/schema/migration)

Each `/api/pr-queue` item is now reconciled against its **live GitHub PR** and carries a `githubStatus` of `OPEN | DRAFT | MERGED | CLOSED | unknown`.

### GitHub auth path
Reuses the **only** GitHub auth path already in the server: the local **`gh` CLI**, authenticated via `GH_TOKEN`/`GITHUB_TOKEN` (same as `server/services/consilium/pr-wrapper.ts`, which writes `prRef`). The new service runs `gh pr view <url> --json state,isDraft` under a **sanitized env** that strips every inherited `GH_*` and re-adds only the intended token var (pr-wrapper H-7b parity) — a poisoned ambient env can't redirect `gh` to an attacker host or leak the token. The token is never read, logged, or returned.

### Degrade path (no server-side auth / GitHub down)
Fully **best-effort and fail-open**. If `gh` is missing/unauthenticated, GitHub is unreachable, rate-limited, times out, or the ref isn't a recognizable GitHub PR URL → `githubStatus: "unknown"` instead of failing the route. Live status simply requires `GH_TOKEN`/`GITHUB_TOKEN` (or a `gh auth login` identity) present for the server process.

### Caching (anti N+1 / anti rate-limit)
`server/services/github-status.ts` holds a **60s-TTL cache per `prRef`** with:
- **in-flight de-duplication** — concurrent misses for one ref collapse to a single `gh` call;
- **`getMany`** dedups duplicate refs and fetches with **bounded concurrency** (6);
- a **size cap** (oldest-inserted eviction) so many distinct refs can't grow it unbounded.

So N poll cycles + duplicate refs across a cluster collapse to one `gh` call per ref per minute.

### Never blocks the route
The route wraps reconciliation in an **8s wall-clock budget** (`withBudget`) plus a try/catch. If GitHub stalls or throws, every item degrades to `"unknown"` and the route still returns **200** promptly. Per-`gh`-call timeout is a separate 15s bound; slow calls keep resolving in the background and land in the cache for the next 5s poll.

### Reconciled-queue UX
- MERGED/CLOSED items leave the active list for a **collapsed, de-emphasized** section: *"Already merged/closed on GitHub — loop state stale (N)"*. Not hidden — a non-terminal loop over a done PR is itself worth surfacing.
- `unknown`/OPEN/DRAFT stay **active** (we only demote a PR we positively know is done).
- Per-card **live status badge**.
- Within a **duplicate cluster**, the live-OPEN PR is elected `currentLoopId` over a newer merged/closed run.

### Not done on purpose
No FSM reconciliation / auto-transition — the mismatch is **surfaced**, not acted on (separate concern, per the ask).

## Tests
- `github-status.test.ts` (new): status mapping OPEN/DRAFT/MERGED/CLOSED; degrade to `unknown` (unrecognized ref → no `gh` call, `gh` throw, non-JSON); canonical-URL validation/reconstruction; TTL hit = 0 extra calls; expiry refetch; in-flight dedup = 1 call; `getMany` dedup; size bound.
- `pr-queue-cluster.test.ts`: live-OPEN elected current over a newer MERGED; unknown/DRAFT treated active; `isResolvedGithubStatus`; backward-compat (no status → newest-first).
- `pr-queue-route.test.ts`: enrichment from the (mocked) cache; **degrade to `unknown` on reject (GitHub down) → still 200**; missing-ref defaults to `unknown`. `gh` is mocked — hermetic.

**Evidence:** `tsc` clean. Full unit suite green: **253 files / 4896 tests passed** (affected trio: 39 passed). No integration tests in this zone. Listed flakes (providers/antigravity, config-sync-multi-instance, tool-builtins, remote-agent-lifecycle, costs) are pre-existing and unrelated; `pull_request` CI is authoritative.

## Adversarial self-review
- **GitHub outage/rate-limit taking down the queue** → 8s batch budget + per-call 15s timeout + try/catch; route always 200, degrades to `unknown`.
- **Token leak** → token only handed to `gh` via sanitized env; never logged/returned; error strings swallowed.
- **N+1 GitHub calls** → 60s cache + in-flight dedup + `getMany` unique-ref dedup + bounded concurrency; PR-bearing filter bounds the set before fetching.

Draft — do not merge.
