### PR TITLE
feat: github trigger polling for local daemons + webhook URL port fix

### DIFF
--- a/client/src/components/triggers/WebhookDetails.tsx
+++ b/client/src/components/triggers/WebhookDetails.tsx
@@ -24,12 +24,39 @@ export function WebhookDetails({ webhookUrl, secret }: WebhookDetailsProps) {
 
   const maskedSecret = `sk_${"•".repeat(16)}`;
 
+  // A localhost / private-LAN URL can NEVER receive a GitHub webhook — GitHub's
+  // servers are on the public internet and cannot POST to a local daemon behind NAT.
+  const isLocalUrl = /(?:localhost|127\.0\.0\.1|\/\/(?:10|192\.168)\.|\/\/172\.(?:1[6-9]|2\d|3[01])\.)/.test(
+    webhookUrl,
+  );
+
   return (
     <div className="space-y-4">
       <Alert className="border-amber-500/50 bg-amber-500/5">
         <AlertTriangle className="h-4 w-4 text-amber-500" />
         <AlertDescription className="text-xs text-amber-700">
           This secret will not be shown again in full. Copy it now and store it securely.
+        </AlertDescription>
+      </Alert>
+
+      <Alert className={isLocalUrl ? "border-red-500/50 bg-red-500/5" : "border-blue-500/40 bg-blue-500/5"}>
+        <AlertTriangle className={`h-4 w-4 ${isLocalUrl ? "text-red-500" : "text-blue-500"}`} />
+        <AlertDescription className={`text-xs ${isLocalUrl ? "text-red-700" : "text-blue-700"}`}>
+          {isLocalUrl ? (
+            <>
+              <span className="font-semibold">This is a local URL — GitHub cannot deliver webhooks to it.</span>{" "}
+              GitHub&apos;s servers cannot reach <span className="font-mono">localhost</span> or a private-LAN
+              address behind NAT, so this trigger will never fire from a webhook.
+            </>
+          ) : (
+            <>For GitHub to deliver events, this URL must be publicly reachable.</>
+          )}{" "}
+          Either point <span className="font-mono">PUBLIC_URL</span> at a public tunnel
+          (<span className="font-mono">cloudflared</span> / <span className="font-mono">ngrok</span>),{" "}
+          <span className="font-semibold">or</span> enable{" "}
+          <span className="font-mono">features.triggers.githubPolling</span> — the poller PULLS events
+          from GitHub over the <span className="font-mono">gh</span> CLI and needs no public endpoint
+          (works behind NAT).
         </AlertDescription>
       </Alert>
 

--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -104,6 +104,24 @@ export const ConfigSchema = z.object({
      */
     triggers: z.object({
       enabled: z.boolean().default(false),
+      /**
+       * github-trigger-polling: a LOCAL daemon behind NAT can NEVER receive a
+       * GitHub webhook (GitHub's servers cannot POST to localhost / a private LAN
+       * IP), so an enabled github_event trigger silently never fires. This
+       * kill-switch turns on a POLLER that PULLS from GitHub via the `gh` CLI
+       * (works behind NAT, no public endpoint) and fires matching triggers through
+       * the SAME dispatch path the webhook receiver uses.
+       *
+       * Default FALSE ⇒ no polling; back-compatible. Polling ALSO requires the
+       * `enabled` master switch above (a poll that fires a loop is gated by it) —
+       * with the master switch off the poller idles without consuming watermarks.
+       * `intervalSec` bounds GitHub traffic (min 60s so a misconfig cannot hammer
+       * the API; max 1h).
+       */
+      githubPolling: z.object({
+        enabled: z.boolean().default(false),
+        intervalSec: z.number().int().min(60).max(3600).default(300),
+      }).default({}),
     }).default({}),
   }).default({}),
   federation: z.object({

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -39,6 +39,7 @@ import { registerLmStudioRoutes } from "./routes/lmstudio";
 import { TriggerService } from "./services/trigger-service";
 import { CronScheduler } from "./services/cron-scheduler";
 import { FileWatcherService } from "./services/file-watcher";
+import { GitHubPoller } from "./services/github-poller";
 import { stopRateLimitCleanup } from "./services/webhook-handler";
 import { requireAuth } from "./auth/middleware";
 import { requireProject } from "./middleware/project";
@@ -327,6 +328,7 @@ export async function registerRoutes(
   let webhookRoutesRegistered = false;
   let cronScheduler: CronScheduler | null = null;
   let fileWatcherService: FileWatcherService | null = null;
+  let githubPoller: GitHubPoller | null = null;
 
   try {
     triggerService = new TriggerService(storage);
@@ -336,8 +338,11 @@ export async function registerRoutes(
     // allows withProject to operate cross-project (no project filter applied in system
     // context). getPipeline validates the pipeline still exists; updateTrigger records
     // the last-fired timestamp. Both operate cross-project in system context.
-    const fireTrigger = async (trigger: import("@shared/schema").TriggerRow, payload: unknown): Promise<void> => {
-      await runAsSystem("fire-trigger", async () => {
+    const fireTrigger = async (
+      trigger: import("@shared/schema").TriggerRow,
+      payload: unknown,
+    ): Promise<import("./services/consilium/trigger-dispatch").TriggerFireResult> => {
+      return runAsSystem("fire-trigger", async () => {
         // T1 RETARGET: a trigger fires a CONSILIUM LOOP (loop template in config),
         // not a (deleted) pipeline run. pipelineId is now NULLABLE — a loop-template
         // trigger has none. We NO LONGER gate on a pipeline lookup (that made every
@@ -358,7 +363,7 @@ export async function registerRoutes(
           !appConfigLoader.get().features.triggers.enabled
         ) {
           log(`[triggers] ${trigger.type} trigger ${trigger.id} not fired — features.triggers.enabled is off`, "triggers");
-          return;
+          return "recorded" as const;
         }
 
         // ── Loop-template dispatch ───────────────────────────────────────────────
@@ -408,6 +413,10 @@ export async function registerRoutes(
         if (result === "skipped-dedup") {
           await storage.incrementTriggerSuppressed(trigger.id);
         }
+        // The github POLLER reads this result to decide whether to advance its
+        // watermark (it holds on "skipped-dedup" → retries next cycle). Other
+        // callers (cron / file watcher / webhook receiver) ignore the return.
+        return result;
       });
     };
 
@@ -434,6 +443,26 @@ export async function registerRoutes(
       fireTrigger,
     });
     await fileWatcherService.bootstrap();
+
+    // github-trigger-polling: a LOCAL daemon behind NAT can NEVER receive a GitHub
+    // webhook, so an enabled github_event trigger silently never fires. When the
+    // kill-switch (features.triggers.githubPolling.enabled) is on, the poller PULLS
+    // from GitHub via the `gh` CLI and fires matching triggers through the SAME
+    // `fireTrigger` seam the webhook receiver uses. Default OFF → not constructed.
+    if (appConfigLoader.get().features.triggers.githubPolling.enabled) {
+      githubPoller = new GitHubPoller({
+        getEnabledTriggersByType: (type) =>
+          runAsSystem("github-poller-bootstrap", () => storage.getAllEnabledTriggersByType(type)),
+        getTrigger: (id) =>
+          runAsSystem("github-poller-get-trigger", () => storage.getTrigger(id)),
+        updateTrigger: (id, updates) =>
+          runAsSystem("github-poller-watermark", () => storage.updateTrigger(id, updates)),
+        fireTrigger,
+        config: () => appConfigLoader.get(),
+        log: (m: string) => log(m, "github-poller"),
+      });
+      githubPoller.start();
+    }
 
     log("[triggers] Trigger subsystem started", "triggers");
   } catch (e) {
@@ -507,6 +536,7 @@ export async function registerRoutes(
     cronScheduler?.stopAll();
     consiliumLoopPoller?.stop();
     fileWatcherService?.stopAll();
+    githubPoller?.stop();
     getRefreshScheduler()?.stop();
     stopRateLimitCleanup();
     await remoteAgentManager?.shutdown();

--- a/server/routes/webhooks.ts
+++ b/server/routes/webhooks.ts
@@ -25,7 +25,8 @@ export function registerWebhookRoutes(
   app: Express,
   storage: IStorage,
   triggerService: TriggerService,
-  fireTrigger: (trigger: TriggerRow, payload: unknown) => Promise<void>,
+  // Returns the shared TriggerFireResult (widened to `unknown` — ignored here).
+  fireTrigger: (trigger: TriggerRow, payload: unknown) => Promise<unknown>,
 ): void {
   // Start the rate-limit map cleanup interval
   startRateLimitCleanup();

--- a/server/services/consilium/trigger-dispatch.ts
+++ b/server/services/consilium/trigger-dispatch.ts
@@ -196,6 +196,17 @@ export type ConsiliumDispatchResult =
   | "noop-event"
   | "failed";
 
+/**
+ * The value `fireTrigger` (server/routes.ts) resolves with. It is the dispatch
+ * result, PLUS `"recorded"` for the paths that record `lastTriggeredAt` but launch
+ * nothing (the master-kill-switch-off early return). Existing callers (cron, file
+ * watcher, webhook receiver) ignore it (their dep is typed `Promise<void>`, which
+ * accepts any return); the github POLLER reads it to decide whether to advance its
+ * watermark — it holds the watermark ONLY on `"skipped-dedup"` so a suppressed
+ * event is retried next cycle rather than lost.
+ */
+export type TriggerFireResult = ConsiliumDispatchResult | "recorded";
+
 export interface ConsiliumTriggerDispatchDeps {
   /**
    * The factory deps, or `null` when the consilium-loop subsystem (kill-switch)

--- a/server/services/cron-scheduler.ts
+++ b/server/services/cron-scheduler.ts
@@ -10,7 +10,9 @@ import type { ScheduleTriggerConfig } from "@shared/types";
 
 export interface CronSchedulerDeps {
   getEnabledTriggersByType: (type: "schedule") => Promise<TriggerRow[]>;
-  fireTrigger: (trigger: TriggerRow, payload: unknown) => Promise<void>;
+  // Returns the shared TriggerFireResult (widened to `unknown` here — this caller
+  // ignores it; only the github poller reads it to advance its watermark).
+  fireTrigger: (trigger: TriggerRow, payload: unknown) => Promise<unknown>;
 }
 
 export class CronScheduler {

--- a/server/services/file-watcher.ts
+++ b/server/services/file-watcher.ts
@@ -98,7 +98,8 @@ export function validateWatchPath(rawPath: string): string {
 
 export interface FileWatcherDeps {
   getEnabledTriggersByType: (type: "file_change") => Promise<TriggerRow[]>;
-  fireTrigger: (trigger: TriggerRow, payload: unknown) => Promise<void>;
+  // Returns the shared TriggerFireResult (widened to `unknown` — ignored here).
+  fireTrigger: (trigger: TriggerRow, payload: unknown) => Promise<unknown>;
 }
 
 interface WatcherEntry {

--- a/server/services/github-event-handler.ts
+++ b/server/services/github-event-handler.ts
@@ -11,7 +11,8 @@ import { verifyHmacSignature } from "./webhook-handler.js";
 export interface GitHubEventHandlerDeps {
   getEnabledTriggersByType: (type: "github_event") => Promise<TriggerRow[]>;
   getSecret: (id: string) => Promise<string | null>;
-  fireTrigger: (trigger: TriggerRow, payload: unknown) => Promise<void>;
+  // Returns the shared TriggerFireResult (widened to `unknown` — ignored here).
+  fireTrigger: (trigger: TriggerRow, payload: unknown) => Promise<unknown>;
 }
 
 /**

--- a/server/services/github-poller.ts
+++ b/server/services/github-poller.ts
@@ -1,0 +1,484 @@
+/**
+ * github-poller.ts — POLLING mode for github_event triggers (github-trigger-polling).
+ *
+ * WHY THIS EXISTS
+ *   A github_event webhook only fires when GitHub POSTs to us. GitHub's servers
+ *   live on the public internet and CANNOT deliver a webhook to a LOCAL daemon
+ *   behind NAT (localhost / a private-LAN IP). So an enabled github trigger on a
+ *   local box has `lastFired: null` forever, despite real PRs. GitHub can't push
+ *   to us — but WE can pull from GitHub (works behind NAT, no public endpoint).
+ *
+ * WHAT IT DOES
+ *   For each ENABLED github_event trigger, on an interval, it PULLS the events the
+ *   trigger watches via the existing `gh` CLI seam (github-status.ts `runGhJson`):
+ *     - pull_request → `gh pr list --repo <o/r> --state open --json
+ *       number,title,headRefOid,baseRefOid,updatedAt` — a NEW open PR, or an open
+ *       PR whose head advanced, fires.
+ *     - push (default branch) → the default branch's current head sha; when it
+ *       ADVANCES past the watermark, a post-merge review of before..after fires.
+ *   Each detected event is SYNTHESIZED into the SAME `{ event, delivery, payload }`
+ *   envelope the webhook receiver (github-event-handler.ts, #471) hands to
+ *   `fireTrigger`, so the SAME `mapGitHubEventToReview` produces IDENTICAL loops —
+ *   webhook and polling are byte-for-byte consistent.
+ *
+ * RAILS (adversarial concerns, addressed)
+ *   (a) RE-FIRE THE SAME PR EVERY POLL — a per-trigger WATERMARK (last-seen PR head
+ *       / default-branch head) is persisted in the trigger's `config` jsonb and only
+ *       ADVANCED when a fire was NOT dedup-suppressed. A PR/push already seen at the
+ *       same sha is skipped; the watermark persists across restarts.
+ *   (b) POLL STORM → UNBOUNDED LOOPS — every fire flows through the SAME
+ *       `launchReviewWithDedup` (one active loop per repo+trigger), the master
+ *       kill-switch (`features.triggers.enabled`) gates firing, and the interval
+ *       (min 60s) bounds cadence. Within one cycle the first PR launches and every
+ *       later PR of the same repo is dedup-suppressed (watermark held → retried).
+ *   (c) gh OUTAGE CRASHING THE POLLER — every `gh` call goes through `runGhJson`
+ *       (never throws, degrades to null); a null result SKIPS that poll and does
+ *       NOT touch the watermark; each trigger + each cycle is wrapped so one failure
+ *       never stops the others or the loop.
+ *   (d) OWNER/REPO PARSE — the owner/repo is taken from `config.repository`
+ *       (already `owner/repo`), else DERIVED from the local repo's git remote via
+ *       `parseOwnerRepo`, which handles BOTH scp-style SSH (`git@host:o/r.git`) and
+ *       URL (`https|ssh|git://host/o/r(.git)`) remotes. No github remote → skip+log.
+ *
+ * SECURITY
+ *   The `gh` token is never read/logged here — `runGhJson` hands it to `gh` via a
+ *   sanitized env only. Every value pulled off GitHub is UNTRUSTED and reaches the
+ *   review objective ONLY through the factory's sanitized seam (same as the webhook
+ *   path). `repoPath` (the LOCAL review target) is `action.repoPath`, re-validated
+ *   against the fail-closed allowlist INSIDE the factory — the poller never widens
+ *   it. Only fixed, non-free-form args are passed to `gh` (owner/repo is shape-
+ *   validated first, so nothing leading-dash / attacker-shaped is read as a flag).
+ */
+import { execFile } from "child_process";
+import { promisify } from "util";
+import type { TriggerRow } from "@shared/schema";
+import type { GitHubEventTriggerConfig, GitHubPollState } from "@shared/types";
+import type { AppConfig } from "../config/schema.js";
+import type { TriggerFireResult } from "./consilium/trigger-dispatch.js";
+import { runGhJson, type ExecFileFn } from "./github-status.js";
+
+const execFileAsync: ExecFileFn = promisify(execFile);
+
+/** A git object id: 7–64 lowercase hex (parity with the event map's SHA_RE). */
+const SHA_RE = /^[0-9a-f]{7,64}$/;
+/** `owner/repo` — conservative GitHub name charset (no leading dash / no flag). */
+const OWNER_REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+/** Cap on tracked open-PR heads per trigger (bounds the watermark jsonb). */
+const MAX_TRACKED_PRS = 200;
+
+function isRealSha(v: string | undefined): v is string {
+  return typeof v === "string" && SHA_RE.test(v) && !/^0+$/.test(v);
+}
+
+/** The `gh pr list --json number,title,headRefOid,baseRefOid,updatedAt` item shape. */
+interface GhPrListItem {
+  number: number;
+  title?: string;
+  headRefOid?: string;
+  baseRefOid?: string;
+  updatedAt?: string;
+}
+
+/**
+ * Parse a git remote URL to `owner/repo`, or null if it is not a recognizable
+ * github-shaped remote. Handles BOTH forms (adversarial concern (d)):
+ *   - scp-style SSH:  git@github.com:owner/repo.git
+ *   - URL:            https://github.com/owner/repo(.git)
+ *                     ssh://git@github.com/owner/repo.git
+ *                     git://github.com/owner/repo.git
+ * A trailing `.git` and trailing slash are stripped. A non-github host is still
+ * parsed to owner/repo (the poller pulls by owner/repo; `gh` targets github.com) —
+ * a non-github remote simply yields no PRs and degrades to a skip.
+ */
+export function parseOwnerRepo(remoteUrl: string): string | null {
+  const s = remoteUrl.trim();
+  if (s.length === 0) return null;
+  // scp-style: [user@]host:owner/repo(.git)
+  let m = /^[\w.-]+@[\w.-]+:([\w.-]+)\/([\w.-]+?)(?:\.git)?\/?$/.exec(s);
+  if (m) return normalizeOwnerRepo(m[1], m[2]);
+  // URL form: scheme://[user@]host/owner/repo(.git)
+  m = /^[a-z][a-z0-9+.-]*:\/\/(?:[\w.-]+@)?[\w.-]+\/([\w.-]+)\/([\w.-]+?)(?:\.git)?\/?$/.exec(s);
+  if (m) return normalizeOwnerRepo(m[1], m[2]);
+  return null;
+}
+
+function normalizeOwnerRepo(owner: string, repo: string): string | null {
+  const candidate = `${owner}/${repo}`;
+  return OWNER_REPO_RE.test(candidate) ? candidate : null;
+}
+
+export interface GitHubPollerDeps {
+  /** Cross-project, system-context load of enabled github_event triggers. */
+  getEnabledTriggersByType: (type: "github_event") => Promise<TriggerRow[]>;
+  /** Re-read a trigger fresh so the watermark write does not clobber a concurrent edit. */
+  getTrigger: (id: string) => Promise<TriggerRow | undefined>;
+  /** Persist the advanced watermark (writes back `config` with `pollState`). */
+  updateTrigger: (id: string, updates: Partial<TriggerRow>) => Promise<unknown>;
+  /**
+   * The SAME `fireTrigger` seam the webhook receiver uses. Returns the dispatch
+   * result so the poller can hold the watermark on `"skipped-dedup"`.
+   */
+  fireTrigger: (trigger: TriggerRow, payload: unknown) => Promise<TriggerFireResult>;
+  /** Live config accessor (kill-switches + interval). */
+  config: () => AppConfig;
+  /** Injectable `gh` runner (tests pass a fake — no real `gh`/network). */
+  runGh?: ExecFileFn;
+  /** Injectable git-remote reader for the owner/repo fallback (default: real `git`). */
+  gitRemoteUrl?: (repoPath: string) => Promise<string | null>;
+  /** Structured logger. */
+  log: (message: string) => void;
+  /** Injectable clock (tests). */
+  now?: () => number;
+}
+
+/**
+ * Default git-remote reader: `git -C <repoPath> remote get-url origin`. NEVER
+ * throws (no remote / not a repo → null). `repoPath` is a trusted local config
+ * value; `--end-of-options` guards a `repoPath` that starts with a dash.
+ */
+async function defaultGitRemoteUrl(
+  repoPath: string,
+  run: ExecFileFn = execFileAsync,
+): Promise<string | null> {
+  try {
+    const { stdout } = await run(
+      "git",
+      ["-C", repoPath, "remote", "get-url", "origin"],
+      { timeout: 10_000 },
+    );
+    const url = (stdout ?? "").trim();
+    return url.length > 0 ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+export class GitHubPoller {
+  private readonly deps: GitHubPollerDeps;
+  private readonly runGh: ExecFileFn;
+  private readonly gitRemoteUrl: (repoPath: string) => Promise<string | null>;
+  private readonly now: () => number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private polling = false;
+
+  constructor(deps: GitHubPollerDeps) {
+    this.deps = deps;
+    this.runGh = deps.runGh ?? execFileAsync;
+    this.gitRemoteUrl = deps.gitRemoteUrl ?? ((p) => defaultGitRemoteUrl(p));
+    this.now = deps.now ?? Date.now;
+  }
+
+  /**
+   * Start the interval poller IFF `features.triggers.githubPolling.enabled`. A
+   * running server never silently starts polling — the caller only constructs +
+   * starts this when the kill-switch is on. Idempotent (a second start is a no-op).
+   */
+  start(): void {
+    if (this.timer) return;
+    const cfg = this.deps.config().features.triggers.githubPolling;
+    if (!cfg.enabled) {
+      this.deps.log("github polling disabled — poller not started");
+      return;
+    }
+    const intervalMs = cfg.intervalSec * 1000;
+    this.timer = setInterval(() => void this.pollAllSafe(), intervalMs);
+    // Node timers keep the event loop alive; a poller should not block shutdown.
+    this.timer.unref?.();
+    this.deps.log(`github poller started (every ${cfg.intervalSec}s)`);
+  }
+
+  /** Stop the interval poller. */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** One poll cycle, fully guarded — a throw here must never kill the interval. */
+  async pollAllSafe(): Promise<void> {
+    if (this.polling) return; // never overlap cycles (a slow gh must not stack up)
+    this.polling = true;
+    try {
+      await this.pollAll();
+    } catch (e) {
+      this.deps.log(`github poll cycle error: ${(e as Error).message}`);
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  /**
+   * Poll every enabled github_event trigger. Gated on the MASTER switch: with
+   * `features.triggers.enabled` off there is no point polling (a fire would be a
+   * no-op that consumes the watermark), so we skip the cycle entirely — the
+   * watermark is untouched and firing resumes cleanly when the switch flips on.
+   */
+  async pollAll(): Promise<void> {
+    if (!this.deps.config().features.triggers.enabled) {
+      this.deps.log("github poll skipped — features.triggers.enabled (master switch) is off");
+      return;
+    }
+    const triggers = await this.deps.getEnabledTriggersByType("github_event");
+    for (const trigger of triggers) {
+      try {
+        await this.pollTrigger(trigger);
+      } catch (e) {
+        this.deps.log(`github poll error for trigger ${trigger.id}: ${(e as Error).message}`);
+      }
+    }
+  }
+
+  /** Poll one trigger: resolve owner/repo, pull watched events, advance + persist. */
+  async pollTrigger(trigger: TriggerRow): Promise<void> {
+    const config = trigger.config as GitHubEventTriggerConfig;
+    const events = Array.isArray(config.events) ? config.events : [];
+    if (events.length === 0) return;
+
+    const ownerRepo = await this.resolveOwnerRepo(config);
+    if (!ownerRepo) {
+      this.deps.log(
+        `github poll skipped for trigger ${trigger.id} — no github owner/repo (config.repository empty and no parseable git remote)`,
+      );
+      return;
+    }
+
+    // Read-modify: work on a COPY of the current watermark.
+    const state: GitHubPollState = { ...(config.pollState ?? {}) };
+    let changed = false;
+
+    if (events.includes("pull_request")) {
+      changed = (await this.pollPullRequests(trigger, ownerRepo, state)) || changed;
+    }
+    if (events.includes("push")) {
+      changed = (await this.pollPush(trigger, ownerRepo, state)) || changed;
+    }
+
+    state.lastPolledAt = new Date(this.now()).toISOString();
+    changed = true; // always persist lastPolledAt for diagnosability
+
+    if (changed) {
+      await this.persistWatermark(trigger.id, state);
+    }
+  }
+
+  /**
+   * Poll open PRs. Returns whether the watermark changed. A PR fires when its head
+   * sha is not what we last saw; the head is recorded ONLY when the fire was not
+   * dedup-suppressed (so a suppressed PR is retried next cycle, never lost).
+   */
+  private async pollPullRequests(
+    trigger: TriggerRow,
+    ownerRepo: string,
+    state: GitHubPollState,
+  ): Promise<boolean> {
+    const prs = await runGhJson<GhPrListItem[]>(
+      [
+        "pr", "list",
+        "--repo", ownerRepo,
+        "--state", "open",
+        "--json", "number,title,headRefOid,baseRefOid,updatedAt",
+        "--limit", "100",
+      ],
+      this.runGh,
+    );
+    if (prs === null || !Array.isArray(prs)) {
+      this.deps.log(`github poll: pr list unavailable for ${ownerRepo} (gh degraded) — skipping PR poll`);
+      return false;
+    }
+
+    const prevHeads = state.prHeads ?? {};
+    const nextHeads: Record<string, string> = {};
+    let changed = false;
+
+    // Deterministic order (ascending PR number) so the FIRST fire in a cycle is
+    // stable; later same-repo PRs dedup-suppress against it and are retried.
+    const sorted = [...prs].sort((a, b) => (a.number ?? 0) - (b.number ?? 0));
+    for (const pr of sorted) {
+      const key = String(pr.number);
+      const head = pr.headRefOid;
+      const base = pr.baseRefOid;
+      // A PR with an unusable head/base can never map to a review — carry the last
+      // watermark forward (if any) and skip without firing.
+      if (!isRealSha(head) || !isRealSha(base)) {
+        if (prevHeads[key]) nextHeads[key] = prevHeads[key];
+        continue;
+      }
+      const lastHead = prevHeads[key];
+      if (lastHead === head) {
+        nextHeads[key] = head; // unchanged → already reviewed at this commit
+        continue;
+      }
+      // New (no lastHead) OR head advanced → fire, mapping to a reviewable action.
+      const action = lastHead ? "synchronize" : "opened";
+      const result = await this.deps.fireTrigger(
+        trigger,
+        this.prEnvelope(ownerRepo, pr, head, base, action),
+      );
+      if (result === "skipped-dedup") {
+        // Hold the watermark at the PRIOR value → retried next cycle (never lost).
+        if (lastHead) nextHeads[key] = lastHead;
+        this.deps.log(`github poll: PR #${key} on ${ownerRepo} dedup-suppressed — watermark held`);
+      } else {
+        nextHeads[key] = head; // advance
+        changed = true;
+        this.deps.log(`github poll: fired ${action} for PR #${key} on ${ownerRepo} (${result})`);
+      }
+    }
+
+    // Prune to open PRs only (bounds the jsonb). If prev != next, mark changed.
+    const bounded = boundHeads(nextHeads);
+    if (!shallowEqual(prevHeads, bounded)) changed = true;
+    state.prHeads = bounded;
+    return changed;
+  }
+
+  /**
+   * Poll the default branch head. Returns whether the watermark changed. The FIRST
+   * observation records a BASELINE (no fire — a first-seen head is the current
+   * state, not a push event); a later ADVANCE fires a post-merge review of
+   * before..after, recorded only when not dedup-suppressed.
+   */
+  private async pollPush(
+    trigger: TriggerRow,
+    ownerRepo: string,
+    state: GitHubPollState,
+  ): Promise<boolean> {
+    const branch = await this.getDefaultBranch(ownerRepo);
+    if (!branch) {
+      this.deps.log(`github poll: default branch unavailable for ${ownerRepo} (gh degraded) — skipping push poll`);
+      return false;
+    }
+    const head = await this.getBranchHead(ownerRepo, branch);
+    if (!isRealSha(head)) {
+      this.deps.log(`github poll: ${branch} head unavailable for ${ownerRepo} (gh degraded) — skipping push poll`);
+      return false;
+    }
+
+    const last = state.lastPushSha;
+    if (!last) {
+      // Baseline: record the current head WITHOUT firing (not a "push" event).
+      state.lastPushSha = head;
+      this.deps.log(`github poll: push baseline set for ${ownerRepo}@${branch} (${head.slice(0, 7)})`);
+      return true;
+    }
+    if (last === head) return false; // unchanged
+
+    const result = await this.deps.fireTrigger(
+      trigger,
+      this.pushEnvelope(ownerRepo, branch, last, head),
+    );
+    if (result === "skipped-dedup") {
+      this.deps.log(`github poll: push to ${ownerRepo}@${branch} dedup-suppressed — watermark held`);
+      return false; // hold last → retried next cycle
+    }
+    state.lastPushSha = head; // advance
+    this.deps.log(`github poll: fired push to ${ownerRepo}@${branch} (${head.slice(0, 7)}, ${result})`);
+    return true;
+  }
+
+  /** Owner/repo from `config.repository` (already owner/repo), else the git remote. */
+  private async resolveOwnerRepo(config: GitHubEventTriggerConfig): Promise<string | null> {
+    const declared = (config.repository ?? "").trim();
+    if (declared.length > 0) {
+      return OWNER_REPO_RE.test(declared) ? declared : null;
+    }
+    const repoPath = config.action?.repoPath;
+    if (!repoPath) return null;
+    const url = await this.gitRemoteUrl(repoPath);
+    return url ? parseOwnerRepo(url) : null;
+  }
+
+  /** Default branch name via `gh repo view <o/r> --json defaultBranchRef`. */
+  private async getDefaultBranch(ownerRepo: string): Promise<string | null> {
+    const meta = await runGhJson<{ defaultBranchRef?: { name?: string } }>(
+      ["repo", "view", ownerRepo, "--json", "defaultBranchRef"],
+      this.runGh,
+    );
+    const name = meta?.defaultBranchRef?.name;
+    return typeof name === "string" && name.length > 0 ? name : null;
+  }
+
+  /** Default-branch head sha via `gh api repos/<o/r>/branches/<branch>`. */
+  private async getBranchHead(ownerRepo: string, branch: string): Promise<string | undefined> {
+    const info = await runGhJson<{ commit?: { sha?: string } }>(
+      ["api", `repos/${ownerRepo}/branches/${encodeURIComponent(branch)}`],
+      this.runGh,
+    );
+    return info?.commit?.sha;
+  }
+
+  /**
+   * Synthesize the SAME `{ event, delivery, payload }` envelope the webhook receiver
+   * hands `fireTrigger` for a pull_request (github-event-handler.ts), so
+   * `mapGitHubEventToReview` produces an IDENTICAL diff-pr-review loop.
+   */
+  private prEnvelope(
+    ownerRepo: string,
+    pr: GhPrListItem,
+    head: string,
+    base: string,
+    action: "opened" | "synchronize",
+  ): unknown {
+    return {
+      event: "pull_request",
+      delivery: `poll-pr-${pr.number}-${head.slice(0, 7)}`,
+      payload: {
+        action,
+        number: pr.number,
+        pull_request: {
+          number: pr.number,
+          title: pr.title ?? "",
+          head: { sha: head },
+          base: { sha: base },
+        },
+        repository: { full_name: ownerRepo },
+      },
+    };
+  }
+
+  /** The webhook-identical envelope for a push to the default branch. */
+  private pushEnvelope(ownerRepo: string, branch: string, before: string, after: string): unknown {
+    return {
+      event: "push",
+      delivery: `poll-push-${after.slice(0, 7)}`,
+      payload: {
+        ref: `refs/heads/${branch}`,
+        before,
+        after,
+        repository: { full_name: ownerRepo, default_branch: branch },
+      },
+    };
+  }
+
+  /** Re-read fresh + write the watermark into `config.pollState` (no migration). */
+  private async persistWatermark(triggerId: string, state: GitHubPollState): Promise<void> {
+    const fresh = await this.deps.getTrigger(triggerId);
+    // The trigger may have been deleted/disabled mid-cycle — nothing to persist.
+    if (!fresh) return;
+    const freshConfig = (fresh.config ?? {}) as GitHubEventTriggerConfig;
+    const nextConfig: GitHubEventTriggerConfig = { ...freshConfig, pollState: state };
+    await this.deps.updateTrigger(triggerId, { config: nextConfig });
+  }
+}
+
+/** Keep at most MAX_TRACKED_PRS heads (highest PR numbers win — most recent). */
+function boundHeads(heads: Record<string, string>): Record<string, string> {
+  const keys = Object.keys(heads);
+  if (keys.length <= MAX_TRACKED_PRS) return heads;
+  const kept = keys
+    .map((k) => Number(k))
+    .sort((a, b) => b - a)
+    .slice(0, MAX_TRACKED_PRS)
+    .map((n) => String(n));
+  const out: Record<string, string> = {};
+  for (const k of kept) out[k] = heads[k];
+  return out;
+}
+
+function shallowEqual(a: Record<string, string>, b: Record<string, string>): boolean {
+  const ak = Object.keys(a);
+  const bk = Object.keys(b);
+  if (ak.length !== bk.length) return false;
+  return ak.every((k) => a[k] === b[k]);
+}

--- a/server/services/github-status.ts
+++ b/server/services/github-status.ts
@@ -110,6 +110,31 @@ export async function fetchPrStatus(
   }
 }
 
+/**
+ * Reusable `gh` JSON seam (github-trigger-polling reuses this exact discipline).
+ * Runs `gh <args>` under the SANITIZED env (drop inherited `GH_*`, re-add only the
+ * intended token var — pr-wrapper H-7b parity), bounded by a wall-clock timeout,
+ * and parses stdout as JSON. NEVER throws and NEVER blocks indefinitely: `gh`
+ * missing / unauthenticated / rate-limited / timed out / non-JSON stdout ALL
+ * degrade to `null`. The caller MUST supply only fixed, non-free-form args
+ * (nothing leading-dash / attacker-shaped can be read as a flag).
+ */
+export async function runGhJson<T>(
+  args: string[],
+  run: ExecFileFn = execFileAsync,
+  timeoutMs: number = GH_TIMEOUT_MS,
+): Promise<T | null> {
+  try {
+    const { stdout } = await run("gh", args, { timeout: timeoutMs, env: sanitizedEnv() });
+    const trimmed = (stdout ?? "").trim();
+    if (trimmed.length === 0) return null;
+    return JSON.parse(trimmed) as T;
+  } catch {
+    // gh absent / unauthenticated / rate-limited / timed out / non-JSON → fail open.
+    return null;
+  }
+}
+
 // ─── TTL + in-flight-dedup + bounded cache ───────────────────────────────────────
 
 interface CacheEntry {

--- a/server/services/trigger-service.ts
+++ b/server/services/trigger-service.ts
@@ -26,9 +26,19 @@ export class TriggerService {
 
   // ─── Public helpers ───────────────────────────────────────────────────────
 
-  /** Synthesize the webhook URL for webhook and github_event triggers. */
+  /**
+   * Synthesize the webhook URL for webhook and github_event triggers.
+   *
+   * FIX: the default now reflects the ACTUAL server port (`PORT`, the dev server
+   * runs on 5050) instead of the hardcoded 5000 — a bare `http://localhost:5000`
+   * URL pointed at nothing. Note that even the correct localhost URL will NEVER
+   * receive a GitHub webhook (GitHub's servers cannot reach a local/LAN address):
+   * for delivery, `PUBLIC_URL` must be a publicly-reachable tunnel (cloudflared/
+   * ngrok), OR use github polling (features.triggers.githubPolling). The UI shows
+   * this guidance next to the copied URL.
+   */
   webhookUrl(triggerId: string): string {
-    const baseUrl = process.env.PUBLIC_URL ?? "http://localhost:5000";
+    const baseUrl = process.env.PUBLIC_URL ?? `http://localhost:${process.env.PORT ?? 5000}`;
     return `${baseUrl}/api/webhooks/${triggerId}`;
   }
 

--- a/server/services/webhook-handler.ts
+++ b/server/services/webhook-handler.ts
@@ -131,7 +131,8 @@ export function checkRateLimit(triggerId: string): boolean {
 export interface WebhookHandlerDeps {
   getTrigger: (id: string) => Promise<TriggerRow | undefined>;
   getSecret: (id: string) => Promise<string | null>;
-  fireTrigger: (trigger: TriggerRow, payload: unknown) => Promise<void>;
+  // Returns the shared TriggerFireResult (widened to `unknown` — ignored here).
+  fireTrigger: (trigger: TriggerRow, payload: unknown) => Promise<unknown>;
 }
 
 export async function handleWebhookRequest(

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1332,11 +1332,39 @@ export interface ScheduleTriggerConfig {
   action?: ConsiliumReviewTriggerAction;
 }
 
+/**
+ * github-trigger-polling watermark. Persisted INSIDE the trigger's `config` jsonb
+ * (no migration) under `pollState`, OWNED by the poller (never authored in the UI).
+ * Tracks what the poller has already seen so it does NOT re-fire the same event:
+ *   - `prHeads`: open-PR number → last-seen head sha. A PR whose head matches is
+ *     already reviewed at that commit; a new number OR a changed head re-fires.
+ *   - `lastPushSha`: last-seen default-branch head sha. The FIRST observation only
+ *     records a baseline (a first-seen head is the current state, not a "push"
+ *     event); a subsequent ADVANCE fires a post-merge review of before..after.
+ *   - `lastPolledAt`: diagnostics only.
+ * The watermark is advanced ONLY when a fire is NOT dedup-suppressed, so an event
+ * suppressed while another loop is active is retried on the next cycle (never lost,
+ * never a re-fire storm).
+ */
+export interface GitHubPollState {
+  lastPolledAt?: string;               // ISO-8601
+  prHeads?: Record<string, string>;    // PR number (as string) → last-seen head sha
+  lastPushSha?: string;                // last-seen default-branch head sha
+}
+
 export interface GitHubEventTriggerConfig {
-  repository: string;   // "owner/repo"
+  repository: string;   // "owner/repo" — ALSO the owner/repo the poller pulls from
   events: string[];     // ["push", "pull_request", "issues", "release"]
   refFilter?: string;   // optional, e.g. "refs/heads/main"
   // secret stored encrypted in secretEncrypted column — not in this object
+  /**
+   * github-trigger-polling watermark (see GitHubPollState). Owned + maintained by
+   * the poller; absent until the poller first runs. Embedded in `config` jsonb so
+   * no schema migration is needed. A UI config edit that omits it resets the
+   * watermark — an ACCEPTED bound: at worst the currently-open PRs re-fire once
+   * (dedup + the master switch + the interval bound the blast).
+   */
+  pollState?: GitHubPollState;
   /**
    * T1-full (loop-triggers.md §3.1): the loop template a matching GitHub event
    * fires. `repoPath` (REQUIRED for a github trigger to launch — there is no

--- a/tests/unit/consilium/github-poller.test.ts
+++ b/tests/unit/consilium/github-poller.test.ts
@@ -1,0 +1,329 @@
+/**
+ * github-poller.test.ts — POLLING mode for github_event triggers behind NAT.
+ *
+ * Injects a FAKE `gh` runner (no real gh / network) + fake storage/fire seams.
+ * Covers the rails from server/services/github-poller.ts:
+ *   - a NEW open PR fires ONCE and sets the watermark; a re-poll at the same head
+ *     does NOT re-fire (adversarial (a): watermark must persist + advance);
+ *   - a dedup-suppressed fire HOLDS the watermark → retried next cycle (never lost);
+ *   - the master switch (features.triggers.enabled) off → no poll, no fire, no gh;
+ *   - no github remote (empty config.repository + no parseable remote) → skip + log;
+ *   - push: first poll BASELINES (no fire); a head ADVANCE fires a post-merge review;
+ *   - a gh outage (runner throws) degrades to a skip — never crashes the poller;
+ *   - parseOwnerRepo handles BOTH scp-SSH and URL remotes (adversarial (d));
+ *   - the synthesized envelope maps IDENTICALLY to the webhook path (#471 reuse).
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  GitHubPoller,
+  parseOwnerRepo,
+  type GitHubPollerDeps,
+} from "../../../server/services/github-poller.js";
+import type { ExecFileFn } from "../../../server/services/github-status.js";
+import { mapGitHubEventToReview } from "../../../server/services/consilium/github-event-map.js";
+import type { TriggerFireResult } from "../../../server/services/consilium/trigger-dispatch.js";
+import type { TriggerRow } from "../../../shared/schema.js";
+import type { AppConfig, GitHubEventTriggerConfig, GitHubPollState } from "../../../shared/types.js";
+
+const HEAD_A = "a".repeat(40);
+const HEAD_B = "b".repeat(40);
+const BASE_SHA = "c".repeat(40);
+const PUSH_1 = "d".repeat(40);
+const PUSH_2 = "e".repeat(40);
+
+/** A github_event trigger row with the given config (deep-cloned so tests don't share). */
+function ghTrigger(config: Partial<GitHubEventTriggerConfig>): TriggerRow {
+  const full: GitHubEventTriggerConfig = {
+    repository: "acme/widget",
+    events: ["pull_request"],
+    action: { kind: "consilium_review", preset: "diff-pr-review", repoPath: "/repo/widget" },
+    ...config,
+  };
+  return {
+    id: "trig-1",
+    projectId: "proj-1",
+    pipelineId: null,
+    type: "github_event",
+    config: JSON.parse(JSON.stringify(full)) as GitHubEventTriggerConfig,
+    secretEncrypted: null,
+    enabled: true,
+    lastTriggeredAt: null,
+    suppressedCount: 0,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  } as TriggerRow;
+}
+
+/** Minimal AppConfig accessor with the two switches under test. */
+function cfg(masterOn: boolean, pollOn = true, intervalSec = 300): () => AppConfig {
+  return () =>
+    ({
+      features: {
+        triggers: {
+          enabled: masterOn,
+          githubPolling: { enabled: pollOn, intervalSec },
+        },
+      },
+    }) as unknown as AppConfig;
+}
+
+interface GhResponses {
+  prs?: unknown;                       // gh pr list → json array
+  defaultBranch?: string;              // gh repo view → defaultBranchRef.name
+  branchHead?: string;                 // gh api branches → commit.sha
+  throwOn?: (args: string[]) => boolean;
+}
+
+/** A fake `gh` runner that answers by argv; records calls. */
+function fakeGh(r: GhResponses): { run: ExecFileFn; argv: string[][] } {
+  const argv: string[][] = [];
+  const run: ExecFileFn = vi.fn(async (_file: string, args: string[]) => {
+    argv.push(args);
+    if (r.throwOn?.(args)) throw new Error("gh boom");
+    if (args[0] === "pr" && args[1] === "list") {
+      return { stdout: JSON.stringify(r.prs ?? []), stderr: "" };
+    }
+    if (args[0] === "repo" && args[1] === "view") {
+      return { stdout: JSON.stringify({ defaultBranchRef: { name: r.defaultBranch ?? "main" } }), stderr: "" };
+    }
+    if (args[0] === "api") {
+      return { stdout: JSON.stringify({ commit: { sha: r.branchHead ?? "" } }), stderr: "" };
+    }
+    return { stdout: "", stderr: "" };
+  });
+  return { run, argv };
+}
+
+/** Build a poller + capture harness around one trigger. */
+function harness(opts: {
+  trigger: TriggerRow;
+  gh: ExecFileFn;
+  masterOn?: boolean;
+  fireResult?: TriggerFireResult | ((payload: unknown) => TriggerFireResult);
+  gitRemoteUrl?: (repoPath: string) => Promise<string | null>;
+}) {
+  let stored = opts.trigger;
+  const firePayloads: unknown[] = [];
+  const fire = vi.fn(async (_t: TriggerRow, payload: unknown): Promise<TriggerFireResult> => {
+    firePayloads.push(payload);
+    const r = opts.fireResult ?? "launched";
+    return typeof r === "function" ? r(payload) : r;
+  });
+  const updates: Array<Partial<TriggerRow>> = [];
+  const deps: GitHubPollerDeps = {
+    getEnabledTriggersByType: async () => [stored],
+    getTrigger: async () => stored,
+    updateTrigger: async (_id, u) => {
+      updates.push(u);
+      // Reflect the watermark write so a follow-up poll sees it (persistence).
+      if (u.config) stored = { ...stored, config: u.config };
+      return stored;
+    },
+    fireTrigger: fire,
+    config: cfg(opts.masterOn ?? true),
+    runGh: opts.gh,
+    gitRemoteUrl: opts.gitRemoteUrl,
+    log: () => {},
+    now: () => 0,
+  };
+  return {
+    poller: new GitHubPoller(deps),
+    fire,
+    firePayloads,
+    updates,
+    lastWatermark: (): GitHubPollState | undefined =>
+      (stored.config as GitHubEventTriggerConfig).pollState,
+  };
+}
+
+describe("parseOwnerRepo (adversarial (d): SSH + HTTPS remotes)", () => {
+  it("parses scp-style SSH remotes", () => {
+    expect(parseOwnerRepo("git@github.com:acme/widget.git")).toBe("acme/widget");
+    expect(parseOwnerRepo("git@github.com:acme/widget")).toBe("acme/widget");
+  });
+  it("parses URL remotes (https / ssh / git), stripping .git and trailing slash", () => {
+    expect(parseOwnerRepo("https://github.com/acme/widget.git")).toBe("acme/widget");
+    expect(parseOwnerRepo("https://github.com/acme/widget")).toBe("acme/widget");
+    expect(parseOwnerRepo("https://github.com/acme/widget/")).toBe("acme/widget");
+    expect(parseOwnerRepo("ssh://git@github.com/acme/widget.git")).toBe("acme/widget");
+    expect(parseOwnerRepo("git://github.com/acme/widget.git")).toBe("acme/widget");
+  });
+  it("returns null for junk / non-remote strings", () => {
+    expect(parseOwnerRepo("")).toBeNull();
+    expect(parseOwnerRepo("not-a-remote")).toBeNull();
+    expect(parseOwnerRepo("https://github.com/acme")).toBeNull();
+  });
+});
+
+describe("GitHubPoller — pull_request polling", () => {
+  const openPr = { number: 42, title: "Add thing", headRefOid: HEAD_A, baseRefOid: BASE_SHA, updatedAt: "2026-07-01T00:00:00Z" };
+
+  it("fires once for a new open PR and sets the watermark", async () => {
+    const h = harness({ trigger: ghTrigger({}), gh: fakeGh({ prs: [openPr] }).run });
+    await h.poller.pollAll();
+
+    expect(h.fire).toHaveBeenCalledTimes(1);
+    expect(h.lastWatermark()?.prHeads).toEqual({ "42": HEAD_A });
+
+    // The synthesized envelope is the SAME { event, delivery, payload } the webhook
+    // receiver hands fireTrigger; env.payload IS the raw github body. Feeding it to
+    // the SAME pure mapper proves webhook and polling produce IDENTICAL loops (#471).
+    const env = h.firePayloads[0] as { event: string; payload: unknown };
+    expect(env.event).toBe("pull_request");
+    const mapped = mapGitHubEventToReview("pull_request", env.payload);
+    expect(mapped.kind).toBe("review");
+    if (mapped.kind === "review") {
+      expect(mapped.mapping.preset).toBe("diff-pr-review");
+      expect(mapped.mapping.ref).toBe(HEAD_A);
+      expect(mapped.mapping.baselineCommit).toBe(BASE_SHA);
+    }
+  });
+
+  it("does NOT re-fire when the watermark already matches the PR head", async () => {
+    const trigger = ghTrigger({ pollState: { prHeads: { "42": HEAD_A } } });
+    const h = harness({ trigger, gh: fakeGh({ prs: [openPr] }).run });
+    await h.poller.pollAll();
+    expect(h.fire).not.toHaveBeenCalled();
+  });
+
+  it("re-fires when the PR head ADVANCES past the watermark", async () => {
+    const trigger = ghTrigger({ pollState: { prHeads: { "42": HEAD_A } } });
+    const movedPr = { ...openPr, headRefOid: HEAD_B };
+    const h = harness({ trigger, gh: fakeGh({ prs: [movedPr] }).run });
+    await h.poller.pollAll();
+    expect(h.fire).toHaveBeenCalledTimes(1);
+    const env = h.firePayloads[0] as { payload: { action: string } };
+    expect(env.payload.action).toBe("synchronize"); // head changed → synchronize
+    expect(h.lastWatermark()?.prHeads).toEqual({ "42": HEAD_B });
+  });
+
+  it("HOLDS the watermark on a dedup-suppressed fire → retried next cycle (adversarial (a)/(b))", async () => {
+    const h = harness({
+      trigger: ghTrigger({}),
+      gh: fakeGh({ prs: [openPr] }).run,
+      fireResult: "skipped-dedup",
+    });
+    await h.poller.pollAll();
+    expect(h.fire).toHaveBeenCalledTimes(1);
+    // Watermark NOT advanced — the PR is retried, not lost.
+    expect(h.lastWatermark()?.prHeads?.["42"]).toBeUndefined();
+  });
+
+  it("skips a PR with an unusable head/base sha (no fire)", async () => {
+    const badPr = { number: 7, title: "x", headRefOid: "not-a-sha", baseRefOid: BASE_SHA };
+    const h = harness({ trigger: ghTrigger({}), gh: fakeGh({ prs: [badPr] }).run });
+    await h.poller.pollAll();
+    expect(h.fire).not.toHaveBeenCalled();
+  });
+});
+
+describe("GitHubPoller — push polling", () => {
+  const pushTrigger = () => ghTrigger({ events: ["push"] });
+
+  it("BASELINES the default-branch head on first poll (no fire)", async () => {
+    const h = harness({
+      trigger: pushTrigger(),
+      gh: fakeGh({ defaultBranch: "main", branchHead: PUSH_1 }).run,
+    });
+    await h.poller.pollAll();
+    expect(h.fire).not.toHaveBeenCalled();
+    expect(h.lastWatermark()?.lastPushSha).toBe(PUSH_1);
+  });
+
+  it("fires a post-merge review when the default-branch head ADVANCES", async () => {
+    const trigger = ghTrigger({ events: ["push"], pollState: { lastPushSha: PUSH_1 } });
+    const h = harness({
+      trigger,
+      gh: fakeGh({ defaultBranch: "main", branchHead: PUSH_2 }).run,
+    });
+    await h.poller.pollAll();
+    expect(h.fire).toHaveBeenCalledTimes(1);
+    const env = h.firePayloads[0] as { event: string; payload: unknown };
+    const mapped = mapGitHubEventToReview("push", env.payload);
+    expect(mapped.kind).toBe("review");
+    if (mapped.kind === "review") {
+      expect(mapped.mapping.preset).toBe("diff-pr-review"); // before..after
+      expect(mapped.mapping.ref).toBe(PUSH_2);
+      expect(mapped.mapping.baselineCommit).toBe(PUSH_1);
+    }
+    expect(h.lastWatermark()?.lastPushSha).toBe(PUSH_2);
+  });
+
+  it("does NOT re-fire when the head is unchanged", async () => {
+    const trigger = ghTrigger({ events: ["push"], pollState: { lastPushSha: PUSH_1 } });
+    const h = harness({
+      trigger,
+      gh: fakeGh({ defaultBranch: "main", branchHead: PUSH_1 }).run,
+    });
+    await h.poller.pollAll();
+    expect(h.fire).not.toHaveBeenCalled();
+  });
+});
+
+describe("GitHubPoller — rails", () => {
+  it("master switch off → no poll, no fire, no gh call", async () => {
+    const gh = fakeGh({ prs: [{ number: 1, headRefOid: HEAD_A, baseRefOid: BASE_SHA }] });
+    const h = harness({ trigger: ghTrigger({}), gh: gh.run, masterOn: false });
+    await h.poller.pollAll();
+    expect(h.fire).not.toHaveBeenCalled();
+    expect(gh.argv.length).toBe(0);
+  });
+
+  it("no github remote (empty repository + no parseable remote) → skip, no fire, no gh call", async () => {
+    const gh = fakeGh({ prs: [] });
+    const h = harness({
+      trigger: ghTrigger({ repository: "" }),
+      gh: gh.run,
+      gitRemoteUrl: async () => null,
+    });
+    await h.poller.pollAll();
+    expect(h.fire).not.toHaveBeenCalled();
+    expect(gh.argv.length).toBe(0);
+  });
+
+  it("derives owner/repo from the git remote when config.repository is empty", async () => {
+    const gh = fakeGh({ prs: [{ number: 9, headRefOid: HEAD_A, baseRefOid: BASE_SHA }] });
+    const h = harness({
+      trigger: ghTrigger({ repository: "" }),
+      gh: gh.run,
+      gitRemoteUrl: async () => "git@github.com:acme/widget.git",
+    });
+    await h.poller.pollAll();
+    expect(h.fire).toHaveBeenCalledTimes(1);
+    // gh pr list was invoked against the derived owner/repo.
+    const prList = gh.argv.find((a) => a[0] === "pr" && a[1] === "list");
+    expect(prList).toContain("acme/widget");
+  });
+
+  it("a gh outage degrades to a skip — never throws, never fires", async () => {
+    const gh = fakeGh({ throwOn: () => true });
+    const h = harness({ trigger: ghTrigger({}), gh: gh.run });
+    await expect(h.poller.pollAll()).resolves.toBeUndefined();
+    expect(h.fire).not.toHaveBeenCalled();
+  });
+
+  it("one trigger's failure does not stop the cycle (guarded per trigger)", async () => {
+    // getEnabledTriggersByType returns two triggers; the first throws in fire.
+    const gh = fakeGh({ prs: [{ number: 1, headRefOid: HEAD_A, baseRefOid: BASE_SHA }] });
+    const t1 = ghTrigger({});
+    const fireCalls: string[] = [];
+    const deps: GitHubPollerDeps = {
+      getEnabledTriggersByType: async () => [t1, { ...t1, id: "trig-2" } as TriggerRow],
+      getTrigger: async (id) => ({ ...t1, id } as TriggerRow),
+      updateTrigger: async () => t1,
+      fireTrigger: async (t) => {
+        fireCalls.push(t.id);
+        if (t.id === "trig-1") throw new Error("first trigger blows up");
+        return "launched";
+      },
+      config: cfg(true),
+      runGh: gh.run,
+      log: () => {},
+      now: () => 0,
+    };
+    const poller = new GitHubPoller(deps);
+    await expect(poller.pollAll()).resolves.toBeUndefined();
+    // Both triggers were attempted despite the first throwing.
+    expect(fireCalls).toEqual(["trig-1", "trig-2"]);
+  });
+});

--- a/tests/unit/consilium/trigger-webhook-url.test.ts
+++ b/tests/unit/consilium/trigger-webhook-url.test.ts
@@ -1,0 +1,48 @@
+/**
+ * trigger-webhook-url.test.ts — webhookUrl() port fix (FIX 1).
+ *
+ * The default used to hardcode :5000 while the dev server runs on :5050, so the
+ * synthesized URL pointed at nothing. It now defaults to the ACTUAL server PORT,
+ * and honors PUBLIC_URL when set. webhookUrl() reads only env (no storage), so we
+ * construct the service with a stub storage.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { TriggerService } from "../../../server/services/trigger-service.js";
+import type { IStorage } from "../../../server/storage.js";
+
+// TriggerService constructs a TriggerCrypto, which requires a 64-hex key. This
+// test only exercises webhookUrl() (env-only, no crypto), but the constructor
+// still needs the key present.
+process.env.TRIGGER_SECRET_KEY ??= "0".repeat(64);
+
+const svc = new TriggerService({} as unknown as IStorage);
+
+const savedPort = process.env.PORT;
+const savedPublic = process.env.PUBLIC_URL;
+
+afterEach(() => {
+  if (savedPort === undefined) delete process.env.PORT;
+  else process.env.PORT = savedPort;
+  if (savedPublic === undefined) delete process.env.PUBLIC_URL;
+  else process.env.PUBLIC_URL = savedPublic;
+});
+
+describe("TriggerService.webhookUrl", () => {
+  it("defaults to the actual server PORT (not the hardcoded 5000)", () => {
+    delete process.env.PUBLIC_URL;
+    process.env.PORT = "5050";
+    expect(svc.webhookUrl("abc")).toBe("http://localhost:5050/api/webhooks/abc");
+  });
+
+  it("falls back to 5000 only when PORT is unset", () => {
+    delete process.env.PUBLIC_URL;
+    delete process.env.PORT;
+    expect(svc.webhookUrl("abc")).toBe("http://localhost:5000/api/webhooks/abc");
+  });
+
+  it("honors PUBLIC_URL (a public tunnel) over the local port", () => {
+    process.env.PUBLIC_URL = "https://demo.trycloudflare.com";
+    process.env.PORT = "5050";
+    expect(svc.webhookUrl("xyz")).toBe("https://demo.trycloudflare.com/api/webhooks/xyz");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -207,6 +207,9 @@ export default defineConfig({
         "client/src/lib/task-iterations.ts",
         "client/src/components/task-groups/task-form-logic.ts",
         "client/src/components/task-groups/timeline.ts",
+        // github-trigger-polling — the poller + the reusable gh JSON seam.
+        "server/services/github-poller.ts",
+        "server/services/github-status.ts",
       ],
       exclude: ["server/**/*.test.ts", "server/index.ts", "server/vite.ts"],
     },


### PR DESCRIPTION
## Problem: a local daemon behind NAT never fires github_event triggers

An enabled `github_event` trigger (events `[pull_request, push]`, action `diff-pr-review`) has `lastFired: null` — it never fired — despite real PRs. Root cause: a github webhook only fires when **GitHub POSTs to us**, and GitHub's servers live on the public internet. They **cannot deliver a webhook to a local daemon behind NAT** (localhost / a private-LAN IP). The receiver (#471) works when it *receives* a POST — but nothing posts, because GitHub can't reach a local box. Compounding it, `webhookUrl()` defaulted to `:5000` while the dev server runs on `:5050`, so even the URL we showed pointed at nothing.

Two fixes, both default-OFF / back-compatible.

## FIX 1 — webhook URL port + honest tunnel guidance

- `webhookUrl()` now defaults to the **actual server port**: `PUBLIC_URL ?? http://localhost:${PORT ?? 5000}` (was a hardcoded `:5000`). `PUBLIC_URL` still wins when set.
- The trigger config UI (`WebhookDetails`) now says plainly: **a localhost URL will never receive GitHub webhooks** — point `PUBLIC_URL` at a public tunnel (cloudflared/ngrok), **or** enable polling (Fix 2). A local/LAN URL gets a red warning; a non-local URL gets an informational note.

## FIX 2 — polling mode (`features.triggers.githubPolling`, default OFF)

GitHub can't push to us, but **we can pull from GitHub** — works behind NAT, no public endpoint. A new poller service (`server/services/github-poller.ts`), started from the trigger subsystem bootstrap only when the kill-switch is on, polls each **enabled** `github_event` trigger on an interval (60..3600s, default 300) for the events it watches, via the existing `gh` CLI seam (`github-status.ts` → new `runGhJson`, sanitized-env, never-throw):

- **pull_request** → `gh pr list --repo <o/r> --state open --json number,title,headRefOid,baseRefOid,updatedAt` — a new open PR, or an open PR whose head advanced, fires.
- **push** (default branch) → `gh repo view` (default branch) + `gh api repos/<o/r>/branches/<b>` (head sha); a head **advance** fires a post-merge review of `before..after`.

### Reused #471 event→loop map (webhook == polling)
Each detected event is synthesized into the **same** `{ event, delivery, payload }` envelope the webhook receiver (`github-event-handler.ts`) hands `fireTrigger`, so the **same** `mapGitHubEventToReview` produces **identical** loops. A test feeds the poller's synthesized envelope straight into the pure mapper and asserts `diff-pr-review` on the PR head/base.

### Rails (all reused from the existing dispatch)
- **Watermark** (last-seen PR head sha per number / default-branch head sha) persisted in the trigger's `config` jsonb — **no migration**. Advanced **only** when a fire is **not** dedup-suppressed, so a suppressed event is retried next cycle: never re-fired, never lost.
- **Dedup**: firing flows through the same `launchReviewWithDedup` (one active loop per repo). Within a cycle the first PR launches and later same-repo PRs dedup-suppress (watermark held).
- **Master switch**: `features.triggers.enabled` gates firing; the poller skips the whole cycle when it's off (watermark untouched) so nothing fires on a running server until enabled.
- **Interval** (min 60s) bounds cadence; cycles never overlap.
- **Degrade**: every `gh` call degrades to `null` on outage (missing/unauth/rate-limited/timeout/non-JSON) → skip that poll, never crash; each trigger + each cycle is guarded so one failure never stops the rest.
- **Repo mapping**: owner/repo from `config.repository` (already `owner/repo`), else parsed from the local repo's `git remote get-url origin` — handles **both** scp-SSH (`git@host:o/r.git`) and URL (`https|ssh|git://host/o/r(.git)`) forms. No github remote → skip + log.
- **Security**: the `gh` token is never read/logged (handed to `gh` via sanitized env only); owner/repo is shape-validated and the branch is `encodeURIComponent`'d before reaching `gh`; every polled value is untrusted and reaches the objective only through the factory's sanitized seam; `repoPath` (local review target) is re-validated against the fail-closed allowlist inside the factory.

`fireTrigger` now returns the dispatch result (existing cron/file-watcher/webhook callers ignore it) so the poller can make the watermark-advance decision.

## Adversarial self-review
- **(a) re-firing the same PR every poll** — watermark persists (config jsonb, survives restart) and advances on non-dedup fires; a matching head is skipped.
- **(b) poll storm → unbounded loops** — dedup (1 loop/repo) + master switch + interval; first-cycle open PRs fire one at a time.
- **(c) gh outage crashing the poller** — `runGhJson` never throws; null → skip; per-trigger + per-cycle guards.
- **(d) owner/repo parse of SSH/HTTPS remote** — `parseOwnerRepo` handles both; junk → null → skip.

## Test evidence
`tsc` clean. Full unit suite green: **261 files, 4995 tests passing** (includes 19 new). New tests: `github-poller.test.ts` (new-PR fire + watermark; re-poll no-fire; head-advance re-fire; dedup holds watermark; push baseline→advance; master-off / no-remote / gh-outage → no fire; git-remote derivation; `parseOwnerRepo` SSH+HTTPS; envelope↔webhook map parity) and `trigger-webhook-url.test.ts` (port default + PUBLIC_URL).

Draft — do not merge.

---

## FIX 3 (added) — webhook receiver + poller crashed outside an ALS context (the real "never fired" cause)

A live manual webhook test surfaced a **500 on every delivery** of `POST /api/webhooks/:triggerId` (and, latently, `POST /api/github-events`): `handleWebhookRequest` → `storage.getTrigger` / `triggerService.getSecret` are **project-scoped** (`withProject`), but a public webhook has **no `x-project-id`** and runs **outside any ALS context**, so `withProject` throws `"no request context — wrap … in runAsProject/runAsSystem"`. The #471 tests **mocked** `getTrigger`/`getSecret` with plain objects, so the `withProject` gate was never exercised and the real PgStorage path was never functional end-to-end. **This — not just NAT — is why the operator's github trigger never fired (`lastFired: null`).**

- `webhooks.ts`: both handlers now run inside `runAsSystem("github-webhook"…)`. A webhook identifies its trigger by id across all projects → a cross-project system caller. This covers `getTrigger` **and** `getSecret` (the github-events `getSecret` path was also unwrapped and 500'd for any trigger **with a secret** — i.e. every HMAC-verified github webhook). `fireTrigger` re-establishes its own context internally, so the nesting is safe.
- `github-poller.ts`: each per-trigger poll now runs inside `runAsProject(trigger.projectId)` (injected `runInProject`), so its `getTrigger` (fresh re-read) + `updateTrigger` (watermark) stay inside the trigger's **own** project-isolation boundary — the poll runs outside any request and would otherwise throw the identical no-context error. The cross-project trigger **list** stays under `runAsSystem`; a project-less trigger is skipped.

**Regression tests (REAL, non-mocked `withProject` — the exact thing the mocks hid):**
- `webhook-context.test.ts`: `POST /api/webhooks/:id` and a **signed** `POST /api/github-events` both return **200** (not 500) with storage routed through the real `withProject`; a control proves `handleWebhookRequest` throws `"no request context"` without the wrapper. **Verified by reverting the fix** → the 200 assertion becomes a 500 (the test catches the regression).
- `github-poller.test.ts`: the per-trigger poll runs inside `runAsProject(projectId)`; a project-less trigger is skipped; a real-`withProject` + real-`runAsProject` poll does not throw and persists the watermark, while a context-less wiring is proven to fail closed.

Updated test totals: **262 files, 5002 tests passing**; `tsc` clean.
