### PR TITLE
feat: per-repo test/lint command overrides

### DIFF
--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -584,6 +584,53 @@ export const ConfigSchema = z.object({
          */
         lintCommand: z.string().nullable().default(null),
         /**
+         * PER-REPO command overrides. A map keyed by the loop's `repoPath` (the SAME
+         * absolute path strings operators put in `allowedRepoPaths`). The GLOBAL
+         * `testCommand` / `lintCommand` / `testRunTimeoutMs` / `coderModel` above run the
+         * same command for EVERY repo — wrong when a loop targets repos with different
+         * toolchains (a Python repo needs `uv run pytest`, a Node repo `npm test`). At
+         * DISPATCH the controller resolves the EFFECTIVE command set for the loop's repo
+         * (`resolveImplementForRepo`): a per-repo field OVERRIDES the sibling global key;
+         * an ABSENT field falls back to the global key; NO entry at all ⇒ byte-for-byte
+         * today's global behavior. Additive + backward-compatible — the global keys stay
+         * the default/fallback and are NEVER removed.
+         *
+         * MATCHING (`selectPerRepoOverride`, pure/lexical — no fs): EXACT repoPath key
+         * first, else the LONGEST configured key that is a path-boundary prefix of the
+         * loop's repoPath (a parent-dir entry can cover a whole tree). Keys are NOT
+         * required to be in `allowedRepoPaths` — an entry for a non-allowlisted repo is
+         * harmless dead config: the allowlist is still enforced INDEPENDENTLY at dispatch
+         * (`assertAllowedRepoPath`), so a per-repo override can never widen repo access.
+         *
+         * SECURITY: identical trust to the global keys — config-sourced ONLY (never
+         * action-point/criterion text), each field re-validated with the SAME schema
+         * (coderModel safe-slug with an alphanumeric first char so it can never look like
+         * a flag; timeout clamped 10s..30min), and run downstream via no-shell argv. An
+         * unknown field on an entry is stripped by zod. Absent (default {}) ⇒ ZERO change.
+         */
+        perRepo: z
+          .record(
+            z.string(),
+            z.object({
+              /** Per-repo test command; null ⇒ auto-detect from package.json. Absent ⇒ inherit global `testCommand`. */
+              testCommand: z.string().nullable().optional(),
+              /** Per-repo lint/format command; null ⇒ no lint run. Absent ⇒ inherit global `lintCommand`. */
+              lintCommand: z.string().nullable().optional(),
+              /** Per-repo single-test-run timeout (ms), same clamp as the global. Absent ⇒ inherit global `testRunTimeoutMs`. */
+              testRunTimeoutMs: z.coerce.number().int().min(10_000).max(1_800_000).optional(),
+              /** Per-repo coder model slug (same safe-slug guard as the global). Absent ⇒ inherit global `coderModel`. */
+              coderModel: z
+                .string()
+                .min(1)
+                .regex(
+                  /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/,
+                  "perRepo.coderModel must be a safe model slug (alphanumeric start; [A-Za-z0-9._-])",
+                )
+                .optional(),
+            }),
+          )
+          .default({}),
+        /**
          * Stage 3 (design §3.C/§6): the RESEARCH archetype implement path — deep web
          * research → synthesize → a structured, web-evidence-verified REPORT (NOT code,
          * NOT a Draft PR). When `enabled` is FALSE (default) a `research` loop's close-out
@@ -665,4 +712,89 @@ export function effectiveVerificationEnabled(config: AppConfig): boolean {
   const impl = config.pipeline.consiliumLoop.implement;
   if (!impl.verification.enabled) return false; // short-circuit: never reads features.
   return config.features?.sandbox?.enabled === true || impl.trustedRepoAck === true;
+}
+
+/** The `consiliumLoop.implement` config block (source of the global keys + `perRepo`). */
+type ImplementConfig = AppConfig["pipeline"]["consiliumLoop"]["implement"];
+
+/**
+ * The EFFECTIVE implement command set for a SINGLE loop's repo, after folding any
+ * per-repo override over the global implement keys. Shape mirrors exactly the four
+ * fields the controller threads into the SDLC request, keeping their existing types
+ * so a threaded value is byte-identical to reading the global key directly.
+ */
+export interface EffectiveImplementCommands {
+  /** Operator test-command override; null ⇒ the executor auto-detects from package.json. */
+  testCommand: string | null;
+  /** Optional lint/format command; null ⇒ no lint run. */
+  lintCommand: string | null;
+  /** Hard per-run test timeout (ms), already clamped by the schema. */
+  testRunTimeoutMs: number;
+  /** Operator-pinned coder model slug; undefined ⇒ the coder CLI's own default model. */
+  coderModel: string | undefined;
+}
+
+/** Strip trailing slashes for path-boundary comparison (never touches a bare "/"). */
+function stripTrailingSlash(p: string): string {
+  return p.length > 1 ? p.replace(/\/+$/, "") : p;
+}
+
+/**
+ * Select the per-repo override entry that applies to `repoPath`: EXACT key match
+ * first, else the LONGEST configured key that is a path-boundary prefix of `repoPath`
+ * (so a parent-dir entry covers a whole tree, and the more specific key wins on ties).
+ * Pure + lexical — no fs, no realpath — because operators key `perRepo` with the SAME
+ * absolute path strings they use for `allowedRepoPaths`. Returns undefined when no key
+ * matches ⇒ the caller falls back to the global keys (today's behavior).
+ */
+export function selectPerRepoOverride(
+  repoPath: string,
+  perRepo: ImplementConfig["perRepo"] | undefined,
+): ImplementConfig["perRepo"][string] | undefined {
+  if (!perRepo) return undefined;
+  // Exact key match (raw first, then trailing-slash-normalized) wins outright.
+  if (Object.prototype.hasOwnProperty.call(perRepo, repoPath)) return perRepo[repoPath];
+  const target = stripTrailingSlash(repoPath);
+  let best: string | undefined;
+  let bestLen = -1;
+  for (const key of Object.keys(perRepo)) {
+    const k = stripTrailingSlash(key);
+    if (k === target) return perRepo[key]; // exact after normalization
+    // Path-boundary prefix: target is strictly nested under k (never a substring match).
+    if (target.startsWith(k + "/") && k.length > bestLen) {
+      best = key;
+      bestLen = k.length;
+    }
+  }
+  return best !== undefined ? perRepo[best] : undefined;
+}
+
+/**
+ * Resolve the EFFECTIVE implement command set for a loop's `repoPath`. Precedence per
+ * field: the matched per-repo override value → else the global implement key → else
+ * today's default. `undefined` on an override field means "inherit the global"; an
+ * explicit `null` (testCommand/lintCommand) means "no command" and DOES override.
+ *
+ * BACKWARD-COMPAT CONTRACT: when no per-repo entry matches (or `perRepo` is empty),
+ * the result is byte-identical to reading the global keys directly — so a config with
+ * no `perRepo` produces exactly today's SDLC request.
+ */
+export function resolveImplementForRepo(
+  repoPath: string,
+  implement: ImplementConfig,
+): EffectiveImplementCommands {
+  const base: EffectiveImplementCommands = {
+    testCommand: implement.testCommand,
+    lintCommand: implement.lintCommand ?? null,
+    testRunTimeoutMs: implement.testRunTimeoutMs,
+    coderModel: implement.coderModel,
+  };
+  const o = selectPerRepoOverride(repoPath, implement.perRepo);
+  if (!o) return base;
+  return {
+    testCommand: o.testCommand !== undefined ? o.testCommand : base.testCommand,
+    lintCommand: o.lintCommand !== undefined ? o.lintCommand : base.lintCommand,
+    testRunTimeoutMs: o.testRunTimeoutMs !== undefined ? o.testRunTimeoutMs : base.testRunTimeoutMs,
+    coderModel: o.coderModel !== undefined ? o.coderModel : base.coderModel,
+  };
 }

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -56,7 +56,7 @@ import type { ActionPoint, ConvergenceVerdict } from "@shared/types";
 import { P0_PRIORITY } from "@shared/types";
 import type { TaskOrchestrator } from "../task-orchestrator.js";
 import type { AppConfig } from "../../config/schema.js";
-import { effectiveVerificationEnabled } from "../../config/schema.js";
+import { effectiveVerificationEnabled, resolveImplementForRepo } from "../../config/schema.js";
 import { readConvergence, extractActionPoints, normalizeActionPointMethods, applyCriteriaQa } from "../orchestrator/convergence.js";
 import { buildDiffContext } from "./diff-context.js";
 import { buildRepoMap, createDbRepoMapSource, listTouchedFiles, repoMapGit } from "./repo-map.js";
@@ -1446,6 +1446,13 @@ export class ConsiliumLoopController {
         "[consilium-loop] verification.enabled ignored: requires features.sandbox or implement.trustedRepoAck",
       );
     }
+    // PER-REPO command overrides: resolve the EFFECTIVE test/lint command, timeout, and
+    // coder model for THIS loop's repo BEFORE building the request — a per-repo override
+    // wins over the sibling global key, an absent field inherits the global, and NO
+    // matching entry ⇒ byte-for-byte today's global values (`resolveImplementForRepo`).
+    // Threading the RESOLVED values (not the raw `cfg.implement.*` keys) is what lets a
+    // Python repo run `uv run pytest` while a Node repo runs `npm test` under one config.
+    const impl = resolveImplementForRepo(loop.repoPath, cfg.implement);
     // REAL path: the SDLC executor cuts an ISOLATED worktree (NEVER the user's
     // checkout), runs the agentic coder to make REAL multi-file edits, then
     // commits + opens a Draft PR. baseRef defaults to the repo's default-branch
@@ -1461,9 +1468,9 @@ export class ConsiliumLoopController {
       // Per-action-point coder timeout (configurable). The executor runs the
       // coder once per action point sequentially; this bounds a SINGLE run.
       coderTimeoutMs: cfg.sdlcTimeoutMs,
-      // Operator-pinned coder model (optional). Absent ⇒ the CLI's default model.
-      // Threaded once at the executor's runCoder seam into every coder invocation.
-      coderModel: cfg.implement.coderModel,
+      // Operator-pinned coder model (optional, per-repo-resolved). Absent ⇒ the CLI's
+      // default model. Threaded once at the executor's runCoder seam into every coder.
+      coderModel: impl.coderModel,
       // Stage 2a archetype-branched skilled coder (null archetype ⇒ default step set).
       archetype: loop.archetype ?? null,
       archetypeParams: loop.archetypeParams ?? null,
@@ -1474,10 +1481,11 @@ export class ConsiliumLoopController {
         ? {
             enabled: true,
             maxFixIterations: cfg.implement.maxFixIterations,
-            testCommand: cfg.implement.testCommand,
-            testRunTimeoutMs: cfg.implement.testRunTimeoutMs,
+            // Per-repo-resolved test command + timeout (fall back to the global keys).
+            testCommand: impl.testCommand,
+            testRunTimeoutMs: impl.testRunTimeoutMs,
             // Stage B: lint-clean folded into the coder's green (null ⇒ no lint run).
-            lintCommand: cfg.implement.lintCommand ?? null,
+            lintCommand: impl.lintCommand,
           }
         : null,
       // Stage A: final-state re-verification config (null when the kill-switch is off OR

--- a/tests/unit/config/implement-per-repo.test.ts
+++ b/tests/unit/config/implement-per-repo.test.ts
@@ -1,0 +1,161 @@
+/**
+ * implement-per-repo.test.ts — PER-REPO test/lint command overrides.
+ *
+ * The SDLC `implement` block carries GLOBAL `testCommand`/`lintCommand`/
+ * `testRunTimeoutMs`/`coderModel` that today run the SAME command for every repo.
+ * `perRepo` adds an OPTIONAL per-repoPath override map; `resolveImplementForRepo`
+ * folds a matched override over the global keys. This file pins the pure resolution
+ * contract + the additive schema:
+ *   1. Schema: `perRepo` defaults to {} (byte-for-byte today), validates fields, and
+ *      re-applies the coderModel safe-slug + timeout clamp.
+ *   2. selectPerRepoOverride: EXACT match, longest path-boundary prefix, no-match.
+ *   3. resolveImplementForRepo: override wins, absent field inherits global, explicit
+ *      null overrides, and NO entry ⇒ byte-identical to the global keys.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  ConfigSchema,
+  resolveImplementForRepo,
+  selectPerRepoOverride,
+  type AppConfig,
+} from "../../../server/config/schema.js";
+
+/** The parsed `implement` block from a (possibly partial) implement config object. */
+function implementOf(implement: Record<string, unknown>): AppConfig["pipeline"]["consiliumLoop"]["implement"] {
+  const parsed = ConfigSchema.parse({
+    pipeline: { consiliumLoop: { implement } },
+  });
+  return parsed.pipeline.consiliumLoop.implement;
+}
+
+describe("schema — implement.perRepo is additive + backward-compatible", () => {
+  it("defaults perRepo to {} when absent (byte-for-byte today's config)", () => {
+    const impl = implementOf({});
+    expect(impl.perRepo).toEqual({});
+  });
+
+  it("parses a per-repo entry and keeps the global keys intact", () => {
+    const impl = implementOf({
+      testCommand: "npm test",
+      lintCommand: "npm run lint",
+      testRunTimeoutMs: 300000,
+      perRepo: {
+        "/repos/py": { testCommand: "uv run pytest", coderModel: "sonnet" },
+      },
+    });
+    expect(impl.testCommand).toBe("npm test"); // global untouched
+    expect(impl.perRepo["/repos/py"]).toEqual({ testCommand: "uv run pytest", coderModel: "sonnet" });
+  });
+
+  it("re-applies the coderModel safe-slug guard to a per-repo entry (rejects flag-like)", () => {
+    expect(() =>
+      implementOf({ perRepo: { "/repos/x": { coderModel: "--dangerously" } } }),
+    ).toThrow();
+    // A valid slug passes.
+    const impl = implementOf({ perRepo: { "/repos/x": { coderModel: "claude-sonnet" } } });
+    expect(impl.perRepo["/repos/x"].coderModel).toBe("claude-sonnet");
+  });
+
+  it("re-applies the testRunTimeoutMs clamp to a per-repo entry", () => {
+    expect(() => implementOf({ perRepo: { "/repos/x": { testRunTimeoutMs: 5 } } })).toThrow(); // below 10s
+    const impl = implementOf({ perRepo: { "/repos/x": { testRunTimeoutMs: 60000 } } });
+    expect(impl.perRepo["/repos/x"].testRunTimeoutMs).toBe(60000);
+  });
+
+  it("strips unknown fields on a per-repo entry (zod object default)", () => {
+    const impl = implementOf({ perRepo: { "/repos/x": { testCommand: "go test ./...", bogus: 1 } } });
+    expect(impl.perRepo["/repos/x"]).toEqual({ testCommand: "go test ./..." });
+  });
+});
+
+describe("selectPerRepoOverride — exact / longest-prefix / no-match", () => {
+  const perRepo = {
+    "/repos/py": { testCommand: "uv run pytest" },
+    "/repos": { testCommand: "make test" },
+    "/repos/node/app": { testCommand: "npm test" },
+  } as const;
+
+  it("EXACT repoPath match wins", () => {
+    expect(selectPerRepoOverride("/repos/py", perRepo)).toEqual({ testCommand: "uv run pytest" });
+  });
+
+  it("longest path-boundary PREFIX wins when no exact key", () => {
+    // /repos/node/app/pkg is nested under both /repos and /repos/node/app → longest wins.
+    expect(selectPerRepoOverride("/repos/node/app/pkg", perRepo)).toEqual({ testCommand: "npm test" });
+    // /repos/other is only under /repos.
+    expect(selectPerRepoOverride("/repos/other", perRepo)).toEqual({ testCommand: "make test" });
+  });
+
+  it("NO match ⇒ undefined (caller falls back to global keys)", () => {
+    expect(selectPerRepoOverride("/elsewhere/repo", perRepo)).toBeUndefined();
+    expect(selectPerRepoOverride("/repos/py", {})).toBeUndefined();
+    expect(selectPerRepoOverride("/repos/py", undefined)).toBeUndefined();
+  });
+
+  it("does NOT prefix-match on a non-boundary substring", () => {
+    // "/repos-backup" starts with "/repos" textually but is NOT nested under it.
+    expect(selectPerRepoOverride("/repos-backup/x", perRepo)).toBeUndefined();
+  });
+
+  it("tolerates a trailing slash on the key or the query", () => {
+    expect(selectPerRepoOverride("/repos/py/", perRepo)).toEqual({ testCommand: "uv run pytest" });
+    expect(selectPerRepoOverride("/repos/py", { "/repos/py/": { testCommand: "x" } })).toEqual({
+      testCommand: "x",
+    });
+  });
+});
+
+describe("resolveImplementForRepo — override precedence + backward-compat", () => {
+  const globalImpl = implementOf({
+    testCommand: "npm test",
+    lintCommand: "npm run lint",
+    testRunTimeoutMs: 300000,
+    coderModel: "claude-sonnet",
+    perRepo: {
+      "/repos/py": {
+        testCommand: "uv run pytest",
+        testRunTimeoutMs: 600000,
+        coderModel: "opus",
+        // lintCommand ABSENT → inherits the global lintCommand.
+      },
+      "/repos/nolint": { lintCommand: null }, // explicit null overrides → no lint run.
+    },
+  });
+
+  it("byte-identical to the GLOBAL keys when no per-repo entry matches", () => {
+    const eff = resolveImplementForRepo("/repos/unmapped", globalImpl);
+    expect(eff).toEqual({
+      testCommand: "npm test",
+      lintCommand: "npm run lint",
+      testRunTimeoutMs: 300000,
+      coderModel: "claude-sonnet",
+    });
+  });
+
+  it("a matched override replaces the field; an ABSENT override field inherits the global", () => {
+    const eff = resolveImplementForRepo("/repos/py", globalImpl);
+    expect(eff).toEqual({
+      testCommand: "uv run pytest", // overridden
+      lintCommand: "npm run lint", // inherited (absent in the entry)
+      testRunTimeoutMs: 600000, // overridden
+      coderModel: "opus", // overridden
+    });
+  });
+
+  it("an explicit null override wins over a non-null global (no command)", () => {
+    const eff = resolveImplementForRepo("/repos/nolint", globalImpl);
+    expect(eff.lintCommand).toBeNull(); // null override beats "npm run lint"
+    expect(eff.testCommand).toBe("npm test"); // other fields still inherit
+  });
+
+  it("with an empty perRepo, resolution equals the raw global keys (contract)", () => {
+    const impl = implementOf({ testCommand: "go test ./...", coderModel: "sonnet" });
+    const eff = resolveImplementForRepo("/anything", impl);
+    expect(eff).toEqual({
+      testCommand: "go test ./...",
+      lintCommand: null, // global default
+      testRunTimeoutMs: 300000, // schema default
+      coderModel: "sonnet",
+    });
+  });
+});

--- a/tests/unit/consilium/loop-per-repo-command-wire.test.ts
+++ b/tests/unit/consilium/loop-per-repo-command-wire.test.ts
@@ -1,0 +1,216 @@
+/**
+ * loop-per-repo-command-wire.test.ts — PER-REPO command overrides reach the executor.
+ *
+ * The controller resolves the EFFECTIVE test/lint command + timeout + coder model for
+ * the loop's repoPath (`resolveImplementForRepo`) and threads the RESOLVED values into
+ * the SDLC request — NOT the raw global keys. Here we assert the observable end: what
+ * `runSdlc` receives for a repo WITH a per-repo entry, for a repo WITHOUT one (falls
+ * back to the global keys), and that an absent `perRepo` is byte-identical to today.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { ConsiliumLoopController } from "../../../server/services/consilium/consilium-loop-controller.js";
+import type { ConsiliumLoopRow, ConsiliumLoopState } from "@shared/schema";
+import type { ConvergenceVerdict } from "@shared/types";
+
+const REPO_PY = "/repos/py";
+const REPO_NODE = "/repos/node";
+
+const verdict = (openP0: number): ConvergenceVerdict => ({
+  converged: false,
+  openP0,
+  openActionPoints: Array.from({ length: openP0 }, (_, i) => ({ title: `ap${i}`, priority: "P0" })),
+});
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+function makeLoop(over: Partial<ConsiliumLoopRow>): ConsiliumLoopRow {
+  return {
+    id: "loop-1",
+    projectId: "proj1",
+    groupId: "grp1",
+    state: "deciding",
+    round: 2,
+    maxRounds: 6,
+    repoPath: REPO_PY,
+    lastReviewedCommit: null,
+    currentIterationNumber: 2,
+    devGroupId: null,
+    prRef: null,
+    headCommitAtReview: null,
+    openP0: null,
+    error: null,
+    createdBy: "user1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    completedAt: null,
+    ...over,
+  } as ConsiliumLoopRow;
+}
+
+function fakeStorage(loop: ConsiliumLoopRow) {
+  let current = loop;
+  return {
+    getLoop: vi.fn(async () => current),
+    getLoops: vi.fn(async () => [current]),
+    getLoopRounds: vi.fn(async () => []),
+    casLoopState: vi.fn(
+      async (id: string, expected: ConsiliumLoopState, next: ConsiliumLoopState, extra?: Record<string, unknown>) => {
+        if (id !== current.id || current.state !== expected) return undefined;
+        current = { ...current, ...(extra ?? {}), state: next };
+        return current;
+      },
+    ),
+    claimRedrive: vi.fn(async () => undefined),
+    appendLoopRound: vi.fn(async () => ({})),
+    updateLoopRoundTestSummary: vi.fn(async () => undefined),
+    updateLoop: vi.fn(async (_id: string, extra?: Record<string, unknown>) => {
+      current = { ...current, ...(extra ?? {}) };
+      return current;
+    }),
+    getTaskGroup: vi.fn(async () => ({ id: current.groupId, input: "objective" })),
+    updateTaskGroup: vi.fn(async () => ({})),
+    getIteration: vi.fn(async () => ({ id: "it1", iterationNumber: 2, status: "completed" })),
+    getExecutionsByIteration: vi.fn(async () => []),
+  };
+}
+
+/** Config with verification effectively ON (ack) + a per-repo override map. */
+const makeConfig =
+  (perRepo?: Record<string, unknown>) =>
+  () =>
+    ({
+      features: { sandbox: { enabled: false } },
+      pipeline: {
+        consiliumLoop: {
+          enabled: true,
+          maxRounds: 6,
+          pollIntervalMs: 5000,
+          maxDiffBytes: 200000,
+          sdlcTimeoutMs: 600000,
+          allowedRepoPaths: [REPO_PY, REPO_NODE],
+          implement: {
+            enabled: true,
+            verification: { enabled: true },
+            trustedRepoAck: true, // ⇒ effectiveVerificationEnabled = true (test cmd threaded)
+            maxFixIterations: 3,
+            testCommand: "npm test", // GLOBAL default
+            lintCommand: "npm run lint", // GLOBAL default
+            testRunTimeoutMs: 300000, // GLOBAL default
+            coderModel: "claude-sonnet", // GLOBAL default
+            perRepo,
+            finalVerification: { enabled: false, maxFinalFixIterations: 1 },
+          },
+        },
+      },
+    }) as never;
+
+function controllerWith(config: () => unknown, runSdlc: ReturnType<typeof vi.fn>, storage: unknown) {
+  return new ConsiliumLoopController({
+    storage: storage as never,
+    taskOrchestrator: {
+      startGroup: vi.fn(),
+      startGroupAsync: vi.fn(),
+      createTaskGroup: vi.fn(),
+      cancelGroup: vi.fn(),
+    } as never,
+    config: config as never,
+    readIterationVerdict: async () => verdict(2),
+    // Inject head read so the virtual (non-existent) repoPaths never hit real git.
+    readRepoHead: async () => "headsha000",
+    runSdlc: runSdlc as never,
+  });
+}
+
+describe("per-repo command wire — the RESOLVED command reaches runSdlc", () => {
+  it("a repo WITH a per-repo entry threads the OVERRIDE (test/lint/timeout/model)", async () => {
+    const loop = makeLoop({ repoPath: REPO_PY });
+    const storage = fakeStorage(loop);
+    const runSdlc = vi.fn(async () => ({ prRef: null, headCommit: "" }));
+    const controller = controllerWith(
+      makeConfig({
+        [REPO_PY]: {
+          testCommand: "uv run pytest",
+          lintCommand: "ruff check",
+          testRunTimeoutMs: 600000,
+          coderModel: "opus",
+        },
+      }),
+      runSdlc,
+      storage,
+    );
+    await controller.tick(loop.id);
+    await flush();
+
+    const req = runSdlc.mock.calls[0][0];
+    expect(req.coderModel).toBe("opus");
+    expect(req.verification).toEqual(
+      expect.objectContaining({
+        testCommand: "uv run pytest",
+        lintCommand: "ruff check",
+        testRunTimeoutMs: 600000,
+      }),
+    );
+  });
+
+  it("a repo WITHOUT a per-repo entry falls back to the GLOBAL keys", async () => {
+    const loop = makeLoop({ repoPath: REPO_NODE });
+    const storage = fakeStorage(loop);
+    const runSdlc = vi.fn(async () => ({ prRef: null, headCommit: "" }));
+    const controller = controllerWith(
+      makeConfig({ [REPO_PY]: { testCommand: "uv run pytest" } }), // only /repos/py mapped
+      runSdlc,
+      storage,
+    );
+    await controller.tick(loop.id);
+    await flush();
+
+    const req = runSdlc.mock.calls[0][0];
+    expect(req.coderModel).toBe("claude-sonnet");
+    expect(req.verification).toEqual(
+      expect.objectContaining({
+        testCommand: "npm test",
+        lintCommand: "npm run lint",
+        testRunTimeoutMs: 300000,
+      }),
+    );
+  });
+
+  it("an ABSENT perRepo is byte-identical to the global-only request (backward-compat)", async () => {
+    const loop = makeLoop({ repoPath: REPO_PY });
+    const storage = fakeStorage(loop);
+    const runSdlc = vi.fn(async () => ({ prRef: null, headCommit: "" }));
+    const controller = controllerWith(makeConfig(undefined), runSdlc, storage);
+    await controller.tick(loop.id);
+    await flush();
+
+    const req = runSdlc.mock.calls[0][0];
+    expect(req.coderModel).toBe("claude-sonnet");
+    expect(req.verification).toEqual(
+      expect.objectContaining({
+        enabled: true,
+        maxFixIterations: 3,
+        testCommand: "npm test",
+        lintCommand: "npm run lint",
+        testRunTimeoutMs: 300000,
+      }),
+    );
+  });
+
+  it("a per-repo entry for a NON-ALLOWLISTED repo is harmless dead config (adversarial)", async () => {
+    // /repos/py is allowlisted; the entry for /elsewhere never matches this loop and the
+    // allowlist is enforced independently — so the loop still runs with the GLOBAL keys.
+    const loop = makeLoop({ repoPath: REPO_PY });
+    const storage = fakeStorage(loop);
+    const runSdlc = vi.fn(async () => ({ prRef: null, headCommit: "" }));
+    const controller = controllerWith(
+      makeConfig({ "/elsewhere/not-allowed": { testCommand: "rm -rf /" } }),
+      runSdlc,
+      storage,
+    );
+    await controller.tick(loop.id);
+    await flush();
+
+    const req = runSdlc.mock.calls[0][0];
+    expect(req.verification.testCommand).toBe("npm test"); // global, NOT the dead entry
+  });
+});

--- a/tests/unit/sdlc/verification-loop.test.ts
+++ b/tests/unit/sdlc/verification-loop.test.ts
@@ -144,6 +144,28 @@ describe("Stage 2b — command source is config, never AP text", () => {
     expect(arg.worktreeDir).toBe(WT);
     expect(arg.timeoutMs).toBe(300_000);
   });
+
+  it("the executor runs the RESOLVED per-repo command/timeout/lint carried in the request", async () => {
+    // Per-repo overrides are resolved by the controller and arrive on the request as
+    // verification.{testCommand,lintCommand,testRunTimeoutMs}. The executor must run
+    // EXACTLY those — proving a Python repo's `uv run pytest` (not the global `npm test`)
+    // is what actually executes. First runTests = tests, second (post-green) = lint.
+    const runTests = sequencedRunTests([pass, pass]);
+    const deps = makeDeps({ runTests });
+    await runSdlcHandoff(
+      baseReq({
+        verification: VCFG({ testCommand: "uv run pytest", lintCommand: "ruff check", testRunTimeoutMs: 600_000 }),
+      }),
+      deps as never,
+    );
+    expect(runTests).toHaveBeenCalledTimes(2);
+    const testArg = runTests.mock.calls[0][0] as { testCommand: string | null; timeoutMs: number };
+    const lintArg = runTests.mock.calls[1][0] as { testCommand: string | null; timeoutMs: number };
+    expect(testArg.testCommand).toBe("uv run pytest");
+    expect(testArg.timeoutMs).toBe(600_000);
+    expect(lintArg.testCommand).toBe("ruff check"); // lint reuses the runner with its own cmd
+    expect(lintArg.timeoutMs).toBe(600_000);
+  });
 });
 
 describe("Stage 2b — bounded code→test→fix loop", () => {


### PR DESCRIPTION
## Problem

The SDLC develop phase reads `pipeline.consiliumLoop.implement.testCommand`, `.lintCommand`, `.testRunTimeoutMs`, and `.coderModel` as **global** config keys, so the same command runs for every repo. That is wrong when a single loop config targets repos with different toolchains — a Python repo needs `uv run pytest`, a Node repo needs `npm test`.

## What changed (additive, backward-compatible)

A new **optional** per-repo override map. The global keys stay and become the default/fallback — nothing is removed.

### Config shape

```yaml
pipeline:
  consiliumLoop:
    implement:
      testCommand: "npm test"          # global default (unchanged)
      lintCommand: "npm run lint"       # global default (unchanged)
      testRunTimeoutMs: 300000          # global default (unchanged)
      coderModel: "claude-sonnet"       # global default (unchanged)
      perRepo:                          # NEW — optional, defaults to {}
        /abs/path/to/py-repo:
          testCommand: "uv run pytest"
          lintCommand: "ruff check"
          testRunTimeoutMs: 600000
          coderModel: "opus"
        /abs/path/to/go-repo:
          testCommand: "go test ./..."
          # absent fields inherit the global keys
```

`perRepo` is a `Record<repoPath, { testCommand?, lintCommand?, testRunTimeoutMs?, coderModel? }>`. The Record shape was chosen over a list because it is keyed exactly by the same absolute `repoPath` strings operators already use in `allowedRepoPaths`, and it makes exact-match the natural common case.

### Resolution rule

At dispatch the controller resolves the **effective** command set for the loop's `repoPath` (`resolveImplementForRepo`):

1. **Match**: EXACT `repoPath` key first, else the **longest** configured key that is a path-boundary prefix of the loop's repoPath (a parent-dir entry can cover a whole tree; more specific wins on ties). Pure/lexical — no fs/realpath.
2. **Per field**: matched per-repo value → else the global key → else today's default. An **absent** override field inherits the global; an explicit `null` (test/lint) overrides to "no command".
3. **No matching entry** (or empty/absent `perRepo`) ⇒ the request is **byte-identical** to reading the global keys directly.

The resolved values are threaded into the SDLC request in place of the raw global keys; the executor runs whatever command the request carries (no executor logic change).

## Backward compatibility

`perRepo` defaults to `{}`. With no `perRepo` and the existing global keys, every dispatch produces exactly today's request. Existing configs are unaffected.

## Security

Identical trust model to the existing global keys: config-sourced only (never action-point/criterion text), run downstream via no-shell argv. Each per-repo field is **re-validated** with the same schema — `coderModel` must pass the safe-slug guard (alphanumeric first char, so it can never look like a flag), `testRunTimeoutMs` is clamped 10s..30min, unknown fields are stripped. A per-repo entry for a non-allowlisted repo is harmless dead config — the `allowedRepoPaths` allowlist is still enforced independently at dispatch, so an override can never widen repo access.

## Test evidence

- `tests/unit/config/implement-per-repo.test.ts` — schema (default `{}`, field validation, safe-slug + timeout clamp re-applied, unknown-field strip) and pure resolution: exact match, longest path-boundary prefix, non-boundary-substring rejection, no-match→undefined, override precedence, absent-field inheritance, explicit-null override, empty-perRepo backward-compat contract.
- `tests/unit/consilium/loop-per-repo-command-wire.test.ts` — controller threads the resolved override into `runSdlc`; repo without an entry falls back to global keys; absent `perRepo` byte-identical to global-only request; adversarial non-allowlisted entry is dead config.
- `tests/unit/sdlc/verification-loop.test.ts` — added: the executor runs the resolved per-repo command/timeout/lint carried in the request.

Affected suites (`tests/unit/consilium`, `tests/unit/sdlc`, `tests/unit/config`): **763 passed**. Full suite: **5762 passed / 5 skipped**, one unrelated flake (`gateway.test.ts > testProvider throws when provider not registered`) — a 5s timeout under parallel load that passes 21/21 in isolation; outside this change's zone. `tsc` clean. `pull_request` CI is authoritative.

## Not in scope

No FSM/migration. No change to the review side (`startReviewRound`) of the controller.