### PR TITLE
fix: Statistics widgets not draggable (key/onLayoutChange)

### DIFF
--- a/client/src/pages/Statistics.tsx
+++ b/client/src/pages/Statistics.tsx
@@ -779,15 +779,39 @@ export default function Statistics() {
     queryFn: () => fetchJson("/api/stats/overview"),
   });
 
+  // ─── Controlled-layout contract (ROOT CAUSE of "widgets won't drag") ────────────
+  //
+  // The grid is seeded from the persisted layout ONCE and then OWNS its interaction
+  // state. We deliberately do NOT re-feed `onLayoutChange` back into the `layouts`
+  // prop.
+  //
+  // Why this matters (the real drag bug): react-grid-layout 2.2.3's
+  // `ResponsiveReactGridLayout` (what `WidthProvider(Responsive)` renders) re-seeds
+  // its internal layout from the `layouts` prop through a prop-sync effect that —
+  // unlike the single-grid `ReactGridLayout`, which bails out with
+  // `if (isDraggingRef.current) return` — has NO "is dragging" guard. `onLayoutChange`
+  // fires mid-gesture (every time the dragged widget crosses into a new grid cell), so
+  // a fully-controlled `layouts={state}` that we `setState` on every change re-enters
+  // that un-guarded effect DURING the drag and overwrites the grid's in-progress
+  // layout with the prop value. The widget stops tracking the cursor and snaps back —
+  // exactly the reported "handle is visible but dragging does not move widgets". This
+  // only manifests under real pointer interaction, so the SSR/jsdom oracles used in
+  // PR #470 could not surface it, and the earlier `touch-action` fix is mouse-inert.
+  //
+  // Persisting only (no setState from the drag) lets the grid complete the gesture
+  // uninterrupted; `loadLayout()`/`saveLayout()` keep the versioned round-trip intact.
+  // Reset bumps `gridKey` to remount the grid so it re-seeds from the fresh defaults.
   const [layouts, setLayouts] = useState<ResponsiveLayouts>(() => loadLayout());
+  const [gridKey, setGridKey] = useState(0);
 
   const handleLayoutChange = (_current: Layout, allLayouts: ResponsiveLayouts) => {
-    setLayouts(allLayouts);
+    // Persist only — never re-feed the controlled prop mid-gesture (see note above).
     saveLayout(allLayouts);
   };
 
   const handleReset = () => {
     setLayouts(resetLayout());
+    setGridKey((k) => k + 1);
   };
 
   return (
@@ -814,6 +838,7 @@ export default function Statistics() {
           Drag widget headers to rearrange · drag corners to resize · use “Reset layout” to restore defaults.
         </p>
         <ResponsiveGridLayout
+          key={gridKey}
           className="stats-dashboard-grid w-full min-w-0"
           layouts={layouts}
           breakpoints={BREAKPOINTS}


### PR DESCRIPTION
## Symptom

After PR #470 the Statistics grid no longer shifts right (layout is correct) and the drag handle/indicator is visible — but **dragging a widget by its header does not move it**. Reported on macOS (mouse/trackpad).

## Real interaction root cause

The drag *configuration* is correct in isolation (`draggableHandle=".widget-drag-handle"`, `isDraggable`, controlled `layouts`, versioned localStorage). Every grid item's `key` matches an `i` in the layout, `draggableHandle` maps to the DraggableCore `handle`, and react-grid-layout 2.2.3 passes `nodeRef` to react-draggable so it is React-19-safe. So the failure is not the config the earlier oracles checked.

The bug is in the **controlled-layout feedback loop**:

- `WidthProvider(Responsive)` renders **`ResponsiveReactGridLayout`**, whose prop-sync effect re-seeds its internal layout from the `layouts` prop **with no "is dragging" guard**. (The single-grid `ReactGridLayout` *does* guard this: `if (isDraggingRef.current) return;` — the Responsive one does not.)
- `onLayoutChange` fires **mid-gesture** — every time the dragged widget crosses into a new grid cell, not just on drop.
- The page fully controlled `layouts` and called `setLayouts(allLayouts)` on **every** `onLayoutChange`. That produces a new `layouts` prop mid-drag, which re-enters the un-guarded Responsive prop-sync effect and **overwrites the grid's in-progress layout with the prop value** → the widget stops tracking the cursor and snaps back → "handle visible but dragging doesn't move widgets".

This only manifests under real pointer interaction, so the SSR/jsdom harnesses used in PR #470 could not surface it, and PR #470's `touch-action: none` fix is **mouse-inert** (it only affects touch/pen/precision-pointer gestures), which is why a mouse/trackpad operator still couldn't drag.

## Fix (`client/src/pages/Statistics.tsx` only)

Seed the grid from the persisted layout **once** and let it own its interaction state:

- `handleLayoutChange` now **persists only** (`saveLayout`) — it no longer re-feeds the controlled `layouts` prop mid-gesture, so the un-guarded Responsive prop-sync effect never fires during a drag/resize.
- Reset bumps a `gridKey` to remount the grid so it re-seeds from the fresh defaults (`resetLayout()`), keeping "Reset layout" reliable.
- `loadLayout()` / `saveLayout()` and the versioned localStorage round-trip are unchanged.

## Adversarial self-review

- **Drag**: RGL owns the gesture uninterrupted → completes → `onLayoutChange` → `saveLayout` persists. No mid-drag re-seed.
- **Resize**: same mechanism; previously also exposed to the mid-gesture re-seed, now equally protected. Not broken.
- **Reset**: `resetLayout()` clears storage + `gridKey` remount re-seeds defaults, reliable even when the current layout already equals default.
- **Persistence**: `dashboard-layout.ts` untouched; schema versioning + reconcile round-trip intact.

## Tests

- `npm run check` (tsc): **clean**.
- `tests/unit/dashboard-layout.test.ts`: **9/9 pass**.
- Full unit project: **4874/4875 pass**. The one failure (`gateway.test.ts > testProvider throws when provider is not registered`) is a **5s timeout flake under heavy parallel import load** (import took 226s); it passes 21/21 in isolation and is outside this change's zone. `pull_request` CI is authoritative.

## Verification note

There is no browser/dev-server or DOM test infra in this repo (tsc + node-only vitest), so **live drag could not be browser-verified**. The root cause and fix are established from the react-grid-layout 2.2.3 source (the guarded vs un-guarded prop-sync effects) and the persistence tests. Please have the operator confirm the drag gesture in a real browser.

Do not merge until operator-confirmed.
