### PR TITLE
feat: scoped repository-map preamble in review context

### DIFF
--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -340,6 +340,27 @@ export const ConfigSchema = z.object({
        */
       allowedRepoPaths: z.array(z.string()).default([]),
       /**
+       * OPTION A (codegraph research): a scoped, READ-ONLY "repository map" preamble
+       * injected into the REVIEW input. For the files each round's diff TOUCHES, a
+       * compact `file → exported symbols + 1-hop importers` map is built from the
+       * EXISTING workspace symbol index (`workspace_symbols`) — never a new
+       * dependency, never a write. It improves debater/judge comprehension of
+       * structural claims (fewer rounds). Hard byte-bounded + secret-redacted.
+       * Default OFF ⇒ BYTE-IDENTICAL: no map section is emitted and the review input
+       * is unchanged. Also gated (like every enhancement here) under the parent
+       * `consiliumLoop.enabled`.
+       */
+      repoMap: z.object({
+        /** Kill-switch: false (default) → no map section (byte-identical off). */
+        enabled: z.boolean().default(false),
+        /**
+         * Hard byte cap on the assembled map body (~4 bytes/token ⇒ ≈1500 tokens at
+         * the 6KiB default). Entries are ranked by importer count and the least-
+         * referenced files are dropped FIRST to fit. 512B..200KB.
+         */
+        maxRepoMapBytes: z.coerce.number().int().min(512).max(200_000).default(6_000),
+      }).default({}),
+      /**
        * Hard wall-clock timeout PER action-point SDLC coder run (ms). The SDLC
        * executor runs the agentic coder once per action point sequentially in one
        * worktree, so this bounds a SINGLE action point, not the whole round.

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -59,6 +59,8 @@ import type { AppConfig } from "../../config/schema.js";
 import { effectiveVerificationEnabled } from "../../config/schema.js";
 import { readConvergence, extractActionPoints, normalizeActionPointMethods, applyCriteriaQa } from "../orchestrator/convergence.js";
 import { buildDiffContext } from "./diff-context.js";
+import { buildRepoMap, createDbRepoMapSource, listTouchedFiles, repoMapGit } from "./repo-map.js";
+import { findLoopWorkspace } from "./workspace-bind.js";
 import type { DevCloseoutResult } from "./dev-closeout.js";
 import { runSdlcHandoff, type SdlcProgress, type JudgeVerifyFn, type JudgeVerifyInput } from "../sdlc/executor.js";
 import { runResearchHandoff, type ResearchGateway } from "../research/research-runner.js";
@@ -1523,6 +1525,10 @@ export class ConsiliumLoopController {
       effectiveVerificationEnabled(this.deps.config()) || this.researchImplementEnabled()
         ? await this.latestRoundTestSummary(loop)
         : undefined;
+    // Option A: scoped repository-map preamble (files touched by this round's diff →
+    // exported symbols + 1-hop importers), read-only over the workspace symbol index.
+    // Kill-switched (default OFF ⇒ undefined ⇒ byte-identical review input).
+    const repoMap = await this.buildReviewRepoMap(loop, cfg);
     const ctx = await buildDiffContext({
       repoPath: loop.repoPath,
       baselineCommit: loop.lastReviewedCommit,
@@ -1534,6 +1540,7 @@ export class ConsiliumLoopController {
       maxDiffBytes: cfg.maxDiffBytes,
       priorFindings,
       testSummary,
+      repoMap,
     });
     if (!ctx.ok) {
       // Surface the (scrubbed) git failure as a loop error; the next tick from
@@ -1554,6 +1561,49 @@ export class ConsiliumLoopController {
       currentIterationNumber: iteration.iterationNumber,
       openP0: null,
     };
+  }
+
+  /**
+   * Option A (codegraph research): build the scoped repository-map preamble for the
+   * REVIEW input. READ-ONLY over the existing workspace symbol index — for the files
+   * this round's diff touches, `file → exported symbols + 1-hop importers`, compact,
+   * secret-redacted and byte-bounded. BEST-EFFORT by design: kill-switch OFF, round 1
+   * (no diff), an unindexed repo, or ANY failure ⇒ `undefined` and the section is
+   * simply omitted (byte-identical review input). NEVER throws — a map problem must
+   * never fail a review round. Kept entirely on the REVIEW side (no develop-side edit).
+   */
+  private async buildReviewRepoMap(
+    loop: ConsiliumLoopRow,
+    cfg: AppConfig["pipeline"]["consiliumLoop"],
+  ): Promise<string | undefined> {
+    const rm = cfg.repoMap;
+    // OFF by default, and round 1 has no baseline ⇒ no diff ⇒ nothing to map.
+    if (!rm?.enabled || loop.lastReviewedCommit === null) return undefined;
+    try {
+      // H-1 parity: re-validate the persisted repoPath ourselves before touching git.
+      const resolvedRepo = assertAllowedRepoPath(loop.repoPath, cfg.allowedRepoPaths);
+      const touched = await listTouchedFiles(
+        repoMapGit(resolvedRepo),
+        loop.lastReviewedCommit,
+        loop.reviewRef,
+      );
+      if (touched.length === 0) return undefined;
+      // READ-ONLY workspace resolve (never creates) — absent ⇒ repo isn't indexed.
+      const workspace = await findLoopWorkspace(this.storage, resolvedRepo, cfg.allowedRepoPaths);
+      if (!workspace) return undefined;
+      const map = await buildRepoMap({
+        touchedFiles: touched,
+        source: createDbRepoMapSource(workspace.id),
+        maxRepoMapBytes: rm.maxRepoMapBytes,
+      });
+      return map ?? undefined;
+    } catch (err) {
+      this.log(
+        loop.id,
+        `repoMap skipped (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    }
   }
 
   /**

--- a/server/services/consilium/diff-context.ts
+++ b/server/services/consilium/diff-context.ts
@@ -73,6 +73,17 @@ export interface DiffContextRequest {
    * findings list oldest-first to stay within budget.
    */
   priorFindings?: string;
+  /**
+   * OPTION A (codegraph research): a scoped, READ-ONLY "repository map" preamble —
+   * for the files this round's diff TOUCHES, a compact `file → exported symbols +
+   * 1-hop importers` map (built by `repo-map.ts` from the EXISTING workspace symbol
+   * index). Placed BETWEEN the objective and the diff so debaters/judge read the
+   * structural context first. Already hard byte-bounded + secret-redacted by the
+   * builder; assembly re-runs `redactSecrets` (H-4 parity — signatures can embed
+   * literals) and applies a DEFENSIVE `maxDiffBytes` clamp. Absent/blank ⇒ NO
+   * section (byte-identical to today). Never executed, never logged.
+   */
+  repoMap?: string;
   /** Injected git client (tests pass a fake); defaults to simple-git(repoPath). */
   gitClient?: GitDiffClient;
 }
@@ -227,10 +238,26 @@ function assembleInput(
   testSummary: string | undefined,
   priorFindings: string | undefined,
   maxDiffBytes: number,
+  repoMap: string | undefined,
 ): { input: string; truncated: boolean } {
   const obj = objective.trim();
   const sections = [obj.length > 0 ? obj : "_No objective supplied; review the changes below._"];
   let truncated = parts?.truncated ?? false;
+  // OPTION A: the scoped repository map goes BETWEEN the objective and the diff so
+  // the model reads structural context (touched files → symbols + importers) before
+  // the changes. The builder already redacted + byte-bounded it; we re-run
+  // redactSecrets (H-4 parity — signatures can carry literals) and apply a DEFENSIVE
+  // maxDiffBytes clamp. Its own internal drop-note carries any map truncation, so we
+  // deliberately do NOT fold it into the shared `truncated` flag (which tracks the
+  // diff/testSummary). Absent/blank ⇒ no section (byte-identical to before).
+  if (repoMap && repoMap.trim().length > 0) {
+    const redacted = redactSecrets(repoMap.trim());
+    const overflow = Buffer.byteLength(redacted, "utf8") > maxDiffBytes;
+    const text = overflow
+      ? Buffer.from(redacted, "utf8").subarray(0, maxDiffBytes).toString("utf8")
+      : redacted;
+    sections.push(`## Repository map (files touched by this diff + their importers)\n\n${text}`);
+  }
   if (parts) {
     const note = parts.truncated ? "\n\n_(diff truncated to the configured byte limit)_" : "";
     // MED-1: collectDiff returns an empty body WITH truncated=true when it refused
@@ -319,7 +346,8 @@ export async function buildDiffContext(
     if (req.objective.trim().length === 0) {
       return fail("unknown", "objective is empty and there is no diff (round 1); refusing to emit a blank review input");
     }
-    const built = assembleInput(req.objective, null, req.testSummary, undefined, req.maxDiffBytes);
+    // Round 1 has no diff, so there are no "touched files" to map ⇒ no repoMap.
+    const built = assembleInput(req.objective, null, req.testSummary, undefined, req.maxDiffBytes, undefined);
     return { ok: true, input: built.input, headCommit: head, baselineCommit: null, truncated: built.truncated };
   }
 
@@ -329,7 +357,7 @@ export async function buildDiffContext(
   const parts = await collectDiff(git, baseline, head, req.maxDiffBytes);
   if (!("stat" in parts)) return parts;
 
-  const built = assembleInput(req.objective, parts, req.testSummary, req.priorFindings, req.maxDiffBytes);
+  const built = assembleInput(req.objective, parts, req.testSummary, req.priorFindings, req.maxDiffBytes, req.repoMap);
   return {
     ok: true,
     input: built.input,

--- a/server/services/consilium/repo-map.ts
+++ b/server/services/consilium/repo-map.ts
@@ -1,0 +1,284 @@
+/**
+ * repo-map.ts — scoped "repository map" preamble for the consilium REVIEW input
+ * (codegraph research recommendation, option A).
+ *
+ * For the files a review round's diff TOUCHES, emit a COMPACT structural map —
+ * each `file → its exported/defined symbols (+ kind, cheap signature)` and its
+ * 1-hop importers (`importedBy`) — so debaters + the judge can reason about
+ * structural claims (blast radius, call sites) WITHOUT the whole tree. This is
+ * READ-ONLY over the EXISTING workspace symbol index (`workspace_symbols`):
+ * never a new dependency, never a write, watcher-maintained + nightly-rebuilt.
+ *
+ * BOUNDS / SAFETY (mirrors diff-context.ts):
+ *   - Hard byte cap (`maxRepoMapBytes`): entries are ranked most→least important
+ *     (importer count, then symbol richness) and the LEAST-referenced files are
+ *     DROPPED FIRST until the render fits. It NEVER dumps the whole index.
+ *   - Secret redaction: symbol signatures can embed literals, so the assembled
+ *     map is run through the SAME `redactSecrets` pass the diff uses BEFORE it is
+ *     returned (defence-in-depth: diff-context redacts it again on assembly).
+ *   - Best-effort: an unindexed / non-TS-JS repo, an empty touched-file set, or
+ *     any git/index failure yields `null` (the caller omits the section) — it
+ *     NEVER throws and NEVER fails a review round.
+ *
+ * The BUILDER (`buildRepoMap`) is a pure function over an injected `RepoMapSource`
+ * so it is unit-testable with a mocked symbol set; `createDbRepoMapSource` is the
+ * thin real adapter over `workspace_symbols` + the existing `DependencyGraph`.
+ */
+import simpleGit from "simple-git";
+import { db } from "../../db.js";
+import { workspaceSymbols } from "@shared/schema";
+import { and, eq } from "drizzle-orm";
+import type { SymbolKind } from "@shared/schema";
+import { DependencyGraph } from "../../workspace/dependency-graph.js";
+import { redactSecrets } from "./diff-redactor.js";
+import { validateReviewRef } from "./ref-validator.js";
+
+/** Kinds worth surfacing — DEFINITIONS/exports, never raw `import` rows. */
+const MAP_SYMBOL_KINDS: readonly SymbolKind[] = [
+  "function",
+  "class",
+  "interface",
+  "type",
+  "variable",
+  "export",
+];
+
+/** Hard structural caps so a single pathological file can never blow the map up. */
+const MAX_FILES = 40;
+const MAX_SYMBOLS_PER_FILE = 24;
+const MAX_IMPORTERS_PER_FILE = 8;
+const MAX_SIGNATURE_CHARS = 120;
+
+const SHA_RE = /^[0-9a-f]{7,64}$/;
+
+// ─── Public types ───────────────────────────────────────────────────────────
+
+export interface RepoMapSymbol {
+  name: string;
+  kind: SymbolKind;
+  /** Optional short type/param signature; may embed literals ⇒ redacted. */
+  signature: string | null;
+}
+
+/** One touched file's entry: its defined/exported symbols + files that import it. */
+export interface RepoMapFileEntry {
+  filePath: string;
+  symbols: RepoMapSymbol[];
+  /** 1-hop importers (files that import this file). */
+  importedBy: string[];
+}
+
+/**
+ * Read-only view over the workspace symbol index the builder consumes. The real
+ * impl (`createDbRepoMapSource`) queries `workspace_symbols` + the `DependencyGraph`;
+ * unit tests inject a fake returning a fixed entry set.
+ */
+export interface RepoMapSource {
+  /** Map entries for the touched files. Files with nothing indexed are omitted. */
+  entriesFor(touchedFiles: readonly string[]): Promise<RepoMapFileEntry[]>;
+}
+
+/** Minimal git surface `listTouchedFiles` needs — lets tests inject a fake. */
+export interface RepoMapGit {
+  revparse(args: string[]): Promise<string>;
+  diff(args: string[]): Promise<string>;
+}
+
+export interface BuildRepoMapRequest {
+  /** Files touched by this round's diff (already bounded by the caller). */
+  touchedFiles: readonly string[];
+  /** Symbol-index adapter (real DB source, or a test fake). */
+  source: RepoMapSource;
+  /** Hard byte cap on the assembled map body (config.repoMap.maxRepoMapBytes). */
+  maxRepoMapBytes: number;
+}
+
+// ─── Touched-file resolution (same discipline as diff-context B-1) ───────────
+
+/**
+ * Resolve the files touched by `baseline..ref` with the SAME security discipline
+ * as diff-context: strict-hex baseline, `ref-validator`-validated ref, and every
+ * git arg pinned behind `--end-of-options` so an option-looking value can never be
+ * parsed as a flag. Best-effort: ANY failure ⇒ `[]` (the caller omits the map).
+ * Never throws. Bounded to `MAX_FILES`.
+ */
+export async function listTouchedFiles(
+  git: RepoMapGit,
+  baseline: string,
+  ref: string | null,
+): Promise<string[]> {
+  if (!SHA_RE.test(baseline)) return [];
+  const headRef = ref ?? "HEAD";
+  if (ref != null) {
+    try {
+      validateReviewRef(ref);
+    } catch {
+      return [];
+    }
+  }
+  try {
+    const base = (await git.revparse(["--verify", "--end-of-options", `${baseline}^{commit}`])).trim();
+    const head = (await git.revparse(["--verify", "--end-of-options", `${headRef}^{commit}`])).trim();
+    if (!SHA_RE.test(base) || !SHA_RE.test(head)) return [];
+    const out = await git.diff(["--name-only", "--end-of-options", `${base}..${head}`]);
+    return out
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0)
+      .slice(0, MAX_FILES);
+  } catch {
+    return [];
+  }
+}
+
+// ─── Rendering ───────────────────────────────────────────────────────────────
+
+/** Collapse whitespace + clip a signature so one field can't dominate the budget. */
+function clampSignature(signature: string): string {
+  const flat = signature.replace(/\s+/g, " ").trim();
+  return flat.length > MAX_SIGNATURE_CHARS ? `${flat.slice(0, MAX_SIGNATURE_CHARS)}…` : flat;
+}
+
+function renderSymbol(sym: RepoMapSymbol): string {
+  const sig = sym.signature ? clampSignature(sym.signature) : "";
+  return `\`${sym.name}\`${sig ? ` ${sig}` : ""} [${sym.kind}]`;
+}
+
+/** Render ONE file entry to its compact markdown block (1–2 lines). */
+function renderEntry(entry: RepoMapFileEntry): string {
+  const shown = entry.symbols.slice(0, MAX_SYMBOLS_PER_FILE).map(renderSymbol);
+  const symOverflow = entry.symbols.length - shown.length;
+  const symText =
+    shown.length > 0
+      ? `${shown.join(", ")}${symOverflow > 0 ? `, …(+${symOverflow} more)` : ""}`
+      : "_(no exported symbols indexed)_";
+  const lines = [`- \`${entry.filePath}\`: ${symText}`];
+  if (entry.importedBy.length > 0) {
+    const imps = entry.importedBy.slice(0, MAX_IMPORTERS_PER_FILE).map((f) => `\`${f}\``);
+    const impOverflow = entry.importedBy.length - imps.length;
+    lines.push(`  imported by: ${imps.join(", ")}${impOverflow > 0 ? ` (+${impOverflow} more)` : ""}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Importance: a file imported by MANY is structurally central (blast radius) →
+ * keep it. Ties broken by symbol richness, then path for a STABLE order.
+ */
+function byImportance(a: RepoMapFileEntry, b: RepoMapFileEntry): number {
+  if (b.importedBy.length !== a.importedBy.length) return b.importedBy.length - a.importedBy.length;
+  if (b.symbols.length !== a.symbols.length) return b.symbols.length - a.symbols.length;
+  return a.filePath < b.filePath ? -1 : a.filePath > b.filePath ? 1 : 0;
+}
+
+/**
+ * Build the compact map BODY (the section header is added by diff-context on
+ * assembly). Ranks entries most→least important, then keeps a PREFIX that fits
+ * `maxRepoMapBytes` — dropping the least-referenced files first — and appends a
+ * one-line omission note when any were dropped. Each block is secret-redacted
+ * BEFORE it counts against the budget. Returns `null` when nothing maps (empty
+ * input, or not even the single most-important entry fits).
+ */
+export async function buildRepoMap(req: BuildRepoMapRequest): Promise<string | null> {
+  const { touchedFiles, source, maxRepoMapBytes } = req;
+  if (touchedFiles.length === 0) return null;
+
+  let entries: RepoMapFileEntry[];
+  try {
+    entries = await source.entriesFor(touchedFiles);
+  } catch {
+    return null; // best-effort: an index read failure omits the map, never throws.
+  }
+  if (entries.length === 0) return null;
+
+  const ranked = [...entries].sort(byImportance);
+
+  const blocks: string[] = [];
+  let running = 0;
+  for (const entry of ranked) {
+    const block = redactSecrets(renderEntry(entry));
+    const size = Buffer.byteLength(block, "utf8") + (blocks.length > 0 ? 1 : 0); // +"\n" join
+    if (running + size > maxRepoMapBytes) break; // stop: all remaining (least important) dropped
+    blocks.push(block);
+    running += size;
+  }
+  if (blocks.length === 0) return null;
+
+  const dropped = ranked.length - blocks.length;
+  const note =
+    dropped > 0
+      ? `\n\n_(repository map truncated to the byte budget; ${dropped} less-referenced file(s) omitted)_`
+      : "";
+  return `${blocks.join("\n")}${note}`;
+}
+
+// ─── Real DB adapter (thin; not the unit-under-test) ─────────────────────────
+
+/** Try common TS/JS forms so a `.ts` edge target matches a touched `.ts` file. */
+function importerKeys(file: string): string[] {
+  const noExt = file.replace(/\.[^./]+$/, "");
+  return [file, `${noExt}.ts`, `${noExt}.tsx`, noExt];
+}
+
+/**
+ * Real `RepoMapSource` over `workspace_symbols` + the existing `DependencyGraph`
+ * (both keyed by `workspaceId`, both already used elsewhere in server/workspace).
+ * Symbol rows are filtered to definition kinds; importers are read from the
+ * dependency graph's edges (`source → target`, so importers of F are the sources
+ * whose target is F). All paths are workspace-relative — the SAME shape git
+ * `--name-only` returns for a 1:1 repo↔workspace bind.
+ */
+export function createDbRepoMapSource(
+  workspaceId: string,
+  graph: DependencyGraph = new DependencyGraph(),
+): RepoMapSource {
+  return {
+    async entriesFor(touchedFiles) {
+      const files = touchedFiles.slice(0, MAX_FILES);
+      if (files.length === 0) return [];
+
+      // 1-hop importers, computed ONCE from the (LRU-cached) dependency graph.
+      const dg = await graph.buildGraph(workspaceId);
+      const importersByTarget = new Map<string, string[]>();
+      for (const edge of dg.edges) {
+        const arr = importersByTarget.get(edge.target) ?? [];
+        arr.push(edge.source);
+        importersByTarget.set(edge.target, arr);
+      }
+
+      const kinds = new Set<string>(MAP_SYMBOL_KINDS);
+      const entries: RepoMapFileEntry[] = [];
+      for (const file of files) {
+        const rows = await db
+          .select()
+          .from(workspaceSymbols)
+          .where(and(eq(workspaceSymbols.workspaceId, workspaceId), eq(workspaceSymbols.filePath, file)));
+        const symbols: RepoMapSymbol[] = rows
+          .filter((r) => kinds.has(r.kind))
+          .map((r) => ({ name: r.name, kind: r.kind as SymbolKind, signature: r.signature }));
+
+        let importedBy: string[] = [];
+        for (const key of importerKeys(file)) {
+          const hit = importersByTarget.get(key);
+          if (hit && hit.length > 0) {
+            importedBy = Array.from(new Set(hit));
+            break;
+          }
+        }
+
+        // Nothing indexed for this file (non-TS/JS, or unindexed) → omit it.
+        if (symbols.length === 0 && importedBy.length === 0) continue;
+        entries.push({ filePath: file, symbols, importedBy });
+      }
+      return entries;
+    },
+  };
+}
+
+/** Build a real (allowlist-resolved) simple-git client for touched-file reads. */
+export function repoMapGit(resolvedRepoPath: string): RepoMapGit {
+  return simpleGit(resolvedRepoPath);
+}
+
+// re-export for callers/tests that want the file cap constant.
+export const REPO_MAP_MAX_FILES = MAX_FILES;

--- a/server/services/consilium/workspace-bind.ts
+++ b/server/services/consilium/workspace-bind.ts
@@ -89,3 +89,25 @@ export async function resolveLoopWorkspace(
     ownerId,
   });
 }
+
+/**
+ * READ-ONLY companion to `resolveLoopWorkspace`: find the `local` workspace bound
+ * to `repoPath` WITHOUT ever creating one. Used by the review-side repository-map
+ * preamble, which is a pure read over the symbol index and must never mutate the
+ * workspace table. Same fail-closed allowlist + realpath discipline; ANY failure
+ * (non-allowlisted path, non-existent path, no match) yields `undefined` so the
+ * caller simply omits the map. Never throws.
+ */
+export async function findLoopWorkspace(
+  storage: Pick<WorkspaceBindStorage, "getWorkspaces">,
+  repoPath: string,
+  allowedRoots: readonly string[],
+): Promise<WorkspaceRow | undefined> {
+  try {
+    assertAllowedRepoPath(repoPath, allowedRoots);
+    const resolvedTarget = realResolve(repoPath);
+    return findBoundWorkspace(await storage.getWorkspaces(), resolvedTarget, allowedRoots);
+  } catch {
+    return undefined;
+  }
+}

--- a/tests/unit/consilium/diff-context.test.ts
+++ b/tests/unit/consilium/diff-context.test.ts
@@ -311,3 +311,54 @@ describe("buildDiffContext — LOW-1 re-validates the stored reviewRef", () => {
     expect(git.revparse).toHaveBeenCalled();
   });
 });
+
+describe("buildDiffContext — Option A repository-map section", () => {
+  const MAP = "- `server/a.ts`: `foo` [function]\n  imported by: `server/b.ts`";
+
+  it("injects the map BETWEEN the objective and the diff, under a header", async () => {
+    const res = await buildDiffContext({ repoPath: REPO, baselineCommit: BASE_SHA, objective: "Obj", allowedRepoPaths: ALLOW, maxDiffBytes: 10_000, repoMap: MAP, gitClient: fakeGit() });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.input).toContain("## Repository map (files touched by this diff + their importers)");
+    expect(res.input).toContain("`server/a.ts`");
+    // ordering: objective < repo map < changes
+    const iObj = res.input.indexOf("Obj");
+    const iMap = res.input.indexOf("## Repository map");
+    const iDiff = res.input.indexOf("## Changes since last review");
+    expect(iObj).toBeGreaterThanOrEqual(0);
+    expect(iMap).toBeGreaterThan(iObj);
+    expect(iDiff).toBeGreaterThan(iMap);
+  });
+
+  it("absent repoMap ⇒ NO map section (byte-identical to before)", async () => {
+    const withArg = await buildDiffContext({ repoPath: REPO, baselineCommit: BASE_SHA, objective: "Obj", allowedRepoPaths: ALLOW, maxDiffBytes: 10_000, repoMap: undefined, gitClient: fakeGit() });
+    const without = await buildDiffContext({ repoPath: REPO, baselineCommit: BASE_SHA, objective: "Obj", allowedRepoPaths: ALLOW, maxDiffBytes: 10_000, gitClient: fakeGit() });
+    expect(withArg.ok && without.ok).toBe(true);
+    if (!withArg.ok || !without.ok) return;
+    expect(withArg.input).toBe(without.input);
+    expect(withArg.input).not.toContain("## Repository map");
+  });
+
+  it("a blank repoMap emits NO section", async () => {
+    const res = await buildDiffContext({ repoPath: REPO, baselineCommit: BASE_SHA, objective: "Obj", allowedRepoPaths: ALLOW, maxDiffBytes: 10_000, repoMap: "   \n  ", gitClient: fakeGit() });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.input).not.toContain("## Repository map");
+  });
+
+  it("defensively redacts a secret that reaches assembly in the map text", async () => {
+    const secret = "AKIAIOSFODNN7EXAMPLEKEYDATA1234567890";
+    const res = await buildDiffContext({ repoPath: REPO, baselineCommit: BASE_SHA, objective: "Obj", allowedRepoPaths: ALLOW, maxDiffBytes: 10_000, repoMap: `- \`c.ts\`: AWS_SECRET_ACCESS_KEY=${secret}`, gitClient: fakeGit() });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.input).not.toContain(secret);
+    expect(res.input).toContain("<REDACTED:");
+  });
+
+  it("round 1 (null baseline) never emits a map even if one is passed", async () => {
+    const res = await buildDiffContext({ repoPath: REPO, baselineCommit: null, objective: "Obj", allowedRepoPaths: ALLOW, maxDiffBytes: 10_000, repoMap: MAP, gitClient: fakeGit() });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.input).not.toContain("## Repository map");
+  });
+});

--- a/tests/unit/consilium/repo-map.test.ts
+++ b/tests/unit/consilium/repo-map.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Unit tests for server/services/consilium/repo-map.ts (Option A — the scoped
+ * repository-map preamble for the consilium REVIEW input).
+ *
+ * The BUILDER is exercised with a MOCKED RepoMapSource (no DB, no index), and
+ * `listTouchedFiles` with a FAKE git. Covers:
+ *   - map built from a mocked symbol set: files → exported symbols (+kind, sig) +
+ *     1-hop importers, compact format.
+ *   - byte clamp drops the LEAST-important (fewest importers) files first + note.
+ *   - secret redaction over signatures BEFORE the map is returned.
+ *   - empty input / empty entries ⇒ null (caller omits the section).
+ *   - listTouchedFiles: name-only parse, strict-hex baseline gate, ref-validator
+ *     gate, `--end-of-options` pin, best-effort [] on failure.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  buildRepoMap,
+  listTouchedFiles,
+  type RepoMapSource,
+  type RepoMapFileEntry,
+  type RepoMapGit,
+} from "../../../server/services/consilium/repo-map.js";
+
+/** A source that returns a fixed entry set regardless of the touched files. */
+function fakeSource(entries: RepoMapFileEntry[]): RepoMapSource {
+  return { entriesFor: vi.fn(async () => entries) };
+}
+
+const entry = (over: Partial<RepoMapFileEntry> & { filePath: string }): RepoMapFileEntry => ({
+  symbols: [],
+  importedBy: [],
+  ...over,
+});
+
+describe("buildRepoMap — assembly from a mocked symbol set", () => {
+  it("renders touched files → exported symbols (+kind, signature) and 1-hop importers", async () => {
+    const entries = [
+      entry({
+        filePath: "server/a.ts",
+        symbols: [
+          { name: "buildThing", kind: "function", signature: "(x: number): string" },
+          { name: "Thing", kind: "interface", signature: null },
+        ],
+        importedBy: ["server/b.ts", "server/c.ts"],
+      }),
+    ];
+    const map = await buildRepoMap({ touchedFiles: ["server/a.ts"], source: fakeSource(entries), maxRepoMapBytes: 4000 });
+    expect(map).not.toBeNull();
+    expect(map).toContain("`server/a.ts`");
+    expect(map).toContain("`buildThing`");
+    expect(map).toContain("[function]");
+    expect(map).toContain("(x: number): string");
+    expect(map).toContain("`Thing`");
+    expect(map).toContain("[interface]");
+    expect(map).toContain("imported by:");
+    expect(map).toContain("`server/b.ts`");
+    expect(map).toContain("`server/c.ts`");
+  });
+
+  it("omits the importers line when a file has no importers", async () => {
+    const entries = [entry({ filePath: "x.ts", symbols: [{ name: "f", kind: "function", signature: null }] })];
+    const map = await buildRepoMap({ touchedFiles: ["x.ts"], source: fakeSource(entries), maxRepoMapBytes: 4000 });
+    expect(map).toContain("`x.ts`");
+    expect(map).not.toContain("imported by:");
+  });
+
+  it("returns null for an empty touched-file set (no source call needed)", async () => {
+    const src = fakeSource([entry({ filePath: "a.ts" })]);
+    const map = await buildRepoMap({ touchedFiles: [], source: src, maxRepoMapBytes: 4000 });
+    expect(map).toBeNull();
+    expect(src.entriesFor).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the index yields no entries (unindexed repo)", async () => {
+    const map = await buildRepoMap({ touchedFiles: ["a.ts"], source: fakeSource([]), maxRepoMapBytes: 4000 });
+    expect(map).toBeNull();
+  });
+
+  it("returns null (never throws) when the source read fails", async () => {
+    const src: RepoMapSource = { entriesFor: vi.fn(async () => { throw new Error("db down"); }) };
+    const map = await buildRepoMap({ touchedFiles: ["a.ts"], source: src, maxRepoMapBytes: 4000 });
+    expect(map).toBeNull();
+  });
+});
+
+describe("buildRepoMap — byte clamp drops least-important first", () => {
+  it("keeps the most-imported files and drops the least-referenced, with a note", async () => {
+    // Three files: importers 5 > 2 > 0. A tight budget fits only the top ~2.
+    const mk = (name: string, importers: number): RepoMapFileEntry =>
+      entry({
+        filePath: name,
+        symbols: [{ name: `sym_${name}`, kind: "function", signature: null }],
+        importedBy: Array.from({ length: importers }, (_, i) => `imp_${name}_${i}.ts`),
+      });
+    const central = mk("central.ts", 5);
+    const middle = mk("middle.ts", 2);
+    const leaf = mk("leaf.ts", 0);
+
+    // Budget = the EXACT rendered size of the top-two blocks (importance order),
+    // so the least-important (leaf) can't fit and is dropped.
+    const topTwo = await buildRepoMap({ touchedFiles: ["a", "b"], source: fakeSource([central, middle]), maxRepoMapBytes: 100_000 });
+    const budget = Buffer.byteLength(topTwo!, "utf8");
+
+    const map = await buildRepoMap({
+      touchedFiles: ["a", "b", "c"],
+      source: fakeSource([leaf, central, middle]), // deliberately unsorted
+      maxRepoMapBytes: budget,
+    });
+    expect(map).not.toBeNull();
+    // most-important two kept:
+    expect(map).toContain("`central.ts`");
+    expect(map).toContain("`middle.ts`");
+    // least-important dropped:
+    expect(map).not.toContain("`leaf.ts`");
+    expect(map).toContain("less-referenced file(s) omitted");
+    // body (blocks, before the note) respects the budget:
+    const body = map!.split("\n\n_(repository map truncated")[0];
+    expect(Buffer.byteLength(body, "utf8")).toBeLessThanOrEqual(budget);
+  });
+});
+
+describe("buildRepoMap — secret redaction", () => {
+  it("redacts secrets embedded in a symbol signature before returning", async () => {
+    const secret = "AKIAIOSFODNN7EXAMPLEKEYDATA1234567890";
+    const entries = [
+      entry({
+        filePath: "cfg.ts",
+        symbols: [
+          { name: "DEFAULT", kind: "variable", signature: `AWS_SECRET_ACCESS_KEY=${secret}` },
+        ],
+      }),
+    ];
+    const map = await buildRepoMap({ touchedFiles: ["cfg.ts"], source: fakeSource(entries), maxRepoMapBytes: 4000 });
+    expect(map).not.toBeNull();
+    expect(map).not.toContain(secret);
+    expect(map).toContain("<REDACTED:");
+  });
+});
+
+describe("listTouchedFiles", () => {
+  const BASE = "b".repeat(40);
+  const HEAD_SHA = "a".repeat(40);
+  const BASE_SHA = "b".repeat(40);
+
+  function fakeGit(over: Partial<RepoMapGit> = {}): RepoMapGit {
+    return {
+      revparse: vi.fn(async (args: string[]) => {
+        const ref = args[args.length - 1];
+        if (ref.startsWith("a".repeat(7)) || ref === "HEAD^{commit}") return HEAD_SHA + "\n";
+        return BASE_SHA + "\n";
+      }),
+      diff: vi.fn(async () => "server/a.ts\nserver/b.ts\n\n"),
+      ...over,
+    };
+  }
+
+  it("parses `git diff --name-only` into a clean file list", async () => {
+    const files = await listTouchedFiles(fakeGit(), BASE, null);
+    expect(files).toEqual(["server/a.ts", "server/b.ts"]);
+  });
+
+  it("pins --end-of-options and uses the resolved shas in the range", async () => {
+    const git = fakeGit();
+    await listTouchedFiles(git, BASE, null);
+    const diffArgs = (git.diff as ReturnType<typeof vi.fn>).mock.calls[0][0] as string[];
+    expect(diffArgs).toContain("--name-only");
+    expect(diffArgs).toContain("--end-of-options");
+    expect(diffArgs).toContain(`${BASE_SHA}..${HEAD_SHA}`);
+  });
+
+  it("rejects a non-hex baseline WITHOUT touching git", async () => {
+    const git = fakeGit();
+    const files = await listTouchedFiles(git, "not-a-sha", null);
+    expect(files).toEqual([]);
+    expect(git.revparse).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid review ref (ref-validator) WITHOUT touching git", async () => {
+    const git = fakeGit();
+    const files = await listTouchedFiles(git, BASE, "--upload-pack=evil");
+    expect(files).toEqual([]);
+    expect(git.revparse).not.toHaveBeenCalled();
+  });
+
+  it("returns [] (never throws) when git fails", async () => {
+    const git = fakeGit({ revparse: vi.fn(async () => { throw new Error("not a repo"); }) });
+    const files = await listTouchedFiles(git, BASE, null);
+    expect(files).toEqual([]);
+  });
+});

--- a/tests/unit/consilium/workspace-bind.test.ts
+++ b/tests/unit/consilium/workspace-bind.test.ts
@@ -11,7 +11,7 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import { realpathSync } from "fs";
-import { resolveLoopWorkspace, type WorkspaceBindStorage } from "../../../server/services/consilium/workspace-bind.js";
+import { resolveLoopWorkspace, findLoopWorkspace, type WorkspaceBindStorage } from "../../../server/services/consilium/workspace-bind.js";
 import type { InsertWorkspace, WorkspaceRow } from "@shared/schema";
 
 const REPO = process.cwd();
@@ -95,5 +95,33 @@ describe("resolveLoopWorkspace", () => {
     expect(ws.id).not.toBe("ws-poisoned");
     expect(createWorkspace).toHaveBeenCalledTimes(1);
     expect((createWorkspace.mock.calls[0][0] as InsertWorkspace).path).toBe(RESOLVED);
+  });
+});
+
+describe("findLoopWorkspace (read-only — never creates)", () => {
+  it("returns an existing matching local workspace WITHOUT creating", async () => {
+    const { storage, createWorkspace } = fakeStorage([row({ id: "ws-existing" })]);
+    const ws = await findLoopWorkspace(storage, REPO, ALLOW);
+    expect(ws?.id).toBe("ws-existing");
+    expect(createWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined when no workspace is bound (never creates)", async () => {
+    const { storage, createWorkspace } = fakeStorage([]);
+    const ws = await findLoopWorkspace(storage, REPO, ALLOW);
+    expect(ws).toBeUndefined();
+    expect(createWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined for a non-allowlisted repoPath (never throws)", async () => {
+    const { storage } = fakeStorage([row({ id: "ws-existing" })]);
+    const ws = await findLoopWorkspace(storage, "/tmp/not-allowed", ALLOW);
+    expect(ws).toBeUndefined();
+  });
+
+  it("skips a poisoned-path row and returns undefined", async () => {
+    const { storage } = fakeStorage([row({ id: "ws-poisoned", path: "/etc/passwd" })]);
+    const ws = await findLoopWorkspace(storage, REPO, ALLOW);
+    expect(ws).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What & why

Injects a scoped, kill-switched **repository map** into the consilium **review** input (codegraph research recommendation, **option A**). For the files each review round's diff *touches*, it emits a compact structural map so debaters + the judge can reason about structural claims (blast radius, call sites) without the whole tree — fewer rounds on structural disputes.

## What's mapped

For each touched file (ranked by importer count, most-central first):
- `file → exported/defined symbols` (name + kind, cheap signature when present) — kinds `function/class/interface/type/variable/export`, never raw `import` rows.
- its **1-hop importers** (`importedBy`).

Built **read-only** from the **existing** workspace symbol index (`workspace_symbols`) + the existing `DependencyGraph` — no new dependency, no write, no new schema/migration/FSM state. Non-TS/JS files, an unindexed repo, round 1 (no diff), or any git/index failure → the section is simply omitted (never throws, never fails a round).

## Placement

A new section, header `## Repository map (files touched by this diff + their importers)`, is assembled **between the objective and the diff**, so it flows to debaters + judge automatically via the existing `iteration.input` wire (no orchestrator change).

## Byte bound

- Hard cap `maxRepoMapBytes` (default **6 KiB ≈ 1500 tokens**). Entries are ranked most→least important and the **least-referenced files are dropped first** until the render fits; a one-line omission note is appended. Structural sub-caps: ≤40 files, ≤24 symbols/file, ≤8 importers/file, signatures clamped to 120 chars. It **never** dumps the whole index.
- `diff-context` applies a **defensive** `maxDiffBytes` clamp on assembly as a second net.

## Redaction

Symbol signatures can embed literals, so the assembled map is run through the **existing** `redactSecrets` pass (same one the diff uses) in the builder **before** it is returned, and again defensively on assembly in `diff-context`.

## Config key

- `pipeline.consiliumLoop.repoMap.enabled` — kill-switch, **default `false`** (byte-identical off).
- `pipeline.consiliumLoop.repoMap.maxRepoMapBytes` — default `6000`, range 512..200000.

## Which step benefits

**Review** only. All edits to `consilium-loop-controller.ts` are confined to `startReviewRound` (+ one new private helper immediately after it) — the develop-side closeout/dispatch path is untouched, to avoid collision with the concurrent develop-side work.

## Test evidence

- `tests/unit/consilium/repo-map.test.ts` — map built from a mocked symbol set (files → exports + importers); byte clamp drops least-important first (+ note); signature secret redaction; empty/unindexed → null; `listTouchedFiles` name-only parse + strict-hex baseline gate + ref-validator gate + `--end-of-options` pin + best-effort `[]`.
- `tests/unit/consilium/diff-context.test.ts` — map placed between objective and diff under the header; absent/blank repoMap → **byte-identical** input (no section); defensive redaction; round-1 never emits a map. Confirms the extended `DiffContextRequest` shape.
- `tests/unit/consilium/workspace-bind.test.ts` — `findLoopWorkspace` is read-only (never creates), returns `undefined` for absent/non-allowlisted/poisoned rows.

Full unit suite green locally: **253 files / 4896 tests passed**; the `diff-context` real-git integration suite (5) passed; `tsc` clean. `pull_request` CI is authoritative.

## Adversarial self-review

- **Token blowup on a big diff** — hard `maxRepoMapBytes` clamp + drop-least-first + per-file caps + `MAX_FILES`; diff-context defensive clamp.
- **Secrets in signatures** — redacted in the builder and again at assembly.
- **Collision with the develop-side controller team** — all controller edits kept strictly on the review side (`startReviewRound`).

Draft — do not merge.
