### PR TITLE
fix: record lastFiredAt + firedCount when a trigger actually fires

### DIFF
--- a/migrations/0045_triggers_fired_counter.sql
+++ b/migrations/0045_triggers_fired_counter.sql
@@ -1,0 +1,28 @@
+-- migration: 0045_triggers_fired_counter
+-- WRITE-on-fire rail for the trigger subsystem (docs/design/loop-triggers.md §6).
+--
+-- BUG: a trigger that SUCCESSFULLY launched consilium loops showed `lastFired: None`
+-- and no fire tally — only `suppressed_count` advanced (on the dedup-suppress branch
+-- of `launchReviewWithDedup`). The successful-launch branch recorded the fire in the
+-- loop's `trigger_provenance` but NEVER wrote back to the trigger row. Symmetric to
+-- 0042's `suppressed_count`, we add TWO additive columns:
+--
+--   triggers.last_fired_at → new TIMESTAMP (nullable). The instant the trigger last
+--     ACTUALLY created a loop. Distinct from `last_triggered_at`, which is recorded
+--     on EVERY fire (including suppressed / no-op). NULL ⇒ never launched a loop.
+--   triggers.fired_count   → new INT NOT NULL DEFAULT 0. Count of loops this trigger
+--     launched — incremented ONLY on the successful-launch branch, never on dedup.
+--     Backfills to 0 for existing rows.
+--
+-- Additive + idempotent (IF NOT EXISTS) — no data dropped or rewritten; safe to
+-- re-apply against a push-managed dev DB (same discipline as 0042).
+
+ALTER TABLE triggers
+  ADD COLUMN IF NOT EXISTS last_fired_at TIMESTAMP;
+
+ALTER TABLE triggers
+  ADD COLUMN IF NOT EXISTS fired_count INTEGER NOT NULL DEFAULT 0;
+
+-- Rollback:
+--   ALTER TABLE triggers DROP COLUMN fired_count;
+--   ALTER TABLE triggers DROP COLUMN last_fired_at;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -399,6 +399,12 @@ export async function registerRoutes(
                 .where(eq(projects.id, projectId));
               return row?.ownerId ?? null;
             }),
+          // WRITE-on-fire (bug fix): when a loop is ACTUALLY created, record the fire
+          // on the trigger row (lastFiredAt + firedCount). Runs in THIS runAsSystem
+          // context (cross-project), mirroring the suppressed-count write below —
+          // fireTrigger is a background/system ctx with no request project scope.
+          recordFire: (triggerId: string, firedAt: Date) =>
+            storage.incrementTriggerFired(triggerId, firedAt),
           log: (m: string) => log(m, "triggers"),
         };
 

--- a/server/services/consilium/trigger-dispatch.ts
+++ b/server/services/consilium/trigger-dispatch.ts
@@ -232,6 +232,15 @@ export interface ConsiliumTriggerDispatchDeps {
    * so the lookup is not project-scoped away. T3.
    */
   resolveOwnerId: (projectId: string) => Promise<string | null>;
+  /**
+   * WRITE-on-fire (bug fix): record that a loop was ACTUALLY created for this
+   * trigger — set `lastFiredAt` and atomically increment `firedCount`. Invoked ONCE,
+   * ONLY on the successful-launch branch of `launchReviewWithDedup` (never on
+   * dedup-suppress — that rides the caller's `incrementTriggerSuppressed`). Wired by
+   * the route to the trigger store under the SAME (system) context as the suppressed
+   * write. `firedAt` is the loop's provenance instant, threaded in for determinism.
+   */
+  recordFire: (triggerId: string, firedAt: Date) => Promise<void>;
   /** Structured logger (the route passes `(m) => log(m, "triggers")`). */
   log: (message: string) => void;
 }
@@ -342,11 +351,16 @@ export async function launchReviewWithDedup(
   // §6 provenance: which trigger + event fired the loop (short payload digest, not
   // the untrusted payload verbatim; + an OPTIONAL human summary). Persisted inert
   // for the launch passport.
+  // The fire instant, computed ONCE at call-time (never Date.now() at import —
+  // determinism rule). Used for BOTH the loop's provenance AND the trigger's
+  // `lastFiredAt`, so the two always agree (the trigger row's lastFiredAt equals
+  // the launched loop's provenance.firedAt).
+  const firedAt = new Date();
   const provenance: TriggerProvenance = {
     triggerId: trigger.id,
     triggerType: trigger.type,
     eventDigest: eventDigest(plan.payload),
-    firedAt: new Date().toISOString(),
+    firedAt: firedAt.toISOString(),
     ...(plan.eventSummary ? { eventSummary: plan.eventSummary } : {}),
   };
 
@@ -408,7 +422,26 @@ export async function launchReviewWithDedup(
       deps.log(
         `review skipped-dedup for trigger ${trigger.id} — active loop ${dedupLoopId} already running for ${resolvedRepo}`,
       );
+      // WATERMARK DISCIPLINE: a dedup-suppressed fire must NOT touch lastFiredAt /
+      // firedCount — the caller counts it via `incrementTriggerSuppressed` instead.
       return "skipped-dedup";
+    }
+
+    // BUG FIX (WRITE-on-fire): the loop was ACTUALLY created (not dedup-suppressed),
+    // so record the fire on the trigger row — set `lastFiredAt = firedAt` and bump
+    // `firedCount`. This is the success-branch counterpart to the caller's suppressed
+    // increment; before this, a trigger that launched loops showed `lastFired: None`
+    // and no fire tally (only suppressedCount advanced). It rides the launched branch
+    // ONLY, so a race between concurrent webhook + poller fires cannot double-count:
+    // the dedup already serializes loop CREATION, and exactly one fire reaches here.
+    // Best-effort telemetry: a counter-write failure must NEVER flip a real launch to
+    // "failed" nor crash the watcher/poller (T4) — the created loop is the source of truth.
+    try {
+      await deps.recordFire(trigger.id, firedAt);
+    } catch (e) {
+      deps.log(
+        `review launched for trigger ${trigger.id} but fire-counter write failed: ${(e as Error).message}`,
+      );
     }
 
     deps.log(

--- a/server/services/trigger-service.ts
+++ b/server/services/trigger-service.ts
@@ -53,6 +53,8 @@ export class TriggerService {
       enabled: row.enabled,
       lastTriggeredAt: row.lastTriggeredAt ?? null,
       suppressedCount: row.suppressedCount ?? 0,
+      lastFiredAt: row.lastFiredAt ?? null,
+      firedCount: row.firedCount ?? 0,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
     };

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -1358,7 +1358,7 @@ export class PgStorage implements IStorage {
   }
 
   async createTrigger(
-    data: Omit<TriggerRow, "id" | "projectId" | "createdAt" | "updatedAt" | "lastTriggeredAt" | "suppressedCount"> & { secretEncrypted?: string | null },
+    data: Omit<TriggerRow, "id" | "projectId" | "createdAt" | "updatedAt" | "lastTriggeredAt" | "suppressedCount" | "lastFiredAt" | "firedCount"> & { secretEncrypted?: string | null },
   ): Promise<TriggerRow> {
     const [row] = await db
       .insert(triggers)
@@ -1399,6 +1399,26 @@ export class PgStorage implements IStorage {
       .update(triggers)
       .set({
         suppressedCount: drizzleSql`${triggers.suppressedCount} + 1`,
+        updatedAt: new Date(),
+      })
+      .where(withProject(triggers, eq(triggers.id, id)));
+  }
+
+  /**
+   * WRITE-on-fire rail: set `last_fired_at` and atomically bump `fired_count` when a
+   * trigger ACTUALLY launches a loop. Called from `launchReviewWithDedup` (via the
+   * injected `recordFire` dep) ONLY on the successful-launch branch — never on
+   * dedup-suppress (that rides `incrementTriggerSuppressed`). The `+ 1` is computed
+   * in SQL (no read-modify-write race between concurrent webhook + poller fires);
+   * `firedAt` is the loop's provenance instant, threaded in for determinism. Scoped
+   * like every other trigger write; in the system context `withProject` applies no filter.
+   */
+  async incrementTriggerFired(id: string, firedAt: Date): Promise<void> {
+    await db
+      .update(triggers)
+      .set({
+        lastFiredAt: firedAt,
+        firedCount: drizzleSql`${triggers.firedCount} + 1`,
         updatedAt: new Date(),
       })
       .where(withProject(triggers, eq(triggers.id, id)));

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -375,11 +375,15 @@ export interface IStorage {
   /** Cross-project query for system/background use: returns ALL enabled triggers of this type
    *  across every project. Must be called within runAsSystem(). See ADR-001 §3.1(d). */
   getAllEnabledTriggersByType(type: string): Promise<TriggerRow[]>;
-  createTrigger(data: Omit<TriggerRow, 'id' | 'projectId' | 'createdAt' | 'updatedAt' | 'lastTriggeredAt' | 'suppressedCount'> & { secretEncrypted?: string | null }): Promise<TriggerRow>;
+  createTrigger(data: Omit<TriggerRow, 'id' | 'projectId' | 'createdAt' | 'updatedAt' | 'lastTriggeredAt' | 'suppressedCount' | 'lastFiredAt' | 'firedCount'> & { secretEncrypted?: string | null }): Promise<TriggerRow>;
   updateTrigger(id: string, updates: Partial<TriggerRow>): Promise<TriggerRow>;
   deleteTrigger(id: string): Promise<void>;
   /** T1 policy rail: atomically bump a trigger's suppressed-fire counter (dedup/budget). */
   incrementTriggerSuppressed(id: string): Promise<void>;
+  /** WRITE-on-fire rail: set `lastFiredAt` and atomically increment `firedCount` when a
+   *  trigger ACTUALLY launches a loop (NOT dedup-suppressed). Symmetric to
+   *  incrementTriggerSuppressed; the caller passes the fire instant (loop provenance firedAt). */
+  incrementTriggerFired(id: string, firedAt: Date): Promise<void>;
 
   // Practice Cards (Active Knowledge Base)
   createPracticeCard(data: InsertPracticeCard): Promise<PracticeCardRow>;
@@ -1959,7 +1963,7 @@ export class MemStorage implements IStorage {
   }
 
   async createTrigger(
-    data: Omit<TriggerRow, 'id' | 'projectId' | 'createdAt' | 'updatedAt' | 'lastTriggeredAt' | 'suppressedCount'> & { secretEncrypted?: string | null },
+    data: Omit<TriggerRow, 'id' | 'projectId' | 'createdAt' | 'updatedAt' | 'lastTriggeredAt' | 'suppressedCount' | 'lastFiredAt' | 'firedCount'> & { secretEncrypted?: string | null },
   ): Promise<TriggerRow> {
     const id = randomUUID();
     const now = new Date();
@@ -1973,6 +1977,8 @@ export class MemStorage implements IStorage {
       enabled: data.enabled ?? true,
       lastTriggeredAt: null,
       suppressedCount: 0,
+      lastFiredAt: null,
+      firedCount: 0,
       createdAt: now,
       updatedAt: now,
     };
@@ -1998,6 +2004,17 @@ export class MemStorage implements IStorage {
     this.triggersMap.set(id, {
       ...existing,
       suppressedCount: (existing.suppressedCount ?? 0) + 1,
+      updatedAt: new Date(),
+    });
+  }
+
+  async incrementTriggerFired(id: string, firedAt: Date): Promise<void> {
+    const existing = this.triggersMap.get(id);
+    if (!existing) return;
+    this.triggersMap.set(id, {
+      ...existing,
+      lastFiredAt: firedAt,
+      firedCount: (existing.firedCount ?? 0) + 1,
       updatedAt: new Date(),
     });
   }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -656,6 +656,14 @@ export const triggers = pgTable(
     // T1 policy rail: monotonically-incremented count of fires suppressed by a
     // policy (dedup today; budget/debounce later). Surfaced on the triggers page.
     suppressedCount: integer("suppressed_count").notNull().default(0),
+    // WRITE-on-fire rail: `last_fired_at`/`fired_count` record when a trigger
+    // ACTUALLY launches a loop (a loop row was created) — as opposed to
+    // `last_triggered_at` (EVERY fire, incl. suppressed/no-op) and
+    // `suppressed_count` (fires the dedup rail suppressed). Populated ONLY on the
+    // successful-launch branch of `launchReviewWithDedup`, so the triggers page can
+    // render "Fired N · Suppressed M". lastFiredAt equals the loop's provenance firedAt.
+    lastFiredAt: timestamp("last_fired_at"),
+    firedCount: integer("fired_count").notNull().default(0),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
   },
@@ -674,6 +682,8 @@ export const insertTriggerSchema = createInsertSchema(triggers).omit({
   lastTriggeredAt: true,
   secretEncrypted: true,
   suppressedCount: true,
+  lastFiredAt: true,
+  firedCount: true,
 });
 
 export type TriggerRow = typeof triggers.$inferSelect;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1503,6 +1503,12 @@ export interface PipelineTrigger {
   // T1 policy rail: count of fires suppressed by a policy (dedup/budget). Surfaced
   // on the triggers page so silence is diagnosable (loop-triggers.md §6).
   suppressedCount: number;
+  // WRITE-on-fire rail (loop-triggers.md §6): the last time this trigger ACTUALLY
+  // created a loop, and how many loops it created. Distinct from lastTriggeredAt
+  // (EVERY fire) and suppressedCount (dedup-suppressed fires). The triggers card
+  // renders "Fired {firedCount} · Suppressed {suppressedCount}".
+  lastFiredAt: Date | null;
+  firedCount: number;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/tests/unit/consilium/github-trigger-dispatch.test.ts
+++ b/tests/unit/consilium/github-trigger-dispatch.test.ts
@@ -56,20 +56,23 @@ function makeDeps(over: Partial<ConsiliumTriggerDispatchDeps> = {}) {
   const log = vi.fn();
   const getLoops = vi.fn().mockResolvedValue([] as ConsiliumLoopRow[]);
   const resolveOwnerId = vi.fn().mockResolvedValue("owner-1");
+  // WRITE-on-fire: the success-branch counter write (lastFiredAt + firedCount).
+  const recordFire = vi.fn().mockResolvedValue(undefined);
   const deps: ConsiliumTriggerDispatchDeps = {
     reviewDeps: { storage: { getLoops } } as unknown as ConsiliumTriggerDispatchDeps["reviewDeps"],
     createReview,
     runInProject,
     resolveOwnerId,
+    recordFire,
     log,
     ...over,
   };
-  return { deps, createReview, runInProject, log, getLoops, resolveOwnerId };
+  return { deps, createReview, runInProject, log, getLoops, resolveOwnerId, recordFire };
 }
 
 describe("maybeLaunchGitHubReview", () => {
   it("pull_request(opened) → launches diff-pr-review on the PR head vs base", async () => {
-    const { deps, createReview, runInProject } = makeDeps();
+    const { deps, createReview, runInProject, recordFire } = makeDeps();
     const trigger = makeTrigger();
 
     const result = await maybeLaunchGitHubReview(deps, trigger, envelope("pull_request", prPayload()));
@@ -77,6 +80,11 @@ describe("maybeLaunchGitHubReview", () => {
     expect(result).toBe("launched");
     expect(runInProject).toHaveBeenCalledWith("proj-1", expect.any(Function));
     expect(createReview).toHaveBeenCalledTimes(1);
+    // WRITE-on-fire also fires on the GITHUB path (shared seam) — the poller funnels
+    // through the same `launchReviewWithDedup`, so a github fire records lastFiredAt.
+    expect(recordFire).toHaveBeenCalledTimes(1);
+    expect(recordFire.mock.calls[0][0]).toBe(trigger.id);
+    expect(recordFire.mock.calls[0][1]).toBeInstanceOf(Date);
     const [, params] = createReview.mock.calls[0];
     expect(params.preset).toBe("diff-pr-review");
     expect(params.repoPath).toBe("/allowed/omnius");

--- a/tests/unit/consilium/trigger-dispatch.test.ts
+++ b/tests/unit/consilium/trigger-dispatch.test.ts
@@ -57,6 +57,7 @@ function makeDeps(
   log: ReturnType<typeof vi.fn>;
   getLoops: ReturnType<typeof vi.fn>;
   resolveOwnerId: ReturnType<typeof vi.fn>;
+  recordFire: ReturnType<typeof vi.fn>;
 } {
   const createReview = vi
     .fn()
@@ -70,15 +71,18 @@ function makeDeps(
   // users.id. The dispatch resolves the PROJECT OWNER; mock it to a fake user id
   // so the factory is called with createdBy === "owner-1" (NOT the literal "system").
   const resolveOwnerId = vi.fn().mockResolvedValue("owner-1");
+  // WRITE-on-fire: the success-branch counter write (lastFiredAt + firedCount).
+  const recordFire = vi.fn().mockResolvedValue(undefined);
   const deps: ConsiliumTriggerDispatchDeps = {
     reviewDeps: { storage: { getLoops } } as unknown as ConsiliumTriggerDispatchDeps["reviewDeps"],
     createReview,
     runInProject,
     resolveOwnerId,
+    recordFire,
     log,
     ...over,
   };
-  return { deps, createReview, runInProject, log, getLoops, resolveOwnerId };
+  return { deps, createReview, runInProject, log, getLoops, resolveOwnerId, recordFire };
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -146,6 +150,57 @@ describe("maybeLaunchConsiliumReview", () => {
     expect(params.objectiveExtra).toMatch(/\/allowed\/omnius\/specs\/00-overview\.md/);
   });
 
+  // ─── WRITE-on-fire: lastFiredAt + firedCount on a SUCCESSFUL launch ──────────
+  // Both the webhook receiver and the github poller funnel through `fireTrigger` →
+  // this shared seam (`launchReviewWithDedup`), so asserting the fire-write ONCE
+  // here covers both entry paths (they cannot diverge — one seam, one write).
+
+  it("a SUCCESSFUL launch records the fire on the trigger: recordFire once with (id, Date)", async () => {
+    const { deps, recordFire } = makeDeps();
+    const trigger = makeTrigger({ watchPath: "/allowed/omnius", patterns: ["**/*.md"], action: CONSILIUM_ACTION });
+
+    const result = await maybeLaunchConsiliumReview(deps, trigger, {
+      filePath: "/allowed/omnius/specs/00-overview.md",
+      watchPath: "/allowed/omnius",
+    });
+
+    expect(result).toBe("launched");
+    // The fire counter (lastFiredAt + firedCount) is written exactly once, for THIS
+    // trigger, with a Date instant — this is the bug fix (previously never written).
+    expect(recordFire).toHaveBeenCalledTimes(1);
+    const [triggerId, firedAt] = recordFire.mock.calls[0];
+    expect(triggerId).toBe("trig-1");
+    expect(firedAt).toBeInstanceOf(Date);
+  });
+
+  it("the recorded lastFiredAt EQUALS the loop's provenance firedAt (single instant)", async () => {
+    // createReview echoes back the triggerProvenance it was handed so the test can
+    // compare the fire instant written to the trigger against the loop's provenance.
+    const createReview = vi.fn().mockImplementation((_deps, params) =>
+      Promise.resolve({ id: "loop-1", repoPath: "/allowed/omnius", state: "reviewing", triggerProvenance: params.triggerProvenance } as unknown as ConsiliumLoopRow),
+    );
+    const { deps, recordFire } = makeDeps({ createReview });
+    const trigger = makeTrigger({ watchPath: "/allowed/omnius", patterns: ["**/*.md"], action: CONSILIUM_ACTION });
+
+    await maybeLaunchConsiliumReview(deps, trigger, {});
+
+    const firedAt = recordFire.mock.calls[0][1] as Date;
+    const provenance = createReview.mock.calls[0][1].triggerProvenance as { firedAt: string };
+    // lastFiredAt written to the trigger === the instant recorded in the loop's provenance.
+    expect(firedAt.toISOString()).toBe(provenance.firedAt);
+  });
+
+  it("a fire-counter write failure does NOT flip a real launch to failed (best-effort telemetry)", async () => {
+    const recordFire = vi.fn().mockRejectedValue(new Error("db down"));
+    const { deps, log } = makeDeps({ recordFire });
+    const trigger = makeTrigger({ watchPath: "/allowed/omnius", patterns: ["**/*.md"], action: CONSILIUM_ACTION });
+
+    const result = await maybeLaunchConsiliumReview(deps, trigger, {});
+    // The loop WAS created → still "launched"; the counter write is best-effort (T4).
+    expect(result).toBe("launched");
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/fire-counter write failed/));
+  });
+
   it("falls back to the watchPath-derived repo root when action.repoPath is absent (T2)", async () => {
     const { deps, createReview } = makeDeps();
     const action = { kind: "consilium_review", preset: "full-viability" } as ConsiliumReviewTriggerAction;
@@ -188,11 +243,13 @@ describe("maybeLaunchConsiliumReview", () => {
 
   it("a factory throw is CAUGHT → failed (never crashes the watcher loop, T4)", async () => {
     const createReview = vi.fn().mockRejectedValue(new Error("[repo-allowlist] outside every allowed repo root"));
-    const { deps, log } = makeDeps({ createReview });
+    const { deps, log, recordFire } = makeDeps({ createReview });
     const trigger = makeTrigger({ watchPath: "/evil/path", patterns: ["**/*.md"], action: { ...CONSILIUM_ACTION, repoPath: "/evil/path" } });
     const result = await maybeLaunchConsiliumReview(deps, trigger, {});
     expect(result).toBe("failed");
     expect(log).toHaveBeenCalledWith(expect.stringMatching(/rejected/));
+    // No loop was created → no fire recorded (a rejected launch is not a fire).
+    expect(recordFire).not.toHaveBeenCalled();
   });
 
   // ─── FIX HIGH-1: active-loop dedup on the TRIGGER path (T5) ──────────────────
@@ -202,7 +259,7 @@ describe("maybeLaunchConsiliumReview", () => {
       // An in-flight review for the SAME repoPath this trigger targets.
       { id: "loop-active", repoPath: "/allowed/omnius", state: "reviewing" },
     ] as unknown as ConsiliumLoopRow[]);
-    const { deps, createReview, log } = makeDeps({
+    const { deps, createReview, log, recordFire } = makeDeps({
       reviewDeps: { storage: { getLoops } } as unknown as ConsiliumTriggerDispatchDeps["reviewDeps"],
     });
     const trigger = makeTrigger({ watchPath: "/allowed/omnius/specs", patterns: ["**/*.md"], action: CONSILIUM_ACTION });
@@ -215,6 +272,9 @@ describe("maybeLaunchConsiliumReview", () => {
     expect(result).toBe("skipped-dedup");
     expect(createReview).not.toHaveBeenCalled(); // no NEW heavy-model dispute spawned
     expect(log).toHaveBeenCalledWith(expect.stringMatching(/skipped-dedup.*loop-active/));
+    // WATERMARK DISCIPLINE: a dedup-suppressed fire must NOT touch lastFiredAt /
+    // firedCount — only suppressedCount advances (counted by the caller). Unchanged.
+    expect(recordFire).not.toHaveBeenCalled();
   });
 
   it("a TERMINAL loop for the same repo does NOT block a new launch (only in-flight loops dedup)", async () => {

--- a/tests/unit/triggers-ui.test.ts
+++ b/tests/unit/triggers-ui.test.ts
@@ -76,6 +76,8 @@ function buildTrigger(overrides: Partial<PipelineTrigger> & { type: TriggerType 
     enabled: true,
     lastTriggeredAt: null,
     suppressedCount: 0,
+    lastFiredAt: null,
+    firedCount: 0,
     createdAt: new Date("2026-01-01"),
     updatedAt: new Date("2026-01-01"),
     config: {},


### PR DESCRIPTION
## The bug

When a trigger **successfully fires and creates a consilium loop**, the trigger row is never updated — `lastFiredAt` stays `None` and there is no fire tally. Only `suppressedCount` advances (on the dedup-suppress branch). So a trigger that actually created loops looks like it never fired.

**Verified evidence** (from loop `triggerProvenance`):
- Trigger `8ed4f87e` created **2 loops** → shows `lastFired=None`, `suppressed=11`
- Trigger `4326ecca` created **1 loop** → shows `lastFired=None`, `suppressed=17`

A repo-wide grep found **no `lastFiredAt` write on the successful-fire path** — the success branch of `launchReviewWithDedup` recorded the fire in the loop's `trigger_provenance` but never wrote back to the trigger row. Only the suppress branch incremented a counter (`incrementTriggerSuppressed`, in the caller).

## The fix

A **WRITE-on-fire rail** symmetric to `suppressed_count`, at the shared seam:

- On the **launched** branch of `launchReviewWithDedup` (loop actually created, not dedup-suppressed) → set `lastFiredAt` and atomically increment `firedCount` via a new injected `recordFire` dep.
- The write rides the **shared** `launchReviewWithDedup` seam, so **both the webhook receiver and the github poller** (they funnel through it) record the fire — no per-caller duplication.
- `lastFiredAt` is the **same instant** recorded in the loop's `trigger_provenance.firedAt` (computed once at call-time and threaded in — never `Date.now()` at import; determinism rule respected).

### Counter storage choice

New **additive columns** `triggers.last_fired_at` (timestamp) + `triggers.fired_count` (int, default 0), mirroring the existing first-class `last_triggered_at` / `suppressed_count`. Chosen over stuffing them into the `config` jsonb because `config` is the **loop template** (operator-authored trigger definition) — a runtime fire counter doesn't belong there, and `lastTriggeredAt`/`suppressedCount` set the precedent that these live as columns. Migration `0045_triggers_fired_counter.sql` is additive + idempotent (`IF NOT EXISTS`), following 0042's pattern (no journal entry, same as 0042).

## Invariants preserved

- **Dedup-suppressed fires** touch only `suppressedCount` — never `lastFiredAt`/`firedCount` (watermark discipline unchanged).
- **Best-effort telemetry**: a counter-write failure logs but never flips a real launch to `failed` nor crashes the watcher/poller loop (T4).
- **No double-count**: the write rides the launched branch only; dedup already serializes loop creation, so exactly one fire reaches the write for concurrent webhook + poller races.
- `firedCount` + `lastFiredAt` are surfaced on the public `PipelineTrigger` shape (next to `suppressedCount`) so the triggers card can render "Fired N · Suppressed M".

## Test evidence

`tsc` clean. Full unit suite green: **5005 passed / 262 files**. Storage mem/pg-parity integration test green (pg-backed cases skipped without a live DB).

New/updated assertions at the shared seam (cover webhook + poller):
- successful fire → `recordFire` called once with `(triggerId, Date)`
- recorded `lastFiredAt` **equals** the loop's provenance `firedAt` (single instant)
- dedup-suppressed fire → `recordFire` **not** called (only suppressed advances)
- rejected launch (factory throw) → `recordFire` **not** called
- counter-write failure → still returns `launched` (best-effort)
- github path → `recordFire` fires too (shared seam)

## Scope

WRITE-on-fire path only: `trigger-dispatch.ts` (launchReviewWithDedup), storage `updateTrigger`/increment, shared trigger types/schema, `trigger-service.toPublic`. Does **not** touch TriggersPage or add a read route (owned by `feat/trigger-fired-loops`).

Draft — do not merge.
