### PR TITLE
feat: trust telemetry (grounding ratio, planner track record)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -37,6 +37,7 @@ import Activity from "@/pages/Activity";
 import ConsiliumLoopList from "@/pages/ConsiliumLoopList";
 import ConsiliumLoopDetail from "@/pages/ConsiliumLoopDetail";
 import PrReviewQueue from "@/pages/PrReviewQueue";
+import TrustTelemetry from "@/pages/TrustTelemetry";
 import ContourObservability from "@/pages/ContourObservability";
 import CredentialAccess from "@/pages/CredentialAccess";
 
@@ -88,6 +89,9 @@ function ProtectedRouter() {
         )} />
         <Route path="/consilium-loops" component={() => (
           <ErrorBoundary><ConsiliumLoopList /></ErrorBoundary>
+        )} />
+        <Route path="/trust" component={() => (
+          <ErrorBoundary><TrustTelemetry /></ErrorBoundary>
         )} />
         <Route path="/pr-queue" component={() => (
           <ErrorBoundary><PrReviewQueue /></ErrorBoundary>

--- a/client/src/components/layout/MainLayout.tsx
+++ b/client/src/components/layout/MainLayout.tsx
@@ -16,6 +16,7 @@ import {
   Radio,
   Repeat,
   GitPullRequest,
+  ShieldCheck,
   KeyRound,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -56,6 +57,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
     { icon: Zap, label: "Triggers", href: "/triggers" },
     { icon: Repeat, label: "Consilium Loops", href: "/consilium-loops" },
     { icon: GitPullRequest, label: "PR Queue", href: "/pr-queue" },
+    { icon: ShieldCheck, label: "Trust", href: "/trust" },
     { icon: FolderGit2, label: "Workspace", href: "/workspaces" },
     // Show "Connections", "Inventory", "Knowledge Base", and "Traces" sub-items
     // when inside a workspace

--- a/client/src/pages/TrustTelemetry.tsx
+++ b/client/src/pages/TrustTelemetry.tsx
@@ -1,0 +1,435 @@
+/**
+ * TrustTelemetry — Stage D (design §7 "observation process" + §9 "Stage 8").
+ *
+ * "How grounded is the system, and can we still trust the planner?" Renders the
+ * READ-ONLY aggregate from GET /api/telemetry/trust:
+ *   - GROUNDING RATIO — the share of acceptance criteria verified by a MECHANICAL
+ *     method (tests / cited evidence / live smoke) vs judged by a model vs
+ *     unverified. Numbers first, honesty framing (design §5 honesty note).
+ *   - PLANNER TRACK RECORD — how often the engineer OVERRIDES the planner's
+ *     archetype, the archetype distribution, and per-skill green-rate.
+ *   - CRITERIA QUALITY — weak-criterion rate, manual-ops surfaced, timeout /
+ *     NOT-ADJUDICATED rate, and final-verification regression rate.
+ *
+ * SECURITY: every value is a NUMBER or an enum/skill NAME from the aggregate — no
+ * untrusted free-text is rendered as markup. Skill/archetype labels are inert
+ * React text. Read-only page; no mutations.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { ShieldCheck, Loader2, TrendingUp, AlertTriangle } from "lucide-react";
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { apiRequest } from "@/hooks/use-pipeline";
+
+// ─── Wire types (subset of server TrustTelemetry) ──────────────────────────────
+
+interface GroundingTrendPoint {
+  period: string;
+  totalCriteria: number;
+  mechanical: number;
+  groundingRatio: number;
+}
+interface SkillGreenRate {
+  skill: string;
+  total: number;
+  green: number;
+  greenRate: number;
+}
+interface TrustTelemetry {
+  window: { loops: number; rounds: number; roundsWithTrace: number };
+  grounding: {
+    totalCriteria: number;
+    mechanical: number;
+    judged: number;
+    unverified: number;
+    groundingRatio: number;
+    judgedRatio: number;
+    byMethod: Record<string, number>;
+    trend: GroundingTrendPoint[];
+  };
+  planner: {
+    archetypeDecided: number;
+    proposed: number;
+    overridden: number;
+    overrideRate: number;
+    archetypeDistribution: Record<string, number>;
+    skillGreenRate: SkillGreenRate[];
+  };
+  criteria: {
+    totalActionPoints: number;
+    weakCriteria: number;
+    weakRate: number;
+    manualOpsSurfaced: number;
+    timedOut: number;
+    timeoutRate: number;
+    finalVerified: number;
+    regressions: number;
+    regressionRate: number;
+  };
+  honesty: string;
+  scan: { limit: number; windowDays: number | null };
+}
+
+// ─── Small presentational helpers ──────────────────────────────────────────────
+
+function pct(ratio: number): string {
+  return `${Math.round(ratio * 100)}%`;
+}
+
+function Card({
+  title,
+  children,
+  hint,
+}: {
+  title: string;
+  children: React.ReactNode;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {title}
+      </div>
+      <div className="mt-2">{children}</div>
+      {hint ? <div className="mt-2 text-xs text-muted-foreground">{hint}</div> : null}
+    </div>
+  );
+}
+
+function BigStat({
+  value,
+  label,
+  tone = "default",
+}: {
+  value: string;
+  label: string;
+  tone?: "default" | "good" | "warn";
+}) {
+  const color =
+    tone === "good"
+      ? "text-emerald-600"
+      : tone === "warn"
+      ? "text-amber-600"
+      : "text-foreground";
+  return (
+    <div>
+      <div className={`text-3xl font-semibold tabular-nums ${color}`}>{value}</div>
+      <div className="mt-1 text-xs text-muted-foreground">{label}</div>
+    </div>
+  );
+}
+
+/** A labeled proportion bar (mechanical / judged / unverified split). */
+function SplitBar({
+  parts,
+}: {
+  parts: { label: string; value: number; className: string }[];
+}) {
+  const total = parts.reduce((s, p) => s + p.value, 0);
+  return (
+    <div>
+      <div className="flex h-3 w-full overflow-hidden rounded-full bg-muted">
+        {parts.map((p) =>
+          p.value > 0 ? (
+            <div
+              key={p.label}
+              className={p.className}
+              style={{ width: `${(p.value / Math.max(total, 1)) * 100}%` }}
+              title={`${p.label}: ${p.value}`}
+            />
+          ) : null,
+        )}
+      </div>
+      <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+        {parts.map((p) => (
+          <span key={p.label} className="flex items-center gap-1.5">
+            <span className={`inline-block h-2 w-2 rounded-full ${p.className}`} />
+            {p.label} <span className="tabular-nums text-foreground">{p.value}</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Page ──────────────────────────────────────────────────────────────────────
+
+export default function TrustTelemetry() {
+  const { data, isLoading, error } = useQuery<TrustTelemetry>({
+    queryKey: ["/api/telemetry/trust"],
+    queryFn: () => apiRequest("GET", "/api/telemetry/trust"),
+  });
+
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <div className="mb-1 flex items-center gap-2">
+        <ShieldCheck className="h-6 w-6 text-primary" />
+        <h1 className="text-2xl font-semibold">Trust Telemetry</h1>
+      </div>
+      <p className="mb-6 max-w-3xl text-sm text-muted-foreground">
+        How grounded is convergence, and can we still trust the planner? Aggregated
+        from what the loop execution traces already record — read-only, no schema
+        change. The mechanical share measures how much of &ldquo;green&rdquo; is
+        ground truth versus a model&rsquo;s judgment.
+      </p>
+
+      {isLoading ? (
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading telemetry…
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+          Failed to load telemetry: {(error as Error).message}
+        </div>
+      ) : !data ? null : (
+        <TelemetryBody data={data} />
+      )}
+    </div>
+  );
+}
+
+function TelemetryBody({ data }: { data: TrustTelemetry }) {
+  const { grounding, planner, criteria, window: win } = data;
+
+  return (
+    <div className="space-y-6">
+      {/* Honesty framing — numbers first. */}
+      <div className="rounded-lg border border-border bg-muted/40 p-4 text-sm">
+        <span className="font-medium">{data.honesty}</span>
+        <div className="mt-1 text-xs text-muted-foreground">
+          Scanned {win.loops} loop{win.loops === 1 ? "" : "s"} · {win.rounds} round
+          {win.rounds === 1 ? "" : "s"} ({win.roundsWithTrace} with an execution
+          trace)
+          {data.scan.windowDays ? ` · last ${data.scan.windowDays}d` : ""} · cap{" "}
+          {data.scan.limit}.
+        </div>
+      </div>
+
+      {/* ── Grounding ─────────────────────────────────────────────── */}
+      <section>
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Grounding
+        </h2>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <Card
+            title="Grounding ratio"
+            hint="Mechanically verified ÷ all acceptance criteria"
+          >
+            <BigStat
+              value={pct(grounding.groundingRatio)}
+              label={`${grounding.mechanical} of ${grounding.totalCriteria} criteria`}
+              tone={
+                grounding.groundingRatio >= 0.5
+                  ? "good"
+                  : grounding.totalCriteria === 0
+                  ? "default"
+                  : "warn"
+              }
+            />
+          </Card>
+          <Card title="Verification split" hint="How each criterion reached green">
+            <SplitBar
+              parts={[
+                {
+                  label: "Mechanical",
+                  value: grounding.mechanical,
+                  className: "bg-emerald-500",
+                },
+                { label: "Judged", value: grounding.judged, className: "bg-amber-500" },
+                {
+                  label: "Unverified",
+                  value: grounding.unverified,
+                  className: "bg-muted-foreground/50",
+                },
+              ]}
+            />
+          </Card>
+          <Card title="By method" hint="Raw per-method criterion counts">
+            <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+              {(
+                ["test-run", "web-evidence", "judge", "manual-ops", "none"] as const
+              ).map((m) => (
+                <div key={m} className="flex justify-between">
+                  <span className="text-muted-foreground">{m}</span>
+                  <span className="tabular-nums">{grounding.byMethod[m] ?? 0}</span>
+                </div>
+              ))}
+            </div>
+          </Card>
+        </div>
+
+        {/* Trend line */}
+        <div className="mt-4 rounded-lg border border-border bg-card p-4">
+          <div className="mb-2 flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            <TrendingUp className="h-4 w-4" /> Grounding ratio over time (by ISO week)
+          </div>
+          {grounding.trend.length === 0 ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              No trend data yet.
+            </div>
+          ) : (
+            <div style={{ width: "100%", height: 220 }}>
+              <ResponsiveContainer>
+                <LineChart data={grounding.trend} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                  <XAxis dataKey="period" tick={{ fontSize: 11 }} />
+                  <YAxis
+                    domain={[0, 1]}
+                    tickFormatter={(v) => `${Math.round(v * 100)}%`}
+                    tick={{ fontSize: 11 }}
+                  />
+                  <Tooltip
+                    formatter={(v: number) => [pct(v), "grounded"]}
+                    labelFormatter={(l) => `Week ${l}`}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="groundingRatio"
+                    stroke="#10b981"
+                    strokeWidth={2}
+                    dot={{ r: 3 }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* ── Planner track record ──────────────────────────────────── */}
+      <section>
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Planner track record
+        </h2>
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+          <Card
+            title="Archetype override rate"
+            hint="How often the engineer corrected the planner's pick"
+          >
+            <BigStat
+              value={pct(planner.overrideRate)}
+              label={`${planner.overridden} overridden of ${planner.archetypeDecided} decided`}
+              tone={planner.overrideRate <= 0.2 ? "good" : "warn"}
+            />
+          </Card>
+          <Card title="Archetype distribution" hint="Loops per chosen archetype">
+            <div className="space-y-1 text-sm">
+              {Object.keys(planner.archetypeDistribution).length === 0 ? (
+                <span className="text-muted-foreground">None decided.</span>
+              ) : (
+                Object.entries(planner.archetypeDistribution).map(([a, n]) => (
+                  <div key={a} className="flex justify-between">
+                    <span className="text-muted-foreground">{a}</span>
+                    <span className="tabular-nums">{n}</span>
+                  </div>
+                ))
+              )}
+            </div>
+          </Card>
+          <Card title="Proposed vs overridden" hint="Planner picks that stood">
+            <SplitBar
+              parts={[
+                {
+                  label: "Stood",
+                  value: planner.proposed,
+                  className: "bg-emerald-500",
+                },
+                {
+                  label: "Overridden",
+                  value: planner.overridden,
+                  className: "bg-amber-500",
+                },
+              ]}
+            />
+          </Card>
+        </div>
+
+        {/* Skill green-rate */}
+        <div className="mt-4 rounded-lg border border-border bg-card p-4">
+          <div className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Green-rate per skill
+          </div>
+          {planner.skillGreenRate.length === 0 ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              No skill runs recorded yet.
+            </div>
+          ) : (
+            <div style={{ width: "100%", height: Math.max(160, planner.skillGreenRate.length * 44) }}>
+              <ResponsiveContainer>
+                <BarChart
+                  layout="vertical"
+                  data={planner.skillGreenRate.map((s) => ({
+                    ...s,
+                    greenPct: Math.round(s.greenRate * 100),
+                  }))}
+                  margin={{ top: 4, right: 24, bottom: 4, left: 24 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" className="stroke-border" horizontal={false} />
+                  <XAxis
+                    type="number"
+                    domain={[0, 100]}
+                    tickFormatter={(v) => `${v}%`}
+                    tick={{ fontSize: 11 }}
+                  />
+                  <YAxis type="category" dataKey="skill" tick={{ fontSize: 11 }} width={90} />
+                  <Tooltip
+                    formatter={(v: number, _n, p) => [
+                      `${v}% (${(p?.payload as SkillGreenRate)?.green}/${(p?.payload as SkillGreenRate)?.total})`,
+                      "green",
+                    ]}
+                  />
+                  <Bar dataKey="greenPct" fill="#10b981" radius={[0, 4, 4, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* ── Criteria quality ──────────────────────────────────────── */}
+      <section>
+        <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          <AlertTriangle className="h-4 w-4" /> Criteria quality
+        </h2>
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+          <Card title="Weak-criterion rate" hint={`${criteria.weakCriteria} of ${criteria.totalActionPoints} APs`}>
+            <BigStat
+              value={pct(criteria.weakRate)}
+              label="Weak / vague DoD (Stage 7)"
+              tone={criteria.weakRate <= 0.15 ? "good" : "warn"}
+            />
+          </Card>
+          <Card title="Manual-ops surfaced" hint="Human actions the loop can't close">
+            <BigStat value={String(criteria.manualOpsSurfaced)} label="criteria" />
+          </Card>
+          <Card title="Timeout rate" hint={`${criteria.timedOut} NOT-ADJUDICATED runs`}>
+            <BigStat
+              value={pct(criteria.timeoutRate)}
+              label="of criteria that ran"
+              tone={criteria.timeoutRate <= 0.1 ? "good" : "warn"}
+            />
+          </Card>
+          <Card
+            title="Regression rate"
+            hint={`${criteria.regressions} of ${criteria.finalVerified} final-verified`}
+          >
+            <BigStat
+              value={pct(criteria.regressionRate)}
+              label="passed then regressed at final"
+              tone={criteria.regressionRate === 0 ? "good" : "warn"}
+            />
+          </Card>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -14,6 +14,7 @@ import { registerGatewayRoutes } from "./routes/gateway";
 import { registerStrategyRoutes } from "./routes/strategies";
 import { registerPrivacyRoutes } from "./routes/privacy";
 import { registerStatsRoutes } from "./routes/stats";
+import { registerTelemetryRoutes } from "./routes/telemetry";
 import { registerMemoryRoutes } from "./routes/memory";
 import { registerLessonRoutes } from "./routes/lessons";
 import { registerToolRoutes } from "./routes/tools";
@@ -151,6 +152,10 @@ export async function registerRoutes(
   app.use("/api/task-groups", requireAuth, requireProject);
   app.use("/api/consilium-loops", requireAuth, requireProject);
   app.use("/api/pr-queue", requireAuth, requireProject);
+  // NEW prefix (Stage D — trust telemetry). Read-only, project-scoped. This mount
+  // is LOAD-BEARING: without it getLoops() has no project context (500) and the
+  // route is unauthenticated (the /api/pr-queue class of bug). Do not drop it.
+  app.use("/api/telemetry", requireAuth, requireProject);
   app.use("/api/consilium-reviews", requireAuth, requireProject);
   app.use("/api/lmstudio", requireAuth, requireProject);       // UNCERTAIN — see note above
   app.use("/api/tracker-connections", requireAuth, requireProject);
@@ -182,6 +187,7 @@ export async function registerRoutes(
   registerStrategyRoutes(app, storage);
   registerPrivacyRoutes(app);
   registerStatsRoutes(app, storage);
+  registerTelemetryRoutes(app, storage);
   registerMemoryRoutes(app, storage);
   registerLessonRoutes(app, storage);
   registerToolRoutes(app, storage);

--- a/server/routes/telemetry.ts
+++ b/server/routes/telemetry.ts
@@ -1,0 +1,94 @@
+/**
+ * telemetry.ts — GET /api/telemetry/trust (Stage 8 / "Stage D", design §7+§9).
+ *
+ * READ-ONLY trust telemetry: aggregates what the consilium loop rounds ALREADY
+ * persist (`execution_trace` jsonb per criterion + loop archetype/archetypeSource)
+ * into the grounding ratio, planner track record, and criteria-quality metrics on
+ * which "trust the planner under observation" is periodically re-decided.
+ *
+ * SCOPING: mounted behind `requireAuth` + `requireProject` in routes.ts under the
+ * NEW `/api/telemetry` prefix. `requireProject` sets the async-local project
+ * context, so `storage.getLoops()` / `getLoopRounds()` return ONLY this project's
+ * rows (they scope through task_groups → withProjectList). Missing that mount would
+ * both 401 (no req.user path) and 500 (getLoops throws "no request context") — the
+ * same class of bug that hit /api/pr-queue.
+ *
+ * BOUNDED SCAN: never reads all history. `limit` (default 50, max 200) caps how
+ * many recent loops are scanned; an optional `windowDays` further restricts to a
+ * time window. The expensive jsonb round-read runs ONLY for the capped loop set.
+ */
+import type { Express } from "express";
+import { z } from "zod";
+import type { IStorage } from "../storage";
+import {
+  computeTrustTelemetry,
+  type TelemetryLoopInput,
+} from "../services/consilium/trust-telemetry";
+
+const querySchema = z.object({
+  /** Max recent loops to scan (bounds the jsonb round-read). */
+  limit: z.coerce.number().int().min(1).max(200).optional().default(50),
+  /** Optional time window (days); loops older than this are excluded. */
+  windowDays: z.coerce.number().int().min(1).max(365).optional(),
+});
+
+export function registerTelemetryRoutes(app: Express, storage: IStorage): void {
+  // GET /api/telemetry/trust — project-scoped, read-only trust telemetry.
+  app.get("/api/telemetry/trust", async (req, res) => {
+    try {
+      // Belt-and-suspenders: the mount already enforces auth, but never trust the
+      // route to be mounted correctly — a populated req.user is required to be here.
+      if (!req.user?.id) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const parsed = querySchema.safeParse(req.query);
+      if (!parsed.success) {
+        res.status(400).json({ error: parsed.error.flatten() });
+        return;
+      }
+      const { limit, windowDays } = parsed.data;
+
+      // Project-scoped via the async-local context set by requireProject.
+      const allLoops = await storage.getLoops();
+
+      // Newest first (getLoops already orders desc, but re-sort defensively), then
+      // apply the optional time window, then CAP — this is the scan bound.
+      const cutoff = windowDays ? Date.now() - windowDays * 86_400_000 : null;
+      const scanned = [...allLoops]
+        .sort((a, b) => msOf(b.createdAt) - msOf(a.createdAt))
+        .filter((l) => (cutoff === null ? true : msOf(l.createdAt) >= cutoff))
+        .slice(0, limit);
+
+      // Fetch rounds ONLY for the capped set (bounded fan-out ≤ limit).
+      const loopInputs: TelemetryLoopInput[] = await Promise.all(
+        scanned.map(async (loop): Promise<TelemetryLoopInput> => {
+          const rounds = await storage.getLoopRounds(loop.id);
+          return {
+            archetype: loop.archetype,
+            archetypeSource: loop.archetypeSource,
+            createdAt: loop.createdAt,
+            rounds: rounds.map((r) => ({
+              createdAt: r.createdAt,
+              executionTrace: r.executionTrace,
+              openActionPoints: r.openActionPoints,
+            })),
+          };
+        }),
+      );
+
+      const telemetry = computeTrustTelemetry(loopInputs);
+      res.json({ ...telemetry, scan: { limit, windowDays: windowDays ?? null } });
+    } catch (err) {
+      console.error("/api/telemetry/trust error:", err);
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+}
+
+function msOf(d: Date | string | null | undefined): number {
+  if (!d) return 0;
+  const t = d instanceof Date ? d.getTime() : new Date(d).getTime();
+  return Number.isNaN(t) ? 0 : t;
+}

--- a/server/services/consilium/trust-telemetry.ts
+++ b/server/services/consilium/trust-telemetry.ts
@@ -1,0 +1,384 @@
+/**
+ * trust-telemetry.ts — Stage 8 / "Stage D" (design §9): TRUST TELEMETRY.
+ *
+ * The §7 "observation process" made concrete. This is the data on which
+ * "trust the planner under observation" is periodically re-decided. It ONLY
+ * aggregates what the execution traces + loop rows ALREADY persist — no new
+ * schema, no FSM, no writes. Pure and read-only.
+ *
+ * What it answers for an operator:
+ *   1. GROUNDING RATIO — the share of acceptance criteria verified by a
+ *      MECHANICAL method (`test-run` / `web-evidence` / `live-deploy-smoke`)
+ *      versus `judge` versus `none`/`manual-ops`. This is THE metric of how
+ *      grounded convergence actually is (design §5 honesty note): `judge`
+ *      re-admits model subjectivity through the back door, so the mechanical
+ *      share measures how much of "green" is ground truth vs a model's opinion.
+ *   2. PLANNER TRACK RECORD — how often the engineer OVERRIDES the planner's
+ *      proposed archetype (the §7 signal for whether to keep trusting it), the
+ *      archetype distribution, and the per-skill green-rate.
+ *   3. CRITERIA QUALITY — weak-criterion rate (Stage 7), manual-ops surfaced,
+ *      timeout / NOT-ADJUDICATED rate, and final-verification regression rate
+ *      (Stage 5 — a criterion that passed at implement time but not at final
+ *      re-verify).
+ *
+ * SECURITY / SAFETY: every input field is UNTRUSTED persisted data (model text,
+ * possibly malformed pre-Stage snapshots). This module reads NUMBERS and ENUMS
+ * only — it never renders, executes, or sinks any string. All arrays are
+ * defensively guarded (a malformed trace contributes 0, never throws) and every
+ * ratio is division-by-zero safe (`ratio(n, 0) === 0`).
+ */
+import type {
+  Archetype,
+  ArchetypeSource,
+  ExecutionTrace,
+  ExecutionCriterion,
+} from "@shared/types";
+
+// ─── Input shape (a slim, DB-agnostic projection so the aggregator is PURE) ────
+//
+// The route maps `ConsiliumLoopRow` + `ConsiliumLoopRoundRow[]` into these; tests
+// build them directly. `openActionPoints` carries the `weakCriterion` flag (it
+// lives on ActionPoint, not on the trace criterion) — typed loose on purpose so a
+// pre-Stage-C row without the field is simply counted as not-weak.
+
+export interface TelemetryRoundInput {
+  createdAt: string | Date;
+  executionTrace: ExecutionTrace | null | undefined;
+  /** ActionPoint[] — only `weakCriterion` and `acceptanceCriterion` are read. */
+  openActionPoints:
+    | ReadonlyArray<{ weakCriterion?: boolean; acceptanceCriterion?: string }>
+    | null
+    | undefined;
+}
+
+export interface TelemetryLoopInput {
+  archetype: Archetype | null | undefined;
+  archetypeSource: ArchetypeSource | null | undefined;
+  createdAt: string | Date;
+  rounds: ReadonlyArray<TelemetryRoundInput>;
+}
+
+// ─── Output shape (the wire contract the FE renders) ───────────────────────────
+
+export interface GroundingTrendPoint {
+  /** ISO week bucket, e.g. "2026-W27". */
+  period: string;
+  totalCriteria: number;
+  mechanical: number;
+  groundingRatio: number;
+}
+
+export interface SkillGreenRate {
+  skill: string;
+  total: number;
+  green: number;
+  greenRate: number;
+}
+
+export interface TrustTelemetry {
+  /** How much history this snapshot covers (already bounded by the route). */
+  window: { loops: number; rounds: number; roundsWithTrace: number };
+
+  grounding: {
+    totalCriteria: number;
+    mechanical: number;
+    judged: number;
+    /** `none` + `manual-ops` — not a ground-truth check of convergence. */
+    unverified: number;
+    /** mechanical / totalCriteria (0 when no criteria). THE grounding metric. */
+    groundingRatio: number;
+    /** judged / totalCriteria. */
+    judgedRatio: number;
+    /** Raw counts per verification method (audit / drill-down). */
+    byMethod: Record<ExecutionCriterion["method"], number>;
+    /** Grounding ratio bucketed by ISO week, oldest→newest (the §5 "trend"). */
+    trend: GroundingTrendPoint[];
+  };
+
+  planner: {
+    /** Loops that carry a decided archetype (archetype != null). */
+    archetypeDecided: number;
+    proposed: number;
+    overridden: number;
+    /** overridden / archetypeDecided (0 when none decided). The §7 trust signal. */
+    overrideRate: number;
+    archetypeDistribution: Record<string, number>;
+    /** Green-rate per skill from the trace skill leaves, most-run first. */
+    skillGreenRate: SkillGreenRate[];
+  };
+
+  criteria: {
+    totalActionPoints: number;
+    weakCriteria: number;
+    /** weakCriteria / totalActionPoints (Stage 7 criteria-QA rate). */
+    weakRate: number;
+    /** Criteria surfaced as `manual-ops` — a human action the loop can't close. */
+    manualOpsSurfaced: number;
+    /** Criteria whose verification run was SIGKILL'd (NOT-ADJUDICATED). */
+    timedOut: number;
+    /** timedOut / criteria that actually ran (0 when none ran). */
+    timeoutRate: number;
+    /** Criteria that carry a `passedAtFinal` (final re-verification ran). */
+    finalVerified: number;
+    /** passed at implement time but FAILED at final re-verify (a late-AP regression). */
+    regressions: number;
+    /** regressions / finalVerified (0 when no final verification ran). */
+    regressionRate: number;
+  };
+
+  /** Operator-facing, numbers-first honesty framing (design §5 honesty note). */
+  honesty: string;
+}
+
+// ─── Method buckets (design §5) ────────────────────────────────────────────────
+//
+// MECHANICAL = ground truth: a test run, a cited source, or a live smoke-test.
+// `live-deploy-smoke` is not part of the persisted `ExecutionCriterion.method`
+// union today, but it IS a mechanical method per §5 — included defensively so it
+// counts as grounded the moment the infra archetype starts emitting it.
+const MECHANICAL_METHODS = new Set(["test-run", "web-evidence", "live-deploy-smoke"]);
+
+// ─── Pure helpers ──────────────────────────────────────────────────────────────
+
+/** Division-by-zero-safe ratio (returns 0 for a 0 or negative denominator). */
+function ratio(numerator: number, denominator: number): number {
+  return denominator > 0 ? numerator / denominator : 0;
+}
+
+/** Round to 4 decimals so the wire carries stable, compact numbers. */
+function round4(n: number): number {
+  return Math.round(n * 1e4) / 1e4;
+}
+
+/** ISO-8601 week key ("YYYY-Www"); a stable "unknown" bucket for bad dates. */
+function isoWeek(input: string | Date): string {
+  const d = input instanceof Date ? new Date(input.getTime()) : new Date(input);
+  if (Number.isNaN(d.getTime())) return "unknown";
+  // ISO week: Thursday-anchored. Work in UTC to stay deterministic across hosts.
+  const date = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const day = date.getUTCDay() || 7; // Sun=0 → 7
+  date.setUTCDate(date.getUTCDate() + 4 - day);
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(((date.getTime() - yearStart.getTime()) / 86_400_000 + 1) / 7);
+  return `${date.getUTCFullYear()}-W${String(week).padStart(2, "0")}`;
+}
+
+function toMillis(input: string | Date): number {
+  const d = input instanceof Date ? input : new Date(input);
+  const t = d.getTime();
+  return Number.isNaN(t) ? 0 : t;
+}
+
+/** Every criterion leaf across a trace's controller → workers, guarded. */
+function criteriaOf(trace: ExecutionTrace | null | undefined): ExecutionCriterion[] {
+  const workers = trace?.controller?.workers;
+  if (!Array.isArray(workers)) return [];
+  const out: ExecutionCriterion[] = [];
+  for (const w of workers) {
+    if (w && Array.isArray(w.criteria)) {
+      for (const c of w.criteria) if (c && typeof c.method === "string") out.push(c);
+    }
+  }
+  return out;
+}
+
+// ─── The aggregator ────────────────────────────────────────────────────────────
+
+/**
+ * Aggregate trust telemetry from a bounded set of loops (+ their rounds). PURE:
+ * same input → same output, no I/O, no throws on malformed data.
+ */
+export function computeTrustTelemetry(
+  loops: ReadonlyArray<TelemetryLoopInput>,
+): TrustTelemetry {
+  const safeLoops = Array.isArray(loops) ? loops : [];
+
+  // Grounding accumulators.
+  const byMethod: Record<ExecutionCriterion["method"], number> = {
+    "test-run": 0,
+    "web-evidence": 0,
+    judge: 0,
+    "manual-ops": 0,
+    none: 0,
+  };
+  let mechanical = 0;
+  let judged = 0;
+  let unverified = 0;
+  let totalCriteria = 0;
+
+  // Grounding trend (ISO week → totals).
+  const trendBuckets = new Map<string, { total: number; mechanical: number }>();
+
+  // Criteria-quality accumulators.
+  let totalActionPoints = 0;
+  let weakCriteria = 0;
+  let manualOpsSurfaced = 0;
+  let ranCount = 0;
+  let timedOut = 0;
+  let finalVerified = 0;
+  let regressions = 0;
+
+  // Skill green-rate accumulators.
+  const skillAgg = new Map<string, { total: number; green: number }>();
+
+  let roundCount = 0;
+  let roundsWithTrace = 0;
+
+  // Planner accumulators.
+  let archetypeDecided = 0;
+  let proposed = 0;
+  let overridden = 0;
+  const archetypeDistribution: Record<string, number> = {};
+
+  for (const loop of safeLoops) {
+    if (!loop) continue;
+
+    // Planner track record (loop-level).
+    if (loop.archetype) {
+      archetypeDecided += 1;
+      archetypeDistribution[loop.archetype] =
+        (archetypeDistribution[loop.archetype] ?? 0) + 1;
+      if (loop.archetypeSource === "override") overridden += 1;
+      else proposed += 1; // `proposed` or null both mean "planner's pick stood"
+    }
+
+    const rounds = Array.isArray(loop.rounds) ? loop.rounds : [];
+    for (const rnd of rounds) {
+      if (!rnd) continue;
+      roundCount += 1;
+
+      // Criteria quality — action points (weakCriterion lives on the AP).
+      const aps = Array.isArray(rnd.openActionPoints) ? rnd.openActionPoints : [];
+      for (const ap of aps) {
+        if (!ap) continue;
+        totalActionPoints += 1;
+        if (ap.weakCriterion === true) weakCriteria += 1;
+      }
+
+      const trace = rnd.executionTrace;
+      const crits = criteriaOf(trace);
+      if (trace && trace.controller) roundsWithTrace += 1;
+
+      // Skill green-rate — walk the trace skill leaves.
+      const workers = trace?.controller?.workers;
+      if (Array.isArray(workers)) {
+        for (const w of workers) {
+          const skills = w && Array.isArray(w.skills) ? w.skills : [];
+          for (const s of skills) {
+            if (!s || typeof s.skillName !== "string") continue;
+            const agg = skillAgg.get(s.skillName) ?? { total: 0, green: 0 };
+            agg.total += 1;
+            if (s.green === true) agg.green += 1;
+            skillAgg.set(s.skillName, agg);
+          }
+        }
+      }
+
+      // Grounding + criteria-quality — the per-criterion leaves. A round with no
+      // criteria contributes NO trend bucket (an empty week is noise, not a 0%).
+      const wk = crits.length > 0 ? isoWeek(rnd.createdAt) : null;
+      const bucket = wk !== null ? trendBuckets.get(wk) ?? { total: 0, mechanical: 0 } : null;
+      for (const c of crits) {
+        totalCriteria += 1;
+        byMethod[c.method] = (byMethod[c.method] ?? 0) + 1;
+        const isMechanical = MECHANICAL_METHODS.has(c.method);
+        if (isMechanical) mechanical += 1;
+        else if (c.method === "judge") judged += 1;
+        else unverified += 1; // none | manual-ops
+
+        if (c.method === "manual-ops") manualOpsSurfaced += 1;
+        if (c.ran === true) ranCount += 1;
+        if (c.timedOut === true) timedOut += 1;
+        if (typeof c.passedAtFinal === "boolean") {
+          finalVerified += 1;
+          if (c.passed === true && c.passedAtFinal === false) regressions += 1;
+        }
+
+        if (bucket) {
+          bucket.total += 1;
+          if (isMechanical) bucket.mechanical += 1;
+        }
+      }
+      if (wk !== null && bucket) trendBuckets.set(wk, bucket);
+    }
+  }
+
+  const skillGreenRate: SkillGreenRate[] = Array.from(skillAgg.entries())
+    .map(([skill, a]) => ({
+      skill,
+      total: a.total,
+      green: a.green,
+      greenRate: round4(ratio(a.green, a.total)),
+    }))
+    .sort((a, b) => b.total - a.total || a.skill.localeCompare(b.skill));
+
+  const trend: GroundingTrendPoint[] = Array.from(trendBuckets.entries())
+    .map(([period, b]) => ({
+      period,
+      totalCriteria: b.total,
+      mechanical: b.mechanical,
+      groundingRatio: round4(ratio(b.mechanical, b.total)),
+    }))
+    // Oldest → newest; "unknown" sinks to the end.
+    .sort((a, b) => {
+      if (a.period === "unknown") return 1;
+      if (b.period === "unknown") return -1;
+      return a.period.localeCompare(b.period);
+    });
+
+  const groundingRatio = round4(ratio(mechanical, totalCriteria));
+  const judgedRatio = round4(ratio(judged, totalCriteria));
+
+  return {
+    window: { loops: safeLoops.length, rounds: roundCount, roundsWithTrace },
+    grounding: {
+      totalCriteria,
+      mechanical,
+      judged,
+      unverified,
+      groundingRatio,
+      judgedRatio,
+      byMethod,
+      trend,
+    },
+    planner: {
+      archetypeDecided,
+      proposed,
+      overridden,
+      overrideRate: round4(ratio(overridden, archetypeDecided)),
+      archetypeDistribution,
+      skillGreenRate,
+    },
+    criteria: {
+      totalActionPoints,
+      weakCriteria,
+      weakRate: round4(ratio(weakCriteria, totalActionPoints)),
+      manualOpsSurfaced,
+      timedOut,
+      timeoutRate: round4(ratio(timedOut, ranCount)),
+      finalVerified,
+      regressions,
+      regressionRate: round4(ratio(regressions, finalVerified)),
+    },
+    honesty: buildHonesty(totalCriteria, groundingRatio, judgedRatio),
+  };
+}
+
+/** Numbers-first, honest one-liner (design §5). Empty data says so plainly. */
+function buildHonesty(
+  totalCriteria: number,
+  groundingRatio: number,
+  judgedRatio: number,
+): string {
+  if (totalCriteria === 0) {
+    return "No verified acceptance criteria in this window yet — nothing to ground.";
+  }
+  const mechPct = Math.round(groundingRatio * 100);
+  const judgePct = Math.round(judgedRatio * 100);
+  const restPct = Math.max(0, 100 - mechPct - judgePct);
+  return (
+    `${mechPct}% of criteria in this window were mechanically verified` +
+    ` (tests / cited evidence / live smoke); ${judgePct}% were judged by a model` +
+    (restPct > 0 ? `; ${restPct}% were unverified or manual-ops.` : ".")
+  );
+}

--- a/tests/unit/consilium/trust-telemetry-route.test.ts
+++ b/tests/unit/consilium/trust-telemetry-route.test.ts
@@ -1,0 +1,157 @@
+/**
+ * trust-telemetry-route.test.ts — GET /api/telemetry/trust (Stage D).
+ *
+ * Wires the REAL `registerTelemetryRoutes` over a fake storage + a requireAuth
+ * stand-in. Asserts:
+ *   - 200 wire shape (grounding / planner / criteria / honesty / scan);
+ *   - the scan is BOUNDED — with `limit=N`, at most N loops' rounds are read
+ *     (getLoopRounds called ≤ N), and `windowDays` excludes older loops;
+ *   - 401 when unauthenticated (the route's belt-and-suspenders guard);
+ *   - REGRESSION GUARD: the `/api/telemetry` auth+project mount actually exists in
+ *     routes.ts — the exact bug class that left /api/pr-queue unprotected.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import express from "express";
+import request from "supertest";
+import type { IStorage } from "../../../server/storage.js";
+import { registerTelemetryRoutes } from "../../../server/routes/telemetry.js";
+import type { ExecutionTrace } from "@shared/types";
+
+const OWNER = "user-1";
+
+function traceWith(method: ExecutionTrace["controller"]["workers"][number]["criteria"][number]["method"]): ExecutionTrace {
+  return {
+    schemaVersion: 1,
+    archetype: "repo-assessment",
+    controller: {
+      kind: "sdlc-executor",
+      label: "sdlc",
+      green: true,
+      workers: [
+        {
+          index: 1,
+          priority: "P0",
+          title: "w",
+          status: "completed",
+          skills: [{ skillName: "coder", capability: "worktree-write", permissionsUsed: ["Edit"], green: true }],
+          criteria: [{ criterion: "When X Then Y", method, ran: true, passed: true }],
+        },
+      ],
+    },
+  };
+}
+
+function loop(over: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: "loop-x",
+    groupId: "grp-1",
+    archetype: "repo-assessment",
+    archetypeSource: "proposed",
+    createdBy: OWNER,
+    createdAt: "2026-06-01T00:00:00.000Z",
+    ...over,
+  };
+}
+
+function makeApp(opts: {
+  loops?: Record<string, unknown>[];
+  roundsByLoop?: Record<string, unknown[]>;
+  user?: { id: string; role?: string };
+} = {}) {
+  const { loops = [], roundsByLoop = {} } = opts;
+  const user = "user" in opts ? opts.user : { id: OWNER };
+
+  const getLoops = vi.fn(async () => loops);
+  const getLoopRounds = vi.fn(async (loopId: string) => roundsByLoop[loopId] ?? []);
+  const storage = { getLoops, getLoopRounds } as unknown as IStorage;
+
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (user) (req as unknown as { user: typeof user }).user = user;
+    next();
+  });
+  registerTelemetryRoutes(app, storage);
+  return { app, getLoops, getLoopRounds };
+}
+
+describe("GET /api/telemetry/trust", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns the aggregated wire shape (200)", async () => {
+    const { app, getLoops } = makeApp({
+      loops: [loop({ id: "l1", archetypeSource: "override" })],
+      roundsByLoop: {
+        l1: [
+          {
+            createdAt: "2026-06-01T00:00:00.000Z",
+            openActionPoints: [{ weakCriterion: true }],
+            executionTrace: traceWith("test-run"),
+          },
+        ],
+      },
+    });
+    const res = await request(app).get("/api/telemetry/trust");
+    expect(res.status).toBe(200);
+    expect(getLoops).toHaveBeenCalledTimes(1);
+    expect(res.body.grounding.groundingRatio).toBe(1); // 1 test-run criterion
+    expect(res.body.planner.overrideRate).toBe(1); // the one loop was overridden
+    expect(res.body.criteria.weakRate).toBe(1);
+    expect(res.body.honesty).toContain("100%");
+    expect(res.body.scan).toEqual({ limit: 50, windowDays: null });
+  });
+
+  it("BOUNDS the scan: limit caps how many loops' rounds are read", async () => {
+    const loops = Array.from({ length: 5 }, (_, i) =>
+      loop({ id: `l${i}`, createdAt: `2026-06-0${i + 1}T00:00:00.000Z` }),
+    );
+    const { app, getLoopRounds } = makeApp({ loops });
+    const res = await request(app).get("/api/telemetry/trust?limit=2");
+    expect(res.status).toBe(200);
+    // Only the 2 newest loops' rounds are fetched — the scan is bounded.
+    expect(getLoopRounds).toHaveBeenCalledTimes(2);
+    expect(res.body.window.loops).toBe(2);
+    expect(res.body.scan.limit).toBe(2);
+  });
+
+  it("windowDays excludes loops older than the window", async () => {
+    const now = Date.now();
+    const recent = loop({ id: "recent", createdAt: new Date(now - 1 * 86_400_000).toISOString() });
+    const old = loop({ id: "old", createdAt: new Date(now - 100 * 86_400_000).toISOString() });
+    const { app, getLoopRounds } = makeApp({ loops: [recent, old] });
+    const res = await request(app).get("/api/telemetry/trust?windowDays=7");
+    expect(res.status).toBe(200);
+    expect(res.body.window.loops).toBe(1);
+    expect(getLoopRounds).toHaveBeenCalledTimes(1);
+    expect(getLoopRounds).toHaveBeenCalledWith("recent");
+  });
+
+  it("rejects an invalid limit (400)", async () => {
+    const { app } = makeApp();
+    const res = await request(app).get("/api/telemetry/trust?limit=9999");
+    expect(res.status).toBe(400);
+  });
+
+  it("401 when unauthenticated (belt-and-suspenders guard)", async () => {
+    const { app, getLoops } = makeApp({ user: undefined });
+    const res = await request(app).get("/api/telemetry/trust");
+    expect(res.status).toBe(401);
+    expect(getLoops).not.toHaveBeenCalled();
+  });
+});
+
+describe("routes.ts — /api/telemetry auth mount (pr-queue regression guard)", () => {
+  it("mounts /api/telemetry behind requireAuth + requireProject", () => {
+    const src = readFileSync(
+      path.resolve(__dirname, "../../../server/routes.ts"),
+      "utf8",
+    );
+    expect(src).toMatch(
+      /app\.use\(\s*["']\/api\/telemetry["']\s*,\s*requireAuth\s*,\s*requireProject\s*\)/,
+    );
+    // and the route module is actually registered
+    expect(src).toContain("registerTelemetryRoutes(app, storage)");
+  });
+});

--- a/tests/unit/consilium/trust-telemetry.test.ts
+++ b/tests/unit/consilium/trust-telemetry.test.ts
@@ -1,0 +1,264 @@
+/**
+ * trust-telemetry.test.ts — Stage D pure aggregator (design §7+§9 "Stage 8").
+ *
+ * `computeTrustTelemetry(loops)` is PURE: given loop rows + their rounds' execution
+ * traces / action points, it produces the grounding ratio, planner track record,
+ * and criteria-quality rates. These tests pin every ratio, the empty-input (div/0)
+ * behavior, and the ISO-week trend bucketing.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  computeTrustTelemetry,
+  type TelemetryLoopInput,
+} from "../../../server/services/consilium/trust-telemetry";
+import type {
+  ExecutionTrace,
+  ExecutionCriterion,
+  ExecutionSkill,
+} from "@shared/types";
+
+// ─── Fixture builders ──────────────────────────────────────────────────────────
+
+function crit(over: Partial<ExecutionCriterion> & Pick<ExecutionCriterion, "method">): ExecutionCriterion {
+  return { criterion: "When X Then Y", ran: true, passed: true, ...over };
+}
+
+function skill(name: string, green: boolean): ExecutionSkill {
+  return { skillName: name, capability: "worktree-write", permissionsUsed: ["Edit"], green };
+}
+
+function trace(opts: {
+  criteria?: ExecutionCriterion[];
+  skills?: ExecutionSkill[];
+}): ExecutionTrace {
+  return {
+    schemaVersion: 1,
+    archetype: "repo-assessment",
+    controller: {
+      kind: "sdlc-executor",
+      label: "sdlc",
+      green: true,
+      workers: [
+        {
+          index: 1,
+          priority: "P0",
+          title: "w",
+          status: "completed",
+          skills: opts.skills ?? [],
+          criteria: opts.criteria ?? [],
+        },
+      ],
+    },
+  };
+}
+
+describe("computeTrustTelemetry — grounding ratio", () => {
+  it("mechanical (test-run/web-evidence) vs judge vs none/manual-ops", () => {
+    const loops: TelemetryLoopInput[] = [
+      {
+        archetype: "repo-assessment",
+        archetypeSource: "proposed",
+        createdAt: "2026-06-01T00:00:00.000Z",
+        rounds: [
+          {
+            createdAt: "2026-06-01T00:00:00.000Z",
+            openActionPoints: [],
+            executionTrace: trace({
+              criteria: [
+                crit({ method: "test-run" }),
+                crit({ method: "web-evidence" }),
+                crit({ method: "judge" }),
+                crit({ method: "manual-ops", ran: false, passed: false }),
+                crit({ method: "none", ran: false, passed: false }),
+              ],
+            }),
+          },
+        ],
+      },
+    ];
+    const t = computeTrustTelemetry(loops);
+    expect(t.grounding.totalCriteria).toBe(5);
+    expect(t.grounding.mechanical).toBe(2);
+    expect(t.grounding.judged).toBe(1);
+    expect(t.grounding.unverified).toBe(2); // manual-ops + none
+    expect(t.grounding.groundingRatio).toBe(0.4); // 2/5
+    expect(t.grounding.judgedRatio).toBe(0.2);
+    expect(t.grounding.byMethod["test-run"]).toBe(1);
+    expect(t.grounding.byMethod["manual-ops"]).toBe(1);
+    expect(t.honesty).toContain("40%");
+  });
+
+  it("counts live-deploy-smoke as mechanical (forward-compatible)", () => {
+    const loops: TelemetryLoopInput[] = [
+      {
+        archetype: "infra",
+        archetypeSource: "proposed",
+        createdAt: "2026-06-01T00:00:00.000Z",
+        rounds: [
+          {
+            createdAt: "2026-06-01T00:00:00.000Z",
+            openActionPoints: [],
+            // cast: live-deploy-smoke isn't in the persisted union yet, but §5 calls it mechanical.
+            executionTrace: trace({
+              criteria: [crit({ method: "live-deploy-smoke" as ExecutionCriterion["method"] })],
+            }),
+          },
+        ],
+      },
+    ];
+    const t = computeTrustTelemetry(loops);
+    expect(t.grounding.mechanical).toBe(1);
+    expect(t.grounding.groundingRatio).toBe(1);
+  });
+
+  it("buckets the trend by ISO week, oldest→newest", () => {
+    const mk = (createdAt: string, method: ExecutionCriterion["method"]): TelemetryLoopInput => ({
+      archetype: "repo-assessment",
+      archetypeSource: "proposed",
+      createdAt,
+      rounds: [{ createdAt, openActionPoints: [], executionTrace: trace({ criteria: [crit({ method })] }) }],
+    });
+    const t = computeTrustTelemetry([
+      mk("2026-06-15T00:00:00.000Z", "judge"), // later week
+      mk("2026-06-01T00:00:00.000Z", "test-run"), // earlier week
+    ]);
+    expect(t.grounding.trend).toHaveLength(2);
+    expect(t.grounding.trend[0].period < t.grounding.trend[1].period).toBe(true);
+    expect(t.grounding.trend[0].groundingRatio).toBe(1); // earlier week: test-run
+    expect(t.grounding.trend[1].groundingRatio).toBe(0); // later week: judge
+  });
+});
+
+describe("computeTrustTelemetry — planner track record", () => {
+  it("override rate, distribution, and per-skill green-rate", () => {
+    const loops: TelemetryLoopInput[] = [
+      {
+        archetype: "repo-assessment",
+        archetypeSource: "override",
+        createdAt: "2026-06-01T00:00:00.000Z",
+        rounds: [
+          {
+            createdAt: "2026-06-01T00:00:00.000Z",
+            openActionPoints: [],
+            executionTrace: trace({ skills: [skill("coder", true), skill("test-author", false)] }),
+          },
+        ],
+      },
+      {
+        archetype: "repo-assessment",
+        archetypeSource: "proposed",
+        createdAt: "2026-06-02T00:00:00.000Z",
+        rounds: [
+          {
+            createdAt: "2026-06-02T00:00:00.000Z",
+            openActionPoints: [],
+            executionTrace: trace({ skills: [skill("coder", true)] }),
+          },
+        ],
+      },
+      {
+        archetype: "research",
+        archetypeSource: null, // null counts as "planner's pick stood"
+        createdAt: "2026-06-03T00:00:00.000Z",
+        rounds: [],
+      },
+    ];
+    const t = computeTrustTelemetry(loops);
+    expect(t.planner.archetypeDecided).toBe(3);
+    expect(t.planner.overridden).toBe(1);
+    expect(t.planner.proposed).toBe(2);
+    expect(t.planner.overrideRate).toBe(round4(1 / 3));
+    expect(t.planner.archetypeDistribution).toEqual({ "repo-assessment": 2, research: 1 });
+    const coder = t.planner.skillGreenRate.find((s) => s.skill === "coder");
+    expect(coder).toEqual({ skill: "coder", total: 2, green: 2, greenRate: 1 });
+    const ta = t.planner.skillGreenRate.find((s) => s.skill === "test-author");
+    expect(ta).toEqual({ skill: "test-author", total: 1, green: 0, greenRate: 0 });
+    // most-run first
+    expect(t.planner.skillGreenRate[0].skill).toBe("coder");
+  });
+
+  it("loops with no archetype do not inflate the decided/override counts", () => {
+    const t = computeTrustTelemetry([
+      { archetype: null, archetypeSource: null, createdAt: "2026-06-01T00:00:00.000Z", rounds: [] },
+    ]);
+    expect(t.planner.archetypeDecided).toBe(0);
+    expect(t.planner.overrideRate).toBe(0); // div/0 safe
+  });
+});
+
+describe("computeTrustTelemetry — criteria quality", () => {
+  it("weak rate, manual-ops, timeout rate, and final regression rate", () => {
+    const loops: TelemetryLoopInput[] = [
+      {
+        archetype: "repo-assessment",
+        archetypeSource: "proposed",
+        createdAt: "2026-06-01T00:00:00.000Z",
+        rounds: [
+          {
+            createdAt: "2026-06-01T00:00:00.000Z",
+            openActionPoints: [
+              { weakCriterion: true, acceptanceCriterion: "vague" },
+              { weakCriterion: false, acceptanceCriterion: "When A Then B" },
+              { acceptanceCriterion: "no flag" }, // undefined → not weak
+            ],
+            executionTrace: trace({
+              criteria: [
+                // a regression: passed at implement, failed at final re-verify
+                crit({ method: "test-run", passed: true, passedAtFinal: false, ran: true }),
+                // clean final pass
+                crit({ method: "test-run", passed: true, passedAtFinal: true, ran: true }),
+                // timed out / NOT-ADJUDICATED
+                crit({ method: "test-run", ran: true, passed: false, timedOut: true }),
+                // surfaced manual-ops
+                crit({ method: "manual-ops", ran: false, passed: false }),
+              ],
+            }),
+          },
+        ],
+      },
+    ];
+    const t = computeTrustTelemetry(loops);
+    expect(t.criteria.totalActionPoints).toBe(3);
+    expect(t.criteria.weakCriteria).toBe(1);
+    expect(t.criteria.weakRate).toBe(round4(1 / 3));
+    expect(t.criteria.manualOpsSurfaced).toBe(1);
+    expect(t.criteria.timedOut).toBe(1);
+    // ran criteria = 3 (two test-run passed + one timed-out ran); manual-ops ran:false
+    expect(t.criteria.timeoutRate).toBe(round4(1 / 3));
+    expect(t.criteria.finalVerified).toBe(2); // two carry passedAtFinal
+    expect(t.criteria.regressions).toBe(1);
+    expect(t.criteria.regressionRate).toBe(0.5); // 1/2
+  });
+});
+
+describe("computeTrustTelemetry — robustness", () => {
+  it("empty input → all zeros, honest message, no throw", () => {
+    const t = computeTrustTelemetry([]);
+    expect(t.window).toEqual({ loops: 0, rounds: 0, roundsWithTrace: 0 });
+    expect(t.grounding.groundingRatio).toBe(0);
+    expect(t.grounding.trend).toEqual([]);
+    expect(t.planner.overrideRate).toBe(0);
+    expect(t.criteria.regressionRate).toBe(0);
+    expect(t.honesty).toMatch(/nothing to ground/i);
+  });
+
+  it("tolerates malformed traces / missing arrays without throwing", () => {
+    const t = computeTrustTelemetry([
+      {
+        archetype: "repo-assessment",
+        archetypeSource: "proposed",
+        createdAt: "not-a-date",
+        // @ts-expect-error — deliberately malformed persisted data
+        rounds: [{ createdAt: "not-a-date", openActionPoints: null, executionTrace: {} }],
+      },
+    ]);
+    expect(t.window.rounds).toBe(1);
+    expect(t.grounding.totalCriteria).toBe(0);
+    // bad date lands in the "unknown" trend bucket only if there were criteria; none here
+    expect(t.grounding.trend).toEqual([]);
+  });
+});
+
+function round4(n: number): number {
+  return Math.round(n * 1e4) / 1e4;
+}


### PR DESCRIPTION
## Stage D — Trust Telemetry

The §7 "observation process" made concrete (design `docs/design/loop-consolidation.md` §9 "Stage 8"). It aggregates **what the consilium loop execution traces already persist** so an operator can judge how *grounded* convergence is and whether the planner is still trustworthy. Read-side only — **no FSM, no schema/migration, no config change**.

### Metrics computed
**1. Grounding ratio** — the share of acceptance criteria verified by a MECHANICAL method (`test-run` / `web-evidence` / `live-deploy-smoke`) vs `judge` vs `none`/`manual-ops`. This is THE metric of how grounded convergence actually is (design §5 honesty note: `judge` re-admits model subjectivity). Includes a per-ISO-week **trend**.

**2. Planner track record** — archetype **override rate** (how often the engineer corrects the planner — the §7 signal for whether to keep trusting it), archetype distribution, and **per-skill green-rate** (from the trace skill leaves).

**3. Criteria quality** — weak-criterion rate (Stage 7), manual-ops surfaced count, timeout / NOT-ADJUDICATED rate, and final-verification **regression rate** (Stage 5: passed at implement time but failed at final re-verify).

### Honesty framing
Numbers first, e.g. *"62% of criteria in this window were mechanically verified (tests / cited evidence / live smoke); 24% were judged by a model; 14% were unverified or manual-ops."* Empty data says so plainly rather than showing a misleading 0%.

### The auth mount (the /api/pr-queue bug class)
`GET /api/telemetry/trust` is on a **NEW `/api/telemetry` prefix**, mounted `app.use("/api/telemetry", requireAuth, requireProject)` in `server/routes.ts`. This mount is load-bearing: without it the route is unauthenticated **and** `getLoops()` has no async-local project context (500) — exactly the bug that once left `/api/pr-queue` open. A unit test greps `routes.ts` to guard against it regressing, and the handler carries a belt-and-suspenders `req.user` 401 guard.

### Adversarial self-review
- **Auth mount** — verified present (route 401s without `req.user`; mount asserted in `routes.ts`).
- **Unbounded scan** — bounded by `limit` (default 50, max 200) + optional `windowDays`; the expensive jsonb round-read runs only for the capped loop set (test asserts `getLoopRounds` called ≤ `limit`).
- **Div-by-zero** — every ratio goes through a safe `ratio(n, d)`; empty-input test pins all-zeros + honest message.
- **Untrusted data** — reads numbers/enums only; malformed traces contribute 0, never throw; the client renders inert text (no free-text-as-markup).

### Files
- `server/services/consilium/trust-telemetry.ts` — pure aggregator (new)
- `server/routes/telemetry.ts` — `GET /api/telemetry/trust` (new)
- `server/routes.ts` — import + `/api/telemetry` auth mount + register (mod)
- `client/src/pages/TrustTelemetry.tsx` — page: cards + recharts trend/bars (new)
- `client/src/App.tsx` — `/trust` route (mod)
- `client/src/components/layout/MainLayout.tsx` — "Trust" nav entry (mod)
- `tests/unit/consilium/trust-telemetry.test.ts` — aggregator (new)
- `tests/unit/consilium/trust-telemetry-route.test.ts` — route shape + auth mount guard (new)

### Test evidence
- `tsc --noEmit` clean.
- Unit project: **4889 passed** (incl. 14 new).
- Integration project: **869 passed / 5 skipped**. One transient `thought-tree-api` 401/404 flake appeared on the first singleFork run and cleared on re-run + in isolation (cross-test state leak; unrelated — no integration files touched). `pull_request` CI is authoritative.

Draft — do not merge.
