### PR TITLE
feat: verify-before-merge — confirm against main-integrated branch before the human ship gate

### DIFF
--- a/docs/design/loop-consolidation.md
+++ b/docs/design/loop-consolidation.md
@@ -92,6 +92,51 @@ develop-from-terminal** flow (§9) — the callout's button drives the same `POS
 promotion into a visible `developing` round; convergence remains "no open P0", nothing new is
 persisted, and the FSM is untouched.
 
+### E. VERIFY-BEFORE-MERGE — confirm before the human ship gate (implemented, kill-switched)
+
+**The confirmation re-review moves BEFORE the human ship gate, and it verifies the
+main-integrated state.** Previously the single-verifier/re-review confirmation ran only
+*after* a human triggered merge-approval:
+`develop → dev_completed → awaiting_merge → [human merge_approved] → reviewing (round 2)`.
+Two problems: (1) the loop could not confirm its own work autonomously — a human had to act
+first; and (2) the round branch was cut from a stale base, so its PR conflicted with `main`
+and the verifier judged a state that is **not** what would actually land (observed:
+Omniscience#353 "Conflicting").
+
+Under the kill-switch `pipeline.consiliumLoop.verifyBeforeMerge.enabled` (default **FALSE** ⇒
+today's flow byte-identical), the develop close-out and the FSM routing change so the loop
+confirms itself first:
+
+1. **Integrate main into the round branch.** As a side effect of the develop close-out (like
+   the existing dev-closeout / PR-open — *not* a reducer change), the executor merges the base
+   branch (`origin/<base>`, else the local base ref) **into** the round branch, producing
+   "base + our changes" — the realistic landing state. This also keeps the eventual PR
+   non-conflicting. A merge **conflict** is surfaced clearly (aborted merge → a no-PR result
+   carrying `integrationConflict`), never silently dropped onto a broken merge.
+2. **Run the confirmation review automatically** (the existing round > 1 re-review —
+   single-verifier when `reviewMode = single-verifier`, else the full dispute) against that
+   integrated branch, with **no human gate to start it**. The review is baselined at
+   `base..roundBranch` (its `reviewRef` is pointed at the integrated round branch), so it
+   judges exactly what will land.
+3. **Loop autonomously.** A converged confirmation → `awaiting_merge` (the human's *only* job
+   is now the FINAL ship of already-confirmed, main-integrated code). A non-converged
+   confirmation with rounds left → `developing` again (address the findings, re-integrate,
+   re-confirm), bounded by `maxRounds` → `stopped_cap` exactly as today.
+4. **The human merge becomes the FINAL ship.** With the switch on, `merge_approved` from
+   `awaiting_merge` terminates the loop as `converged` — it does **not** trigger a second
+   review (the confirmation already ran). With the switch off, `merge_approved` re-enters
+   `building_context` (today's re-review trigger), byte-identical.
+
+**FSM discipline — no new states.** The existing transitions are reused: after `dev_completed`
+the loop routes into `reviewing` (via `building_context`) **before** `awaiting_merge`, instead
+of after; `awaiting_merge` becomes the post-confirmation ship gate. The only reducer tweaks are
+three guarded, kill-switched edges (`developing→building_context` on a clean close-out;
+`deciding`-converged→`awaiting_merge` once code has been developed, i.e. round ≥ 2;
+`awaiting_merge`-`merge_approved`→`converged`); each is reversible and inert when the switch is
+off. The main-integration and the confirmation `reviewRef`/baseline are controller side effects
+(deriving the round branch from `buildBranchName`), not reducer state. No schema migration — the
+existing `reviewRef` / `lastReviewedCommit` / round columns and round mechanics are reused.
+
 ## 4. Skills — the unit of agent capability
 
 A loop's steps are executed by **agents**, each dynamically pulling a **skill**. multiqlti

--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -514,6 +514,25 @@ export const ConfigSchema = z.object({
           .default("claude-opus"),
       }).default({}),
       /**
+       * §3E verify-before-merge: move the CONFIRMATION re-review BEFORE the human ship
+       * gate. When `enabled` (default FALSE ⇒ byte-identical to today), after the develop
+       * close-out the loop (1) integrates its BASE branch INTO the round branch — so the
+       * PR is "base + our changes", the realistic landing state — and (2) runs the
+       * confirmation review AUTOMATICALLY (no human gate to START it). A converged
+       * confirmation lands at `awaiting_merge` where the human's ONLY job is the FINAL ship
+       * of already-confirmed code (the `merge_approved` event then terminates the loop with
+       * NO second review). A non-converged confirmation re-develops (bounded by maxRounds).
+       * Default FALSE keeps today's `awaiting_merge → merge_approved → round-2 review` flow
+       * BYTE-IDENTICAL. Gated (like every enhancement here) under the parent
+       * `consiliumLoop.enabled`.
+       */
+      verifyBeforeMerge: z.object({
+        /** Kill-switch: false (default) → today's human-triggered confirmation flow
+         *  (byte-identical). true → confirm against the main-integrated branch BEFORE
+         *  the human ship gate. */
+        enabled: z.boolean().default(false),
+      }).default({}),
+      /**
        * Stage 2a (design §3.C/§4): the SKILLED, archetype-branched implement
        * (develop) phase. When `enabled` is FALSE the loop runs TODAY'S single
        * unskilled coder per action point (byte-for-byte unchanged). When TRUE the

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -65,6 +65,7 @@ import type { DevCloseoutResult } from "./dev-closeout.js";
 import { runSdlcHandoff, type SdlcProgress, type JudgeVerifyFn, type JudgeVerifyInput } from "../sdlc/executor.js";
 import { runResearchHandoff, type ResearchGateway } from "../research/research-runner.js";
 import { assertAllowedRepoPath } from "./repo-allowlist.js";
+import { buildBranchName } from "./pr-wrapper.js";
 import { assertRepoIsProjectWorkspace, backtickFence, stripControlMultiline, buildSingleVerifierTask, VERIFIER_TASK_NAME } from "./review-factory.js";
 
 // ─── FSM events (design §3 "Event / guard" column) ──────────────────────────
@@ -76,7 +77,7 @@ export type LoopEvent =
   | { kind: "review_completed"; verdict: ConvergenceVerdict }
   | { kind: "review_failed"; error: string }
   | { kind: "decided"; verdict: ConvergenceVerdict; priorOpenP0: number[] }
-  | { kind: "dev_completed"; prRef: string | null; headCommit: string; error?: string }
+  | { kind: "dev_completed"; prRef: string | null; headCommit: string; error?: string; integrationBase?: string }
   | { kind: "merge_approved" }
   // HUMAN-only: an authorized re-open of a verdict-terminal loop back to
   // DEVELOPING (injected ONLY by `controller.develop`, NEVER by `deriveEvent` —
@@ -470,7 +471,16 @@ export function composeCancelExplanation(at: Date, actor?: string, reason?: stri
  * `event`, return the single transition to commit, or `null` for a no-op.
  * No storage, no I/O, no `any` — the whole table is unit-testable in isolation.
  */
-export function reduce(state: ConsiliumLoopState, event: LoopEvent): LoopTransition | null {
+export function reduce(
+  state: ConsiliumLoopState,
+  event: LoopEvent,
+  opts?: { verifyBeforeMerge?: boolean },
+): LoopTransition | null {
+  // §3E verify-before-merge (kill-switched, default OFF ⇒ every branch below is
+  // byte-identical to today). When ON it (a) routes the CONFIRMATION review BEFORE the
+  // human ship gate, (b) lands a converged confirmation at awaiting_merge, and (c) makes
+  // the human `merge_approved` the FINAL ship (terminal, NO second review).
+  const vbm = opts?.verifyBeforeMerge ?? false;
   // `cancel` from any non-terminal state → CANCELLED (design §3 last row). Same
   // target/extra shape as before (NO FSM state-table change) plus the `error`
   // column reused as a terminal explanation so the UI never shows a bare
@@ -516,7 +526,7 @@ export function reduce(state: ConsiliumLoopState, event: LoopEvent): LoopTransit
       return null;
 
     case "deciding":
-      if (event.kind === "decided") return decide(event.verdict, event.priorOpenP0);
+      if (event.kind === "decided") return decide(event.verdict, event.priorOpenP0, vbm);
       return null;
 
     case "developing":
@@ -524,11 +534,18 @@ export function reduce(state: ConsiliumLoopState, event: LoopEvent): LoopTransit
         // H-2: the SDLC close-out ran in the BACKGROUND while the loop sat in
         // `developing`; the event carries the REAL prRef/headCommit (+ optional
         // error) the coder produced. The CAS persists them atomically with the
-        // state change, so AWAITING_MERGE always opens with a real PR (never a
-        // half-open gate).
+        // state change, so the gate always opens with a real PR (never a half-open gate).
+        //
+        // §3E: when verify-before-merge is ON and the close-out was CLEAN, route into
+        // `building_context` FIRST — the confirmation re-review of the main-integrated
+        // round branch runs AUTOMATICALLY (no human gate). An integration/close-out ERROR
+        // (`event.error`, incl. an integration CONFLICT) must NOT run a confirmation on a
+        // broken merge, so it falls through to `awaiting_merge` where the human sees it.
+        // Default OFF ⇒ `awaiting_merge`, byte-identical.
+        const confirmFirst = vbm && !event.error;
         return {
           from: "developing",
-          to: "awaiting_merge",
+          to: confirmFirst ? "building_context" : "awaiting_merge",
           extra: {
             prRef: event.prRef,
             headCommitAtReview: event.headCommit,
@@ -539,7 +556,14 @@ export function reduce(state: ConsiliumLoopState, event: LoopEvent): LoopTransit
       return null;
 
     case "awaiting_merge":
-      if (event.kind === "merge_approved") return { from: "awaiting_merge", to: "building_context" };
+      // §3E: with verify-before-merge the confirmation ALREADY ran before this gate, so the
+      // human merge is the FINAL ship of confirmed, main-integrated code → CONVERGED
+      // (terminal, NO second review). Default OFF ⇒ today's re-review re-entry.
+      if (event.kind === "merge_approved") {
+        return vbm
+          ? { from: "awaiting_merge", to: "converged", extra: { completedAt: new Date() } }
+          : { from: "awaiting_merge", to: "building_context" };
+      }
       return null;
 
     default:
@@ -548,16 +572,23 @@ export function reduce(state: ConsiliumLoopState, event: LoopEvent): LoopTransit
 }
 
 /** DECIDING precedence: converged → cap → anti-stall → DEVELOPING (design §3). */
-function decide(verdict: ConvergenceVerdict, priorOpenP0: number[]): LoopTransition {
+function decide(verdict: ConvergenceVerdict, priorOpenP0: number[], vbm = false): LoopTransition {
   const completedAt = new Date();
+  // `priorOpenP0` already includes this round's count as its last element; its length is
+  // the round number reached (round 1 = the initial review before any develop).
+  const round = priorOpenP0.length;
   // 1. A clean verdict wins, even at the cap round (design §3 "round 6 clean").
   if (verdict.converged) {
+    // §3E: a converged CONFIRMATION (round >= 2 ⇒ code WAS developed and re-reviewed) lands
+    // at the human ship gate so the human ships already-confirmed, main-integrated code.
+    // Round-1 immediate convergence (NOTHING developed) stays terminal as before. Default
+    // OFF ⇒ always terminal CONVERGED (byte-identical).
+    if (vbm && round >= 2) {
+      return { from: "deciding", to: "awaiting_merge", extra: { completedAt } };
+    }
     return { from: "deciding", to: "converged", extra: { completedAt } };
   }
   // 2. Cap: the last-allowed round produced open P0s → STOPPED_CAP.
-  //    `priorOpenP0` already includes this round's count as its last element;
-  //    its length is the round number reached.
-  const round = priorOpenP0.length;
   // 3. Anti-stall: open_p0 flat (non-decreasing) across 2 consecutive rounds.
   if (isAntiStall(priorOpenP0, round)) {
     return { from: "deciding", to: "escalated", extra: { completedAt } };
@@ -707,6 +738,19 @@ export class ConsiliumLoopController {
   }
 
   /**
+   * §3E verify-before-merge kill-switch: TRUE only when the parent loop AND
+   * verifyBeforeMerge are both enabled. The SINGLE gate that (a) tells the reducer to
+   * confirm-before-ship (threaded into `reduce`/`onMergeApproved`) and (b) tells the develop
+   * close-out to integrate the base branch into the round branch (`integrateBase` on the SDLC
+   * request). Optional-chained so a hand-built test config omitting the block reads as OFF
+   * ⇒ byte-identical to today.
+   */
+  private verifyBeforeMergeEnabled(): boolean {
+    const cfg = this.loopConfig();
+    return cfg.enabled && (cfg.verifyBeforeMerge?.enabled ?? false);
+  }
+
+  /**
    * Preflight (bug #4) for the research archetype's ONLY tool, web_search. TRUE when
    * its research-grade backend — Tavily — has an API key. web_search's DuckDuckGo
    * fallback needs no key, but its instant-answer API is degenerate for research
@@ -759,7 +803,11 @@ export class ConsiliumLoopController {
     const loop = await this.storage.getLoop(loopId);
     if (!loop || loop.state !== "awaiting_merge") return null;
     const mergedHead = await this.readRepoHead(loop); // SERVER-read, never client.
-    const transition = reduce(loop.state, { kind: "merge_approved" });
+    // §3E: when verify-before-merge is on, `merge_approved` is the FINAL ship → CONVERGED
+    // (terminal, NO second review). Off ⇒ today's re-review re-entry (building_context).
+    const transition = reduce(loop.state, { kind: "merge_approved" }, {
+      verifyBeforeMerge: this.verifyBeforeMergeEnabled(),
+    });
     if (!transition) return null;
     // Audit the delta vs the HEAD we reviewed (M-3); empty string = unreadable.
     const error =
@@ -1146,7 +1194,9 @@ export class ConsiliumLoopController {
       });
     }
 
-    const transition = reduce(loop.state, event);
+    const transition = reduce(loop.state, event, {
+      verifyBeforeMerge: this.verifyBeforeMergeEnabled(),
+    });
     if (!transition) return null;
 
     // H-3 (BLOCKER fix): CLAIM the transition with the CAS FIRST, then run any
@@ -1468,8 +1518,11 @@ export class ConsiliumLoopController {
   private deriveDevEvent(loop: ConsiliumLoopRow): LoopEvent | null {
     const run = this.sdlcRuns.get(loop.id);
     if (!run || run.round !== loop.round || !run.done || !run.result) return null;
-    const { prRef, headCommit, error } = run.result;
-    return { kind: "dev_completed", prRef, headCommit, error };
+    const { prRef, headCommit, error, integrationBase } = run.result;
+    // §3E: `integrationBase` (the base sha merged into the round branch) rides the event so
+    // the developing→building_context side effect can baseline the confirmation review at
+    // `base..roundBranch`. Undefined when verify-before-merge is off ⇒ unused (byte-identical).
+    return { kind: "dev_completed", prRef, headCommit, error, integrationBase };
   }
 
   /**
@@ -1487,12 +1540,29 @@ export class ConsiliumLoopController {
     if (transition.to === "developing" && event.kind === "decided") {
       return this.startDevHandoff(loop, event.verdict);
     }
+    // §3E verify-before-merge: developing→building_context is the CONFIRMATION entry (fires
+    // ONLY on `dev_completed` when verifyBeforeMerge is on and the close-out was clean — the
+    // `start` and human-`merge_approved` routes into building_context carry OTHER events and
+    // fall through untouched, byte-identical). Point the confirmation review at the
+    // main-integrated round branch (`buildBranchName(loop.id, loop.round)`) baselined at the
+    // integrated base sha, so it diffs EXACTLY what will land (`base..roundBranch`).
+    if (transition.to === "building_context" && event.kind === "dev_completed") {
+      const extra: Record<string, unknown> = { reviewRef: buildBranchName(loop.id, loop.round) };
+      if (event.integrationBase) extra.lastReviewedCommit = event.integrationBase;
+      return extra;
+    }
     // §14.4 H-2: the SDLC close-out already ran in the BACKGROUND during
     // `developing`; the `dev_completed` event carried prRef/headCommit/error which
     // `reduce` wrote into this transition's extra. Nothing to run here — just drop
     // the settled registry entry so it can never be re-read.
     if (transition.to === "awaiting_merge") {
       this.sdlcRuns.delete(loop.id);
+      // §3E: a converged CONFIRMATION reaches the ship gate from DECIDING (`decided`), not
+      // from developing — so the terminal `recordRound` branch below is bypassed. Record the
+      // round audit here too so the Rounds panel is complete (idempotent, CAS-winner-only).
+      // The develop entry (from `developing`, `dev_completed`) already recorded on develop
+      // start, and the disabled path never routes DECIDING→awaiting_merge ⇒ byte-identical.
+      if (event.kind === "decided") await this.recordRound(loop, event.verdict);
       return {};
     }
     // Verdict-terminal exits (converged / stopped_cap / escalated) leave DECIDING
@@ -1677,6 +1747,12 @@ export class ConsiliumLoopController {
       actionPoints: routedActionPoints,
       allowedRepoPaths: cfg.allowedRepoPaths,
       ownerId: loop.createdBy ?? "",
+      // §3E verify-before-merge: when on, the executor merges the base branch INTO the round
+      // branch after the coders commit, so the Draft PR is "base + our changes" (the
+      // realistic landing state) and does NOT conflict with main. Off ⇒ no integration merge
+      // (byte-identical). On conflict the executor returns a no-PR result with an error the
+      // `dev_completed` event carries to the human ship gate (no confirmation on a broken merge).
+      integrateBase: this.verifyBeforeMergeEnabled(),
       // Per-action-point coder timeout (configurable). The executor runs the
       // coder once per action point sequentially; this bounds a SINGLE run.
       coderTimeoutMs: cfg.sdlcTimeoutMs,

--- a/server/services/consilium/dev-closeout.ts
+++ b/server/services/consilium/dev-closeout.ts
@@ -48,6 +48,18 @@ export interface DevCloseoutResult {
   /** Scrubbed error/fallback note — present on any non-happy path. */
   error?: string;
   /**
+   * §3E verify-before-merge: the base sha merged INTO the round branch (present only when
+   * the close-out integrated the base branch AND produced a PR). The controller uses it as
+   * the confirmation review's diff baseline (`base..roundBranch`). Undefined otherwise.
+   */
+  integrationBase?: string;
+  /**
+   * §3E: true when the base→round integration merge CONFLICTED (merge aborted, nothing
+   * pushed). Pairs with `prRef: null` + an `error`; the controller surfaces it at the
+   * human ship gate instead of confirming a broken merge.
+   */
+  integrationConflict?: boolean;
+  /**
    * Stage 2b: the aggregated per-criterion test summary for the round, surfaced by
    * the SDLC executor when verification ran (kill-switch on). The controller persists
    * it to `consilium_loop_rounds.testSummary` so the NEXT review round grounds its

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -365,6 +365,17 @@ export interface SdlcHandoffRequest {
    * A single-AP round always takes the sequential path (nothing to parallelize).
    */
   parallel?: ParallelConfig | null;
+  /**
+   * §3E verify-before-merge: after all action points commit, MERGE the base branch
+   * (`origin/<base>`, else local `<base>`) INTO the round branch so the pushed branch +
+   * Draft PR are "base + our changes" — the realistic landing state that a confirmation
+   * review then judges, and a PR that does NOT conflict with main. ABSENT/false (default)
+   * ⇒ NO integration merge runs (byte-for-byte today's develop path). Threaded true by the
+   * controller ONLY when `consiliumLoop.verifyBeforeMerge.enabled`. On a merge CONFLICT the
+   * executor ABORTS the merge and returns a no-PR result with `integrationConflict: true` —
+   * it NEVER pushes a broken merge (adversarial risk: silent dropped changes).
+   */
+  integrateBase?: boolean;
 }
 
 /** Parallel-develop config threaded into {@link runSdlcHandoff} (mirror of
@@ -419,6 +430,20 @@ export interface SdlcHandoffResult {
   headCommit: string;
   /** Scrubbed note present on any non-happy path. */
   error?: string;
+  /**
+   * §3E verify-before-merge: the resolved base sha (`origin/<base>` / local `<base>`) that
+   * was merged INTO the round branch. Present ONLY when `req.integrateBase` was set AND the
+   * merge succeeded; the controller uses it as the confirmation review's diff baseline
+   * (`base..roundBranch` = exactly what will land). Undefined ⇒ integration did not run.
+   */
+  integrationBase?: string;
+  /**
+   * §3E: set true when `req.integrateBase` was requested but the base→round merge
+   * CONFLICTED (the merge was aborted, nothing pushed). Pairs with `prRef: null` + an
+   * `error` describing the conflict, so the controller surfaces it at the human ship gate
+   * instead of running a confirmation on a broken merge.
+   */
+  integrationConflict?: boolean;
   /**
    * Stage 2b: the aggregated, bounded per-criterion test summary for this round.
    * Present ONLY when verification ran (kill-switch on); undefined otherwise (so the
@@ -1034,12 +1059,31 @@ export async function runSdlcHandoff(
         if (await commitFinalFixes(gitRaw, wt, req)) committedCount += 1;
       }
 
+      // §3E verify-before-merge: MERGE the base branch INTO the round branch BEFORE the
+      // push, so the Draft PR is "base + our changes" (the realistic landing state) and
+      // does NOT conflict with main. Only when something was actually committed (an empty
+      // round has no branch to integrate). Off by default ⇒ this whole block is skipped and
+      // the push path is byte-for-byte unchanged. A CONFLICT aborts + surfaces (never pushes
+      // a broken merge, never silently drops our commits).
+      let integrationBase: string | undefined;
+      if ((req.integrateBase ?? false) && committedCount > 0) {
+        const integ = await integrateBaseBranch(gitRaw, wt.worktreeDir, base);
+        if (!integ.ok) {
+          const head = await gitRaw(wt.worktreeDir, ["rev-parse", "HEAD"]).then((s) => s.trim()).catch(() => "");
+          return { prRef: null, headCommit: head, error: integ.error, integrationConflict: true };
+        }
+        integrationBase = integ.integrationBase;
+      }
+
       const result = await pushAndOpenPr(req, branch, base, wt, outcomes, committedCount, {
         gitRaw,
         push,
         openPr,
         emit: progress.beat,
       }, finalVerification);
+      // §3E: surface the integrated base sha (present only when the integration merge ran
+      // and a PR/branch was produced) so the controller can diff `base..roundBranch`.
+      if (integrationBase && result.prRef) result.integrationBase = integrationBase;
       // Stage 2b: aggregate the per-criterion verification into ONE bounded round
       // testSummary, surfaced on the result so the controller can persist it to
       // `consilium_loop_rounds.testSummary` (the convergence wire). Undefined when
@@ -2171,4 +2215,47 @@ async function pushAndOpenPr(
     return { prRef: null, headCommit, error: `pushed branch ${branch}; open PR manually` };
   }
   return { prRef: pr.prUrl, headCommit };
+}
+
+/**
+ * §3E verify-before-merge: MERGE the loop's base branch INTO the round branch (in the
+ * round worktree) so the branch becomes "base + our changes" — the realistic landing
+ * state. Best-effort `git fetch origin <base>` first (a repo with no `origin` / offline
+ * falls back to the LOCAL base ref); the resolved base sha is returned so the controller
+ * can diff `base..roundBranch`. A merge CONFLICT (or any merge failure) is caught, the
+ * merge is ABORTED so the worktree is left clean, and an error is returned — the caller
+ * NEVER pushes a broken merge. `base` is server-derived (resolveDefaultBranch) and pinned
+ * behind `--end-of-options`, so it can never inject a git flag.
+ */
+async function integrateBaseBranch(
+  gitRaw: GitRunner,
+  worktreeDir: string,
+  base: string,
+): Promise<{ ok: true; integrationBase: string } | { ok: false; error: string }> {
+  // Refresh the remote base (non-fatal — offline / no origin falls back to the local ref).
+  await gitRaw(worktreeDir, ["fetch", "origin", "--end-of-options", base]).catch(() => undefined);
+  // Prefer the freshly-fetched remote-tracking ref; fall back to the local base branch.
+  const remoteRef = `origin/${base}`;
+  const remoteSha = await gitRaw(worktreeDir, ["rev-parse", "--verify", "--quiet", `${remoteRef}^{commit}`])
+    .then((s) => s.trim())
+    .catch(() => "");
+  const target = remoteSha ? remoteRef : base;
+  const resolved = await gitRaw(worktreeDir, ["rev-parse", "--end-of-options", target])
+    .then((s) => s.trim())
+    .catch(() => "");
+  if (!resolved) {
+    return { ok: false, error: `integration: base ref '${base}' is unresolvable` };
+  }
+  try {
+    // --no-edit keeps a server-derived merge message (never model/AP text). If `base` is
+    // already an ancestor this is a no-op ("Already up to date"); otherwise a merge commit.
+    await gitRaw(worktreeDir, ["merge", "--no-edit", "--end-of-options", resolved]);
+  } catch (err) {
+    await gitRaw(worktreeDir, ["merge", "--abort"]).catch(() => undefined);
+    return {
+      ok: false,
+      error: scrub(`integration conflict merging ${base} into the round branch: ${err instanceof Error ? err.message : String(err)}`),
+    };
+  }
+  return { ok: true, integrationBase: resolved };
 }

--- a/tests/unit/consilium/loop-verify-before-merge.test.ts
+++ b/tests/unit/consilium/loop-verify-before-merge.test.ts
@@ -1,0 +1,290 @@
+/**
+ * loop-verify-before-merge.test.ts — §3E verify-before-merge.
+ *
+ * The confirmation re-review moves BEFORE the human ship gate: after `dev_completed`
+ * the loop (1) integrates its base branch into the round branch (so the PR is the
+ * REALISTIC landing state) and (2) runs the confirmation review AUTOMATICALLY — no human
+ * gate to START it. A converged confirmation lands at `awaiting_merge` where the human's
+ * only job is the FINAL ship; the `merge_approved` event then TERMINATES the loop with NO
+ * second review. All kill-switched under `pipeline.consiliumLoop.verifyBeforeMerge.enabled`
+ * (default FALSE ⇒ today's flow byte-identical).
+ *
+ * Coverage:
+ *   A. PURE reducer routing (enabled vs disabled) for all three touched transitions.
+ *   B. Controller tick wiring: enabled → integrate (integrateBase=true) + confirmation
+ *      BEFORE awaiting_merge; converged → awaiting_merge; not-converged → develop again;
+ *      disabled → awaiting_merge (byte-identical); the human merge on an enabled loop does
+ *      NOT trigger a second review.
+ *   C. Adversarial: an integration CONFLICT (dev_completed carries an error) must NOT run a
+ *      confirmation on a broken merge — it falls through to the human ship gate.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  reduce,
+  ConsiliumLoopController,
+  type LoopEvent,
+} from "../../../server/services/consilium/consilium-loop-controller.js";
+import type { ConsiliumLoopRow, ConsiliumLoopState } from "@shared/schema";
+import type { ConvergenceVerdict } from "@shared/types";
+
+const verdict = (converged: boolean, openP0: number): ConvergenceVerdict => ({
+  converged,
+  openP0,
+  openActionPoints: Array.from({ length: openP0 }, (_, i) => ({ title: `ap${i}`, priority: "P0" })),
+});
+
+const VBM_ON = { verifyBeforeMerge: true } as const;
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+// ─── A. PURE reducer — verify-before-merge routing (enabled vs default OFF) ──────
+
+describe("reduce — §3E verify-before-merge routing", () => {
+  const devDone: LoopEvent = { kind: "dev_completed", prRef: "pr/1", headCommit: "h1", integrationBase: "base1" };
+
+  it("DEFAULT OFF is byte-identical: developing+dev_completed → AWAITING_MERGE", () => {
+    expect(reduce("developing", devDone)?.to).toBe("awaiting_merge");
+    // and, per default, converged terminates + merge_approved re-reviews (today's flow).
+    expect(reduce("deciding", { kind: "decided", verdict: verdict(true, 0), priorOpenP0: [3, 0] })?.to).toBe("converged");
+    expect(reduce("awaiting_merge", { kind: "merge_approved" })?.to).toBe("building_context");
+  });
+
+  it("ON + CLEAN close-out: developing+dev_completed → BUILDING_CONTEXT (confirm before ship)", () => {
+    const t = reduce("developing", devDone, VBM_ON);
+    expect(t?.to).toBe("building_context");
+    // prRef + reviewed head are still carried atomically (as they are into awaiting_merge).
+    expect(t?.extra?.prRef).toBe("pr/1");
+    expect(t?.extra?.headCommitAtReview).toBe("h1");
+  });
+
+  it("ON + close-out/integration ERROR: developing+dev_completed → AWAITING_MERGE (surface, no confirm on a broken merge)", () => {
+    const t = reduce(
+      "developing",
+      { kind: "dev_completed", prRef: null, headCommit: "h", error: "integration conflict merging main into the round branch" },
+      VBM_ON,
+    );
+    expect(t?.to).toBe("awaiting_merge"); // NOT building_context
+    expect(t?.extra?.error).toContain("integration conflict");
+  });
+
+  it("ON: a converged CONFIRMATION (round>=2, code was developed) → AWAITING_MERGE (ship gate)", () => {
+    const t = reduce("deciding", { kind: "decided", verdict: verdict(true, 0), priorOpenP0: [3, 0] }, VBM_ON);
+    expect(t?.to).toBe("awaiting_merge");
+  });
+
+  it("ON: round-1 IMMEDIATE convergence (nothing developed) → CONVERGED (terminal, unchanged)", () => {
+    const t = reduce("deciding", { kind: "decided", verdict: verdict(true, 0), priorOpenP0: [0] }, VBM_ON);
+    expect(t?.to).toBe("converged");
+  });
+
+  it("ON: a non-converged confirmation with room left → DEVELOPING (re-develop; unchanged)", () => {
+    const t = reduce("deciding", { kind: "decided", verdict: verdict(false, 1), priorOpenP0: [3, 1] }, VBM_ON);
+    expect(t?.to).toBe("developing");
+  });
+
+  it("ON: awaiting_merge+merge_approved → CONVERGED (FINAL ship, NO second review)", () => {
+    const t = reduce("awaiting_merge", { kind: "merge_approved" }, VBM_ON);
+    expect(t?.to).toBe("converged");
+    expect(t?.extra?.completedAt).toBeInstanceOf(Date);
+  });
+});
+
+// ─── B/C. Controller tick wiring over fakes ─────────────────────────────────────
+
+function makeLoop(over: Partial<ConsiliumLoopRow>): ConsiliumLoopRow {
+  return {
+    id: "loop-vbm",
+    projectId: "proj1",
+    groupId: "grp1",
+    state: "deciding",
+    round: 1,
+    maxRounds: 6,
+    repoPath: process.cwd(),
+    lastReviewedCommit: null,
+    reviewRef: null,
+    reviewMode: null,
+    archetype: null,
+    currentIterationNumber: 1,
+    devGroupId: null,
+    prRef: null,
+    headCommitAtReview: null,
+    openP0: null,
+    error: null,
+    createdBy: "user1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    completedAt: null,
+    ...over,
+  } as ConsiliumLoopRow;
+}
+
+function fakeStorage(loop: ConsiliumLoopRow, rounds: { round: number; openP0: number }[] = []) {
+  let current = loop;
+  const storage = {
+    getLoop: vi.fn(async () => current),
+    getLoops: vi.fn(async () => [current]),
+    getLoopRounds: vi.fn(async () => rounds.map((r) => ({ ...r }))),
+    casLoopState: vi.fn(async (id: string, expected: ConsiliumLoopState, next: ConsiliumLoopState, extra?: Record<string, unknown>) => {
+      if (id !== current.id || current.state !== expected) return undefined;
+      current = { ...current, ...(extra ?? {}), state: next };
+      return current;
+    }),
+    claimRedrive: vi.fn(async () => undefined),
+    appendLoopRound: vi.fn(async () => ({})),
+    updateLoop: vi.fn(async (_id: string, extra?: Record<string, unknown>) => {
+      current = { ...current, ...(extra ?? {}) };
+      return current;
+    }),
+    getTaskGroup: vi.fn(async () => ({ id: current.groupId, input: "objective" })),
+    updateTaskGroup: vi.fn(async () => ({})),
+    getIteration: vi.fn(async () => ({ id: "it1", iterationNumber: current.currentIterationNumber ?? 1, status: "completed" })),
+    getExecutionsByIteration: vi.fn(async () => []),
+    getSkills: vi.fn(async () => []),
+  };
+  return { storage, get: () => current };
+}
+
+/** Config for the controller. `vbm` toggles the ONLY kill-switch under test. */
+const makeConfig =
+  (vbm: boolean) =>
+  () =>
+    ({
+      pipeline: {
+        consiliumLoop: {
+          enabled: true,
+          maxRounds: 6,
+          pollIntervalMs: 5000,
+          maxDiffBytes: 200000,
+          allowedRepoPaths: [process.cwd()],
+          sdlcTimeoutMs: 300000,
+          verifyBeforeMerge: { enabled: vbm },
+          // The skilled SDLC executor is the only develop path; enable it so develop
+          // dispatches the (injected) runSdlc. Verification OFF (schema default).
+          implement: {
+            enabled: true,
+            verification: { enabled: false },
+            maxFixIterations: 3,
+            testCommand: null,
+            testRunTimeoutMs: 300000,
+            research: { enabled: false, maxResearchIterations: 3, model: "claude-sonnet" },
+          },
+        },
+      },
+    }) as never;
+
+const orchestrator = () => {
+  const sg = vi.fn(async () => ({ group: {}, iteration: { iterationNumber: 1 } }));
+  return { taskOrchestrator: { startGroup: sg, startGroupAsync: sg, createTaskGroup: vi.fn(), cancelGroup: vi.fn() }, sg };
+};
+
+/** A clean develop close-out that integrated `base-sha` into the round branch. */
+const cleanRunSdlc = () =>
+  vi.fn(async (_req: unknown) => ({ prRef: "https://github.com/x/y/pull/9", headCommit: "devhead", integrationBase: "base-sha" }));
+
+describe("controller — §3E verify-before-merge wiring", () => {
+  it("ENABLED: develop dispatches integrateBase=true, then confirms BEFORE awaiting_merge (reviewRef→round branch, baseline→integrated base)", async () => {
+    const loop = makeLoop({ state: "deciding", round: 1, currentIterationNumber: 1 });
+    const { storage } = fakeStorage(loop);
+    const { taskOrchestrator } = orchestrator();
+    const runSdlc = cleanRunSdlc();
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: taskOrchestrator as never,
+      config: makeConfig(true),
+      readIterationVerdict: async () => verdict(false, 2), // open P0s, room left → DEVELOPING
+      readRepoHead: async () => "repohead",
+      runSdlc: runSdlc as never,
+    });
+
+    const t1 = await controller.tick(loop.id); // deciding → developing (dispatch background)
+    expect(t1?.state).toBe("developing");
+    await flush(); // let the fire-and-forget close-out settle into the registry
+
+    // The develop close-out was asked to integrate the base branch (§3E).
+    expect(runSdlc).toHaveBeenCalledTimes(1);
+    expect((runSdlc.mock.calls[0][0] as { integrateBase?: boolean }).integrateBase).toBe(true);
+
+    const t2 = await controller.tick(loop.id); // developing → BUILDING_CONTEXT (confirmation entry)
+    expect(t2?.state).toBe("building_context"); // NOT awaiting_merge — confirmation runs first
+    expect(t2?.reviewRef).toBe("consilium/loop-loop-vbm/round-1"); // review the integrated round branch
+    expect(t2?.lastReviewedCommit).toBe("base-sha"); // diff base..roundBranch = what will land
+  });
+
+  it("ENABLED: a CONVERGED confirmation (round>=2) lands at AWAITING_MERGE (the human ship gate)", async () => {
+    const loop = makeLoop({ state: "deciding", round: 2, currentIterationNumber: 2 });
+    const { storage } = fakeStorage(loop, [{ round: 1, openP0: 3 }]);
+    const { taskOrchestrator } = orchestrator();
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: taskOrchestrator as never,
+      config: makeConfig(true),
+      readIterationVerdict: async () => verdict(true, 0), // confirmation CONVERGED
+    });
+    const res = await controller.tick(loop.id);
+    expect(res?.state).toBe("awaiting_merge");
+  });
+
+  it("ENABLED: a NON-converged confirmation with room left → DEVELOPING (loop keeps going, bounded by maxRounds)", async () => {
+    const loop = makeLoop({ state: "deciding", round: 2, currentIterationNumber: 2 });
+    const { storage } = fakeStorage(loop, [{ round: 1, openP0: 3 }]);
+    const { taskOrchestrator } = orchestrator();
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: taskOrchestrator as never,
+      config: makeConfig(true),
+      readIterationVerdict: async () => verdict(false, 1), // still open, decreasing → re-develop
+      runSdlc: cleanRunSdlc() as never,
+    });
+    const res = await controller.tick(loop.id);
+    expect(res?.state).toBe("developing");
+  });
+
+  it("DISABLED: develop → AWAITING_MERGE and NO integration requested (byte-identical to today)", async () => {
+    const loop = makeLoop({ state: "deciding", round: 1, currentIterationNumber: 1 });
+    const { storage } = fakeStorage(loop);
+    const { taskOrchestrator } = orchestrator();
+    const runSdlc = cleanRunSdlc();
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: taskOrchestrator as never,
+      config: makeConfig(false), // kill-switch OFF
+      readIterationVerdict: async () => verdict(false, 2),
+      runSdlc: runSdlc as never,
+    });
+    await controller.tick(loop.id); // deciding → developing
+    await flush();
+    // Off ⇒ the executor is NOT asked to integrate.
+    expect((runSdlc.mock.calls[0][0] as { integrateBase?: boolean }).integrateBase).toBe(false);
+    const t2 = await controller.tick(loop.id); // developing → AWAITING_MERGE (today's flow)
+    expect(t2?.state).toBe("awaiting_merge");
+    expect(t2?.reviewRef ?? null).toBeNull(); // reviewRef untouched on the disabled path
+  });
+
+  it("ENABLED: the human merge on an awaiting_merge loop → CONVERGED and does NOT trigger a second review", async () => {
+    const loop = makeLoop({ state: "awaiting_merge", round: 2, headCommitAtReview: "confirmedhead" });
+    const { storage } = fakeStorage(loop);
+    const { taskOrchestrator, sg } = orchestrator();
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: taskOrchestrator as never,
+      config: makeConfig(true),
+      readRepoHead: async () => "confirmedhead",
+    });
+    const res = await controller.onMergeApproved(loop.id);
+    expect(res?.state).toBe("converged"); // FINAL ship — terminal
+    expect(sg).not.toHaveBeenCalled(); // NO round-2 review dispatched
+  });
+
+  it("DISABLED: the human merge re-enters BUILDING_CONTEXT (today's re-review trigger, byte-identical)", async () => {
+    const loop = makeLoop({ state: "awaiting_merge", round: 1, headCommitAtReview: "h" });
+    const { storage } = fakeStorage(loop);
+    const { taskOrchestrator } = orchestrator();
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: taskOrchestrator as never,
+      config: makeConfig(false),
+      readRepoHead: async () => "h",
+    });
+    const res = await controller.onMergeApproved(loop.id);
+    expect(res?.state).toBe("building_context");
+  });
+});

--- a/tests/unit/sdlc/executor.test.ts
+++ b/tests/unit/sdlc/executor.test.ts
@@ -452,3 +452,64 @@ describe("runSdlcHandoff — LIVE per-AP task list (progress.aps)", () => {
     expect(events[0].aps![99].i).toBe(100);
   });
 });
+
+// ─── §3E verify-before-merge — base→round integration merge ─────────────────────
+
+/** A git runner that discriminates the integration calls; `merge` conflicts when
+ *  `conflict` is set. Records every call for assertion. */
+function makeIntegGitRaw(opts: { conflict?: boolean; remoteResolves?: boolean } = {}) {
+  return vi.fn(async (_repo: string, args: string[]) => {
+    if (args[0] === "status") return " M server/x.ts\n"; // dirty → commits happen
+    if (args[0] === "fetch") return "";
+    if (args[0] === "rev-parse") {
+      if (args.includes("HEAD")) return "headsha000\n";
+      if (args.includes("--verify")) return opts.remoteResolves === false ? "" : "originsha\n";
+      return "basesha111\n"; // resolved integration base (--end-of-options <target>)
+    }
+    if (args[0] === "merge") {
+      if (args[1] === "--abort") return "";
+      if (opts.conflict) throw new Error("merge conflict in server/x.ts");
+      return "";
+    }
+    return "";
+  });
+}
+
+describe("runSdlcHandoff — §3E integration merge (integrateBase)", () => {
+  it("integrateBase=true, CLEAN merge: merges the base INTO the round branch, pushes, returns integrationBase", async () => {
+    const gitRaw = makeIntegGitRaw();
+    const deps = makeDeps({ gitRaw });
+    const res = await runSdlcHandoff(baseReq({ integrateBase: true }), deps as never);
+    // A merge of the resolved base ran before the push.
+    const merged = gitRaw.mock.calls.find((c) => (c[1] as string[])[0] === "merge" && (c[1] as string[]).includes("basesha111"));
+    expect(merged).toBeDefined();
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9"); // PR still opened
+    expect(res.integrationBase).toBe("basesha111"); // baseline the controller diffs against
+    expect(res.integrationConflict).toBeUndefined();
+    expect(deps.push).toHaveBeenCalledTimes(1);
+  });
+
+  it("integrateBase=true, CONFLICT: aborts the merge, surfaces the error, NEVER pushes a broken merge", async () => {
+    const gitRaw = makeIntegGitRaw({ conflict: true });
+    const deps = makeDeps({ gitRaw });
+    const res = await runSdlcHandoff(baseReq({ integrateBase: true }), deps as never);
+    expect(res.prRef).toBeNull();
+    expect(res.integrationConflict).toBe(true);
+    expect(res.error).toContain("integration conflict");
+    // The merge was aborted and NOTHING was pushed / PR'd (no silent broken-merge landing).
+    expect(gitRaw.mock.calls.some((c) => (c[1] as string[])[0] === "merge" && (c[1] as string[])[1] === "--abort")).toBe(true);
+    expect(deps.push).not.toHaveBeenCalled();
+    expect(deps.openPr).not.toHaveBeenCalled();
+    expect(deps.removeWorktree).toHaveBeenCalledTimes(1); // cleanup still guaranteed
+  });
+
+  it("integrateBase absent (default): NO fetch/merge runs — byte-identical to today", async () => {
+    const gitRaw = makeIntegGitRaw();
+    const deps = makeDeps({ gitRaw });
+    const res = await runSdlcHandoff(baseReq(), deps as never); // integrateBase omitted
+    expect(gitRaw.mock.calls.some((c) => (c[1] as string[])[0] === "fetch")).toBe(false);
+    expect(gitRaw.mock.calls.some((c) => (c[1] as string[])[0] === "merge")).toBe(false);
+    expect(res.integrationBase).toBeUndefined();
+    expect(res.prRef).toBe("https://github.com/x/y/pull/9");
+  });
+})


### PR DESCRIPTION
## The flow change

Today the single-verifier/re-review **confirmation** only runs *after* a human triggers merge-approval:

```
develop → dev_completed → awaiting_merge → [human merge_approved] → reviewing (round 2 confirmation)
```

So the loop cannot confirm its own work — a human must act first. Worse, the round branch is cut from a stale base, so its PR conflicts with `main` (observed: Omniscience#353 "Conflicting") and the verifier judges a state that is **not** what will land.

This PR moves the confirmation **before** the human ship gate and verifies it against the **main-integrated** branch. Kill-switched under `pipeline.consiliumLoop.verifyBeforeMerge.enabled` (default **FALSE** → today's flow byte-identical).

When enabled, after `dev_completed`:
1. **Integrate main into the round branch** — merge/`base + our changes` — the realistic landing state (and a non-conflicting PR).
2. **Run the confirmation review automatically** (single-verifier when `reviewMode=single-verifier`, else full dispute) against that integrated branch, baselined at `base..roundBranch` — **no human gate** to start it.
3. **Loop autonomously** — converged → `awaiting_merge` (the human's only job is the FINAL ship of already-confirmed code); not-converged with rounds left → `developing` again (re-integrate + re-confirm), bounded by `maxRounds` → `stopped_cap`.
4. **The human merge becomes the FINAL ship** — `merge_approved` terminates the loop as `converged` with **no second review**.

Disabled → exact current flow (`awaiting_merge → merge_approved → round-2 review`), byte-identical.

## Main-integration + conflict handling

As a side effect of the develop close-out (not a reducer change), the SDLC executor merges the base branch (`origin/<base>`, else the local base ref) **into** the round branch after the coders commit and before the push. A merge **conflict** aborts the merge and returns a no-PR result carrying `integrationConflict` + a scrubbed error; the controller routes that to the human ship gate — it **never** pushes a broken merge or silently drops changes.

## FSM discipline (no new states)

Existing transitions reused: after `dev_completed` the loop routes into `reviewing` (via `building_context`) **before** `awaiting_merge`; `awaiting_merge` becomes the post-confirmation ship gate. Three guarded, kill-switched reducer edges — `developing→building_context` (clean close-out), `deciding`-converged→`awaiting_merge` (once code was developed, round ≥ 2), `awaiting_merge`-`merge_approved`→`converged`. Each is reversible and inert when the switch is off. Main-integration and the confirmation `reviewRef`/baseline are controller side effects (round branch from `buildBranchName`), not reducer state. **No schema migration** — reuses `reviewRef` / `lastReviewedCommit` / round columns.

## Design doc

`docs/design/loop-consolidation.md` §3E "verify-before-merge": confirmation moves before the human ship gate; verification is against the main-integrated state; the human merge becomes the final ship of confirmed code; kill-switch.

## Test evidence

New `tests/unit/consilium/loop-verify-before-merge.test.ts` (13) proves, via the FSM + injected fakes:
- enabled → after `dev_completed` the loop requests integration (`integrateBase=true`) and runs the confirmation **before** `awaiting_merge` (reviewRef → round branch, baseline → integrated base);
- converged → `awaiting_merge`; not-converged → `developing` again;
- disabled → `awaiting_merge` (byte-identical), no integration requested, reviewRef untouched;
- the human merge on an enabled loop → `converged` and does **not** dispatch a second review.

New executor cases in `tests/unit/sdlc/executor.test.ts` (3) cover the real git plumbing via a fake runner: clean merge → `integrationBase` returned + PR opened; conflict → aborted + surfaced + nothing pushed; `integrateBase` absent → no fetch/merge (byte-identical).

Adversarial self-review: (a) infinite develop↔verify loop — bounded by `maxRounds`→`stopped_cap`; (b) integration conflict silently dropping changes — surfaced, never pushed; (c) double-review on the human merge — terminal, no second review; (d) disabled-path drift — byte-identical tests.

- `tsc --noEmit` clean
- full unit suite green: **4947 passed** (258 files)