### PR TITLE
feat: live per-participant activity and stall detection in the review step

### DIFF
--- a/client/src/components/task-groups/iterations-panel.tsx
+++ b/client/src/components/task-groups/iterations-panel.tsx
@@ -11,7 +11,7 @@
  * SECURITY: the summary/error/output are owner-gated server-side and rendered here
  * as INERT React text — never via dangerouslySetInnerHTML.
  */
-import { useEffect, useState, type ReactElement } from "react";
+import { useEffect, useRef, useState, type ReactElement } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -23,6 +23,7 @@ import {
   Play,
   CheckCircle2,
   AlertCircle,
+  AlertTriangle,
   Ban,
 } from "lucide-react";
 import {
@@ -30,11 +31,15 @@ import {
   useSaveIterationNote,
 } from "@/hooks/use-task-iterations";
 import { useToast } from "@/hooks/use-toast";
+import type { IterationExecution } from "@/lib/task-iterations";
 import {
-  buildTimelineFromExecutions,
-  formatDuration,
-  type ExecutionRowInput,
-} from "./timeline";
+  computeReviewActivity,
+  participantHeading,
+  formatElapsed,
+  noActivityMinutes,
+  type ParticipantActivityStatus,
+  type ReviewParticipant,
+} from "./review-activity";
 
 // ─── Status badge ──────────────────────────────────────────────────────────────
 //
@@ -73,11 +78,99 @@ export function ExecutionStatusBadge({ status }: { status: string }): ReactEleme
   );
 }
 
+// ─── Live participant activity (review step) ─────────────────────────────────
+//
+// The `reviewing`/`deciding` step was a 30-min spinner: the operator couldn't
+// tell which model was which role, whether it was working or a zombie, how long
+// it had run, or what it was producing. These pieces make each participant row
+// self-explanatory — identity, status, a live elapsed, a live "generating…" (or
+// "thinking…") beat, and a STALLED badge for a running-but-quiet execution. The
+// activity model itself is the pure `computeReviewActivity` (unit-tested); this
+// file is only its rendering.
+
+/** Operator-facing status badge (queued/running/stalled/completed/failed). */
+const ACTIVITY_STATUS_STYLE: Record<
+  ParticipantActivityStatus,
+  { color: string; icon: ReactElement; label: string }
+> = {
+  queued: {
+    color: "bg-muted text-muted-foreground",
+    icon: <Clock className="h-3 w-3" />,
+    label: "queued",
+  },
+  running: {
+    color: "bg-blue-500 text-white",
+    icon: <Loader2 className="h-3 w-3 animate-spin" />,
+    label: "running",
+  },
+  stalled: {
+    color: "bg-amber-500 text-white",
+    icon: <AlertTriangle className="h-3 w-3" />,
+    label: "stalled",
+  },
+  completed: {
+    color: "bg-green-600 text-white",
+    icon: <CheckCircle2 className="h-3 w-3" />,
+    label: "completed",
+  },
+  failed: {
+    color: "bg-red-600 text-white",
+    icon: <AlertCircle className="h-3 w-3" />,
+    label: "failed",
+  },
+  cancelled: {
+    color: "bg-gray-500 text-white",
+    icon: <Ban className="h-3 w-3" />,
+    label: "cancelled",
+  },
+};
+
+function ParticipantStatusBadge({ status }: { status: ParticipantActivityStatus }): ReactElement {
+  const cfg = ACTIVITY_STATUS_STYLE[status] ?? ACTIVITY_STATUS_STYLE.queued;
+  return (
+    <Badge className={`${cfg.color} gap-1`}>
+      {cfg.icon}
+      {cfg.label}
+    </Badge>
+  );
+}
+
+/**
+ * A per-second clock that drives the live elapsed / stall countdown BETWEEN the
+ * panel's 3s data polls (it adds NO API traffic — it is a local timer only).
+ * Ticks only while `active`; otherwise it returns a single render-time snapshot so
+ * a settled/historical round stays static and re-renders nothing.
+ */
+function useNowTicker(active: boolean, intervalMs = 1000): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(id);
+  }, [active, intervalMs]);
+  return now;
+}
+
+/**
+ * The live context for the review step, threaded in ONLY from the loop page's
+ * "Current round (live)" section. Absent for a historical round (which is
+ * terminal — nothing runs, so the enriched cards render static, no stall).
+ */
+export interface LiveReviewContext {
+  /** The loop row's `updatedAt` heartbeat — folds into the no-progress signal. */
+  loopUpdatedAt?: string | Date | null;
+  /** Round number for the one-line summary (falls back to the iteration number). */
+  roundLabel?: string | number | null;
+  /** Override the 5-min stall threshold (tests / tuning). */
+  stallThresholdMs?: number;
+}
+
 interface IterationDetailViewProps {
   groupId: string;
   iterationNumber: number;
-  /** Optional badge override; defaults to the self-contained ExecutionStatusBadge. */
-  StatusBadge?: (props: { status: string }) => ReactElement;
+  /** Present ⇒ live review framing (per-second timer, stall detection, summary). */
+  live?: LiveReviewContext;
 }
 
 /**
@@ -180,17 +273,28 @@ export function IterationNoteEditor({
 }
 
 /**
- * One round's dispute detail: the human-note editor plus per-participant execution
- * cards (each debater + the judge) built from the iteration's executions, with an
- * expandable raw-output block per execution. The owner-gated detail is fetched
- * lazily — mount this only when the round's dispute section is expanded.
+ * One round's dispute detail: the human-note editor plus a self-explanatory
+ * per-participant activity list (each debater + the judge) built from the
+ * iteration's executions via `computeReviewActivity` — identity, status, live
+ * elapsed, a "generating…"/"thinking…" beat, a STALLED badge, and the existing
+ * expandable raw output. Pass `live` (from the loop page's "Current round (live)"
+ * section) to enable the per-second timer + stall detection; omit it for a
+ * historical round (terminal — the same cards render static). The owner-gated
+ * detail is fetched lazily — mount this only when the dispute section is expanded.
  */
 export function IterationDetailView({
   groupId,
   iterationNumber,
-  StatusBadge = ExecutionStatusBadge,
+  live,
 }: IterationDetailViewProps) {
   const { data, isLoading, error } = useIterationDetail(groupId, iterationNumber);
+
+  // A round with a live-running participant needs a per-second clock so the
+  // elapsed/stall readouts advance between the panel's 3s data polls. Derive the
+  // trigger from the RAW status (independent of `now`) so the hook order is stable.
+  const isLive = !!live;
+  const hasRunning = isLive && (data?.executions?.some((e) => e.status === "running") ?? false);
+  const now = useNowTicker(hasRunning);
 
   if (isLoading) {
     return (
@@ -213,8 +317,13 @@ export function IterationDetailView({
     );
   }
 
-  const executions = data.executions as ExecutionRowInput[];
-  const timeline = buildTimelineFromExecutions(executions);
+  const activity = computeReviewActivity(data.executions, {
+    now,
+    loopUpdatedAt: live?.loopUpdatedAt ?? null,
+    roundLabel: live?.roundLabel ?? iterationNumber,
+    stallThresholdMs: live?.stallThresholdMs,
+  });
+  const execById = new Map(data.executions.map((e) => [e.id, e]));
 
   return (
     <div className="space-y-3">
@@ -226,7 +335,7 @@ export function IterationDetailView({
       />
 
       {/* Per-participant execution cards (summary/error owner-gated, inert text). */}
-      {data.executions.length === 0 ? (
+      {activity.participants.length === 0 ? (
         <Card>
           <CardContent className="py-6 text-center text-sm text-muted-foreground">
             This round has no recorded participant executions.
@@ -234,59 +343,138 @@ export function IterationDetailView({
         </Card>
       ) : (
         <div className="space-y-3">
-          {timeline.map((entry, i) => {
-            const exec = data.executions.find((e) => e.id === entry.id);
-            return (
-              <Card key={entry.id} className={entry.status === "running" ? "border-blue-500/50" : ""}>
-                <CardHeader className="py-3 pb-1">
-                  <div className="flex items-center justify-between gap-2">
-                    <CardTitle className="text-sm font-medium">
-                      {i + 1}. {entry.name}
-                    </CardTitle>
-                    <StatusBadge status={entry.status} />
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-1 py-2">
-                  <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
-                    {entry.modelSlug && <span className="font-mono">{entry.modelSlug}</span>}
-                    {entry.durationMs !== null && (
-                      <span className="tabular-nums">{formatDuration(entry.durationMs)}</span>
-                    )}
-                    {entry.startedAt && (
-                      <span title={entry.startedAt}>
-                        started {new Date(entry.startedAt).toLocaleTimeString()}
-                      </span>
-                    )}
-                  </div>
-                  {exec?.summary && (
-                    <div className="mt-2 rounded bg-green-50 p-2 text-xs text-green-800 dark:bg-green-950 dark:text-green-200">
-                      {exec.summary}
-                    </div>
-                  )}
-                  {exec?.errorMessage && (
-                    <div className="mt-2 rounded bg-red-50 p-2 text-xs text-red-800 dark:bg-red-950 dark:text-red-200">
-                      {exec.errorMessage}
-                    </div>
-                  )}
-                  {(() => {
-                    const raw = formatExecutionOutput(exec?.output);
-                    return raw ? (
-                      <details className="mt-2">
-                        <summary className="cursor-pointer select-none text-xs text-muted-foreground hover:text-foreground">
-                          Raw output / reasoning
-                        </summary>
-                        <pre className="mt-1 max-h-96 overflow-auto whitespace-pre-wrap break-words rounded bg-muted p-2 font-mono text-xs">
-                          {raw}
-                        </pre>
-                      </details>
-                    ) : null;
-                  })()}
-                </CardContent>
-              </Card>
-            );
-          })}
+          {/* One-line round summary: who + how many in each state + elapsed. */}
+          <div
+            className="flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-1.5 text-xs text-muted-foreground"
+            data-testid="review-activity-summary"
+          >
+            {activity.summary.stalled > 0 ? (
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-500" aria-hidden="true" />
+            ) : activity.summary.running > 0 ? (
+              <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-blue-500" aria-hidden="true" />
+            ) : (
+              <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-green-600" aria-hidden="true" />
+            )}
+            <span className="tabular-nums">{activity.oneLine}</span>
+          </div>
+
+          {activity.participants.map((p) => (
+            <ParticipantCard key={p.id} participant={p} exec={execById.get(p.id)} />
+          ))}
         </div>
       )}
     </div>
   );
+}
+
+/**
+ * One participant row of the review step, made self-explanatory: a numbered
+ * identity heading ("1. Opus — primary debater"), the OBSERVED model slug, a
+ * status badge, a live elapsed timer, and an ACTIVITY line that says what it is
+ * doing right now — "generating…" while producing (the platform streams no partial
+ * tokens to the read side, so we show an honest "generating…"/"thinking…" beat
+ * rather than a token count), or an amber "stalled — no activity for Nm" when a
+ * running execution has gone quiet past the threshold. Terminal rows show their
+ * summary/error and the existing expandable raw output.
+ */
+function ParticipantCard({
+  participant: p,
+  exec,
+}: {
+  participant: ReviewParticipant;
+  exec: IterationExecution | undefined;
+}): ReactElement {
+  const borderClass =
+    p.status === "stalled"
+      ? "border-amber-500/60"
+      : p.status === "running"
+        ? "border-blue-500/50"
+        : "";
+
+  return (
+    <Card className={borderClass}>
+      <CardHeader className="py-3 pb-1">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="min-w-0 truncate text-sm font-medium">
+            {p.index}. {participantHeading(p)}
+          </CardTitle>
+          <ParticipantStatusBadge status={p.status} />
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-1 py-2">
+        {/* Identity + timing: role · observed model · elapsed. */}
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+          <span className="capitalize">{p.role.label}</span>
+          {p.modelSlug && <span className="font-mono">{p.modelSlug}</span>}
+          {p.elapsedMs !== null && (
+            <span className="tabular-nums" title={p.startedAt ?? undefined}>
+              {p.status === "running" || p.status === "stalled" ? "running " : "took "}
+              {formatElapsed(p.elapsedMs)}
+            </span>
+          )}
+        </div>
+
+        {/* Live activity beat — the fix for the dead 30-min spinner. */}
+        <ParticipantActivityLine participant={p} />
+
+        {exec?.summary && (
+          <div className="mt-2 rounded bg-green-50 p-2 text-xs text-green-800 dark:bg-green-950 dark:text-green-200">
+            {exec.summary}
+          </div>
+        )}
+        {exec?.errorMessage && (
+          <div className="mt-2 rounded bg-red-50 p-2 text-xs text-red-800 dark:bg-red-950 dark:text-red-200">
+            {exec.errorMessage}
+          </div>
+        )}
+        {(() => {
+          const raw = formatExecutionOutput(exec?.output);
+          return raw ? (
+            <details className="mt-2">
+              <summary className="cursor-pointer select-none text-xs text-muted-foreground hover:text-foreground">
+                Raw output / reasoning
+              </summary>
+              <pre className="mt-1 max-h-96 overflow-auto whitespace-pre-wrap break-words rounded bg-muted p-2 font-mono text-xs">
+                {raw}
+              </pre>
+            </details>
+          ) : null;
+        })()}
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * The one-line "what is it doing right now" beat under a participant. Running →
+ * an honest "generating…"/"thinking…" spinner with the elapsed; stalled → an
+ * amber "stalled — no activity for Nm" so a dead review looks visibly dead;
+ * queued → "waiting to start". Terminal rows render nothing here (their
+ * summary/output speaks for them).
+ */
+function ParticipantActivityLine({ participant: p }: { participant: ReviewParticipant }): ReactElement | null {
+  if (p.status === "stalled") {
+    const mins = p.noProgressMs !== null ? noActivityMinutes(p.noProgressMs) : 0;
+    return (
+      <div className="flex items-center gap-1.5 text-xs font-medium text-amber-600 dark:text-amber-400">
+        <AlertTriangle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        stalled — no activity for {mins}m
+      </div>
+    );
+  }
+  if (p.status === "running") {
+    return (
+      <div className="flex items-center gap-1.5 text-xs text-blue-600 dark:text-blue-400">
+        <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" aria-hidden="true" />
+        {p.hasOutput ? "generating…" : "thinking…"}
+        {p.elapsedMs !== null && (
+          <span className="tabular-nums text-muted-foreground">· {formatElapsed(p.elapsedMs)}</span>
+        )}
+      </div>
+    );
+  }
+  if (p.status === "queued") {
+    return <div className="text-xs text-muted-foreground">waiting to start…</div>;
+  }
+  return null;
 }

--- a/client/src/components/task-groups/review-activity.ts
+++ b/client/src/components/task-groups/review-activity.ts
@@ -1,0 +1,437 @@
+/**
+ * Pure helpers that turn a consilium round's participant EXECUTIONS into a
+ * self-explanatory, live "who is doing what, and is it alive?" model for the
+ * REVIEW step (the `reviewing`/`deciding` phase). Consumed by
+ * iterations-panel.tsx's IterationDetailView; unit-tested without a DOM renderer
+ * (the repo's unit project runs in `node`, no jsdom).
+ *
+ * WHY this exists: during `reviewing` the operator saw only a spinner for 30+
+ * minutes with no way to tell WHICH model was which role, whether it was
+ * actively working or a zombie, how long it had run, or what it was producing.
+ * These pure functions compute, per participant: identity (role + observed
+ * model), a mapped status, a live elapsed, and — critically — a STALL verdict.
+ *
+ * STALL is deliberately based on NO-PROGRESS, not raw elapsed. The platform does
+ * NOT stream partial tokens to the read side: `task_executions.output` is written
+ * ONCE at completion and there is no per-execution heartbeat column (see
+ * server/services/task-orchestrator.ts). So "activity" is defined as the set of
+ * observable progress EVENTS across the whole round — any execution flipping to
+ * `running` (a fresh `startedAt`), any execution finishing (a `completedAt`), and
+ * the loop row's `updatedAt` heartbeat (bumped by the controller/poller on every
+ * transition/partial update). A running participant is flagged `stalled` only
+ * when the ENTIRE round has produced no such event for the threshold. This never
+ * trips on a legitimately slow-but-working panel: while debaters complete in
+ * sequence each completion is a progress event that resets the clock; only a
+ * genuinely frozen round (nothing starts, nothing finishes, the loop heartbeat is
+ * stale) goes amber.
+ *
+ * SECURITY: every field here is metadata (status / model slug / task name /
+ * timestamps) already owner-gated by the server; nothing is rendered as HTML.
+ */
+
+/** The minimal execution shape the activity model needs (subset of IterationExecution). */
+export interface ReviewExecutionInput {
+  id: string;
+  /** Denormalized task-definition name; encodes role + seat (e.g. "Opus primary"). */
+  taskName?: string | null;
+  /** Raw task_execution status (pending|blocked|ready|running|completed|failed|cancelled). */
+  status: string;
+  /** OBSERVED (resolved) model slug the execution actually ran on. */
+  modelSlug?: string | null;
+  startedAt?: string | null;
+  completedAt?: string | null;
+  /** Present (non-empty) once the model's output has landed (only at completion). */
+  output?: unknown;
+  summary?: string | null;
+  errorMessage?: string | null;
+}
+
+/** The role a participant execution plays in the cross-review dispute. */
+export type ParticipantRoleKind = "primary" | "rebuttal" | "judge" | "participant";
+
+/** A classified participant role: its kind, a human label, and the seat (model name). */
+export interface ParticipantRole {
+  kind: ParticipantRoleKind;
+  /** Human role label, e.g. "primary debater", "rebuts Gemini", "judge". */
+  label: string;
+  /** The seat / reviewer display name parsed from the task name (e.g. "Opus"), or null. */
+  seat: string | null;
+}
+
+/**
+ * The activity status shown to the operator, mapped from the raw execution
+ * status (plus the derived stall verdict). Narrower and more legible than the raw
+ * task statuses: pending/blocked/ready collapse to `queued`; a `running` row that
+ * has gone quiet past the threshold becomes `stalled`.
+ */
+export type ParticipantActivityStatus =
+  | "queued"
+  | "running"
+  | "stalled"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+/** One participant row of the review-activity model. */
+export interface ReviewParticipant {
+  id: string;
+  /** 1-based position in the round's timeline ordering. */
+  index: number;
+  taskName: string | null;
+  role: ParticipantRole;
+  /** OBSERVED model slug (preferred over any declared/composition value). */
+  modelSlug: string | null;
+  /** The raw task_execution status, kept for callers that need the source value. */
+  rawStatus: string;
+  /** The mapped, operator-facing status (stall folded in). */
+  status: ParticipantActivityStatus;
+  startedAt: string | null;
+  completedAt: string | null;
+  /**
+   * Wall-clock elapsed in ms: for a terminal row it is startedAt→completedAt;
+   * for a running row it is startedAt→now; null when it has not started.
+   */
+  elapsedMs: number | null;
+  /** True iff running AND the round has had no progress for the threshold. */
+  stalled: boolean;
+  /** ms since the last round-level progress event (running rows only), else null. */
+  noProgressMs: number | null;
+  /** Whether the execution's output has landed (a completion signal). */
+  hasOutput: boolean;
+}
+
+/** A compact roll-up used for the one-line section summary. */
+export interface ReviewActivitySummary {
+  total: number;
+  queued: number;
+  running: number;
+  stalled: number;
+  completed: number;
+  failed: number;
+  cancelled: number;
+  /** Number of primary debater seats (rebuttals belong to the same debaters). */
+  debaterCount: number;
+  hasJudge: boolean;
+  /** Round elapsed: earliest start → now (or → latest completion when none run), ms. */
+  elapsedMs: number | null;
+  /** ms since the last observable progress event across the whole round. */
+  lastProgressMs: number | null;
+}
+
+/** The full review-activity model for one round's executions. */
+export interface ReviewActivity {
+  participants: ReviewParticipant[];
+  summary: ReviewActivitySummary;
+  /** e.g. "Round 2 review — 2 debaters + judge · 2 running, 1 queued · elapsed 6m". */
+  oneLine: string;
+}
+
+/** Default stall threshold: 5 minutes of no round-level activity. */
+export const DEFAULT_STALL_THRESHOLD_MS = 5 * 60_000;
+
+const TERMINAL_STATUSES: ReadonlySet<string> = new Set([
+  "completed",
+  "failed",
+  "cancelled",
+]);
+
+/** Parse an ISO string / Date / epoch to epoch ms, or null when absent/unparseable. */
+function toEpoch(value: string | Date | number | null | undefined): number | null {
+  if (value == null) return null;
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  const ms = value instanceof Date ? value.getTime() : Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/** Whether an execution's `output` carries anything to show (a completion signal). */
+function outputPresent(output: unknown): boolean {
+  if (output == null) return false;
+  if (typeof output === "string") return output.trim().length > 0;
+  if (typeof output === "object") {
+    if ("raw" in output) {
+      const raw = (output as { raw?: unknown }).raw;
+      return typeof raw === "string" ? raw.trim().length > 0 : raw != null;
+    }
+    return Object.keys(output as object).length > 0;
+  }
+  return true;
+}
+
+/**
+ * Classify a participant's role from its task name. Task names are authored by the
+ * review factory and are stable + self-describing: "<Seat> primary",
+ * "<Seat> rebuts <Other>", "Judge verdict". Falls back to a generic participant
+ * for anything unrecognised (never throws). Pure.
+ */
+export function classifyParticipantRole(
+  taskName: string | null | undefined,
+): ParticipantRole {
+  const name = (taskName ?? "").trim();
+  if (!name) return { kind: "participant", label: "participant", seat: null };
+
+  if (/\bjudge\b/i.test(name)) {
+    return { kind: "judge", label: "judge", seat: null };
+  }
+
+  const rebut = name.match(/^(.*?)\s+rebuts\s+(.*)$/i);
+  if (rebut) {
+    const seat = rebut[1].trim() || null;
+    const target = rebut[2].trim();
+    return {
+      kind: "rebuttal",
+      label: target ? `rebuts ${target}` : "rebuttal",
+      seat,
+    };
+  }
+
+  const primary = name.match(/^(.*?)\s+primary$/i);
+  if (primary) {
+    const seat = primary[1].trim() || null;
+    return { kind: "primary", label: "primary debater", seat };
+  }
+
+  return { kind: "participant", label: "participant", seat: null };
+}
+
+/**
+ * A display heading for a participant: the seat (or "Judge") plus its role,
+ * e.g. "Opus — primary debater", "Gemini — rebuts Opus", "Judge". The numbering
+ * is applied by the caller. Pure.
+ */
+export function participantHeading(p: ReviewParticipant): string {
+  const { role } = p;
+  if (role.kind === "judge") return "Judge";
+  const seat = role.seat ?? p.modelSlug ?? p.taskName ?? "Participant";
+  if (role.kind === "participant") return p.taskName?.trim() || seat;
+  return `${seat} — ${role.label}`;
+}
+
+/** Map a raw execution status (+ stall) to the operator-facing activity status. */
+function mapStatus(rawStatus: string, stalled: boolean): ParticipantActivityStatus {
+  switch (rawStatus) {
+    case "running":
+      return stalled ? "stalled" : "running";
+    case "completed":
+      return "completed";
+    case "failed":
+      return "failed";
+    case "cancelled":
+      return "cancelled";
+    // pending / blocked / ready and any unknown pre-run state → queued
+    default:
+      return "queued";
+  }
+}
+
+/**
+ * Order executions for a stable, meaningful timeline: started rows first by
+ * `startedAt` ascending, then not-yet-started rows in their given order. Stable
+ * for ties; never mutates the input. Mirrors buildTimeline's ordering so the
+ * numbering matches the rest of the panel.
+ */
+function orderExecutions(
+  executions: readonly ReviewExecutionInput[],
+): ReviewExecutionInput[] {
+  return executions
+    .map((e, i) => ({ e, i, start: toEpoch(e.startedAt) }))
+    .sort((a, b) => {
+      if (a.start !== null && b.start !== null) return a.start - b.start || a.i - b.i;
+      if (a.start !== null) return -1;
+      if (b.start !== null) return 1;
+      return a.i - b.i;
+    })
+    .map(({ e }) => e);
+}
+
+/** ms → a compact label: "45s", "6m", "6m 12s", "1h 4m". */
+export function formatElapsed(ms: number | null): string {
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return "—";
+  const totalSec = Math.floor(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const totalMin = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  if (totalMin < 60) return sec ? `${totalMin}m ${sec}s` : `${totalMin}m`;
+  const hr = Math.floor(totalMin / 60);
+  const min = totalMin % 60;
+  return min ? `${hr}h ${min}m` : `${hr}h`;
+}
+
+/** ms → whole minutes, rounded down, min 1 (for the "no activity for Nm" badge). */
+export function noActivityMinutes(ms: number): number {
+  return Math.max(1, Math.floor(ms / 60_000));
+}
+
+/**
+ * Compute the full review-activity model for one round's executions.
+ *
+ * `now` is injected so the function stays pure/testable (the UI passes a
+ * per-second ticker). `loopUpdatedAt` is the loop row's heartbeat, folded into
+ * the round-level progress signal so a controller/poller tick keeps a legitimately
+ * slow round out of the stall state. `stallThresholdMs` defaults to 5 minutes.
+ */
+export function computeReviewActivity(
+  executions: readonly ReviewExecutionInput[],
+  opts: {
+    now: number;
+    loopUpdatedAt?: string | Date | null;
+    stallThresholdMs?: number;
+    roundLabel?: string | number | null;
+  },
+): ReviewActivity {
+  const stallThresholdMs = opts.stallThresholdMs ?? DEFAULT_STALL_THRESHOLD_MS;
+  const now = opts.now;
+  const ordered = orderExecutions(executions);
+
+  // Round-level "last progress" = the most recent observable progress event:
+  // any start, any completion, or the loop heartbeat. This is the anti-false-
+  // positive core of the stall rule.
+  const progressStamps: number[] = [];
+  for (const e of ordered) {
+    const s = toEpoch(e.startedAt);
+    const c = toEpoch(e.completedAt);
+    if (s !== null) progressStamps.push(s);
+    if (c !== null) progressStamps.push(c);
+  }
+  const loopBeat = toEpoch(opts.loopUpdatedAt);
+  if (loopBeat !== null) progressStamps.push(loopBeat);
+  const lastProgressAt = progressStamps.length ? Math.max(...progressStamps) : null;
+  const lastProgressMs = lastProgressAt !== null ? Math.max(0, now - lastProgressAt) : null;
+
+  const participants: ReviewParticipant[] = ordered.map((e, idx) => {
+    const role = classifyParticipantRole(e.taskName);
+    const startedAt = e.startedAt ?? null;
+    const completedAt = e.completedAt ?? null;
+    const startEpoch = toEpoch(startedAt);
+    const endEpoch = toEpoch(completedAt);
+    const isRunning = e.status === "running";
+
+    // No-progress is a ROUND-level signal; a running row is stalled only when the
+    // whole round has been quiet past the threshold (never on raw elapsed alone).
+    const noProgressMs = isRunning ? lastProgressMs : null;
+    const stalled = isRunning && noProgressMs !== null && noProgressMs > stallThresholdMs;
+
+    let elapsedMs: number | null = null;
+    if (startEpoch !== null) {
+      const end = endEpoch !== null ? endEpoch : isRunning ? now : null;
+      if (end !== null) elapsedMs = Math.max(0, end - startEpoch);
+    }
+
+    return {
+      id: e.id,
+      index: idx + 1,
+      taskName: e.taskName ?? null,
+      role,
+      modelSlug: e.modelSlug ?? null,
+      rawStatus: e.status,
+      status: mapStatus(e.status, stalled),
+      startedAt,
+      completedAt,
+      elapsedMs,
+      stalled,
+      noProgressMs,
+      hasOutput: outputPresent(e.output),
+    };
+  });
+
+  const summary = summarize(participants, now);
+  const oneLine = buildOneLine(summary, opts.roundLabel ?? null);
+  return { participants, summary, oneLine };
+}
+
+function summarize(
+  participants: readonly ReviewParticipant[],
+  now: number,
+): ReviewActivitySummary {
+  let queued = 0;
+  let running = 0;
+  let stalled = 0;
+  let completed = 0;
+  let failed = 0;
+  let cancelled = 0;
+  let debaterCount = 0;
+  let hasJudge = false;
+  const starts: number[] = [];
+  const ends: number[] = [];
+
+  for (const p of participants) {
+    switch (p.status) {
+      case "queued":
+        queued += 1;
+        break;
+      case "running":
+        running += 1;
+        break;
+      case "stalled":
+        stalled += 1;
+        break;
+      case "completed":
+        completed += 1;
+        break;
+      case "failed":
+        failed += 1;
+        break;
+      case "cancelled":
+        cancelled += 1;
+        break;
+    }
+    if (p.role.kind === "primary") debaterCount += 1;
+    if (p.role.kind === "judge") hasJudge = true;
+    const s = toEpoch(p.startedAt);
+    const c = toEpoch(p.completedAt);
+    if (s !== null) starts.push(s);
+    if (c !== null) ends.push(c);
+  }
+
+  // Round elapsed: from the earliest start to now while anything is live, else to
+  // the latest completion (a finished round has a fixed span).
+  let elapsedMs: number | null = null;
+  if (starts.length) {
+    const earliest = Math.min(...starts);
+    const anyLive = running > 0 || stalled > 0 || queued > 0;
+    const end = anyLive ? now : ends.length ? Math.max(...ends) : now;
+    elapsedMs = Math.max(0, end - earliest);
+  }
+
+  return {
+    total: participants.length,
+    queued,
+    running,
+    stalled,
+    completed,
+    failed,
+    cancelled,
+    debaterCount,
+    hasJudge,
+    elapsedMs,
+    lastProgressMs: null, // filled by caller context if needed; not used in one-liner
+  };
+}
+
+/** Build the compact one-line section summary from the roll-up. */
+function buildOneLine(
+  summary: ReviewActivitySummary,
+  roundLabel: string | number | null,
+): string {
+  const round = roundLabel != null && `${roundLabel}`.trim() ? `Round ${roundLabel} ` : "";
+  const seats =
+    summary.debaterCount > 0
+      ? `${summary.debaterCount} debater${summary.debaterCount === 1 ? "" : "s"}${
+          summary.hasJudge ? " + judge" : ""
+        }`
+      : summary.hasJudge
+        ? "judge"
+        : `${summary.total} participant${summary.total === 1 ? "" : "s"}`;
+
+  const parts: string[] = [];
+  if (summary.running) parts.push(`${summary.running} running`);
+  if (summary.stalled) parts.push(`${summary.stalled} stalled`);
+  if (summary.queued) parts.push(`${summary.queued} queued`);
+  if (summary.completed) parts.push(`${summary.completed} done`);
+  if (summary.failed) parts.push(`${summary.failed} failed`);
+  const counts = parts.length ? ` · ${parts.join(", ")}` : "";
+
+  const elapsed =
+    summary.elapsedMs != null ? ` · elapsed ${formatElapsed(summary.elapsedMs)}` : "";
+
+  return `${round}review — ${seats}${counts}${elapsed}`;
+}

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -1855,10 +1855,14 @@ function LiveCurrentRound({ loop }: { loop: ConsiliumLoopDetailRow }) {
       </CardHeader>
       <CardContent className="space-y-2">
         <p className="text-[11px] text-muted-foreground/80">
-          The dispute for round {loop.round || 1} is running (iteration #{iter}). Cards
-          update as each participant completes.
+          The dispute for round {loop.round || 1} is running (iteration #{iter}). Each
+          row shows what its model is doing, for how long, and flags a stalled run.
         </p>
-        <IterationDetailView groupId={loop.groupId} iterationNumber={iter} />
+        <IterationDetailView
+          groupId={loop.groupId}
+          iterationNumber={iter}
+          live={{ loopUpdatedAt: loop.updatedAt, roundLabel: loop.round || 1 }}
+        />
       </CardContent>
     </Card>
   );

--- a/tests/unit/review-activity.test.ts
+++ b/tests/unit/review-activity.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Unit tests for the consilium REVIEW-step activity model (frontend). Like
+ * task-iterations-logic.test.ts these exercise the PURE helpers behind the Loop
+ * detail "Current round (live)" section without a DOM renderer — they import
+ * from @/components/task-groups/review-activity (no React).
+ *
+ * Covers: role classification from task names, status mapping, live elapsed, the
+ * NO-PROGRESS stall rule (and its anti-false-positive guarantees on a slow-but-
+ * working panel + on a fresh loop heartbeat), and the one-line summary.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  classifyParticipantRole,
+  computeReviewActivity,
+  participantHeading,
+  formatElapsed,
+  noActivityMinutes,
+  DEFAULT_STALL_THRESHOLD_MS,
+  type ReviewExecutionInput,
+} from "@/components/task-groups/review-activity";
+
+const T0 = Date.parse("2026-07-03T10:00:00.000Z");
+const MIN = 60_000;
+
+function exec(overrides: Partial<ReviewExecutionInput> = {}): ReviewExecutionInput {
+  // NB: use `in` checks for the nullable timestamps so an EXPLICIT `null` (a
+  // queued row that has not started) is preserved rather than collapsed by `??`.
+  return {
+    id: overrides.id ?? "e1",
+    taskName: overrides.taskName ?? "Opus primary",
+    status: overrides.status ?? "running",
+    modelSlug: overrides.modelSlug ?? "claude-opus",
+    startedAt: "startedAt" in overrides ? overrides.startedAt : new Date(T0).toISOString(),
+    completedAt: "completedAt" in overrides ? overrides.completedAt : null,
+    output: overrides.output,
+    summary: overrides.summary ?? null,
+    errorMessage: overrides.errorMessage ?? null,
+  };
+}
+
+describe("classifyParticipantRole", () => {
+  it("classifies a primary debater and parses the seat", () => {
+    const r = classifyParticipantRole("Opus primary");
+    expect(r.kind).toBe("primary");
+    expect(r.seat).toBe("Opus");
+    expect(r.label).toBe("primary debater");
+  });
+
+  it("classifies a rebuttal with its target", () => {
+    const r = classifyParticipantRole("Gemini rebuts Opus");
+    expect(r.kind).toBe("rebuttal");
+    expect(r.seat).toBe("Gemini");
+    expect(r.label).toBe("rebuts Opus");
+  });
+
+  it("classifies the judge", () => {
+    const r = classifyParticipantRole("Judge verdict");
+    expect(r.kind).toBe("judge");
+    expect(r.seat).toBeNull();
+    expect(r.label).toBe("judge");
+  });
+
+  it("falls back to a generic participant for unknown names", () => {
+    expect(classifyParticipantRole("something else").kind).toBe("participant");
+    expect(classifyParticipantRole(null).kind).toBe("participant");
+    expect(classifyParticipantRole("").kind).toBe("participant");
+  });
+});
+
+describe("participantHeading", () => {
+  it("builds seat + role headings and a bare Judge heading", () => {
+    const act = computeReviewActivity(
+      [
+        exec({ id: "a", taskName: "Opus primary" }),
+        exec({ id: "b", taskName: "Gemini rebuts Opus", modelSlug: "gemini-3-1-pro-high" }),
+        exec({ id: "c", taskName: "Judge verdict", modelSlug: "claude-opus", status: "queued", startedAt: null }),
+      ],
+      { now: T0 + MIN },
+    );
+    const byId = Object.fromEntries(act.participants.map((p) => [p.id, participantHeading(p)]));
+    expect(byId.a).toBe("Opus — primary debater");
+    expect(byId.b).toBe("Gemini — rebuts Opus");
+    expect(byId.c).toBe("Judge");
+  });
+});
+
+describe("computeReviewActivity — status mapping + elapsed", () => {
+  it("maps pending/blocked/ready to queued and computes no elapsed", () => {
+    const act = computeReviewActivity(
+      [exec({ status: "pending", startedAt: null }), exec({ id: "e2", status: "ready", startedAt: null })],
+      { now: T0 + MIN },
+    );
+    expect(act.participants.every((p) => p.status === "queued")).toBe(true);
+    expect(act.participants.every((p) => p.elapsedMs === null)).toBe(true);
+  });
+
+  it("computes live elapsed for a running row from startedAt→now", () => {
+    const act = computeReviewActivity([exec({ status: "running" })], { now: T0 + 90 * 1000 });
+    expect(act.participants[0].status).toBe("running");
+    expect(act.participants[0].elapsedMs).toBe(90 * 1000);
+  });
+
+  it("computes fixed elapsed for a completed row from startedAt→completedAt", () => {
+    const act = computeReviewActivity(
+      [
+        exec({
+          status: "completed",
+          completedAt: new Date(T0 + 3 * MIN).toISOString(),
+          output: "the verdict",
+        }),
+      ],
+      { now: T0 + 10 * MIN },
+    );
+    expect(act.participants[0].status).toBe("completed");
+    expect(act.participants[0].elapsedMs).toBe(3 * MIN);
+    expect(act.participants[0].hasOutput).toBe(true);
+  });
+});
+
+describe("computeReviewActivity — the no-progress stall rule", () => {
+  it("flags a running row as stalled once the round is quiet past the threshold", () => {
+    // Only one execution, started 6 min ago, still running, no other activity.
+    const act = computeReviewActivity([exec({ status: "running" })], {
+      now: T0 + 6 * MIN,
+    });
+    const p = act.participants[0];
+    expect(p.stalled).toBe(true);
+    expect(p.status).toBe("stalled");
+    expect(p.noProgressMs).toBe(6 * MIN);
+  });
+
+  it("does NOT stall before the threshold", () => {
+    const act = computeReviewActivity([exec({ status: "running" })], { now: T0 + 4 * MIN });
+    expect(act.participants[0].stalled).toBe(false);
+    expect(act.participants[0].status).toBe("running");
+  });
+
+  it("does NOT false-positive a slow debater while a sibling recently completed", () => {
+    // Judge started 6 min ago and is still running, BUT a debater completed 1 min
+    // ago → the round HAS made progress recently → the judge is working, not stalled.
+    const now = T0 + 6 * MIN;
+    const act = computeReviewActivity(
+      [
+        exec({
+          id: "debater",
+          taskName: "Opus primary",
+          status: "completed",
+          startedAt: new Date(T0).toISOString(),
+          completedAt: new Date(now - 1 * MIN).toISOString(),
+          output: "done",
+        }),
+        exec({
+          id: "judge",
+          taskName: "Judge verdict",
+          status: "running",
+          startedAt: new Date(T0).toISOString(),
+        }),
+      ],
+      { now },
+    );
+    const judge = act.participants.find((p) => p.id === "judge")!;
+    expect(judge.stalled).toBe(false);
+    expect(judge.status).toBe("running");
+    // its own elapsed is still the honest 6 min
+    expect(judge.elapsedMs).toBe(6 * MIN);
+  });
+
+  it("does NOT stall when the loop heartbeat is fresh even if the exec is old", () => {
+    // Running 20 min, but the loop's updatedAt was bumped 30s ago (poller alive).
+    const now = T0 + 20 * MIN;
+    const act = computeReviewActivity(
+      [exec({ status: "running", startedAt: new Date(T0).toISOString() })],
+      { now, loopUpdatedAt: new Date(now - 30 * 1000).toISOString() },
+    );
+    expect(act.participants[0].stalled).toBe(false);
+  });
+
+  it("respects a custom stall threshold", () => {
+    const act = computeReviewActivity([exec({ status: "running" })], {
+      now: T0 + 3 * MIN,
+      stallThresholdMs: 2 * MIN,
+    });
+    expect(act.participants[0].stalled).toBe(true);
+  });
+
+  it("never stalls a completed or queued row", () => {
+    const now = T0 + 30 * MIN;
+    const act = computeReviewActivity(
+      [
+        exec({ id: "c", status: "completed", completedAt: new Date(T0 + MIN).toISOString() }),
+        exec({ id: "q", status: "pending", startedAt: null }),
+      ],
+      { now },
+    );
+    expect(act.participants.every((p) => p.stalled === false)).toBe(true);
+  });
+
+  it("defaults the threshold to 5 minutes", () => {
+    expect(DEFAULT_STALL_THRESHOLD_MS).toBe(5 * MIN);
+  });
+});
+
+describe("computeReviewActivity — ordering + one-line summary", () => {
+  it("orders started rows by startedAt, queued rows last", () => {
+    const act = computeReviewActivity(
+      [
+        exec({ id: "queued", status: "pending", startedAt: null }),
+        exec({ id: "late", status: "completed", startedAt: new Date(T0 + 2 * MIN).toISOString(), completedAt: new Date(T0 + 3 * MIN).toISOString() }),
+        exec({ id: "early", status: "completed", startedAt: new Date(T0).toISOString(), completedAt: new Date(T0 + MIN).toISOString() }),
+      ],
+      { now: T0 + 5 * MIN },
+    );
+    expect(act.participants.map((p) => p.id)).toEqual(["early", "late", "queued"]);
+    expect(act.participants.map((p) => p.index)).toEqual([1, 2, 3]);
+  });
+
+  it("builds a self-explanatory one-line summary", () => {
+    const now = T0 + 6 * MIN;
+    const act = computeReviewActivity(
+      [
+        exec({ id: "d1", taskName: "Opus primary", status: "running" }),
+        exec({ id: "d2", taskName: "Gemini primary", status: "running" }),
+        exec({ id: "j", taskName: "Judge verdict", status: "pending", startedAt: null }),
+      ],
+      // Fresh loop heartbeat → the debaters read as running (not stalled).
+      { now, roundLabel: 2, loopUpdatedAt: new Date(now - 10 * 1000).toISOString() },
+    );
+    expect(act.oneLine).toBe("Round 2 review — 2 debaters + judge · 2 running, 1 queued · elapsed 6m");
+    expect(act.summary.debaterCount).toBe(2);
+    expect(act.summary.hasJudge).toBe(true);
+  });
+
+  it("surfaces a stalled count in the one-liner", () => {
+    const act = computeReviewActivity(
+      [exec({ id: "d1", taskName: "Opus primary", status: "running" })],
+      { now: T0 + 7 * MIN, roundLabel: 1 },
+    );
+    expect(act.oneLine).toContain("1 stalled");
+  });
+});
+
+describe("formatElapsed + noActivityMinutes", () => {
+  it("formats compact durations", () => {
+    expect(formatElapsed(45 * 1000)).toBe("45s");
+    expect(formatElapsed(6 * MIN)).toBe("6m");
+    expect(formatElapsed(6 * MIN + 12 * 1000)).toBe("6m 12s");
+    expect(formatElapsed(64 * MIN)).toBe("1h 4m");
+    expect(formatElapsed(null)).toBe("—");
+    expect(formatElapsed(-5)).toBe("—");
+  });
+
+  it("floors no-activity minutes with a floor of 1", () => {
+    expect(noActivityMinutes(90 * 1000)).toBe(1);
+    expect(noActivityMinutes(5 * MIN + 30 * 1000)).toBe(5);
+    expect(noActivityMinutes(10 * 1000)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Why

During a consilium loop's **review** step (`reviewing`/`deciding`) the operator saw only a spinner for 30+ minutes with no way to tell **which** model was which role, whether it was **actively working or a zombie**, **how long** it had been running, or **what** it was producing. #457 added a "Current round (live)" section but its cards were still opaque. This makes each participant row self-explanatory.

## What each participant row now shows

For every dispute participant (each debater + the judge) in the current reviewing/deciding iteration:

1. **Identity** — a numbered heading with seat + role, e.g. `1. Opus — primary debater`, `2. Gemini — rebuts Opus`, `Judge`, plus the role label and the **observed** model slug (from the execution, preferred over the declared composition value). Role/seat are parsed from the execution's task name (`"<Seat> primary"`, `"<Seat> rebuts <Other>"`, `"Judge verdict"`).
2. **Status** — `queued | running | stalled | completed | failed`, mapped from the raw `task_execution` status, with a **live per-second elapsed timer** (`started → now`) while running.
3. **Activity beat** — an honest `generating…` / `thinking…` line with the elapsed while a model works, instead of a dead spinner. The platform does **not** stream partial tokens to the read side (`task_executions.output` is written once at completion, and there is no per-execution heartbeat column), so we show an honest beat rather than a fake token count. The full output stays expandable as it lands (unchanged).
4. **STALLED indicator** — a running-but-quiet execution is badged amber **`stalled — no activity for Nm`** instead of a hopeful spinner, so a dead review looks visibly dead.
5. **One-line summary** at the section top: `Round N review — 2 debaters + judge · 2 running, 1 queued · elapsed 6m`.

## The stall rule (no-progress, not raw elapsed)

`stalled` fires for a `running` participant **only** when the **whole round** has produced no observable progress for the threshold. "Progress" = the max of: every execution's `startedAt`, every execution's `completedAt`, and the loop row's `updatedAt` heartbeat (bumped by the controller/poller on transitions/partial updates). Default threshold **5 minutes** (`DEFAULT_STALL_THRESHOLD_MS`).

This is deliberately anti-false-positive:
- A legitimately slow panel that completes debaters **in sequence** never trips it — each completion is a progress event that resets the clock.
- A **fresh loop heartbeat** keeps a long-but-live round out of the stall state even when a single model runs for 20 min.
- Because a running execution's own `startedAt` counts as progress, a freshly started row is never stalled; a row is stalled only if it has itself been running past the threshold **and** nothing else in the round moved since.
- The badge text (`no activity for Nm`) is literally true given the available read-side signals.

## Read-side support

No read-side change was needed. The iteration detail endpoint (`GET /api/task-groups/:id/iterations/:n`) already exposes per-execution `taskName`, `modelSlug`, `status`, `startedAt`, `completedAt`, `output`, `summary`, `errorMessage`, and `loop.updatedAt` is already on the loop GET. There is no per-execution `updated_at` column and no partial-output stream to surface (output is atomic-at-completion), so nothing additive was possible without an out-of-scope schema/FSM change. This kept the PR client-only.

No new polling: the live elapsed/stall countdown is driven by a **local** per-second clock that ticks only while a participant is running; the panel keeps its existing 3s data cadence and the loop its 5s cadence.

## Scope

Client + tests only. `ConsiliumLoopDetail.tsx` (LiveCurrentRound now threads `live={{ loopUpdatedAt, roundLabel }}`), `iterations-panel.tsx` (the #457 IterationDetailView — enriched cards + summary + per-second ticker), and a new pure `review-activity.ts` activity model. The server-side review recovery (controller/poller) was intentionally **not** touched. Historical rounds reuse the same cards, static (no `live` prop).

## Test evidence

- New pure unit suite `tests/unit/review-activity.test.ts` — **20 tests**, covering role classification, status mapping, live vs fixed elapsed, the stall rule and its anti-false-positive guarantees (sibling-completed, fresh heartbeat, custom threshold), ordering, and the one-line summary.
- `tsc` clean.
- Full unit project: **253 files / 4853 tests pass**; quarantined flaky project (PR #479): **6 files / 128 pass**. No pre-existing quarantined flake was touched.