### PR TITLE
chore: fix port-bind flake, retry timing-flaky suites, CI concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,52 @@ on:
   pull_request:
     branches: [main]
 
+# Supersede in-progress runs: a newer push to the same PR (github.head_ref) or
+# the same branch/tag (github.ref for push events) cancels the older run, so only
+# the latest commit for a given head keeps running. De-duplication of the
+# push-vs-pull_request pair for one commit is handled by the `guard` job below,
+# not here (they resolve to different groups on purpose).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+# `gh pr list` in the guard job needs read access to pull requests.
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
+  # De-duplicate push + pull_request. The pull_request run is authoritative
+  # ("green CI = merge arbiter"), so a push run is skipped when the branch has an
+  # open PR. push on main always runs (post-merge validation + e2e); pushes to a
+  # branch with no PR still run so you get CI before opening the PR.
+  guard:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"          # PR run is authoritative
+          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"          # main push: post-merge + e2e
+          else
+            open=$(gh pr list --repo "${{ github.repository }}" \
+              --head "${{ github.ref_name }}" --state open --json number --jq 'length')
+            if [ "$open" = "0" ]; then
+              echo "run=true" >> "$GITHUB_OUTPUT"         # no PR yet: run push CI
+            else
+              echo "run=false" >> "$GITHUB_OUTPUT"        # PR exists: PR run covers it
+              echo "Skipping push run: branch has an open PR (pull_request run is authoritative)."
+            fi
+          fi
+
   lint-typecheck:
+    needs: guard
+    if: needs.guard.outputs.run == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,6 +63,8 @@ jobs:
       - run: npm run check
 
   unit-integration:
+    needs: guard
+    if: needs.guard.outputs.run == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -35,6 +81,8 @@ jobs:
         continue-on-error: true
 
   helm-validate:
+    needs: guard
+    if: needs.guard.outputs.run == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -60,8 +108,9 @@ jobs:
         run: helm template multiqlti helm/multiqlti -f helm/multiqlti/values-prod.yaml --set image.repository=test/multiqlti > /dev/null
 
   e2e:
+    needs: guard
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: needs.guard.outputs.run == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     services:
       postgres:
         image: postgres:16

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,12 @@ on:
     - cron: "0 3 * * *"
   workflow_dispatch:
 
+# Serialize nightly runs — a manual dispatch won't stack on top of a scheduled
+# one. Don't cancel an in-flight nightly (the full suite/e2e is worth finishing).
+concurrency:
+  group: nightly
+  cancel-in-progress: false
+
 jobs:
   nightly-full:
     runs-on: ubuntu-latest

--- a/tests/helpers/test-agent.ts
+++ b/tests/helpers/test-agent.ts
@@ -2,9 +2,10 @@
  * Test agent helper for E2E and integration tests.
  *
  * Provides an in-process A2A-compliant HTTP agent built on top of BaseAgent.
- * Starts on a random high port (30000-40000) to avoid conflicts with
- * parallel test runs.
+ * Each agent binds an OS-assigned ephemeral port (via listen(0)) so it can
+ * never collide with a sibling agent or a leftover socket from a prior test.
  */
+import { createServer as createNetServer } from "node:net";
 import { BaseAgent } from "../../packages/remote-agent/src/base-agent.js";
 import type { AgentToolHandler } from "../../packages/remote-agent/src/base-agent.js";
 
@@ -38,9 +39,41 @@ class TestAgent extends BaseAgent {
   }
 }
 
-/** Pick a random port in the 30000-40000 range. */
-function randomPort(): number {
-  return 30000 + Math.floor(Math.random() * 10000);
+/**
+ * Ask the OS for a free ephemeral port by binding a throwaway server to port 0
+ * and reading back the assigned port. This is the same technique the `get-port`
+ * family of libraries uses: the kernel guarantees the port is currently free,
+ * and it will not re-hand the same ephemeral port to a second listener that
+ * quickly, so serial test runs never collide.
+ *
+ * `portsHandedOut` additionally guards against the OS returning a port we have
+ * already given to a still-running agent in this process (e.g. the "three
+ * agents concurrently" test), eliminating the residual TOCTOU window entirely.
+ */
+const portsHandedOut = new Set<number>();
+
+function freeEphemeralPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createNetServer();
+    srv.unref();
+    srv.once("error", reject);
+    srv.listen(0, "0.0.0.0", () => {
+      const addr = srv.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+async function getEphemeralPort(): Promise<number> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const port = await freeEphemeralPort();
+    if (port !== 0 && !portsHandedOut.has(port)) {
+      portsHandedOut.add(port);
+      return port;
+    }
+  }
+  throw new Error("could not obtain a free ephemeral port after 20 attempts");
 }
 
 export interface TestAgentHandle {
@@ -67,13 +100,16 @@ export async function startTestAgent(
   port?: number,
   tools?: AgentToolHandler[],
 ): Promise<TestAgentHandle> {
-  const p = port ?? randomPort();
+  const p = port ?? (await getEphemeralPort());
   const agent = new TestAgent(p, tools ?? []);
   await agent.start();
   return {
     agent,
     port: p,
     url: `http://localhost:${p}`,
-    stop: () => agent.stop(),
+    stop: async () => {
+      await agent.stop();
+      portsHandedOut.delete(p);
+    },
   };
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,50 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, configDefaults } from "vitest/config";
 import path from "path";
+
+// ─── Flake quarantine (retry: 2, SCOPED to these files only) ────────────────
+//
+// These files exhibit *non-deterministic* failures (timing / async-propagation
+// races, provider timeouts, occasional unhandled errors) that pass on a re-run.
+// Root causes are fixed at the source where cheap — the remote-agent port-bind
+// flake is fixed in tests/helpers/test-agent.ts (OS-assigned ephemeral ports).
+// The retries below cover the *residual* timing races only.
+//
+// IMPORTANT (anti-masking guarantee): `retry` is applied via dedicated vitest
+// projects that include EXACTLY the files listed here — it is never global.
+// Every other test in the suite still fails on its first failure. A file listed
+// here that fails *deterministically* (a real regression) still fails all 3
+// attempts and turns CI red; only genuine flakes (pass-on-retry) are absorbed.
+// When a root cause is fixed, remove the file from the relevant list.
+const FLAKY_UNIT = [
+  // Provider tests that occasionally time out under load (external-ish timing).
+  "tests/unit/providers/antigravity.test.ts",
+  "tests/unit/providers/antigravity-cli.test.ts",
+  "tests/unit/providers/antigravity-model-resolution.test.ts",
+  // Occasional "unhandled error" races in tool/RAG teardown.
+  "tests/unit/tools/tool-builtins.test.ts",
+  "tests/unit/rag/memory-search-tool.test.ts",
+  // Route-registration ordering sensitivity.
+  "tests/unit/costs/costs-routes.test.ts",
+];
+const FLAKY_INTEGRATION = [
+  // Port-bind EADDRINUSE — root-caused in tests/helpers/test-agent.ts (ephemeral
+  // ports). Retry kept as belt-and-suspenders for any residual startup timing.
+  "tests/integration/remote-agent-lifecycle.test.ts",
+  // Async config-propagation timing race ("expected length 2, got 1"). Test-side
+  // timing only; see PR notes re: a possible product-side race (follow-up).
+  "tests/integration/config-sync-multi-instance.test.ts",
+];
+
+// The whole integration suite runs in ONE process (pool: forks, singleFork) —
+// 50+ files, ~800 tests, serially. Under that sustained load, GC / event-loop
+// pauses occasionally push an otherwise-fast test past the default 5s deadline
+// (observed: models-api "Test timed out in 5000ms", runs-extended "Hook timed
+// out in 10000ms" — both pass in isolation in <200ms). Raising the deadlines
+// removes these *load-induced* timeouts. This does NOT mask real failures: a
+// timeout is not an assertion failure, and a genuinely hung/broken test still
+// fails — just after a longer, load-tolerant deadline.
+const INTEGRATION_TEST_TIMEOUT_MS = 20_000;
+const INTEGRATION_HOOK_TIMEOUT_MS = 30_000;
 
 export default defineConfig({
   resolve: {
@@ -15,7 +60,19 @@ export default defineConfig({
         test: {
           name: "unit",
           include: ["tests/unit/**/*.test.ts"],
+          exclude: [...configDefaults.exclude, ...FLAKY_UNIT],
           environment: "node",
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "unit-flaky",
+          include: [...FLAKY_UNIT],
+          environment: "node",
+          // antigravity CLI/provider tests occasionally exceed 5s under load.
+          testTimeout: 15_000,
+          retry: 2,
         },
       },
       {
@@ -23,9 +80,25 @@ export default defineConfig({
         test: {
           name: "integration",
           include: ["tests/integration/**/*.test.ts"],
+          exclude: [...configDefaults.exclude, ...FLAKY_INTEGRATION],
           environment: "node",
           pool: "forks",
           singleFork: true,
+          testTimeout: INTEGRATION_TEST_TIMEOUT_MS,
+          hookTimeout: INTEGRATION_HOOK_TIMEOUT_MS,
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "integration-flaky",
+          include: [...FLAKY_INTEGRATION],
+          environment: "node",
+          pool: "forks",
+          singleFork: true,
+          testTimeout: INTEGRATION_TEST_TIMEOUT_MS,
+          hookTimeout: INTEGRATION_HOOK_TIMEOUT_MS,
+          retry: 2,
         },
       },
     ],


### PR DESCRIPTION
## Why

Flaky tests produced false-red `pull_request` runs (undermining "green CI = merge arbiter"), and every head ran CI twice (`push` + `pull_request`). This hardens CI: root-causes the port-bind flake, scopes retries to named timing-flaky files, raises load-induced timeouts, and de-duplicates + supersedes runs.

**Zone:** only `.github/workflows/*.yml`, `vitest.config.ts`, and `tests/helpers/test-agent.ts` (a test helper). No product/feature files touched.

## Per-flake disposition

| Flake | Cause | Disposition |
|-------|-------|-------------|
| `remote-agent-lifecycle` EADDRINUSE (`Server.setupListenHandle`) | Helper picked a random port in a fixed 30000–40000 range with no collision handling; `BaseAgent.start()` has no `error` handler, so a collision hard-crashes | **Root-caused** in `tests/helpers/test-agent.ts`: bind an OS-assigned **ephemeral** port (`net.listen(0)` → read back), plus an in-process `portsHandedOut` guard so two live agents can never share a port. Kept in the retry bucket as belt-and-suspenders. |
| `config-sync-multi-instance` "expected length 2, got 1" | Async config-propagation timing race in the test's delivery model | **retry: 2** (scoped). Possible product-side race noted for follow-up; only test-side timing addressed here. |
| `antigravity`, `antigravity-cli`, `antigravity-model-resolution` timeouts | Provider/CLI tests occasionally exceed 5s under load | **retry: 2** + `testTimeout: 15s` on `unit-flaky` |
| `tool-builtins`, `memory-search-tool` unhandled errors | Teardown/async races | **retry: 2** (scoped) |
| `costs-routes` ordering | Route-registration ordering sensitivity | **retry: 2** (scoped) |
| `models-api` "Test timed out in 5000ms" *(surfaced during hardening; reproduces on `origin/main` — ~2-of-3 full-shard runs)* | Not a logic bug — the visibility allowlist it asserts is a hardcoded const. Under `singleFork` (50+ files, ~800 tests, one serial process) GC/event-loop pauses push a <200ms test past the 5s default | **Raised integration `testTimeout` → 20s** (systemic, not retry — a timeout is not an assertion failure) |
| `runs-extended` "Hook timed out in 10000ms" *(also surfaced)* | Same load cause, in a hook | **Raised integration `hookTimeout` → 30s** |

## Retry scoping (anti-masking)

Retries live in **dedicated vitest projects** (`unit-flaky`, `integration-flaky`) whose `include` is EXACTLY the named files — never global. The base `unit`/`integration` projects `exclude` those files, so nothing double-runs. Every other test still fails on its first failure; a named file that fails *deterministically* (a real regression) fails all 3 attempts and reds CI — only genuine pass-on-retry flakes are absorbed. Raising `testTimeout`/`hookTimeout` is a separate, non-masking mechanism (it only extends deadlines; a hung/broken test still fails, just later).

## CI concurrency + de-duplication

- **`concurrency`** = `ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}`, `cancel-in-progress: true` — a newer push to the same PR/branch cancels the superseded in-progress run.
- **`guard` job** de-dupes `push` vs `pull_request`: the `pull_request` run is authoritative; a `push` run is **skipped when the branch has an open PR** (`gh pr list --head`). `push` on `main` always runs (post-merge + e2e); pushes to a branch with no PR still run (pre-PR CI). All downstream jobs gate on `needs: guard` + `if: needs.guard.outputs.run == 'true'`.
- `nightly.yml`: `concurrency: { group: nightly, cancel-in-progress: false }` so a manual dispatch doesn't stack on a scheduled run.

## Evidence

- `tsc` clean; `actionlint` clean on both workflows.
- Full suite sharded as CI runs it (`vitest run --shard=n/3`): **all 3 shards green** — shard1 1981 passed / 5 skipped, shard2 1879, shard3 1884. (Before: shard1 red on the models-api timeout.)
- `origin/main` reproduction confirmed models-api/runs-extended are pre-existing, not introduced here.
- Flaky files run **3× back-to-back, all green**: `integration-flaky` 47/47 each run, `unit-flaky` 128/128 each run.

## Follow-ups (out of scope here)

- `config-sync-multi-instance`: investigate the product-side propagation race.
- `tests/unit/federation-transport.test.ts` + `federation-encryption-transport.test.ts` still use a synchronous `randomPort()` (30000–50000) that binds real WS ports — a latent collision risk (not observed flaking; converting 30+ sync call sites to ephemeral is a separate change).
- `models-api`/`runs-extended`: structural test-isolation under `singleFork` load (the timeout raise mitigates; a deeper fix could split the integration fork or reset module state between files).

_Draft — do not merge._
