### PR TITLE
feat: explain every loop status on the loop page

### DIFF
--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -50,6 +50,8 @@ import {
   FlaskConical,
   GitBranch,
   Radio,
+  Info,
+  CheckCircle2,
 } from "lucide-react";
 import {
   useConsiliumLoop,
@@ -119,6 +121,10 @@ import { IterationDetailView } from "@/components/task-groups/iterations-panel";
 import type { ActionPoint, Archetype, OpenRemainder } from "@shared/types";
 import { ARCHETYPES } from "@shared/types";
 import { summarizeNonP0Remainder } from "@shared/consilium-remainder";
+import {
+  explainLoopState,
+  type LoopStatusTone,
+} from "@shared/loop-status";
 
 // Priority palette for action-point severity tiers (P0–P3). The loop page is now
 // the canonical home of this taxonomy (the task-group verdict panel is retired).
@@ -665,6 +671,69 @@ function RoundRow({
 
 // ─── Result panel — the human-gate outcome surface ─────────────────────────────
 //
+// ─── Status callout — a plain-English "what & why" for EVERY state ──────────────
+//
+// The FSM stepper shows WHERE the loop is with colour; this adds the WORDS. #466
+// gave a CANCELLED loop a callout that rendered its error ("who/when/why"); an
+// operator who hit `stopped_cap` got no words at all. This generalizes it: for
+// EVERY state — non-terminal and terminal — `explainLoopState` (shared, pure,
+// unit-tested) returns a toned `{ title, detail }` grounded in the loop's own
+// numbers (round/maxRounds/open remainder/open P0). It reuses #466's behaviour
+// for failed/cancelled (detail = the loop's error) and NEVER renders blank (a
+// safe neutral default backs any unknown state).
+//
+// SECURITY: `detail` may be the loop/user-authored `error` (cancellation note /
+// last-round error) — rendered as INERT React text, exactly as #466 did.
+const STATUS_TONE_STYLE: Record<
+  LoopStatusTone,
+  { card: string; icon: string; title: string; body: string; Icon: typeof Info }
+> = {
+  good: {
+    card: "border-green-600/50 bg-green-600/10",
+    icon: "text-green-600 dark:text-green-400",
+    title: "text-green-700 dark:text-green-300",
+    body: "text-green-700/90 dark:text-green-300/90",
+    Icon: CheckCircle2,
+  },
+  warning: {
+    card: "border-amber-500/50 bg-amber-500/10",
+    icon: "text-amber-600 dark:text-amber-400",
+    title: "text-amber-700 dark:text-amber-300",
+    body: "text-amber-700/90 dark:text-amber-300/90",
+    Icon: AlertTriangle,
+  },
+  bad: {
+    card: "border-red-600/50 bg-red-600/10",
+    icon: "text-red-600 dark:text-red-400",
+    title: "text-red-700 dark:text-red-300",
+    body: "text-red-700/90 dark:text-red-300/90",
+    Icon: AlertTriangle,
+  },
+  neutral: {
+    card: "border-border bg-muted/40",
+    icon: "text-muted-foreground",
+    title: "text-foreground",
+    body: "text-muted-foreground",
+    Icon: Info,
+  },
+};
+
+function LoopStatusCallout({ loop }: { loop: ConsiliumLoopDetailRow }) {
+  const { title, tone, detail } = explainLoopState(loop);
+  const s = STATUS_TONE_STYLE[tone];
+  const Icon = s.Icon;
+  return (
+    <div className={`flex items-start gap-2 rounded-md border p-3 text-sm ${s.card}`}>
+      <Icon className={`h-4 w-4 shrink-0 mt-0.5 ${s.icon}`} aria-hidden="true" />
+      <div className="min-w-0">
+        <p className={`font-medium ${s.title}`}>{title}</p>
+        {/* INERT loop/user-authored text (error/cancellation note) or a code template. */}
+        <p className={`break-words ${s.body}`}>{detail}</p>
+      </div>
+    </div>
+  );
+}
+
 // What did the latest SDLC round actually produce? The stepper shows WHERE the
 // loop is; this panel shows WHAT to decide on. It is rendered near the top so a
 // human arriving at `awaiting_merge` is never met with a blank gate. Every field
@@ -699,18 +768,17 @@ function ResultPanel({
         <CardTitle className="text-sm">Result</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        {/* Terminal explanation from `loop.error`. For a CANCELLED loop this is the
-            composed "Cancelled by <actor> at <ISO> — <reason>" note (who/when/why),
-            NOT a failure — so it reads as "Cancellation". For every other state it
-            is the last-round degradation signal. Same amber (neutral, not red)
-            treatment either way; the text is INERT loop/user-authored content. */}
-        {loop.error && (
+        {/* Last-round degradation signal from `loop.error`. The CANCELLED and
+            FAILED cases (where `error` IS the state explanation) are now owned by
+            the top-of-page LoopStatusCallout — rendering them here too would
+            duplicate. For every OTHER state (e.g. a stopped_cap/escalated round
+            that recorded an error) this remains the amber "Last round error"
+            note. INERT loop/user-authored content. */}
+        {loop.error && loop.state !== "cancelled" && loop.state !== "failed" && (
           <div className="flex items-start gap-2 rounded-md border border-amber-500/50 bg-amber-500/10 p-3 text-sm">
             <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
             <div className="min-w-0">
-              <p className="font-medium text-amber-700 dark:text-amber-300">
-                {loop.state === "cancelled" ? "Cancellation" : "Last round error"}
-              </p>
+              <p className="font-medium text-amber-700 dark:text-amber-300">Last round error</p>
               {/* INERT loop/user-authored text */}
               <p className="text-amber-700/90 dark:text-amber-300/90 break-words">{loop.error}</p>
             </div>
@@ -2081,6 +2149,10 @@ export default function ConsiliumLoopDetail() {
       </header>
 
       <div className="flex-1 overflow-y-auto p-6 space-y-5">
+        {/* Status — a plain-English "what this state means and why the loop is
+            here" for EVERY state (generalizes #466's cancel-reason callout). */}
+        <LoopStatusCallout loop={loop} />
+
         {/* Result — the outcome the human gate decides on (near the top). */}
         <ResultPanel loop={loop} terminal={terminal} />
 

--- a/shared/loop-status.ts
+++ b/shared/loop-status.ts
@@ -1,0 +1,274 @@
+/**
+ * loop-status.ts — a PLAIN-ENGLISH explanation for every consilium-loop state.
+ *
+ * #466 gave a CANCELLED loop an amber callout that rendered its `error` (the
+ * "who / when / why" of the cancellation). But every OTHER state on the loop
+ * detail page showed no words at all — an operator who hit `stopped_cap` had no
+ * idea what it meant or why the loop was sitting there. This helper generalizes
+ * that idea: for ANY state it returns a `{ title, tone, detail }` that says what
+ * the state means AND, where relevant, WHY — grounded in the loop's OWN numbers
+ * (round / maxRounds / the open remainder / open P0), never hardcoded.
+ *
+ * Pure and client-safe (no drizzle, no React): the loop detail page, the loop
+ * list, and unit tests all share ONE implementation. Type-only imports keep the
+ * server schema (and its drizzle runtime) out of the client bundle.
+ *
+ * SECURITY: `error` is loop/user-authored INERT text — passed straight through
+ * as data for the caller to render as inert React text (never a sink). Every
+ * other string here is a fixed, code-authored template; only COUNTS (never model
+ * prose) are interpolated from `openRemainder` / `openP0`.
+ */
+import type { ConsiliumLoopState } from "./schema.js";
+import { P0_PRIORITY, type OpenRemainder } from "./types.js";
+
+/** Visual/semantic tone for the status callout. */
+export type LoopStatusTone = "neutral" | "good" | "warning" | "bad";
+
+/** A plain-English explanation of one loop state. */
+export interface LoopStatusExplanation {
+  /** Short human title (e.g. "Stopped at the round limit"). */
+  title: string;
+  /** Semantic tone → colour: good=green, warning=amber, bad=red, neutral=muted. */
+  tone: LoopStatusTone;
+  /** One or two sentences: what the state means and, where relevant, WHY. */
+  detail: string;
+}
+
+/**
+ * The minimal loop shape `explainLoopState` reads. Both the detail row and the
+ * list item are structurally assignable to it, so callers pass their loop as-is.
+ */
+export interface LoopStatusInput {
+  state: ConsiliumLoopState;
+  round: number;
+  maxRounds: number;
+  openP0?: number | null;
+  openRemainder?: OpenRemainder | null;
+  /** INERT loop/user-authored text (cancellation note or last-round error). */
+  error?: string | null;
+  prRef?: string | null;
+  /**
+   * Optional live dev progress (the `developing` state): the active action-point
+   * index/total. Structurally compatible with the client `DevProgress`.
+   */
+  devProgress?: {
+    actionPointIndex?: number | null;
+    actionPointTotal?: number | null;
+  } | null;
+}
+
+/** The round to SHOW: a not-yet-ticked loop reports round 0 → read it as round 1. */
+function displayRound(round: number): number {
+  return round > 0 ? round : 1;
+}
+
+/**
+ * A full, P0-FIRST breakdown of an open remainder — e.g. `"3 items open (1 P0,
+ * 2 P1)"`. Ordered P0 → P1 → … → P? so the highest-severity tier leads. Returns
+ * `null` when there is nothing to summarize (so callers can fall back to the raw
+ * `openP0` count or omit the clause entirely).
+ */
+function summarizeAllOpen(
+  remainder: OpenRemainder | null | undefined,
+): { total: number; breakdown: string } | null {
+  if (!remainder || remainder.total <= 0) return null;
+  // P0 sorts FIRST (0), then P1, P2, …; an un-numbered "P?" sorts LAST.
+  const tier = (label: string): number => {
+    const n = Number.parseInt(label.replace(/^P/i, ""), 10);
+    return Number.isNaN(n) ? Number.POSITIVE_INFINITY : n;
+  };
+  const entries = Object.entries(remainder.byPriority)
+    .filter(([, count]) => count > 0)
+    .sort((a, b) => tier(a[0]) - tier(b[0]) || a[0].localeCompare(b[0]));
+  if (entries.length === 0) return null;
+  return {
+    total: remainder.total,
+    breakdown: entries.map(([priority, count]) => `${count} ${priority}`).join(", "),
+  };
+}
+
+/** The NON-P0 tier of a remainder (for the "converged, but…" note). */
+function summarizeNonP0(
+  remainder: OpenRemainder | null | undefined,
+): { total: number; breakdown: string } | null {
+  if (!remainder) return null;
+  const tier = (label: string): number => {
+    const n = Number.parseInt(label.replace(/^P/i, ""), 10);
+    return Number.isNaN(n) ? Number.POSITIVE_INFINITY : n;
+  };
+  const entries = Object.entries(remainder.byPriority)
+    .filter(([priority, count]) => priority !== P0_PRIORITY && count > 0)
+    .sort((a, b) => tier(a[0]) - tier(b[0]) || a[0].localeCompare(b[0]));
+  const total = entries.reduce((sum, [, count]) => sum + count, 0);
+  if (total <= 0) return null;
+  return { total, breakdown: entries.map(([p, c]) => `${c} ${p}`).join(", ") };
+}
+
+/**
+ * Build the "N items remain open (…)" clause for a capped/escalated loop,
+ * grounded in the loop's real numbers: prefer the full priority breakdown, fall
+ * back to the raw open-P0 count, and finally to a neutral phrasing.
+ */
+function openWorkClause(loop: LoopStatusInput): string {
+  const all = summarizeAllOpen(loop.openRemainder);
+  if (all) {
+    const one = all.total === 1;
+    return `${all.total} item${one ? "" : "s"} remain${one ? "s" : ""} open (${all.breakdown})`;
+  }
+  const p0 = loop.openP0;
+  if (typeof p0 === "number" && p0 > 0) {
+    const one = p0 === 1;
+    return `${p0} P0 item${one ? "" : "s"} remain${one ? "s" : ""} open`;
+  }
+  return "some items may still be open";
+}
+
+/** Humanize a raw state token as a last-resort title (never render blank). */
+function humanizeState(state: string): string {
+  return state
+    .split("_")
+    .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
+    .join(" ");
+}
+
+/**
+ * Explain ONE loop state in plain English. Total function over
+ * `ConsiliumLoopState` — every state returns a non-empty title + detail, and an
+ * unknown/future token falls through to a safe neutral default so the callout
+ * NEVER renders blank (the whole point of this helper).
+ */
+export function explainLoopState(loop: LoopStatusInput): LoopStatusExplanation {
+  const round = displayRound(loop.round);
+  const { maxRounds } = loop;
+
+  switch (loop.state) {
+    case "pending":
+      return {
+        title: "Pending",
+        tone: "neutral",
+        detail:
+          "This loop hasn't started yet — start it to run the first review round.",
+      };
+
+    case "building_context":
+      return {
+        title: "Building context",
+        tone: "neutral",
+        detail: `Gathering the repository context for round ${round} of up to ${maxRounds} before the reviewers debate.`,
+      };
+
+    case "reviewing":
+      return {
+        title: "Reviewing",
+        tone: "neutral",
+        detail: `The reviewers are debating the changes in round ${round} of up to ${maxRounds}.`,
+      };
+
+    case "deciding":
+      return {
+        title: "Deciding",
+        tone: "neutral",
+        detail: `Tallying the round ${round} verdict — deciding whether every acceptance criterion is met.`,
+      };
+
+    case "developing": {
+      const idx = loop.devProgress?.actionPointIndex;
+      const total = loop.devProgress?.actionPointTotal;
+      const progress =
+        typeof idx === "number" && typeof total === "number" && total > 0
+          ? ` (AP ${idx}/${total})`
+          : "";
+      return {
+        title: "Developing",
+        tone: "neutral",
+        detail: `Implementing the action points raised by the last review round${progress}.`,
+      };
+    }
+
+    case "awaiting_merge":
+      return {
+        title: "Awaiting merge",
+        tone: "neutral",
+        detail: loop.prRef
+          ? "A Draft PR is open and waiting for a human to review and merge it. Merge it (or approve to continue) to advance the loop."
+          : "The developing round finished but produced no PR — approve to advance the loop against the current HEAD, or cancel it.",
+      };
+
+    case "converged": {
+      const nonP0 = summarizeNonP0(loop.openRemainder);
+      const base =
+        "Converged — every acceptance criterion was confirmed, so the loop is done.";
+      return {
+        title: "Converged",
+        tone: "good",
+        detail: nonP0
+          ? `${base} ${nonP0.total} lower-priority item${nonP0.total === 1 ? "" : "s"} (${nonP0.breakdown}) remain${nonP0.total === 1 ? "s" : ""} open by design — hand them off if you want them addressed.`
+          : base,
+      };
+    }
+
+    case "stopped_cap": {
+      // Context-aware (mirrors loopStateLabel): a single-round loop is an
+      // ASSESSMENT, not a remediation — reaching the cap is success, not a stall.
+      if (maxRounds === 1) {
+        return {
+          title: "Completed — review",
+          tone: "good",
+          detail:
+            "The single review round finished. This was an assessment (max rounds = 1), not a remediation loop, so it stops here.",
+        };
+      }
+      return {
+        title: "Stopped at the round limit",
+        tone: "warning",
+        detail: `Reached the round limit (max ${maxRounds}) without converging; ${openWorkClause(loop)}. Raise the round limit or develop the remainder to continue.`,
+      };
+    }
+
+    case "escalated": {
+      const p0 = loop.openP0;
+      const p0Clause =
+        typeof p0 === "number" && p0 > 0
+          ? ` There ${p0 === 1 ? "is" : "are"} still ${p0} P0 item${p0 === 1 ? "" : "s"} open.`
+          : "";
+      return {
+        title: "Escalated",
+        tone: "warning",
+        detail: `Escalated — the open-P0 count stopped improving across rounds, so the loop paused for a human to look.${p0Clause}`,
+      };
+    }
+
+    case "failed":
+      return {
+        title: "Failed",
+        tone: "bad",
+        // Reuse #466: render the loop's own error as the explanation.
+        detail: loop.error
+          ? loop.error
+          : "The last round failed with an unrecoverable error. See the round details below.",
+      };
+
+    case "cancelled":
+      return {
+        title: "Cancelled",
+        // Neutral, not red: a cancellation is an operator choice, NOT a failure
+        // (mirrors #466's amber, "not a failure" treatment).
+        tone: "neutral",
+        // Reuse #466: the composed "Cancelled by <actor> at <ISO> — <reason>".
+        detail: loop.error
+          ? loop.error
+          : "This loop was cancelled by an operator. No reason was recorded.",
+      };
+
+    default: {
+      // Exhaustive over the current union; a future/unknown token still gets a
+      // safe, non-blank explanation so the callout NEVER renders empty.
+      const state: string = loop.state;
+      return {
+        title: humanizeState(state),
+        tone: "neutral",
+        detail: `The loop is in the "${state}" state.`,
+      };
+    }
+  }
+}

--- a/tests/unit/consilium/loop-status.test.ts
+++ b/tests/unit/consilium/loop-status.test.ts
@@ -1,0 +1,257 @@
+/**
+ * loop-status.test.ts — unit coverage for `explainLoopState`
+ * (`shared/loop-status.ts`): the plain-English "what & why" for EVERY consilium
+ * loop state, generalizing #466's cancel-reason callout.
+ *
+ * Covers, for each state, the title / tone / detail — and that the WHY numbers
+ * (round, maxRounds, the open remainder, open P0) are interpolated from the
+ * loop's OWN fields, never hardcoded. Special focus on:
+ *   - stopped_cap WITH a remainder (the state the operator hit blind)
+ *   - stopped_cap as a single-round ASSESSMENT (context-aware, success tone)
+ *   - converged (clean vs. with a non-P0 remainder)
+ *   - failed / cancelled reusing the loop's `error` (#466 behaviour, not regressed)
+ *   - a safe neutral default so the callout NEVER renders blank
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  explainLoopState,
+  type LoopStatusInput,
+} from "../../../shared/loop-status.js";
+import { CONSILIUM_LOOP_STATES } from "../../../shared/schema.js";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "../../..");
+
+function loop(over: Partial<LoopStatusInput> = {}): LoopStatusInput {
+  return {
+    state: "pending",
+    round: 1,
+    maxRounds: 6,
+    openP0: null,
+    openRemainder: null,
+    error: null,
+    prRef: null,
+    devProgress: null,
+    ...over,
+  };
+}
+
+describe("explainLoopState — every state is non-blank", () => {
+  it("returns a non-empty title + detail for every declared FSM state", () => {
+    for (const state of CONSILIUM_LOOP_STATES) {
+      const out = explainLoopState(loop({ state }));
+      expect(out.title.length, `title for ${state}`).toBeGreaterThan(0);
+      expect(out.detail.length, `detail for ${state}`).toBeGreaterThan(0);
+      expect(["neutral", "good", "warning", "bad"]).toContain(out.tone);
+    }
+  });
+
+  it("falls through to a safe neutral default for an unknown/future state (never blank)", () => {
+    const out = explainLoopState(loop({ state: "frozen" as LoopStatusInput["state"] }));
+    expect(out.tone).toBe("neutral");
+    expect(out.title).toBe("Frozen");
+    expect(out.detail).toContain("frozen");
+  });
+});
+
+describe("explainLoopState — non-terminal states (what's happening now)", () => {
+  it("pending → neutral, says it hasn't started", () => {
+    const out = explainLoopState(loop({ state: "pending" }));
+    expect(out.tone).toBe("neutral");
+    expect(out.detail).toMatch(/hasn't started/i);
+  });
+
+  it("building_context → interpolates the round window (round 0 reads as round 1)", () => {
+    const out = explainLoopState(loop({ state: "building_context", round: 0, maxRounds: 6 }));
+    expect(out.tone).toBe("neutral");
+    expect(out.title).toBe("Building context");
+    expect(out.detail).toContain("round 1 of up to 6");
+  });
+
+  it("reviewing → interpolates the current round / maxRounds", () => {
+    const out = explainLoopState(loop({ state: "reviewing", round: 3, maxRounds: 8 }));
+    expect(out.tone).toBe("neutral");
+    expect(out.detail).toContain("round 3 of up to 8");
+  });
+
+  it("deciding → interpolates the round being tallied", () => {
+    const out = explainLoopState(loop({ state: "deciding", round: 4 }));
+    expect(out.detail).toContain("round 4");
+    expect(out.detail).toMatch(/acceptance criterion/i);
+  });
+
+  it("developing → shows the live AP k/N when devProgress carries it", () => {
+    const out = explainLoopState(
+      loop({ state: "developing", devProgress: { actionPointIndex: 2, actionPointTotal: 5 } }),
+    );
+    expect(out.tone).toBe("neutral");
+    expect(out.detail).toContain("AP 2/5");
+  });
+
+  it("developing → omits the AP counter when progress is absent", () => {
+    const out = explainLoopState(loop({ state: "developing", devProgress: null }));
+    expect(out.detail).not.toContain("AP ");
+    expect(out.detail).toMatch(/implementing the action points/i);
+  });
+
+  it("awaiting_merge → points at the open Draft PR when prRef is set", () => {
+    const out = explainLoopState(loop({ state: "awaiting_merge", prRef: "https://x/pr/1" }));
+    expect(out.tone).toBe("neutral");
+    expect(out.detail).toMatch(/draft pr is open/i);
+  });
+
+  it("awaiting_merge → explains the no-PR gate when prRef is absent", () => {
+    const out = explainLoopState(loop({ state: "awaiting_merge", prRef: null }));
+    expect(out.detail).toMatch(/no pr/i);
+  });
+});
+
+describe("explainLoopState — converged", () => {
+  it("clean convergence → good tone, 'the loop is done', no remainder note", () => {
+    const out = explainLoopState(loop({ state: "converged", openRemainder: null }));
+    expect(out.tone).toBe("good");
+    expect(out.title).toBe("Converged");
+    expect(out.detail).toMatch(/every acceptance criterion was confirmed/i);
+    expect(out.detail).not.toMatch(/lower-priority/i);
+  });
+
+  it("converged WITH a non-P0 remainder → notes the leftover items (tier-ordered)", () => {
+    const out = explainLoopState(
+      loop({ state: "converged", openRemainder: { total: 3, byPriority: { P2: 1, P1: 2 } } }),
+    );
+    expect(out.tone).toBe("good");
+    expect(out.detail).toContain("3 lower-priority items (2 P1, 1 P2)");
+  });
+
+  it("converged with a P0-ONLY remainder → no non-P0 note (nothing lower-priority to show)", () => {
+    const out = explainLoopState(
+      loop({ state: "converged", openRemainder: { total: 1, byPriority: { P0: 1 } } }),
+    );
+    expect(out.detail).not.toMatch(/lower-priority/i);
+  });
+});
+
+describe("explainLoopState — stopped_cap", () => {
+  it("multi-round cap WITH a remainder → warning + the round limit + the open breakdown", () => {
+    const out = explainLoopState(
+      loop({
+        state: "stopped_cap",
+        maxRounds: 6,
+        openP0: 1,
+        openRemainder: { total: 3, byPriority: { P0: 1, P1: 2 } },
+      }),
+    );
+    expect(out.tone).toBe("warning");
+    expect(out.title).toBe("Stopped at the round limit");
+    expect(out.detail).toContain("max 6");
+    // P0-first full breakdown, grounded in the loop's own remainder.
+    expect(out.detail).toContain("3 items remain open (1 P0, 2 P1)");
+    expect(out.detail).toMatch(/raise the round limit|develop the remainder/i);
+  });
+
+  it("multi-round cap with only openP0 (no remainder) → falls back to the P0 count", () => {
+    const out = explainLoopState(
+      loop({ state: "stopped_cap", maxRounds: 4, openP0: 2, openRemainder: null }),
+    );
+    expect(out.tone).toBe("warning");
+    expect(out.detail).toContain("2 P0 items remain open");
+  });
+
+  it("multi-round cap with no open info → a neutral phrasing (never blank)", () => {
+    const out = explainLoopState(
+      loop({ state: "stopped_cap", maxRounds: 6, openP0: null, openRemainder: null }),
+    );
+    expect(out.detail).toContain("some items may still be open");
+  });
+
+  it("single-round loop (maxRounds === 1) → an ASSESSMENT: good tone, 'Completed — review'", () => {
+    const out = explainLoopState(loop({ state: "stopped_cap", maxRounds: 1, openP0: 1 }));
+    expect(out.tone).toBe("good");
+    expect(out.title).toBe("Completed — review");
+    expect(out.detail).toMatch(/assessment/i);
+  });
+
+  it("singular grammar: exactly one open item reads 'remains'", () => {
+    const out = explainLoopState(
+      loop({ state: "stopped_cap", maxRounds: 6, openRemainder: { total: 1, byPriority: { P1: 1 } } }),
+    );
+    expect(out.detail).toContain("1 item remains open (1 P1)");
+  });
+});
+
+describe("explainLoopState — escalated", () => {
+  it("warning + 'stopped improving' + the still-open P0 count", () => {
+    const out = explainLoopState(loop({ state: "escalated", openP0: 3 }));
+    expect(out.tone).toBe("warning");
+    expect(out.title).toBe("Escalated");
+    expect(out.detail).toMatch(/stopped improving/i);
+    expect(out.detail).toContain("3 P0 items open");
+  });
+
+  it("singular P0 grammar", () => {
+    const out = explainLoopState(loop({ state: "escalated", openP0: 1 }));
+    expect(out.detail).toContain("1 P0 item open");
+  });
+
+  it("omits the P0 clause when none are open", () => {
+    const out = explainLoopState(loop({ state: "escalated", openP0: 0 }));
+    expect(out.detail).not.toMatch(/P0 item/);
+  });
+});
+
+describe("explainLoopState — failed / cancelled reuse the loop error (#466, not regressed)", () => {
+  it("failed → bad tone, detail IS the loop error", () => {
+    const out = explainLoopState(loop({ state: "failed", error: "worker crashed at step 3" }));
+    expect(out.tone).toBe("bad");
+    expect(out.title).toBe("Failed");
+    expect(out.detail).toBe("worker crashed at step 3");
+  });
+
+  it("failed with no error → a safe fallback (still non-blank)", () => {
+    const out = explainLoopState(loop({ state: "failed", error: null }));
+    expect(out.tone).toBe("bad");
+    expect(out.detail).toMatch(/unrecoverable error/i);
+  });
+
+  it("cancelled → neutral (NOT a failure), detail IS the cancellation note", () => {
+    const note = "Cancelled by alice at 2026-07-01T00:00:00Z — superseded";
+    const out = explainLoopState(loop({ state: "cancelled", error: note }));
+    expect(out.tone).toBe("neutral");
+    expect(out.title).toBe("Cancelled");
+    expect(out.detail).toBe(note);
+  });
+
+  it("cancelled with no reason → a safe fallback (still non-blank)", () => {
+    const out = explainLoopState(loop({ state: "cancelled", error: null }));
+    expect(out.tone).toBe("neutral");
+    expect(out.detail).toMatch(/cancelled by an operator/i);
+  });
+});
+
+// The repo has no @testing-library/react; UI rendering is asserted at the source
+// level (see pipeline-ux.test.ts). This guards that the callout is wired into the
+// page body UNCONDITIONALLY — so it renders for a non-terminal state too, not just
+// terminal ones (the whole point of generalizing #466).
+describe("ConsiliumLoopDetail — status callout is rendered for every state", () => {
+  const source = readFileSync(
+    resolve(PROJECT_ROOT, "client/src/pages/ConsiliumLoopDetail.tsx"),
+    "utf8",
+  );
+
+  it("renders <LoopStatusCallout loop={loop} /> in the page body", () => {
+    expect(source).toContain("<LoopStatusCallout loop={loop} />");
+  });
+
+  it("does not gate the callout behind a terminal-only condition", () => {
+    // The callout call must not sit inside a `terminal && (…)` / `isTerminal…` guard.
+    const idx = source.indexOf("<LoopStatusCallout loop={loop} />");
+    expect(idx).toBeGreaterThan(-1);
+    const preceding = source.slice(Math.max(0, idx - 200), idx);
+    expect(preceding).not.toMatch(/terminal\s*&&\s*\($/);
+  });
+
+  it("uses the shared explainLoopState helper (single source of truth)", () => {
+    expect(source).toContain("explainLoopState(loop)");
+  });
+});


### PR DESCRIPTION
## Why

#466 gave a **cancelled** loop an amber callout that rendered its `error` (the who / when / why). But every **other** state on the loop detail page showed no words — an operator who hit `stopped_cap` had no idea what it meant or why the loop was sitting there. This generalizes #466 so **every** state gets a plain-English "what this means and why the loop is here" explanation.

> Operator: "хочу чтобы все статусы которые могут быть в процессе имели объяснение, так же как и cancelled".

## The `explainLoopState(loop)` helper (`shared/loop-status.ts`)

Pure, client-safe (no drizzle/React), unit-tested. Given the loop (`state` + `round`/`maxRounds` + `openRemainder` + `openP0` + `error` + `prRef` + live `devProgress`), returns `{ title, tone: 'neutral'|'good'|'warning'|'bad', detail }`. The WHY is grounded in the loop's **own numbers** — nothing is hardcoded.

## States covered (all 11 + a safe default)

| State | Tone | Explanation (grounded in the loop's numbers) |
|---|---|---|
| `pending` | neutral | Hasn't started yet — start it to run the first round. |
| `building_context` | neutral | Gathering context for round N of up to M. |
| `reviewing` | neutral | Reviewers debating round N of up to M. |
| `deciding` | neutral | Tallying the round N verdict against the acceptance criteria. |
| `developing` | neutral | Implementing the action points (AP k/N from live `devProgress`). |
| `awaiting_merge` | neutral | Draft PR open, waiting for a human to merge — or the no-PR gate. |
| `converged` | good | Every criterion confirmed; the loop is done (+ non-P0 remainder note). |
| **`stopped_cap`** | **warning** | **Reached the round limit (max M) without converging; X items remain open (… P0, … P1). Raise the limit or develop the remainder.** |
| `stopped_cap` (maxRounds=1) | good | Assessment loop — completed, not a stall (mirrors `loopStateLabel`). |
| `escalated` | warning | Open-P0 count stopped improving across rounds; still N P0 open. |
| `failed` | bad | The loop's `error` (reuses #466). |
| `cancelled` | neutral | The `error` cancellation note (reuses #466 — not a failure). |
| unknown/future | neutral | Safe humanized default — **never renders blank**. |

## Rendering

A compact toned `LoopStatusCallout` at the top of `ConsiliumLoopDetail.tsx` renders for **every** state (good=green, warning=amber, bad=red, neutral=muted). The FSM stepper still shows the state visually; this adds the **words**. The existing `ResultPanel` error block is scoped to non-cancelled/non-failed states so the callout owns cancelled/failed without duplicating the error text — **#466 is not regressed**.

## Tests / evidence

- `tests/unit/consilium/loop-status.test.ts` — `explainLoopState` per state (title/tone/detail, numbers interpolated), incl. **stopped_cap-with-remainder** (`3 items remain open (1 P0, 2 P1)`), the single-round assessment case, converged clean vs. non-P0 remainder, failed/cancelled reusing `error`, and the safe default. Plus a source-level guard that the callout is wired **unconditionally** (renders for non-terminal states too).
- `npx tsc --noEmit` → clean (client + server).
- New file: **28** tests pass. Consilium unit dir: **626** pass. Full `--project unit`: **4959** pass (flake quarantine per #479 untouched, pre-existing).

## Constraints honoured

Read/derive-only — no FSM/schema/migration/server change. English strings. INERT `error` rendered as React text (security preserved). Draft PR; do not merge.