### PR TITLE
docs: spec-as-task + tracker-triggers v2 (spec-first, 6 trackers, mandatory write-back)

### DIFF
--- a/docs/design/spec-as-task.md
+++ b/docs/design/spec-as-task.md
@@ -1,0 +1,142 @@
+# SPEC: Spec-as-Task — a committed spec/ADR is the unit of work
+
+> Status: **spec / design**. The factory's **execution substrate**: the durable, version-controlled
+> unit of work is a **committed spec** (under `docs/specs/`) or **ADR** (under `docs/adr/`), not a
+> raw chat message or a raw ticket. A default repo-watch trigger fires a consilium loop when a new
+> *ready* spec/ADR lands. Every other intake — a Jira ticket, a GitHub issue, a human idea — is
+> funnelled **through** a committed spec first. This is the single execution route.
+> Companion to [task-tracker-triggers.md](task-tracker-triggers.md) (the tracker intake that
+> *produces* specs), [loop-triggers.md](loop-triggers.md), [loop-consolidation.md](loop-consolidation.md)
+> (the spec = the "task envelope"/intent I1), and [standing-role.md](standing-role.md). Aligned to
+> the platform canon in `100rd/genai-enablement` (ADR-0003 quality-gated Done). **Humans own decisions;
+> L4 never L5** — and here the human owns TWO gates: approve the *spec* (what to build) and merge the
+> *code PR* (ship it).
+
+## 1. Why the spec is the unit (not the ticket, not the chat)
+
+- **Intent must be crystallised before expensive execution.** A raw ticket ("fix the flaky login")
+  is under-specified; a loop that runs on it guesses. A spec pins the problem, scope, and
+  **acceptance criteria** — which become the loop's verification criteria (ADR-0003 Done).
+- **Version-controlled, reviewable, durable.** A spec is a file in git: diffable, PR-reviewable,
+  attributable, and permanent. The task queue is the repo history, not an ephemeral message bus.
+- **One execution route.** Tickets (via connectors), ADRs, and human ideas all converge on
+  "a committed spec under `docs/specs|adr/`". The loop only ever consumes a spec — it never parses a
+  ticket directly. This keeps the loop's input uniform and the intake pluggable.
+- **Two human gates, cleanly separated.** The human approves the **spec** (the *what* — via the spec
+  PR) and later merges the **code PR** (the *how/ship*). The factory automates only the work between
+  them. Strong L4.
+
+## 2. The spec artifact (schema)
+
+A spec is a Markdown file with YAML frontmatter, under `docs/specs/<slug>.md` (or an ADR under
+`docs/adr/NNNN-<slug>.md`). Minimal contract the watch-trigger and planner rely on:
+
+```yaml
+---
+title:   "Short imperative title"
+status:  draft | ready | in-progress | done   # only `ready` fires a loop (the consent gate)
+source:  { kind: human | jira | github | gitlab | bitbucket | linear | azure, ref?, url? }  # provenance
+repo:    <target repo path/slug>               # where the work lands (defaults to the spec's own repo)
+role?:   <standing-role name>                  # optional: which Role owns this (skills+persona)
+skills?: [ ... ]                               # optional explicit skill set (else derived from role/repo)
+acceptanceCriteria:                            # the DoD → the loop's verification criteria (ADR-0003)
+  - "<criterion, each testable/verifiable>"
+---
+
+## Problem            # what's wrong / the goal
+## Scope              # in scope
+## Out of scope       # explicitly excluded (bounds blast radius)
+## Notes              # context, links, constraints
+```
+
+Rules: `acceptanceCriteria` is REQUIRED for `status: ready` (no criteria ⇒ not ready — a loop has
+nothing to verify against). `source` is REQUIRED (auditability — where did this task come from).
+An **ADR** is a spec whose `acceptanceCriteria` are "the decision is implemented + …"; a new ADR
+under `docs/adr/` that implies work is a task too.
+
+## 3. The watch trigger (spec/ADR → loop)
+
+A **default, per-repo** `file_change` trigger (loop-triggers.md) watches `docs/specs/**` and
+`docs/adr/**` on the default branch. It is the standard on-by-default intake (behind the master
+`triggers.enabled` switch); a repo opts a path in via config.
+
+- **Fires when:** a spec/ADR file is added or transitions to `status: ready` on the default branch
+  (i.e. after its spec PR merges — §4). A `draft` spec never fires.
+- **Maps to a loop:** `engineerInstruction` = the spec body (fenced); verification criteria =
+  `acceptanceCriteria`; `repoPath` = `repo`; `skillIds` = `skills`/`role`. Provenance records the
+  spec path + commit + `source`.
+- **Rails (loop-triggers §4):** **dedup — one active loop per spec** (keyed by spec path); budget per
+  repo/day; `cascadeDepth` (a loop that writes a new spec can't recurse past the cap); kill-switches
+  per repo/path/class. On `status: ready → in-progress` the trigger marks the spec so re-runs don't
+  double-fire.
+- **Convergence:** a human writing `docs/specs/foo.md` and a connector committing the same file are
+  indistinguishable to this trigger — one route, one set of rails.
+
+## 4. The spec lifecycle (the two-gate flow)
+
+```
+intent (ticket / ADR / human idea)
+   │  → normalise/synthesise into a spec file (status: draft)
+   ▼
+docs/specs/<slug>.md  →  SPEC PR  →  human reviews the INTENT  →  merge (status flips to ready)   [GATE 1: the WHAT]
+   │  watch trigger fires
+   ▼
+consilium loop: assess → plan → develop → verify (criteria = acceptanceCriteria)
+   │
+   ▼
+CODE PR (references the spec)  →  human reviews & merges                                            [GATE 2: ship]
+   │  on merge: spec status → done (a small follow-up commit or the code PR flips it)
+   ▼
+write-back to the origin (if `source` is a ticket — see task-tracker-triggers.md §C)
+```
+
+**Default = spec PR (human approves intent before the factory builds).** For trusted, low-stakes
+flows an operator may allow **auto-commit** of the spec to the default branch (skips gate 1) — a
+per-repo/per-role policy, off by default. Even then gate 2 (the code PR merge) always stands.
+
+## 5. Boundaries & safety
+
+- **Only `ready` fires.** Drafts, WIP, and specs without `acceptanceCriteria` are inert. The
+  ready-transition (a merged spec PR, or an explicit marker) is the consent that this intent is
+  approved to execute.
+- **The spec is reviewed intent.** Because it lands via a PR (default), a human has seen the *what*.
+  Untrusted-origin text (a synthesised spec from a public ticket) is still fenced when it enters any
+  prompt, and the spec PR is where a human sanity-checks it before it can fire.
+- **Scope is bounded by the spec.** `Out of scope` + `acceptanceCriteria` constrain the loop; the
+  loop verifies against the criteria and does not wander.
+- **No silent drift.** The spec's `status` is the single source of truth for "is this being worked /
+  done"; the loop updates it, never a hidden state.
+
+## 6. Relationship to the rest
+
+- **loop-consolidation:** the spec IS the intent/"task envelope" (I1); `acceptanceCriteria` are the
+  criteria the per-criterion verification methods evaluate.
+- **ADR-0003 (quality-gated Done):** Done = all `acceptanceCriteria` verified — the spec makes the
+  gate explicit and per-task.
+- **Standing Role:** a Role can own a `docs/specs/` path (its inbox); its skills/persona apply to
+  every spec there; the Dream accumulates experience per (role, spec-class).
+- **task-tracker-triggers:** connectors are *spec producers* — they turn a ticket into a committed
+  spec (and write back to the ticket). They never fire loops directly.
+- **Experience/Dream:** a completed spec + its verified outcome is prime Dream input (claim + DoD +
+  evidence).
+
+## 7. Staging (each shippable, inert-by-default, kill-switched)
+
+- **SPEC-0** — this doc + the spec schema fixed.
+- **SPEC-1 — watch:** the `docs/specs|adr` file_change trigger → loop, ready-gated, dedup, provenance.
+  Human-authored specs only (no connectors yet). Proves the substrate.
+- **SPEC-2 — status lifecycle:** the trigger flips `draft→ready→in-progress→done`; the code PR merge
+  closes the spec; re-run discipline.
+- **SPEC-3 — auto-commit policy:** the trusted per-repo/role option to skip gate 1.
+- **SPEC-4 — ADR intake:** treat new `docs/adr/` entries as tasks (with the "implement the decision"
+  criteria shape).
+- **SPEC-5 — graduate:** a genai-enablement ADR making "committed spec = unit of work" a cross-repo
+  contract; omnius consumes it for governed intake.
+
+## 8. Open questions
+
+- Spec vs ADR: same trigger, or distinct criteria-shapes/rails per kind?
+- Where the spec status lives when the loop is mid-flight (frontmatter vs a sidecar vs loop state) —
+  frontmatter is human-visible but churns the file; pick one.
+- Multi-repo specs: a spec in repo A targeting repo B (`repo:` field) — cross-repo rails + auth.
+- Spec supersession: a new spec that replaces an old one (`supersedes:`), and how the watch handles it.

--- a/docs/design/task-tracker-triggers.md
+++ b/docs/design/task-tracker-triggers.md
@@ -1,40 +1,43 @@
-# SPEC: Task-tracker integrations & triggers — a ticket becomes a loop
+# SPEC: Task-tracker integrations & triggers — a ticket becomes a spec becomes a loop
 
-> Status: **spec / design**. This is the factory's **inbound front door**: a ticket created in
-> a tracker (Jira, GitHub / GitLab / Bitbucket Issues) becomes a consilium loop, runs the full
-> cycle (assess → plan → develop → verify → PR), and the resulting PR closes the ticket. Turns
-> multiqlti from "an engineer runs a loop by hand" into "work arrives as tickets and is executed."
-> Extends [loop-triggers.md](loop-triggers.md) (a new trigger source class) and composes with
-> [standing-role.md](standing-role.md), the [knowledge-planes](knowledge-planes.md) and the
-> [Dream](experience-plane-dream.md). Aligned to the platform canon in `100rd/genai-enablement`.
-> **Humans own decisions; L4 never L5** — a ticket triggers the WORK; a human still merges the PR
-> and thereby closes the ticket.
+> Status: **spec / design** (v2). The factory's **inbound front door**: a ticket created in a tracker
+> (Jira, GitHub / GitLab / Bitbucket Issues, **Linear**, **Azure DevOps**) is turned into a
+> **committed spec** (per [spec-as-task.md](spec-as-task.md)), the spec fires a consilium loop, and
+> the loop **writes back to the origin ticket** at every step. Connectors are *spec producers +
+> ticket updaters* — they never fire loops directly; the committed spec does (one execution route).
+> Extends [loop-triggers.md](loop-triggers.md) (a new source class), composes with
+> [spec-as-task.md](spec-as-task.md), [standing-role.md](standing-role.md),
+> [knowledge-planes.md](knowledge-planes.md), and the [Dream](experience-plane-dream.md). Aligned to
+> the platform canon in `100rd/genai-enablement`. **Humans own decisions; L4 never L5** — a ticket
+> triggers the WORK; a human approves the spec (the *what*) and merges the PR (the *ship*), which
+> closes the ticket.
 
-## 1. The shape of the idea
+## 1. The shape of the idea (v2 — spec-first)
 
 ```
-  Jira / GitHub Issue / GitLab Issue / Bitbucket Issue
-        │  a ticket is created / labeled / assigned  (by the operator or anyone)
+  Jira / GitHub Issue / GitLab / Bitbucket / Linear / Azure DevOps
+        │  a ticket is created / labeled / assigned
         ▼
-   Tracker Trigger  ──maps ticket → loop template──►  Consilium Loop
-        │                                                 │  assess → plan → develop → verify
-        │                                                 ▼
-        │◄──────── loop updates the ticket ──────  Draft PR (references the ticket)
-        │          (status, PR link, comments)
+   Tracker Connector ── synthesise/normalise ──►  docs/specs/<slug>.md  (status: draft, source: <tracker>)
+        │  (+ comment back on the ticket: "picked up → spec at <link>")   │  SPEC PR → human approves the WHAT
+        │                                                                  ▼  (status: ready on merge)
+        │                                            spec-as-task watch trigger fires
+        │                                                                  ▼
+        │                                            Consilium Loop  (criteria = acceptanceCriteria)
+        │◄─────────── write-back at every step ──────────────  Draft CODE PR (references spec + ticket)
         ▼
-   human merges the PR  ──►  ticket auto-closes (PR "Closes #N" / Jira smart-commit)
+   human merges the code PR  ──►  ticket auto-closes ("Closes #N" / transition) + spec status → done
 ```
 
-The ticket is the **intent** (loop-consolidation §A/ADR-0003 I1 "task envelope"); the loop is the
-execution; the PR is the artifact; the merge is the human decision that ships it and closes the
-ticket. Nothing about our safety model changes — we add an inbound source, not an autonomy tier.
+The ticket is the **raw intent**; the **committed spec** is the crystallised, reviewed intent (the
+"task envelope"); the loop is execution; the PR is the artifact; the human merge ships it and closes
+the ticket. We add an inbound source and a **spec-first gate**, not an autonomy tier.
 
-## 2. Part A — Integrations (the connectors)
+## 2. Part A — Integrations (the six connectors)
 
-A **Tracker Connector** is a small, uniform adapter per system. It does three things: **watch**
-(learn of new/changed tickets), **read** (fetch a ticket's fields), **write-back** (update status
-/ comment / link). All four trackers reduce to the same connector interface; only the API dialect
-differs.
+A **Tracker Connector** is a small, uniform adapter per system doing three things: **watch** (learn of
+new/changed tickets), **read** (fetch a ticket's fields), **write-back** (comment / transition /
+link). All six reduce to the same interface; only the API dialect differs.
 
 | Tracker | Watch | Read | Write-back | Auth |
 |---|---|---|---|---|
@@ -42,77 +45,95 @@ differs.
 | **GitHub Issues** | webhook (issues.opened/labeled) **or** `gh issue list` poll | `gh api /repos/…/issues/{n}` | comment, label, close-on-PR | `gh` / PAT / GitHub App |
 | **GitLab Issues** | webhook (Issue Hook) **or** `/issues?updated_after=` poll | `/projects/:id/issues/:iid` | note, label, `Closes #iid` | PAT / project token |
 | **Bitbucket Issues** | webhook **or** `/issues?q=updated_on>` poll | `/repositories/…/issues/{id}` | comment, state, PR link | app password / OAuth |
+| **Linear** | webhook (Issue events) **or** GraphQL poll (`issues(filter:{updatedAt})`) | GraphQL `issue(id)` | GraphQL `commentCreate`, state update, attachment link | API key / OAuth |
+| **Azure DevOps** | Service Hook (workitem.created/updated) **or** WIQL poll | REST `/wit/workitems/{id}` | `/comments`, state field, PR link (artifact) | PAT / Entra OAuth |
 
-**Reuse — do not rebuild:** watching is exactly the trigger runtime we just built. Webhooks land on
-the existing `/api/webhooks/:triggerId` receiver (HMAC-verified, `runAsSystem`-scoped); when the
-tracker is behind NAT/unreachable from the internet, the **polling mode (#492)** applies verbatim —
-a tracker poll is `gh issue list` / a JQL search on an interval with a per-trigger watermark. So
-Part A is mostly **N connector adapters over one existing watch/fire spine.**
+**Reuse — do not rebuild:** watching is exactly the trigger runtime we built. Webhooks land on the
+existing `/api/webhooks/:triggerId` receiver (HMAC-verified, `runAsSystem`-scoped, per #494); when the
+tracker is behind NAT / can't reach us, the **polling mode (#492)** applies verbatim — a tracker poll
+is `gh issue list` / a JQL / WIQL / GraphQL query on an interval with a per-trigger watermark. So Part
+A is mostly **six adapters over one existing watch spine + one spec-writer.**
 
-**Auth & secrets:** every connector holds a scoped API token, sourced from a secret manager (never
-committed), fail-closed. A connector for one tracker site/project cannot read another's — same
-workspace-scoped posture as Omniscience tokens.
+**Auth & secrets:** every connector holds a scoped API token from a secret manager (never committed),
+fail-closed. A connector for one tracker site/project cannot read another's — workspace-scoped, same
+posture as Omniscience tokens.
 
-## 3. Part B — Triggers (reacting to tracker events)
+## 3. Part B — The spec-first gate (ticket → committed spec)
 
-A **Tracker Trigger** is a new `TriggerType` (`tracker_event`) in the loop-triggers model
-(source → filter → loop template → policy). It binds a connector + a filter to a loop template.
+A **Tracker Trigger** (`tracker_event` type) does NOT launch a loop. It produces a **committed spec**
+and hands off to the spec-as-task watch trigger. This is the load-bearing v2 change.
 
-### 3.1 Filters — which tickets become loops (never *all* of them)
-A firing is gated by an explicit predicate so the factory doesn't swallow every ticket:
-- **Label / tag:** e.g. Jira label `agent` or `dark-factory`, GitHub label `agent-run`. **Recommended default** — opt-in per ticket.
-- **Project / board / component:** all tickets in a named project or component.
+### 3.1 Filters — which tickets become specs (never *all* of them)
+An explicit predicate gates intake so the factory doesn't swallow every ticket:
+- **Label / tag:** Jira label `agent`, GitHub label `agent-run`, Linear label, Azure tag. **Recommended default** — opt-in per ticket.
+- **Project / board / area-path / team:** all tickets in a named project/board/area.
 - **Assignee:** tickets assigned to a designated "agent" user.
-- **Query:** a saved JQL / issue query (the most expressive).
-- **Event kind:** created | labeled | assigned | commented-with-command (`/run`).
+- **Query:** a saved JQL / WIQL / GraphQL filter / issue query (most expressive).
+- **Event kind:** created | labeled | assigned | commented-with-command (`/spec`, `/run`).
 
-### 3.2 Ticket → loop mapping (the intent translation)
-The connector reads the ticket and composes the loop:
-- **`engineerInstruction`** = the ticket **title + body**, control-stripped + fenced (untrusted
-  text — same discipline as a PR title). Optionally run **magic-mode reformulation** (#465) first:
-  turn a rough ticket into a well-formed engineer instruction, and (optionally) post the proposed
-  instruction back as a ticket comment for the human to confirm before the loop proceeds — keeping
-  the human in the intent loop.
-- **`repoPath`** = resolved from the ticket's project → repo mapping (a connector config: "Jira
-  project ACME → repo X"). Absent/ambiguous → no-op with a comment asking for the repo.
-- **`skillIds` / preset / reviewMode / maxRounds** = from the trigger's loop template, or from a
-  **Standing Role** the trigger names (§5).
-- **provenance** = the loop records the ticket (tracker, key, url) — shown on the launch passport;
-  the PR back-references it.
+### 3.2 Ticket → spec (the crystallisation step)
+The connector reads the ticket and produces a spec file (spec-as-task.md §2):
+- **If the ticket is already spec-shaped** (has structured acceptance criteria / a template) →
+  **normalise** it into the spec schema (map fields → frontmatter + sections). No LLM guessing.
+- **Else** → **synthesise** a spec: an LLM (magic-mode reformulation, #465) turns title + body into
+  `Problem / Scope / Out of scope / acceptanceCriteria`. Untrusted ticket text is fenced/clamped
+  (github-event-map discipline) before it enters the prompt.
+- **Frontmatter:** `title` (from the ticket), `source: { kind:<tracker>, ref:<key>, url:<link> }`
+  (REQUIRED — this is what write-back keys off), `repo` (resolved §3.4), `role`/`skills` (from the
+  trigger's Standing Role or template), `status: draft`.
+- **acceptanceCriteria are REQUIRED.** If the ticket gives none and synthesis can't infer testable
+  ones, the connector posts a comment back asking the human to add them, and does NOT proceed — a
+  spec without a DoD is not `ready`.
 
-### 3.3 Rails (loop-triggers §4, applied to tickets)
-- **Dedup:** **one active loop per ticket** (keyed by tracker+ticket id) — a ticket edited 5×
-  doesn't spawn 5 loops; the existing loop picks up the latest on its next round.
-- **Budget:** max tracker-born loops per project/day + global cap; over budget ⇒ `suppressed:budget`
+### 3.3 Committing the spec (the WHAT gate)
+- **Default:** the connector opens a **spec PR** adding `docs/specs/<slug>.md` (status: draft). A human
+  reviews the *intent*; on merge the status flips to `ready` and the spec-as-task watch trigger fires
+  the loop. Two clean gates (spec merge = the *what*; code PR merge = ship).
+- **Trusted option:** a per-repo/per-Role policy may **auto-commit** the spec to the default branch as
+  `ready` (skips the spec PR), for low-stakes flows. Gate 2 (code PR) always stands.
+- The connector records the spec commit on the ticket (§4) so the human sees "your ticket became this
+  spec."
+
+### 3.4 Ticket → repo resolution
+`repo` comes from, in order: an explicit connector config map (`Jira project ACME → repo X`); a field
+on the ticket (a `repo:` label / custom field); else the tracker project's default repo. Ambiguous /
+absent ⇒ the connector comments on the ticket asking for the repo and does NOT create a spec.
+
+### 3.5 Rails (loop-triggers §4, applied at intake)
+- **Dedup:** one spec per ticket (keyed by tracker+ticket id); a ticket edited 5× updates the same
+  spec, never spawns 5. Downstream, one loop per spec (spec-as-task §3).
+- **Budget:** max tracker-born specs per project/day + global cap; over budget ⇒ `suppressed:budget`
   + a ticket comment, never silent.
-- **Human confirm option:** a per-trigger flag to require a human `/approve` comment (or the
-  magic-mode confirm) before the loop starts — for higher-stakes projects.
-- **cascadeDepth:** a tracker-born loop is depth 0; it may not itself open new tickets that trigger
-  further loops beyond the §4.4 cap.
+- **Human confirm:** the spec PR IS the confirm by default; a per-trigger flag can additionally require
+  an `/approve` comment before even creating the spec (highest-stakes projects).
+- **cascadeDepth:** a tracker-born spec is depth 0; a loop may not open tickets that trigger further
+  specs beyond the §4.4 cap.
 - **Kill-switches:** per connector, per trigger, per class (`triggers.tracker.enabled`), all default
-  OFF. No ticket fires a loop on a running server until an operator enables it.
+  OFF.
 
-## 4. Part C — Write-back (the loop talks to the ticket)
+## 4. Part C — Write-back is MANDATORY (the loop keeps the ticket a live record)
 
-The loop is not fire-and-forget; it keeps the ticket a live record (bidirectional):
-- **On start:** comment "🤖 picked up by the factory — loop <link>", optionally transition the
-  ticket (To Do → In Progress).
-- **On verdict / develop:** optional progress comment (the action points found, per-criterion
-  results) — the ticket becomes the human-readable status the operator already watches.
-- **On PR open:** comment the Draft PR link; add a remote link (Jira) / `Closes #N` (GitHub/GitLab).
-- **On terminal:** `converged` → "ready for review, PR <link>"; `stopped_cap`/`failed` → the
-  status-explanation (#486) as a comment so a human knows why and what remains.
-- **On human merge:** the PR's `Closes #N` / smart-commit **auto-closes the ticket** — the human's
-  merge is the single act that both ships and resolves. (We do not auto-transition to Done; the
-  merge does, through the tracker's own PR-link mechanism.)
+**Non-negotiable in v2:** wherever a task *came from a ticket*, the factory **writes back to that
+ticket** at every meaningful transition. The ticket's `source` frontmatter on the spec carries the
+origin so the loop (and its terminal write-back) always knows where to report. Write-back is idempotent
+(dedup comments by spec/loop id) and best-effort (a tracker outage never breaks the loop — it degrades
+to no comment, like the PR-queue GitHub degrade).
 
-Write-back is idempotent (dedup comments by loop id) and best-effort (a tracker outage never breaks
-the loop — it degrades to no comment, like the PR-queue GitHub degrade).
+| When | Write-back to the origin ticket |
+|---|---|
+| **Spec created** | comment "🤖 picked up by the factory — spec at `<spec PR/commit link>`"; optionally transition To Do → In Progress. **This is the "wrote where it took the task from" requirement.** |
+| **Spec approved (ready)** | comment "intent approved, work starting — loop `<link>`". |
+| **Develop / verdict** | optional progress comment (action points, per-criterion results) — the ticket becomes the human-readable status the operator already watches. |
+| **Code PR opened** | comment the Draft PR link; add a remote link (Jira/Azure artifact) / `Closes #N` (GitHub/GitLab). |
+| **Terminal** | `converged` → "ready for review, PR `<link>`"; `stopped_cap`/`failed` → the status-explanation (#486) as a comment so a human knows why + what remains. |
+| **Human merges code PR** | `Closes #N` / smart-commit auto-closes the ticket (GitHub/GitLab) or the connector transitions it (Jira/Azure/Linear/Bitbucket); spec status → done. |
 
-## 5. Composition — this is where Standing Role clicks
+The human's merge is the single act that both ships and resolves; the factory never auto-transitions to
+Done independently of a merged PR.
 
-A **Standing Role** (standing-role.md) whose *concern* is a tracker project turns this into a durable
-digital employee:
+## 5. Composition — Standing Role on a tracker
+
+A **Standing Role** whose *concern* is a tracker project turns this into a durable digital employee:
 
 ```
 StandingRole "backend-dev"
@@ -121,46 +142,57 @@ StandingRole "backend-dev"
                 repoPath: <service-repo>, focus: "implement the ticket" } ]
 ```
 
-Every ACME ticket labeled `agent` wakes the backend-dev Role → spawns a loop with its skills +
-persona → runs the full cycle → PR closes the ticket. Over time the **Dream** teaches *this Role on
-this project*: "tickets of type X here close by pattern Y (verified)". The tracker is the role's
-inbox; the loop is its work; the PR is its output; the human merge is the decision. This is the
-operator's vision — *independent execution of tasks* — expressed entirely in primitives we already
-have plus these connectors.
+Every ACME ticket labeled `agent` wakes the backend-dev Role → the connector writes a spec (with the
+Role's skills/persona baked into frontmatter) → the spec fires a loop → PR closes the ticket. The
+**Dream** teaches *this Role on this project* ("tickets of type X here close by pattern Y, verified").
+The tracker is the role's inbox; the spec is the crystallised task; the loop is its work; the human
+merge is the decision. This is the operator's *independent execution of tasks* — from primitives we
+already have plus these connectors.
 
 ## 6. Boundaries & safety (unchanged posture, new surface)
 
-- **Untrusted input:** a ticket title/body is attacker-influenced text (anyone may file a ticket) —
-  fenced/clamped before it enters any prompt, exactly like a PR title (github-event-map discipline).
-  A ticket cannot inject tool access or scope; it only supplies the objective.
-- **The label gate is the consent:** firing on *labeled* (not merely *created*) means a human (or a
-  policy) opted this ticket into the factory. "Fire on any created ticket" is available but is the
-  high-trust setting.
-- **Human still merges:** the ticket triggers the work; a human reviews and merges the PR, which
-  closes the ticket. No ticket ever auto-ships code. L4, never L5.
-- **Scoping:** a connector/trigger is bound to one tracker project ↔ one repo; cross-project firing
-  needs explicit config. Tokens are scoped and fail-closed.
+- **Untrusted input:** a ticket title/body is attacker-influenced (anyone may file one) — fenced/clamped
+  before any prompt, exactly like a PR title. A ticket cannot inject tool access or scope; it only
+  seeds the spec's objective, and the **spec PR is where a human sanity-checks it** before it can fire.
+- **The label gate is consent to intake; the spec PR is consent to execute.** Firing on *labeled* (not
+  merely *created*) means a human opted this ticket in; the spec PR merge means a human approved the
+  *what*. "Auto-commit ready specs" is the high-trust setting.
+- **Human still merges.** The ticket triggers work; a human merges the code PR, which closes the ticket.
+  No ticket ever auto-ships code. L4, never L5.
+- **Scoping:** a connector/trigger binds one tracker project ↔ one repo; cross-project needs explicit
+  config. Tokens scoped, fail-closed.
 
 ## 7. Staging (each shippable, inert-by-default, kill-switched)
 
-- **TRACK-0** — this spec.
-- **TRACK-1 — GitHub Issues first** (we already have the `gh` seam + polling #492): `tracker_event`
-  type, label-filtered, ticket→loop mapping, minimal write-back (PR-link comment). Proves the spine
-  on the cheapest connector.
-- **TRACK-2 — write-back & lifecycle:** start/verdict/terminal comments + transitions + status
-  explanations to the ticket.
-- **TRACK-3 — Jira connector** (webhook + JQL poll; the org-standard tracker).
-- **TRACK-4 — GitLab & Bitbucket connectors** (same interface, different dialect).
-- **TRACK-5 — Standing Role on a tracker project** (§5) + magic-mode intent confirmation in-ticket.
-- **TRACK-6 — graduate:** a genai-enablement ADR for the cross-repo tracker-connector contract;
+- **TRACK-0** — this spec + [spec-as-task.md](spec-as-task.md) (the substrate; ship SPEC-1 first).
+- **TRACK-1 — GitHub Issues → spec** (cheapest: `gh` seam + polling #492): `tracker_event` type,
+  label-filtered, ticket→spec synthesis, spec PR, mandatory PR-link + status write-back. Proves the
+  spine on one connector, riding the spec-as-task watch.
+- **TRACK-2 — full write-back lifecycle:** all rows of §4 (start/verdict/terminal/close) + transitions.
+- **TRACK-3 — Jira connector** (webhook + JQL; the org-standard tracker).
+- **TRACK-4 — GitLab + Bitbucket connectors.**
+- **TRACK-5 — Linear + Azure DevOps connectors** (GraphQL / WIQL dialects).
+- **TRACK-6 — Standing Role on a tracker** + `/spec`,`/approve` comment commands.
+- **TRACK-7 — graduate:** a genai-enablement ADR for the cross-repo tracker-connector + spec contract;
   omnius consumes it for org-scale governed intake.
 
-## 8. Open questions
+## 8. Resolved design decisions (was §8 open questions)
 
-- Ticket→repo resolution: config map vs a field on the ticket vs inferred from the project.
-- How much loop progress to mirror into the ticket (signal vs noise for the human).
-- Command-in-comment (`/run`, `/approve`, `/stop`) as a control channel — scope + auth of who may command.
-- Two-way sync conflicts: the ticket edited mid-loop — pick up on next round (like PR synchronize) vs ignore.
-- Whether the connector layer should be shared with Omniscience's ingestion (it already ingests
-  chat/alerts) — trackers as another Omniscience source vs a multiqlti-local connector. Likely: state
-  (the ticket exists, its status) is Omniscience; the *act of executing it* is a multiqlti trigger.
+- **Ticket→repo:** config map → ticket field → project default, in that order; ambiguous ⇒ ask on the
+  ticket, don't guess (§3.4).
+- **How much progress to mirror:** start/PR/terminal are mandatory; per-verdict progress is opt-in per
+  trigger (signal vs noise).
+- **Command-in-comment:** `/spec` (force intake), `/approve` (approve the spec), `/stop` (cancel the
+  loop) — authorised to ticket assignees/maintainers only; the connector verifies the commenter's role
+  via the tracker API before acting.
+- **Two-way sync mid-flight:** a ticket edited while its loop runs updates the SPEC (a new spec commit);
+  the running loop picks up the change on its next round (like PR `synchronize`), never mid-round.
+- **State vs execution boundary:** the *fact* a ticket exists and its status is Omniscience state; the
+  *act of executing it* is a multiqlti trigger; the crystallised intent is a committed spec. Three
+  planes, one flow.
+
+## 9. Still open
+
+- Spec supersession when a ticket is reopened after `done` (new spec vs revive).
+- Cross-tracker dedup (the same work filed in both Jira and GitHub) — key on repo+title similarity?
+- Bulk intake (a sprint of 30 tickets) → 30 spec PRs vs one batched spec-PR with a human triage step.


### PR DESCRIPTION
Reworks the tracker-intake design around three things you asked for: **more trackers, spec-first intake, and mandatory write-back** — plus a new substrate that makes committed specs the unit of work.

## New: `spec-as-task.md` — the execution substrate
A **committed spec** (`docs/specs/`) or **ADR** (`docs/adr/`) is the unit of work. A **default per-repo `file_change` watch trigger** fires a consilium loop when a *ready* spec/ADR lands — i.e. **ordinary triggers watch the repo by default, and new tasks appearing under `docs/specs`/`docs/adr` start work** (your requirement). One execution route: humans and connectors both produce specs into the same place. Spec schema = frontmatter (`status`, `source`, `repo`, `role`, **`acceptanceCriteria`**) + body; **acceptanceCriteria become the loop's verification criteria** (ADR-0003 Done). **Two human gates:** approve the spec (the *what*, via the spec PR) and merge the code PR (ship). Only `status: ready` fires; drafts are inert.

## `task-tracker-triggers.md` → v2
- **Six connectors now:** added **Linear** (GraphQL) and **Azure DevOps** (WIQL/Service Hooks) alongside Jira / GitHub / GitLab / Bitbucket.
- **Spec-first gate (your requirement):** a ticket **no longer fires a loop directly** — the connector **normalises (if already spec-shaped) or synthesises a committed spec** and opens a **spec PR** (`docs/specs/<slug>.md`, `source: <tracker>`). The spec-as-task watch then fires the loop. So *the ticket must be in spec format, or a spec is made for it and added to git* — exactly as asked. `acceptanceCriteria` are required; no DoD ⇒ the connector asks on the ticket, doesn't proceed.
- **Write-back is MANDATORY (your requirement):** the loop **writes back to the origin ticket at every transition** — spec-created ("picked up → spec at <link>", *the ticket learns where its task went*), ready, PR-opened, terminal (with the #486 status-explanation), and merge (auto-close/transition). Idempotent + best-effort.
- Deepened ticket→spec→loop mapping, repo resolution (config→field→default→ask), `/spec`/`/approve`/`/stop` comment commands with commenter-role auth, two-way sync mid-flight, and the state/execution/intent three-plane boundary. Closed the prior open questions.

Composes with Standing Role (a Role owns a tracker project / a specs dir) and the Dream (a completed spec + verified outcome is prime experience). Docs-only. Staging: SPEC-1 (watch) first, then TRACK-1 (GitHub Issues → spec).