### PR TITLE
feat: show a trigger's fired loops, fire counter, and last-fire event

### DIFF
--- a/client/src/components/triggers/TriggerCard.tsx
+++ b/client/src/components/triggers/TriggerCard.tsx
@@ -1,12 +1,17 @@
+import { useState } from "react";
+import { useLocation } from "wouter";
 import { formatDistanceToNow } from "date-fns";
-import { Pencil, Trash2, Zap, Clock, Github, FolderSearch } from "lucide-react";
+import {
+  Pencil, Trash2, Zap, Clock, Github, FolderSearch,
+  ChevronRight, ChevronDown, GitPullRequest, ArrowUpRight, AlertTriangle,
+} from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
-import { useEnableTrigger, useDisableTrigger } from "@/hooks/use-triggers";
-import type { PipelineTrigger, TriggerType, ScheduleTriggerConfig, GitHubEventTriggerConfig, FileChangeTriggerConfig } from "@shared/types";
+import { useEnableTrigger, useDisableTrigger, useTriggerLoops } from "@/hooks/use-triggers";
+import type { PipelineTrigger, TriggerType, ScheduleTriggerConfig, GitHubEventTriggerConfig, FileChangeTriggerConfig, TriggerFiredLoop } from "@shared/types";
 import { loopTargetSummary } from "./trigger-form-logic";
 
 // ─── Type badge config ────────────────────────────────────────────────────────
@@ -57,6 +62,58 @@ function configSummary(trigger: PipelineTrigger): string {
   }
 }
 
+// ─── Fired-loop helpers ───────────────────────────────────────────────────────
+
+/** Safe relative time — returns null for a missing/unparseable instant. */
+function relativeTime(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return null;
+  return formatDistanceToNow(new Date(ms), { addSuffix: true });
+}
+
+/** First 7 chars of a PR ref/commit-ish for a compact "hash" chip. */
+function shortRef(ref: string | null): string | null {
+  if (!ref) return null;
+  const trimmed = ref.trim();
+  return trimmed.length > 12 ? trimmed.slice(0, 12) + "…" : trimmed;
+}
+
+/** One row in the expandable fired-loop list — clicking opens ConsiliumLoopDetail. */
+function FiredLoopRow({ loop, onOpen }: { loop: TriggerFiredLoop; onOpen: (id: string) => void }) {
+  const when = relativeTime(loop.firedAt);
+  const pr = shortRef(loop.prRef);
+  const label = loop.eventSummary ?? `Loop ${loop.loopId.slice(0, 8)}`;
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(loop.loopId)}
+      className="w-full text-left rounded-md border border-border/60 hover:border-border hover:bg-muted/50 px-2.5 py-2 transition-colors group"
+      aria-label={`Open fired loop ${loop.loopId}`}
+    >
+      <div className="flex items-center gap-2 min-w-0">
+        <Badge variant="outline" className="text-[9px] h-4 px-1 shrink-0 font-mono">
+          {loop.state}
+        </Badge>
+        <span className="text-[11px] truncate flex-1 min-w-0">{label}</span>
+        <ArrowUpRight className="h-3 w-3 text-muted-foreground opacity-0 group-hover:opacity-100 shrink-0" />
+      </div>
+      <div className="flex items-center gap-2 mt-1 text-[10px] text-muted-foreground font-mono">
+        {pr && (
+          <span className="inline-flex items-center gap-1">
+            <GitPullRequest className="h-2.5 w-2.5" />
+            {pr}
+          </span>
+        )}
+        <span className="inline-flex items-center gap-1" title={loop.eventDigest}>
+          #{loop.eventDigest}
+        </span>
+        {when && <span>· {when}</span>}
+      </div>
+    </button>
+  );
+}
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 interface TriggerCardProps {
@@ -68,6 +125,11 @@ interface TriggerCardProps {
 export function TriggerCard({ trigger, onEdit, onDelete }: TriggerCardProps) {
   const enable = useEnableTrigger();
   const disable = useDisableTrigger();
+  const [, navigate] = useLocation();
+  const [expanded, setExpanded] = useState(false);
+
+  // The loops this trigger actually fired (newest first) + the total fire count.
+  const { data: fired, isLoading: firedLoading } = useTriggerLoops(trigger.id);
 
   const meta = TYPE_META[trigger.type];
   const Icon = meta.Icon;
@@ -82,9 +144,26 @@ export function TriggerCard({ trigger, onEdit, onDelete }: TriggerCardProps) {
     }
   }
 
-  const lastTriggered = trigger.lastTriggeredAt
+  const firedCount = fired?.firedCount ?? 0;
+  const firedLoops = fired?.loops ?? [];
+  const lastFired = firedLoops[0]; // newest first from the endpoint
+  const hasFired = firedCount > 0;
+
+  // Prefer the ACTUAL last-fire instant from the newest fired loop's provenance —
+  // it is authoritative. `trigger.lastTriggeredAt` is a denormalised mirror the
+  // firing path maintains; if it lags the real fire we flag it (rendering what is
+  // there, per the firing-path/render split) rather than silently trusting it.
+  const lastFireIso = lastFired?.firedAt ?? null;
+  const lastFireRel = relativeTime(lastFireIso);
+  const triggerStampRel = trigger.lastTriggeredAt
     ? formatDistanceToNow(new Date(trigger.lastTriggeredAt), { addSuffix: true })
-    : "Never";
+    : null;
+  // Stale iff we have a real fire but the trigger's own stamp is missing or older.
+  const lastFireMs = lastFireIso ? Date.parse(lastFireIso) : NaN;
+  const stampMs = trigger.lastTriggeredAt ? new Date(trigger.lastTriggeredAt).getTime() : NaN;
+  const stampStale =
+    hasFired && !Number.isNaN(lastFireMs) &&
+    (Number.isNaN(stampMs) || stampMs < lastFireMs - 60_000);
 
   return (
     <Card className="border-border p-5">
@@ -114,15 +193,86 @@ export function TriggerCard({ trigger, onEdit, onDelete }: TriggerCardProps) {
               {configSummary(trigger)}
             </p>
 
-            <p className="text-[10px] text-muted-foreground mt-1">
-              Last triggered: <span className="font-medium">{lastTriggered}</span>
-              {trigger.suppressedCount > 0 && (
+            {/* Fire counter (loops actually created) DISTINCT from suppressed. */}
+            <p className="text-[10px] text-muted-foreground mt-1.5">
+              {firedLoading && !fired ? (
+                <span>Loading fire history…</span>
+              ) : (
                 <>
+                  <span className="font-medium text-foreground">Fired {firedCount}</span>
                   {" · "}
-                  <span className="font-medium">{trigger.suppressedCount}</span> suppressed
+                  <span className="font-medium">Suppressed {trigger.suppressedCount}</span>
                 </>
               )}
             </p>
+
+            {/* Last firing's event — from the newest fired loop's provenance. */}
+            {hasFired && lastFired ? (
+              <div className="mt-1.5 rounded-md bg-muted/40 border border-border/50 px-2.5 py-1.5">
+                <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+                  <Zap className="h-3 w-3 text-primary shrink-0" />
+                  <span className="font-medium text-foreground">Last fire</span>
+                  {lastFireRel && <span>· {lastFireRel}</span>}
+                  {stampStale && (
+                    <span
+                      className="inline-flex items-center gap-0.5 text-amber-600"
+                      title="The trigger's own lastTriggeredAt stamp is behind the newest fired loop — the firing path may not be advancing it."
+                    >
+                      <AlertTriangle className="h-2.5 w-2.5" /> stamp stale
+                    </span>
+                  )}
+                </div>
+                <p className="text-[11px] mt-0.5 truncate" title={lastFired.eventSummary ?? undefined}>
+                  {lastFired.eventSummary ?? `Loop ${lastFired.loopId.slice(0, 8)}`}
+                </p>
+                <div className="flex items-center gap-2 mt-0.5 text-[10px] text-muted-foreground font-mono">
+                  {shortRef(lastFired.prRef) && (
+                    <span className="inline-flex items-center gap-1">
+                      <GitPullRequest className="h-2.5 w-2.5" />
+                      {shortRef(lastFired.prRef)}
+                    </span>
+                  )}
+                  <span title="event digest">#{lastFired.eventDigest}</span>
+                </div>
+              </div>
+            ) : (
+              !firedLoading && (
+                <p className="text-[10px] text-muted-foreground mt-1.5 italic">
+                  Never fired
+                  {triggerStampRel && !hasFired && (
+                    <span className="not-italic"> · last checked {triggerStampRel}</span>
+                  )}
+                </p>
+              )
+            )}
+
+            {/* Expandable list of fired loops → click a loop to open its detail. */}
+            {hasFired && (
+              <div className="mt-1.5">
+                <button
+                  type="button"
+                  onClick={() => setExpanded((v) => !v)}
+                  className="inline-flex items-center gap-1 text-[10px] font-medium text-muted-foreground hover:text-foreground"
+                  aria-expanded={expanded}
+                  aria-label={expanded ? "Hide fired loops" : "Show fired loops"}
+                >
+                  {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+                  {expanded ? "Hide" : "View"} fired loop{firedCount === 1 ? "" : "s"}
+                  {firedCount > firedLoops.length && ` (showing ${firedLoops.length} of ${firedCount})`}
+                </button>
+                {expanded && (
+                  <div className="mt-1.5 flex flex-col gap-1.5">
+                    {firedLoops.map((loop) => (
+                      <FiredLoopRow
+                        key={loop.loopId}
+                        loop={loop}
+                        onOpen={(id) => navigate(`/consilium-loops/${id}`)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         </div>
 

--- a/client/src/hooks/use-triggers.ts
+++ b/client/src/hooks/use-triggers.ts
@@ -1,6 +1,9 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import type { PipelineTrigger, InsertTrigger, UpdateTrigger } from "@shared/types";
+import type { PipelineTrigger, InsertTrigger, UpdateTrigger, TriggerFiredLoopsResponse } from "@shared/types";
 import type { TriggerValidationIssue } from "@/components/triggers/trigger-form-logic";
+// Project-scoped transport: buildAuthHeaders attaches `x-project-id` (the pr-queue
+// 401 lesson — a project-scoped read that omits the header gets rejected).
+import { apiRequest as projectApiRequest } from "@/hooks/use-pipeline";
 
 /** Error thrown by {@link apiRequest}, carrying the server's structured validation issues. */
 export type TriggerApiError = Error & {
@@ -62,6 +65,21 @@ export function useTrigger(id: string) {
     queryKey: ["/api/triggers", id],
     queryFn: () => apiRequest("GET", `/api/triggers/${id}`) as Promise<PipelineTrigger>,
     enabled: !!id,
+  });
+}
+
+/**
+ * The consilium loops a trigger actually fired (newest first), plus the total
+ * `firedCount`. Powers the TriggerCard's fire counter, last-fire event, and the
+ * expandable "find the result" loop links. Uses the project-scoped transport so
+ * `x-project-id` is attached (the route inherits requireAuth + requireProject).
+ */
+export function useTriggerLoops(id: string, enabled = true) {
+  return useQuery<TriggerFiredLoopsResponse>({
+    queryKey: ["/api/triggers", id, "loops"],
+    queryFn: () =>
+      projectApiRequest("GET", `/api/triggers/${id}/loops`) as Promise<TriggerFiredLoopsResponse>,
+    enabled: enabled && !!id,
   });
 }
 

--- a/server/routes/triggers.ts
+++ b/server/routes/triggers.ts
@@ -15,13 +15,26 @@ import { randomUUID } from "crypto";
 import type { TriggerService } from "../services/trigger-service.js";
 import type { IStorage } from "../storage.js";
 import { requireRole, requireOwnerOrRole } from "../auth/middleware.js";
-import { CONSILIUM_REVIEW_PRESETS } from "@shared/types";
+import { CONSILIUM_REVIEW_PRESETS, TRIGGER_FIRED_LOOPS_LIMIT } from "@shared/types";
+import type { TriggerFiredLoop, TriggerFiredLoopsResponse } from "@shared/types";
+import type { ConsiliumLoopRow } from "@shared/schema";
 
 // ─── Correlation ID helper ────────────────────────────────────────────────────
 
 /** Generate a short correlation ID for error tracking. */
 function correlationId(): string {
   return randomUUID().slice(0, 8);
+}
+
+/**
+ * Sort key for a fired loop: the provenance `firedAt` instant in ms, falling back
+ * to the row's `createdAt` when a legacy row has no firedAt. Used to order fired
+ * loops newest-first for GET /api/triggers/:id/loops.
+ */
+function firedAtMs(loop: ConsiliumLoopRow): number {
+  const firedAt = loop.triggerProvenance?.firedAt;
+  const t = firedAt ? Date.parse(firedAt) : NaN;
+  return Number.isNaN(t) ? new Date(loop.createdAt).getTime() : t;
 }
 
 // ─── Fix 3: Strict per-type config schemas (no passthrough catch-all) ─────────
@@ -342,6 +355,69 @@ export function registerTriggerRoutes(app: Express, triggerService: TriggerServi
       }
       const cid = correlationId();
       console.error(`[triggers] GET trigger error cid=${cid}`, e);
+      return res.status(500).json({ error: "Internal server error", correlationId: cid });
+    }
+  });
+
+  // GET /api/triggers/:id/loops
+  //
+  // The "how do I find the result of a fire" endpoint. A trigger fire creates a
+  // consilium loop that records `triggerProvenance` (triggerId, firedAt,
+  // eventDigest, eventSummary) on the loop row (#457/#471). This route returns the
+  // loops THIS trigger created, newest first, so the operator can click through to
+  // each ConsiliumLoopDetail and read the PR / verdict.
+  //
+  // AUTH: inherits `requireAuth + requireProject` from the `/api/triggers` mount
+  // (routes.ts) — no per-route auth to forget (the /api/pr-queue 401 lesson). The
+  // trigger is additionally fetched via the PROJECT-SCOPED `getTrigger` and gated
+  // by assertTriggerAccess, exactly like GET /api/triggers/:id.
+  //
+  // SCOPE: loops are read via `storage.getLoops()`, which is PROJECT-scoped by the
+  // requireProject ALS context (a loop belongs to a project-scoped task group) —
+  // NOT owner-scoped, because a trigger-fired loop's `createdBy` is the project
+  // OWNER, so owner-scoping would hide fires from other project members. We then
+  // keep only loops whose `triggerProvenance.triggerId === :id` (human/API loops
+  // have null provenance and are correctly excluded). `firedCount` is the full
+  // total; the returned `loops` list is BOUNDED (a trigger with hundreds of fires
+  // must not return them all).
+  app.get("/api/triggers/:id/loops", async (req, res) => {
+    try {
+      const trigger = await triggerService.getTrigger(String(req.params.id));
+      if (!trigger) return res.status(404).json({ error: "Trigger not found" });
+
+      const allowed = await assertTriggerAccess(trigger, storage, req, res);
+      if (!allowed) return;
+
+      const all = await storage.getLoops();
+      const fired = all
+        .filter((l) => l.triggerProvenance?.triggerId === trigger.id)
+        // Newest fire first. `firedAt` is the provenance instant; fall back to
+        // the row's createdAt if a legacy row lacks it.
+        .sort((a, b) => firedAtMs(b) - firedAtMs(a));
+
+      const loops: TriggerFiredLoop[] = fired
+        .slice(0, TRIGGER_FIRED_LOOPS_LIMIT)
+        .map((l) => {
+          const prov = l.triggerProvenance!;
+          return {
+            loopId: l.id,
+            state: l.state,
+            prRef: l.prRef ?? null,
+            eventSummary: prov.eventSummary ?? null,
+            eventDigest: prov.eventDigest,
+            firedAt: prov.firedAt ?? new Date(l.createdAt).toISOString(),
+          };
+        });
+
+      const body: TriggerFiredLoopsResponse = {
+        triggerId: trigger.id,
+        firedCount: fired.length,
+        loops,
+      };
+      return res.json(body);
+    } catch (e) {
+      const cid = correlationId();
+      console.error(`[triggers] GET trigger loops error cid=${cid}`, e);
       return res.status(500).json({ error: "Internal server error", correlationId: cid });
     }
   });

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1507,6 +1507,45 @@ export interface PipelineTrigger {
   updatedAt: Date;
 }
 
+/**
+ * One consilium loop a trigger actually fired, for the Triggers page "result"
+ * view (GET /api/triggers/:id/loops). Computed from the loops whose
+ * `triggerProvenance.triggerId` matches the trigger — only trigger-born loops
+ * carry provenance, so a human/API loop never appears here. `state`/`prRef` are
+ * the loop's OWN fields (where the result lives); `eventSummary`/`eventDigest`/
+ * `firedAt` come from the loop's INERT trigger provenance (already single-line
+ * control-stripped + clamped at the mapping boundary — rendered as inert text).
+ */
+export interface TriggerFiredLoop {
+  loopId: string;
+  /** ConsiliumLoopState (kept as string here to avoid a schema→types cycle). */
+  state: string;
+  /** The loop's Draft PR ref, or null before one exists. */
+  prRef: string | null;
+  /** Firing event label (e.g. "PR #352: <title>"); absent for schedule/file_change. */
+  eventSummary: string | null;
+  /** Short hex digest correlating the loop to its firing payload. */
+  eventDigest: string;
+  /** ISO-8601 instant the trigger fired this loop (from provenance). */
+  firedAt: string;
+}
+
+/**
+ * GET /api/triggers/:id/loops response. `firedCount` is the UNBOUNDED total of
+ * loops this trigger created (the card's "Fired N" counter, DISTINCT from the
+ * trigger's suppressedCount); `loops` is the newest-first list bounded to
+ * {@link TRIGGER_FIRED_LOOPS_LIMIT} (a trigger with hundreds of fires never
+ * returns them all).
+ */
+export interface TriggerFiredLoopsResponse {
+  triggerId: string;
+  firedCount: number;
+  loops: TriggerFiredLoop[];
+}
+
+/** Max fired loops returned by GET /api/triggers/:id/loops (newest first). */
+export const TRIGGER_FIRED_LOOPS_LIMIT = 50;
+
 export interface InsertTrigger {
   // Legacy/nullable — new loop-template triggers are project-scoped, no pipeline.
   pipelineId?: string | null;

--- a/tests/unit/trigger-fired-loops.test.ts
+++ b/tests/unit/trigger-fired-loops.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+import { registerTriggerRoutes } from "../../server/routes/triggers";
+import type { TriggerService } from "../../server/services/trigger-service";
+import type { IStorage } from "../../server/storage";
+import type { ConsiliumLoopRow } from "../../shared/schema";
+import type { PipelineTrigger, TriggerProvenance } from "../../shared/types";
+import { TRIGGER_FIRED_LOOPS_LIMIT } from "../../shared/types";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const TRIGGER_ID = "trig-1";
+
+/** A project-scoped (pipeline-less) trigger — assertTriggerAccess passes without a pipeline owner lookup. */
+function makeTrigger(overrides: Partial<PipelineTrigger> = {}): PipelineTrigger {
+  return {
+    id: TRIGGER_ID,
+    pipelineId: null,
+    type: "github_event",
+    config: { repository: "owner/repo", events: ["pull_request"] } as never,
+    hasSecret: false,
+    enabled: true,
+    lastTriggeredAt: new Date("2026-07-01T10:00:00Z"),
+    suppressedCount: 3,
+    createdAt: new Date("2026-06-01T00:00:00Z"),
+    updatedAt: new Date("2026-06-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+/** Minimal loop row — the route reads only id/state/prRef/createdAt/triggerProvenance. */
+function makeLoop(
+  id: string,
+  provenance: TriggerProvenance | null,
+  extra: Partial<ConsiliumLoopRow> = {},
+): ConsiliumLoopRow {
+  return {
+    id,
+    state: "reviewing",
+    prRef: null,
+    createdAt: new Date("2026-07-01T00:00:00Z"),
+    triggerProvenance: provenance,
+    ...extra,
+  } as unknown as ConsiliumLoopRow;
+}
+
+function prov(overrides: Partial<TriggerProvenance> = {}): TriggerProvenance {
+  return {
+    triggerId: TRIGGER_ID,
+    triggerType: "github_event",
+    eventDigest: "abc1234",
+    firedAt: "2026-07-01T12:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeStorage(loops: ConsiliumLoopRow[]): IStorage {
+  return {
+    getLoops: vi.fn(async () => loops),
+  } as unknown as IStorage;
+}
+
+function makeService(trigger: PipelineTrigger | null): TriggerService {
+  return {
+    getTrigger: vi.fn(async (id: string) => (trigger && trigger.id === id ? trigger : null)),
+  } as unknown as TriggerService;
+}
+
+/**
+ * Build the app the way production mounts it: an auth+project gate on the
+ * `/api/triggers` PREFIX (routes.ts `app.use("/api/triggers", requireAuth,
+ * requireProject)`), so the `:id/loops` sub-route inherits it. `authed=false`
+ * simulates a missing token to prove the sub-route is guarded (the /api/pr-queue
+ * 401 lesson).
+ */
+function buildApp(service: TriggerService, storage: IStorage, authed = true): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/triggers", (req, res, next) => {
+    if (!authed) return res.status(401).json({ error: "Authentication required" });
+    (req as unknown as { user: { id: string; role: string }; projectId: string }).user = {
+      id: "user-1",
+      role: "admin",
+    };
+    (req as unknown as { projectId: string }).projectId = "proj-1";
+    next();
+  });
+  registerTriggerRoutes(app, service, storage);
+  return app;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/triggers/:id/loops", () => {
+  let trigger: PipelineTrigger;
+
+  beforeEach(() => {
+    trigger = makeTrigger();
+  });
+
+  it("returns only loops whose provenance.triggerId matches, newest fire first", async () => {
+    const loops = [
+      makeLoop("loop-old", prov({ firedAt: "2026-07-01T08:00:00Z", eventDigest: "old111", eventSummary: "PR #1: old" }), { prRef: "pr-1" }),
+      makeLoop("loop-new", prov({ firedAt: "2026-07-01T20:00:00Z", eventDigest: "new222", eventSummary: "PR #2: new" }), { prRef: "pr-2", state: "done" }),
+      // A different trigger's loop — must be excluded.
+      makeLoop("loop-other", prov({ triggerId: "trig-OTHER", firedAt: "2026-07-01T23:00:00Z" })),
+      // A human/API loop — null provenance, correctly excluded.
+      makeLoop("loop-human", null),
+    ];
+    const app = buildApp(makeService(trigger), makeStorage(loops));
+
+    const res = await request(app).get(`/api/triggers/${TRIGGER_ID}/loops`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.triggerId).toBe(TRIGGER_ID);
+    expect(res.body.firedCount).toBe(2);
+    expect(res.body.loops.map((l: { loopId: string }) => l.loopId)).toEqual(["loop-new", "loop-old"]);
+    expect(res.body.loops[0]).toMatchObject({
+      loopId: "loop-new",
+      state: "done",
+      prRef: "pr-2",
+      eventSummary: "PR #2: new",
+      eventDigest: "new222",
+      firedAt: "2026-07-01T20:00:00Z",
+    });
+  });
+
+  it("fire count is DISTINCT from suppressedCount (independent numbers)", async () => {
+    // Trigger says suppressed=3; it fired exactly 1 loop → firedCount must be 1, not 3.
+    const loops = [makeLoop("loop-a", prov())];
+    const app = buildApp(makeService(makeTrigger({ suppressedCount: 3 })), makeStorage(loops));
+
+    const res = await request(app).get(`/api/triggers/${TRIGGER_ID}/loops`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.firedCount).toBe(1);
+    // The endpoint never echoes suppressedCount — the card pairs them client-side.
+    expect(res.body.suppressedCount).toBeUndefined();
+  });
+
+  it("returns an empty list + zero count for a never-fired trigger", async () => {
+    const app = buildApp(makeService(trigger), makeStorage([makeLoop("loop-human", null)]));
+
+    const res = await request(app).get(`/api/triggers/${TRIGGER_ID}/loops`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.firedCount).toBe(0);
+    expect(res.body.loops).toEqual([]);
+  });
+
+  it("bounds the returned list but reports the full fired count (hundreds of fires)", async () => {
+    const many = Array.from({ length: TRIGGER_FIRED_LOOPS_LIMIT + 25 }, (_, i) =>
+      makeLoop(`loop-${i}`, prov({ firedAt: new Date(2026, 6, 1, 0, i).toISOString(), eventDigest: `d${i}` })),
+    );
+    const app = buildApp(makeService(trigger), makeStorage(many));
+
+    const res = await request(app).get(`/api/triggers/${TRIGGER_ID}/loops`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.firedCount).toBe(TRIGGER_FIRED_LOOPS_LIMIT + 25);
+    expect(res.body.loops).toHaveLength(TRIGGER_FIRED_LOOPS_LIMIT);
+  });
+
+  it("404s when the trigger does not exist / is outside the project", async () => {
+    const app = buildApp(makeService(null), makeStorage([]));
+
+    const res = await request(app).get(`/api/triggers/${TRIGGER_ID}/loops`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("is guarded by the /api/triggers auth mount (401 without a token — the pr-queue lesson)", async () => {
+    const service = makeService(trigger);
+    const storage = makeStorage([makeLoop("loop-a", prov())]);
+    const app = buildApp(service, storage, /* authed */ false);
+
+    const res = await request(app).get(`/api/triggers/${TRIGGER_ID}/loops`);
+
+    expect(res.status).toBe(401);
+    // The handler never ran — no storage read happened behind the gate.
+    expect(storage.getLoops).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## The gaps

An operator reported a trigger fired and created a consilium loop, but the Triggers page showed no way to follow the result. All the card said was:

> Last triggered: about 2 hours ago · 3 suppressed

Three concrete gaps:
1. **No link to the fired loop** — the loop (and its PR / verdict) was unreachable from the trigger.
2. **No fire counter** — only `suppressedCount` was surfaced; there was no count of loops the trigger actually created.
3. **No last-fire event detail** — which PR/commit fired it lives on the loop's `triggerProvenance`, never shown on the trigger.

The data already exists: every trigger-fired loop records `triggerProvenance = { triggerId, triggerType, firedAt, eventDigest, eventSummary }` (#457/#471), so loops are queryable by `triggerId`.

## The endpoint (read-side only)

`GET /api/triggers/:id/loops` — project-scoped, no schema/FSM/migration.

```jsonc
{
  "triggerId": "trig-1",
  "firedCount": 128,          // UNBOUNDED total of loops this trigger created
  "loops": [                  // newest fire first, BOUNDED to 50
    { "loopId": "…", "state": "reviewing", "prRef": "…",
      "eventSummary": "PR #352: Consilium round 1…", "eventDigest": "abc1234",
      "firedAt": "2026-07-01T20:00:00Z" }
  ]
}
```

- **Provenance grouping**: keeps loops whose `triggerProvenance.triggerId === :id`. Human/API loops have null provenance and are correctly excluded.
- **Scope**: reads `storage.getLoops()`, which is project-scoped by the `requireProject` ALS context. NOT owner-scoped — a trigger-fired loop's `createdBy` is the project *owner*, so owner-scoping would hide fires from other project members.
- **Auth**: inherits `requireAuth + requireProject` from the existing `app.use("/api/triggers", …)` mount — no per-route auth to forget (the `/api/pr-queue` 401 lesson). The trigger is additionally fetched via the project-scoped `getTrigger` and gated by `assertTriggerAccess`, exactly like `GET /api/triggers/:id`.
- **Bounded**: a trigger with hundreds of fires returns at most 50 loops while `firedCount` reports the true total.

## The card UX

- **Fire counter distinct from suppressed**: `Fired N · Suppressed M` (suppressed kept visible — dedup working is meaningful).
- **Last firing's event**: the newest fired loop's `eventSummary` + PR ref + short `eventDigest`, with an **accurate relative timestamp read from the loop's provenance `firedAt`** (authoritative), not the denormalised `trigger.lastTriggeredAt`. If the trigger's own stamp lags the real fire, a subtle **"stamp stale"** flag is shown (rendering what's there and flagging it — advancing `lastTriggeredAt` is the firing path's job).
- **Expandable fired-loop list** → clicking a loop navigates to its `ConsiliumLoopDetail` (`/consilium-loops/:id`). This is the "how do I find the result" the operator asked for.
- **"Never fired"** rendered cleanly when `firedCount === 0`.

## Adversarial self-review

- Auth mount — covered by a test that gates the `/api/triggers` prefix and asserts the sub-route 401s without a token (storage never read).
- Provenance grouping excludes null-provenance (human/API) loops — that's correct, only trigger-born loops carry provenance.
- A trigger with hundreds of fired loops — list bounded to 50, full count reported separately.

## Test evidence

- New `tests/unit/trigger-fired-loops.test.ts` (6 tests): provenance grouping + newest-first, fired-vs-suppressed distinction, empty/never-fired, bounding, 404, and the auth-mount guard.
- Existing `tests/unit/triggers-ui.test.ts`: 40 passed.
- `tsc`: clean.
- Full unit suite: **263 files / 5008 tests passed** (no flakes hit). `pull_request` CI is authoritative.

Draft — do not merge.