### PR TITLE
fix: recover stranded reviewing loops (stall + restart orphan)

### DIFF
--- a/migrations/0043_consilium_loops_review_redrive.sql
+++ b/migrations/0043_consilium_loops_review_redrive.sql
@@ -1,0 +1,35 @@
+-- migration: 0043_consilium_loops_review_redrive
+-- Adds a nullable `review_redrive` jsonb column to consilium_loops for bug #7
+-- (stranded-review recovery).
+--
+-- A review round runs in the in-process consilium workers. If they die (a crash or,
+-- most commonly, a server restart) the round's task_executions stay `running`
+-- forever, deriveReviewEvent never settles, and the loop sits in `reviewing` with
+-- zero LLM activity and NO recovery (unlike the develop phase's redriveStranded).
+-- Live evidence: loop 76ce2ecd sat reviewing 45+ min with 2 executions "running"
+-- and 0 LLM requests after a restart.
+--
+-- The controller now RE-LAUNCHES a stalled review round automatically (bounded by
+-- `pipeline.consiliumLoop.reviewMaxRedrives`), falling back to `failed` only once
+-- the budget is exhausted. This column records the per-round auto re-launch count
+-- as `{ round, count }` so the bound SURVIVES a restart (a process-local counter
+-- would reset on boot → an unbounded redrive storm across crash-loops) and the
+-- launch passport can surface "re-launched attempt k/N after a stall".
+--
+-- `round`-scoped: a stored value whose `round` differs from the loop's current
+-- round counts as 0, so the counter auto-resets each round with no explicit clear.
+-- INERT display/audit data — never a prompt/shell/branch/PR sink.
+--
+-- We add a DEDICATED column (rather than riding archetype_params) because that
+-- jsonb is UI-rendered as archetype key/value chips AND is forwarded to the SDLC
+-- executor — a redrive write there would corrupt display and coder behavior.
+-- Nullable; no backfill — null means "never re-launched", exactly the pre-feature
+-- behavior, so every pre-existing loop keeps working unchanged (full back-compat).
+--
+-- Idempotent (IF NOT EXISTS) so re-applying against a push-managed dev DB is safe.
+
+ALTER TABLE consilium_loops
+  ADD COLUMN IF NOT EXISTS review_redrive JSONB;
+
+-- Rollback:
+--   ALTER TABLE consilium_loops DROP COLUMN review_redrive;

--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -369,6 +369,30 @@ export const ConfigSchema = z.object({
        */
       sdlcTimeoutMs: z.coerce.number().int().min(60_000).max(1_800_000).default(1_200_000),
       /**
+       * Bug #7 — stranded-REVIEW recovery threshold. A review round runs in the
+       * in-process consilium workers; if they die (crash / server restart) the
+       * iteration's task_executions stay `running` forever and the loop sits in
+       * `reviewing` with zero LLM activity, with NO recovery (unlike develop's
+       * redriveStranded). When the current review iteration has made NO PROGRESS —
+       * no new llm_requests, no task-execution status change, iteration unsettled —
+       * for longer than this, the controller treats the review as stranded and
+       * re-launches it (see `reviewMaxRedrives`). Detection is NO-PROGRESS based
+       * (NOT wall-clock since start), so a slow-but-live review is never touched.
+       * 1min..24h; default 15min. Set very HIGH ⇒ recovery is effectively OFF
+       * (today's behavior — the loop waits forever, as before).
+       */
+      reviewStallTimeoutMs: z.coerce.number().int().min(60_000).max(86_400_000).default(900_000),
+      /**
+       * Bug #7 — bounded auto re-launches for a stranded review round before giving
+       * up. On a detected stall the round is re-launched with a FRESH iteration for
+       * the SAME round number (the loop stays `reviewing`, just gets a live worker
+       * again); only after this many exhausted re-launches does the loop fall back
+       * to `failed` via the existing `review_failed` event — failure is the last
+       * resort, not the first move. 0 ⇒ never re-launch (fail on first detected
+       * stall). 0..20; default 3.
+       */
+      reviewMaxRedrives: z.coerce.number().int().min(0).max(20).default(3),
+      /**
        * Judge timeout resilience (fix: bounded retry with model fallback for
        * judge timeouts). In a consilium dispute the JUDGE task receives the FULL
        * debate context — the largest-context call of the round — and can hit the

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -49,7 +49,7 @@
 import { z } from "zod";
 import type { IStorage } from "../../storage.js";
 import { runAsSystem, runAsProject } from "../../context.js";
-import type { ConsiliumLoopRow, ConsiliumLoopRoundRow, ConsiliumLoopState } from "@shared/schema";
+import type { ConsiliumLoopRow, ConsiliumLoopRoundRow, ConsiliumLoopState, TaskGroupIterationRow } from "@shared/schema";
 import { ARCHETYPES } from "@shared/types";
 import type { Archetype } from "@shared/types";
 import type { ActionPoint, ConvergenceVerdict } from "@shared/types";
@@ -653,6 +653,26 @@ export class ConsiliumLoopController {
     return this.deps.config().pipeline.consiliumLoop;
   }
 
+  /** Bug #7: no-progress threshold before a `reviewing` round is treated as
+   *  stranded. Very high ⇒ recovery effectively OFF (today's wait-forever). */
+  private reviewStallTimeoutMs(): number {
+    return this.loopConfig().reviewStallTimeoutMs ?? 900_000;
+  }
+
+  /** Bug #7: bounded auto re-launches for a stranded review before failing it. */
+  private reviewMaxRedrives(): number {
+    const n = this.loopConfig().reviewMaxRedrives;
+    return typeof n === "number" ? n : 3;
+  }
+
+  /** Bug #7: auto re-launches ALREADY spent on the loop's CURRENT review round.
+   *  `round`-scoped so the counter auto-resets when a fresh round starts (a stored
+   *  value from an earlier round reads as 0). */
+  private reviewRedriveCount(loop: ConsiliumLoopRow): number {
+    const rr = loop.reviewRedrive;
+    return rr && rr.round === loop.round ? rr.count : 0;
+  }
+
   /**
    * Stage 3 research kill-switch: TRUE only when the parent loop, the skilled
    * implement path, AND research are all enabled. The single gate for both the
@@ -1084,6 +1104,13 @@ export class ConsiliumLoopController {
 
     const event = await this.deriveEvent(loop);
     if (!event) {
+      // Bug #7: no event means the review iteration is genuinely still `running`
+      // (a settled one would have produced review_completed/failed above). If it
+      // has gone idle past the stall window, RE-LAUNCH the round (bounded) or fail.
+      // Running this AFTER deriveEvent closes the TOCTOU: a review that just settled
+      // is advanced normally, never mistaken for stalled.
+      const recovered = await this.recoverStalledReview(loop);
+      if (recovered) return recovered;
       this.log(loopId, `no-op in state=${loop.state} (no event)`);
       return null;
     }
@@ -1197,6 +1224,166 @@ export class ConsiliumLoopController {
     }
     const extra = await this.startDevHandoff(claimed, verdict);
     return Object.keys(extra).length === 0 ? claimed : this.storage.updateLoop(claimed.id, extra);
+  }
+
+  /**
+   * Bug #7 — stranded-REVIEW recovery (the review-phase peer of `redriveStranded`).
+   *
+   * A review round runs in the IN-PROCESS consilium workers. If they die (a crash
+   * or, most commonly, a server restart) the round's task_executions stay `running`
+   * forever, `deriveReviewEvent` never settles, and the loop sits in `reviewing`
+   * with zero LLM activity and no recovery. `redriveStranded` does NOT catch this:
+   * it only matches a NULL child ref (a crash BEFORE the iteration row was written);
+   * here the iteration IS set — it's simply orphaned mid-run.
+   *
+   * This runs ONLY when `deriveEvent` found nothing to do, so the iteration is
+   * genuinely still `running` (a settled iteration would already have advanced the
+   * loop). Detection is NO-PROGRESS based: the max of the iteration's lifecycle
+   * timestamps, its task-executions' timestamps, and the latest llm_request for the
+   * group's run. Past `reviewStallTimeoutMs` of silence the review is stranded.
+   *
+   * Recovery is AUTONOMOUS re-launch, not cancellation: the stranded iteration is
+   * superseded and the SAME round is re-run fresh (the loop stays `reviewing`, just
+   * gets a live worker again), bounded by `reviewMaxRedrives`. Only once the budget
+   * is exhausted does it fall back to `failed` via the EXISTING `review_failed`
+   * event — NO new FSM state. Single-flight: the in-process lock (tick) plus an
+   * atomic `claimReviewRedrive` (state=reviewing AND same stale iteration AND
+   * updatedAt < window) make exactly ONE instance act; a loser and a review that
+   * just finished both no-op (the latter re-checked after the claim, below).
+   */
+  private async recoverStalledReview(loop: ConsiliumLoopRow): Promise<ConsiliumLoopRow | null> {
+    // FSM constraint: only `reviewing` has a `review_failed` edge, and only the
+    // review phase runs the in-process workers that can die mid-run. `deciding`
+    // does no background work (it resolves the settled verdict synchronously), so
+    // it is not subject to this worker-death stall.
+    if (loop.state !== "reviewing") return null;
+    const n = loop.currentIterationNumber;
+    if (n == null) return null; // null child ref → redriveStranded's job, not ours.
+
+    const timeoutMs = this.reviewStallTimeoutMs();
+    const iteration = await this.storage.getIteration(loop.groupId, n);
+    // Absent, or already settled (completed/failed/cancelled) → not a live stall;
+    // deriveReviewEvent settles a completed/failed one on this very tick.
+    if (!iteration || iteration.status !== "running") return null;
+
+    const lastActivityMs = await this.reviewLastActivityMs(loop, iteration);
+    const idleMs = Date.now() - lastActivityMs;
+    if (idleMs < timeoutMs) return null; // recent/live activity → never touch it.
+
+    // Cross-instance single-flight: only the winner (still reviewing, still on THIS
+    // stale iteration, untouched past the window) proceeds. Bumps updatedAt so a
+    // racing instance backs off. Same discipline as claimRedrive.
+    const staleThreshold = new Date(Date.now() - timeoutMs);
+    const claimed = await this.storage.claimReviewRedrive(loop.id, n, staleThreshold);
+    if (!claimed) {
+      this.log(loop.id, `review stall claim lost for iter #${n} (another instance recovering) — no-op`);
+      return null;
+    }
+
+    // TOCTOU guard: re-read the iteration AFTER winning the claim. A worker that
+    // finished between the idle read and the claim leaves a settled iteration →
+    // abort so the NEXT tick emits review_completed (never fail/re-run a done review).
+    const fresh = await this.storage.getIteration(loop.groupId, n);
+    if (!fresh || fresh.status !== "running") {
+      this.log(loop.id, `review iter #${n} settled (${fresh?.status ?? "gone"}) after claim — abort recovery`);
+      return claimed; // updatedAt bumped; the settle advances on the next tick.
+    }
+
+    const idleMin = Math.max(1, Math.round(idleMs / 60_000));
+    const used = this.reviewRedriveCount(claimed);
+    const max = this.reviewMaxRedrives();
+
+    if (used >= max) {
+      // Last resort: bounded re-launches exhausted → fail via the EXISTING event.
+      const error =
+        `Review stalled: no activity for ${idleMin}m and re-launched ${used} time(s) ` +
+        `without progress (in-process review workers likely died repeatedly — e.g. a ` +
+        `restart); marked failed for re-run.`;
+      this.log(loop.id, `review stall — redrives exhausted (${used}/${max}) → failing loop`);
+      const transition = reduce("reviewing", { kind: "review_failed", error });
+      if (!transition) return null;
+      return this.commit(claimed, transition);
+    }
+
+    // RE-LAUNCH the SAME round. Two ordering hazards to close:
+    //   (a) `startGroupAsync` refuses to start while an iteration is `running`
+    //       (RunActiveError) — so the orphan MUST be superseded first;
+    //   (b) but a `cancelled` orphan STILL reachable as `currentIterationNumber`
+    //       would make a CONCURRENT (cross-instance) tick derive `review_failed`
+    //       and fail the loop mid-re-launch.
+    // Close both by NULLing the child ref FIRST (the proven null-ref redrive
+    // invariant): a concurrent tick then sees currentIterationNumber == null →
+    // deriveReviewEvent returns null (never fails the orphan), and redriveStranded
+    // holds off because the claim just bumped updatedAt (within grace). Only then
+    // cancel the orphan and re-run; startReviewRound repopulates the child ref.
+    const attempt = used + 1;
+    await this.storage.updateLoop(claimed.id, { currentIterationNumber: null });
+    await this.storage.updateIteration(fresh.id, { status: "cancelled", completedAt: new Date() });
+    this.log(
+      loop.id,
+      `review stall — re-launching round ${claimed.round} (attempt ${attempt}/${max}) after ${idleMin}m idle`,
+    );
+    const extra = await this.startReviewRound(claimed, { relaunch: true });
+    if (extra.error) {
+      // The re-launch itself failed to build (e.g. git) — record it and leave the
+      // loop reviewing with a null child ref; the null-ref redrive re-attempts it
+      // after the grace window (bounded overall by maxRounds).
+      return this.storage.updateLoop(claimed.id, extra);
+    }
+    return this.storage.updateLoop(claimed.id, {
+      ...extra,
+      reviewRedrive: { round: claimed.round, count: attempt },
+    });
+  }
+
+  /**
+   * Bug #7 — the review round's "last progress" wall-clock (ms since epoch). The
+   * max of everything that moves while a review is genuinely alive: the iteration's
+   * own lifecycle timestamps, each task-execution's status-change timestamps, and —
+   * the true heartbeat — the latest llm_request for this group's run (runId =
+   * groupId). Falls back to the loop's `updatedAt` (round-start) so a review that
+   * has emitted nothing yet is measured from when it began, never flagged instantly.
+   * Optional/newer reads are feature-detected + fail-soft so a partial test double
+   * (or a transient storage error) can never crash a poller tick.
+   */
+  private async reviewLastActivityMs(
+    loop: ConsiliumLoopRow,
+    iteration: TaskGroupIterationRow,
+  ): Promise<number> {
+    const times: number[] = [];
+    const push = (d?: Date | string | null) => {
+      if (!d) return;
+      const t = new Date(d).getTime();
+      if (!Number.isNaN(t)) times.push(t);
+    };
+
+    // Round-start / iteration lifecycle floor.
+    push(loop.updatedAt);
+    push(iteration.startedAt);
+    push(iteration.completedAt);
+    push(iteration.createdAt);
+
+    // Task-execution status changes for THIS iteration (started/completed bumps).
+    if (typeof this.storage.getExecutionsByIteration === "function") {
+      const execs = await this.storage
+        .getExecutionsByIteration(loop.groupId, iteration.id)
+        .catch(() => [] as Awaited<ReturnType<IStorage["getExecutionsByIteration"]>>);
+      for (const e of execs) {
+        push(e.startedAt);
+        push(e.completedAt);
+        push(e.createdAt);
+      }
+    }
+
+    // The real heartbeat: the newest LLM request for the group's run.
+    if (typeof this.storage.getLlmRequests === "function") {
+      const llm = await this.storage
+        .getLlmRequests({ runId: loop.groupId, page: 1, limit: 1 })
+        .catch(() => ({ rows: [], total: 0 }));
+      push(llm.rows[0]?.createdAt ?? null);
+    }
+
+    return times.length ? Math.max(...times) : Date.now();
   }
 
   /**
@@ -1511,7 +1698,10 @@ export class ConsiliumLoopController {
    * KICKOFF (milliseconds) — `deriveReviewEvent` then polls the settle (§14.5).
    * `round` only ever increments here (M-2).
    */
-  private async startReviewRound(loop: ConsiliumLoopRow): Promise<Record<string, unknown>> {
+  private async startReviewRound(
+    loop: ConsiliumLoopRow,
+    opts?: { relaunch?: boolean },
+  ): Promise<Record<string, unknown>> {
     const cfg = this.loopConfig();
     const group = await this.storage.getTaskGroup(loop.groupId);
     const objective = group?.input ?? "";
@@ -1556,7 +1746,14 @@ export class ConsiliumLoopController {
       return { error: ctx.message };
     }
     await this.storage.updateTaskGroup(loop.groupId, { input: ctx.input });
-    this.log(loop.id, `startReviewRound -> startGroupAsync(group=${loop.groupId}) round ${loop.round + 1}`);
+    // Bug #7: a RE-LAUNCH re-runs the SAME round (round is unchanged — M-2 still
+    // holds: `round` only ever increments on a genuine new round). A normal entry
+    // advances to round+1. Both mint a fresh iteration via startGroupAsync.
+    const nextRound = opts?.relaunch ? loop.round : loop.round + 1;
+    this.log(
+      loop.id,
+      `startReviewRound${opts?.relaunch ? " (relaunch)" : ""} -> startGroupAsync(group=${loop.groupId}) round ${nextRound}`,
+    );
     // §14.5: NON-BLOCKING — returns the instant the iteration row is created, NOT
     // after the consilium round completes. The child runs in the background and
     // settles the iteration; `deriveReviewEvent` polls that settle.
@@ -1565,7 +1762,7 @@ export class ConsiliumLoopController {
     });
     this.log(loop.id, `startReviewRound done -> iteration #${iteration.iterationNumber} (dispatched)`);
     return {
-      round: loop.round + 1,
+      round: nextRound,
       currentIterationNumber: iteration.iterationNumber,
       openP0: null,
     };
@@ -2016,6 +2213,13 @@ export class ConsiliumLoopPoller {
     if (this.timer) return;
     this.timer = setInterval(() => void this.sweep(), this.intervalMs);
     if (typeof this.timer.unref === "function") this.timer.unref();
+    // Bug #7 (startup orphan sweep): tick every non-terminal loop ONCE at boot,
+    // without waiting a full interval, so a review left `reviewing` by a PRIOR
+    // process (its in-process workers died on the restart) is re-evaluated — and,
+    // if stalled past the window, re-launched — immediately. Mirrors how develop's
+    // redriveStranded runs inside the same tick path; a healthy loop is a harmless
+    // single-flight no-op. Fire-and-forget: start() must not block boot.
+    void this.sweep();
   }
 
   stop(): void {
@@ -2023,8 +2227,9 @@ export class ConsiliumLoopPoller {
     this.timer = null;
   }
 
-  /** One sweep: tick every non-terminal loop. Errors are swallowed per-loop. */
-  private async sweep(): Promise<void> {
+  /** One sweep: tick every non-terminal loop. Errors are swallowed per-loop.
+   *  Public so a boot sequence / test can drive an explicit orphan sweep. */
+  async sweep(): Promise<void> {
     if (this.sweeping) return; // never overlap sweeps
     this.sweeping = true;
     try {

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -1229,6 +1229,30 @@ export class PgStorage implements IStorage {
     return row;
   }
 
+  async claimReviewRedrive(
+    id: string,
+    expectedIterationNumber: number,
+    staleThreshold: Date,
+  ): Promise<ConsiliumLoopRow | undefined> {
+    // Bug #7: atomic cross-instance claim for a STALLED (not crash-null) review.
+    // The conditional UPDATE matches ONLY a row still `reviewing`, still on the
+    // SAME stale iteration, untouched since `staleThreshold`. It bumps updated_at to
+    // now — so a concurrent instance (or a tick that raced a just-advanced review)
+    // no longer matches → 0 rows → undefined → back off. Same discipline as
+    // casLoopState/claimRedrive; the re-launch side effect runs ONLY for the winner.
+    const [row] = await db
+      .update(consiliumLoops)
+      .set({ updatedAt: new Date() })
+      .where(withProject(consiliumLoops, and(
+          eq(consiliumLoops.id, id),
+          eq(consiliumLoops.state, "reviewing"),
+          eq(consiliumLoops.currentIterationNumber, expectedIterationNumber),
+          lt(consiliumLoops.updatedAt, staleThreshold),
+        ),))
+      .returning();
+    return row;
+  }
+
   async appendLoopRound(data: InsertConsiliumLoopRound): Promise<ConsiliumLoopRoundRow> {
     const [row] = await db.insert(consiliumLoopRounds).values(withProjectInsert(consiliumLoopRounds, data)).returning();
     return row;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -524,6 +524,23 @@ export interface IStorage {
     expected: ConsiliumLoopState,
     graceMs: number,
   ): Promise<ConsiliumLoopRow | undefined>;
+  /**
+   * Bug #7 (stranded-REVIEW recovery) — atomically CLAIM a stalled review round's
+   * re-launch across instances. Unlike `claimRedrive` (which matches a NULL child
+   * ref = a crash BEFORE the iteration was written), this matches a review whose
+   * iteration IS set but has gone idle: a conditional UPDATE that bumps `updatedAt`
+   * ONLY when the row is still `reviewing`, still on the SAME stale iteration
+   * (`current_iteration_number = expectedIterationNumber`), AND untouched since
+   * `staleThreshold` (updatedAt < staleThreshold). The winner's UPDATE moves
+   * updatedAt to now, so a concurrent instance's predicate no longer matches → 0
+   * rows → `undefined` → it backs off. Exactly one instance re-launches; a loser
+   * (and a review that legitimately advanced its iteration in the meantime) no-op.
+   */
+  claimReviewRedrive(
+    id: string,
+    expectedIterationNumber: number,
+    staleThreshold: Date,
+  ): Promise<ConsiliumLoopRow | undefined>;
   /** Append one round (UNIQUE(loop, round) — idempotent re-append throws). */
   appendLoopRound(data: InsertConsiliumLoopRound): Promise<ConsiliumLoopRoundRow>;
   getLoopRounds(loopId: string): Promise<ConsiliumLoopRoundRow[]>;
@@ -1720,6 +1737,7 @@ export class MemStorage implements IStorage {
       archetypeParams: data.archetypeParams ?? null,
       archetypeDecidedAt: data.archetypeDecidedAt ?? null,
       currentIterationNumber: data.currentIterationNumber ?? null,
+      reviewRedrive: data.reviewRedrive ?? null,
       devGroupId: data.devGroupId ?? null,
       prRef: data.prRef ?? null,
       headCommitAtReview: data.headCommitAtReview ?? null,
@@ -1820,6 +1838,24 @@ export class MemStorage implements IStorage {
     // Past-grace predicate: updatedAt < now - graceMs.
     if (Date.now() - existing.updatedAt.getTime() < graceMs) return undefined;
     // Atomic claim: bump updatedAt to now so a concurrent claim's grace check fails.
+    const claimed: ConsiliumLoopRow = { ...existing, updatedAt: new Date() };
+    this.consiliumLoopsMap.set(id, claimed);
+    return claimed;
+  }
+
+  async claimReviewRedrive(
+    id: string,
+    expectedIterationNumber: number,
+    staleThreshold: Date,
+  ): Promise<ConsiliumLoopRow | undefined> {
+    const existing = this.consiliumLoopsMap.get(id);
+    if (!existing || existing.state !== "reviewing") return undefined;
+    // Same STALE iteration (a review that advanced its iteration since we read it
+    // no longer matches → the winner-of-a-just-finished-review race no-ops).
+    if (existing.currentIterationNumber !== expectedIterationNumber) return undefined;
+    // Untouched since the stall window opened (mirrors the Pg `updatedAt < threshold`).
+    if (existing.updatedAt.getTime() >= staleThreshold.getTime()) return undefined;
+    // Atomic claim: bump updatedAt so a concurrent instance's predicate fails.
     const claimed: ConsiliumLoopRow = { ...existing, updatedAt: new Date() };
     this.consiliumLoopsMap.set(id, claimed);
     return claimed;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -2049,6 +2049,16 @@ export const consiliumLoops = pgTable(
     archetypeParams: jsonb("archetype_params").$type<Record<string, string>>(),
     archetypeDecidedAt: timestamp("archetype_decided_at"),
     currentIterationNumber: integer("current_iteration_number"),
+    // Bug #7 (stranded-review recovery): per-round auto re-launch bookkeeping. A
+    // review round runs in the in-process consilium workers; if they die (crash /
+    // restart) the iteration is orphaned `running` and the loop sits in `reviewing`
+    // forever. The controller RE-LAUNCHES the round on a no-progress stall, bounded
+    // by `reviewMaxRedrives`; this column records `{ round, count }` so the bound
+    // survives a restart (a process-local counter would reset → redrive storm) and
+    // the passport can surface "re-launched attempt k/N". `round`-scoped: a read
+    // whose `round` != the loop's current round counts as 0 (auto-resets each round,
+    // no explicit clear). INERT display/audit — never a prompt/shell/branch sink.
+    reviewRedrive: jsonb("review_redrive").$type<{ round: number; count: number }>(),
     devGroupId: varchar("dev_group_id"),
     prRef: text("pr_ref"),
     // M-3 (TOCTOU): HEAD captured when entering AWAITING_MERGE; merge-approved

--- a/tests/unit/consilium/loop-review-recovery.test.ts
+++ b/tests/unit/consilium/loop-review-recovery.test.ts
@@ -1,0 +1,371 @@
+/**
+ * loop-review-recovery.test.ts — Bug #7: recover a STRANDED `reviewing` loop.
+ *
+ * A review round runs in the IN-PROCESS consilium workers. If they die (a crash or,
+ * most commonly, a server restart) the round's task_executions stay `running`
+ * forever, `deriveReviewEvent` never settles, and the loop sits in `reviewing` with
+ * ZERO LLM activity — with no recovery (unlike develop's `redriveStranded`). Live
+ * evidence: loop 76ce2ecd sat reviewing 45+ min with 2 executions "running" and 0
+ * LLM requests after a restart.
+ *
+ * The controller now, on a NO-PROGRESS stall past `reviewStallTimeoutMs`:
+ *   1. RE-LAUNCHES the SAME round (supersede the orphan iteration → fresh run),
+ *      bounded by `reviewMaxRedrives`, recording `reviewRedrive = { round, count }`;
+ *   2. only once the budget is exhausted, FAILS via the existing `review_failed`
+ *      event (NO new FSM state);
+ *   3. runs on every tick AND on the poller's startup sweep (the restart case).
+ *
+ * These tests assert: redrive-then-eventually-fail, a fresh-active review is
+ * untouched, the startup sweep recovers a pre-restart orphan, the CAS/TOCTOU guard
+ * never fails a just-finished review, and a very-high timeout == today's behavior.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Deterministic review-input build: decouple `startReviewRound` from real git so a
+// re-launch reliably reaches `startGroupAsync` regardless of the worktree's state.
+vi.mock("../../../server/services/consilium/diff-context.js", () => ({
+  buildDiffContext: vi.fn(async () => ({ ok: true, input: "REVIEW INPUT" })),
+}));
+
+import {
+  ConsiliumLoopController,
+  ConsiliumLoopPoller,
+} from "../../../server/services/consilium/consilium-loop-controller.js";
+import type { ConsiliumLoopRow, ConsiliumLoopState } from "@shared/schema";
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+const MIN = 60_000;
+
+function makeLoop(over: Partial<ConsiliumLoopRow>): ConsiliumLoopRow {
+  return {
+    id: "loop-1",
+    projectId: "proj1",
+    groupId: "grp1",
+    state: "reviewing",
+    round: 1,
+    maxRounds: 6,
+    repoPath: process.cwd(),
+    lastReviewedCommit: null,
+    reviewRef: null,
+    currentIterationNumber: 2,
+    reviewRedrive: null,
+    devGroupId: null,
+    prRef: null,
+    headCommitAtReview: null,
+    openP0: null,
+    error: null,
+    createdBy: "user1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    completedAt: null,
+    ...over,
+  } as ConsiliumLoopRow;
+}
+
+interface Cfg {
+  reviewStallTimeoutMs?: number;
+  reviewMaxRedrives?: number;
+}
+const makeConfig =
+  (over: Cfg = {}) =>
+  () =>
+    ({
+      pipeline: {
+        consiliumLoop: {
+          enabled: true,
+          maxRounds: 6,
+          pollIntervalMs: 5000,
+          maxDiffBytes: 200_000,
+          allowedRepoPaths: [process.cwd()],
+          reviewStallTimeoutMs: over.reviewStallTimeoutMs ?? 900_000, // 15m
+          reviewMaxRedrives: over.reviewMaxRedrives ?? 3,
+          implement: {
+            enabled: false,
+            verification: { enabled: false },
+            maxFixIterations: 3,
+            testCommand: null,
+            testRunTimeoutMs: 300_000,
+            research: { enabled: false, maxResearchIterations: 3, model: "claude-sonnet" },
+          },
+        },
+      },
+    }) as never;
+
+interface StoreOpts {
+  /** Timestamps that make the review look alive; omit ⇒ nothing recent. */
+  iterationStartedAt?: Date | null;
+  llmLastAt?: Date | null;
+  execs?: { startedAt?: Date | null; completedAt?: Date | null; createdAt?: Date | null }[];
+  /** Iteration status returned per getIteration call (queue); falls back to `iterStatus`. */
+  iterStatusSeq?: string[];
+  iterStatus?: string;
+}
+
+function fakeStorage(loop: ConsiliumLoopRow, opts: StoreOpts = {}) {
+  let current = loop;
+  const statusSeq = [...(opts.iterStatusSeq ?? [])];
+  // Real storage assigns iterationNumber from getLatestIteration, independent of
+  // the loop's currentIterationNumber pointer (which the re-launch NULLs mid-flight).
+  let latestIter = loop.currentIterationNumber ?? 0;
+
+  const startGroupAsync = vi.fn(async () => {
+    latestIter += 1;
+    return { group: {}, iteration: { iterationNumber: latestIter } };
+  });
+
+  const getIteration = vi.fn(async (_g: string, n: number) => {
+    if (n !== current.currentIterationNumber) return undefined;
+    const status = statusSeq.length ? statusSeq.shift()! : (opts.iterStatus ?? "running");
+    return {
+      id: `it${n}`,
+      iterationNumber: n,
+      status,
+      startedAt: opts.iterationStartedAt ?? null,
+      completedAt: null,
+      createdAt: opts.iterationStartedAt ?? null,
+    };
+  });
+
+  const updateIteration = vi.fn(async () => ({}));
+
+  // Faithful atomic claim (mirrors Pg/Mem): reviewing + SAME stale iteration +
+  // updatedAt < threshold, then bump updatedAt so a concurrent claim loses.
+  const claimReviewRedrive = vi.fn(async (id: string, expIter: number, staleThreshold: Date) => {
+    if (id !== current.id || current.state !== "reviewing") return undefined;
+    if (current.currentIterationNumber !== expIter) return undefined;
+    if (new Date(current.updatedAt).getTime() >= staleThreshold.getTime()) return undefined;
+    current = { ...current, updatedAt: new Date() };
+    return current;
+  });
+
+  const casLoopState = vi.fn(
+    async (id: string, expected: ConsiliumLoopState, next: ConsiliumLoopState, extra?: Record<string, unknown>) => {
+      if (id !== current.id || current.state !== expected) return undefined;
+      current = { ...current, ...(extra ?? {}), state: next };
+      return current;
+    },
+  );
+
+  const updateLoop = vi.fn(async (_id: string, extra?: Record<string, unknown>) => {
+    current = { ...current, ...(extra ?? {}) };
+    return current;
+  });
+
+  const storage = {
+    getLoop: vi.fn(async () => current),
+    getLoops: vi.fn(async () => [current]),
+    getLoopRounds: vi.fn(async () => []),
+    getTaskGroup: vi.fn(async () => ({ id: current.groupId, input: "objective", projectId: current.projectId })),
+    updateTaskGroup: vi.fn(async () => ({})),
+    getIteration,
+    updateIteration,
+    getExecutionsByIteration: vi.fn(async () => opts.execs ?? []),
+    getLlmRequests: vi.fn(async () => ({
+      rows: opts.llmLastAt ? [{ createdAt: opts.llmLastAt }] : [],
+      total: opts.llmLastAt ? 1 : 0,
+    })),
+    claimReviewRedrive,
+    claimRedrive: vi.fn(async () => undefined),
+    casLoopState,
+    updateLoop,
+    appendLoopRound: vi.fn(async () => ({})),
+  };
+
+  return { storage, startGroupAsync, claimReviewRedrive, casLoopState, updateIteration, get: () => current };
+}
+
+function makeController(storage: unknown, startGroupAsync: unknown, config: () => unknown) {
+  return new ConsiliumLoopController({
+    storage: storage as never,
+    taskOrchestrator: {
+      startGroup: startGroupAsync,
+      startGroupAsync,
+      createTaskGroup: vi.fn(),
+      cancelGroup: vi.fn(),
+    } as never,
+    config: config as never,
+    readRepoHead: async () => "abc1234",
+  });
+}
+
+/** A review with no activity for `min` minutes (updatedAt + iteration start both old). */
+function strandedLoop(min = 30, over: Partial<ConsiliumLoopRow> = {}) {
+  const at = new Date(Date.now() - min * MIN);
+  return makeLoop({ state: "reviewing", round: 1, currentIterationNumber: 2, updatedAt: at, ...over });
+}
+
+describe("Bug #7 — stranded review is RE-LAUNCHED (redrive-first, bounded)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("a review idle past the stall window is re-launched for the SAME round (attempt 1/K)", async () => {
+    const loop = strandedLoop(30);
+    const { storage, startGroupAsync, updateIteration, claimReviewRedrive } = fakeStorage(loop, {
+      iterationStartedAt: new Date(Date.now() - 30 * MIN),
+      llmLastAt: null,
+    });
+    const controller = makeController(storage, startGroupAsync, makeConfig());
+
+    const res = await controller.tick(loop.id);
+
+    expect(claimReviewRedrive).toHaveBeenCalledTimes(1);
+    // Race fix: child ref is NULLed before the orphan is cancelled (a concurrent
+    // tick sees null → never derives review_failed on the superseded iteration).
+    expect(storage.updateLoop).toHaveBeenCalledWith("loop-1", { currentIterationNumber: null });
+    expect(updateIteration).toHaveBeenCalledWith("it2", expect.objectContaining({ status: "cancelled" }));
+    expect(startGroupAsync).toHaveBeenCalledTimes(1); // fresh review round dispatched
+    expect(res?.state).toBe("reviewing"); // stays reviewing — autonomy, not failure
+    expect(res?.round).toBe(1); // SAME round (not incremented)
+    expect(res?.currentIterationNumber).toBe(3); // superseding iteration
+    expect(res?.reviewRedrive).toEqual({ round: 1, count: 1 });
+  });
+
+  it("re-launches up to K, then FAILS via review_failed with a clear reason (last resort)", async () => {
+    // Budget already spent (count === max) ⇒ the next detected stall fails.
+    const loop = strandedLoop(30, { reviewRedrive: { round: 1, count: 3 } });
+    const { storage, startGroupAsync, casLoopState } = fakeStorage(loop, {
+      iterationStartedAt: new Date(Date.now() - 30 * MIN),
+    });
+    const controller = makeController(storage, startGroupAsync, makeConfig({ reviewMaxRedrives: 3 }));
+
+    const res = await controller.tick(loop.id);
+
+    expect(startGroupAsync).not.toHaveBeenCalled(); // no more re-launches
+    expect(casLoopState).toHaveBeenCalledWith("loop-1", "reviewing", "failed", expect.any(Object));
+    expect(res?.state).toBe("failed");
+    expect(res?.error).toContain("Review stalled");
+    expect(res?.error).toContain("marked failed for re-run");
+  });
+
+  it("reviewMaxRedrives = 0 ⇒ fail on the FIRST detected stall (redrive disabled)", async () => {
+    const loop = strandedLoop(30);
+    const { storage, startGroupAsync } = fakeStorage(loop, {
+      iterationStartedAt: new Date(Date.now() - 30 * MIN),
+    });
+    const controller = makeController(storage, startGroupAsync, makeConfig({ reviewMaxRedrives: 0 }));
+
+    const res = await controller.tick(loop.id);
+
+    expect(startGroupAsync).not.toHaveBeenCalled();
+    expect(res?.state).toBe("failed");
+  });
+});
+
+describe("Bug #7 — a live / fresh review is NEVER touched (no false positives)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("recent LLM activity (heartbeat) ⇒ not stalled, untouched", async () => {
+    // Loop row itself is old, but an LLM request landed seconds ago ⇒ alive.
+    const loop = strandedLoop(30);
+    const { storage, startGroupAsync, claimReviewRedrive, casLoopState } = fakeStorage(loop, {
+      iterationStartedAt: new Date(Date.now() - 30 * MIN),
+      llmLastAt: new Date(), // heartbeat NOW
+    });
+    const controller = makeController(storage, startGroupAsync, makeConfig());
+
+    const res = await controller.tick(loop.id);
+
+    expect(claimReviewRedrive).not.toHaveBeenCalled();
+    expect(startGroupAsync).not.toHaveBeenCalled();
+    expect(casLoopState).not.toHaveBeenCalled();
+    expect(res).toBeNull(); // no-op; still reviewing, waiting on the live round
+  });
+
+  it("a recent task-execution status change ⇒ not stalled, untouched", async () => {
+    const loop = strandedLoop(30);
+    const { storage, startGroupAsync, claimReviewRedrive } = fakeStorage(loop, {
+      iterationStartedAt: new Date(Date.now() - 30 * MIN),
+      execs: [{ completedAt: new Date() }], // a debater just finished
+    });
+    const controller = makeController(storage, startGroupAsync, makeConfig());
+
+    await controller.tick(loop.id);
+
+    expect(claimReviewRedrive).not.toHaveBeenCalled();
+    expect(startGroupAsync).not.toHaveBeenCalled();
+  });
+
+  it("very HIGH reviewStallTimeoutMs ⇒ recovery effectively OFF (today's wait-forever)", async () => {
+    const loop = strandedLoop(30);
+    const { storage, startGroupAsync, claimReviewRedrive } = fakeStorage(loop, {
+      iterationStartedAt: new Date(Date.now() - 30 * MIN),
+    });
+    // 24h timeout: a 30-min-idle review is nowhere near the window.
+    const controller = makeController(storage, startGroupAsync, makeConfig({ reviewStallTimeoutMs: 86_400_000 }));
+
+    const res = await controller.tick(loop.id);
+
+    expect(claimReviewRedrive).not.toHaveBeenCalled();
+    expect(startGroupAsync).not.toHaveBeenCalled();
+    expect(res).toBeNull();
+  });
+});
+
+describe("Bug #7 — CAS / TOCTOU: never fail or re-run a just-finished review", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("iteration settles between the idle read and the claim ⇒ abort recovery", async () => {
+    // getIteration calls: deriveReviewEvent(running) → idle-check(running) → post-claim(completed).
+    const loop = strandedLoop(30);
+    const { storage, startGroupAsync, updateIteration, casLoopState } = fakeStorage(loop, {
+      iterationStartedAt: new Date(Date.now() - 30 * MIN),
+      iterStatusSeq: ["running", "running", "completed"],
+    });
+    const controller = makeController(storage, startGroupAsync, makeConfig());
+
+    await controller.tick(loop.id);
+
+    expect(startGroupAsync).not.toHaveBeenCalled(); // no re-launch
+    expect(updateIteration).not.toHaveBeenCalled(); // orphan NOT cancelled
+    expect(casLoopState).not.toHaveBeenCalledWith("loop-1", "reviewing", "failed", expect.any(Object));
+  });
+
+  it("claim lost to a concurrent instance ⇒ no-op (no double re-launch)", async () => {
+    const loop = strandedLoop(30);
+    const { storage, startGroupAsync, updateIteration } = fakeStorage(loop, {
+      iterationStartedAt: new Date(Date.now() - 30 * MIN),
+    });
+    // Simulate the loser: claim returns undefined.
+    storage.claimReviewRedrive = vi.fn(async () => undefined);
+    const controller = makeController(storage, startGroupAsync, makeConfig());
+
+    const res = await controller.tick(loop.id);
+
+    expect(startGroupAsync).not.toHaveBeenCalled();
+    expect(updateIteration).not.toHaveBeenCalled();
+    expect(res).toBeNull();
+  });
+});
+
+describe("Bug #7 — startup sweep recovers a pre-restart orphan", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("poller.sweep() re-launches a loop left `reviewing` by a prior process", async () => {
+    const loop = strandedLoop(30);
+    const { storage, startGroupAsync } = fakeStorage(loop, {
+      iterationStartedAt: new Date(Date.now() - 30 * MIN),
+    });
+    const controller = makeController(storage, startGroupAsync, makeConfig());
+    const poller = new ConsiliumLoopPoller(controller, storage as never, 5000);
+
+    await poller.sweep();
+
+    expect(startGroupAsync).toHaveBeenCalledTimes(1); // orphan re-launched on boot
+    expect(storage.getLoops).toHaveBeenCalled();
+  });
+
+  it("poller.start() kicks an immediate sweep (no waiting a full interval)", async () => {
+    const loop = strandedLoop(30);
+    const { storage, startGroupAsync } = fakeStorage(loop, {
+      iterationStartedAt: new Date(Date.now() - 30 * MIN),
+    });
+    const controller = makeController(storage, startGroupAsync, makeConfig());
+    const poller = new ConsiliumLoopPoller(controller, storage as never, 5000);
+
+    poller.start();
+    await flush();
+    await flush();
+    poller.stop();
+
+    expect(storage.getLoops).toHaveBeenCalled(); // swept at boot, not after 5s
+  });
+});


### PR DESCRIPTION
## Bug #7 — a `reviewing` loop never recovers when its in-process review workers die

A consilium review round runs in the **in-process** consilium workers. When they die (a crash or, most commonly, a **server restart**) the round's `task_executions` stay `running` forever, `deriveReviewEvent` never settles, and the loop sits in `reviewing` with **zero LLM activity** and **no recovery** — unlike the develop phase's `redriveStranded` (which only catches a *null* child ref, i.e. a crash *before* the iteration was written; here the iteration IS set, just orphaned mid-run).

**Live evidence:** loop `76ce2ecd` sat in `reviewing` 45+ min with 2 executions `running` and 0 LLM requests after a restart.

## Detection rule

Runs in `tick()` **after** `deriveEvent` returns no event — so the iteration is genuinely still `running` (a settled one would already have produced `review_completed`/`review_failed`; this closes the TOCTOU of misreading a just-finished review). A `reviewing` loop is **stranded** when its current review iteration has made **NO PROGRESS** for longer than `reviewStallTimeoutMs`. Progress = the max of:

- the iteration's lifecycle timestamps (`startedAt`/`completedAt`/`createdAt`),
- each task-execution's `startedAt`/`completedAt`/`createdAt` (a status change), and
- the **heartbeat**: the latest `llm_request.createdAt` for the group's run (`runId = groupId`),
- with `loop.updatedAt` (round-start) as a floor.

**No-progress based, not wall-clock-since-start** — a slow-but-live review (recent LLM/exec activity) is never touched.

New config (additive, `pipeline.consiliumLoop`):
- `reviewStallTimeoutMs` — 1min..24h, **default 15min**. Set **very high ⇒ recovery effectively OFF** (today's wait-forever behavior).
- `reviewMaxRedrives` — 0..20, **default 3**.

## Recovery choice: RE-LAUNCH first, fail last (not fail-first)

Per the autonomy goal of a Loop, a stranded review is **re-launched automatically**, not cancelled:

1. On a detected stall, **re-launch the SAME round** — supersede the orphan iteration and re-run the review round fresh via the existing `startReviewRound` path (round number unchanged; the loop stays `reviewing`, just gets a live worker again).
2. **Bounded** by `reviewMaxRedrives`, tracked per-round in a new `review_redrive` `{ round, count }` jsonb column (round-scoped ⇒ auto-resets each round, no explicit clear).
3. **Only once the budget is exhausted** does the loop fall back to `failed` via the **existing `review_failed` event** — **no new FSM state**. `reviewMaxRedrives: 0` ⇒ fail on the first detected stall.

### Reason recorded
The terminal failure sets `error` (rendered on the loop page per #466):

> `Review stalled: no activity for Nm and re-launched K time(s) without progress (in-process review workers likely died repeatedly — e.g. a restart); marked failed for re-run.`

The per-round `review_redrive.count` persists the self-heal attempts (survives a restart — a process-local counter would reset → redrive storm) so the passport can surface "re-launched attempt k/N after a stall".

## Startup sweep (the restart case)

`ConsiliumLoopPoller.start()` now fires **one immediate sweep at boot** (instead of waiting a full interval), so a review left `reviewing` by a prior process is re-evaluated — and re-launched if stalled — immediately. Detection lives in `tick()`, so the periodic poller and the startup sweep share one code path (mirrors how develop's `redriveStranded` runs inside `tick`).

## Single-flight / CAS (adversarial review)

- **Racing a just-completed review:** detection is activity-based (a live review has a recent heartbeat ⇒ never flagged), and after winning the claim the iteration status is **re-read**; a settled one aborts recovery so the next tick emits `review_completed`.
- **Recovery storm:** each re-launch bumps `updatedAt` and mints a new iteration number, so the loop can't be re-detected for another full window; the per-round counter (persisted, restart-safe) caps total re-launches then fails.
- **Cross-instance double-run:** an atomic `claimReviewRedrive` (state `reviewing` AND same stale iteration AND `updatedAt < window`, bump `updatedAt`) lets exactly one instance act; losers no-op. The re-launch **NULLs the child ref before** cancelling the orphan, so a concurrent tick sees `currentIterationNumber == null` → `deriveReviewEvent` returns null and can never derive `review_failed` on the superseded iteration.

Scope note: `deciding` is intentionally left out — it does no background work (it resolves the settled verdict synchronously) and the FSM only has a `review_failed` edge from `reviewing`.

## Why a 1-column additive migration (not a jsonb reuse)

`archetype_params` (the only generic jsonb) is **UI-rendered** as archetype key/value chips **and forwarded to the SDLC executor** — a redrive write there would corrupt display and coder behavior. So `review_redrive` is a dedicated nullable jsonb (`migrations/0043_...`, `ADD COLUMN IF NOT EXISTS`, null = pre-feature behavior, full back-compat), matching the additive-column precedents 0030/0031/0041/0042.

## Test evidence

New `tests/unit/consilium/loop-review-recovery.test.ts` (10 tests): stranded review → re-launched (attempt 1/K, same round, orphan cancelled, child-ref-null ordering); re-launch bounded then fails with the reason; `reviewMaxRedrives:0` fails first stall; live heartbeat / recent exec-change / very-high-timeout ⇒ untouched; TOCTOU (iteration settles after claim) → abort; claim lost → no-op; `poller.sweep()` recovers a pre-restart orphan; `poller.start()` kicks an immediate sweep.

- `vitest run --project unit` → **4843 passed**
- `tests/unit/consilium` + `tests/unit/storage` + `tests/integration/consilium/loop-routes` → **681 passed**
- `tsc --noEmit` → **0 errors**

Client untouched (the REVIEW-STEP UI is another team's zone).
