### PR TITLE
feat: spec-as-task watch — a ready spec/ADR fires a loop (SPEC-1)

### DIFF
--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -551,6 +551,30 @@ export const ConfigSchema = z.object({
         enabled: z.boolean().default(false),
       }).default({}),
       /**
+       * SPEC-1 (spec-as-task.md §3): the spec-watch. A `file_change` trigger whose
+       * changed file matches one of these globs is parsed as a committed spec/ADR;
+       * a spec with `status: ready` AND non-empty `acceptanceCriteria` fires ONE
+       * consilium loop (review-only, per the T6 fs-event rail). Everything else is a
+       * logged no-op (`draft` / `no-acceptance-criteria` / `not-a-spec` / `status:done`).
+       * Dedup is keyed by the SPEC PATH (not the repo), so two distinct specs in the
+       * same repo each fire their own loop.
+       *
+       * Default FALSE ⇒ BYTE-IDENTICAL: the spec pre-check is skipped entirely and a
+       * file_change trigger behaves exactly as before. Firing ALSO requires the master
+       * `features.triggers.enabled` switch (wired in the route) AND the parent
+       * `pipeline.consiliumLoop.enabled` (the loop subsystem) — triple-gated.
+       */
+      specWatch: z.object({
+        /** Kill-switch: false (default) → no spec parsing, no spec fires (inert). */
+        enabled: z.boolean().default(false),
+        /**
+         * Repo-relative globs identifying committed specs/ADRs under the watched
+         * base. A changed file matching ANY glob is treated as a spec candidate.
+         * config.yaml only (arrays are not env-mapped — matches allowedRepoPaths).
+         */
+        globs: z.array(z.string()).default(["docs/specs/**/*.md", "docs/adr/**/*.md"]),
+      }).default({}),
+      /**
        * Stage 2a (design §3.C/§4): the SKILLED, archetype-branched implement
        * (develop) phase. When `enabled` is FALSE the loop runs TODAY'S single
        * unskilled coder per action point (byte-for-byte unchanged). When TRUE the

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -405,6 +405,20 @@ export async function registerRoutes(
           // fireTrigger is a background/system ctx with no request project scope.
           recordFire: (triggerId: string, firedAt: Date) =>
             storage.incrementTriggerFired(triggerId, firedAt),
+          // SPEC-1 (spec-as-task.md §3): the spec-watch config, master-gated HERE so
+          // the dispatch sees ONE boolean. `enabled` folds the master trigger switch
+          // (features.triggers.enabled) AND the spec-watch kill-switch — either off ⇒
+          // the spec pre-check is skipped and the file_change dispatch is byte-identical.
+          // The parent consiliumLoop.enabled gate is enforced downstream (reviewDeps null).
+          specWatch: () => {
+            const c = appConfigLoader.get();
+            return {
+              enabled:
+                c.features.triggers.enabled && c.pipeline.consiliumLoop.specWatch.enabled,
+              globs: c.pipeline.consiliumLoop.specWatch.globs,
+              allowedRepoPaths: c.pipeline.consiliumLoop.allowedRepoPaths,
+            };
+          },
           log: (m: string) => log(m, "triggers"),
         };
 

--- a/server/services/consilium/spec-parser.ts
+++ b/server/services/consilium/spec-parser.ts
@@ -1,0 +1,396 @@
+/**
+ * spec-parser.ts — parse a committed spec/ADR Markdown file into its YAML
+ * frontmatter + body, and decide whether it is a *ready* unit of work.
+ *
+ * Contract: docs/design/spec-as-task.md §2 (schema) + §3 (watch trigger).
+ * A spec is a Markdown file with YAML frontmatter:
+ *
+ *   ---
+ *   title:   "..."
+ *   status:  draft | ready | in-progress | done   # only `ready` fires a loop
+ *   source:  { kind, ref?, url? }                  # provenance (required)
+ *   repo?:   <target repo path/slug>
+ *   role?:   <standing-role name>
+ *   skills?: [ ... ]
+ *   acceptanceCriteria:                            # the DoD → verification criteria
+ *     - "<criterion>"
+ *   ---
+ *   <body>
+ *
+ * SECURITY / ROBUSTNESS (flagged for the adversarial reviewer):
+ *   P1. This module NEVER throws on bad input. A malformed / missing frontmatter,
+ *       an oversized file, a binary blob, or an unreadable path all degrade to a
+ *       safe `{ kind: "not-a-spec", reason }` result — a poisoned file under the
+ *       watched globs must never crash the watcher loop.
+ *   P2. YAML is parsed with `js-yaml` default `load` (v4 — the default schema is
+ *       safe: no `!!js/function`, no code execution). We additionally cap the
+ *       file size read from disk and reject NUL-byte (binary) content BEFORE the
+ *       YAML parse so a huge/binary file can never blow the parser up.
+ *   P3. The spec body is human-authored (lower risk) but is STILL byte-bounded
+ *       before it becomes the loop objective — the caller clamps via
+ *       `buildSpecInstruction`, and the factory clamps again downstream.
+ *   P4. Glob matching (`pathMatchesSpecGlobs`) is a dependency-free, anchored
+ *       regex conversion — no reliance on a transitive glob lib, deterministic,
+ *       and matches a repo-relative glob against any absolute path suffix.
+ */
+import { readFileSync, statSync } from "fs";
+
+// ─── Bounds (P2, P3) ────────────────────────────────────────────────────────
+
+/** Max on-disk size we will read as a candidate spec. Specs are small prose. */
+export const SPEC_MAX_FILE_BYTES = 512 * 1024; // 512 KiB
+/**
+ * Byte budget for the WHOLE engineerInstruction (DoD + body). Deliberately UNDER
+ * the factory's `OBJECTIVE_EXTRA_MAX_BYTES` (8 KiB) head-keeping clamp so the
+ * instruction we build is never itself truncated downstream — the criteria (§3
+ * contract) always survive (Security H1). 7 KiB leaves headroom for the factory's
+ * skill-append budgeting on top.
+ */
+export const SPEC_INSTRUCTION_MAX_BYTES = 7 * 1024; // 7 KiB (< the factory's 8 KiB clamp)
+/** Floor reserved for the spec body so a criteria-heavy spec never starves context. */
+export const SPEC_BODY_MIN_BYTES = 1_000;
+/** Max bytes of a single acceptance-criterion line (defensive clamp). */
+export const SPEC_CRITERION_MAX_BYTES = 1_000;
+/** Max number of acceptance criteria rendered into the DoD (defensive clamp). */
+export const SPEC_MAX_CRITERIA = 200;
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/** The `source` provenance object (spec-as-task §2). All fields best-effort. */
+export interface SpecSource {
+  kind: string;
+  ref?: string;
+  url?: string;
+}
+
+/** The parsed, type-coerced frontmatter. Every field is optional at parse time;
+ *  the ready-gate enforces which are required to FIRE. */
+export interface SpecFrontmatter {
+  title?: string;
+  status?: string;
+  source?: SpecSource;
+  repo?: string;
+  role?: string;
+  skills?: string[];
+  acceptanceCriteria: string[];
+}
+
+/** Why a candidate file is NOT a fireable spec (logged, never thrown). */
+export type SpecParseReason =
+  | "no-frontmatter"
+  | "malformed-yaml"
+  | "not-object"
+  | "empty"
+  | "too-large"
+  | "binary"
+  | "unreadable";
+
+export type SpecParseResult =
+  | { kind: "spec"; frontmatter: SpecFrontmatter; body: string }
+  | { kind: "not-a-spec"; reason: SpecParseReason };
+
+/** The ready-gate decision (spec-as-task §3/§5). A spec fires ONLY when
+ *  `status: ready` AND acceptanceCriteria is non-empty. */
+export type ReadyGateReason =
+  | "not-a-spec"
+  | "draft"
+  | "no-acceptance-criteria"
+  | "status:in-progress"
+  | "status:done"
+  | "unknown-status";
+
+export type ReadyGateResult =
+  | { fire: true; frontmatter: SpecFrontmatter; body: string }
+  | { fire: false; reason: ReadyGateReason };
+
+// ─── Frontmatter parsing ───────────────────────────────────────────────────────
+
+/**
+ * Matches a leading YAML frontmatter block: `---\n<yaml>\n---\n<body>`.
+ * Tolerant of CRLF. The body is everything after the closing fence.
+ */
+const FRONTMATTER_RE = /^\uFEFF?---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n([\s\S]*))?$/;
+
+/** Coerce an unknown YAML value to a trimmed non-empty string, else undefined. */
+function asString(v: unknown): string | undefined {
+  if (typeof v !== "string") return undefined;
+  const t = v.trim();
+  return t.length > 0 ? t : undefined;
+}
+
+/** Coerce an unknown YAML value to a string[] (drops non-string / empty items). */
+function asStringArray(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  const out: string[] = [];
+  for (const item of v) {
+    const s = asString(item);
+    if (s !== undefined) out.push(s);
+  }
+  return out;
+}
+
+/** Coerce the `source` field to a SpecSource (best-effort; kind is required). */
+function asSource(v: unknown): SpecSource | undefined {
+  if (typeof v !== "object" || v === null || Array.isArray(v)) return undefined;
+  const rec = v as Record<string, unknown>;
+  const kind = asString(rec.kind);
+  if (kind === undefined) return undefined;
+  const source: SpecSource = { kind };
+  const ref = asString(rec.ref);
+  const url = asString(rec.url);
+  if (ref !== undefined) source.ref = ref;
+  if (url !== undefined) source.url = url;
+  return source;
+}
+
+/**
+ * Parse spec CONTENT (already read from disk) into `{ frontmatter, body }` or a
+ * safe not-a-spec result. Pure + synchronous; never throws (P1).
+ *
+ * `loadYaml` is injected so the module has ONE import site for js-yaml and tests
+ * can exercise the malformed-YAML path deterministically.
+ */
+export function parseSpecContent(
+  content: string,
+  loadYaml: (s: string) => unknown,
+): SpecParseResult {
+  if (content.length === 0) return { kind: "not-a-spec", reason: "empty" };
+  // Binary guard (P2): a NUL byte means this is not a text spec.
+  if (content.indexOf("\u0000") !== -1) return { kind: "not-a-spec", reason: "binary" };
+
+  const m = FRONTMATTER_RE.exec(content);
+  if (m === null) return { kind: "not-a-spec", reason: "no-frontmatter" };
+
+  const yamlText = m[1];
+  const body = (m[2] ?? "").replace(/^\r?\n/, ""); // drop the single leading blank line
+
+  let parsed: unknown;
+  try {
+    parsed = loadYaml(yamlText);
+  } catch {
+    // Malformed YAML ⇒ safe not-a-spec, NEVER a throw (P1).
+    return { kind: "not-a-spec", reason: "malformed-yaml" };
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return { kind: "not-a-spec", reason: "not-object" };
+  }
+
+  const rec = parsed as Record<string, unknown>;
+  const frontmatter: SpecFrontmatter = {
+    title: asString(rec.title),
+    status: asString(rec.status)?.toLowerCase(),
+    source: asSource(rec.source),
+    repo: asString(rec.repo),
+    role: asString(rec.role),
+    skills: asStringArray(rec.skills),
+    acceptanceCriteria: asStringArray(rec.acceptanceCriteria),
+  };
+  return { kind: "spec", frontmatter, body };
+}
+
+// ─── File reading (size + binary guarded) ──────────────────────────────────────
+
+/**
+ * Read a candidate spec file from disk and parse it. Guards size (P2) and any
+ * fs error (deleted/unreadable) → safe not-a-spec (P1). `readFile`/`statSize`
+ * are injected for testability; they default to the fs sync primitives.
+ */
+export function readSpecFile(
+  filePath: string,
+  loadYaml: (s: string) => unknown,
+  io: {
+    statSize?: (p: string) => number;
+    readFile?: (p: string) => string;
+  } = {},
+): SpecParseResult {
+  const statSize = io.statSize ?? ((p: string) => statSync(p).size);
+  const readFile = io.readFile ?? ((p: string) => readFileSync(p, "utf8"));
+  let size: number;
+  try {
+    size = statSize(filePath);
+  } catch {
+    return { kind: "not-a-spec", reason: "unreadable" };
+  }
+  if (size > SPEC_MAX_FILE_BYTES) return { kind: "not-a-spec", reason: "too-large" };
+
+  let content: string;
+  try {
+    content = readFile(filePath);
+  } catch {
+    return { kind: "not-a-spec", reason: "unreadable" };
+  }
+  return parseSpecContent(content, loadYaml);
+}
+
+// ─── Ready-gate (spec-as-task §3/§5) ────────────────────────────────────────────
+
+const RECOGNIZED_STATUSES = new Set(["draft", "ready", "in-progress", "done"]);
+
+/**
+ * Decide whether a parsed candidate FIRES a loop. Fires ONLY when
+ * `status: ready` AND acceptanceCriteria is non-empty. Every other outcome is a
+ * NO-OP with a specific, loggable reason (spec-as-task §5).
+ */
+export function evaluateReadyGate(parsed: SpecParseResult): ReadyGateResult {
+  if (parsed.kind === "not-a-spec") return { fire: false, reason: "not-a-spec" };
+
+  const { frontmatter, body } = parsed;
+  const status = frontmatter.status;
+
+  // A frontmatter block with no recognizable spec status is just a markdown doc
+  // with some metadata — not a spec envelope.
+  if (status === undefined || !RECOGNIZED_STATUSES.has(status)) {
+    return { fire: false, reason: status === undefined ? "not-a-spec" : "unknown-status" };
+  }
+
+  if (status === "draft") return { fire: false, reason: "draft" };
+  if (status === "in-progress") return { fire: false, reason: "status:in-progress" };
+  if (status === "done") return { fire: false, reason: "status:done" };
+
+  // status === "ready": REQUIRES non-empty acceptanceCriteria (the DoD the loop
+  // verifies against — no criteria ⇒ nothing to verify ⇒ not ready).
+  if (frontmatter.acceptanceCriteria.length === 0) {
+    return { fire: false, reason: "no-acceptance-criteria" };
+  }
+  return { fire: true, frontmatter, body };
+}
+
+// ─── Spec → engineerInstruction (the loop objective) ────────────────────────────
+
+const TRUNCATION_MARKER = "\n… [truncated]";
+
+/**
+ * Truncate a string to a UTF-8 byte budget, appending a marker when clamped. The
+ * marker is RESERVED WITHIN the budget so the returned string is never longer than
+ * `maxBytes` (the caller's budget math stays exact — see buildSpecInstruction H1).
+ */
+function clampBytes(s: string, maxBytes: number): string {
+  const buf = Buffer.from(s, "utf8");
+  if (buf.length <= maxBytes) return s;
+  const room = Math.max(0, maxBytes - Buffer.byteLength(TRUNCATION_MARKER, "utf8"));
+  // Slice on a byte boundary, then drop a possibly-broken trailing multibyte char.
+  const slice = buf.subarray(0, room).toString("utf8").replace(/\uFFFD+$/, "");
+  return `${slice}${TRUNCATION_MARKER}`;
+}
+
+/** UTF-8 byte length of a string. */
+function byteLen(s: string): number {
+  return Buffer.byteLength(s, "utf8");
+}
+
+/**
+ * Render the acceptance-criteria block, PACKING whole criteria under a byte budget
+ * (whole items dropped — never a criterion truncated mid-line — with a trailing
+ * "N omitted" note). Always keeps at least the first criterion. Each line is
+ * clamped to SPEC_CRITERION_MAX_BYTES and the count to SPEC_MAX_CRITERIA. This
+ * bounds the DoD independently so a spec with hundreds of criteria cannot blow the
+ * objective budget (L1) and drop the LATER criteria to a downstream clamp.
+ */
+function renderCriteria(acceptanceCriteria: string[], budgetBytes: number): string {
+  const capped = acceptanceCriteria.slice(0, SPEC_MAX_CRITERIA);
+  const lines: string[] = [];
+  let used = 0;
+  let dropped = 0;
+  for (let i = 0; i < capped.length; i++) {
+    const line = `- ${clampBytes(capped[i].trim(), SPEC_CRITERION_MAX_BYTES)}`;
+    const cost = byteLen(line) + 1; // + newline
+    if (lines.length > 0 && used + cost > budgetBytes) {
+      dropped = capped.length - i;
+      break;
+    }
+    lines.push(line);
+    used += cost;
+  }
+  const omitted = dropped > 0 ? `\n- … (${dropped} more criteria omitted to fit budget)` : "";
+  return lines.join("\n") + omitted;
+}
+
+/**
+ * Build the loop's `engineerInstruction` from a ready spec. The acceptance-criteria
+ * Definition-of-Done is emitted FIRST, then the human-authored spec body.
+ *
+ * WHY DoD-first (Security H1): the whole instruction rides the factory's
+ * `untrustedExtraBlock`, which HARD-CLAMPS to a byte budget by KEEPING THE HEAD and
+ * dropping the tail. A body-first layout would let a long spec body push the
+ * criteria — the contract the loop verifies against (§3) — off the end and out of
+ * the objective entirely. Emitting the DoD first (and budgeting the whole
+ * instruction under SPEC_INSTRUCTION_MAX_BYTES < the factory's 8 KiB objective
+ * clamp) guarantees the criteria ALWAYS reach the reviewers. The body then gets
+ * whatever budget remains (a minimum is reserved so context is never fully starved).
+ *
+ * `role`, when present, is surfaced as a one-line context header (it is NOT a
+ * skill id — see the dispatch note — so it never risks a skill-resolution throw).
+ */
+export function buildSpecInstruction(
+  body: string,
+  acceptanceCriteria: string[],
+  role?: string,
+): string {
+  const header = role ? `Role: ${clampBytes(role, 200)}\n\n` : "";
+  const open = "Definition of Done — every criterion must be satisfied and verified:\n```\n";
+  const close = "\n```\n\n## Spec\n";
+  const overhead = byteLen(header) + byteLen(open) + byteLen(close);
+
+  // Reserve a floor for the body so a criteria-heavy spec never fully starves the
+  // context, and cap the criteria block with the remainder of the budget.
+  const criteriaBudget = Math.max(
+    200,
+    SPEC_INSTRUCTION_MAX_BYTES - overhead - SPEC_BODY_MIN_BYTES,
+  );
+  const criteria = renderCriteria(acceptanceCriteria, criteriaBudget);
+
+  const fixed = `${header}${open}${criteria}${close}`;
+  const bodyBudget = Math.max(0, SPEC_INSTRUCTION_MAX_BYTES - byteLen(fixed));
+  const clampedBody = clampBytes(body.trim(), bodyBudget);
+
+  return `${fixed}${clampedBody}`;
+}
+
+// ─── Glob matching (dependency-free, anchored) ─────────────────────────────────
+
+/**
+ * Convert a repo-relative glob (e.g. a `docs/specs` recursive `.md` glob) to a RegExp that
+ * matches any ABSOLUTE path whose suffix satisfies the glob at a path boundary.
+ * Supports `**` (any path segments, incl. zero), `*` (within a segment), `?`
+ * (one non-separator char); every other char is matched literally. Anchored to a
+ * `/` boundary so `docs/specs/x.md` matches `/repo/docs/specs/x.md` but a glob is
+ * never matched mid-segment (e.g. `xdocs/specs`). Deterministic; no lib (P4).
+ */
+export function globToRegExp(glob: string): RegExp {
+  let re = "";
+  for (let i = 0; i < glob.length; i++) {
+    const ch = glob[i];
+    if (ch === "*") {
+      if (glob[i + 1] === "*") {
+        // `**` (optionally followed by `/`) → zero or more full path segments.
+        i++;
+        if (glob[i + 1] === "/") {
+          i++;
+          re += "(?:[^/]*/)*";
+        } else {
+          re += ".*";
+        }
+      } else {
+        re += "[^/]*";
+      }
+    } else if (ch === "?") {
+      re += "[^/]";
+    } else if ("\\^$.|+()[]{}".includes(ch)) {
+      re += `\\${ch}`;
+    } else {
+      re += ch;
+    }
+  }
+  // Match the glob as a suffix at a path boundary (start-of-string or a `/`).
+  return new RegExp(`(?:^|/)${re}$`);
+}
+
+/** True when `absPath` matches ANY of the repo-relative globs. */
+export function pathMatchesSpecGlobs(absPath: string, globs: readonly string[]): boolean {
+  const normalized = absPath.replace(/\\/g, "/");
+  for (const glob of globs) {
+    if (globToRegExp(glob).test(normalized)) return true;
+  }
+  return false;
+}

--- a/server/services/consilium/trigger-dispatch.ts
+++ b/server/services/consilium/trigger-dispatch.ts
@@ -70,7 +70,8 @@
  */
 import { existsSync, realpathSync } from "fs";
 import { createHash } from "crypto";
-import { dirname, join } from "path";
+import { basename, dirname, join, resolve } from "path";
+import { load as jsYamlLoad } from "js-yaml";
 import {
   CONSILIUM_LOOP_TERMINAL_STATES,
   type TriggerRow,
@@ -81,8 +82,15 @@ import type {
   ConsiliumReviewPreset,
   GitHubEventTriggerConfig,
   TriggerProvenance,
+  SpecProvenance,
 } from "@shared/types";
 import { mapGitHubEventToReview } from "./github-event-map.js";
+import {
+  readSpecFile,
+  evaluateReadyGate,
+  buildSpecInstruction,
+  pathMatchesSpecGlobs,
+} from "./spec-parser.js";
 import type {
   CreateConsiliumReviewDeps,
   CreateConsiliumReviewParams,
@@ -241,6 +249,16 @@ export interface ConsiliumTriggerDispatchDeps {
    * write. `firedAt` is the loop's provenance instant, threaded in for determinism.
    */
   recordFire: (triggerId: string, firedAt: Date) => Promise<void>;
+  /**
+   * SPEC-1 (spec-as-task.md §3): the spec-watch config accessor, or absent when the
+   * caller does not wire it (every existing test / non-route caller). Returns the
+   * ALREADY-master-gated view — the route folds `features.triggers.enabled` INTO
+   * `enabled` so a single boolean decides whether the spec pre-check runs. When
+   * absent OR `enabled === false`, `maybeLaunchConsiliumReview` skips the pre-check
+   * entirely and is BYTE-IDENTICAL to the pre-SPEC-1 dispatch. `allowedRepoPaths`
+   * is the consilium-loop repo allowlist (used to resolve a spec's `repo:` field).
+   */
+  specWatch?: () => { enabled: boolean; globs: string[]; allowedRepoPaths: string[] };
   /** Structured logger (the route passes `(m) => log(m, "triggers")`). */
   log: (message: string) => void;
 }
@@ -263,6 +281,23 @@ export async function maybeLaunchConsiliumReview(
   trigger: TriggerRow,
   payload: unknown,
 ): Promise<ConsiliumDispatchResult> {
+  // ── SPEC-1 pre-check (spec-as-task.md §3) ──────────────────────────────────
+  // A file_change whose changed file is under the spec globs (and spec-watch is
+  // enabled — already master-gated by the route) is parsed as a committed spec and
+  // routed to the spec path BEFORE the legacy action dispatch. This is the ONLY
+  // added surface on the off path: when `specWatch` is absent or disabled, or the
+  // changed file is not under the globs, control falls straight through and the
+  // dispatch is BYTE-IDENTICAL to before. A file that matches the globs is handled
+  // ENTIRELY by the spec path (fires or logs a reason) — it never also runs the
+  // legacy action, so a spec write can never double-launch.
+  const specCfg = deps.specWatch?.();
+  if (specCfg?.enabled && trigger.type === "file_change") {
+    const filePath = payloadString(payload, "filePath");
+    if (filePath && pathMatchesSpecGlobs(filePath, specCfg.globs)) {
+      return maybeLaunchSpecReview(deps, trigger, payload, filePath, specCfg.allowedRepoPaths);
+    }
+  }
+
   const config = trigger.config as LoopTemplateConfig;
   const action = config?.action;
   if (action?.kind !== "consilium_review") return "noop";
@@ -308,6 +343,153 @@ export async function maybeLaunchConsiliumReview(
   });
 }
 
+// ─── SPEC-1: spec-watch → consilium loop (spec-as-task.md §3) ──────────────────
+
+/** The default preset for a spec fire when the trigger action does not pin one. */
+const SPEC_DEFAULT_PRESET: ConsiliumReviewPreset = "sdlc-cross-review";
+
+/**
+ * Resolve a spec's `repo:` field to an ALLOWLISTED local path, fail-closed.
+ *   - No `repo:` field ⇒ the trigger's OWN repo (`derivedRepo`, from the watchPath).
+ *     May be undefined ⇒ the caller no-ops (no-repo).
+ *   - An absolute `repo:` whose realpath is within/equals an allowed root ⇒ that
+ *     canonical path.
+ *   - A slug/basename `repo:` that matches the basename of exactly one allowed root
+ *     ⇒ that allowed root.
+ *   - Anything else (a `repo:` that maps to no allowed root) ⇒ `null` (no-op + log).
+ *
+ * The factory RE-VALIDATES the returned path against the same allowlist (+ the
+ * project's workspaces), so this is a convenience resolver whose only failure mode
+ * is to reject — it can NEVER widen access beyond the allowlist.
+ */
+export function resolveSpecRepo(
+  repoField: string | undefined,
+  derivedRepo: string | undefined,
+  allowedRepoPaths: readonly string[],
+): string | null {
+  if (repoField === undefined || repoField.length === 0) {
+    return derivedRepo ?? null;
+  }
+  const allowedCanon = allowedRepoPaths.map((p) => ({ raw: p, canon: resolve(canonicalRepoPath(p)) }));
+
+  // Absolute path: accept iff its realpath is within/equal to an allowed root.
+  if (repoField.startsWith("/")) {
+    // M2 (defense-in-depth): realpathSync collapses `..` for an EXISTING path, but
+    // a non-existent path falls back to the RAW string with `..` intact — which
+    // could string-prefix-match an allowed root. `resolve` normalizes the traversal
+    // LEXICALLY so `/allowed/root/../../etc` can never prefix-match `/allowed/root/`.
+    const canonField = resolve(canonicalRepoPath(repoField));
+    for (const a of allowedCanon) {
+      if (canonField === a.canon || canonField.startsWith(a.canon + "/")) return canonField;
+    }
+    return null;
+  }
+
+  // Slug / basename: match the basename of exactly one allowed root.
+  const matches = allowedCanon.filter((a) => basename(a.canon) === repoField);
+  if (matches.length === 1) return matches[0].canon;
+  return null;
+}
+
+/**
+ * Parse a changed `docs/specs|adr` file as a committed spec and, IFF it is a
+ * `ready` spec with acceptance criteria, launch ONE consilium loop for it
+ * (spec-as-task.md §3). The caller has already confirmed the file is under the
+ * spec globs and spec-watch is enabled (master-gated). Every non-firing outcome is
+ * a logged NO-OP (never a throw): `draft` / `no-acceptance-criteria` / `not-a-spec`
+ * / `status:done` / `no-repo`. The loop is:
+ *   - `engineerInstruction` = the human-authored body + the acceptanceCriteria
+ *     rendered as an explicit, fenced Definition-of-Done (byte-bounded).
+ *   - `repoPath` = the spec's `repo:` resolved to an allowlisted path, else the
+ *     trigger's own repo (unresolvable ⇒ no-op).
+ *   - `skillIds` = the spec's explicit `skills` (the `role`, if any, is folded into
+ *     the instruction header — NOT passed as a skill id, so it can never trigger a
+ *     skill-resolution throw for a role that is not a registered skill).
+ *   - dedup keyed by the SPEC PATH (one active loop per spec).
+ *   - `triggerProvenance.spec = { specPath, source, status }`.
+ *
+ * Like every trigger path, the launch is FORCED review-only (maxRounds=1, T6) —
+ * an unattended file-system event never reaches the SDLC coder; escalation to
+ * develop is a human/UI action (SPEC-2+ boundary). Reuses the SAME
+ * `launchReviewWithDedup` owner/factory/T4 core as every other trigger.
+ */
+export async function maybeLaunchSpecReview(
+  deps: ConsiliumTriggerDispatchDeps,
+  trigger: TriggerRow,
+  payload: unknown,
+  filePath: string,
+  allowedRepoPaths: readonly string[],
+): Promise<ConsiliumDispatchResult> {
+  if (!deps.reviewDeps) {
+    deps.log(`spec-watch skipped for ${filePath} — consilium loop disabled`);
+    return "skipped";
+  }
+  const projectId = trigger.projectId;
+  if (!projectId) {
+    deps.log(`spec-watch skipped for ${filePath} — trigger has no projectId`);
+    return "skipped";
+  }
+
+  // Parse + ready-gate. readSpecFile is size/binary/error-guarded and NEVER throws,
+  // so a malformed/huge/binary/deleted file under the globs degrades to a no-op.
+  const parsed = readSpecFile(filePath, (s) => jsYamlLoad(s));
+  const gate = evaluateReadyGate(parsed);
+  if (!gate.fire) {
+    deps.log(`spec-watch no-op for ${filePath} — ${gate.reason}`);
+    return "skipped";
+  }
+  const { frontmatter, body } = gate;
+
+  // Resolve the target repo (spec `repo:` → allowlisted path, else the trigger's own).
+  const config = trigger.config as LoopTemplateConfig;
+  const watchPath = payloadString(payload, "watchPath") ?? config?.watchPath;
+  const repoPath = resolveSpecRepo(frontmatter.repo, deriveRepoRoot(watchPath), allowedRepoPaths);
+  if (repoPath === null) {
+    deps.log(`spec-watch no-op for ${filePath} — no-repo (repo="${frontmatter.repo ?? ""}")`);
+    return "skipped";
+  }
+
+  const engineerInstruction = buildSpecInstruction(
+    body,
+    frontmatter.acceptanceCriteria,
+    frontmatter.role,
+  );
+  // ACCEPTED for SPEC-1 (M1): a skill id the factory cannot resolve project-scoped
+  // THROWS → the launch is caught (T4) and returns "failed" (fail-closed, no
+  // cross-tenant leak). SPEC-1 is HUMAN-AUTHORED specs only (no connectors — TRACK-1),
+  // so the operator owns these ids and a typo failing visibly is acceptable; graceful
+  // "drop unknown skill" is deferred to the connector-fed path (a synthesised spec).
+  const skillIds =
+    frontmatter.skills && frontmatter.skills.length > 0 ? frontmatter.skills : undefined;
+  const preset = config?.action?.preset ?? SPEC_DEFAULT_PRESET;
+
+  // The spec title is UNTRUSTED (frontmatter): single-line + clamp before it becomes
+  // the inert provenance passport label (never a prompt/shell sink — display only).
+  const titleLabel = (frontmatter.title ?? basename(filePath))
+    .replace(/[\u0000-\u001f\u007f]+/g, " ")
+    .trim()
+    .slice(0, 120);
+
+  return launchReviewWithDedup(deps, trigger, {
+    projectId,
+    repoPath,
+    preset,
+    engineerInstruction,
+    skillIds,
+    // Per-spec dedup (NOT per-repo) — two specs in one repo each fire their own loop.
+    specDedupKey: filePath,
+    specProvenance: {
+      specPath: filePath,
+      status: frontmatter.status ?? "ready",
+      ...(frontmatter.source ? { source: frontmatter.source } : {}),
+    },
+    // H2: use the SANITIZED title (single-line, control-stripped, length-clamped) —
+    // NOT the raw frontmatter title — for the inert provenance passport label.
+    eventSummary: `spec ready: ${titleLabel}`,
+    payload,
+  });
+}
+
 /**
  * The launch plan the shared core turns into a factory call. `preset`/`repoPath`
  * are already chosen by the caller (the action's for file_change/schedule; the
@@ -326,6 +508,22 @@ export interface ReviewLaunchPlan {
   engineerInstruction?: string;
   objectiveExtra?: string;
   eventSummary?: string;
+  /**
+   * SPEC-1: operator/spec-selected skill ids, resolved PROJECT-SCOPED inside the
+   * factory (a foreign id throws → "failed", caught by T4). Absent for every
+   * non-spec path (byte-identical). The spec path passes `frontmatter.skills`.
+   */
+  skillIds?: string[];
+  /**
+   * SPEC-1 (spec-as-task.md §3): when set, the dedup key is the SPEC PATH — dedup
+   * matches an active loop by `triggerProvenance.spec.specPath === specDedupKey`,
+   * NOT by repoPath. This is what lets TWO distinct specs in the SAME repo each
+   * fire their own loop (per-spec dedup, not per-repo). Absent ⇒ the historical
+   * per-repoPath dedup (unchanged for every non-spec fire).
+   */
+  specDedupKey?: string;
+  /** SPEC-1: spec origin folded into the loop's provenance (`{specPath,source,status}`). */
+  specProvenance?: SpecProvenance;
   payload: unknown;
 }
 
@@ -362,10 +560,16 @@ export async function launchReviewWithDedup(
     eventDigest: eventDigest(plan.payload),
     firedAt: firedAt.toISOString(),
     ...(plan.eventSummary ? { eventSummary: plan.eventSummary } : {}),
+    // SPEC-1 (§3): carry the spec origin so the per-spec dedup below and a future
+    // write-back can find it. Inert jsonb; never a prompt/shell sink.
+    ...(plan.specProvenance ? { spec: plan.specProvenance } : {}),
   };
 
   // T5: dedup key — match against the CANONICAL path the factory persists.
   const resolvedRepo = canonicalRepoPath(plan.repoPath);
+  // SPEC-1: a spec fire dedups on the SPEC PATH (one active loop per spec), NOT the
+  // repo — so two distinct specs in the same repo each fire their own loop.
+  const specDedupKey = plan.specDedupKey;
 
   // FK FIX: a trigger-launched review has no `req.user`. Resolve the PROJECT OWNER
   // (a real `users.id`). Inside the try so a lookup throw is caught (T4) rather
@@ -387,11 +591,16 @@ export async function launchReviewWithDedup(
       // a spec-write burst) must not fan out into unbounded heavy-model disputes.
       // (The explicit UI endpoint calls the factory directly and is NOT deduped.)
       const existing = await reviewDeps.storage.getLoops();
-      const active = existing.find(
-        (l) =>
-          !TERMINAL_LOOP_STATES.has(l.state) &&
-          (l.repoPath === resolvedRepo || l.repoPath === plan.repoPath),
-      );
+      const active = existing.find((l) => {
+        if (TERMINAL_LOOP_STATES.has(l.state)) return false;
+        // SPEC-1: a spec fire dedups PURELY on the spec path (a distinct spec, even
+        // in the same repo, is a DIFFERENT unit of work → its own loop). A non-spec
+        // fire keeps the historical per-repoPath dedup.
+        if (specDedupKey !== undefined) {
+          return l.triggerProvenance?.spec?.specPath === specDedupKey;
+        }
+        return l.repoPath === resolvedRepo || l.repoPath === plan.repoPath;
+      });
       if (active) {
         dedupLoopId = active.id;
         return null; // signal: deduped, do NOT launch the factory
@@ -401,6 +610,9 @@ export async function launchReviewWithDedup(
         projectId: plan.projectId,
         repoPath: plan.repoPath,
         preset: plan.preset,
+        // SPEC-1: spec-selected skills (resolved project-scoped in the factory);
+        // undefined for every non-spec path (byte-identical).
+        skillIds: plan.skillIds,
         // FK FIX: real `users.id` (project owner), NOT the literal "system".
         createdBy,
         // T6 (FIX MED-2): FORCE review-only on EVERY trigger path. An unattended,
@@ -420,7 +632,9 @@ export async function launchReviewWithDedup(
 
     if (loop === null) {
       deps.log(
-        `review skipped-dedup for trigger ${trigger.id} — active loop ${dedupLoopId} already running for ${resolvedRepo}`,
+        specDedupKey !== undefined
+          ? `review skipped-dedup:spec for trigger ${trigger.id} — active loop ${dedupLoopId} already running for spec ${specDedupKey}`
+          : `review skipped-dedup for trigger ${trigger.id} — active loop ${dedupLoopId} already running for ${resolvedRepo}`,
       );
       // WATERMARK DISCIPLINE: a dedup-suppressed fire must NOT touch lastFiredAt /
       // firedCount — the caller counts it via `incrementTriggerSuppressed` instead.

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1477,6 +1477,27 @@ export interface TriggerProvenance {
    * prompt/shell sink.
    */
   eventSummary?: string;
+  /**
+   * SPEC-1 (spec-as-task.md §3): present when the loop was fired by the spec-watch
+   * (a `docs/specs|adr` file transitioning to `status: ready`). Carries the ORIGIN
+   * of the spec so the SPEC dedup key (one active loop per spec path) and a future
+   * write-back (SPEC-2+: status flip / ticket write-back) can find it. Persisted
+   * INERT as jsonb; never a prompt/shell sink. Absent for every non-spec fire.
+   */
+  spec?: SpecProvenance;
+}
+
+/**
+ * SPEC-1 provenance recorded on a spec-fired consilium loop (spec-as-task.md §3).
+ * `specPath` is the ABSOLUTE path of the committed spec that fired the loop — it
+ * is the DEDUP KEY (one active loop per spec path) and the anchor a future
+ * write-back keys off. `source` is the spec's declared origin ({kind, ref?, url?})
+ * for auditability; `status` is the spec status at fire time (`ready`). All inert.
+ */
+export interface SpecProvenance {
+  specPath: string;
+  status: string;
+  source?: { kind: string; ref?: string; url?: string };
 }
 
 export type TriggerConfig =

--- a/tests/unit/consilium/spec-parser.test.ts
+++ b/tests/unit/consilium/spec-parser.test.ts
@@ -1,0 +1,262 @@
+/**
+ * spec-parser.test.ts — unit coverage for the SPEC-1 spec parser + ready-gate
+ * (server/services/consilium/spec-parser.ts, spec-as-task.md §2/§3/§5).
+ *
+ * Pure/synchronous surface: frontmatter parse, the ready-gate reasons, the
+ * body+DoD instruction builder, and the dependency-free glob matcher. YAML is
+ * injected (js-yaml) so the malformed path is deterministic and NEVER throws.
+ */
+import { describe, it, expect } from "vitest";
+import { load as jsYamlLoad } from "js-yaml";
+import {
+  parseSpecContent,
+  readSpecFile,
+  evaluateReadyGate,
+  buildSpecInstruction,
+  pathMatchesSpecGlobs,
+  globToRegExp,
+  SPEC_INSTRUCTION_MAX_BYTES,
+  SPEC_MAX_FILE_BYTES,
+} from "../../../server/services/consilium/spec-parser.js";
+
+const load = (s: string) => jsYamlLoad(s);
+
+const READY_SPEC = `---
+title: "Add rate limiting"
+status: ready
+source: { kind: human, ref: "chat-42" }
+repo: omnius
+role: backend
+skills: [security-review, api-design]
+acceptanceCriteria:
+  - "When a client exceeds 100 req/min Then requests are 429'd"
+  - "When the window resets Then the client can call again"
+---
+## Problem
+The login endpoint has no rate limit.
+
+## Scope
+Add a token-bucket limiter to the auth router.
+`;
+
+// ─── parseSpecContent ──────────────────────────────────────────────────────────
+
+describe("parseSpecContent", () => {
+  it("parses a well-formed spec into frontmatter + body (type-coerced)", () => {
+    const r = parseSpecContent(READY_SPEC, load);
+    expect(r.kind).toBe("spec");
+    if (r.kind !== "spec") return;
+    expect(r.frontmatter.title).toBe("Add rate limiting");
+    expect(r.frontmatter.status).toBe("ready");
+    expect(r.frontmatter.source).toEqual({ kind: "human", ref: "chat-42" });
+    expect(r.frontmatter.repo).toBe("omnius");
+    expect(r.frontmatter.role).toBe("backend");
+    expect(r.frontmatter.skills).toEqual(["security-review", "api-design"]);
+    expect(r.frontmatter.acceptanceCriteria).toHaveLength(2);
+    expect(r.body).toMatch(/^## Problem/);
+    expect(r.body).toMatch(/token-bucket limiter/);
+  });
+
+  it("lowercases status and drops non-string skills/criteria defensively", () => {
+    const r = parseSpecContent(
+      `---\nstatus: READY\nskills: [ok, 42, null]\nacceptanceCriteria: ["c1", 7]\n---\nbody`,
+      load,
+    );
+    expect(r.kind).toBe("spec");
+    if (r.kind !== "spec") return;
+    expect(r.frontmatter.status).toBe("ready");
+    expect(r.frontmatter.skills).toEqual(["ok"]);
+    expect(r.frontmatter.acceptanceCriteria).toEqual(["c1"]);
+  });
+
+  it("returns not-a-spec (no-frontmatter) for a plain markdown file", () => {
+    const r = parseSpecContent("# Just a doc\n\nno frontmatter here", load);
+    expect(r).toEqual({ kind: "not-a-spec", reason: "no-frontmatter" });
+  });
+
+  it("returns not-a-spec (malformed-yaml) WITHOUT throwing on broken YAML", () => {
+    const broken = `---\nstatus: ready\n  bad: : indent: [\n---\nbody`;
+    expect(() => parseSpecContent(broken, load)).not.toThrow();
+    expect(parseSpecContent(broken, load)).toEqual({ kind: "not-a-spec", reason: "malformed-yaml" });
+  });
+
+  it("returns not-a-spec (not-object) when the frontmatter is a scalar/array", () => {
+    expect(parseSpecContent(`---\njust a string\n---\nbody`, load).kind).toBe("not-a-spec");
+    expect(parseSpecContent(`---\n- a\n- b\n---\nbody`, load)).toEqual({
+      kind: "not-a-spec",
+      reason: "not-object",
+    });
+  });
+
+  it("returns not-a-spec (empty) for empty content and (binary) for NUL content", () => {
+    expect(parseSpecContent("", load)).toEqual({ kind: "not-a-spec", reason: "empty" });
+    expect(parseSpecContent("---\nstatus: ready\n---\n\u0000\u0001bin", load)).toEqual({
+      kind: "not-a-spec",
+      reason: "binary",
+    });
+  });
+});
+
+// ─── readSpecFile (size/error guarded, injected io) ────────────────────────────
+
+describe("readSpecFile", () => {
+  it("rejects an oversized file as not-a-spec (too-large), never reading it", () => {
+    let read = false;
+    const r = readSpecFile("/x/big.md", load, {
+      statSize: () => SPEC_MAX_FILE_BYTES + 1,
+      readFile: () => {
+        read = true;
+        return "";
+      },
+    });
+    expect(r).toEqual({ kind: "not-a-spec", reason: "too-large" });
+    expect(read).toBe(false);
+  });
+
+  it("degrades a stat/read error to not-a-spec (unreadable), never throwing", () => {
+    const r = readSpecFile("/gone.md", load, {
+      statSize: () => {
+        throw new Error("ENOENT");
+      },
+    });
+    expect(r).toEqual({ kind: "not-a-spec", reason: "unreadable" });
+  });
+
+  it("parses a readable file through the same path as parseSpecContent", () => {
+    const r = readSpecFile("/x/spec.md", load, {
+      statSize: () => READY_SPEC.length,
+      readFile: () => READY_SPEC,
+    });
+    expect(r.kind).toBe("spec");
+  });
+});
+
+// ─── evaluateReadyGate (spec-as-task §3/§5) ────────────────────────────────────
+
+describe("evaluateReadyGate", () => {
+  const gate = (content: string) => evaluateReadyGate(parseSpecContent(content, load));
+
+  it("FIRES only for status:ready WITH non-empty acceptanceCriteria", () => {
+    const r = gate(READY_SPEC);
+    expect(r.fire).toBe(true);
+    if (!r.fire) return;
+    expect(r.frontmatter.acceptanceCriteria.length).toBeGreaterThan(0);
+  });
+
+  it("draft → no-op(draft)", () => {
+    expect(gate(`---\nstatus: draft\nacceptanceCriteria: ["c"]\n---\nb`)).toEqual({
+      fire: false,
+      reason: "draft",
+    });
+  });
+
+  it("in-progress → no-op(status:in-progress); done → no-op(status:done)", () => {
+    expect(gate(`---\nstatus: in-progress\nacceptanceCriteria: ["c"]\n---\nb`)).toEqual({
+      fire: false,
+      reason: "status:in-progress",
+    });
+    expect(gate(`---\nstatus: done\nacceptanceCriteria: ["c"]\n---\nb`)).toEqual({
+      fire: false,
+      reason: "status:done",
+    });
+  });
+
+  it("ready but NO acceptanceCriteria → no-op(no-acceptance-criteria) — NEVER fires", () => {
+    expect(gate(`---\nstatus: ready\n---\nb`)).toEqual({
+      fire: false,
+      reason: "no-acceptance-criteria",
+    });
+    expect(gate(`---\nstatus: ready\nacceptanceCriteria: []\n---\nb`)).toEqual({
+      fire: false,
+      reason: "no-acceptance-criteria",
+    });
+  });
+
+  it("frontmatter with no status → not-a-spec; unknown status → unknown-status", () => {
+    expect(gate(`---\ntitle: x\nacceptanceCriteria: ["c"]\n---\nb`)).toEqual({
+      fire: false,
+      reason: "not-a-spec",
+    });
+    expect(gate(`---\nstatus: wip\nacceptanceCriteria: ["c"]\n---\nb`)).toEqual({
+      fire: false,
+      reason: "unknown-status",
+    });
+  });
+
+  it("a not-a-spec parse → no-op(not-a-spec)", () => {
+    expect(evaluateReadyGate({ kind: "not-a-spec", reason: "no-frontmatter" })).toEqual({
+      fire: false,
+      reason: "not-a-spec",
+    });
+  });
+});
+
+// ─── buildSpecInstruction ──────────────────────────────────────────────────────
+
+describe("buildSpecInstruction", () => {
+  it("renders the fenced Definition-of-Done from the criteria + the body", () => {
+    const out = buildSpecInstruction("The body.", ["do X", "do Y"]);
+    expect(out).toContain("The body.");
+    expect(out).toContain("Definition of Done — every criterion must be satisfied and verified:");
+    expect(out).toContain("- do X");
+    expect(out).toContain("- do Y");
+    // The DoD list is fenced.
+    expect(out).toMatch(/```[\s\S]*- do X[\s\S]*```/);
+  });
+
+  it("emits the DoD BEFORE the body (H1: survives a downstream head-keeping clamp)", () => {
+    const out = buildSpecInstruction("BODY_MARKER", ["CRIT_MARKER"]);
+    expect(out.indexOf("CRIT_MARKER")).toBeLessThan(out.indexOf("BODY_MARKER"));
+  });
+
+  it("surfaces the role as a header line (NOT a skill id)", () => {
+    expect(buildSpecInstruction("b", ["c"], "backend")).toMatch(/^Role: backend/);
+  });
+
+  it("H1: a HUGE body cannot push the criteria out — DoD survives, total < the factory clamp", () => {
+    const huge = "x".repeat(SPEC_INSTRUCTION_MAX_BYTES * 4);
+    const out = buildSpecInstruction(huge, ["keep-me-1", "keep-me-2"]);
+    // The whole instruction stays UNDER the 8 KiB factory objective clamp, so it is
+    // never itself truncated downstream (criteria always reach the reviewers).
+    expect(Buffer.byteLength(out, "utf8")).toBeLessThanOrEqual(SPEC_INSTRUCTION_MAX_BYTES);
+    expect(out).toContain("[truncated]"); // the BODY is what gets clamped
+    expect(out).toContain("- keep-me-1");
+    expect(out).toContain("- keep-me-2");
+  });
+
+  it("L1: hundreds of large criteria are packed under budget with an 'omitted' note", () => {
+    const many = Array.from({ length: 300 }, (_, i) => `criterion-${i} ` + "y".repeat(500));
+    const out = buildSpecInstruction("body", many);
+    expect(Buffer.byteLength(out, "utf8")).toBeLessThanOrEqual(SPEC_INSTRUCTION_MAX_BYTES);
+    expect(out).toContain("- criterion-0"); // the first is always kept
+    expect(out).toMatch(/more criteria omitted to fit budget/);
+  });
+});
+
+// ─── glob matching (dependency-free) ───────────────────────────────────────────
+
+describe("pathMatchesSpecGlobs / globToRegExp", () => {
+  const globs = ["docs/specs/**/*.md", "docs/adr/**/*.md"];
+
+  it("matches specs/ADRs at any depth under an absolute path", () => {
+    expect(pathMatchesSpecGlobs("/repo/docs/specs/foo.md", globs)).toBe(true);
+    expect(pathMatchesSpecGlobs("/repo/docs/specs/sub/dir/bar.md", globs)).toBe(true);
+    expect(pathMatchesSpecGlobs("/repo/docs/adr/0001-x.md", globs)).toBe(true);
+  });
+
+  it("does NOT match non-.md, sibling dirs, or mid-segment collisions", () => {
+    expect(pathMatchesSpecGlobs("/repo/docs/specs/readme.txt", globs)).toBe(false);
+    expect(pathMatchesSpecGlobs("/repo/docs/notes.md", globs)).toBe(false);
+    expect(pathMatchesSpecGlobs("/repo/xdocs/specs/foo.md", globs)).toBe(false);
+    expect(pathMatchesSpecGlobs("/repo/docs/specsX/foo.md", globs)).toBe(false);
+  });
+
+  it("normalizes windows separators", () => {
+    expect(pathMatchesSpecGlobs("C:\\r\\docs\\specs\\a.md", globs)).toBe(true);
+  });
+
+  it("globToRegExp: ** spans zero segments; * stays within a segment", () => {
+    expect(globToRegExp("docs/specs/**/*.md").test("/r/docs/specs/a.md")).toBe(true);
+    expect(globToRegExp("a/*.md").test("/r/a/b/c.md")).toBe(false); // * is not /
+  });
+});

--- a/tests/unit/consilium/spec-watch-dispatch.test.ts
+++ b/tests/unit/consilium/spec-watch-dispatch.test.ts
@@ -1,0 +1,330 @@
+/**
+ * spec-watch-dispatch.test.ts — SPEC-1 (spec-as-task.md §3): the spec-watch seam
+ * in server/services/consilium/trigger-dispatch.ts.
+ *
+ * The factory is INJECTED (`createReview`) so we assert the ready-gate, the
+ * spec→loop mapping (body + fenced DoD → engineerInstruction), the SPEC provenance,
+ * the PER-SPEC dedup (vs the existing per-repo), and the kill-switch OFF byte-
+ * identity — all WITHOUT a DB / Express / ALS. Real temp files exercise the
+ * size/binary/error guards of the on-disk parser.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, writeSync, openSync, closeSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { TriggerRow, ConsiliumLoopRow } from "@shared/schema";
+import {
+  maybeLaunchConsiliumReview,
+  maybeLaunchSpecReview,
+  resolveSpecRepo,
+  type ConsiliumTriggerDispatchDeps,
+} from "../../../server/services/consilium/trigger-dispatch.js";
+
+// ─── On-disk fixtures ──────────────────────────────────────────────────────────
+
+let root: string; // <tmp>
+let specsDir: string; // <tmp>/docs/specs
+
+function specFile(name: string, content: string): string {
+  const p = join(specsDir, name);
+  writeFileSync(p, content, "utf8");
+  return p;
+}
+
+const READY = `---
+title: "Rate limit login"
+status: ready
+source: { kind: human, ref: "chat-7" }
+skills: [security-review]
+acceptanceCriteria:
+  - "When >100 req/min Then 429"
+---
+## Problem
+No limiter on /login.
+`;
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "spec-watch-"));
+  specsDir = join(root, "docs", "specs");
+  mkdirSync(specsDir, { recursive: true });
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+// ─── Deps / trigger fixtures (mirror trigger-dispatch.test.ts) ─────────────────
+
+const DEFAULT_GLOBS = ["docs/specs/**/*.md", "docs/adr/**/*.md"];
+
+function makeTrigger(over: Partial<TriggerRow> = {}): TriggerRow {
+  return {
+    id: "trig-1",
+    projectId: "proj-1",
+    pipelineId: null,
+    type: "file_change",
+    config: { watchPath: specsDir, patterns: ["**/*.md"] },
+    ...over,
+  } as unknown as TriggerRow;
+}
+
+function makeDeps(
+  over: Partial<ConsiliumTriggerDispatchDeps> = {},
+  loops: ConsiliumLoopRow[] = [],
+  specWatch: { enabled: boolean; globs: string[]; allowedRepoPaths: string[] } | undefined = {
+    enabled: true,
+    globs: DEFAULT_GLOBS,
+    allowedRepoPaths: [],
+  },
+) {
+  const createReview = vi
+    .fn()
+    .mockImplementation((_deps, params) =>
+      Promise.resolve({ id: "loop-new", repoPath: params.repoPath, state: "reviewing" } as ConsiliumLoopRow),
+    );
+  const runInProject = vi.fn().mockImplementation((_pid: string, fn: () => Promise<unknown>) => fn());
+  const log = vi.fn();
+  const getLoops = vi.fn().mockResolvedValue(loops);
+  const resolveOwnerId = vi.fn().mockResolvedValue("owner-1");
+  const recordFire = vi.fn().mockResolvedValue(undefined);
+  const deps: ConsiliumTriggerDispatchDeps = {
+    reviewDeps: { storage: { getLoops } } as unknown as ConsiliumTriggerDispatchDeps["reviewDeps"],
+    createReview,
+    runInProject,
+    resolveOwnerId,
+    recordFire,
+    specWatch: specWatch ? () => specWatch : undefined,
+    log,
+    ...over,
+  };
+  return { deps, createReview, runInProject, log, getLoops, recordFire };
+}
+
+/** An in-flight loop that carries SPEC provenance for a given spec path. */
+function activeSpecLoop(specPath: string, repoPath: string): ConsiliumLoopRow {
+  return {
+    id: `loop-${specPath}`,
+    state: "reviewing",
+    repoPath,
+    triggerProvenance: { spec: { specPath } },
+  } as unknown as ConsiliumLoopRow;
+}
+
+// ─── resolveSpecRepo (pure) ────────────────────────────────────────────────────
+
+describe("resolveSpecRepo", () => {
+  it("no repo field → the trigger's own (derived) repo", () => {
+    expect(resolveSpecRepo(undefined, "/repo/omnius", [])).toBe("/repo/omnius");
+    expect(resolveSpecRepo(undefined, undefined, [])).toBeNull();
+  });
+
+  it("a slug matching exactly one allowlisted basename resolves to that root", () => {
+    expect(resolveSpecRepo("omnius", "/x", ["/allowed/omnius"])).toBe("/allowed/omnius");
+  });
+
+  it("an unresolvable slug/path → null (fail-closed, factory never widens)", () => {
+    expect(resolveSpecRepo("ghost", "/x", ["/allowed/omnius"])).toBeNull();
+    expect(resolveSpecRepo("/evil/path", "/x", ["/allowed/omnius"])).toBeNull();
+  });
+
+  it("M2: an absolute `..` traversal is normalized and CANNOT prefix-match an allowed root", () => {
+    // Without lexical normalization "/allowed/omnius/../../etc" would string-prefix
+    // "/allowed/omnius/"; `resolve` collapses it to "/etc" → rejected.
+    expect(resolveSpecRepo("/allowed/omnius/../../etc/x", "/x", ["/allowed/omnius"])).toBeNull();
+  });
+});
+
+// ─── maybeLaunchSpecReview — the ready-gate + mapping ──────────────────────────
+
+describe("maybeLaunchSpecReview — ready gate", () => {
+  it("a READY spec FIRES: body + fenced DoD → engineerInstruction, spec provenance, review-only", async () => {
+    const p = specFile("ready.md", READY);
+    const { deps, createReview, recordFire } = makeDeps();
+    const result = await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: specsDir }, p, ["/whatever"]);
+
+    expect(result).toBe("launched");
+    expect(createReview).toHaveBeenCalledTimes(1);
+    const [, params] = createReview.mock.calls[0];
+    // engineerInstruction = body + explicit fenced Definition of Done.
+    expect(params.engineerInstruction).toContain("No limiter on /login.");
+    expect(params.engineerInstruction).toContain("Definition of Done — every criterion must be satisfied and verified:");
+    expect(params.engineerInstruction).toContain("- When >100 req/min Then 429");
+    // provenance carries {specPath, source, status} for the future write-back.
+    expect(params.triggerProvenance.spec).toEqual({
+      specPath: p,
+      status: "ready",
+      source: { kind: "human", ref: "chat-7" },
+    });
+    // T6: forced review-only — an fs event never reaches the SDLC coder.
+    expect(params.maxRounds).toBe(1);
+    // Explicit skills pass through to the factory.
+    expect(params.skillIds).toEqual(["security-review"]);
+    // repoPath falls back to the trigger's own repo (no `repo:` in the spec).
+    expect(params.repoPath).toBe(specsDir);
+    expect(recordFire).toHaveBeenCalledTimes(1);
+  });
+
+  it("a DRAFT spec → no-op(draft), factory NOT called", async () => {
+    const p = specFile("draft.md", `---\nstatus: draft\nsource: {kind: human}\nacceptanceCriteria: ["c"]\n---\nb`);
+    const { deps, createReview, log } = makeDeps();
+    expect(await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: specsDir }, p, [])).toBe("skipped");
+    expect(createReview).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/no-op.*draft/));
+  });
+
+  it("READY but NO acceptanceCriteria → no-op(no-acceptance-criteria), NEVER fires", async () => {
+    const p = specFile("no-crit.md", `---\nstatus: ready\nsource: {kind: human}\n---\nb`);
+    const { deps, createReview, log } = makeDeps();
+    expect(await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: specsDir }, p, [])).toBe("skipped");
+    expect(createReview).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/no-acceptance-criteria/));
+  });
+
+  it("a non-spec .md → no-op(not-a-spec)", async () => {
+    const p = specFile("plain.md", `# Just docs\n\nno frontmatter`);
+    const { deps, createReview, log } = makeDeps();
+    expect(await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: specsDir }, p, [])).toBe("skipped");
+    expect(createReview).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/not-a-spec/));
+  });
+
+  it("malformed frontmatter → no-op, NEVER throws", async () => {
+    const p = specFile("bad.md", `---\nstatus: ready\n bad: : [\n---\nb`);
+    const { deps, createReview } = makeDeps();
+    let result: string | undefined;
+    await expect(
+      (async () => {
+        result = await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: specsDir }, p, []);
+      })(),
+    ).resolves.not.toThrow();
+    expect(result).toBe("skipped");
+    expect(createReview).not.toHaveBeenCalled();
+  });
+
+  it("a HUGE + a BINARY file under the globs → no-op, watcher never crashes", async () => {
+    const big = specFile("huge.md", `---\nstatus: ready\n---\n` + "x".repeat(600 * 1024));
+    const binPath = join(specsDir, "bin.md");
+    const fd = openSync(binPath, "w");
+    writeSync(fd, Buffer.from([0x2d, 0x2d, 0x2d, 0x0a, 0x00, 0x01, 0x02, 0x0a]));
+    closeSync(fd);
+    const { deps, createReview } = makeDeps();
+    expect(await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: specsDir }, big, [])).toBe("skipped");
+    expect(await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: specsDir }, binPath, [])).toBe("skipped");
+    expect(createReview).not.toHaveBeenCalled();
+  });
+
+  it("H2: a hostile spec title is single-lined + clamped in the provenance eventSummary", async () => {
+    const nasty = `---\ntitle: "a\\nb\\tc ${"Z".repeat(300)}"\nstatus: ready\nsource: {kind: human}\nacceptanceCriteria: ["c"]\n---\nbody`;
+    const p = specFile("nasty-title.md", nasty);
+    const { deps, createReview } = makeDeps();
+    await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: specsDir }, p, []);
+    const summary = createReview.mock.calls[0][1].triggerProvenance.eventSummary as string;
+    expect(summary).not.toMatch(/[\n\t]/); // control chars stripped to single line
+    expect(summary.length).toBeLessThanOrEqual("spec ready: ".length + 120);
+    expect(summary).toMatch(/^spec ready: a b c/);
+  });
+
+  it("a spec `repo:` that resolves to NO allowlisted path → no-op(no-repo)", async () => {
+    const p = specFile("ghost-repo.md", `---\nstatus: ready\nrepo: ghost\nsource: {kind: human}\nacceptanceCriteria: ["c"]\n---\nb`);
+    const { deps, createReview, log } = makeDeps();
+    const result = await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: specsDir }, p, ["/allowed/omnius"]);
+    expect(result).toBe("skipped");
+    expect(createReview).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/no-repo/));
+  });
+});
+
+// ─── PER-SPEC dedup (the SPEC-1 headline vs the per-repo dedup) ─────────────────
+
+describe("maybeLaunchSpecReview — per-SPEC dedup", () => {
+  it("TWO distinct specs in the SAME repo each fire their OWN loop (not collapsed)", async () => {
+    const spec1 = specFile("s1.md", READY);
+    const spec2 = specFile("s2.md", READY.replace("Rate limit login", "Add audit log"));
+
+    // spec1 already has an ACTIVE loop; firing spec2 (same repoPath) must still launch —
+    // the per-repo dedup would WRONGLY collapse these; the per-spec key does not.
+    const { deps, createReview } = makeDeps({}, [activeSpecLoop(spec1, specsDir)]);
+    const result = await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: specsDir }, spec2, []);
+
+    expect(result).toBe("launched");
+    expect(createReview).toHaveBeenCalledTimes(1);
+    expect(createReview.mock.calls[0][1].triggerProvenance.spec.specPath).toBe(spec2);
+  });
+
+  it("the SAME spec fired again while its loop is ACTIVE → one loop (skipped-dedup:spec)", async () => {
+    const spec1 = specFile("s1b.md", READY);
+    const { deps, createReview, log, recordFire } = makeDeps({}, [activeSpecLoop(spec1, specsDir)]);
+    const result = await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: specsDir }, spec1, []);
+
+    expect(result).toBe("skipped-dedup");
+    expect(createReview).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/skipped-dedup:spec/));
+    // A dedup-suppressed fire does NOT record a fire (watermark discipline).
+    expect(recordFire).not.toHaveBeenCalled();
+  });
+
+  it("a TERMINAL loop for the same spec does NOT block a re-fire", async () => {
+    const spec1 = specFile("s1c.md", READY);
+    const terminal = { ...activeSpecLoop(spec1, specsDir), state: "converged" } as ConsiliumLoopRow;
+    const { deps, createReview } = makeDeps({}, [terminal]);
+    expect(await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: specsDir }, spec1, [])).toBe("launched");
+    expect(createReview).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── Kill-switch + glob routing via maybeLaunchConsiliumReview ──────────────────
+
+describe("maybeLaunchConsiliumReview — spec pre-check routing", () => {
+  it("kill-switch OFF → spec pre-check skipped; an action-less file_change stays noop (byte-identical)", async () => {
+    const p = specFile("ready-off.md", READY);
+    const { deps, createReview } = makeDeps({}, [], { enabled: false, globs: DEFAULT_GLOBS, allowedRepoPaths: [] });
+    const result = await maybeLaunchConsiliumReview(deps, makeTrigger(), { filePath: p, watchPath: specsDir });
+    expect(result).toBe("noop"); // legacy path: no action ⇒ record-only no-op
+    expect(createReview).not.toHaveBeenCalled();
+  });
+
+  it("spec-watch UNWIRED (deps.specWatch absent) → byte-identical legacy path", async () => {
+    const p = specFile("ready-unwired.md", READY);
+    // Explicitly UNWIRE the spec-watch dep (an existing caller that never wires it).
+    const { deps, createReview } = makeDeps({ specWatch: undefined });
+    const result = await maybeLaunchConsiliumReview(deps, makeTrigger(), { filePath: p, watchPath: specsDir });
+    expect(result).toBe("noop");
+    expect(createReview).not.toHaveBeenCalled();
+  });
+
+  it("ON + a changed file UNDER the globs → routes to the spec path and FIRES", async () => {
+    const p = specFile("routed.md", READY);
+    const { deps, createReview } = makeDeps();
+    const result = await maybeLaunchConsiliumReview(deps, makeTrigger(), { filePath: p, watchPath: specsDir });
+    expect(result).toBe("launched");
+    expect(createReview.mock.calls[0][1].triggerProvenance.spec.specPath).toBe(p);
+  });
+
+  it("ON but a changed file NOT under the globs → falls through to the legacy path (noop)", async () => {
+    // A .txt (or a .md outside docs/specs) does not match the globs.
+    const outside = join(root, "README.md");
+    writeFileSync(outside, READY, "utf8");
+    const { deps, createReview } = makeDeps();
+    const result = await maybeLaunchConsiliumReview(deps, makeTrigger(), { filePath: outside, watchPath: specsDir });
+    expect(result).toBe("noop"); // legacy path (no action) — NOT parsed as a spec
+    expect(createReview).not.toHaveBeenCalled();
+  });
+
+  it("M3: ON + a NON-ready file under the globs is handled by the spec path — a legacy action does NOT run", async () => {
+    // A file_change trigger that ALSO carries a legacy consilium_review action, whose
+    // changed .md matches the spec globs but is a draft. The spec pre-check owns it
+    // (no-op draft); the legacy action is intentionally NOT run (documented precedence).
+    const p = specFile("draft-with-action.md", `---\nstatus: draft\nsource: {kind: human}\nacceptanceCriteria: ["c"]\n---\nb`);
+    const trigger = makeTrigger({
+      config: {
+        watchPath: specsDir,
+        patterns: ["**/*.md"],
+        action: { kind: "consilium_review", preset: "full-viability", repoPath: "/allowed/omnius" },
+      },
+    } as Partial<TriggerRow>);
+    const { deps, createReview } = makeDeps();
+    const result = await maybeLaunchConsiliumReview(deps, trigger, { filePath: p, watchPath: specsDir });
+    expect(result).toBe("skipped"); // spec no-op(draft) — NOT the legacy action's launch
+    expect(createReview).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## SPEC-1: spec-as-task watch — a ready spec/ADR fires a loop

Implements **SPEC-1** from `docs/design/spec-as-task.md` (§2 schema, §3 watch trigger): a committed `docs/specs|adr` markdown file with YAML frontmatter that is `status: ready` (with acceptance criteria) fires **one** consilium loop. Human-authored specs only — **no tracker connectors** (that is TRACK-1, out of scope).

Built **on** the existing spine — the `file_change` trigger, `FileWatcher`, `fireTrigger`, and `launchReviewWithDedup` — no new watcher.

### The §3 contract, implemented
- **Fires when** a watched file under the spec globs is added/changed AND parses to `status: ready` with a non-empty `acceptanceCriteria`.
- **Maps to a loop:** `engineerInstruction` = the human-authored body + the acceptance criteria rendered as an explicit fenced *"Definition of Done — every criterion must be satisfied and verified:"* list; `repoPath` = frontmatter `repo` resolved to an allowlisted path (else the trigger's own repo); `skillIds` = explicit `skills`; `preset`/rounds from the trigger template or defaults.
- **Rails:** dedup — **one active loop per spec** (keyed by spec path); review-only (`maxRounds=1`, the existing T6 fs-event rail); provenance records the spec path + source + status.

### The parser (`server/services/consilium/spec-parser.ts`, new)
Pure/synchronous, **never throws**. `parseSpecContent` splits YAML frontmatter (js-yaml default `load` — safe schema) from body and type-coerces the fields. `readSpecFile` guards size (512 KiB cap) and binary/NUL content **before** the YAML parse and degrades any fs error to a safe `not-a-spec`. `evaluateReadyGate` returns the fire decision or a specific no-op reason (`draft` / `no-acceptance-criteria` / `not-a-spec` / `status:in-progress` / `status:done` / `unknown-status`). `buildSpecInstruction` renders + byte-bounds the body+DoD. `pathMatchesSpecGlobs` is a dependency-free, anchored glob→regex matcher (no transitive-lib reliance).

### The ready-gate & spec→loop mapping (`trigger-dispatch.ts`)
`maybeLaunchConsiliumReview` gets a **spec pre-check** at the top: a `file_change` under the spec globs (with spec-watch enabled) is routed to the new `maybeLaunchSpecReview` **before** the legacy action dispatch. `resolveSpecRepo` maps a spec's `repo:` to an allowlisted path fail-closed (unresolvable ⇒ no-op `no-repo`); the factory re-validates it, so this can never widen access. `role` is folded into the instruction header, **not** passed as a skill id (a non-registered role would otherwise throw skill resolution).

### Per-**SPEC** dedup (vs the existing per-**repo**)
This is the SPEC-1 headline. `launchReviewWithDedup` now takes an optional `specDedupKey`: a spec fire dedups on `triggerProvenance.spec.specPath`, **not** repoPath — so **two distinct specs in the same repo each fire their own loop**, while the **same** spec is suppressed (`skipped-dedup:spec`) while its loop is active. The historical per-repo dedup for every non-spec fire is unchanged.

### Provenance
`TriggerProvenance.spec = { specPath, status, source }` (new `SpecProvenance` type) is persisted inert on the loop. This is the anchor a future write-back (SPEC-2+) keys off to find a spec's loop.

### Kill-switch (default OFF, byte-identical when off)
`pipeline.consiliumLoop.specWatch: { enabled: false, globs: ["docs/specs/**/*.md","docs/adr/**/*.md"] }`. Firing is **triple-gated**: the master `features.triggers.enabled` (folded into the dep in the route) AND `specWatch.enabled` AND the parent `consiliumLoop.enabled`. When any is off, the spec pre-check is skipped entirely and the dispatch is byte-identical to before.

### Test evidence
Two new suites, **39 tests**, all green; **782** green across all trigger/consilium/watcher suites; `tsc` clean.
- `spec-parser.test.ts` — parse, ready-gate reasons, body+DoD builder, size/binary/unreadable guards, glob matcher.
- `spec-watch-dispatch.test.ts` — ready fires (engineerInstruction body+DoD, provenance `{specPath,source}`, review-only, skills); draft / no-acceptance-criteria / not-a-spec / malformed / huge / binary → no-op no-throw; repo unresolvable → `no-repo`; **two specs one repo → two loops**; same spec active → `skipped-dedup:spec`; kill-switch off & unwired → byte-identical; glob routing on/off.

### Adversarial self-review (findings resolved before this PR)
An independent adversarial pass was run on the diff. Resolved:
- **H1 (ship-blocker):** the acceptance-criteria DoD was being silently dropped — `engineerInstruction` rides the factory's `untrustedExtraBlock`, which head-keeps and clamps to 8 KiB, so a body-first layout pushed the criteria off the end for any body >~8 KB. **Fix:** DoD is now emitted **first**, and the whole instruction is budgeted under `SPEC_INSTRUCTION_MAX_BYTES` (7 KiB) — criteria packed under budget (whole items dropped with an "N omitted" note, first always kept), body given the remainder with a reserved floor. Criteria now always reach the reviewers.
- **H2 (ship-blocker):** a computed title sanitizer (`titleLabel`) was dead code; the raw untrusted title flowed into the persisted provenance `eventSummary`. **Fix:** the sanitized, single-lined, length-clamped label is used.
- **M2:** `resolveSpecRepo`'s absolute-path prefix check could admit a `..` traversal on a non-existent path. **Fix:** lexical `resolve()` normalization on both sides before the prefix test.
- **M1 (accepted for SPEC-1):** an unknown skill id fails the launch closed (`"failed"`, caught). Documented — human-authored specs mean the operator owns skill ids; graceful "drop unknown skill" is deferred to the connector-fed path.
- **M3 / L1:** legacy-action precedence on overlapping globs documented + regression-tested; the criteria block is now byte-packed.

Confirmed sound and unchanged: the off-path byte-identity, the ready-gate, the per-spec dedup (does not weaken per-repo), no-crash on hostile input, the forced review-only (`maxRounds=1`) fs-event rail, and the glob anchoring (no ReDoS).

### SPEC-2 boundary (deferred)
The full status lifecycle — the trigger flipping `draft→ready→in-progress→done`, the code-PR merge closing the spec, and re-run discipline beyond the active-loop dedup — is **SPEC-2**. For SPEC-1, "only `ready` fires" + the per-spec active-loop dedup is the guard. Escalation past review-only to the SDLC coder remains a human/UI action (the existing fs-event rail is preserved for the spec path).

Draft — do not merge.
