### PR TITLE
fix: classify tool-not-found (ran-but-tool-missing) as not-adjudicated

### DIFF
--- a/server/services/consilium/execution-trace.ts
+++ b/server/services/consilium/execution-trace.ts
@@ -99,6 +99,8 @@ function clampCriterion(c: ExecutionCriterion): ExecutionCriterion {
   if (typeof c.passedAtFinal === "boolean") out.passedAtFinal = c.passedAtFinal;
   // Timeout policy: additive NOT-ADJUDICATED flag — carried verbatim (boolean).
   if (typeof c.timedOut === "boolean") out.timedOut = c.timedOut;
+  // Tool-not-found policy: additive NOT-ADJUDICATED (tooling) flag — carried verbatim.
+  if (typeof c.toolMissing === "boolean") out.toolMissing = c.toolMissing;
   return out;
 }
 
@@ -160,6 +162,8 @@ export interface SdlcOutcomeLike {
     criterion: string;
     /** Timeout policy: this AP's own verification run was killed by the wall-clock cap. */
     timedOut?: boolean;
+    /** Tool-not-found policy: the command RAN but its own tool is missing (env gap). */
+    toolMissing?: boolean;
   };
 }
 
@@ -236,6 +240,10 @@ export function buildSdlcTrace(
             ...(o.verification.timedOut || (o.verification.method === "test-run" && finalTimedOut)
               ? { timedOut: true }
               : {}),
+            // Tool-not-found policy: NOT-ADJUDICATED (tooling) — the AP's command ran but
+            // its own tool is missing (env gap). Carried through so the trace distinguishes
+            // it from a bare not-run and from a regression (an env gap, never a red).
+            ...(o.verification.toolMissing ? { toolMissing: true } : {}),
           },
         ]
       : [];

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -181,6 +181,14 @@ export interface ApVerification {
    * stays true (the process DID run, unlike a launch failure). Absent on adjudicated runs.
    */
   timedOut?: boolean;
+  /**
+   * Additive: the test command RAN but reported ITS OWN TOOL missing (`uv run pytest`
+   * where uv spawned but pytest is absent) → an ENVIRONMENT gap classified `ran:false`
+   * (fix loop SKIPPED, like a launch failure) but surfaced as NOT-ADJUDICATED (tooling)
+   * so the operator configures the test command rather than expecting a code fix. Absent
+   * unless a tool-missing signature matched.
+   */
+  toolMissing?: boolean;
 }
 
 /**
@@ -208,6 +216,12 @@ export interface FinalVerification {
    * the final fix loop was SKIPPED. `ran` stays true (the process DID run). Absent otherwise.
    */
   timedOut?: boolean;
+  /**
+   * Additive: the FINAL whole-suite run RAN but reported ITS OWN TOOL missing → an
+   * ENVIRONMENT gap classified `ran:false` (final fix loop SKIPPED) and surfaced as
+   * NOT-ADJUDICATED (tooling). Absent unless a tool-missing signature matched.
+   */
+  toolMissing?: boolean;
 }
 
 /**
@@ -676,7 +690,7 @@ export function buildPrStatusBody(input: PrStatusBodyInput): string {
     const verifyTag = v
       ? v.method === "manual-ops"
         ? " [manual op — needs human]"
-        : ` [${v.method === "judge" ? "judge: " : "verify: "}${!v.ran ? "not-run" : v.timedOut ? "not-adjudicated (timeout)" : v.passed ? "green" : "RED"}${v.fixIterations > 0 ? ` after ${v.fixIterations} fix` : ""}]`
+        : ` [${v.method === "judge" ? "judge: " : "verify: "}${!v.ran ? (v.toolMissing ? "not-adjudicated (tooling)" : "not-run") : v.timedOut ? "not-adjudicated (timeout)" : v.passed ? "green" : "RED"}${v.fixIterations > 0 ? ` after ${v.fixIterations} fix` : ""}]`
       : "";
     return `- [${o.status}] (${o.priority}) ${sanitizeLine(o.title, PR_BODY_TITLE_MAX)}${skillTag}${verifyTag}${tail}`;
   });
@@ -718,7 +732,9 @@ export function buildPrStatusBody(input: PrStatusBodyInput): string {
           const v = o.verification;
           const reason =
             v && !v.ran
-              ? sanitizeLine(v.summary, 160)
+              ? v.toolMissing
+                ? `NOT-ADJUDICATED (tooling) — ${sanitizeLine(v.summary, 160)}`
+                : sanitizeLine(v.summary, 160)
               : v && v.timedOut
                 ? `NOT-ADJUDICATED (timeout) — ${sanitizeLine(v.summary, 160)}`
                 : "tests still failing";
@@ -759,7 +775,15 @@ export function buildPrStatusBody(input: PrStatusBodyInput): string {
     // A TIMED-OUT final run is NOT-ADJUDICATED (timeout), never RED (checked before
     // `passed`) — the whole-suite run was killed before a verdict, so it is not a
     // confirmed regression.
-    const status = !fv.ran ? "NOT-RUN" : fv.timedOut ? "NOT-ADJUDICATED (timeout)" : fv.passed ? "GREEN" : "RED";
+    const status = !fv.ran
+      ? fv.toolMissing
+        ? "NOT-ADJUDICATED (tooling)"
+        : "NOT-RUN"
+      : fv.timedOut
+        ? "NOT-ADJUDICATED (timeout)"
+        : fv.passed
+          ? "GREEN"
+          : "RED";
     const fixTag = fv.fixIterations > 0 ? ` (after ${fv.fixIterations} final fix attempt(s))` : "";
     finalBlock.push(
       "",
@@ -769,9 +793,11 @@ export function buildPrStatusBody(input: PrStatusBodyInput): string {
         ? "The full test suite passes against the FINAL combined worktree (all action points applied) — no cross-AP regression detected."
         : fv.timedOut
           ? "TIMED OUT — the full test suite was KILLED by the wall-clock cap before a verdict (the suite may exceed testRunTimeoutMs, or a change may have introduced a hang). NOT adjudicated; the final fix loop was skipped. This is NOT a confirmed regression — review before merging (raise the cap for a slow suite, or investigate a possible hang)."
-          : !fv.ran
-            ? "The full test suite could NOT be re-run against the final worktree (no test command resolved). The final combined state is UNVERIFIED — review before merging."
-            : "REGRESSION — the full test suite does NOT pass against the FINAL combined worktree. A later action point may have regressed an earlier one. This Draft PR still opens for human review; review before merging.",
+          : fv.toolMissing
+            ? `TOOL NOT AVAILABLE — the test command RAN but its own tool is missing (${sanitizeLine(fv.summary, 200)}). NOT adjudicated; the final fix loop was skipped. This is a config/environment gap, NOT a regression — configure implement.testCommand / perRepo for this repo, then re-run.`
+            : !fv.ran
+              ? "The full test suite could NOT be re-run against the final worktree (no test command resolved). The final combined state is UNVERIFIED — review before merging."
+              : "REGRESSION — the full test suite does NOT pass against the FINAL combined worktree. A later action point may have regressed an earlier one. This Draft PR still opens for human review; review before merging.",
     );
   }
 
@@ -1780,6 +1806,9 @@ async function runFinalVerification(
     fixIterations,
     // Additive: mark NOT-ADJUDICATED only when the final run timed out (legacy shape else).
     ...(result.timedOut ? { timedOut: true } : {}),
+    // Additive: a ran-but-tool-missing final run (ran:false) surfaces as NOT-ADJUDICATED
+    // (tooling) — an env gap, not a regression; the final fix loop was already skipped.
+    ...(result.toolMissing ? { toolMissing: true } : {}),
   };
 }
 
@@ -1902,6 +1931,9 @@ async function runVerifyFixLoop(
     criterion,
     // Additive: mark NOT-ADJUDICATED only when this AP's run timed out (legacy shape else).
     ...(result.timedOut ? { timedOut: true } : {}),
+    // Additive: a ran-but-tool-missing run (ran:false) surfaces as NOT-ADJUDICATED
+    // (tooling) — an env gap, not a red; the fix loop was already skipped on `!ran`.
+    ...(result.toolMissing ? { toolMissing: true } : {}),
   };
 }
 
@@ -1965,7 +1997,15 @@ function aggregateTestSummary(
       const v = o.verification as ApVerification;
       // A TIMED-OUT run is NOT-ADJUDICATED (ambiguous, fix loop skipped), never FAIL —
       // so the next review round grounds on "unadjudicated", not a confirmed red.
-      const status = !v.ran ? "NOT-RUN" : v.timedOut ? "NOT-ADJUDICATED (timeout)" : v.passed ? "PASS" : "FAIL";
+      const status = !v.ran
+        ? v.toolMissing
+          ? "NOT-ADJUDICATED (tooling)"
+          : "NOT-RUN"
+        : v.timedOut
+          ? "NOT-ADJUDICATED (timeout)"
+          : v.passed
+            ? "PASS"
+            : "FAIL";
       const fixes = v.fixIterations > 0 ? ` after ${v.fixIterations} fix attempt(s)` : "";
       const crit = v.criterion ? ` — criterion: ${v.criterion}` : "";
       const via = v.method === "judge" ? " [via judge]" : "";
@@ -2000,15 +2040,25 @@ function aggregateTestSummary(
 
 /** Stage A: the round `testSummary` block for the final whole-suite re-verification. */
 function buildFinalVerificationSummary(fv: FinalVerification): string {
-  const status = !fv.ran ? "NOT-RUN" : fv.timedOut ? "NOT-ADJUDICATED (timeout)" : fv.passed ? "PASS" : "FAIL";
+  const status = !fv.ran
+    ? fv.toolMissing
+      ? "NOT-ADJUDICATED (tooling)"
+      : "NOT-RUN"
+    : fv.timedOut
+      ? "NOT-ADJUDICATED (timeout)"
+      : fv.passed
+        ? "PASS"
+        : "FAIL";
   const fixes = fv.fixIterations > 0 ? ` after ${fv.fixIterations} final fix attempt(s)` : "";
   const verdict = fv.passed
     ? "The full test suite passes against the final combined worktree (no cross-AP regression)."
     : fv.timedOut
       ? "The full test suite TIMED OUT (killed by the wall-clock cap) before a verdict — NOT adjudicated (the suite may exceed testRunTimeoutMs, or a change may have introduced a hang); the final fix loop was skipped. Not a confirmed regression."
-      : !fv.ran
-        ? "The full test suite could not be re-run against the final worktree (no test command)."
-        : "REGRESSION: the full test suite does NOT pass against the final combined worktree.";
+      : fv.toolMissing
+        ? "The full test suite RAN but its own tool is missing — NOT adjudicated (a config/environment gap, not a regression); the final fix loop was skipped. Configure the repo's test command."
+        : !fv.ran
+          ? "The full test suite could not be re-run against the final worktree (no test command)."
+          : "REGRESSION: the full test suite does NOT pass against the final combined worktree.";
   return [`Final-state re-verification: [${status}]${fixes}.`, verdict, `    ${sanitizeLine(fv.summary, 280)}`].join("\n");
 }
 

--- a/server/services/sdlc/test-runner.ts
+++ b/server/services/sdlc/test-runner.ts
@@ -110,6 +110,16 @@ export interface TestRunResult {
   /** True when a test command was resolved + actually spawned. False ⇒ no command
    *  (config unset and no usable package.json script) — nothing executed. */
   ran: boolean;
+  /**
+   * Additive: the command SPAWNED and ran, but its combined output reveals that ITS OWN
+   * TOOL is missing — e.g. `uv run pytest` where `uv` launches fine but `pytest` is not
+   * installed (uv exits non-zero with `Failed to spawn: pytest`). This is an ENVIRONMENT
+   * gap no code change can fix, so it is classified like a top-level spawn failure
+   * (`ran:false`) — but flagged here so the caller can surface it as NOT-ADJUDICATED
+   * (tooling) distinctly from a launch failure / "no command". OPTIONAL/ADDITIVE —
+   * absent unless a tool-missing signature matched the runner's OWN error framing.
+   */
+  toolMissing?: boolean;
 }
 
 /** A resolved, argv-shaped command — the ONLY shape the runner will execute. */
@@ -259,6 +269,150 @@ function launchFailureSummary(err: unknown): string {
  */
 function timeoutSummary(timeoutMs: number): string {
   return `TIMED OUT after ${timeoutMs}ms — suite may exceed testRunTimeoutMs (raise the cap for a slow suite) or the change introduced a hang; not adjudicated, fix loop skipped`.slice(
+    0,
+    SUMMARY_MAX,
+  );
+}
+
+/**
+ * Known TEST-RUNNER python modules. The `No module named X` signature is treated as a
+ * tool-not-found ENVIRONMENT error ONLY when X is one of these (i.e. `python -m pytest`
+ * ran but pytest is not installed). We do NOT generalize to ANY missing module: an
+ * arbitrary `No module named <app_dep>` is left as a REAL failure (conservative — a
+ * false-negative, never a false-positive that masks a genuine red). Kept TIGHT.
+ */
+const TEST_RUNNER_MODULES: ReadonlySet<string> = new Set([
+  "pytest",
+  "unittest",
+  "nose",
+  "nose2",
+  "tox",
+]);
+
+/** Strip decorating quotes/backticks/trailing punctuation off an extracted tool token. */
+function cleanTool(raw: string | null | undefined): string | null {
+  if (typeof raw !== "string") return null;
+  const t = raw.replace(/^[`'"]+|[`'".,:;]+$/g, "").trim();
+  return t.length > 0 ? t : null;
+}
+
+/**
+ * Error/assertion FRAMING words that are NEVER an invoked tool name. Guards the shell
+ * `<tool>: command not found` / `<tool>: not found` patterns against a GENUINE failure
+ * line like `Error: command not found` (a thrown `Error("command not found")`) being
+ * misread as a shell tool-missing — the token before the colon would be `Error`, not a
+ * real command. If the captured "tool" is one of these, we do NOT classify (fall through
+ * ⇒ real failure ⇒ the fix loop still engages: the preferred false-negative direction).
+ */
+const NON_TOOL_TOKENS: ReadonlySet<string> = new Set([
+  "error",
+  "assertionerror",
+  "typeerror",
+  "rangeerror",
+  "referenceerror",
+  "syntaxerror",
+  "evalerror",
+  "urierror",
+  "expected",
+  "received",
+  "actual",
+  "warning",
+  "note",
+  "caused",
+  "at",
+]);
+
+/** cleanTool + reject error/assertion framing words (see {@link NON_TOOL_TOKENS}). */
+function plausibleTool(raw: string | null | undefined): string | null {
+  const t = cleanTool(raw);
+  if (t === null) return null;
+  return NON_TOOL_TOKENS.has(t.toLowerCase()) ? null : t;
+}
+
+/**
+ * TOOL-NOT-FOUND (ran-but-tool-missing) detection on the child's OWN combined output.
+ *
+ * The distinction from a top-level launch failure (ENOENT/EACCES on the spawn `error`
+ * event) is: HERE the command binary SPAWNED fine and RAN, then reported — via its own
+ * error framing on a NON-ZERO exit — that a tool IT needs is missing (`uv run pytest`
+ * where uv is present but pytest is not). Node sees a normal non-zero `close`, so without
+ * this the executor treats it as a REAL test failure and burns the whole fix budget on an
+ * environment gap no code edit can fix (the observed omnius bug: 3 APs × 3 iterations on
+ * `Failed to spawn: pytest`).
+ *
+ * FALSE-POSITIVE DEFENSE (the key risk — masking a real test failure): every signature is
+ * a LINE-ANCHORED (`^…` with the `m` flag), COLUMN-0 match of a TOOL's or SHELL's own
+ * error line — NOT an arbitrary substring. A genuine test failure that merely mentions
+ * "pytest" / "not found" / "command not found" does so INSIDE an assertion diff — indented
+ * and/or quoted (`  Expected: "command not found: pytest"`), never at column 0 ending its
+ * own line — so it does NOT match. We prefer a FALSE-NEGATIVE (treat as a real failure,
+ * enter the fix loop) over a FALSE-POSITIVE (skip the loop, mask a red). Detection runs on
+ * the RAW output (pre-scrub) so line structure is intact, and ONLY on a non-zero exit.
+ *
+ * Returns the matched tool name (best-effort, for the summary) or null when unmatched.
+ */
+function detectToolMissing(output: string): { tool: string | null } | null {
+  if (typeof output !== "string" || output.length === 0) return null;
+
+  // 1. uv / spawn-wrapper (col 0): `error: Failed to spawn: `pytest`` (+ `Caused by: No
+  //    such file or directory`). Keyed on the distinctive `Failed to spawn:` framing.
+  let m = /^(?:error:\s*)?Failed to spawn:\s*(?<tool>[`'"]?[\w.\-/]+)/im.exec(output);
+  if (m) return { tool: cleanTool(m.groups?.tool) };
+
+  // 3a. shell (col 0): `bash: pytest: command not found` / `pytest: command not found`.
+  //     Anchored to end-of-line ($) so a mid-line assertion mention cannot match; the tool
+  //     token is plausibility-checked so `Error: command not found` is NOT misread.
+  m = /^(?:[\w.\-/]+:[ \t]*)?(?<tool>[\w.\-/]+):[ \t]*command not found[ \t]*$/im.exec(output);
+  if (m) {
+    const tool = plausibleTool(m.groups?.tool);
+    if (tool) return { tool };
+  }
+
+  // 3b. zsh (col 0): `zsh: command not found: pytest`. End-anchored.
+  m = /^(?:[\w.\-/]+:[ \t]*)?command not found:[ \t]*(?<tool>[\w.\-/]+)[ \t]*$/im.exec(output);
+  if (m) {
+    const tool = plausibleTool(m.groups?.tool);
+    if (tool) return { tool };
+  }
+
+  // 4b. dash/busybox (col 0): `sh: 1: pytest: not found` / `sh: pytest: not found`. The
+  //     `sh:` prefix is required, so this is tightly the shell's own line.
+  m = /^sh:[ \t]*(?:\d+:[ \t]*)?(?<tool>[\w.\-/]+):[ \t]*not found[ \t]*$/im.exec(output);
+  if (m) {
+    const tool = plausibleTool(m.groups?.tool);
+    if (tool) return { tool };
+  }
+
+  // 4a. npm (col 0): `npm ERR! could not determine executable to run` — no tool name.
+  if (/^npm ERR!.*could not determine executable/im.test(output)) return { tool: null };
+
+  // 5. CLI wrapper (col 0, clap/cobra framing): `error: unrecognized subcommand 'foo'`.
+  m = /^error:[ \t]*unrecognized subcommand[ \t:'"`]*(?<tool>[\w.\-]+)?/im.exec(output);
+  if (m) return { tool: cleanTool(m.groups?.tool ?? null) };
+
+  // 2. python (col 0): `... : No module named pytest` / `ModuleNotFoundError: No module
+  //    named 'pytest'` — ONLY when the module is a known TEST RUNNER (see the set), so a
+  //    missing APP dependency is left as a real failure (conservative).
+  m = /^(?:.*?:[ \t]*)?(?:ModuleNotFoundError:[ \t]*)?No module named[ \t]*['"]?(?<mod>[\w.]+)/im.exec(
+    output,
+  );
+  if (m) {
+    const mod = (m.groups?.mod ?? "").split(".")[0];
+    if (mod.length > 0 && TEST_RUNNER_MODULES.has(mod)) return { tool: mod };
+  }
+
+  return null;
+}
+
+/**
+ * Build the summary for a ran-but-tool-missing result. Reads unambiguously as a config/
+ * environment gap (NOT a code failure), names the missing tool, and states the policy
+ * (not adjudicated; fix loop skipped) so the operator knows to configure the test command
+ * rather than expect a coder to "fix" it.
+ */
+function toolMissingSummary(tool: string | null): string {
+  const name = tool ? `'${tool}'` : "a required test tool";
+  return `Test tooling not available: ${name} not found (command ran but its tool is missing) — configure implement.testCommand / perRepo for this repo. Not adjudicated; fix loop skipped.`.slice(
     0,
     SUMMARY_MAX,
   );
@@ -453,15 +607,37 @@ export function runTests(opts: RunTestsOptions): Promise<TestRunResult> {
     // skipped" summary naming the configured cap. The caller SKIPS the fix loop on the
     // `timedOut` flag (see the executor's `!result.timedOut` gate). A NORMAL exit keeps
     // the pass/fail summary with the captured output tail.
-    child.on("close", (code: number | null) =>
+    //
+    // TOOL-NOT-FOUND (ran-but-tool-missing): on a NON-ZERO, non-timeout exit we inspect the
+    // child's OWN output for a tool-missing signature (`uv run pytest` → uv ran but pytest
+    // is absent). A match is an ENVIRONMENT gap no code edit can fix, so — exactly like the
+    // top-level ENOENT (#444) — we classify it `ran:false` (the caller's `result.ran` gate
+    // SKIPS the fix loop, saving the whole budget) and flag `toolMissing` so it surfaces as
+    // NOT-ADJUDICATED (tooling), distinct from a real red. Only checked on a non-zero exit,
+    // and only against the runner's own line-anchored error framing (no false positives).
+    child.on("close", (code: number | null) => {
+      if (!timedOut && code !== 0) {
+        const missing = detectToolMissing(output);
+        if (missing) {
+          finish({
+            passed: false,
+            summary: toolMissingSummary(missing.tool),
+            exitCode: code,
+            timedOut: false,
+            ran: false, // env gap — no code fix; caller SKIPS the fix loop (like ENOENT).
+            toolMissing: true,
+          });
+          return;
+        }
+      }
       finish({
         passed: !timedOut && code === 0,
         summary: timedOut ? timeoutSummary(timeoutMs) : buildSummary(output, code, timedOut, truncated),
         exitCode: code,
         timedOut,
         ran: true,
-      }),
-    );
+      });
+    });
   });
 }
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -2024,6 +2024,15 @@ export interface ExecutionCriterion {
    * adjudicated runs and on pre-timeout-policy snapshots (no schemaVersion bump).
    */
   timedOut?: boolean;
+  /**
+   * Additive: the test command RAN but reported ITS OWN TOOL missing (e.g. `uv run
+   * pytest` where uv launched but pytest is absent) — an ENVIRONMENT gap classified
+   * `ran:false` (fix loop SKIPPED, like a launch failure) but surfaced as NOT-ADJUDICATED
+   * (tooling). Distinct from a real red (`passed:false`), a timeout (`timedOut`), and a
+   * bare launch failure (`ran:false` with no `toolMissing`). OPTIONAL/ADDITIVE — absent
+   * unless a tool-missing signature matched (no schemaVersion bump).
+   */
+  toolMissing?: boolean;
 }
 
 /** A worker agent: one action point (coder) or one research step. */

--- a/tests/unit/sdlc/final-verification.test.ts
+++ b/tests/unit/sdlc/final-verification.test.ts
@@ -93,6 +93,18 @@ const timedOut: TestRunResult = {
   exitCode: null,
   timedOut: true,
 };
+/** Tool-not-found at the final phase: the whole-suite command SPAWNED and ran, then exited
+ *  non-zero because its OWN tool is missing (`uv run pytest`, pytest absent). ran:false ⇒
+ *  the final fix loop must be SKIPPED; toolMissing ⇒ surfaced NOT-ADJUDICATED (tooling). */
+const toolMissing: TestRunResult = {
+  passed: false,
+  ran: false,
+  toolMissing: true,
+  summary:
+    "Test tooling not available: 'pytest' not found (command ran but its tool is missing) — configure implement.testCommand / perRepo for this repo. Not adjudicated; fix loop skipped.",
+  exitCode: 2,
+  timedOut: false,
+};
 
 function makeGitRaw() {
   return vi.fn(async (_repo: string, args: string[]) => {
@@ -372,6 +384,56 @@ describe("Stage A — final-run TIMEOUT (ambiguous) SKIPS the final fix loop, NO
   });
 
   it("CONTRAST: a non-timeout final RED still enters the final fix loop", async () => {
+    const runTests = sequencedRunTests([fail, pass]); // red → fix → pass
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(
+      baseReq({ finalVerification: FVCFG({ maxFinalFixIterations: 3 }) }),
+      deps as never,
+    );
+    expect(runTests).toHaveBeenCalledTimes(2); // initial + one re-verify
+    expect(res.finalVerification).toEqual(expect.objectContaining({ passed: true, fixIterations: 1 }));
+  });
+});
+
+describe("Stage A — final-run TOOL-NOT-FOUND (ran but tool missing) SKIPS the final fix loop, NOT-ADJUDICATED", () => {
+  it("a tool-not-found final run burns ZERO final fix iterations even with budget left (the omnius bug)", async () => {
+    const runTests = sequencedRunTests([toolMissing]);
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(
+      baseReq({ finalVerification: FVCFG({ maxFinalFixIterations: 3 }) }),
+      deps as never,
+    );
+    // ONE final run; the loop is skipped (ran:false env gap) despite a budget of 3.
+    expect(runTests).toHaveBeenCalledTimes(1);
+    // Only the 2 skilled implement steps; ZERO final fix coder re-invocations.
+    expect((deps.runCoder as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+    expect(res.finalVerification).toEqual(
+      expect.objectContaining({ ran: false, passed: false, fixIterations: 0, toolMissing: true }),
+    );
+    // NEVER blocks PR creation.
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+  });
+
+  it("classifies the final block NOT-ADJUDICATED (tooling), never RED/REGRESSION/NOT-RUN", async () => {
+    const runTests = sequencedRunTests([toolMissing]);
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(
+      baseReq({ finalVerification: FVCFG({ maxFinalFixIterations: 3 }) }),
+      deps as never,
+    );
+    const body = prBody(deps);
+    expect(body).toMatch(/Final-state re-verification: NOT-ADJUDICATED \(tooling\)/);
+    expect(body).not.toMatch(/Final-state re-verification: RED/);
+    expect(body).not.toMatch(/Final-state re-verification: NOT-RUN/);
+    expect(body).not.toMatch(/REGRESSION/);
+    expect(body).toMatch(/TOOL NOT AVAILABLE/i);
+    expect(body).toMatch(/config\/environment gap/i);
+    // The testSummary (convergence wire) grounds the next review on NOT-ADJUDICATED.
+    expect(res.testSummary).toMatch(/NOT-ADJUDICATED \(tooling\)/);
+    expect(res.testSummary).not.toMatch(/REGRESSION/);
+  });
+
+  it("CONTRAST: a non-tool-missing final RED still enters the final fix loop", async () => {
     const runTests = sequencedRunTests([fail, pass]); // red → fix → pass
     const deps = makeDeps({ runTests });
     const res = await runSdlcHandoff(

--- a/tests/unit/sdlc/test-runner.test.ts
+++ b/tests/unit/sdlc/test-runner.test.ts
@@ -365,3 +365,109 @@ describe("runTests / verifyInWorktree — degrade, never throw", () => {
     expect(calls[0].options.cwd).toBe(WT);
   });
 });
+
+// ─── TOOL-NOT-FOUND (ran-but-tool-missing) classification ───────────────────
+//
+// The command SPAWNED fine (unlike ENOENT) and ran, then exited NON-ZERO reporting that
+// ITS OWN tool is missing (`uv run pytest` → uv present, pytest absent). Without this it
+// looks like a real red and burns the fix budget on an env gap. It must classify like a
+// launch failure — ran:false (fix loop skipped) — but flagged `toolMissing:true` and with
+// an ENV-flavored, actionable summary. The KEY RISK is the inverse: a GENUINE test failure
+// that merely mentions these words in an assertion must STILL be ran:true (enters the loop).
+describe("runTests — tool-not-found (ran but its own tool missing) ⇒ ran:false, toolMissing", () => {
+  it("uv `Failed to spawn: pytest` (exit 2) ⇒ ran:false + toolMissing + env-flavored summary", async () => {
+    // The exact omnius live-bug output: uv launched, pytest was not installed.
+    const stderr = "error: Failed to spawn: `pytest`\n  Caused by: No such file or directory (os error 2)\n";
+    const { fn } = makeSpawn({ stderr, code: 2 });
+    const res = await runTests({ worktreeDir: WT, command: CMD, spawnFn: fn });
+    expect(res.ran).toBe(false); // ← env gap, NOT a test failure — caller SKIPS the fix loop
+    expect(res.toolMissing).toBe(true);
+    expect(res.passed).toBe(false);
+    expect(res.exitCode).toBe(2); // the child DID run + exit (unlike a spawn ENOENT → null)
+    expect(res.summary).toMatch(/Test tooling not available/i);
+    expect(res.summary).toMatch(/'pytest'/);
+    expect(res.summary).toMatch(/Not adjudicated; fix loop skipped/i);
+    expect(res.summary).toMatch(/configure implement\.testCommand/);
+  });
+
+  it.each([
+    ["shell bash: `bash: pytest: command not found`", "bash: pytest: command not found\n", "pytest"],
+    ["shell plain: `pytest: command not found`", "pytest: command not found\n", "pytest"],
+    ["zsh: `zsh: command not found: pytest`", "zsh: command not found: pytest\n", "pytest"],
+    ["dash: `sh: 1: pytest: not found`", "sh: 1: pytest: not found\n", "pytest"],
+    ["python module: `No module named pytest`", "/usr/bin/python: No module named pytest\n", "pytest"],
+    ["python ModuleNotFoundError: pytest", "ModuleNotFoundError: No module named 'pytest'\n", "pytest"],
+  ])("%s ⇒ ran:false + toolMissing", async (_label, stderr, tool) => {
+    const { fn } = makeSpawn({ stderr, code: 1 });
+    const res = await runTests({ worktreeDir: WT, command: CMD, spawnFn: fn });
+    expect(res.ran).toBe(false);
+    expect(res.toolMissing).toBe(true);
+    expect(res.summary).toMatch(new RegExp(`'${tool}'`));
+  });
+
+  it("npm `could not determine executable` (no tool name) ⇒ ran:false + toolMissing (generic)", async () => {
+    const { fn } = makeSpawn({ stderr: "npm ERR! could not determine executable to run\n", code: 1 });
+    const res = await runTests({ worktreeDir: WT, command: CMD, spawnFn: fn });
+    expect(res.ran).toBe(false);
+    expect(res.toolMissing).toBe(true);
+    expect(res.summary).toMatch(/a required test tool/i);
+  });
+
+  it("CLI wrapper `error: unrecognized subcommand` ⇒ ran:false + toolMissing", async () => {
+    const { fn } = makeSpawn({ stderr: "error: unrecognized subcommand 'run'\n", code: 2 });
+    const res = await runTests({ worktreeDir: WT, command: CMD, spawnFn: fn });
+    expect(res.ran).toBe(false);
+    expect(res.toolMissing).toBe(true);
+  });
+
+  // ── the CRITICAL no-false-positive guard ──────────────────────────────────
+  it("NO FALSE POSITIVE: a GENUINE test failure whose ASSERTION mentions 'pytest' / 'command not found' / 'not found' ⇒ STILL ran:true (enters the fix loop)", async () => {
+    // A real vitest red whose diff QUOTES these exact words — but indented + inside quotes,
+    // never at column 0 ending its own line. Line-anchored (col-0, `$`) signatures must NOT
+    // match this, or a real red would be masked as an env gap (the reviewer's key risk).
+    const stdout = [
+      "FAIL  src/spawn.test.ts > surfaces a helpful message when a binary is absent",
+      "AssertionError: expected error to contain the string",
+      `  Expected: "command not found: pytest"`,
+      `  Received: "No module named pytest was the wrong message"`,
+      "  the CLI should print 'pytest: command not found' but printed 'not found' alone",
+      " ❯ src/spawn.test.ts:12:34",
+      "",
+      "Test Files  1 failed (1)",
+      "     Tests  1 failed (1)",
+    ].join("\n");
+    const { fn } = makeSpawn({ stdout, code: 1 });
+    const res = await runTests({ worktreeDir: WT, command: CMD, spawnFn: fn });
+    expect(res.ran).toBe(true); // ← a REAL red — the fix loop MUST engage
+    expect(res.toolMissing).toBeUndefined();
+    expect(res.passed).toBe(false);
+    expect(res.summary).toMatch(/FAILED/);
+  });
+
+  it("NO FALSE POSITIVE: exit 0 with a tool-missing-looking string in output ⇒ passed:true, never toolMissing (detection is gated on non-zero exit)", async () => {
+    const { fn } = makeSpawn({ stdout: "pytest: command not found\n", code: 0 });
+    const res = await runTests({ worktreeDir: WT, command: CMD, spawnFn: fn });
+    expect(res.passed).toBe(true);
+    expect(res.toolMissing).toBeUndefined();
+  });
+
+  it("NO FALSE POSITIVE: a thrown `Error: command not found` at col 0 ⇒ ran:true (framing word rejected — not a shell tool)", async () => {
+    // A test throwing `new Error("command not found")` can print `Error: command not found`
+    // at column 0 (unhandled rejection). The token before the colon is a framing word
+    // (`Error`), NOT an invoked command — the plausibility guard must reject it so this
+    // stays a REAL failure that engages the fix loop.
+    const { fn } = makeSpawn({ stderr: "Error: command not found\n    at foo (x.ts:1:1)\n", code: 1 });
+    const res = await runTests({ worktreeDir: WT, command: CMD, spawnFn: fn });
+    expect(res.ran).toBe(true);
+    expect(res.toolMissing).toBeUndefined();
+  });
+
+  it("NON-runner missing module (`No module named requests`) is left as a REAL failure ⇒ ran:true (tight allowlist — no over-classification)", async () => {
+    // A missing APP dependency is NOT in the test-runner allowlist; conservatively treated
+    // as a real (adjudicated) failure so we never mask genuine reds behind an env label.
+    const { fn } = makeSpawn({ stderr: "ModuleNotFoundError: No module named 'requests'\n", code: 1 });
+    const res = await runTests({ worktreeDir: WT, command: CMD, spawnFn: fn });
+    expect(res.ran).toBe(true);
+    expect(res.toolMissing).toBeUndefined();
+  });
+});

--- a/tests/unit/sdlc/verification-loop.test.ts
+++ b/tests/unit/sdlc/verification-loop.test.ts
@@ -81,6 +81,19 @@ const timedOut: TestRunResult = {
   exitCode: null,
   timedOut: true,
 };
+/** The tool-not-found bug shape (the omnius live run): the command SPAWNED and ran, then
+ *  exited non-zero because ITS OWN tool is missing (`uv run pytest`, pytest not installed).
+ *  ran:false ⇒ the fix loop must be SKIPPED (an env gap no code change fixes); toolMissing
+ *  ⇒ surfaced as NOT-ADJUDICATED (tooling), distinct from a launch failure or a real red. */
+const toolMissing: TestRunResult = {
+  passed: false,
+  ran: false,
+  toolMissing: true,
+  summary:
+    "Test tooling not available: 'pytest' not found (command ran but its tool is missing) — configure implement.testCommand / perRepo for this repo. Not adjudicated; fix loop skipped.",
+  exitCode: 2,
+  timedOut: false,
+};
 
 function makeGitRaw() {
   return vi.fn(async (_repo: string, args: string[]) => {
@@ -321,6 +334,84 @@ describe("Stage 2b — test-run TIMEOUT (ambiguous) SKIPS the fix loop, NOT-ADJU
 
   it("emits NO fix-coder progress beat for a timed-out run", async () => {
     const runTests = sequencedRunTests([timedOut]);
+    const deps = makeDeps({ runTests });
+    const events: SdlcProgress[] = [];
+    await runSdlcHandoff(
+      baseReq({ verification: VCFG({ maxFixIterations: 3 }) }),
+      deps as never,
+      (p) => events.push(JSON.parse(JSON.stringify(p)) as SdlcProgress),
+    );
+    expect(events.some((e) => e.step === "test-runner")).toBe(true);
+    expect(events.some((e) => e.step === "fix-coder")).toBe(false);
+  });
+});
+
+describe("Stage 2b — tool-not-found (ran but tool missing) SKIPS the fix loop, NOT-ADJUDICATED", () => {
+  it("a tool-not-found run burns ZERO fix iterations even with budget left (the omnius bug)", async () => {
+    // The live omnius bug: 3 APs each burned 3 fix iterations on `Failed to spawn: pytest`.
+    // The run exited non-zero, but ran:false (env gap) ⇒ the loop must skip entirely.
+    const runTests = sequencedRunTests([toolMissing]);
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(baseReq({ verification: VCFG({ maxFixIterations: 3 }) }), deps as never);
+
+    // Exactly ONE test run — the initial one — then the loop is skipped (no re-verify).
+    expect(runTests).toHaveBeenCalledTimes(1);
+    // Only the 2 skilled implement steps ran; ZERO fix-coder re-invocations (budget saved).
+    expect((deps.runCoder as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+    // The Draft PR still opens (never blocked).
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+  });
+
+  it("CONTRAST: a real red whose OUTPUT mentions the tool (ran:true) STILL enters the fix loop", async () => {
+    // The no-false-positive guarantee at the loop level: a genuinely-red run (ran:true) is a
+    // NORMAL signal — even if its summary text mentions pytest/not-found — and MUST engage
+    // the loop. Only the ran:false env gap is skipped.
+    const redMentioningTool: TestRunResult = {
+      passed: false,
+      ran: true,
+      summary: "FAILED (exit 1)\nAssertionError: expected 'command not found: pytest' in output",
+      exitCode: 1,
+      timedOut: false,
+    };
+    const runTests = sequencedRunTests([redMentioningTool, pass]); // red → fix → pass
+    const deps = makeDeps({ runTests });
+    await runSdlcHandoff(baseReq({ verification: VCFG({ maxFixIterations: 3 }) }), deps as never);
+    expect((deps.runCoder as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(3); // 2 skilled + 1 fix
+    expect(runTests).toHaveBeenCalledTimes(2); // initial + one re-verify
+  });
+
+  it("classifies the criterion NOT-ADJUDICATED (tooling), never FAIL/RED, in the PR body + testSummary", async () => {
+    const runTests = sequencedRunTests([toolMissing]);
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(baseReq({ verification: VCFG({ maxFixIterations: 3 }) }), deps as never);
+
+    const prBody = (deps.openPr as ReturnType<typeof vi.fn>).mock.calls[0][1].body as string;
+    // The per-AP verify tag reads not-adjudicated (tooling), never RED.
+    expect(prBody).toMatch(/not-adjudicated \(tooling\)/i);
+    expect(prBody).not.toMatch(/\bRED\b/);
+    // The gate flags it (unmet P0) and surfaces the actionable env-gap summary.
+    expect(prBody).toMatch(/FLAGGED/);
+    expect(prBody).toMatch(/NOT-ADJUDICATED \(tooling\)/);
+    expect(prBody).toMatch(/Test tooling not available/i);
+    expect(prBody).toMatch(/configure implement\.testCommand/);
+    // The round testSummary (convergence wire) grounds the next review on NOT-ADJUDICATED.
+    expect(res.testSummary).toMatch(/NOT-ADJUDICATED \(tooling\)/);
+    expect(res.testSummary).not.toMatch(/\[FAIL\]/);
+  });
+
+  it("stamps toolMissing:true on the trace criterion (ran:false, not a regression)", async () => {
+    const runTests = sequencedRunTests([toolMissing]);
+    const deps = makeDeps({ runTests });
+    const res = await runSdlcHandoff(baseReq({ verification: VCFG({ maxFixIterations: 3 }) }), deps as never);
+    const crit = res.executionTrace?.controller.workers[0].criteria[0];
+    expect(crit?.toolMissing).toBe(true);
+    expect(crit?.ran).toBe(false); // env gap — like a launch failure, unlike a timeout
+    expect(crit?.passed).toBe(false);
+    expect(crit?.timedOut).toBeUndefined(); // NOT conflated with the timeout policy
+  });
+
+  it("emits NO fix-coder progress beat for a tool-not-found run", async () => {
+    const runTests = sequencedRunTests([toolMissing]);
     const deps = makeDeps({ runTests });
     const events: SdlcProgress[] = [];
     await runSdlcHandoff(


### PR DESCRIPTION
## The bug (live evidence, omnius)

PR #444 classified **top-level spawn failures** (ENOENT/EACCES — the command binary itself missing) as `ran:false` / NOT-ADJUDICATED, so the fix loop is skipped. But when the command **runs** and reports that **its own tool** is missing — e.g. `uv run pytest` where `uv` spawns fine but `pytest` isn't installed → `uv` exits 2 with `Failed to spawn: pytest — No such file or directory` — the old code saw *uv spawned + a non-zero exit* and treated it as a **real test failure**, burning the whole fix budget (3 coder attempts) on an environment problem no code change can fix.

Observed on a live omnius run: **3 action points each burned 3 fix iterations** on `Failed to spawn: pytest`.

## The fix (extends #444/#449, no regression)

On a **non-zero, non-timeout exit**, `runTests` now inspects the child's **own** combined output for a tool-missing signature. A match is an environment gap → classified `ran:false` (fix loop skipped, **exactly like #444's ENOENT**) plus an additive `toolMissing` flag so it surfaces as **NOT-ADJUDICATED (tooling)** — distinct from a launch failure, a timeout (#449), and a real red.

Applied in **both** loops: `runVerifyFixLoop` (per-AP) and `runFinalVerification` (final-state). A tool-not-found result skips the fix loop **and** is not counted as a red criterion; it is surfaced NOT-ADJUDICATED in the per-AP verify tag, the pre-PR gate, the final-state block, the `testSummary` convergence wire, and the execution trace (reusing the #449 NOT-ADJUDICATED path).

Actionable, distinct summary:
> `Test tooling not available: 'pytest' not found (command ran but its tool is missing) — configure implement.testCommand / perRepo for this repo. Not adjudicated; fix loop skipped.`

## The tight signature set

Case-insensitive, **line-anchored to column 0** (the runner's/shell's own error framing), end-anchored where applicable:

| Tool | Signature |
|------|-----------|
| uv / spawn-wrapper | `error: Failed to spawn: `<tool>`` |
| shell (bash/plain) | `<tool>: command not found$` |
| zsh | `command not found: <tool>$` |
| dash/busybox | `sh: [n:] <tool>: not found$` |
| npm | `npm ERR! … could not determine executable` |
| CLI wrapper (clap/cobra) | `error: unrecognized subcommand …` |
| python | `No module named <runner>` — **only** for an allowlisted test runner (`pytest`/`unittest`/`nose`/`nose2`/`tox`); a missing app dep is left as a real failure |

Kept deliberately **tight**: prefer a false-negative (treat as a real failure, enter the fix loop) over a false-positive (mask a real red).

## No-false-positive guarantee

The key risk is a false positive masking a real test failure. Defenses:

1. **Column-0 line anchoring** (`^…` + `m`, `$`-anchored) — a genuine assertion diff that merely quotes `pytest` / `command not found` / `not found` is **indented and/or quoted** (`  Expected: "command not found: pytest"`), never at column 0 ending its own line, so it does **not** match.
2. **Framing-word guard** — the shell patterns reject a token like `Error`/`AssertionError`/`Expected` before the colon, so a thrown `Error: command not found` at col 0 stays a **real** failure.
3. **Gated on a non-zero exit** — an exit-0 run with a matching string is never reclassified.
4. **Runs on raw (pre-scrub) output** so line structure is intact.

Proven by tests: a real failing test whose **assertion** contains `pytest` / `command not found` / `not found` **still** returns `ran:true` and **enters the fix loop**; `Error: command not found` at col 0 → `ran:true`; a non-runner missing module → `ran:true`.

## Test coverage (tsc + vitest; per-AP + final)

- `test-runner.test.ts` — every signature → `ran:false` + `toolMissing`; the exact omnius `Failed to spawn: pytest` (exit 2); **3 no-false-positive tests** (assertion mention, framing-word `Error:`, non-runner module) + exit-0 gate.
- `verification-loop.test.ts` — per-AP: tool-not-found burns **0 fix iterations** with budget=3, surfaces NOT-ADJUDICATED (tooling) in PR body + testSummary, stamps `toolMissing` on the trace criterion (`ran:false`, no `timedOut`), no fix-coder beat; CONTRAST: a real red still enters the loop.
- `final-verification.test.ts` — final phase: tool-not-found burns **0 final fix iterations**, `NOT-ADJUDICATED (tooling)` block + testSummary, never RED/REGRESSION/NOT-RUN; CONTRAST: a real red still enters the loop.

Full suite green (5925 passed, 5 pre-existing skips from #479). `#444` ENOENT and `#449` timeout paths still work unchanged. No FSM/schema/migration; additive optional fields only (mirroring how #449 added `timedOut?`).

> Draft — do not merge.