### PR TITLE
feat: parallel dependency-aware develop (wave scheduling + worktree fan-out)

### DIFF
--- a/docs/design/loop-consolidation.md
+++ b/docs/design/loop-consolidation.md
@@ -117,6 +117,66 @@ criterion**. This is exactly the existing *agent-team* pattern (lead + workers).
 The loop is therefore **fractal and observable**: `loop → phase → controller-agent → N
 skill-agents`, each with a skill, a green/red, and the permissions it used (§8).
 
+### 4a. Parallel, dependency-aware develop (implemented — kill-switched)
+
+The develop phase's "controller + N coders for N features" is realized as **wave-scheduled,
+dependency-aware parallel execution**. It is gated by
+`pipeline.consiliumLoop.implement.parallel.enabled` (**default false** → today's sequential
+single-worktree loop runs byte-for-byte unchanged; `ap.dependsOn` is never read).
+
+**Dependencies come from the dispute (the judge, not a config).** The graph is *discovered*,
+not declared by an operator. Each `action_point` **may** carry an additive
+`dependsOn: (number | string)[]` — the *other* action points that must complete before it
+(1-based ordinal, numeric string, or exact title). The judge is instructed to declare a
+dependency **only when a later fix genuinely requires an earlier one's result** (e.g. "confirm
+CI green" depends on the fixes it verifies); the default is **no dependency → independent →
+parallelizable**. The field rides the existing `verdict/openActionPoints` jsonb — **no
+migration** — and is bounded/clamped alongside the other untrusted judge fields.
+
+**The planner builds the wave schedule** (`buildWaveSchedule`, pure + unit-tested, sibling to
+`normalizeActionPointMethods`). It validates the edges, then topologically sorts into **waves**
+(levels): wave 0 = APs with no surviving dependency; wave *N* = APs whose deps all land in
+waves `< N`. Adversarial guarantees baked into the planner, not left to the executor:
+
+- a ref to a **nonexistent** AP (out-of-range index / unknown title) is **dropped** (+ warn);
+- a **self**-dependency is dropped;
+- a **cycle** (A→B→A) is **detected and broken** — the residue Kahn's algorithm cannot drain is
+  scheduled as one final independent wave (+ warn), so a cyclic `dependsOn` can never deadlock
+  or infinitely wait. Every AP appears exactly once; within a wave the original order holds.
+
+**The executor fans out per wave, merges after** (`runWaveScheduledImplement`). The round's
+existing round branch is the **integration branch**. For each wave: every AP runs
+**concurrently** — bounded by `maxConcurrency` (1..8, default 3) — in its **own isolated git
+worktree** on a dedicated `consilium/loop-<uuid>/round-<n>/ap-<k>` branch cut off the
+**current integration HEAD** (the merged result of all prior waves), doing its full skilled
+run (test-author → coder → per-criterion verification) exactly as the sequential path does.
+After the wave, each AP's branch is **merged back into the integration branch sequentially in
+deterministic ordinal order**:
+
+- a **clean** merge (independent APs touching different files) → proceed;
+- a **conflict** → the merge is **aborted** (integration tree restored) and the AP's coder is
+  **re-run sequentially on the integrated tree** (the simpler, more robust of the two options —
+  it reuses the exact per-AP machinery and cannot silently drop work). The conflict is
+  **surfaced** on that AP's outcome/PR note, never hidden.
+
+A per-AP failure, a create-worktree failure, a merge conflict, or the whole-run wall-clock
+deadline degrades **that AP** to partial/failed and is surfaced — the round does **not** halt
+(same partial-success contract as today: completed/partial/failed per AP, one PR if anything
+committed). The PR opens from the final integration branch, and the existing **Stage-A final
+verification runs the whole suite against the merged tree** — the safety net for two APs that
+were each green in isolation but conflict when combined.
+
+**Worktree lifecycle is unconditional.** Every per-AP worktree is removed in a `finally`
+(mirroring the single-worktree cleanup) so a crash mid-wave leaks nothing; a git-admin mutex
+serializes the fast `worktree add/remove` calls (the coder runs stay concurrent) so N workers
+never race on `.git/worktrees`; and the whole-run wall-clock deadline stops new work so a
+wedged run cannot leak forever.
+
+**Config:** `implement.parallel: { enabled: bool = false, maxConcurrency: int 1..8 = 3 }`.
+Independent of verification — it changes only *how* the round's coders are fanned out, not
+*what* each AP does; the live per-AP status list (§8, #435/#480) already renders **multiple
+concurrent `active`** rows (one per in-flight AP in a wave).
+
 ## 5. Acceptance criteria + verification methods
 
 Two distinct levels of "green" — keep them separate:

--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -710,6 +710,33 @@ export const ConfigSchema = z.object({
            */
           maxFinalFixIterations: z.coerce.number().int().min(0).max(3).default(1),
         }).default({}),
+        /**
+         * Parallel-develop (design §4 "development = controller + N coders for N features"):
+         * run a round's action points CONCURRENTLY in DEPENDENCY-AWARE WAVES instead of
+         * sequentially in one shared worktree. The JUDGE declares the dependency edges
+         * (`ap.dependsOn`, from the dispute); the planner (`buildWaveSchedule`) validates them,
+         * breaks cycles, and topologically sorts the round into waves. Each wave's APs run in
+         * their OWN isolated worktree branched off the ROUND's integration branch (the merged
+         * result of all prior waves), bounded by `maxConcurrency`; after a wave, each AP's
+         * branch is merged back SEQUENTIALLY (clean merge → proceed; conflict → the AP is
+         * re-run on the integrated tree). The final PR opens from the integration branch and
+         * the SAME Stage-A final verification runs on the merged tree (the cross-AP safety net).
+         *
+         * Kill-switch DEFAULT FALSE ⇒ BYTE-IDENTICAL off: the executor takes today's sequential
+         * single-worktree path and never reads any `ap.dependsOn`. Gated by the parent
+         * `consiliumLoop.enabled` AND `implement.enabled`. Independent of verification — it
+         * changes only HOW the round's coders are fanned out, not WHAT each AP does.
+         */
+        parallel: z.object({
+          /** Kill-switch: false (default) → today's sequential develop (byte-identical). */
+          enabled: z.boolean().default(false),
+          /**
+           * Max action points executing CONCURRENTLY within one wave (worktree fan-out
+           * ceiling — adversarial risk e: bounds disk + CPU + coder processes). 1..8;
+           * default 3. 1 ⇒ still wave-ordered but one-at-a-time. NaN/out-of-range fails load.
+           */
+          maxConcurrency: z.coerce.number().int().min(1).max(8).default(3),
+        }).default({}),
       }).default({}),
     }).default({}),
   }).default({}),

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -1622,6 +1622,10 @@ export class ConsiliumLoopController {
     // test-run harness as green. Default OFF ⇒ byte-identical (no lint, no demotion).
     // Optional-chain `planner` — a hand-built test config may omit the whole block (→ off).
     const criteriaQaOn = cfg.planner?.criteriaQa?.enabled ?? false;
+    // Parallel-develop (design §4): dependency-aware wave scheduling + worktree-per-AP
+    // fan-out. Default OFF ⇒ the executor takes today's sequential single-worktree path.
+    // Optional-chained so a hand-built test config that omits the block degrades to OFF.
+    const parallelOn = cfg.implement.parallel?.enabled ?? false;
     let routedActionPoints = perCriterionOn
       ? normalizeActionPointMethods(verdict.openActionPoints, loop.archetype ?? null)
       : verdict.openActionPoints;
@@ -1682,6 +1686,15 @@ export class ConsiliumLoopController {
             enabled: true,
             maxFinalFixIterations: cfg.implement.finalVerification.maxFinalFixIterations,
           }
+        : null,
+      // Parallel-develop (design §4): run the round's action points in dependency-aware
+      // waves (worktree-per-AP fan-out + merge). Gated by its OWN kill-switch on TOP of the
+      // parent consiliumLoop.enabled + implement.enabled. null when off ⇒ the executor takes
+      // today's SEQUENTIAL single-worktree path, byte-for-byte unchanged (no dependsOn read).
+      // Independent of verification — it only changes HOW coders are fanned out, and the SAME
+      // Stage-A final verification runs on the merged tree as the cross-AP safety net.
+      parallel: parallelOn
+        ? { enabled: true, maxConcurrency: cfg.implement.parallel.maxConcurrency }
         : null,
     }, {
       getSkills: () => this.storage.getSkills(),

--- a/server/services/consilium/pr-wrapper.ts
+++ b/server/services/consilium/pr-wrapper.ts
@@ -93,6 +93,14 @@ const execFileAsync: ExecFileFn = promisify(execFile);
  * rejects anything that is not the exact server-built form before git/gh runs.
  */
 const BRANCH_RE = /^consilium\/loop-[0-9a-f-]{36}\/round-[0-9]+$/;
+/**
+ * Parallel-develop: the PER-ACTION-POINT worktree branch shape,
+ * `consilium/loop-<uuid>/round-<n>/ap-<k>`. Server-derived (loopId + round + 1-based AP
+ * index) — NEVER model text. A DEDICATED shape (not the round branch) so a per-AP branch
+ * can NEVER be mistaken for a PR head: `isValidLoopBranch` (the PR-head gate) stays strict,
+ * while `isValidLoopWorktreeBranch` (worktree creation only) accepts EITHER shape.
+ */
+const AP_BRANCH_RE = /^consilium\/loop-[0-9a-f-]{36}\/round-[0-9]+\/ap-[0-9]+$/;
 /** Well-formed `owner/repo` (GitHub slug chars only) — H-7 origin validation. */
 const OWNER_REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
 
@@ -125,9 +133,33 @@ export const SDLC_PR_LABEL_SPECS: readonly LabelSpec[] = [
 /** Just the label NAMES, in apply order (server constants). */
 export const SDLC_PR_LABELS: readonly string[] = SDLC_PR_LABEL_SPECS.map((l) => l.name);
 
-/** True iff `branch` is a server-derived consilium branch (B-3). */
+/** True iff `branch` is a server-derived consilium ROUND branch (B-3). This is the PR-HEAD
+ *  gate — it stays STRICT (a per-AP `ap-<k>` branch must NEVER be a PR head). */
 export function isValidLoopBranch(branch: string): boolean {
   return BRANCH_RE.test(branch);
+}
+
+/** Parallel-develop: true iff `branch` is a server-derived per-ACTION-POINT branch
+ *  (`consilium/loop-<uuid>/round-<n>/ap-<k>`). */
+export function isValidLoopApBranch(branch: string): boolean {
+  return AP_BRANCH_RE.test(branch);
+}
+
+/** Parallel-develop: the branch gate for WORKTREE CREATION — a round branch (the
+ *  integration worktree / PR head) OR a per-AP branch (a wave worker's worktree). Used only
+ *  by `createSdlcWorktree`; the PR-head path keeps calling the strict `isValidLoopBranch`. */
+export function isValidLoopWorktreeBranch(branch: string): boolean {
+  return isValidLoopBranch(branch) || isValidLoopApBranch(branch);
+}
+
+/**
+ * Parallel-develop: build the per-ACTION-POINT worktree branch
+ * (`consilium/loop-<uuid>/round-<n>/ap-<k>`) from SERVER-controlled inputs (loopId + round +
+ * 1-based AP index) — NEVER model/action-point text. Gated through `isValidLoopApBranch`
+ * before it reaches git, exactly like `buildBranchName`/`isValidLoopBranch` for the round.
+ */
+export function buildApBranchName(loopId: string, round: number, apIndex: number): string {
+  return `consilium/loop-${loopId}/round-${round}/ap-${apIndex}`;
 }
 
 /**

--- a/server/services/orchestrator/convergence.ts
+++ b/server/services/orchestrator/convergence.ts
@@ -36,6 +36,12 @@ const actionPointSchema = z.object({
   // WHOLE action point parse — a prompt-injected method can never smuggle a value past
   // the enum or drop a legitimate action point. Absent ⇒ back-compat.
   verificationMethod: z.enum(JUDGE_PROPOSABLE_METHODS).optional().catch(undefined),
+  // Parallel-develop: the judge-declared dependency edges (design §4). Each entry is
+  // another AP's 1-based ORDINAL (number or numeric string) or an exact title (string).
+  // `.catch(undefined)` DROPS a malformed value to absent rather than failing the whole
+  // action-point parse — a prompt-injected shape can never smuggle past the union or drop
+  // a legitimate AP. Absent ⇒ no dependency (back-compat). Bounded on persist below.
+  dependsOn: z.array(z.union([z.number(), z.string()])).optional().catch(undefined),
 });
 
 /** The trusted `output.convergence` object, when the judge emits one. */
@@ -69,6 +75,12 @@ const MAX_FIELD_LEN = 1000;
 // Stage 1: the per-AP acceptance criterion is UNTRUSTED model text — clamp it the
 // same way as the other free-text fields so a huge criterion can't bloat the row.
 const MAX_CRITERION_LEN = 1000;
+// Parallel-develop: cap the judge-declared dependency list per AP (bounded with the same
+// defensive spirit as MAX_ACTION_POINTS) and clamp each string entry — a malicious judge
+// must not bloat the row or the wave graph. A ref beyond these caps is simply dropped; the
+// wave planner drops nonexistent refs anyway, so over-bounding is safe.
+const MAX_DEPENDS_ON = 50;
+const MAX_DEPENDS_REF_LEN = 500;
 
 /** Truncate a string to `max` chars; pass through `undefined`. */
 function clampStr(v: string | undefined, max: number): string | undefined {
@@ -92,7 +104,18 @@ function boundActionPoint(p: ActionPoint): ActionPoint {
     // it survives the verdict round-trip + DEV handoff. Already bounded to the fixed
     // union by the schema; a `undefined` is simply absent (planner default fills it).
     ...(p.verificationMethod !== undefined ? { verificationMethod: p.verificationMethod } : {}),
+    // Parallel-develop: carry the (bounded) dependency edges through the same rebuild so
+    // they survive the verdict round-trip + DEV handoff. Length-capped; each string entry
+    // clamped. Absent ⇒ the field is simply omitted (back-compat / no dependency).
+    ...(p.dependsOn !== undefined ? { dependsOn: boundDependsOn(p.dependsOn) } : {}),
   };
+}
+
+/** Cap the dependency list length and clamp each string entry (numbers pass through). */
+function boundDependsOn(refs: ReadonlyArray<number | string>): Array<number | string> {
+  return refs
+    .slice(0, MAX_DEPENDS_ON)
+    .map((r) => (typeof r === "string" ? (clampStr(r, MAX_DEPENDS_REF_LEN) ?? "") : r));
 }
 
 /** Cap the list length and truncate each entry's fields. */
@@ -306,4 +329,139 @@ export function applyCriteriaQa(actionPoints: readonly ActionPoint[]): ActionPoi
       ap.verificationMethod === "manual-ops" ? "manual-ops" : "judge";
     return { ...ap, weakCriterion: true, verificationMethod: method };
   });
+}
+
+// ─── Parallel-develop (design §4) — the WAVE SCHEDULE from the dispute ────────
+// The judge declares dependency edges on each action point (`ap.dependsOn`); this PURE
+// planner step validates them and topologically sorts the round into WAVES (levels): wave
+// 0 = APs with no (surviving) dependency, wave N = APs whose every dependency lands in a
+// wave < N. Every AP appears EXACTLY ONCE; within a wave the ORIGINAL order is preserved
+// (deterministic). Called ONLY when `implement.parallel.enabled`; when the switch is off
+// the executor never invokes this and the develop path is byte-for-byte the sequential one.
+//
+// Adversarial hardening (the whole point of validating BEFORE scheduling):
+//   - a ref to a NONEXISTENT AP (out-of-range index / unknown title) is DROPPED (+ warn) —
+//     never a dangling edge that could wedge the topo sort.
+//   - a SELF dependency is dropped (a trivial 1-cycle).
+//   - a genuine CYCLE (A→B→A) would leave nodes unschedulable forever (deadlock / infinite
+//     wait — adversarial risk b). We DETECT the residue Kahn's algorithm cannot drain and
+//     BREAK it: the still-blocked APs are treated as INDEPENDENT and appended as one final
+//     wave (+ warn), so the round always makes progress and no AP is ever lost.
+
+/** Optional structured warning sink (default: console.warn). Kept injectable so the pure
+ *  scheduler is unit-testable by CAPTURING warnings instead of asserting on stderr. */
+export type WaveWarnFn = (message: string) => void;
+
+const defaultWaveWarn: WaveWarnFn = (m) => {
+  // eslint-disable-next-line no-console
+  console.warn(`[parallel-develop] ${m}`);
+};
+
+/**
+ * Resolve ONE `dependsOn` entry to a 0-based index into `aps`, or `null` when it names no
+ * existing AP. A number (or numeric string) is a 1-based ORDINAL; any other string is
+ * matched against an AP `title` (trimmed, case-insensitive, FIRST match). Pure.
+ */
+function resolveDepRef(
+  ref: number | string,
+  aps: readonly ActionPoint[],
+  titleIndex: ReadonlyMap<string, number>,
+): number | null {
+  // Numeric (number, or a string that is purely an integer) ⇒ 1-based ordinal.
+  const asNum =
+    typeof ref === "number"
+      ? ref
+      : /^\s*-?\d+\s*$/.test(ref)
+        ? Number.parseInt(ref, 10)
+        : NaN;
+  if (Number.isFinite(asNum)) {
+    const idx0 = asNum - 1;
+    return idx0 >= 0 && idx0 < aps.length ? idx0 : null;
+  }
+  // Otherwise a title reference (case-insensitive, trimmed).
+  const key = String(ref).trim().toLowerCase();
+  const hit = titleIndex.get(key);
+  return hit === undefined ? null : hit;
+}
+
+/**
+ * Build the dependency-aware WAVE SCHEDULE for a round's action points. Returns an array of
+ * waves (each an array of {@link ActionPoint}); flattening it yields every input AP exactly
+ * once. PURE — no I/O, no mutation of the inputs; the only side effect is the (injectable,
+ * default console.warn) `onWarn` for dropped refs + broken cycles.
+ *
+ * @param actionPoints the round's APs, in the order the executor will index/commit them
+ *                     (1-based ordinal = position, matching `ap.dependsOn` numeric refs).
+ * @param onWarn       structured warning sink (tests capture; prod logs).
+ */
+export function buildWaveSchedule(
+  actionPoints: readonly ActionPoint[],
+  onWarn: WaveWarnFn = defaultWaveWarn,
+): ActionPoint[][] {
+  const n = actionPoints.length;
+  if (n === 0) return [];
+  if (n === 1) return [[actionPoints[0]]];
+
+  // Title → FIRST index (case-insensitive) for title-based dependency refs.
+  const titleIndex = new Map<string, number>();
+  actionPoints.forEach((ap, i) => {
+    const key = (ap.title ?? "").trim().toLowerCase();
+    if (key.length > 0 && !titleIndex.has(key)) titleIndex.set(key, i);
+  });
+
+  // Adjacency: for each AP index, the SET of prerequisite indices (validated, de-duped, no
+  // self-edge). in[i] = number of surviving prerequisites (Kahn in-degree).
+  const prereqs: Set<number>[] = actionPoints.map(() => new Set<number>());
+  for (let i = 0; i < n; i++) {
+    const refs = actionPoints[i].dependsOn;
+    if (!refs || refs.length === 0) continue;
+    for (const ref of refs) {
+      const dep = resolveDepRef(ref, actionPoints, titleIndex);
+      if (dep === null) {
+        onWarn(`AP #${i + 1} depends on nonexistent "${String(ref)}" — dropped`);
+        continue;
+      }
+      if (dep === i) {
+        onWarn(`AP #${i + 1} depends on itself — dropped`);
+        continue;
+      }
+      prereqs[i].add(dep);
+    }
+  }
+
+  // Kahn's algorithm, LEVEL by LEVEL (each level = one wave). Ready = every prereq already
+  // scheduled. Deterministic: scan indices ascending, so within a wave original order holds.
+  const scheduled = new Array<boolean>(n).fill(false);
+  const waves: ActionPoint[][] = [];
+  let remaining = n;
+  while (remaining > 0) {
+    const wave: number[] = [];
+    for (let i = 0; i < n; i++) {
+      if (scheduled[i]) continue;
+      let ready = true;
+      for (const dep of prereqs[i]) {
+        if (!scheduled[dep]) {
+          ready = false;
+          break;
+        }
+      }
+      if (ready) wave.push(i);
+    }
+    if (wave.length === 0) {
+      // No node became ready but some remain ⇒ a CYCLE (or a chain into one). Break it:
+      // schedule ALL remaining APs as one independent final wave so the round completes.
+      const stuck: number[] = [];
+      for (let i = 0; i < n; i++) if (!scheduled[i]) stuck.push(i);
+      onWarn(
+        `dependency cycle detected among AP(s) ${stuck.map((i) => `#${i + 1}`).join(", ")} — ` +
+          `treating them as independent (final wave)`,
+      );
+      waves.push(stuck.map((i) => actionPoints[i]));
+      break;
+    }
+    for (const i of wave) scheduled[i] = true;
+    remaining -= wave.length;
+    waves.push(wave.map((i) => actionPoints[i]));
+  }
+  return waves;
 }

--- a/server/services/orchestrator/judge-prompt.ts
+++ b/server/services/orchestrator/judge-prompt.ts
@@ -60,4 +60,14 @@ Rules:
       cloud setting). The pipeline can only SURFACE these for a human; it can
       NEVER close them. Use this whenever the action is not a source change.
   Omit the field when unsure (the planner assigns a default from the task type).
+- OPTIONALLY, for each action point add a \`dependsOn\` field (exactly this
+  camelCase key): an array naming the OTHER action points that must be COMPLETED
+  before this one can be worked. Reference each by its 1-based position in the
+  \`open_action_points\` list (a number, e.g. \`[1, 3]\`) or by its exact
+  \`title\`. Declare a dependency ONLY when a later fix GENUINELY requires an
+  earlier one's result — e.g. an action point that "confirms CI is green" depends
+  on the fixes it verifies. The DEFAULT is NO dependency: independent action
+  points (which is most of them) are run in PARALLEL, so leave \`dependsOn\` absent
+  unless the ordering is real. Do NOT invent ordering to be safe — a false
+  dependency needlessly serializes the work.
 `.trim();

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -58,7 +58,15 @@ import type { ActionPoint, Archetype, ExecutionTrace } from "@shared/types";
 import type { Skill } from "@shared/schema";
 import { selectSkillSet, bindSkillStep, type BoundSkillStep } from "../consilium/skills/catalog.js";
 import { buildSdlcTrace } from "../consilium/execution-trace.js";
-import { buildBranchName, isValidLoopBranch, pushBranch, openDraftPr } from "../consilium/pr-wrapper.js";
+import {
+  buildBranchName,
+  buildApBranchName,
+  isValidLoopBranch,
+  isValidLoopApBranch,
+  pushBranch,
+  openDraftPr,
+} from "../consilium/pr-wrapper.js";
+import { buildWaveSchedule } from "../orchestrator/convergence.js";
 import {
   createSdlcWorktree,
   removeSdlcWorktree,
@@ -334,6 +342,23 @@ export interface SdlcHandoffRequest {
    * runs it only when a `verification` context (test runner + fixer step) exists.
    */
   finalVerification?: FinalVerificationConfig | null;
+  /**
+   * Parallel-develop (design §4): run the round's action points in DEPENDENCY-AWARE WAVES,
+   * each AP in its own worktree branched off the round's integration branch, bounded by
+   * `maxConcurrency`, merged back sequentially after each wave. ABSENT or `{ enabled: false }`
+   * ⇒ today's SEQUENTIAL single-worktree loop (byte-for-byte unchanged; `ap.dependsOn` is
+   * never read). Threaded by the controller ONLY when `implement.parallel.enabled` is true.
+   * A single-AP round always takes the sequential path (nothing to parallelize).
+   */
+  parallel?: ParallelConfig | null;
+}
+
+/** Parallel-develop config threaded into {@link runSdlcHandoff} (mirror of
+ *  `pipeline.consiliumLoop.implement.parallel`). */
+export interface ParallelConfig {
+  enabled: boolean;
+  /** Max APs executing concurrently within a wave (worktree fan-out ceiling). 1..8. */
+  maxConcurrency: number;
 }
 
 /**
@@ -911,29 +936,61 @@ export async function runSdlcHandoff(
             }
           : null;
 
-      // SEQUENTIAL per-action-point runs in the ONE shared worktree (avoid edit
-      // conflicts). Each `runActionPoint` NEVER throws — a coder timeout/error is
-      // caught, its work committed `[partial]`, and the loop continues.
       const total = req.actionPoints.length;
-      const outcomes: ApOutcome[] = [];
-      let committedCount = 0;
+      let outcomes: ApOutcome[];
+      let committedCount: number;
       // Stage B: per-criterion method routing context (INERT unless perCriterionMethod on).
       const routing = { enabled: req.perCriterionMethod ?? false, judgeVerify: deps.judgeVerify };
-      for (let i = 0; i < total; i++) {
-        const outcome = await runActionPoint(
-          { gitRaw, runCoder, progress, completedBefore: committedCount, skilledSteps, verify: verifyCtx, routing },
-          wt,
+
+      // Parallel-develop (design §4): when the switch is on AND there is >1 AP to fan out,
+      // run the round in DEPENDENCY-AWARE WAVES — each AP in its OWN worktree branched off
+      // the integration branch (`wt`), bounded by `maxConcurrency`, merged back after each
+      // wave. Otherwise (default) take today's SEQUENTIAL single-worktree loop, BYTE-FOR-BYTE
+      // unchanged — `ap.dependsOn` is never read and no extra worktree is ever cut.
+      if ((req.parallel?.enabled ?? false) && total > 1) {
+        const waveResult = await runWaveScheduledImplement(
+          {
+            gitRaw,
+            runCoder,
+            progress,
+            skilledSteps,
+            verify: verifyCtx,
+            routing,
+            createWorktree,
+            removeWorktree,
+            maxConcurrency: req.parallel!.maxConcurrency,
+            // Reuse the SAME whole-run wall-clock budget as verification (adversarial risk a
+            // + b): no wave/AP is started once it elapses, so a wedged run can't leak forever.
+            deadline: now() + WHOLE_RUN_BUDGET_MS,
+            now,
+          },
           req,
-          req.actionPoints[i],
-          i + 1,
-          total,
+          wt,
         );
-        outcomes.push(outcome);
-        if (outcome.committed) committedCount += 1;
-        // AP end: fold the settled status into the shared live snapshot. It surfaces
-        // on the very next beat (the next AP's start, or the push/done beat below) —
-        // the poll-based UI reads the latest snapshot, so no separate end beat.
-        progress.setStatus(i + 1, outcome.status);
+        outcomes = waveResult.outcomes;
+        committedCount = waveResult.committedCount;
+      } else {
+        // SEQUENTIAL per-action-point runs in the ONE shared worktree (avoid edit
+        // conflicts). Each `runActionPoint` NEVER throws — a coder timeout/error is
+        // caught, its work committed `[partial]`, and the loop continues.
+        outcomes = [];
+        committedCount = 0;
+        for (let i = 0; i < total; i++) {
+          const outcome = await runActionPoint(
+            { gitRaw, runCoder, progress, completedBefore: committedCount, skilledSteps, verify: verifyCtx, routing },
+            wt,
+            req,
+            req.actionPoints[i],
+            i + 1,
+            total,
+          );
+          outcomes.push(outcome);
+          if (outcome.committed) committedCount += 1;
+          // AP end: fold the settled status into the shared live snapshot. It surfaces
+          // on the very next beat (the next AP's start, or the push/done beat below) —
+          // the poll-based UI reads the latest snapshot, so no separate end beat.
+          progress.setStatus(i + 1, outcome.status);
+        }
       }
 
       // Stage A: FINAL-STATE re-verification. After every action point has been applied
@@ -1223,6 +1280,285 @@ async function runActionPoint(
     committed: true,
     note,
   };
+}
+
+// ─── Parallel-develop (design §4) — wave-scheduled fan-out + merge ───────────
+//
+// The per-AP IO the wave executor threads into `runActionPoint` (same shape the sequential
+// loop builds inline; `completedBefore` is added per call). Extracted so both the isolated
+// per-AP worktree run and the conflict-fallback run on the integration tree reuse it.
+interface ApImplementIo {
+  gitRaw: GitRunner;
+  runCoder: NonNullable<SdlcExecutorDeps["runCoder"]>;
+  progress: ProgressTracker;
+  skilledSteps: readonly BoundSkillStep[];
+  verify: VerifyContext | null;
+  routing: { enabled: boolean; judgeVerify?: JudgeVerifyFn };
+}
+
+/** Context for the wave executor — the per-AP IO plus the worktree fan-out machinery. */
+interface WaveImplementCtx extends ApImplementIo {
+  createWorktree: NonNullable<SdlcExecutorDeps["createWorktree"]>;
+  removeWorktree: NonNullable<SdlcExecutorDeps["removeWorktree"]>;
+  /** Max APs run CONCURRENTLY within a wave (adversarial risk e — fan-out ceiling). */
+  maxConcurrency: number;
+  /** Whole-run wall-clock deadline (epoch ms) — no wave/AP starts once it elapses. */
+  deadline: number;
+  now: () => number;
+}
+
+/** A wave worker's captured result: its outcome + the branch to merge (if it committed). */
+interface WaveApResult {
+  index: number; // 1-based original ordinal
+  ap: ActionPoint;
+  apBranch: string;
+  outcome: ApOutcome;
+}
+
+/**
+ * A minimal FIFO async mutex: serializes the git-ADMIN-mutating calls (`worktree add` /
+ * `remove` / `prune`) so N concurrent wave workers never race on the repo's
+ * `.git/worktrees` lock. The CODER runs (the expensive part) stay fully concurrent — only
+ * the fast create/remove bookends are serialized. Never throws on its own.
+ */
+function createGitAdminMutex(): <T>(fn: () => Promise<T>) => Promise<T> {
+  let tail: Promise<unknown> = Promise.resolve();
+  return <T>(fn: () => Promise<T>): Promise<T> => {
+    const run = tail.then(fn, fn); // run after the prior op, regardless of its outcome
+    // Keep the chain alive but swallow errors so one failure can't poison the queue.
+    tail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  };
+}
+
+/**
+ * Run `worker` over `items` with at most `limit` in flight. `worker` must NEVER throw (the
+ * wave worker catches internally); results land at their input index. Order of completion is
+ * irrelevant — the caller re-sorts by original ordinal before merging (determinism).
+ */
+async function runBounded<T, R>(
+  items: readonly T[],
+  limit: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const lanes = Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, async () => {
+    for (;;) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await worker(items[i]);
+    }
+  });
+  await Promise.all(lanes);
+  return results;
+}
+
+/** Build the sanitized (priority,title) pair the way `runActionPoint` does — for the
+ *  outcomes the wave executor synthesizes without entering `runActionPoint` (deadline /
+ *  create-worktree failure). Keeps those rows consistent with the coder-produced ones. */
+function apLabels(ap: ActionPoint): { priority: string; title: string } {
+  return {
+    priority: sanitizeLine(ap.priority ?? "-", PRIORITY_MAX) || "-",
+    title: sanitizeLine(ap.title ?? "", PR_BODY_TITLE_MAX),
+  };
+}
+
+/**
+ * Merge one AP's branch into the integration worktree. `--no-ff --no-edit` so every AP is a
+ * distinct merge commit (auditable) with no editor. Returns `{ ok:true }` on a clean merge;
+ * on ANY failure (the common case: a CONFLICT) it ABORTS the merge so the integration tree
+ * is left clean for the caller's sequential fallback, and reports `{ ok:false }`. NEVER
+ * throws. `apBranch` is server-derived (`buildApBranchName`) + re-gated here, so it can
+ * never be a git flag.
+ */
+async function mergeApBranch(
+  gitRaw: GitRunner,
+  integrationDir: string,
+  apBranch: string,
+): Promise<{ ok: boolean; message?: string }> {
+  if (apBranch.startsWith("-") || !isValidLoopApBranch(apBranch)) {
+    return { ok: false, message: "rejected ap branch name" };
+  }
+  try {
+    await gitRaw(integrationDir, ["merge", "--no-ff", "--no-edit", apBranch]);
+    return { ok: true };
+  } catch (err) {
+    // Conflict (or any merge error): restore the integration tree to pre-merge state so the
+    // fallback re-run starts clean. `--abort` is best-effort (a no-op if nothing to abort).
+    await gitRaw(integrationDir, ["merge", "--abort"]).catch(() => undefined);
+    return { ok: false, message: scrub(err instanceof Error ? err.message : String(err)) };
+  }
+}
+
+/**
+ * Parallel-develop CONTROLLER (design §4). Fan the round's action points out into
+ * DEPENDENCY-AWARE WAVES (`buildWaveSchedule` from the judge-declared `dependsOn`), run each
+ * wave's APs CONCURRENTLY — each in its OWN isolated worktree branched off the round's
+ * INTEGRATION branch (`integrationWt`, the merged result of all prior waves) — then MERGE
+ * each AP's branch back into the integration branch SEQUENTIALLY in deterministic ordinal
+ * order. NEVER throws (same partial-success contract as the sequential path): a per-AP
+ * failure, a create-worktree failure, a merge conflict, or the wall-clock deadline degrades
+ * that AP to partial/failed and is SURFACED — never silently dropped (adversarial risks
+ * a/b/c). Worktree cleanup is UNCONDITIONAL (a `finally` per worker + the git-admin mutex),
+ * so a crash mid-run leaks no per-AP worktree.
+ *
+ * @returns the per-AP outcomes (in ORIGINAL ordinal order) + how many landed a commit ON THE
+ *   INTEGRATION BRANCH (a committed-but-unmerged AP does NOT count until its merge/fallback
+ *   lands — the PR reflects the integration tree, not the isolated branches).
+ */
+async function runWaveScheduledImplement(
+  ctx: WaveImplementCtx,
+  req: SdlcHandoffRequest,
+  integrationWt: CreateWorktreeResult,
+): Promise<{ outcomes: ApOutcome[]; committedCount: number; waveCount: number; mergeConflicts: number }> {
+  const total = req.actionPoints.length;
+  // Original 1-based ordinal per AP (identity map — the schedule reorders but never clones).
+  const ordinalOf = new Map<ActionPoint, number>();
+  req.actionPoints.forEach((ap, i) => ordinalOf.set(ap, i + 1));
+
+  const waves = buildWaveSchedule(req.actionPoints, (m) => {
+    // eslint-disable-next-line no-console
+    console.warn(`[parallel-develop] loop=${req.loopId} round=${req.round}: ${m}`);
+  });
+
+  const outcomes = new Array<ApOutcome | undefined>(total);
+  let committedCount = 0;
+  let mergeConflicts = 0;
+  const gitAdmin = createGitAdminMutex();
+
+  for (const wave of waves) {
+    // Wall-clock backstop (risk a/b): once the whole-run budget elapses, do NOT start more
+    // work. Remaining APs are settled as failed below so none is silently lost.
+    if (ctx.now() >= ctx.deadline) break;
+
+    // The integration branch HEAD after all prior waves — the base every AP in THIS wave
+    // branches off, so each worker sees the merged result of everything before it.
+    const integrationHead = (await ctx.gitRaw(integrationWt.worktreeDir, ["rev-parse", "HEAD"])).trim();
+
+    // Run the wave's APs concurrently (bounded). Each worker is FULLY self-contained: cut a
+    // worktree, run the AP, and ALWAYS remove the worktree in a `finally`.
+    const waveResults = await runBounded<ActionPoint, WaveApResult>(
+      wave,
+      ctx.maxConcurrency,
+      async (ap) => {
+        const index = ordinalOf.get(ap)!;
+        const apBranch = buildApBranchName(req.loopId, req.round, index);
+        // Deadline re-check at worker start (a long earlier wave may have consumed the budget).
+        if (ctx.now() >= ctx.deadline) {
+          const { priority, title } = apLabels(ap);
+          ctx.progress.setStatus(index, "failed");
+          return {
+            index,
+            ap,
+            apBranch,
+            outcome: { index, priority, title, status: "failed", committed: false, note: "round wall-clock deadline exceeded before start" },
+          };
+        }
+        let apWt: CreateWorktreeResult | null = null;
+        try {
+          // Serialize the git-admin call; the coder run below stays concurrent.
+          apWt = await gitAdmin(() =>
+            ctx.createWorktree({
+              repoPath: req.repoPath,
+              branch: apBranch,
+              baseRef: integrationHead, // off the CURRENT integration state.
+              allowedRepoPaths: req.allowedRepoPaths,
+              gitRaw: ctx.gitRaw,
+            }),
+          );
+          const outcome = await runActionPoint(
+            { ...ctx, completedBefore: committedCount },
+            apWt,
+            req,
+            ap,
+            index,
+            total,
+          );
+          return { index, ap, apBranch, outcome };
+        } catch (err) {
+          // Create-worktree (or an unexpected throw) failed for THIS AP — surface it as a
+          // failed outcome (never silent) and let the round continue.
+          const { priority, title } = apLabels(ap);
+          ctx.progress.setStatus(index, "failed");
+          return {
+            index,
+            ap,
+            apBranch,
+            outcome: { index, priority, title, status: "failed", committed: false, note: scrub(err instanceof Error ? err.message : String(err)) },
+          };
+        } finally {
+          // UNCONDITIONAL cleanup (risk a): remove the worktree even on a throw. The branch
+          // ref persists in the object store, so the sequential merge below still sees the
+          // AP's commits. Serialized through the same git-admin mutex.
+          if (apWt) {
+            const dir = apWt.worktreeDir;
+            const baseDir = apWt.baseDir;
+            await gitAdmin(() => ctx.removeWorktree(req.repoPath, dir, { baseDir, gitRaw: ctx.gitRaw }));
+          }
+        }
+      },
+    );
+
+    // MERGE back into the integration branch SEQUENTIALLY in deterministic ordinal order
+    // (risk d: independent-in-isolation APs are combined here; the final Stage-A verification
+    // then runs the whole suite on THIS merged tree — the cross-AP regression safety net).
+    const ordered = waveResults.slice().sort((a, b) => a.index - b.index);
+    for (const r of ordered) {
+      // An AP that produced NO commit (failed / no changes) has nothing to merge — record it.
+      if (!r.outcome.committed) {
+        outcomes[r.index - 1] = r.outcome;
+        continue;
+      }
+      const merged = await mergeApBranch(ctx.gitRaw, integrationWt.worktreeDir, r.apBranch);
+      if (merged.ok) {
+        // Clean merge — the AP's work is now ON the integration branch.
+        outcomes[r.index - 1] = r.outcome;
+        committedCount += 1;
+        continue;
+      }
+      // CONFLICT (risk c): the merge was aborted (tree restored). FALL BACK — re-run the AP's
+      // coder SEQUENTIALLY on the INTEGRATED tree (the simpler, more robust of the two options
+      // in the design: it reuses the exact per-AP machinery and cannot silently drop work).
+      mergeConflicts += 1;
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[parallel-develop] loop=${req.loopId} round=${req.round}: AP #${r.index} merge conflict — ` +
+          `re-running on the integrated tree`,
+      );
+      ctx.progress.setStatus(r.index, "active");
+      const fallback = await runActionPoint(
+        { ...ctx, completedBefore: committedCount },
+        integrationWt, // run DIRECTLY on the integration worktree.
+        req,
+        r.ap,
+        r.index,
+        total,
+      );
+      // Surface that this AP went through conflict resolution (never hide it — risk c).
+      const note = fallback.note
+        ? `merge conflict — re-run on integrated tree: ${fallback.note}`
+        : "merge conflict — re-run on integrated tree";
+      outcomes[r.index - 1] = { ...fallback, note };
+      if (fallback.committed) committedCount += 1;
+      ctx.progress.setStatus(r.index, fallback.status);
+    }
+  }
+
+  // Settle any AP that never got an outcome (deadline cut the schedule short) as failed —
+  // so the count/contract holds and nothing is silently lost.
+  for (let i = 0; i < total; i++) {
+    if (outcomes[i] !== undefined) continue;
+    const ap = req.actionPoints[i];
+    const { priority, title } = apLabels(ap);
+    ctx.progress.setStatus(i + 1, "failed");
+    outcomes[i] = { index: i + 1, priority, title, status: "failed", committed: false, note: "round wall-clock deadline exceeded" };
+  }
+
+  return { outcomes: outcomes as ApOutcome[], committedCount, waveCount: waves.length, mergeConflicts };
 }
 
 /**

--- a/server/services/sdlc/worktree.ts
+++ b/server/services/sdlc/worktree.ts
@@ -30,7 +30,7 @@ import { mkdtemp, rm } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import simpleGit from "simple-git";
-import { isValidLoopBranch } from "../consilium/pr-wrapper.js";
+import { isValidLoopWorktreeBranch } from "../consilium/pr-wrapper.js";
 import { assertAllowedRepoPath } from "../consilium/repo-allowlist.js";
 
 /** Arg-array git runner seam: `(repoPath, args) => stdout`. Never a shell string. */
@@ -121,9 +121,10 @@ export async function createSdlcWorktree(opts: CreateWorktreeOptions): Promise<C
   // traversal + denylist). Throws when the path escapes confinement.
   const repo = assertAllowedRepoPath(opts.repoPath, opts.allowedRepoPaths);
 
-  // B-3: the branch must be the EXACT server-derived shape. Reject anything else
-  // (incl. a leading-dash branch) before git runs.
-  if (opts.branch.startsWith("-") || !isValidLoopBranch(opts.branch)) {
+  // B-3: the branch must be an EXACT server-derived shape — the round branch
+  // (`round-<n>`) OR, for parallel-develop, a per-AP branch (`round-<n>/ap-<k>`).
+  // Reject anything else (incl. a leading-dash branch) before git runs.
+  if (opts.branch.startsWith("-") || !isValidLoopWorktreeBranch(opts.branch)) {
     throw new Error(`createSdlcWorktree: rejected branch name (B-3): ${opts.branch}`);
   }
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1806,6 +1806,23 @@ export interface ActionPoint {
    * the criterion passed the lint.
    */
   weakCriterion?: boolean;
+  /**
+   * Parallel-develop (design §4 "development = controller + N coders for N features"):
+   * the OTHER action points that MUST complete before this one — the dependency edges the
+   * JUDGE declares from the dispute. Each entry references another action point by its
+   * 1-based ORDINAL in this list (a number, or a numeric string) OR by an exact `title`
+   * match (a string). The planner's {@link buildWaveSchedule} validates these (drops refs
+   * to nonexistent APs, BREAKS cycles) and topologically sorts the round into WAVES that
+   * run concurrently. DEFAULT = NO dependency (absent/empty ⇒ independent ⇒ wave 0,
+   * parallelizable) — a judge only declares one when a later fix genuinely requires an
+   * earlier one's result (e.g. "confirm CI green" depends on the fixes it verifies).
+   *
+   * Absent on every pre-parallel verdict and on judges that don't follow the prompt, and
+   * IGNORED entirely unless `implement.parallel.enabled` ⇒ fully back-compat. UNTRUSTED
+   * model input: treated as DATA only (index/title lookup), never a shell/branch/PR sink;
+   * bounded + validated by the planner before it can influence scheduling.
+   */
+  dependsOn?: Array<number | string>;
 }
 
 /**

--- a/tests/unit/orchestrator/wave-schedule.test.ts
+++ b/tests/unit/orchestrator/wave-schedule.test.ts
@@ -1,0 +1,124 @@
+/**
+ * wave-schedule.test.ts — the parallel-develop PLANNER (design §4).
+ *
+ * `buildWaveSchedule(aps)` turns the judge-declared `dependsOn` edges into topologically
+ * sorted WAVES (levels) the executor runs concurrently. Load-bearing / adversarial:
+ *   - independent APs ⇒ ONE wave (all parallelizable) — the default.
+ *   - a linear chain A→B→C ⇒ three single-AP waves in order.
+ *   - a diamond (D depends on B,C which depend on A) ⇒ waves [A] [B,C] [D].
+ *   - refs to a NONEXISTENT AP are dropped (never a dangling edge / wedge).
+ *   - a SELF dependency is dropped.
+ *   - a CYCLE is BROKEN (the stuck APs become a final independent wave) — never a deadlock.
+ *   - title-based refs resolve; numeric-string refs resolve.
+ *   - every AP appears EXACTLY once; within a wave ORIGINAL order is preserved.
+ */
+import { describe, it, expect } from "vitest";
+import { buildWaveSchedule } from "../../../server/services/orchestrator/convergence.js";
+import type { ActionPoint } from "@shared/types";
+
+/** Build an AP with a title = its label and optional deps. */
+const ap = (title: string, dependsOn?: Array<number | string>): ActionPoint =>
+  dependsOn ? { title, dependsOn } : { title };
+
+/** Map a wave schedule to titles for terse assertions. */
+const titles = (waves: ActionPoint[][]): string[][] => waves.map((w) => w.map((a) => a.title));
+
+/** Collect warnings into an array (the injectable sink) instead of console. */
+function capture(): { warn: (m: string) => void; msgs: string[] } {
+  const msgs: string[] = [];
+  return { warn: (m) => msgs.push(m), msgs };
+}
+
+describe("buildWaveSchedule — happy paths", () => {
+  it("empty list ⇒ no waves", () => {
+    expect(buildWaveSchedule([], () => {})).toEqual([]);
+  });
+
+  it("single AP ⇒ one wave of one", () => {
+    expect(titles(buildWaveSchedule([ap("A")], () => {}))).toEqual([["A"]]);
+  });
+
+  it("all independent ⇒ ONE wave (fully parallel) in original order", () => {
+    const waves = buildWaveSchedule([ap("A"), ap("B"), ap("C")], () => {});
+    expect(titles(waves)).toEqual([["A", "B", "C"]]);
+  });
+
+  it("linear chain A→B→C (1-based numeric refs) ⇒ three ordered single-AP waves", () => {
+    // B(#2) depends on A(#1); C(#3) depends on B(#2).
+    const waves = buildWaveSchedule([ap("A"), ap("B", [1]), ap("C", [2])], () => {});
+    expect(titles(waves)).toEqual([["A"], ["B"], ["C"]]);
+  });
+
+  it("diamond: [A] [B,C] [D] — D waits for both B and C which wait for A", () => {
+    const waves = buildWaveSchedule(
+      [ap("A"), ap("B", [1]), ap("C", [1]), ap("D", [2, 3])],
+      () => {},
+    );
+    expect(titles(waves)).toEqual([["A"], ["B", "C"], ["D"]]);
+  });
+
+  it("resolves TITLE references (case-insensitive, trimmed)", () => {
+    const waves = buildWaveSchedule([ap("Fix parser"), ap("Verify CI", ["  fix PARSER "])], () => {});
+    expect(titles(waves)).toEqual([["Fix parser"], ["Verify CI"]]);
+  });
+
+  it("resolves NUMERIC-STRING references", () => {
+    const waves = buildWaveSchedule([ap("A"), ap("B", ["1"])], () => {});
+    expect(titles(waves)).toEqual([["A"], ["B"]]);
+  });
+});
+
+describe("buildWaveSchedule — adversarial hardening", () => {
+  it("drops a ref to a NONEXISTENT AP (out-of-range index) and warns", () => {
+    const cap = capture();
+    // B depends on #9 which doesn't exist ⇒ edge dropped ⇒ B is independent.
+    const waves = buildWaveSchedule([ap("A"), ap("B", [9])], cap.warn);
+    expect(titles(waves)).toEqual([["A", "B"]]);
+    expect(cap.msgs.join(" ")).toMatch(/nonexistent/i);
+  });
+
+  it("drops an unknown TITLE ref and warns", () => {
+    const cap = capture();
+    const waves = buildWaveSchedule([ap("A"), ap("B", ["does not exist"])], cap.warn);
+    expect(titles(waves)).toEqual([["A", "B"]]);
+    expect(cap.msgs.join(" ")).toMatch(/nonexistent/i);
+  });
+
+  it("drops a SELF dependency and warns", () => {
+    const cap = capture();
+    // A(#1) depends on itself ⇒ edge dropped ⇒ A stays independent (wave 0 with B).
+    const waves = buildWaveSchedule([ap("A", [1]), ap("B")], cap.warn);
+    expect(titles(waves)).toEqual([["A", "B"]]);
+    expect(cap.msgs.join(" ")).toMatch(/itself/i);
+  });
+
+  it("BREAKS a 2-cycle (A↔B) — never deadlocks; stuck APs become a final wave + warn", () => {
+    const cap = capture();
+    // A(#1) depends on B(#2); B(#2) depends on A(#1) ⇒ neither can start ⇒ cycle broken.
+    const waves = buildWaveSchedule([ap("A", [2]), ap("B", [1])], cap.warn);
+    // All APs still scheduled exactly once (as one broken-cycle wave).
+    const flat = waves.flat().map((a) => a.title).sort();
+    expect(flat).toEqual(["A", "B"]);
+    expect(cap.msgs.join(" ")).toMatch(/cycle/i);
+  });
+
+  it("BREAKS a 3-cycle while still scheduling an independent AP normally first", () => {
+    const cap = capture();
+    // A independent; B→C→D→B is a cycle. B,C,D are broken into a final wave; A is wave 0.
+    const waves = buildWaveSchedule(
+      [ap("A"), ap("B", [4]), ap("C", [2]), ap("D", [3])],
+      cap.warn,
+    );
+    expect(titles(waves)[0]).toEqual(["A"]); // independent AP scheduled first
+    const flat = waves.flat().map((a) => a.title).sort();
+    expect(flat).toEqual(["A", "B", "C", "D"]); // nothing lost
+    expect(cap.msgs.join(" ")).toMatch(/cycle/i);
+  });
+
+  it("every AP appears exactly once across all waves (no dup, no drop)", () => {
+    const aps = [ap("A"), ap("B", [1]), ap("C", [1, 2]), ap("D"), ap("E", [4])];
+    const flat = buildWaveSchedule(aps, () => {}).flat();
+    expect(flat).toHaveLength(aps.length);
+    expect(new Set(flat.map((a) => a.title)).size).toBe(aps.length);
+  });
+});

--- a/tests/unit/sdlc/parallel-develop.test.ts
+++ b/tests/unit/sdlc/parallel-develop.test.ts
@@ -1,0 +1,245 @@
+/**
+ * parallel-develop.test.ts — wave-scheduled, dependency-aware develop (design §4).
+ *
+ * Drives `runSdlcHandoff` with `parallel.enabled` over FULLY injected seams (per-AP
+ * worktree create/remove, coder, push, openPr, git runner). Load-bearing / adversarial:
+ *   - OFF (default) ⇒ BYTE-IDENTICAL sequential path: ONE worktree, NO `ap-` branch, NO
+ *     merge — proof the feature is inert when disabled.
+ *   - ON, independent APs ⇒ N per-AP worktrees (each on a `…/ap-<k>` branch off the
+ *     integration HEAD) merged back into the ROUND branch; ONE PR from the round branch.
+ *   - CONCURRENCY is bounded by `maxConcurrency` (risk e).
+ *   - MERGE CONFLICT (risk c) ⇒ the AP is re-run on the integrated tree, its work SURFACED
+ *     (note mentions the conflict), never silently dropped.
+ *   - worktree cleanup is UNCONDITIONAL — one remove per created worktree, even on throw.
+ *   - the wall-clock DEADLINE (risk a/b) settles remaining APs as failed, opens no PR.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  runSdlcHandoff,
+  type SdlcHandoffRequest,
+} from "../../../server/services/sdlc/executor.js";
+import type { ActionPoint } from "@shared/types";
+
+const LOOP = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const REPO = "/allowlisted/omniscience";
+const ROOTS = ["/allowlisted"];
+const ROUND = 2;
+const ROUND_BRANCH = `consilium/loop-${LOOP}/round-${ROUND}`;
+
+const TWO_INDEP: ActionPoint[] = [
+  { title: "Fix parser", priority: "P0" },
+  { title: "Add redactor", priority: "P1" },
+];
+
+const baseReq = (over: Partial<SdlcHandoffRequest> = {}): SdlcHandoffRequest => ({
+  repoPath: REPO,
+  loopId: LOOP,
+  round: ROUND,
+  actionPoints: TWO_INDEP,
+  allowedRepoPaths: ROOTS,
+  ...over,
+});
+
+/** A createWorktree whose dir/baseDir ENCODE the branch, so commit/merge calls can be
+ *  attributed to the integration worktree vs. a specific per-AP worktree. */
+function makeCreateWorktree() {
+  return vi.fn(async (opts: { branch: string; baseRef?: string }) => ({
+    worktreeDir: `/tmp/tree/${opts.branch}`,
+    baseDir: `/tmp/base/${opts.branch}`,
+    branch: opts.branch,
+    baseRef: opts.baseRef ?? "main",
+  }));
+}
+
+/** git runner: `status` = dirty, `rev-parse` = a sha, `merge` = clean unless `conflictOn`
+ *  matches the ap-branch arg (then it throws like a real conflict). Records all calls. */
+function makeGitRaw(opts: { conflictOn?: RegExp } = {}) {
+  return vi.fn(async (_repo: string, args: string[]) => {
+    if (args[0] === "status") return " M server/x.ts\n";
+    if (args[0] === "rev-parse") return "headsha000\n";
+    if (args[0] === "merge" && args[1] === "--no-ff") {
+      const branch = args[3];
+      if (opts.conflictOn && opts.conflictOn.test(branch)) {
+        throw new Error(`CONFLICT (content): Merge conflict in server/x.ts`);
+      }
+      return "";
+    }
+    return "";
+  });
+}
+
+function makeDeps(over: Record<string, unknown> = {}) {
+  return {
+    createWorktree: makeCreateWorktree(),
+    removeWorktree: vi.fn(async () => undefined),
+    resolveDefaultBranchFn: vi.fn(async () => "main"),
+    runCoder: vi.fn(async () => ({ ok: true, summary: "edited", tokensUsed: 5 })),
+    push: vi.fn(async () => ({ ok: true as const, branch: ROUND_BRANCH })),
+    openPr: vi.fn(async () => ({ ok: true as const, prUrl: "https://github.com/x/y/pull/9" })),
+    gitRaw: makeGitRaw(),
+    ...over,
+  };
+}
+
+/** All branches ever handed to createWorktree, in call order. */
+const createdBranches = (deps: ReturnType<typeof makeDeps>): string[] =>
+  (deps.createWorktree as ReturnType<typeof vi.fn>).mock.calls.map((c) => (c[0] as { branch: string }).branch);
+
+/** All `git merge --no-ff` target branches. */
+const mergedBranches = (deps: ReturnType<typeof makeDeps>): string[] =>
+  (deps.gitRaw as ReturnType<typeof vi.fn>).mock.calls
+    .filter((c) => (c[1] as string[])[0] === "merge" && (c[1] as string[])[1] === "--no-ff")
+    .map((c) => (c[1] as string[])[3]);
+
+describe("parallel OFF (default) — byte-identical sequential path", () => {
+  it("cuts ONE worktree, NO ap-branch, NO merge", async () => {
+    const deps = makeDeps();
+    const res = await runSdlcHandoff(baseReq(), deps as never); // parallel absent
+    expect(createdBranches(deps)).toEqual([ROUND_BRANCH]); // exactly one worktree
+    expect(createdBranches(deps).some((b) => /\/ap-\d+$/.test(b))).toBe(false);
+    expect(mergedBranches(deps)).toHaveLength(0);
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+    expect(deps.removeWorktree).toHaveBeenCalledTimes(1);
+  });
+
+  it("explicit { enabled:false } is also the sequential path", async () => {
+    const deps = makeDeps();
+    await runSdlcHandoff(baseReq({ parallel: { enabled: false, maxConcurrency: 3 } }), deps as never);
+    expect(createdBranches(deps)).toEqual([ROUND_BRANCH]);
+    expect(mergedBranches(deps)).toHaveLength(0);
+  });
+
+  it("single-AP round takes the sequential path even when parallel is ON", async () => {
+    const deps = makeDeps();
+    await runSdlcHandoff(
+      baseReq({ actionPoints: [{ title: "only one", priority: "P0" }], parallel: { enabled: true, maxConcurrency: 3 } }),
+      deps as never,
+    );
+    expect(createdBranches(deps)).toEqual([ROUND_BRANCH]); // no fan-out for a single AP
+    expect(mergedBranches(deps)).toHaveLength(0);
+  });
+});
+
+describe("parallel ON — wave fan-out + merge", () => {
+  it("cuts an integration worktree + one per-AP worktree, merges each ap-branch back", async () => {
+    const deps = makeDeps();
+    const res = await runSdlcHandoff(
+      baseReq({ parallel: { enabled: true, maxConcurrency: 3 } }),
+      deps as never,
+    );
+    const branches = createdBranches(deps);
+    // integration (round) branch first, then one per-AP branch each.
+    expect(branches[0]).toBe(ROUND_BRANCH);
+    expect(branches).toContain(`${ROUND_BRANCH}/ap-1`);
+    expect(branches).toContain(`${ROUND_BRANCH}/ap-2`);
+    expect(branches).toHaveLength(3);
+    // Both ap-branches merged back into the integration branch, in deterministic order.
+    expect(mergedBranches(deps)).toEqual([`${ROUND_BRANCH}/ap-1`, `${ROUND_BRANCH}/ap-2`]);
+    // ONE PR, opened from the round (integration) branch.
+    expect(deps.openPr).toHaveBeenCalledTimes(1);
+    const [dir, prOpts] = (deps.openPr as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(dir).toBe(`/tmp/tree/${ROUND_BRANCH}`); // pushed from the integration worktree
+    expect(prOpts.head).toBe(ROUND_BRANCH);
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+  });
+
+  it("removes EVERY worktree it created (unconditional cleanup) — integration + per-AP", async () => {
+    const deps = makeDeps();
+    await runSdlcHandoff(baseReq({ parallel: { enabled: true, maxConcurrency: 3 } }), deps as never);
+    // 2 per-AP worktrees + 1 integration worktree = 3 removals.
+    expect(deps.removeWorktree).toHaveBeenCalledTimes(3);
+  });
+
+  it("bounds concurrency by maxConcurrency (risk e)", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const runCoder = vi.fn(async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight -= 1;
+      return { ok: true, summary: "edited", tokensUsed: 1 };
+    });
+    const threeIndep: ActionPoint[] = [
+      { title: "A", priority: "P0" },
+      { title: "B", priority: "P0" },
+      { title: "C", priority: "P0" },
+    ];
+    const deps = makeDeps({ runCoder });
+    await runSdlcHandoff(
+      baseReq({ actionPoints: threeIndep, parallel: { enabled: true, maxConcurrency: 2 } }),
+      deps as never,
+    );
+    expect(peak).toBeLessThanOrEqual(2); // never more than the cap in flight at once
+    expect(runCoder).toHaveBeenCalledTimes(3); // all three still ran
+  });
+
+  it("respects judge-declared dependencies — a dependent AP runs in a LATER wave", async () => {
+    // B depends on A (#1): A must be merged before B's worktree is cut off the integration
+    // HEAD. Observe: A's ap-1 branch is merged BEFORE B's ap-2 worktree is created.
+    const order: string[] = [];
+    const createWorktree = vi.fn(async (opts: { branch: string; baseRef?: string }) => {
+      order.push(`create:${opts.branch}`);
+      return { worktreeDir: `/tmp/tree/${opts.branch}`, baseDir: `/tmp/base/${opts.branch}`, branch: opts.branch, baseRef: opts.baseRef ?? "main" };
+    });
+    const gitRaw = vi.fn(async (_repo: string, args: string[]) => {
+      if (args[0] === "status") return " M x\n";
+      if (args[0] === "rev-parse") return "headsha000\n";
+      if (args[0] === "merge" && args[1] === "--no-ff") {
+        order.push(`merge:${args[3]}`);
+        return "";
+      }
+      return "";
+    });
+    const deps = makeDeps({ createWorktree, gitRaw });
+    const aps: ActionPoint[] = [
+      { title: "A", priority: "P0" },
+      { title: "B", priority: "P0", dependsOn: [1] },
+    ];
+    await runSdlcHandoff(baseReq({ actionPoints: aps, parallel: { enabled: true, maxConcurrency: 3 } }), deps as never);
+    const mergeA = order.indexOf(`merge:${ROUND_BRANCH}/ap-1`);
+    const createB = order.indexOf(`create:${ROUND_BRANCH}/ap-2`);
+    expect(mergeA).toBeGreaterThanOrEqual(0);
+    expect(createB).toBeGreaterThan(mergeA); // B fanned out only AFTER A merged
+  });
+});
+
+describe("parallel ON — adversarial", () => {
+  it("MERGE CONFLICT (risk c) ⇒ the AP is re-run on the integrated tree and SURFACED", async () => {
+    // ap-1 conflicts on merge → abort → fallback re-run on the integration worktree.
+    const gitRaw = makeGitRaw({ conflictOn: /\/ap-1$/ });
+    const deps = makeDeps({ gitRaw });
+    const res = await runSdlcHandoff(
+      baseReq({ parallel: { enabled: true, maxConcurrency: 3 } }),
+      deps as never,
+    );
+    // The conflicting merge was attempted then aborted.
+    const g = deps.gitRaw as ReturnType<typeof vi.fn>;
+    expect(g.mock.calls.some((c) => (c[1] as string[])[0] === "merge" && (c[1] as string[])[1] === "--abort")).toBe(true);
+    // A fallback commit ran ON THE INTEGRATION worktree (not a per-AP dir).
+    const integrationCommits = g.mock.calls.filter(
+      (c) => c[0] === `/tmp/tree/${ROUND_BRANCH}` && (c[1] as string[])[0] === "commit",
+    );
+    expect(integrationCommits.length).toBeGreaterThanOrEqual(1);
+    // The PR opens; the conflicted AP's note surfaces the conflict (never silent — risk c).
+    const [, prOpts] = (deps.openPr as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(prOpts.body).toMatch(/merge conflict/i);
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+  });
+
+  it("wall-clock DEADLINE (risk a/b) ⇒ remaining APs failed, no PR, worktrees still cleaned", async () => {
+    // now(): first call (deadline compute) = 0 ⇒ deadline = +budget; subsequent = huge ⇒
+    // the first wave check trips immediately, no AP runs.
+    const now = vi.fn().mockReturnValueOnce(0).mockReturnValue(9_000_000_000);
+    const deps = makeDeps({ now });
+    const res = await runSdlcHandoff(
+      baseReq({ parallel: { enabled: true, maxConcurrency: 3 } }),
+      deps as never,
+    );
+    expect(deps.runCoder).not.toHaveBeenCalled(); // nothing started
+    expect(res.prRef).toBeNull(); // zero commits → no PR
+    expect(res.error).toBeTruthy();
+    // The integration worktree is still removed in the outer finally.
+    expect(deps.removeWorktree).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Parallel, dependency-aware develop (design §4)

The consilium loop's develop phase implements a round's action points (APs)
**sequentially in one shared worktree** (one coder, one branch). This adds an
opt-in path that runs them **in parallel, in dependency-aware waves**, with the
dependencies **determined by the dispute** — the judge annotates which APs depend
on which.

Gated by `pipeline.consiliumLoop.implement.parallel.enabled` (**default false** →
today's sequential path runs **byte-for-byte unchanged**; `ap.dependsOn` is never
read, no extra worktree is ever cut).

### 1. Dependencies come from the dispute (the judge, not config)

The dependency graph is **discovered**, not operator-declared. Each `action_point`
may carry an additive `dependsOn: (number | string)[]` — the *other* APs that must
complete before it (1-based ordinal, numeric string, or exact title). Judge-prompt
guidance: declare a dependency **only when a later fix genuinely requires an earlier
one's result** (e.g. "confirm CI green" depends on the fixes it verifies); the
**default is no dependency → independent → parallelizable**.

Shape:
```ts
interface ActionPoint {
  // …existing fields…
  dependsOn?: Array<number | string>;   // judge-declared edges (design §4)
}
```
It **rides the existing `verdict/openActionPoints` jsonb — NO migration**, and is
length-capped + entry-clamped in `boundActionPoint` alongside the other untrusted
judge fields.

### 2. Planner validates + builds the wave schedule

`buildWaveSchedule(aps) → ActionPoint[][]` (pure, unit-tested; sibling to
`normalizeActionPointMethods` in `convergence.ts`) validates edges then
topologically sorts into **waves** (levels): wave 0 = APs with no surviving
dependency; wave *N* = APs whose deps all land in waves `< N`. Adversarial
guarantees are in the **planner**, not left to the executor:

- a ref to a **nonexistent** AP (out-of-range index / unknown title) is **dropped** + logged;
- a **self**-dependency is dropped;
- a **cycle** (A→B→A) is **detected and broken** — the residue Kahn's algorithm
  cannot drain becomes one final independent wave (+ log), so a cyclic `dependsOn`
  can **never deadlock or infinitely wait**;
- every AP appears exactly once; within a wave the original order is preserved (deterministic).

### 3. Wave/merge algorithm (executor)

`runWaveScheduledImplement` in `executor.ts`. The round's existing branch is the
**integration branch**. Per wave:

- run the wave's APs **concurrently**, bounded by `maxConcurrency`, each in its **own
  isolated worktree** on a dedicated `consilium/loop-<uuid>/round-<n>/ap-<k>` branch
  cut off the **current integration HEAD** (the merged result of all prior waves).
  Each AP does its full skilled run (test-author → coder → per-criterion verify)
  exactly as today.
- after the wave, **merge each AP branch back into the integration branch
  sequentially in deterministic ordinal order**:
  - **clean** merge (independent APs, different files) → proceed;
  - **conflict** → `git merge --abort` (integration tree restored) then **re-run that
    AP's coder sequentially on the integrated tree** (the simpler, more robust of the
    two design options — reuses the exact per-AP machinery, cannot silently drop
    work). The conflict is **surfaced** on the AP's outcome/PR note.
- start the next wave off the updated integration branch.

A per-AP failure, a create-worktree failure, a merge conflict, or the deadline
degrades **that AP** to partial/failed and is surfaced — the round does **not** halt
(same partial-success contract: completed/partial/failed per AP; one PR if anything
committed). The PR opens from the final integration branch, and the existing
**Stage-A final verification runs the whole suite against the merged tree** — the
safety net for two APs each green in isolation but conflicting when combined.

### 4. Conflict handling

Chosen: **sequential fallback on the integrated tree** (not a merge-coder pass). On a
merge failure the merge is aborted (tree left clean) and the AP's coder is re-run
directly on the integration worktree via the same `runActionPoint` path. Simpler,
reuses tested machinery, and structurally cannot drop the AP's work — the AP is
recorded partial/failed with a note that names the conflict, never silent.

### 5. Worktree lifecycle / cleanup guarantee

- **Unconditional removal**: each per-AP worktree is removed in a `finally` per
  worker (mirrors the single-worktree cleanup) — even on a coder throw / timeout /
  create failure. The branch ref persists in the object store, so the sequential
  merge still sees the AP's commits after its worktree is gone.
- **Git-admin mutex**: the fast `worktree add/remove/prune` calls are serialized so N
  concurrent workers never race on `.git/worktrees`; the coder runs stay concurrent.
- **Wall-clock deadline**: reuses the whole-run budget — no wave/AP starts once it
  elapses; remaining APs are settled failed (never lost), so a wedged run can't leak
  worktrees forever.

### 6. Config

```
implement.parallel: { enabled: bool (default false), maxConcurrency: int 1..8 (default 3) }
```
Independent of verification — changes only *how* coders are fanned out, not *what*
each AP does.

### Byte-identical-when-off — evidence

- The sequential per-AP loop is kept **verbatim**, wrapped in the `else` of
  `if ((req.parallel?.enabled ?? false) && total > 1)`. When off, `buildWaveSchedule`,
  `buildApBranchName`, and any per-AP worktree are **never** reached.
- Controller threads `parallel: null` when the switch is off (mirrors
  `verification`/`finalVerification`).
- Test `parallel OFF (default)` asserts: exactly **one** worktree cut (the round
  branch), **no** `…/ap-<k>` branch, **no** `git merge`. Also covered: explicit
  `{ enabled:false }`, and a single-AP round (sequential even when parallel is ON).

### Adversarial self-review (all covered by tests)

- **(a) leaked worktrees on crash** — unconditional `finally` removal + git-admin
  mutex + wall-clock deadline. Test asserts one `removeWorktree` per created
  worktree (integration + per-AP).
- **(b) cycle in `dependsOn` → deadlock/infinite wait** — planner detects the
  undrainable residue and breaks it into a final wave (tested: 2-cycle + 3-cycle,
  nothing lost).
- **(c) merge conflict silently dropping an AP's work** — conflict aborts + re-runs
  on the integrated tree; the AP is recorded partial/failed with a conflict note
  (tested: fallback commit lands on the integration worktree, PR body says "merge
  conflict").
- **(d) two APs green in isolation but conflicting when merged** — the existing
  Stage-A final verification runs the whole suite on the **merged** integration tree
  (unchanged; kept as the safety net).
- **(e) unbounded concurrency** — `maxConcurrency` cap (1..8) enforced by the bounded
  runner (tested: peak in-flight ≤ cap with 3 APs / cap 2).

### Live UI (multiple concurrent `active`)

`DevTaskList` (ConsiliumLoopDetail.tsx, #435/#480) renders one row per AP keyed by
`ap.i` with per-row `isActive = status === "active"`, so **multiple concurrent
`active` rows render gracefully** (no key collision, correct per-row status icons).
The progress tracker's `aps[]` snapshot already flips each AP's status independently.
**Note (cosmetic, out of scope):** the `step`/`fixIteration` badge is a single
top-level field on the beat, so while several APs are active every active row shows
the most-recent beat's step. Per-AP step granularity would require moving `step` into
the `aps[]` entries — additive future work; no crash, core rendering is correct.

### Test evidence

- New: `tests/unit/orchestrator/wave-schedule.test.ts` (13 tests — independent/chain/
  diamond, title + numeric-string refs, nonexistent/self drop, 2-cycle + 3-cycle
  break, exactly-once).
- New: `tests/unit/sdlc/parallel-develop.test.ts` (9 tests — off=byte-identical,
  fan-out + merge, unconditional cleanup, concurrency cap, dependency ordering,
  merge-conflict fallback, wall-clock deadline).
- `tsc` clean. Full unit suite green except one **pre-existing** concurrency flake in
  `tests/unit/sdlc/completed-count.test.ts` (a `/api/task-groups` HTTP route test,
  unrelated to this change; passes in isolation and in the `sdlc`-only run — the #479
  quarantine class).

### Repo protocol

- No FSM/reducer change; develop still emits `dev_completed`. No migration (`dependsOn`
  rides existing jsonb).
- Draft PR only; agents never merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
