### PR TITLE
fix: parallel executor fan-out produced no commits (worktree/merge bug)

### DIFF
--- a/server/services/consilium/pr-wrapper.ts
+++ b/server/services/consilium/pr-wrapper.ts
@@ -95,12 +95,20 @@ const execFileAsync: ExecFileFn = promisify(execFile);
 const BRANCH_RE = /^consilium\/loop-[0-9a-f-]{36}\/round-[0-9]+$/;
 /**
  * Parallel-develop: the PER-ACTION-POINT worktree branch shape,
- * `consilium/loop-<uuid>/round-<n>/ap-<k>`. Server-derived (loopId + round + 1-based AP
+ * `consilium/loop-<uuid>/round-<n>-ap-<k>`. Server-derived (loopId + round + 1-based AP
  * index) — NEVER model text. A DEDICATED shape (not the round branch) so a per-AP branch
  * can NEVER be mistaken for a PR head: `isValidLoopBranch` (the PR-head gate) stays strict,
  * while `isValidLoopWorktreeBranch` (worktree creation only) accepts EITHER shape.
+ *
+ * BUG-FIX (worktree fan-out produced 0 commits): the AP segment is a SIBLING of the round
+ * branch (`round-<n>-ap-<k>`), NOT a child (`round-<n>/ap-<k>`). git stores each branch as a
+ * loose ref FILE, so once the round branch `…/round-<n>` exists, a child ref `…/round-<n>/ap-<k>`
+ * is a directory/file (D/F) conflict — `git worktree add` fails with "cannot lock ref … exists;
+ * cannot create …". That made EVERY per-AP worktree creation throw ⇒ every AP failed ⇒ no
+ * branches, no commits. The sibling shape shares only the `round-<n>` PREFIX (not the ref path),
+ * so `…/round-<n>` and `…/round-<n>-ap-<k>` coexist as distinct loose refs.
  */
-const AP_BRANCH_RE = /^consilium\/loop-[0-9a-f-]{36}\/round-[0-9]+\/ap-[0-9]+$/;
+const AP_BRANCH_RE = /^consilium\/loop-[0-9a-f-]{36}\/round-[0-9]+-ap-[0-9]+$/;
 /** Well-formed `owner/repo` (GitHub slug chars only) — H-7 origin validation. */
 const OWNER_REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
 
@@ -140,7 +148,7 @@ export function isValidLoopBranch(branch: string): boolean {
 }
 
 /** Parallel-develop: true iff `branch` is a server-derived per-ACTION-POINT branch
- *  (`consilium/loop-<uuid>/round-<n>/ap-<k>`). */
+ *  (`consilium/loop-<uuid>/round-<n>-ap-<k>`). */
 export function isValidLoopApBranch(branch: string): boolean {
   return AP_BRANCH_RE.test(branch);
 }
@@ -154,12 +162,16 @@ export function isValidLoopWorktreeBranch(branch: string): boolean {
 
 /**
  * Parallel-develop: build the per-ACTION-POINT worktree branch
- * (`consilium/loop-<uuid>/round-<n>/ap-<k>`) from SERVER-controlled inputs (loopId + round +
+ * (`consilium/loop-<uuid>/round-<n>-ap-<k>`) from SERVER-controlled inputs (loopId + round +
  * 1-based AP index) — NEVER model/action-point text. Gated through `isValidLoopApBranch`
  * before it reaches git, exactly like `buildBranchName`/`isValidLoopBranch` for the round.
+ *
+ * The `-ap-<k>` segment is a SIBLING of the round branch, not a child path (`/ap-<k>`): a child
+ * ref collides with the round branch's loose ref FILE (git D/F conflict) and makes every
+ * `git worktree add` throw. See `AP_BRANCH_RE` for the full incident note.
  */
 export function buildApBranchName(loopId: string, round: number, apIndex: number): string {
-  return `consilium/loop-${loopId}/round-${round}/ap-${apIndex}`;
+  return `consilium/loop-${loopId}/round-${round}-ap-${apIndex}`;
 }
 
 /**

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -967,6 +967,8 @@ export async function runSdlcHandoff(
       let committedCount: number;
       // Stage B: per-criterion method routing context (INERT unless perCriterionMethod on).
       const routing = { enabled: req.perCriterionMethod ?? false, judgeVerify: deps.judgeVerify };
+      // The per-AP IO shared by the fan-out workers, the sequential default, and the fallback.
+      const apIo: ApImplementIo = { gitRaw, runCoder, progress, skilledSteps, verify: verifyCtx, routing };
 
       // Parallel-develop (design §4): when the switch is on AND there is >1 AP to fan out,
       // run the round in DEPENDENCY-AWARE WAVES — each AP in its OWN worktree branched off
@@ -976,12 +978,7 @@ export async function runSdlcHandoff(
       if ((req.parallel?.enabled ?? false) && total > 1) {
         const waveResult = await runWaveScheduledImplement(
           {
-            gitRaw,
-            runCoder,
-            progress,
-            skilledSteps,
-            verify: verifyCtx,
-            routing,
+            ...apIo,
             createWorktree,
             removeWorktree,
             maxConcurrency: req.parallel!.maxConcurrency,
@@ -993,30 +990,28 @@ export async function runSdlcHandoff(
           req,
           wt,
         );
-        outcomes = waveResult.outcomes;
-        committedCount = waveResult.committedCount;
-      } else {
-        // SEQUENTIAL per-action-point runs in the ONE shared worktree (avoid edit
-        // conflicts). Each `runActionPoint` NEVER throws — a coder timeout/error is
-        // caught, its work committed `[partial]`, and the loop continues.
-        outcomes = [];
-        committedCount = 0;
-        for (let i = 0; i < total; i++) {
-          const outcome = await runActionPoint(
-            { gitRaw, runCoder, progress, completedBefore: committedCount, skilledSteps, verify: verifyCtx, routing },
-            wt,
-            req,
-            req.actionPoints[i],
-            i + 1,
-            total,
+        // FAIL-LOUD FALLBACK (fan-out fix): if the fan-out landed NOTHING on the integration
+        // branch AND at least one AP failed at worktree SETUP (the D/F-ref / git-admin
+        // breakage class), the parallel machinery is broken for this round — degrade to the
+        // SEQUENTIAL path so the operator gets working output, not an empty 0-commit PR. Guard
+        // on committedCount===0 so we NEVER double-run: if any AP already landed on `wt`, the
+        // fan-out worked and we keep its result untouched. `wt` is still at the base commit
+        // here (nothing merged), so the sequential re-run starts clean.
+        if (waveResult.committedCount === 0 && waveResult.setupFailures > 0) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[parallel-develop] loop=${req.loopId} round=${req.round}: fan-out produced 0 commits ` +
+              `with ${waveResult.setupFailures}/${total} worktree-setup failure(s) — FALLING BACK to ` +
+              `the sequential path so the round still produces output.`,
           );
-          outcomes.push(outcome);
-          if (outcome.committed) committedCount += 1;
-          // AP end: fold the settled status into the shared live snapshot. It surfaces
-          // on the very next beat (the next AP's start, or the push/done beat below) —
-          // the poll-based UI reads the latest snapshot, so no separate end beat.
-          progress.setStatus(i + 1, outcome.status);
+          ({ outcomes, committedCount } = await runSequentialImplement(apIo, wt, req));
+        } else {
+          outcomes = waveResult.outcomes;
+          committedCount = waveResult.committedCount;
         }
+      } else {
+        // SEQUENTIAL per-action-point runs in the ONE shared worktree (avoid edit conflicts).
+        ({ outcomes, committedCount } = await runSequentialImplement(apIo, wt, req));
       }
 
       // Stage A: FINAL-STATE re-verification. After every action point has been applied
@@ -1440,7 +1435,13 @@ async function runWaveScheduledImplement(
   ctx: WaveImplementCtx,
   req: SdlcHandoffRequest,
   integrationWt: CreateWorktreeResult,
-): Promise<{ outcomes: ApOutcome[]; committedCount: number; waveCount: number; mergeConflicts: number }> {
+): Promise<{
+  outcomes: ApOutcome[];
+  committedCount: number;
+  waveCount: number;
+  mergeConflicts: number;
+  setupFailures: number;
+}> {
   const total = req.actionPoints.length;
   // Original 1-based ordinal per AP (identity map — the schedule reorders but never clones).
   const ordinalOf = new Map<ActionPoint, number>();
@@ -1454,6 +1455,10 @@ async function runWaveScheduledImplement(
   const outcomes = new Array<ApOutcome | undefined>(total);
   let committedCount = 0;
   let mergeConflicts = 0;
+  // Per-AP worktree-creation failures (the D/F-ref / git-admin breakage class). When the WHOLE
+  // fan-out trips this uniformly (every AP), committedCount stays 0 and the caller degrades to
+  // the sequential path so the round still produces output instead of an empty PR.
+  let setupFailures = 0;
   const gitAdmin = createGitAdminMutex();
 
   for (const wave of waves) {
@@ -1507,7 +1512,11 @@ async function runWaveScheduledImplement(
           return { index, ap, apBranch, outcome };
         } catch (err) {
           // Create-worktree (or an unexpected throw) failed for THIS AP — surface it as a
-          // failed outcome (never silent) and let the round continue.
+          // failed outcome (never silent), COUNT it as a setup failure (drives the caller's
+          // sequential fallback when the whole fan-out breaks), and let the round continue.
+          // The read-then-write is synchronous (no await between), so it is race-free despite
+          // the concurrent lanes.
+          setupFailures += 1;
           const { priority, title } = apLabels(ap);
           ctx.progress.setStatus(index, "failed");
           return {
@@ -1584,7 +1593,41 @@ async function runWaveScheduledImplement(
     outcomes[i] = { index: i + 1, priority, title, status: "failed", committed: false, note: "round wall-clock deadline exceeded" };
   }
 
-  return { outcomes: outcomes as ApOutcome[], committedCount, waveCount: waves.length, mergeConflicts };
+  return { outcomes: outcomes as ApOutcome[], committedCount, waveCount: waves.length, mergeConflicts, setupFailures };
+}
+
+/**
+ * SEQUENTIAL per-action-point implement loop in the ONE shared (integration) worktree — the
+ * DEFAULT path (parallel off) AND the fan-out FALLBACK. Each `runActionPoint` NEVER throws (a
+ * coder timeout/error is caught, its work committed `[partial]`, and the loop continues), so
+ * this returns a full outcome set. Behavior is byte-for-byte the historical inline loop — it
+ * was extracted verbatim so the off-path and the fallback share ONE implementation.
+ */
+async function runSequentialImplement(
+  io: ApImplementIo,
+  wt: CreateWorktreeResult,
+  req: SdlcHandoffRequest,
+): Promise<{ outcomes: ApOutcome[]; committedCount: number }> {
+  const total = req.actionPoints.length;
+  const outcomes: ApOutcome[] = [];
+  let committedCount = 0;
+  for (let i = 0; i < total; i++) {
+    const outcome = await runActionPoint(
+      { ...io, completedBefore: committedCount },
+      wt,
+      req,
+      req.actionPoints[i],
+      i + 1,
+      total,
+    );
+    outcomes.push(outcome);
+    if (outcome.committed) committedCount += 1;
+    // AP end: fold the settled status into the shared live snapshot. It surfaces on the very
+    // next beat (the next AP's start, or the push/done beat) — the poll-based UI reads the
+    // latest snapshot, so no separate end beat.
+    io.progress.setStatus(i + 1, outcome.status);
+  }
+  return { outcomes, committedCount };
 }
 
 /**

--- a/server/services/sdlc/worktree.ts
+++ b/server/services/sdlc/worktree.ts
@@ -122,8 +122,10 @@ export async function createSdlcWorktree(opts: CreateWorktreeOptions): Promise<C
   const repo = assertAllowedRepoPath(opts.repoPath, opts.allowedRepoPaths);
 
   // B-3: the branch must be an EXACT server-derived shape — the round branch
-  // (`round-<n>`) OR, for parallel-develop, a per-AP branch (`round-<n>/ap-<k>`).
-  // Reject anything else (incl. a leading-dash branch) before git runs.
+  // (`round-<n>`) OR, for parallel-develop, a per-AP branch (`round-<n>-ap-<k>`, a
+  // SIBLING of the round branch — a child `round-<n>/ap-<k>` would be a git ref D/F
+  // conflict with the round branch's loose ref file). Reject anything else (incl. a
+  // leading-dash branch) before git runs.
   if (opts.branch.startsWith("-") || !isValidLoopWorktreeBranch(opts.branch)) {
     throw new Error(`createSdlcWorktree: rejected branch name (B-3): ${opts.branch}`);
   }

--- a/tests/integration/sdlc-worktree-fanout.test.ts
+++ b/tests/integration/sdlc-worktree-fanout.test.ts
@@ -1,0 +1,166 @@
+/**
+ * sdlc-worktree-fanout.test.ts — REAL-GIT integration for parallel-develop fan-out.
+ *
+ * WHY THIS EXISTS (the incident it locks down): the parallel-develop fan-out shipped with a
+ * per-AP branch shape `consilium/loop-<id>/round-<n>/ap-<k>` — a CHILD of the round branch.
+ * git stores each branch as a loose ref FILE, so once the round branch `…/round-<n>` exists,
+ * creating a child ref `…/round-<n>/ap-<k>` is a directory/file (D/F) conflict and
+ * `git worktree add` fails with "cannot lock ref … exists; cannot create …". EVERY per-AP
+ * worktree creation threw ⇒ every AP failed ⇒ ZERO branches, ZERO commits, integration stayed
+ * at base. The fully-mocked unit tests never hit real git, so they MISSED it. This test drives
+ * the REAL `createSdlcWorktree` / `removeSdlcWorktree` / git runner against a scratch repo, so
+ * a regression to the child shape (or any real-git fan-out breakage) fails here deterministically.
+ *
+ * The only injected seams are the CODER (writes a file so the tree is dirty; the executor
+ * stages + commits it) and push/openPr (no network). Everything git is real.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { execFileSync } from "child_process";
+import { mkdtempSync, rmSync, readFileSync, realpathSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { writeFile } from "fs/promises";
+import {
+  runSdlcHandoff,
+  type SdlcHandoffRequest,
+} from "../../server/services/sdlc/executor.js";
+import type { ActionPoint } from "@shared/types";
+
+const LOOP = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const ROUND = 1;
+const ROUND_BRANCH = `consilium/loop-${LOOP}/round-${ROUND}`;
+
+let repoDir: string;
+let baseSha: string;
+
+/** Run a real git command in `repoDir`, returning trimmed stdout. */
+function git(...args: string[]): string {
+  return execFileSync("git", ["-C", repoDir, ...args], { encoding: "utf8" }).trim();
+}
+
+beforeEach(() => {
+  // A scratch repo under the OS temp root, realpath'd so it agrees with the allowlist check
+  // (assertAllowedRepoPath realpaths both sides — on macOS /var → /private/var).
+  repoDir = realpathSync(mkdtempSync(join(tmpdir(), "sdlc-fanout-repo-")));
+  git("init", "-q", "-b", "main");
+  git("config", "user.email", "test@example.com");
+  git("config", "user.name", "Test");
+  git("config", "commit.gpgsign", "false");
+  execFileSync("git", ["-C", repoDir, "commit", "-q", "--allow-empty", "-m", "base"]);
+  baseSha = git("rev-parse", "HEAD");
+});
+
+afterEach(() => {
+  // Best-effort: drop any worktrees the run may have left, then the repo.
+  try {
+    execFileSync("git", ["-C", repoDir, "worktree", "prune"]);
+  } catch {
+    /* ignore */
+  }
+  rmSync(repoDir, { recursive: true, force: true });
+});
+
+/** Three independent APs, each writing a distinct file (via the fake coder). */
+const APS: ActionPoint[] = [
+  { title: "alpha", priority: "P0" },
+  { title: "beta", priority: "P0" },
+  { title: "gamma", priority: "P0" },
+];
+
+/** Fake coder: writes `<title>.txt` into the per-AP worktree so the executor commits it. */
+function makeFileWritingCoder() {
+  return vi.fn(async (worktreeDir: string, aps: readonly ActionPoint[]) => {
+    const ap = aps[0];
+    await writeFile(join(worktreeDir, `${ap.title}.txt`), `content for ${ap.title}\n`, "utf8");
+    return { ok: true, summary: `wrote ${ap.title}.txt`, tokensUsed: 1 };
+  });
+}
+
+function baseReq(over: Partial<SdlcHandoffRequest> = {}): SdlcHandoffRequest {
+  return {
+    repoPath: repoDir,
+    loopId: LOOP,
+    round: ROUND,
+    actionPoints: APS,
+    allowedRepoPaths: [repoDir],
+    base: "main",
+    baseRef: baseSha, // cut the integration branch off the base commit
+    parallel: { enabled: true, maxConcurrency: 3 },
+    ...over,
+  };
+}
+
+function baseDeps(over: Record<string, unknown> = {}) {
+  return {
+    runCoder: makeFileWritingCoder(),
+    push: vi.fn(async () => ({ ok: true as const, branch: ROUND_BRANCH })),
+    openPr: vi.fn(async () => ({ ok: true as const, prUrl: "https://github.com/x/y/pull/1" })),
+    resolveDefaultBranchFn: vi.fn(async () => "main"),
+    // createWorktree / removeWorktree / gitRaw are the REAL defaults (not injected).
+    ...over,
+  };
+}
+
+describe("parallel-develop fan-out — REAL git", () => {
+  it("creates a per-AP SIBLING branch, commits in each worktree, merges all into the integration branch", async () => {
+    const deps = baseDeps();
+    const res = await runSdlcHandoff(baseReq(), deps as never);
+
+    // A PR opened ⇒ commits landed (pushAndOpenPr returns null on ZERO commits — the exact
+    // symptom of the bug this locks down).
+    expect(res.error).toBeUndefined();
+    expect(res.prRef).toBe("https://github.com/x/y/pull/1");
+    expect(res.headCommit).toMatch(/^[0-9a-f]{40}$/);
+
+    // The integration branch ADVANCED past the base (git rev-list --count base..head > 0 was
+    // literally 0 in the incident). Each AP = its own commit + a --no-ff merge commit ⇒ >= 3.
+    const advanced = Number(git("rev-list", "--count", `${baseSha}..${res.headCommit}`));
+    expect(advanced).toBeGreaterThanOrEqual(APS.length);
+
+    // Every AP's file is present in the FINAL integration tree — all three merged in.
+    const tree = git("ls-tree", "-r", "--name-only", res.headCommit).split("\n");
+    expect(tree).toContain("alpha.txt");
+    expect(tree).toContain("beta.txt");
+    expect(tree).toContain("gamma.txt");
+    // And the content is the coder's (proves the per-AP worktree edit reached the branch).
+    expect(git("show", `${res.headCommit}:alpha.txt`)).toContain("content for alpha");
+
+    // FAN-OUT actually ran (NOT the sequential fallback): the per-AP SIBLING branches exist.
+    // Under the buggy CHILD shape (`…/round-1/ap-k`) none of these are ever created.
+    const branches = git("branch", "--list", "--format=%(refname:short)").split("\n");
+    expect(branches).toContain(`${ROUND_BRANCH}-ap-1`);
+    expect(branches).toContain(`${ROUND_BRANCH}-ap-2`);
+    expect(branches).toContain(`${ROUND_BRANCH}-ap-3`);
+    // The coder ran once per AP in its OWN worktree (3 distinct dirs).
+    const coderDirs = new Set(
+      (deps.runCoder as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0] as string),
+    );
+    expect(coderDirs.size).toBe(APS.length);
+
+    // Cleanup held: NO leaked worktrees remain — only the main repo is registered.
+    const worktrees = git("worktree", "list", "--porcelain")
+      .split("\n")
+      .filter((l) => l.startsWith("worktree "));
+    expect(worktrees).toHaveLength(1);
+  });
+
+  it("dependency-aware waves: a dependent AP is merged after its prerequisite and still lands", async () => {
+    // gamma (#3) depends on alpha (#1): alpha must merge before gamma's worktree is cut off the
+    // integration HEAD. All three still land on the integration branch.
+    const aps: ActionPoint[] = [
+      { title: "alpha", priority: "P0" },
+      { title: "beta", priority: "P0" },
+      { title: "gamma", priority: "P0", dependsOn: [1] },
+    ];
+    const deps = baseDeps();
+    const res = await runSdlcHandoff(baseReq({ actionPoints: aps }), deps as never);
+
+    expect(res.prRef).toBe("https://github.com/x/y/pull/1");
+    const tree = git("ls-tree", "-r", "--name-only", res.headCommit).split("\n");
+    expect(tree).toEqual(expect.arrayContaining(["alpha.txt", "beta.txt", "gamma.txt"]));
+    const worktrees = git("worktree", "list", "--porcelain")
+      .split("\n")
+      .filter((l) => l.startsWith("worktree "));
+    expect(worktrees).toHaveLength(1);
+  });
+});

--- a/tests/unit/sdlc/parallel-develop.test.ts
+++ b/tests/unit/sdlc/parallel-develop.test.ts
@@ -5,8 +5,8 @@
  * worktree create/remove, coder, push, openPr, git runner). Load-bearing / adversarial:
  *   - OFF (default) ⇒ BYTE-IDENTICAL sequential path: ONE worktree, NO `ap-` branch, NO
  *     merge — proof the feature is inert when disabled.
- *   - ON, independent APs ⇒ N per-AP worktrees (each on a `…/ap-<k>` branch off the
- *     integration HEAD) merged back into the ROUND branch; ONE PR from the round branch.
+ *   - ON, independent APs ⇒ N per-AP worktrees (each on a `…/round-<n>-ap-<k>` SIBLING branch
+ *     off the integration HEAD) merged back into the ROUND branch; ONE PR from the round branch.
  *   - CONCURRENCY is bounded by `maxConcurrency` (risk e).
  *   - MERGE CONFLICT (risk c) ⇒ the AP is re-run on the integrated tree, its work SURFACED
  *     (note mentions the conflict), never silently dropped.
@@ -96,7 +96,7 @@ describe("parallel OFF (default) — byte-identical sequential path", () => {
     const deps = makeDeps();
     const res = await runSdlcHandoff(baseReq(), deps as never); // parallel absent
     expect(createdBranches(deps)).toEqual([ROUND_BRANCH]); // exactly one worktree
-    expect(createdBranches(deps).some((b) => /\/ap-\d+$/.test(b))).toBe(false);
+    expect(createdBranches(deps).some((b) => /-ap-\d+$/.test(b))).toBe(false);
     expect(mergedBranches(deps)).toHaveLength(0);
     expect(res.prRef).toBe("https://github.com/x/y/pull/9");
     expect(deps.removeWorktree).toHaveBeenCalledTimes(1);
@@ -130,11 +130,11 @@ describe("parallel ON — wave fan-out + merge", () => {
     const branches = createdBranches(deps);
     // integration (round) branch first, then one per-AP branch each.
     expect(branches[0]).toBe(ROUND_BRANCH);
-    expect(branches).toContain(`${ROUND_BRANCH}/ap-1`);
-    expect(branches).toContain(`${ROUND_BRANCH}/ap-2`);
+    expect(branches).toContain(`${ROUND_BRANCH}-ap-1`);
+    expect(branches).toContain(`${ROUND_BRANCH}-ap-2`);
     expect(branches).toHaveLength(3);
     // Both ap-branches merged back into the integration branch, in deterministic order.
-    expect(mergedBranches(deps)).toEqual([`${ROUND_BRANCH}/ap-1`, `${ROUND_BRANCH}/ap-2`]);
+    expect(mergedBranches(deps)).toEqual([`${ROUND_BRANCH}-ap-1`, `${ROUND_BRANCH}-ap-2`]);
     // ONE PR, opened from the round (integration) branch.
     expect(deps.openPr).toHaveBeenCalledTimes(1);
     const [dir, prOpts] = (deps.openPr as ReturnType<typeof vi.fn>).mock.calls[0];
@@ -197,8 +197,8 @@ describe("parallel ON — wave fan-out + merge", () => {
       { title: "B", priority: "P0", dependsOn: [1] },
     ];
     await runSdlcHandoff(baseReq({ actionPoints: aps, parallel: { enabled: true, maxConcurrency: 3 } }), deps as never);
-    const mergeA = order.indexOf(`merge:${ROUND_BRANCH}/ap-1`);
-    const createB = order.indexOf(`create:${ROUND_BRANCH}/ap-2`);
+    const mergeA = order.indexOf(`merge:${ROUND_BRANCH}-ap-1`);
+    const createB = order.indexOf(`create:${ROUND_BRANCH}-ap-2`);
     expect(mergeA).toBeGreaterThanOrEqual(0);
     expect(createB).toBeGreaterThan(mergeA); // B fanned out only AFTER A merged
   });
@@ -207,7 +207,7 @@ describe("parallel ON — wave fan-out + merge", () => {
 describe("parallel ON — adversarial", () => {
   it("MERGE CONFLICT (risk c) ⇒ the AP is re-run on the integrated tree and SURFACED", async () => {
     // ap-1 conflicts on merge → abort → fallback re-run on the integration worktree.
-    const gitRaw = makeGitRaw({ conflictOn: /\/ap-1$/ });
+    const gitRaw = makeGitRaw({ conflictOn: /-ap-1$/ });
     const deps = makeDeps({ gitRaw });
     const res = await runSdlcHandoff(
       baseReq({ parallel: { enabled: true, maxConcurrency: 3 } }),
@@ -224,6 +224,52 @@ describe("parallel ON — adversarial", () => {
     // The PR opens; the conflicted AP's note surfaces the conflict (never silent — risk c).
     const [, prOpts] = (deps.openPr as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(prOpts.body).toMatch(/merge conflict/i);
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+  });
+
+  it("FAIL-LOUD FALLBACK ⇒ when EVERY per-AP worktree setup fails, degrade to the sequential path (no empty PR)", async () => {
+    // Simulate the fan-out breakage class (the shipped D/F-ref bug): createWorktree SUCCEEDS
+    // for the round (integration) branch but THROWS for every per-AP branch. With 0 commits on
+    // the integration branch + setup failures, the executor must fall back to sequential and
+    // still produce a PR — not an empty 0-commit result.
+    const createWorktree = vi.fn(async (opts: { branch: string; baseRef?: string }) => {
+      if (/-ap-\d+$/.test(opts.branch)) throw new Error("fatal: cannot lock ref (simulated D/F)");
+      return { worktreeDir: `/tmp/tree/${opts.branch}`, baseDir: `/tmp/base/${opts.branch}`, branch: opts.branch, baseRef: opts.baseRef ?? "main" };
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const deps = makeDeps({ createWorktree });
+    const res = await runSdlcHandoff(baseReq({ parallel: { enabled: true, maxConcurrency: 3 } }), deps as never);
+
+    // The fan-out was attempted (per-AP creates threw) THEN the sequential path ran on the
+    // integration worktree, committing both APs there.
+    const integrationCommits = (deps.gitRaw as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c) => c[0] === `/tmp/tree/${ROUND_BRANCH}` && (c[1] as string[])[0] === "commit",
+    );
+    expect(integrationCommits.length).toBe(2); // both APs committed sequentially on the integration tree
+    // NO merge was performed (sequential path merges nothing) and a PR still opened.
+    expect(mergedBranches(deps)).toHaveLength(0);
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+    // The degrade was surfaced LOUDLY.
+    expect(warn.mock.calls.some((c) => /FALLING BACK to.*sequential/i.test(String(c[0])))).toBe(true);
+    warn.mockRestore();
+  });
+
+  it("NO double-run: a PARTIAL fan-out (some APs committed) does NOT trigger the sequential fallback", async () => {
+    // ap-2's worktree create throws, but ap-1 fans out + merges fine (committedCount > 0), so the
+    // guard must NOT re-run the whole round sequentially (that would double-apply ap-1).
+    const createWorktree = vi.fn(async (opts: { branch: string; baseRef?: string }) => {
+      if (/-ap-2$/.test(opts.branch)) throw new Error("fatal: cannot lock ref (simulated)");
+      return { worktreeDir: `/tmp/tree/${opts.branch}`, baseDir: `/tmp/base/${opts.branch}`, branch: opts.branch, baseRef: opts.baseRef ?? "main" };
+    });
+    const deps = makeDeps({ createWorktree });
+    const res = await runSdlcHandoff(baseReq({ parallel: { enabled: true, maxConcurrency: 3 } }), deps as never);
+    // ap-1 merged via the fan-out; ap-2 surfaced as failed. NO sequential re-commit on the
+    // integration worktree (the fan-out path never commits directly on it).
+    expect(mergedBranches(deps)).toEqual([`${ROUND_BRANCH}-ap-1`]);
+    const integrationCommits = (deps.gitRaw as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c) => c[0] === `/tmp/tree/${ROUND_BRANCH}` && (c[1] as string[])[0] === "commit",
+    );
+    expect(integrationCommits).toHaveLength(0);
     expect(res.prRef).toBe("https://github.com/x/y/pull/9");
   });
 


### PR DESCRIPTION
## Symptom

On its FIRST real run the parallel-develop executor (PR #482) produced **ZERO commits**: all 8 action points ended `failed`, no per-AP branches were created, and the integration branch stayed at the base commit (`git rev-list --count base..integration = 0`). A final-verification fix-coder then ran pointlessly against the empty integration tree.

## Root cause — a git ref directory/file (D/F) conflict

The fan-out cut each per-AP branch as a **child** of the round (integration) branch:

```
integration branch: consilium/loop-<id>/round-1        → ref FILE .git/refs/heads/consilium/loop-<id>/round-1
per-AP branch:       consilium/loop-<id>/round-1/ap-1   → needs round-1 to be a DIRECTORY
```

git stores each branch as a **loose ref file**. Once `…/round-1` exists as a file, creating `…/round-1/ap-1` requires `round-1` to be a directory — a D/F conflict. `git worktree add` fails:

```
fatal: cannot lock ref 'refs/heads/consilium/loop-<id>/round-1/ap-1':
'refs/heads/consilium/loop-<id>/round-1' exists; cannot create '.../round-1/ap-1'
```

Reproduced in a scratch repo: the integration worktree is created fine (base commit), then **every** per-AP `git worktree add` throws. In the executor each throw is caught → AP marked `failed` → no branch, no commit. All APs hit the same failure → 0 branches, 0 commits, integration at base. The `-B` recovery in `addWorktree` does not help — the error is "cannot lock ref", not "already exists/checked out", so it rethrows.

The per-AP worktrees are already cut off the **main** repo with an explicit base **SHA** (`integrationHead`), not nested off the integration worktree — so nesting/checked-out-branch was not the issue. The branch **name shape** was.

## The fix

1. **Per-AP branch is now a SIBLING, not a child**: `consilium/loop-<id>/round-<n>-ap-<k>`. `…/round-1` and `…/round-1-ap-1` are distinct loose refs (they share only the `round-1` *prefix*, not the ref *path*), so they coexist. Verified in a scratch repo: 3 sibling per-AP worktrees create cleanly alongside the round branch. Changed `buildApBranchName`, `AP_BRANCH_RE`, and the worktree-gate comment. The strict PR-head gate (`isValidLoopBranch`) is unaffected — a `round-1-ap-1` branch still never matches it.

2. **Fail-loud sequential fallback**: `runWaveScheduledImplement` now counts per-AP worktree-**setup** failures. When the fan-out lands **0 commits** on the integration branch **and** there was >=1 setup failure, the round degrades to the **sequential** path (`runSequentialImplement`) so the operator gets working output instead of an empty PR. The degrade is logged loudly (`FALLING BACK to the sequential path …`). Guarded on `committedCount === 0` so a *partial* fan-out is **never double-run** (no double-apply of an AP that already merged); at that point `wt` is still at the base commit, so the sequential re-run starts clean.

3. **Shared sequential loop**: the historical inline sequential loop was extracted verbatim into `runSequentialImplement`, used by both the default off-path (byte-for-byte unchanged) and the fallback.

## Real-git test (mocks missed this)

`tests/integration/sdlc-worktree-fanout.test.ts` drives `runSdlcHandoff` with `parallel.enabled` against a **real scratch git repo** (only the coder + push/openPr are faked). 3 trivial APs each write + commit a file via the real git helper. It asserts:

- a PR opened (⇒ commits exist — `null` on 0 commits is the exact bug symptom),
- `rev-list base..head >= 3` (**the integration branch advanced** — was literally 0),
- all three files (`alpha/beta/gamma.txt`) are in the final integration tree,
- the per-AP **sibling** branches `…-ap-1/2/3` exist (proves the *fan-out* ran, not the fallback),
- **no leaked worktrees** remain (`worktree list` = just the main repo).

Proof it catches the regression: temporarily reverting to the child shape makes this test **fail** on the sibling-branch assertion (and the fallback log fires), while the run still produces output via the new fallback.

Two deterministic mocked tests were also added: the fail-loud fallback (all per-AP setups throw ⇒ sequential path ⇒ PR still opens, warn logged) and the no-double-run guard (partial fan-out ⇒ no sequential re-run).

## Evidence / gates

- `tsc` clean.
- Full unit suite: **5038 passed** (flake-quarantine projects unchanged, pre-existing).
- Full integration suite: **871 passed / 5 skipped** (56 files, incl. the new real-git test).
- Kill-switch unchanged (default off); off-path byte-identical. Worktree cleanup remains unconditional (per-worker `finally` + git-admin mutex).

Draft — do not merge.
