### PR TITLE
fix: verify-before-merge integration git argv (flag+ref concatenated)

### DIFF
--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -438,10 +438,13 @@ export interface SdlcHandoffResult {
    */
   integrationBase?: string;
   /**
-   * §3E: set true when `req.integrateBase` was requested but the base→round merge
-   * CONFLICTED (the merge was aborted, nothing pushed). Pairs with `prRef: null` + an
-   * `error` describing the conflict, so the controller surfaces it at the human ship gate
-   * instead of running a confirmation on a broken merge.
+   * §3E: set true ONLY when `req.integrateBase` was requested and the base→round merge hit a
+   * real CONTENT conflict (overlapping edits ⇒ unmerged index entries; the merge was aborted,
+   * nothing pushed). A malformed-command / unresolvable-ref failure is NOT a conflict — it
+   * leaves this `false`/undefined and instead carries an "integration could not run …"
+   * `error`, so the human ship gate is not told there's a conflict when the merge command was
+   * simply wrong. Either way pairs with `prRef: null` (the controller runs no confirmation on
+   * a broken/absent merge).
    */
   integrationConflict?: boolean;
   /**
@@ -1070,7 +1073,16 @@ export async function runSdlcHandoff(
         const integ = await integrateBaseBranch(gitRaw, wt.worktreeDir, base);
         if (!integ.ok) {
           const head = await gitRaw(wt.worktreeDir, ["rev-parse", "HEAD"]).then((s) => s.trim()).catch(() => "");
-          return { prRef: null, headCommit: head, error: integ.error, integrationConflict: true };
+          // Only a REAL content conflict is flagged `integrationConflict`; a command / ref
+          // ERROR carries the distinct "could not run" wording (kind: "error") so the human
+          // ship gate is not told there's a conflict when the merge command was just wrong.
+          // Both paths abort the merge and fall back safely (prRef: null, nothing pushed).
+          return {
+            prRef: null,
+            headCommit: head,
+            error: integ.error,
+            integrationConflict: integ.kind === "conflict",
+          };
         }
         integrationBase = integ.integrationBase;
       }
@@ -2222,39 +2234,87 @@ async function pushAndOpenPr(
  * round worktree) so the branch becomes "base + our changes" — the realistic landing
  * state. Best-effort `git fetch origin <base>` first (a repo with no `origin` / offline
  * falls back to the LOCAL base ref); the resolved base sha is returned so the controller
- * can diff `base..roundBranch`. A merge CONFLICT (or any merge failure) is caught, the
- * merge is ABORTED so the worktree is left clean, and an error is returned — the caller
- * NEVER pushes a broken merge. `base` is server-derived (resolveDefaultBranch) and pinned
- * behind `--end-of-options`, so it can never inject a git flag.
+ * can diff `base..roundBranch`.
+ *
+ * ROOT CAUSE this locks down (the live incident): the base sha was resolved with
+ * `git rev-parse --end-of-options <ref>`, which — in rev-parse's DEFAULT (echo) mode —
+ * prints the literal `--end-of-options` token back on its OWN line BEFORE the sha
+ * (`--end-of-options\n<sha>`). `.trim()` only strips the OUTER whitespace, so `resolved`
+ * became the two-line string `"--end-of-options\n<sha>"`. That whole string was then handed
+ * to `git merge --no-edit --end-of-options <resolved>` as a SINGLE positional (the real
+ * `--end-of-options` before it having disabled option parsing) ⇒ git:
+ * `merge: --end-of-options <sha> - not something we can merge` (the `\n` renders as a space
+ * in single-line logs) — a false "integration conflict" when the command itself was
+ * malformed. FIX: resolve with rev-parse's SINGLE-object VERIFY mode
+ * (`--verify [--quiet] --end-of-options <ref>^{commit}`), which emits ONLY the sha and never
+ * echoes the flag. `base` stays server-derived (resolveDefaultBranch), gated `isSafeRef`,
+ * and pinned behind `--end-of-options`, so it can never inject a git flag.
+ *
+ * A merge failure leaves the worktree ABORTED (clean) and returns an error — the caller NEVER
+ * pushes a broken merge. IMPORTANT: the git runner (simple-git `.raw`) does NOT reject on a
+ * merge CONFLICT — it resolves with the "CONFLICT …" text and leaves an UNMERGED index — so we
+ * do NOT rely on the merge throwing; we inspect `git ls-files --unmerged` AFTER the merge and
+ * treat unmerged entries as a conflict. We DISTINGUISH a real content CONFLICT (overlapping
+ * edits ⇒ unmerged index entries ⇒ `kind: "conflict"`) from a command / unresolvable-ref ERROR
+ * (`kind: "error"`), so the operator is not told "conflict" when the command was simply wrong.
+ * Both abort and fall back safely (no PR).
  */
-async function integrateBaseBranch(
+export async function integrateBaseBranch(
   gitRaw: GitRunner,
   worktreeDir: string,
   base: string,
-): Promise<{ ok: true; integrationBase: string } | { ok: false; error: string }> {
+): Promise<
+  | { ok: true; integrationBase: string }
+  | { ok: false; kind: "conflict" | "error"; error: string }
+> {
   // Refresh the remote base (non-fatal — offline / no origin falls back to the local ref).
-  await gitRaw(worktreeDir, ["fetch", "origin", "--end-of-options", base]).catch(() => undefined);
-  // Prefer the freshly-fetched remote-tracking ref; fall back to the local base branch.
-  const remoteRef = `origin/${base}`;
-  const remoteSha = await gitRaw(worktreeDir, ["rev-parse", "--verify", "--quiet", `${remoteRef}^{commit}`])
-    .then((s) => s.trim())
-    .catch(() => "");
-  const target = remoteSha ? remoteRef : base;
-  const resolved = await gitRaw(worktreeDir, ["rev-parse", "--end-of-options", target])
-    .then((s) => s.trim())
-    .catch(() => "");
+  // On success both `origin/<base>` and FETCH_HEAD advance to the object we need to merge,
+  // so a round branch cut from a STALE base can still resolve the advanced base here.
+  const fetched = await gitRaw(worktreeDir, ["fetch", "origin", "--end-of-options", base])
+    .then(() => true)
+    .catch(() => false);
+  // Resolve to a CLEAN sha via rev-parse VERIFY mode (no flag echo — see the block comment).
+  // Candidate order: freshly-fetched remote-tracking ref → FETCH_HEAD (the just-fetched
+  // object, present even when the tracking ref was not updated) → the LOCAL base ref.
+  const candidates = [`origin/${base}`, ...(fetched ? ["FETCH_HEAD"] : []), base];
+  let resolved = "";
+  for (const target of candidates) {
+    resolved = await gitRaw(worktreeDir, ["rev-parse", "--verify", "--quiet", "--end-of-options", `${target}^{commit}`])
+      .then((s) => s.trim())
+      .catch(() => "");
+    if (resolved) break;
+  }
   if (!resolved) {
-    return { ok: false, error: `integration: base ref '${base}' is unresolvable` };
+    // The base object is genuinely not present (and could not be fetched). This is a
+    // command/ref ERROR, NOT a content conflict — classify it distinctly.
+    return { ok: false, kind: "error", error: `integration could not run: base ref '${base}' is unresolvable` };
   }
   try {
     // --no-edit keeps a server-derived merge message (never model/AP text). If `base` is
     // already an ancestor this is a no-op ("Already up to date"); otherwise a merge commit.
     await gitRaw(worktreeDir, ["merge", "--no-edit", "--end-of-options", resolved]);
   } catch (err) {
+    // The runner threw — a command / ref failure (a clean sha reached merge, so this is not a
+    // normal content conflict). Classify by index state anyway (defensive): unmerged entries ⇒
+    // conflict, otherwise a command error. Abort AFTER inspecting (abort clears the index).
+    const unmerged = await gitRaw(worktreeDir, ["ls-files", "--unmerged"]).then((s) => s.trim()).catch(() => "");
+    await gitRaw(worktreeDir, ["merge", "--abort"]).catch(() => undefined);
+    const reason = err instanceof Error ? err.message : String(err);
+    return unmerged
+      ? { ok: false, kind: "conflict", error: scrub(`integration conflict merging ${base} into the round branch: ${reason}`) }
+      : { ok: false, kind: "error", error: scrub(`integration could not run merging ${base} into the round branch: ${reason}`) };
+  }
+  // CRITICAL: the git runner (simple-git `.raw`) does NOT reject on a merge-CONFLICT exit —
+  // it returns the "CONFLICT …" text as stdout and leaves an UNMERGED index. So a real content
+  // conflict does NOT throw above; we MUST detect the unmerged state explicitly, ABORT it, and
+  // report it — otherwise a broken half-merged tree would be treated as success and pushed.
+  const unmerged = await gitRaw(worktreeDir, ["ls-files", "--unmerged"]).then((s) => s.trim()).catch(() => "");
+  if (unmerged) {
     await gitRaw(worktreeDir, ["merge", "--abort"]).catch(() => undefined);
     return {
       ok: false,
-      error: scrub(`integration conflict merging ${base} into the round branch: ${err instanceof Error ? err.message : String(err)}`),
+      kind: "conflict",
+      error: scrub(`integration conflict merging ${base} into the round branch (overlapping edits)`),
     };
   }
   return { ok: true, integrationBase: resolved };

--- a/tests/integration/sdlc-verify-before-merge-integration.test.ts
+++ b/tests/integration/sdlc-verify-before-merge-integration.test.ts
@@ -1,0 +1,181 @@
+/**
+ * sdlc-verify-before-merge-integration.test.ts — REAL-GIT integration for §3E
+ * verify-before-merge's `integrateBaseBranch` helper.
+ *
+ * WHY THIS EXISTS (the incident it locks down): the base sha was resolved with
+ * `git rev-parse --end-of-options <ref>`. In rev-parse's DEFAULT (echo) mode git prints the
+ * literal `--end-of-options` token back on its OWN line before the sha
+ * (`--end-of-options\n<sha>`); `.trim()` only strips the OUTER whitespace, so `resolved`
+ * became the two-line string `"--end-of-options\n<sha>"`. Handed to
+ * `git merge --no-edit --end-of-options <resolved>` that whole string is ONE positional
+ * (the real `--end-of-options` before it disables option parsing) ⇒
+ * `merge: --end-of-options <sha> - not something we can merge` — a FALSE "integration
+ * conflict" when the command itself was malformed. Fully-mocked unit tests never run real
+ * git, so they miss this exactly like the #482→#485 fan-out D/F bug. This test drives the
+ * REAL helper + real `git` against scratch repos, so a regression fails deterministically.
+ *
+ * Coverage:
+ *  (a) a branch cut from an OLDER base, with "main" advanced, MERGES cleanly (argv correct,
+ *      ref resolvable) and the branch advances;
+ *  (b) a genuine overlapping-edit conflict is reported as a `kind: "conflict"` and ABORTED
+ *      (worktree left clean);
+ *  (c) the merge argv is SEPARATE elements — the sha is a lone clean 40-hex token, never a
+ *      `--end-of-options <sha>` concatenation, and resolution uses rev-parse VERIFY mode.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "child_process";
+import { mkdtempSync, rmSync, realpathSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { integrateBaseBranch } from "../../server/services/sdlc/executor.js";
+import { defaultGitRaw, type GitRunner } from "../../server/services/sdlc/worktree.js";
+
+let originDir: string;
+let cloneDir: string;
+let oldBaseSha: string;
+
+/** Run a real git command in `dir`, returning trimmed stdout. */
+function gitIn(dir: string, ...args: string[]): string {
+  return execFileSync("git", ["-C", dir, ...args], { encoding: "utf8" }).trim();
+}
+
+function initRepo(dir: string): void {
+  gitIn(dir, "init", "-q", "-b", "main");
+  gitIn(dir, "config", "user.email", "test@example.com");
+  gitIn(dir, "config", "user.name", "Test");
+  gitIn(dir, "config", "commit.gpgsign", "false");
+}
+
+beforeEach(() => {
+  // origin: a normal repo used as the fetch remote; realpath'd (macOS /var → /private/var).
+  originDir = realpathSync(mkdtempSync(join(tmpdir(), "vbm-origin-")));
+  initRepo(originDir);
+  execFileSync("git", ["-C", originDir, "commit", "-q", "--allow-empty", "-m", "base"]);
+  oldBaseSha = gitIn(originDir, "rev-parse", "HEAD");
+
+  // clone: the "round worktree". `origin/main` starts at the OLD base (stale) until the
+  // helper fetches. We cut the round branch off the old base and add OUR commit on it.
+  cloneDir = realpathSync(mkdtempSync(join(tmpdir(), "vbm-clone-")));
+  execFileSync("git", ["clone", "-q", originDir, cloneDir]);
+  gitIn(cloneDir, "config", "user.email", "test@example.com");
+  gitIn(cloneDir, "config", "user.name", "Test");
+  gitIn(cloneDir, "config", "commit.gpgsign", "false");
+  gitIn(cloneDir, "checkout", "-q", "-b", "consilium/loop-x/round-1");
+});
+
+afterEach(() => {
+  for (const d of [cloneDir, originDir]) {
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+});
+
+/** Write + commit a file in `dir` on the current branch. */
+function commitFile(dir: string, name: string, content: string, msg: string): string {
+  execFileSync("bash", ["-c", `printf '%s' "$2" > "$0/$1"`, dir, name, content]);
+  gitIn(dir, "add", "-A");
+  gitIn(dir, "commit", "-q", "-m", msg);
+  return gitIn(dir, "rev-parse", "HEAD");
+}
+
+/** A gitRaw that records every (args) it is asked to run, then delegates to the real runner. */
+function recordingGitRaw(): { runner: GitRunner; calls: string[][] } {
+  const calls: string[][] = [];
+  const runner: GitRunner = (repoPath, args) => {
+    calls.push([...args]);
+    return defaultGitRaw(repoPath, args);
+  };
+  return { runner, calls };
+}
+
+describe("integrateBaseBranch — REAL git", () => {
+  it("(a) merges an advanced base into a branch cut from an older base; branch advances", async () => {
+    // OUR commit on the round branch touches feature.txt.
+    commitFile(cloneDir, "feature.txt", "our work\n", "feat: round work");
+    const roundHeadBefore = gitIn(cloneDir, "rev-parse", "HEAD");
+
+    // "main" advances on origin (a NON-overlapping file) AFTER the branch was cut.
+    const advancedSha = commitFile(originDir, "advanced.txt", "from main\n", "chore: advance main");
+    expect(advancedSha).not.toBe(oldBaseSha);
+
+    const { runner, calls } = recordingGitRaw();
+    const res = await integrateBaseBranch(runner, cloneDir, "main");
+
+    // Clean merge: ok, and the returned integrationBase is the freshly-fetched advanced sha.
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error(res.error);
+    expect(res.integrationBase).toMatch(/^[0-9a-f]{40}$/);
+    expect(res.integrationBase).toBe(advancedSha);
+
+    // The round branch ADVANCED (a real merge commit) past its own pre-merge HEAD, and now
+    // contains BOTH our work and main's advancement.
+    const roundHeadAfter = gitIn(cloneDir, "rev-parse", "HEAD");
+    expect(roundHeadAfter).not.toBe(roundHeadBefore);
+    const tree = gitIn(cloneDir, "ls-tree", "-r", "--name-only", "HEAD").split("\n");
+    expect(tree).toContain("feature.txt");
+    expect(tree).toContain("advanced.txt");
+    // The advanced base sha is now an ANCESTOR of the round HEAD (it was truly integrated).
+    expect(() =>
+      execFileSync("git", ["-C", cloneDir, "merge-base", "--is-ancestor", advancedSha, "HEAD"]),
+    ).not.toThrow();
+    // Worktree left clean.
+    expect(gitIn(cloneDir, "status", "--porcelain")).toBe("");
+
+    // (c) ARGV: the merge call passes SEPARATE elements — flag and a lone clean sha.
+    const mergeCall = calls.find((c) => c[0] === "merge");
+    expect(mergeCall).toBeDefined();
+    expect(mergeCall).toEqual(["merge", "--no-edit", "--end-of-options", advancedSha]);
+    // The last element is a bare 40-hex sha — NOT a `--end-of-options <sha>` concatenation
+    // and free of any embedded flag/newline (the exact bug shape).
+    const mergeRef = mergeCall![mergeCall!.length - 1];
+    expect(mergeRef).toMatch(/^[0-9a-f]{40}$/);
+    expect(mergeRef).not.toContain("--end-of-options");
+    expect(mergeRef).not.toMatch(/\s/);
+    // NO argv element anywhere collapses a flag and a ref into one token.
+    for (const call of calls) {
+      for (const arg of call) {
+        expect(arg).not.toMatch(/--end-of-options\s+\S/);
+      }
+    }
+    // Resolution used rev-parse VERIFY mode (single-object, no flag echo) — the actual fix.
+    const revParseVerify = calls.find((c) => c[0] === "rev-parse" && c.includes("--verify"));
+    expect(revParseVerify).toBeDefined();
+  });
+
+  it("(b) reports a genuine overlapping-edit conflict as kind:'conflict' and aborts cleanly", async () => {
+    // OUR commit edits conflict.txt one way…
+    commitFile(cloneDir, "conflict.txt", "OUR VERSION\n", "feat: our edit");
+    // …and main edits the SAME file differently → a real content conflict on merge.
+    const advancedSha = commitFile(originDir, "conflict.txt", "MAIN VERSION\n", "chore: main edit");
+
+    const res = await integrateBaseBranch(defaultGitRaw, cloneDir, "main");
+
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected conflict");
+    expect(res.kind).toBe("conflict");
+    expect(res.error).toMatch(/integration conflict merging main/);
+    // The merge was ABORTED — no in-progress merge, worktree clean, HEAD unchanged from ours.
+    expect(gitIn(cloneDir, "status", "--porcelain")).toBe("");
+    expect(() => gitIn(cloneDir, "rev-parse", "--verify", "MERGE_HEAD")).toThrow();
+    // The advanced base was NOT merged (it is not an ancestor — we aborted).
+    expect(() =>
+      execFileSync("git", ["-C", cloneDir, "merge-base", "--is-ancestor", advancedSha, "HEAD"]),
+    ).toThrow();
+  });
+
+  it("(c) an unresolvable base ref is a command ERROR, not a conflict", async () => {
+    commitFile(cloneDir, "feature.txt", "our work\n", "feat: round work");
+    // A base that no fetch/ref can resolve → the helper must NOT call it a content conflict.
+    const res = await integrateBaseBranch(defaultGitRaw, cloneDir, "no-such-base-ref");
+
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error("expected error");
+    expect(res.kind).toBe("error");
+    expect(res.error).toMatch(/integration could not run/);
+    // Nothing was merged; worktree stays clean.
+    expect(gitIn(cloneDir, "status", "--porcelain")).toBe("");
+  });
+});

--- a/tests/unit/sdlc/executor.test.ts
+++ b/tests/unit/sdlc/executor.test.ts
@@ -455,20 +455,31 @@ describe("runSdlcHandoff — LIVE per-AP task list (progress.aps)", () => {
 
 // ─── §3E verify-before-merge — base→round integration merge ─────────────────────
 
-/** A git runner that discriminates the integration calls; `merge` conflicts when
- *  `conflict` is set. Records every call for assertion. */
-function makeIntegGitRaw(opts: { conflict?: boolean; remoteResolves?: boolean } = {}) {
+/** A git runner that discriminates the integration calls. A real content CONFLICT is modeled
+ *  the way the production runner (simple-git `.raw`) actually behaves: `merge` does NOT throw —
+ *  it returns the "CONFLICT …" text and leaves an UNMERGED index (`ls-files --unmerged`
+ *  non-empty). `commandError` models a merge that genuinely throws (malformed cmd / bad ref)
+ *  with NO unmerged entries. Records every call for assertion. */
+function makeIntegGitRaw(opts: { conflict?: boolean; commandError?: boolean; remoteResolves?: boolean } = {}) {
   return vi.fn(async (_repo: string, args: string[]) => {
     if (args[0] === "status") return " M server/x.ts\n"; // dirty → commits happen
     if (args[0] === "fetch") return "";
+    if (args[0] === "ls-files" && args.includes("--unmerged")) {
+      // Unmerged index entries exist ONLY for a real content conflict.
+      return opts.conflict ? "100644 aaa 1\tserver/x.ts\n100644 bbb 2\tserver/x.ts\n" : "";
+    }
     if (args[0] === "rev-parse") {
-      if (args.includes("HEAD")) return "headsha000\n";
-      if (args.includes("--verify")) return opts.remoteResolves === false ? "" : "originsha\n";
-      return "basesha111\n"; // resolved integration base (--end-of-options <target>)
+      // The caller's plain `rev-parse HEAD` (no --verify) → the round HEAD.
+      if (args.includes("HEAD") && !args.includes("--verify")) return "headsha000\n";
+      // The helper resolves the base via rev-parse VERIFY mode (single-object, no flag echo).
+      if (args.includes("--verify")) return opts.remoteResolves === false ? "" : "basesha111\n";
+      return "";
     }
     if (args[0] === "merge") {
       if (args[1] === "--abort") return "";
-      if (opts.conflict) throw new Error("merge conflict in server/x.ts");
+      if (opts.commandError) throw new Error("--end-of-options basesha111 - not something we can merge");
+      // simple-git `.raw` does NOT reject on a content conflict — it resolves with the text.
+      if (opts.conflict) return "CONFLICT (content): Merge conflict in server/x.ts\n";
       return "";
     }
     return "";
@@ -498,6 +509,22 @@ describe("runSdlcHandoff — §3E integration merge (integrateBase)", () => {
     expect(res.error).toContain("integration conflict");
     // The merge was aborted and NOTHING was pushed / PR'd (no silent broken-merge landing).
     expect(gitRaw.mock.calls.some((c) => (c[1] as string[])[0] === "merge" && (c[1] as string[])[1] === "--abort")).toBe(true);
+    expect(deps.push).not.toHaveBeenCalled();
+    expect(deps.openPr).not.toHaveBeenCalled();
+    expect(deps.removeWorktree).toHaveBeenCalledTimes(1); // cleanup still guaranteed
+  });
+
+  it("integrateBase=true, COMMAND ERROR: reported as 'could not run' NOT a conflict, never pushes", async () => {
+    // A merge that fails for a NON-content reason (malformed cmd / unresolvable ref) leaves no
+    // unmerged entries — it must be classified distinctly so the operator is not told there's a
+    // conflict when the command was simply wrong. Still aborts + falls back safely (no PR).
+    const gitRaw = makeIntegGitRaw({ commandError: true });
+    const deps = makeDeps({ gitRaw });
+    const res = await runSdlcHandoff(baseReq({ integrateBase: true }), deps as never);
+    expect(res.prRef).toBeNull();
+    expect(res.integrationConflict).toBeFalsy(); // NOT flagged a conflict
+    expect(res.error).toContain("integration could not run");
+    expect(res.error).not.toContain("integration conflict");
     expect(deps.push).not.toHaveBeenCalled();
     expect(deps.openPr).not.toHaveBeenCalled();
     expect(deps.removeWorktree).toHaveBeenCalledTimes(1); // cleanup still guaranteed


### PR DESCRIPTION
## Root cause (reproduced precisely)

`integrateBaseBranch` (verify-before-merge, #487) resolved the base sha with `git rev-parse --end-of-options <ref>`. In rev-parse's **default (echo) mode**, git prints the literal `--end-of-options` token back on its **own line before the sha**:

```
$ git rev-parse --end-of-options main
--end-of-options
1c8bba206...
```

`.trim()` only strips the **outer** whitespace, so `resolved` became the two-line string `"--end-of-options\n<sha>"`. That whole string was then handed to:

```
git merge --no-edit --end-of-options <resolved>
```

Because the real `--end-of-options` before it disables option parsing, git treats the entire `"--end-of-options\n<sha>"` as a **single positional** rev:

```
merge: --end-of-options
<sha> - not something we can merge
```

The `\n` renders as a **space** in single-line logs, producing the live error `merge: --end-of-options <sha> - not something we can merge` — a **false "integration conflict"** when the command itself was malformed (the sha is a real, reachable commit; `--end-of-options` is valid for merge). This is effectively the flag+ref concatenated into one argv element, exactly as diagnosed — the mechanism is rev-parse's flag echo, not a manual string-join.

## Fix

1. **Argv / echo:** resolve with rev-parse's **single-object VERIFY mode** — `rev-parse --verify --quiet --end-of-options <ref>^{commit}` — which emits **only** the sha and never echoes the flag. This is the same safe pattern already used in `diff-context.ts` / `repo-map.ts`; `integrateBaseBranch` was the **only** echo-prone site (audited repo-wide). The merge then gets a bare 40-hex sha as its own argv element.

2. **Stale base resolvable:** the round branch may be cut from a stale base while `origin/main` advanced. The helper fetches the base, then resolves against candidates **`origin/<base>` → `FETCH_HEAD` → local `<base>`** (first that verifies). A genuinely absent object is reported as a command **error**, never a false conflict.

3. **Command error ≠ content conflict:** the git runner (simple-git `.raw`) does **NOT** reject on a merge-conflict exit — it returns the `CONFLICT …` text and leaves an **unmerged index** — so the old `try/catch` never actually caught real conflicts. We now inspect `git ls-files --unmerged` **after** the merge:
   - unmerged entries → **abort** + `kind:"conflict"` (`integrationConflict: true`, error "integration conflict merging …") — a real overlapping-edit conflict, falls back safely.
   - a thrown command/ref failure with **no** unmerged entries → `kind:"error"` (error "integration could not run …", `integrationConflict` unset) — the operator is **not** told there's a conflict when the command was just wrong.

   Both paths abort the merge and fall back (no PR pushed).

## Tests

New **real-git** integration test `tests/integration/sdlc-verify-before-merge-integration.test.ts` (real scratch repos, not mocks — mocks missed this the same way they missed the #482→#485 fan-out D/F bug):

- **(a)** a branch cut from an **older base** with "main" advanced **merges cleanly** — argv correct, ref resolvable, `integrationBase` is a clean 40-hex sha, the branch advances and the advanced base is an ancestor; **and** the merge argv is asserted to be **separate elements** (`["merge","--no-edit","--end-of-options",<40-hex sha>]`, no `--end-of-options <sha>` concatenation, resolution uses `--verify`).
- **(b)** a genuine **overlapping-edit conflict** is reported `kind:"conflict"` and **aborted** (worktree clean, no `MERGE_HEAD`, base not merged).
- **(c)** an **unresolvable base ref** is a command **error**, not a conflict.

Unit `executor.test.ts` mock updated to model the **real** runner (a content conflict does not throw and leaves an unmerged index) plus a new command-error case asserting the conflict-vs-error distinction.

## Evidence

- `tsc --noEmit`: clean.
- Full unit project: **4976 passed** (259 files).
- Integration project: **827 passed**, 5 skipped (55 files) — includes the new real-git test and the #485 fan-out test.
- Exact live error reproduced from the two-line `resolved`, and the VERIFY-mode resolution reproduced as a clean single-line sha.

## Constraints

No FSM/schema/migration. Kill-switch unchanged (`integrateBase`/`verifyBeforeMerge` default off; this only fixes the enabled path). Worktree cleanup remains unconditional. Draft — do not merge.