### PR TITLE
test: lock spec-watch master-switch-off invariant

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -55,7 +55,7 @@ import { registerTaskGroupResolveRoute } from "./routes/task-group-resolve";
 import { registerConsiliumLoopRoutes } from "./routes/consilium-loops";
 import { registerConsiliumReviewRoutes } from "./routes/consilium-reviews";
 import { createConsiliumReview } from "./services/consilium/review-factory";
-import { maybeLaunchConsiliumReview, maybeLaunchGitHubReview } from "./services/consilium/trigger-dispatch";
+import { maybeLaunchConsiliumReview, maybeLaunchGitHubReview, resolveSpecWatchConfig } from "./services/consilium/trigger-dispatch";
 import { ConsiliumLoopController, ConsiliumLoopPoller } from "./services/consilium/consilium-loop-controller";
 import { registerModelSkillBindingRoutes } from "./routes/model-skill-bindings";
 import { registerTaskTraceRoutes } from "./routes/task-traces";
@@ -406,19 +406,12 @@ export async function registerRoutes(
           recordFire: (triggerId: string, firedAt: Date) =>
             storage.incrementTriggerFired(triggerId, firedAt),
           // SPEC-1 (spec-as-task.md §3): the spec-watch config, master-gated HERE so
-          // the dispatch sees ONE boolean. `enabled` folds the master trigger switch
-          // (features.triggers.enabled) AND the spec-watch kill-switch — either off ⇒
-          // the spec pre-check is skipped and the file_change dispatch is byte-identical.
-          // The parent consiliumLoop.enabled gate is enforced downstream (reviewDeps null).
-          specWatch: () => {
-            const c = appConfigLoader.get();
-            return {
-              enabled:
-                c.features.triggers.enabled && c.pipeline.consiliumLoop.specWatch.enabled,
-              globs: c.pipeline.consiliumLoop.specWatch.globs,
-              allowedRepoPaths: c.pipeline.consiliumLoop.allowedRepoPaths,
-            };
-          },
+          // the dispatch sees ONE boolean. `resolveSpecWatchConfig` folds the master
+          // trigger switch (features.triggers.enabled) AND the spec-watch kill-switch —
+          // either off ⇒ the spec pre-check is skipped and the file_change dispatch is
+          // byte-identical. The parent consiliumLoop.enabled gate is enforced downstream
+          // (reviewDeps null). The fold lives in one tested helper (see its unit test).
+          specWatch: () => resolveSpecWatchConfig(appConfigLoader.get()),
           log: (m: string) => log(m, "triggers"),
         };
 

--- a/server/services/consilium/trigger-dispatch.ts
+++ b/server/services/consilium/trigger-dispatch.ts
@@ -258,7 +258,7 @@ export interface ConsiliumTriggerDispatchDeps {
    * entirely and is BYTE-IDENTICAL to the pre-SPEC-1 dispatch. `allowedRepoPaths`
    * is the consilium-loop repo allowlist (used to resolve a spec's `repo:` field).
    */
-  specWatch?: () => { enabled: boolean; globs: string[]; allowedRepoPaths: string[] };
+  specWatch?: () => SpecWatchDispatchView;
   /** Structured logger (the route passes `(m) => log(m, "triggers")`). */
   log: (message: string) => void;
 }
@@ -347,6 +347,36 @@ export async function maybeLaunchConsiliumReview(
 
 /** The default preset for a spec fire when the trigger action does not pin one. */
 const SPEC_DEFAULT_PRESET: ConsiliumReviewPreset = "sdlc-cross-review";
+
+/** The spec-watch view the dispatch reads (the folded, master-gated config). */
+export interface SpecWatchDispatchView {
+  enabled: boolean;
+  globs: string[];
+  allowedRepoPaths: string[];
+}
+
+/**
+ * Fold the spec-watch dispatch view from AppConfig. The master
+ * `features.triggers.enabled` switch is AND-ed into `enabled` HERE, in ONE place, so
+ * the dispatch sees a single boolean: master-off ⇒ effective-off ⇒ the spec
+ * pre-check never runs and the file_change dispatch is BYTE-IDENTICAL to before.
+ * (The parent `consiliumLoop.enabled` gate is enforced separately downstream via
+ * `reviewDeps`, which is null when that subsystem is off.) The route wires this as
+ * `specWatch: () => resolveSpecWatchConfig(appConfigLoader.get())`.
+ */
+export function resolveSpecWatchConfig(config: {
+  features: { triggers: { enabled: boolean } };
+  pipeline: {
+    consiliumLoop: { allowedRepoPaths: string[]; specWatch: { enabled: boolean; globs: string[] } };
+  };
+}): SpecWatchDispatchView {
+  const sw = config.pipeline.consiliumLoop.specWatch;
+  return {
+    enabled: config.features.triggers.enabled && sw.enabled,
+    globs: sw.globs,
+    allowedRepoPaths: config.pipeline.consiliumLoop.allowedRepoPaths,
+  };
+}
 
 /**
  * Resolve a spec's `repo:` field to an ALLOWLISTED local path, fail-closed.

--- a/tests/unit/consilium/spec-watch-dispatch.test.ts
+++ b/tests/unit/consilium/spec-watch-dispatch.test.ts
@@ -17,8 +17,10 @@ import {
   maybeLaunchConsiliumReview,
   maybeLaunchSpecReview,
   resolveSpecRepo,
+  resolveSpecWatchConfig,
   type ConsiliumTriggerDispatchDeps,
 } from "../../../server/services/consilium/trigger-dispatch.js";
+import { ConfigSchema } from "../../../server/config/schema.js";
 
 // ─── On-disk fixtures ──────────────────────────────────────────────────────────
 
@@ -231,6 +233,50 @@ describe("maybeLaunchSpecReview — ready gate", () => {
     expect(result).toBe("skipped");
     expect(createReview).not.toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith(expect.stringMatching(/no-repo/));
+  });
+});
+
+// ─── Route-level fold: the MASTER switch alone disables spec-watch ─────────────
+
+describe("resolveSpecWatchConfig — master-switch fold", () => {
+  /** A real AppConfig with the three spec-watch-relevant flags set explicitly. */
+  const cfg = (masterEnabled: boolean, specWatchEnabled: boolean) =>
+    ConfigSchema.parse({
+      features: { triggers: { enabled: masterEnabled } },
+      pipeline: {
+        consiliumLoop: {
+          enabled: true, // isolate the master switch as the sole disabler
+          allowedRepoPaths: ["/allowed/omnius"],
+          specWatch: { enabled: specWatchEnabled },
+        },
+      },
+    });
+
+  it("features.triggers.enabled=false ALONE zeroes effective enabled (even with specWatch+loop on)", () => {
+    const view = resolveSpecWatchConfig(cfg(false, true));
+    expect(view.enabled).toBe(false); // the master switch off ⇒ spec-watch off
+    // The other fields still pass through (they are inert while disabled).
+    expect(view.globs).toEqual(["docs/specs/**/*.md", "docs/adr/**/*.md"]);
+    expect(view.allowedRepoPaths).toEqual(["/allowed/omnius"]);
+  });
+
+  it("both switches on ⇒ effective enabled true; specWatch off alone ⇒ false", () => {
+    expect(resolveSpecWatchConfig(cfg(true, true)).enabled).toBe(true);
+    expect(resolveSpecWatchConfig(cfg(true, false)).enabled).toBe(false);
+  });
+
+  it("master-switch OFF ⇒ NO spec fires end-to-end (byte-identical), even for a ready spec", async () => {
+    const p = specFile("ready-master-off.md", READY);
+    // The EXACT view the route hands the dispatch, folded from a real config with the
+    // master switch OFF but specWatch+loop ON — proves the fold, not a duplicated bool.
+    const folded = resolveSpecWatchConfig(cfg(false, true));
+    const { deps, createReview } = makeDeps({}, [], folded);
+    const result = await maybeLaunchConsiliumReview(deps, makeTrigger(), {
+      filePath: p,
+      watchPath: specsDir,
+    });
+    expect(result).toBe("noop"); // legacy path (no action) — spec pre-check never ran
+    expect(createReview).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Follow-up to SPEC-1 (#499): lock the master-switch-off invariant

The kill-switch-fold refactor + test I wrote for #499 landed on the merged feature branch **after** #499 was merged, so they never reached main. This re-lands them cleanly off current main (a cherry-pick conflicts because the base diverged). **Behavior is unchanged** — this is one fold refactor + tests.

### The fold, extracted to a tested helper
The route previously computed the spec-watch dispatch view inline in the `fireTrigger` closure. That fold — where the master `features.triggers.enabled` switch is AND-ed with `specWatch.enabled` — is now a single exported helper `resolveSpecWatchConfig(config)` in `trigger-dispatch.ts`, and `routes.ts` calls it:

```ts
specWatch: () => resolveSpecWatchConfig(appConfigLoader.get()),
```

So the master-switch fold lives in **one place the tests exercise directly**, instead of a boolean duplicated in the route closure (untestable without Express).

### The test — `describe("resolveSpecWatchConfig — master-switch fold")`
Built on a real `ConfigSchema.parse(...)` config (not a hand-rolled object):
- **`features.triggers.enabled = false` ALONE** ⇒ `resolveSpecWatchConfig(...).enabled === false`, even with `specWatch.enabled = true` **and** `consiliumLoop.enabled = true` (the master switch is isolated as the sole disabler; globs/allowlist still pass through inert).
- both on ⇒ `enabled === true`; `specWatch` off alone ⇒ `false`.
- **End-to-end:** the master-off folded view is wired into `maybeLaunchConsiliumReview`, a **ready** spec under the globs is fired, and the result is `"noop"` with `createReview` never called — locking "byte-identical when off" at the master-switch layer (previously only the dispatch-off and unwired paths were covered).

### Verification
`tsc` clean. Full unit suite green — **271 files, 5191 tests**, no failures (no flakes hit). Diff: +84 / −15 across `routes.ts`, `trigger-dispatch.ts`, `spec-watch-dispatch.test.ts`.

Draft — do not merge.