### PR TITLE
fix: parse real Omniscience v0.2 search response (hits, not mock chunks)

### DIFF
--- a/server/memory/omniscience-provider.ts
+++ b/server/memory/omniscience-provider.ts
@@ -2,10 +2,13 @@
  * OmniscienceProvider — world-knowledge retrieval via Omniscience's MCP `search`
  * tool (memory-architecture ADR, Track A).
  *
- * Contract-first: built against Omniscience ADR 0004's stable `search` contract
- * while Omniscience itself is pre-v0.1. The provider:
+ * Contract-first: validated against the REAL Omniscience v0.2 `search` response
+ * (the server's Pydantic `SearchResponse`/`SearchHit` models), proven live over
+ * MCP. The response is `hits: SearchHit[]` — an earlier build parsed a top-level
+ * `chunks[]` that only ever matched a mock and threw `chunks: Required` against a
+ * real server. The provider:
  *   - calls the `search` MCP tool with { query, retrieval_strategy, as_of, ... },
- *   - validates the returned chunk+citation payload at the boundary (zod),
+ *   - validates the returned hits+citation payload at the boundary (zod),
  *   - maps results into the existing RetrievalResult shape so the Retriever can
  *     route to it transparently.
  *
@@ -45,36 +48,73 @@ export interface OmniscienceSearchParams {
   filters?: { source_types?: string[] };
 }
 
-// ─── Boundary validation: search tool result ───────────────────────────────────
+// ─── Boundary validation: search tool result (Omniscience v0.2 SearchResponse) ──
+//
+// Ground truth = the running server's Pydantic models. The top-level response is
+// `SearchHit[]` under `hits` (NOT a top-level `chunks[]` — that was the shape of
+// an early mock and never matched a real Omniscience). Sibling fields
+// (query_stats, effective_as_of, degraded_subsystems, meta, min_applied_version,
+// staleness_seconds, pinned_watermark, snapshot_id, next_cursor) are tolerated
+// and ignored via `.passthrough()`; an empty `hits: []` is a valid response.
 
 /**
- * A single citation attached to a chunk. Omniscience returns chunks WITH
- * citations; the caller LLM synthesizes from them.
+ * SourceInfo — the source a hit came from. Nested object (id/name/type), NOT the
+ * flat source_id/source_type the old mock used.
  */
-const citationSchema = z.object({
-  source_id: z.string(),
-  source_type: z.string().optional(),
-  uri: z.string().optional(),
-  title: z.string().optional(),
-  locator: z.string().optional(),
-});
+const sourceInfoSchema = z
+  .object({
+    id: z.string(),
+    name: z.string().optional(),
+    type: z.string(),
+  })
+  .passthrough();
 
-const searchResultChunkSchema = z.object({
-  id: z.string(),
-  text: z.string(),
-  score: z.number(),
-  source_id: z.string().optional(),
-  source_type: z.string().optional(),
-  citations: z.array(citationSchema).optional(),
-  metadata: z.record(z.unknown()).optional(),
-});
+/**
+ * A SINGLE citation object per hit (not an array). Tolerant: `title` may be null,
+ * and indexed_at/doc_version may be absent on some hits.
+ */
+const hitCitationSchema = z
+  .object({
+    uri: z.string(),
+    title: z.string().nullish(),
+    indexed_at: z.string().optional(),
+    doc_version: z.number().optional(),
+  })
+  .passthrough();
 
-const searchResultSchema = z.object({
-  chunks: z.array(searchResultChunkSchema),
-});
+/**
+ * SearchHit — one retrieved chunk. Required: chunk_id/score/text. `source` and
+ * `citation` are present in practice but modeled tolerantly (a hit may omit the
+ * citation). Scoring/lineage extras are accepted and ignored; unknown score_type
+ * strings are allowed. Extra fields pass through so future server additions never
+ * break validation.
+ */
+const searchHitSchema = z
+  .object({
+    chunk_id: z.string(),
+    document_id: z.string().optional(),
+    score: z.number(),
+    text: z.string(),
+    source: sourceInfoSchema.optional(),
+    citation: hitCitationSchema.nullish(),
+    metadata: z.record(z.unknown()).optional(),
+    // Accepted-and-ignored (or threaded into metadata) scoring/provenance extras.
+    confidence: z.number().nullish(),
+    score_type: z.string().nullish(),
+    impact: z.number().nullish(),
+    source_instance: z.string().nullish(),
+    lineage: z.unknown().optional(),
+  })
+  .passthrough();
+
+const searchResultSchema = z
+  .object({
+    hits: z.array(searchHitSchema),
+  })
+  .passthrough();
 
 export type OmniscienceSearchResult = z.infer<typeof searchResultSchema>;
-type OmniscienceChunk = z.infer<typeof searchResultChunkSchema>;
+type OmniscienceHit = z.infer<typeof searchHitSchema>;
 
 // ─── Tool caller seam ──────────────────────────────────────────────────────────
 
@@ -95,8 +135,14 @@ const DEFAULT_TOP_K = 5;
 const DEFAULT_MAX_TOKENS = 2000;
 const CHARS_PER_TOKEN = 4;
 
-/** Map an Omniscience source_type string onto our ChunkSourceType union. */
+/**
+ * Map an Omniscience `source.type` string onto our ChunkSourceType union.
+ * Covers the real Omniscience v0.2 source_type enum
+ * (git/fs/confluence/notion/slack/jira/grafana/k8s/terraform/otel/k8s_operator/
+ * s3/aws/alerts) plus legacy/contract aliases. Anything unknown → "document".
+ */
 const SOURCE_TYPE_MAP: Record<string, ChunkSourceType> = {
+  // Legacy / contract aliases.
   code: "code",
   document: "document",
   doc: "document",
@@ -105,6 +151,21 @@ const SOURCE_TYPE_MAP: Record<string, ChunkSourceType> = {
   infra: "document",
   pipeline_run: "pipeline_run",
   memory_entry: "memory_entry",
+  // Real Omniscience v0.2 source_type enum.
+  git: "code",
+  terraform: "code",
+  k8s: "document",
+  k8s_operator: "document",
+  fs: "document",
+  s3: "document",
+  aws: "document",
+  confluence: "document",
+  notion: "document",
+  slack: "document",
+  jira: "document",
+  grafana: "document",
+  otel: "document",
+  alerts: "document",
 };
 
 function mapSourceType(raw: string | undefined): ChunkSourceType {
@@ -191,18 +252,36 @@ export function parseSearchResult(raw: string): OmniscienceSearchResult {
 
 // ─── Mapping to RetrievalResult ──────────────────────────────────────────────────
 
-function toRetrievedChunk(chunk: OmniscienceChunk): RetrievedChunk {
-  const metadata: Record<string, unknown> = { ...(chunk.metadata ?? {}) };
-  if (chunk.citations && chunk.citations.length > 0) {
-    metadata.citations = chunk.citations;
+function toRetrievedChunk(hit: OmniscienceHit): RetrievedChunk {
+  const metadata: Record<string, unknown> = { ...(hit.metadata ?? {}) };
+  const sourceId = hit.source?.id ?? hit.chunk_id;
+  const sourceType = hit.source?.type;
+
+  // The real hit carries ONE `citation` object; normalize it into the existing
+  // `metadata.citations` array shape the formatter/consumers already expect.
+  if (hit.citation) {
+    metadata.citations = [
+      {
+        source_id: sourceId,
+        source_type: sourceType,
+        uri: hit.citation.uri,
+        title: hit.citation.title ?? undefined,
+      },
+    ];
   }
+
+  // Thread useful provenance/scoring extras into metadata (best-effort).
+  if (hit.confidence != null) metadata.confidence = hit.confidence;
+  if (hit.document_id) metadata.documentId = hit.document_id;
+  if (hit.lineage != null) metadata.lineage = hit.lineage;
+
   metadata.backend = "omniscience";
   return {
-    id: chunk.id,
-    sourceType: mapSourceType(chunk.source_type),
-    sourceId: chunk.source_id ?? chunk.id,
-    chunkText: chunk.text,
-    score: chunk.score,
+    id: hit.chunk_id,
+    sourceType: mapSourceType(sourceType),
+    sourceId,
+    chunkText: hit.text,
+    score: hit.score,
     metadata,
   };
 }
@@ -216,8 +295,8 @@ function toRetrievalResult(
   const selected: RetrievedChunk[] = [];
   let usedChars = 0;
 
-  for (const chunk of result.chunks) {
-    const mapped = toRetrievedChunk(chunk);
+  for (const hit of result.hits) {
+    const mapped = toRetrievedChunk(hit);
     if (usedChars + mapped.chunkText.length > maxChars && selected.length > 0) break;
     selected.push(mapped);
     usedChars += mapped.chunkText.length;

--- a/tests/helpers/mock-omniscience.ts
+++ b/tests/helpers/mock-omniscience.ts
@@ -1,14 +1,15 @@
 /**
  * Mock Omniscience `search` MCP tool (memory-architecture ADR, Track A).
  *
- * A contract-faithful test double of Omniscience ADR 0004's `search` tool — no
+ * A contract-faithful test double of the real Omniscience v0.2 `search` tool — no
  * live Omniscience needed. It:
  *   - enforces the tool name `search`,
  *   - validates params (required `query`; `retrieval_strategy` enum with the
  *     v0.1 downgrade of structural/keyword/auto → hybrid; optional ISO-8601
  *     `as_of`; optional limit/filters),
- *   - returns citation-bearing chunk results as the JSON text payload an MCP
- *     tool call would yield.
+ *   - returns the real v0.2 `SearchResponse` envelope (`hits: SearchHit[]` plus
+ *     sibling fields like query_stats/degraded_subsystems) as the JSON text
+ *     payload an MCP tool call would yield.
  *
  * Exposes:
  *   - `makeMockOmniscienceCaller()` → an OmniscienceToolCaller for the provider,
@@ -44,39 +45,53 @@ export function downgradeStrategy(_requested: RequestedStrategy): EffectiveStrat
   return "hybrid";
 }
 
-// ─── Result shaping ─────────────────────────────────────────────────────────────
+// ─── Result shaping (real Omniscience v0.2 SearchHit shape) ─────────────────────
 
-export interface MockChunk {
-  id: string;
-  text: string;
+/**
+ * A test double of the real `SearchHit`: nested `source` (id/name/type), a SINGLE
+ * `citation` object (not an array), plus optional scoring/provenance extras.
+ */
+export interface MockHit {
+  chunk_id: string;
+  document_id?: string;
   score: number;
-  source_id?: string;
-  source_type?: string;
-  citations?: Array<{ source_id: string; uri?: string; title?: string }>;
+  text: string;
+  source?: { id: string; name?: string; type: string };
+  citation?: { uri: string; title?: string | null; indexed_at?: string; doc_version?: number } | null;
   metadata?: Record<string, unknown>;
+  confidence?: number | null;
+  score_type?: string | null;
+  impact?: number | null;
+  source_instance?: string | null;
+  lineage?: unknown;
 }
 
-/** Default citation-bearing fixture chunks. */
-export function defaultMockChunks(): MockChunk[] {
+/** Default citation-bearing fixture hits, in the real v0.2 SearchHit shape. */
+export function defaultMockHits(): MockHit[] {
   return [
     {
-      id: "c1",
-      text: "The retry policy uses exponential backoff with a 1s base.",
+      chunk_id: "c1",
+      document_id: "d1",
       score: 0.92,
-      source_id: "src-retry",
-      source_type: "code",
-      citations: [
-        { source_id: "src-retry", uri: "git://repo/server/retry.ts#L10", title: "retry.ts" },
-      ],
+      text: "The retry policy uses exponential backoff with a 1s base.",
+      source: { id: "src-retry", name: "retry.ts", type: "git" },
+      citation: {
+        uri: "git://repo/server/retry.ts#L10",
+        title: "retry.ts",
+        indexed_at: "2026-06-01T00:00:00.000Z",
+        doc_version: 3,
+      },
+      confidence: 0.88,
+      score_type: "calibrated",
       metadata: { commit: "abc123" },
     },
     {
-      id: "c2",
-      text: "Incident #42: backoff misconfiguration caused a thundering herd.",
+      chunk_id: "c2",
+      document_id: "d2",
       score: 0.81,
-      source_id: "inc-42",
-      source_type: "incident",
-      citations: [{ source_id: "inc-42", title: "Incident 42 postmortem" }],
+      text: "Incident #42: backoff misconfiguration caused a thundering herd.",
+      source: { id: "inc-42", name: "Incident 42", type: "jira" },
+      citation: { uri: "jira://INC-42", title: "Incident 42 postmortem", indexed_at: "2026-06-02T00:00:00.000Z", doc_version: 1 },
     },
   ];
 }
@@ -91,8 +106,8 @@ export interface CapturedCall {
 }
 
 export interface MockOmniscienceOptions {
-  /** Chunks to return; defaults to defaultMockChunks(). */
-  chunks?: MockChunk[];
+  /** Hits to return; defaults to defaultMockHits(). */
+  hits?: MockHit[];
   /** When set, the caller rejects with this error (to test fallback). */
   failWith?: Error;
   /** When true, return malformed (non-contract) JSON to test boundary validation. */
@@ -128,13 +143,33 @@ export function makeMockOmniscienceCaller(
     state.lastCall = { toolName, params: parsed.data, effectiveStrategy };
 
     if (options.returnMalformed) {
+      // No top-level `hits` → fails boundary validation, as a real malformed
+      // payload would.
       return JSON.stringify({ results: "not the contract shape" });
     }
 
-    const chunks = options.chunks ?? defaultMockChunks();
+    const hits = options.hits ?? defaultMockHits();
     const limited =
-      parsed.data.limit !== undefined ? chunks.slice(0, parsed.data.limit) : chunks;
-    return JSON.stringify({ chunks: limited });
+      parsed.data.limit !== undefined ? hits.slice(0, parsed.data.limit) : hits;
+    // Full v0.2 SearchResponse envelope: hits + sibling fields the provider must
+    // tolerate and ignore.
+    return JSON.stringify({
+      hits: limited,
+      query_stats: {
+        total_matches_before_filters: hits.length,
+        vector_matches: hits.length,
+        text_matches: 0,
+        duration_ms: 3,
+      },
+      effective_as_of: null,
+      meta: null,
+      min_applied_version: null,
+      degraded_subsystems: [],
+      staleness_seconds: null,
+      pinned_watermark: null,
+      snapshot_id: null,
+      next_cursor: null,
+    });
   }) as OmniscienceToolCaller & { lastCall: CapturedCall | null };
 
   Object.defineProperty(caller, "lastCall", {

--- a/tests/unit/rag/omniscience-provider.test.ts
+++ b/tests/unit/rag/omniscience-provider.test.ts
@@ -1,14 +1,21 @@
 /**
  * Contract tests for OmniscienceProvider (memory-architecture ADR, Track A).
  *
- * Drives the provider against the mock Omniscience `search` tool double and
- * proves:
- *   - it calls the `search` tool with contract-correct params,
- *   - it passes as_of + retrieval_strategy through,
- *   - it preserves the strategy contract (strategy reaches the server even when
- *     v0.1 downgrades it),
- *   - it maps chunk+citation results into RetrievalResult,
- *   - it validates the response shape at the boundary and throws on malformed
+ * Validated against the REAL Omniscience v0.2 `search` response — `hits:
+ * SearchHit[]`, nested `source`, a SINGLE `citation` object, plus sibling fields
+ * (query_stats/degraded_subsystems/...). An earlier build parsed a top-level
+ * `chunks[]` that only ever matched a mock and threw `chunks: Required` against a
+ * real server; those chunk-shaped assertions have been replaced here.
+ *
+ * Proves the provider:
+ *   - calls the `search` tool with contract-correct params,
+ *   - passes as_of + retrieval_strategy through,
+ *   - preserves the strategy contract (strategy reaches the server even when v0.1
+ *     downgrades it),
+ *   - maps real SearchHit + citation results into RetrievalResult,
+ *   - accepts an empty `hits: []` as a valid (empty) result — the exact reported
+ *     bug — and tolerates missing citations and unknown extra fields,
+ *   - validates the response shape at the boundary and throws on malformed
  *     payloads (so the Retriever can fall back).
  */
 import { describe, it, expect } from "vitest";
@@ -21,11 +28,27 @@ import {
 import type { RetrievalOptions } from "../../../server/memory/retriever";
 import {
   makeMockOmniscienceCaller,
-  defaultMockChunks,
+  defaultMockHits,
 } from "../../helpers/mock-omniscience";
 
 function baseOptions(overrides: Partial<RetrievalOptions> = {}): RetrievalOptions {
   return { query: "how does retry work", workspaceId: "ws-1", ...overrides };
+}
+
+/** Build the real v0.2 SearchResponse envelope around a set of hits. */
+function envelope(hits: unknown[], extra: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    hits,
+    query_stats: {
+      total_matches_before_filters: hits.length,
+      vector_matches: hits.length,
+      text_matches: 0,
+      duration_ms: 4,
+    },
+    effective_as_of: null,
+    degraded_subsystems: ["qdrant", "neo4j"],
+    ...extra,
+  });
 }
 
 describe("OmniscienceProvider.retrieveContext", () => {
@@ -81,28 +104,41 @@ describe("OmniscienceProvider.retrieveContext", () => {
     expect(caller.lastCall?.params.limit).toBe(1);
   });
 
-  it("maps chunk results into RetrievedChunk with score and source", async () => {
+  it("maps real SearchHit results into RetrievedChunk (id⇐chunk_id, sourceId⇐source.id, sourceType⇐source.type)", async () => {
     const provider = new OmniscienceProvider(makeMockOmniscienceCaller());
 
     const result = await provider.retrieveContext(baseOptions());
 
     expect(result.chunks).toHaveLength(2);
-    expect(result.chunks[0].id).toBe("c1");
-    expect(result.chunks[0].sourceType).toBe("code");
-    expect(result.chunks[0].sourceId).toBe("src-retry");
+    expect(result.chunks[0].id).toBe("c1"); // ⇐ chunk_id
+    expect(result.chunks[0].sourceType).toBe("code"); // ⇐ mapSourceType(source.type "git")
+    expect(result.chunks[0].sourceId).toBe("src-retry"); // ⇐ source.id
     expect(result.chunks[0].score).toBeCloseTo(0.92);
     expect(result.chunks[0].chunkText).toContain("exponential backoff");
   });
 
-  it("preserves citations in chunk metadata", async () => {
+  it("normalizes the single `citation` object into the citations metadata array", async () => {
     const provider = new OmniscienceProvider(makeMockOmniscienceCaller());
 
     const result = await provider.retrieveContext(baseOptions());
 
-    const citations = result.chunks[0].metadata.citations;
+    const citations = result.chunks[0].metadata.citations as Array<Record<string, unknown>>;
     expect(Array.isArray(citations)).toBe(true);
-    expect((citations as unknown[]).length).toBe(1);
+    expect(citations).toHaveLength(1);
+    expect(citations[0].source_id).toBe("src-retry");
+    expect(citations[0].source_type).toBe("git");
+    expect(citations[0].uri).toBe("git://repo/server/retry.ts#L10");
+    expect(citations[0].title).toBe("retry.ts");
     expect(result.chunks[0].metadata.backend).toBe("omniscience");
+  });
+
+  it("threads confidence + document_id into metadata (nice-to-have)", async () => {
+    const provider = new OmniscienceProvider(makeMockOmniscienceCaller());
+
+    const result = await provider.retrieveContext(baseOptions());
+
+    expect(result.chunks[0].metadata.confidence).toBeCloseTo(0.88);
+    expect(result.chunks[0].metadata.documentId).toBe("d1");
   });
 
   it("surfaces citations in the formatted context", async () => {
@@ -115,9 +151,9 @@ describe("OmniscienceProvider.retrieveContext", () => {
     expect(result.context).toContain("git://repo/server/retry.ts#L10");
   });
 
-  it("maps an unknown source_type to document", async () => {
+  it("maps an unknown source.type to document", async () => {
     const caller = makeMockOmniscienceCaller({
-      chunks: [{ id: "x", text: "t", score: 0.5, source_type: "wiki" }],
+      hits: [{ chunk_id: "x", text: "t", score: 0.5, source: { id: "s", type: "wiki" } }],
     });
     const provider = new OmniscienceProvider(caller);
 
@@ -126,8 +162,29 @@ describe("OmniscienceProvider.retrieveContext", () => {
     expect(result.chunks[0].sourceType).toBe("document");
   });
 
-  it("returns empty result when search yields no chunks", async () => {
-    const provider = new OmniscienceProvider(makeMockOmniscienceCaller({ chunks: [] }));
+  it("maps a hit that omits the optional citation (no crash, no citations metadata)", async () => {
+    const caller = makeMockOmniscienceCaller({
+      hits: [
+        {
+          chunk_id: "nc1",
+          text: "no citation here",
+          score: 0.4,
+          source: { id: "src-nc", type: "slack" },
+        },
+      ],
+    });
+    const provider = new OmniscienceProvider(caller);
+
+    const result = await provider.retrieveContext(baseOptions());
+
+    expect(result.chunks[0].id).toBe("nc1");
+    expect(result.chunks[0].sourceId).toBe("src-nc");
+    expect(result.chunks[0].metadata.citations).toBeUndefined();
+    expect(result.chunks[0].metadata.backend).toBe("omniscience");
+  });
+
+  it("returns an empty result when search yields no hits (the reported bug — empty must NOT throw)", async () => {
+    const provider = new OmniscienceProvider(makeMockOmniscienceCaller({ hits: [] }));
 
     const result = await provider.retrieveContext(baseOptions());
 
@@ -171,15 +228,71 @@ describe("buildSearchParams", () => {
   });
 });
 
-describe("parseSearchResult", () => {
+describe("parseSearchResult (real v0.2 SearchResponse)", () => {
   it("rejects non-JSON payloads", () => {
     expect(() => parseSearchResult("<<not json>>")).toThrow(/non-JSON/i);
   });
 
-  it("accepts a contract-shaped payload", () => {
-    const raw = JSON.stringify({ chunks: defaultMockChunks() });
+  it("accepts a contract-shaped payload with real hits", () => {
+    const result = parseSearchResult(envelope(defaultMockHits()));
+    expect(result.hits).toHaveLength(2);
+    expect(result.hits[0].chunk_id).toBe("c1");
+    expect(result.hits[0].source?.type).toBe("git");
+  });
+
+  it("accepts an EMPTY hits response without throwing (the reported bug: chunks: Required)", () => {
+    // A real empty Omniscience response — carries hits:[] plus sibling stats.
+    const raw = JSON.stringify({
+      hits: [],
+      query_stats: { total_matches_before_filters: 0, vector_matches: 0, text_matches: 0, duration_ms: 2 },
+      effective_as_of: "2026-06-30T00:00:00.000Z",
+      degraded_subsystems: ["qdrant", "neo4j"],
+    });
     const result = parseSearchResult(raw);
-    expect(result.chunks).toHaveLength(2);
+    expect(result.hits).toHaveLength(0);
+  });
+
+  it("tolerates unknown extra top-level and per-hit fields (forward-compatible)", () => {
+    const raw = envelope(
+      [
+        {
+          chunk_id: "c9",
+          document_id: "d9",
+          score: 0.5,
+          text: "future hit",
+          source: { id: "s9", name: "n9", type: "terraform" },
+          citation: { uri: "s3://bucket/key", title: null, indexed_at: "2026-06-01T00:00:00.000Z", doc_version: 2 },
+          score_type: "some_future_score_type", // unknown score_type allowed
+          impact: 0.3,
+          source_instance: "inst-1",
+          lineage: { parents: ["p1"] },
+          some_future_field: { anything: true }, // unknown per-hit field tolerated
+        },
+      ],
+      { some_future_top_level_field: 123 }, // unknown top-level field tolerated
+    );
+
+    const result = parseSearchResult(raw);
+    expect(result.hits).toHaveLength(1);
+    expect(result.hits[0].chunk_id).toBe("c9");
+    expect(result.hits[0].score_type).toBe("some_future_score_type");
+  });
+
+  it("tolerates a null citation and a null citation.title (no crash)", () => {
+    const raw = envelope([
+      { chunk_id: "n1", score: 0.6, text: "null citation", source: { id: "s1", type: "git" }, citation: null },
+      {
+        chunk_id: "n2",
+        score: 0.6,
+        text: "null title",
+        source: { id: "s2", type: "confluence" },
+        citation: { uri: "conf://page", title: null },
+      },
+    ]);
+    const result = parseSearchResult(raw);
+    expect(result.hits).toHaveLength(2);
+    expect(result.hits[0].citation).toBeNull();
+    expect(result.hits[1].citation?.title).toBeNull();
   });
 });
 


### PR DESCRIPTION
## The bug (live evidence)

multiqlti's own Omniscience client connected to a **real local Omniscience over MCP** — handshake ok, token accepted — called `search`, got a response, and threw:

```
Omniscience search response failed validation: chunks: Required
```

Root cause: the response parser was built against an early **mock** that returned a top-level `chunks[]`. The real Omniscience v0.2 `SearchResponse` returns **`hits: SearchHit[]`** with a different hit shape. An empty response (`{"hits":[],"query_stats":{...},"degraded_subsystems":["qdrant","neo4j"],...}`) failed validation because `chunks` was `Required`.

## The real v0.2 contract (ground truth: the server's Pydantic models)

Top-level `SearchResponse`: `{ hits: SearchHit[], query_stats, effective_as_of, meta, min_applied_version, degraded_subsystems, staleness_seconds, pinned_watermark, snapshot_id, next_cursor }`.

`SearchHit`: `{ chunk_id, document_id, score, text, source: { id, name, type }` (nested, **not** flat)`, citation: { uri, title|null, indexed_at, doc_version }` (a **single** object, not an array)`, metadata, source_instance, confidence, score_type, impact, lineage }`.

## The fix (response-parsing only)

Zone: `server/memory/omniscience-provider.ts` — the schema + `parseSearchResult` + `toRetrievedChunk` mapping. The request side (`buildSearchParams`) is unchanged — the server accepted the request; this was purely a response-parsing bug.

- **`searchResultSchema`** rewritten to `{ hits: SearchHit[] }` with `.passthrough()`; sibling fields (query_stats/effective_as_of/degraded_subsystems/…) are tolerated and ignored. **An empty `hits: []` now parses to an empty `RetrievalResult` instead of throwing** — the exact reported bug.
- **`SearchHit` schema**: `chunk_id`/`score`/`text` required; nested `source {id,name,type}`; a nullable/optional single `citation {uri, title(nullable), indexed_at, doc_version}`; optional `confidence`/`score_type`(unknown strings allowed)/`impact`/`source_instance`/`lineage`. Extra fields pass through (forward-compatible).
- **`toRetrievedChunk` mapping**: `id ⇐ chunk_id`, `sourceId ⇐ source.id` (fallback `chunk_id`), `sourceType ⇐ mapSourceType(source.type)`, `chunkText ⇐ text`, `score ⇐ score`. The single `citation` object is normalized into the existing `metadata.citations` array (`[{source_id, source_type, uri, title}]`, only when present), preserving `metadata.backend = "omniscience"`. `confidence`/`document_id`/`lineage` threaded into metadata.
- **`mapSourceType`** extended with the real source_type enum: `git`/`terraform` → `code`; `fs`/`s3`/`aws`/`confluence`/`notion`/`slack`/`jira`/`grafana`/`otel`/`alerts`/`k8s`/`k8s_operator` → `document`; unknown → `document`.

## The mock encoded the bug

`tests/helpers/mock-omniscience.ts` was the wrong-shaped mock — it emitted `{chunks:[...]}` and drove both `omniscience-provider.test.ts` and `retriever-routing.test.ts`. It now emits the real v0.2 `{hits, query_stats, degraded_subsystems, …}` envelope. The provider unit test previously asserted the old `chunks[]` shape (`parseSearchResult` "accepts a contract-shaped payload" with `{chunks: defaultMockChunks()}`) — that test **encoded the mock's wrong shape** and has been replaced with real-shape assertions.

## Test evidence

- `tsc` clean.
- Affected files (`omniscience-provider.test.ts` + `retriever-routing.test.ts`): **27 passed**.
- Full unit suite: **263 files / 5016 tests passed, 0 failures** (the usual flaky suites were green this run).

New/updated tests cover: (a) empty `hits:[]` parses to an empty result (no throw — the bug); (b) a populated real `SearchHit` (nested source, single citation, extra confidence/score_type) maps correctly; (c) a hit missing the optional citation still maps; (d) unknown extra top-level/per-hit fields don't break validation; plus a null `citation` and null `citation.title` don't crash.

**Draft — do not merge.** Behavioral change is limited to the Omniscience response parser + its fixtures/tests.
