### PR TITLE
fix: webhook receiver + github poller crash outside ALS context (follow-up to #492)

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -451,12 +451,14 @@ export async function registerRoutes(
     // `fireTrigger` seam the webhook receiver uses. Default OFF → not constructed.
     if (appConfigLoader.get().features.triggers.githubPolling.enabled) {
       githubPoller = new GitHubPoller({
+        // The ONLY cross-project read — under runAsSystem (unscopedSystemQuery).
         getEnabledTriggersByType: (type) =>
           runAsSystem("github-poller-bootstrap", () => storage.getAllEnabledTriggersByType(type)),
-        getTrigger: (id) =>
-          runAsSystem("github-poller-get-trigger", () => storage.getTrigger(id)),
-        updateTrigger: (id, updates) =>
-          runAsSystem("github-poller-watermark", () => storage.updateTrigger(id, updates)),
+        // Per-trigger storage runs INSIDE runAsProject(trigger.projectId) below
+        // (project isolation) — these deps are plain; the poller owns the context.
+        runInProject: runAsProject,
+        getTrigger: (id) => storage.getTrigger(id),
+        updateTrigger: (id, updates) => storage.updateTrigger(id, updates),
         fireTrigger,
         config: () => appConfigLoader.get(),
         log: (m: string) => log(m, "github-poller"),

--- a/server/routes/webhooks.ts
+++ b/server/routes/webhooks.ts
@@ -34,11 +34,21 @@ export function registerWebhookRoutes(
   // POST /api/webhooks/:triggerId — generic webhook receiver
   app.post("/api/webhooks/:triggerId", async (req, res) => {
     try {
-      await handleWebhookRequest(req, res, {
-        getTrigger: (id) => storage.getTrigger(id),
-        getSecret: (id) => triggerService.getSecret(id),
-        fireTrigger,
-      });
+      // CONTEXT FIX: a public webhook POST has NO x-project-id header and runs
+      // outside any request-scoped ALS context, but `storage.getTrigger` /
+      // `triggerService.getSecret` are project-scoped (they call `withProject`,
+      // which THROWS "no request context" otherwise → a 500 on every delivery).
+      // A webhook identifies its trigger by id across ALL projects, so it is a
+      // cross-project SYSTEM caller: establish a system context for the whole
+      // handler (getTrigger + getSecret). `fireTrigger` re-establishes its own
+      // system/project context internally, so the nesting is safe.
+      await runAsSystem("github-webhook", () =>
+        handleWebhookRequest(req, res, {
+          getTrigger: (id) => storage.getTrigger(id),
+          getSecret: (id) => triggerService.getSecret(id),
+          fireTrigger,
+        }),
+      );
     } catch (e) {
       if (e instanceof ZodError) {
         return res.status(400).json({ error: "Validation failed", issues: e.issues });
@@ -52,21 +62,23 @@ export function registerWebhookRoutes(
   // POST /api/github-events — GitHub webhook event router
   app.post("/api/github-events", async (req, res) => {
     try {
-      const result = await handleGitHubEvent(
-        req.rawBody,
-        req.headers as Record<string, string | string[] | undefined>,
-        req.body as unknown,
-        {
-          // getEnabledTriggersByType must run cross-project (no ALS context on github-events).
-          // runAsSystem establishes a system context; getAllEnabledTriggersByType bypasses
-          // the project filter so all matching triggers across all projects are returned.
-          getEnabledTriggersByType: (type) =>
-            runAsSystem("github-event-trigger-lookup", () =>
-              storage.getAllEnabledTriggersByType(type),
-            ),
-          getSecret: (id) => triggerService.getSecret(id),
-          fireTrigger,
-        },
+      // CONTEXT FIX: like the generic receiver, this public endpoint has no ALS
+      // context. `getAllEnabledTriggersByType` (cross-project) AND `getSecret`
+      // (→ storage.getTrigger → withProject) BOTH require a system context — the
+      // latter was previously unwrapped and 500'd for any trigger WITH a secret
+      // (i.e. every HMAC-verified github webhook). Wrap the whole handler in ONE
+      // system context so both reads succeed; fireTrigger nests its own context.
+      const result = await runAsSystem("github-webhook-event", () =>
+        handleGitHubEvent(
+          req.rawBody,
+          req.headers as Record<string, string | string[] | undefined>,
+          req.body as unknown,
+          {
+            getEnabledTriggersByType: (type) => storage.getAllEnabledTriggersByType(type),
+            getSecret: (id) => triggerService.getSecret(id),
+            fireTrigger,
+          },
+        ),
       );
 
       // VETO-3 fix: do NOT return internal trigger IDs or raw error strings to the

--- a/server/services/github-poller.ts
+++ b/server/services/github-poller.ts
@@ -108,11 +108,31 @@ function normalizeOwnerRepo(owner: string, repo: string): string | null {
 }
 
 export interface GitHubPollerDeps {
-  /** Cross-project, system-context load of enabled github_event triggers. */
+  /**
+   * Cross-project, system-context load of enabled github_event triggers. This is
+   * the ONLY cross-project call — it MUST be wired under `runAsSystem` (it uses
+   * `unscopedSystemQuery`). Every subsequent per-trigger storage call runs under
+   * `runInProject(trigger.projectId)` instead (ADR-001 project isolation).
+   */
   getEnabledTriggersByType: (type: "github_event") => Promise<TriggerRow[]>;
-  /** Re-read a trigger fresh so the watermark write does not clobber a concurrent edit. */
+  /**
+   * Establish a project-scoped ALS context for one trigger's poll (= runAsProject).
+   * The poll runs OUTSIDE any request, so `getTrigger`/`updateTrigger` (which call
+   * the project-scoped `withProject`) would throw "no request context" without
+   * this — the SAME crash the public webhook receiver hit. Scoping to the
+   * trigger's OWN project (not a broad system context) keeps the watermark
+   * read/write inside that project's isolation boundary.
+   */
+  runInProject: <T>(projectId: string, fn: () => Promise<T>) => Promise<T>;
+  /**
+   * Re-read a trigger fresh so the watermark write does not clobber a concurrent
+   * edit. Called INSIDE `runInProject` — do NOT wrap it in a context yourself.
+   */
   getTrigger: (id: string) => Promise<TriggerRow | undefined>;
-  /** Persist the advanced watermark (writes back `config` with `pollState`). */
+  /**
+   * Persist the advanced watermark (writes back `config` with `pollState`). Called
+   * INSIDE `runInProject` — do NOT wrap it in a context yourself.
+   */
   updateTrigger: (id: string, updates: Partial<TriggerRow>) => Promise<unknown>;
   /**
    * The SAME `fireTrigger` seam the webhook receiver uses. Returns the dispatch
@@ -235,6 +255,14 @@ export class GitHubPoller {
     const events = Array.isArray(config.events) ? config.events : [];
     if (events.length === 0) return;
 
+    // A github polling trigger MUST carry a project: its storage calls are
+    // project-scoped, and a review cannot launch without a projectId anyway
+    // (maybeLaunchGitHubReview returns "skipped"). Skip a project-less trigger.
+    if (!trigger.projectId) {
+      this.deps.log(`github poll skipped for trigger ${trigger.id} — trigger has no projectId`);
+      return;
+    }
+
     const ownerRepo = await this.resolveOwnerRepo(config);
     if (!ownerRepo) {
       this.deps.log(
@@ -243,23 +271,29 @@ export class GitHubPoller {
       return;
     }
 
-    // Read-modify: work on a COPY of the current watermark.
-    const state: GitHubPollState = { ...(config.pollState ?? {}) };
-    let changed = false;
+    // CONTEXT FIX: the poll runs OUTSIDE any request. `getTrigger`/`updateTrigger`
+    // (and, defensively, `fireTrigger`) call the project-scoped `withProject`,
+    // which throws "no request context" without an ALS context — the SAME crash
+    // the public webhook receiver hit. Scope the WHOLE per-trigger poll to the
+    // trigger's OWN project so the watermark read/write stays inside that
+    // project's isolation boundary. `fireTrigger` re-establishes its own context
+    // internally, so the nesting is harmless.
+    const projectId = trigger.projectId;
+    await this.deps.runInProject(projectId, async () => {
+      // Read-modify: work on a COPY of the current watermark.
+      const state: GitHubPollState = { ...(config.pollState ?? {}) };
 
-    if (events.includes("pull_request")) {
-      changed = (await this.pollPullRequests(trigger, ownerRepo, state)) || changed;
-    }
-    if (events.includes("push")) {
-      changed = (await this.pollPush(trigger, ownerRepo, state)) || changed;
-    }
+      if (events.includes("pull_request")) {
+        await this.pollPullRequests(trigger, ownerRepo, state);
+      }
+      if (events.includes("push")) {
+        await this.pollPush(trigger, ownerRepo, state);
+      }
 
-    state.lastPolledAt = new Date(this.now()).toISOString();
-    changed = true; // always persist lastPolledAt for diagnosability
-
-    if (changed) {
+      // Always persist (advances the watermark + records lastPolledAt for diagnosis).
+      state.lastPolledAt = new Date(this.now()).toISOString();
       await this.persistWatermark(trigger.id, state);
-    }
+    });
   }
 
   /**

--- a/tests/unit/consilium/github-poller.test.ts
+++ b/tests/unit/consilium/github-poller.test.ts
@@ -22,7 +22,10 @@ import {
 import type { ExecFileFn } from "../../../server/services/github-status.js";
 import { mapGitHubEventToReview } from "../../../server/services/consilium/github-event-map.js";
 import type { TriggerFireResult } from "../../../server/services/consilium/trigger-dispatch.js";
-import type { TriggerRow } from "../../../shared/schema.js";
+import { runAsProject } from "../../../server/context.js";
+import { withProject } from "../../../server/db.js";
+import { triggers, type TriggerRow } from "../../../shared/schema.js";
+import { eq } from "drizzle-orm";
 import type { AppConfig, GitHubEventTriggerConfig, GitHubPollState } from "../../../shared/types.js";
 
 const HEAD_A = "a".repeat(40);
@@ -110,8 +113,14 @@ function harness(opts: {
     return typeof r === "function" ? r(payload) : r;
   });
   const updates: Array<Partial<TriggerRow>> = [];
+  const projectIds: string[] = [];
   const deps: GitHubPollerDeps = {
     getEnabledTriggersByType: async () => [stored],
+    // Pass-through project context (real ALS wiring is covered by a separate test).
+    runInProject: async (pid, fn) => {
+      projectIds.push(pid);
+      return fn();
+    },
     getTrigger: async () => stored,
     updateTrigger: async (_id, u) => {
       updates.push(u);
@@ -131,6 +140,7 @@ function harness(opts: {
     fire,
     firePayloads,
     updates,
+    projectIds,
     lastWatermark: (): GitHubPollState | undefined =>
       (stored.config as GitHubEventTriggerConfig).pollState,
   };
@@ -295,6 +305,25 @@ describe("GitHubPoller — rails", () => {
     expect(prList).toContain("acme/widget");
   });
 
+  it("scopes the per-trigger poll to the trigger's OWN project (runInProject)", async () => {
+    const h = harness({
+      trigger: ghTrigger({ pollState: { prHeads: {} } }),
+      gh: fakeGh({ prs: [{ number: 3, headRefOid: HEAD_A, baseRefOid: BASE_SHA }] }).run,
+    });
+    await h.poller.pollAll();
+    expect(h.projectIds).toEqual(["proj-1"]); // storage ran inside runAsProject(proj-1)
+  });
+
+  it("skips a project-less trigger (cannot scope storage / launch a review)", async () => {
+    const gh = fakeGh({ prs: [{ number: 1, headRefOid: HEAD_A, baseRefOid: BASE_SHA }] });
+    const trigger = { ...ghTrigger({}), projectId: null } as TriggerRow;
+    const h = harness({ trigger, gh: gh.run });
+    await h.poller.pollAll();
+    expect(h.fire).not.toHaveBeenCalled();
+    expect(h.projectIds).toEqual([]); // never entered a project context
+    expect(gh.argv.length).toBe(0);
+  });
+
   it("a gh outage degrades to a skip — never throws, never fires", async () => {
     const gh = fakeGh({ throwOn: () => true });
     const h = harness({ trigger: ghTrigger({}), gh: gh.run });
@@ -309,6 +338,7 @@ describe("GitHubPoller — rails", () => {
     const fireCalls: string[] = [];
     const deps: GitHubPollerDeps = {
       getEnabledTriggersByType: async () => [t1, { ...t1, id: "trig-2" } as TriggerRow],
+      runInProject: async (_pid, fn) => fn(),
       getTrigger: async (id) => ({ ...t1, id } as TriggerRow),
       updateTrigger: async () => t1,
       fireTrigger: async (t) => {
@@ -325,5 +355,78 @@ describe("GitHubPoller — rails", () => {
     await expect(poller.pollAll()).resolves.toBeUndefined();
     // Both triggers were attempted despite the first throwing.
     expect(fireCalls).toEqual(["trig-1", "trig-2"]);
+  });
+});
+
+// ─── REAL context path (non-mocked withProject) — regression guard ─────────────
+//
+// The #471-style tests mocked storage so the project-scoped `withProject` gate
+// was never exercised — that hid a crash where background/webhook callers with no
+// ALS context throw "no request context". These tests route the poller's storage
+// through the REAL `withProject` (server/db.ts) + REAL `runAsProject`
+// (server/context.ts) so a missing/incorrect context cannot regress silently.
+describe("GitHubPoller — real project-context path (withProject regression)", () => {
+  // A storage stub whose reads/writes go through the REAL project-scope gate.
+  function contextCheckedStorage(trigger: TriggerRow) {
+    let stored = trigger;
+    return {
+      getTrigger: async (id: string) => {
+        // Throws "no request context" if called outside runAsProject/runAsSystem.
+        withProject(triggers, eq(triggers.id, id));
+        return stored;
+      },
+      updateTrigger: async (id: string, u: Partial<TriggerRow>) => {
+        withProject(triggers, eq(triggers.id, id));
+        if (u.config) stored = { ...stored, config: u.config } as TriggerRow;
+        return stored;
+      },
+      current: () => stored,
+    };
+  }
+
+  const openPr = { number: 5, title: "ctx", headRefOid: HEAD_A, baseRefOid: BASE_SHA };
+
+  it("does NOT throw when per-trigger storage runs inside the REAL runAsProject", async () => {
+    const trigger = ghTrigger({});
+    const store = contextCheckedStorage(trigger);
+    const gh = fakeGh({ prs: [openPr] });
+    const poller = new GitHubPoller({
+      getEnabledTriggersByType: async () => [trigger],
+      runInProject: runAsProject, // REAL ALS context
+      getTrigger: store.getTrigger,
+      updateTrigger: store.updateTrigger,
+      fireTrigger: async () => "launched",
+      config: cfg(true),
+      runGh: gh.run,
+      log: () => {},
+      now: () => 0,
+    });
+    await expect(poller.pollAll()).resolves.toBeUndefined();
+    // The watermark WAS written through the real project-scope gate.
+    expect((store.current().config as GitHubEventTriggerConfig).pollState?.prHeads).toEqual({
+      "5": HEAD_A,
+    });
+  });
+
+  it("PROVES the guard bites: the same storage throws 'no request context' with a pass-through runInProject", async () => {
+    const trigger = ghTrigger({});
+    const store = contextCheckedStorage(trigger);
+    const gh = fakeGh({ prs: [openPr] });
+    const poller = new GitHubPoller({
+      getEnabledTriggersByType: async () => [trigger],
+      // BROKEN wiring: does NOT establish an ALS context (the original bug shape).
+      runInProject: async (_pid, fn) => fn(),
+      getTrigger: store.getTrigger,
+      updateTrigger: store.updateTrigger,
+      fireTrigger: async () => "launched",
+      config: cfg(true),
+      runGh: gh.run,
+      log: () => {},
+      now: () => 0,
+    });
+    // pollAll swallows per-trigger errors, so assert the write never landed
+    // (persistWatermark threw inside the guarded cycle → watermark unchanged).
+    await poller.pollAll();
+    expect((store.current().config as GitHubEventTriggerConfig).pollState).toBeUndefined();
   });
 });

--- a/tests/unit/consilium/webhook-context.test.ts
+++ b/tests/unit/consilium/webhook-context.test.ts
@@ -1,0 +1,151 @@
+/**
+ * webhook-context.test.ts — REGRESSION GUARD for the public webhook receiver's
+ * project-context crash.
+ *
+ * The bug: `POST /api/webhooks/:triggerId` and `POST /api/github-events` are
+ * PUBLIC (no x-project-id) and run outside any request-scoped ALS context, but
+ * `storage.getTrigger` / `triggerService.getSecret` are project-scoped — they call
+ * `withProject`, which THROWS "no request context" without an ALS context → a 500
+ * on EVERY delivery. The real PgStorage path was never functional end-to-end; the
+ * #471 tests mocked getTrigger/getSecret with plain objects, so the `withProject`
+ * gate was never exercised and the crash was invisible.
+ *
+ * These tests route the receiver's storage through the REAL `withProject`
+ * (server/db.ts) so the missing-context crash cannot regress: the route must
+ * establish a system context (runAsSystem) for the whole handler.
+ */
+import { describe, it, expect, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+import { createHmac } from "crypto";
+import { eq } from "drizzle-orm";
+import { registerWebhookRoutes } from "../../../server/routes/webhooks.js";
+import { handleWebhookRequest } from "../../../server/services/webhook-handler.js";
+import { withProject } from "../../../server/db.js";
+import { triggers, type TriggerRow } from "../../../shared/schema.js";
+import type { IStorage } from "../../../server/storage.js";
+import type { TriggerService } from "../../../server/services/trigger-service.js";
+import type { Request, Response } from "express";
+
+/** An enabled github_event trigger row (no pipeline; project-scoped). */
+function ghTrigger(id: string, secretEncrypted: string | null = null): TriggerRow {
+  return {
+    id,
+    projectId: "proj-1",
+    pipelineId: null,
+    type: "github_event",
+    config: {
+      repository: "acme/widget",
+      events: ["pull_request"],
+      action: { kind: "consilium_review", preset: "diff-pr-review", repoPath: "/repo" },
+    },
+    secretEncrypted,
+    enabled: true,
+    lastTriggeredAt: null,
+    suppressedCount: 0,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  } as TriggerRow;
+}
+
+/**
+ * Build an express app with ONLY the webhook routes, backed by a storage +
+ * triggerService whose reads go through the REAL `withProject` gate (so a missing
+ * ALS context throws exactly as PgStorage would).
+ */
+function buildApp(opts: {
+  trigger: TriggerRow;
+  secret?: string | null;
+  fireTrigger: (t: TriggerRow, p: unknown) => Promise<unknown>;
+}) {
+  const app = express();
+  app.use(
+    express.json({
+      verify: (req, _res, buf) => {
+        (req as Request & { rawBody?: Buffer }).rawBody = buf;
+      },
+    }),
+  );
+
+  const storage = {
+    // Real project-scope gate — throws "no request context" outside runAsSystem/Project.
+    getTrigger: async (id: string) => {
+      withProject(triggers, eq(triggers.id, id));
+      return opts.trigger.id === id ? opts.trigger : undefined;
+    },
+    getAllEnabledTriggersByType: async (_type: string) => [opts.trigger],
+  } as unknown as IStorage;
+
+  const triggerService = {
+    getSecret: async (id: string) => {
+      withProject(triggers, eq(triggers.id, id));
+      return opts.secret ?? null;
+    },
+  } as unknown as TriggerService;
+
+  registerWebhookRoutes(app, storage, triggerService, opts.fireTrigger);
+  return app;
+}
+
+describe("POST /api/webhooks/:triggerId — real project-context path", () => {
+  it("returns 200 (not 500) and fires — the route establishes a system context", async () => {
+    const fire = vi.fn(async () => "launched");
+    const app = buildApp({ trigger: ghTrigger("trig-generic-1"), fireTrigger: fire });
+
+    const res = await request(app)
+      .post("/api/webhooks/trig-generic-1")
+      .set("X-GitHub-Event", "pull_request")
+      .send({ action: "opened", number: 1 });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(fire).toHaveBeenCalledTimes(1);
+  });
+
+  it("PROVES the gate bites: handleWebhookRequest WITHOUT a context wrapper throws 'no request context'", async () => {
+    // This is the exact shape the #471 route had (unwrapped) — it 500'd in prod.
+    const req = {
+      params: { triggerId: "trig-x" },
+      headers: {},
+      body: {},
+    } as unknown as Request;
+    const res = { status: () => res, json: () => res } as unknown as Response;
+
+    await expect(
+      handleWebhookRequest(req, res, {
+        getTrigger: async (id) => {
+          withProject(triggers, eq(triggers.id, id)); // real gate, no context → throws
+          return ghTrigger(id);
+        },
+        getSecret: async () => null,
+        fireTrigger: async () => "launched",
+      }),
+    ).rejects.toThrow(/no request context/i);
+  });
+});
+
+describe("POST /api/github-events — real project-context path (getSecret)", () => {
+  it("returns 200 for an HMAC-signed event — getSecret runs inside the system context", async () => {
+    // A github trigger WITH a secret: getSecret → withProject was previously
+    // unwrapped and 500'd. The signed body must pass HMAC, then fire.
+    const secret = "webhook-secret-key";
+    const fire = vi.fn(async () => "launched");
+    const app = buildApp({ trigger: ghTrigger("trig-gh-1", "enc"), secret, fireTrigger: fire });
+
+    const bodyObj = { action: "opened", number: 2, repository: { full_name: "acme/widget" } };
+    const jsonString = JSON.stringify(bodyObj);
+    const raw = Buffer.from(jsonString, "utf8");
+    const sig = "sha256=" + createHmac("sha256", secret).update(raw).digest("hex");
+
+    const res = await request(app)
+      .post("/api/github-events")
+      .set("Content-Type", "application/json")
+      .set("X-GitHub-Event", "pull_request")
+      .set("X-Hub-Signature-256", sig)
+      .send(jsonString); // exact bytes → req.rawBody matches the signed payload
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ fired: 1 });
+    expect(fire).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Follow-up to #492, which was **merged at its first commit (`beb6d7d`) before this critical fix was pushed** — so the context fix below is on the branch but **not yet in `main`**. This PR carries only that fix.

## The 500-on-every-webhook bug (the real "never fired" cause)

A live manual webhook test surfaced a **500 on every delivery** of `POST /api/webhooks/:triggerId` (and, latently, `POST /api/github-events`):

`handleWebhookRequest` → `storage.getTrigger` / `triggerService.getSecret` are **project-scoped** (`withProject`), but a public webhook has **no `x-project-id`** and runs **outside any ALS context**, so `withProject` throws `"no request context — wrap … in runAsProject/runAsSystem"`. #471's tests **mocked** `getTrigger`/`getSecret` with plain objects, so the `withProject` gate was never exercised and the real PgStorage path was never functional end-to-end. **This — not just NAT — is why the operator's github trigger never fired (`lastFired: null`).** The poller would hit the identical crash on its watermark storage calls.

## Fix
- **`webhooks.ts`**: wrap both handlers in `runAsSystem("github-webhook"…)`. A webhook identifies its trigger by id across all projects → a cross-project system caller. This covers `getTrigger` **and** `getSecret` (the github-events `getSecret` path was also unwrapped and 500'd for any trigger **with a secret** — i.e. every HMAC-verified github webhook). `fireTrigger` re-establishes its own context internally, so the nesting is safe.
- **`github-poller.ts`**: scope each per-trigger poll to `runAsProject(trigger.projectId)` (injected `runInProject`) so its `getTrigger` (fresh re-read) + `updateTrigger` (watermark) stay inside the trigger's **own** project-isolation boundary — the poll runs outside any request and would otherwise throw the same no-context error. The cross-project trigger **list** stays under `runAsSystem`; a project-less trigger is skipped.

## Tests (REAL, non-mocked `withProject` — the exact thing the mocks hid)
- `webhook-context.test.ts`: `POST /api/webhooks/:id` and a **signed** `POST /api/github-events` both return **200** (not 500) with storage routed through the real `withProject`; a control proves `handleWebhookRequest` throws `"no request context"` without the wrapper. **Verified by reverting the fix** → the 200 assertion becomes a 500, so the test catches the regression.
- `github-poller.test.ts`: the per-trigger poll runs inside `runAsProject(projectId)`; a project-less trigger is skipped; a real-`withProject` + real-`runAsProject` poll does not throw and persists the watermark, while a context-less wiring is proven to fail closed.

`tsc` clean. Full unit suite green: **262 files, 5002 tests passing**.

Draft — do not merge.
