### PR TITLE
fix: harden trigger-card render + diff-pr-review unresolved-ref handling

### DIFF
--- a/client/src/components/triggers/TriggerCard.tsx
+++ b/client/src/components/triggers/TriggerCard.tsx
@@ -11,8 +11,8 @@ import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { useEnableTrigger, useDisableTrigger, useTriggerLoops } from "@/hooks/use-triggers";
-import type { PipelineTrigger, TriggerType, ScheduleTriggerConfig, GitHubEventTriggerConfig, FileChangeTriggerConfig, TriggerFiredLoop } from "@shared/types";
-import { loopTargetSummary } from "./trigger-form-logic";
+import type { PipelineTrigger, TriggerType, TriggerFiredLoop } from "@shared/types";
+import { configSummary, loopTargetSummary } from "./trigger-form-logic";
 
 // ─── Type badge config ────────────────────────────────────────────────────────
 
@@ -38,29 +38,6 @@ const TYPE_META: Record<TriggerType, { label: string; className: string; Icon: R
     Icon: FolderSearch,
   },
 };
-
-// ─── Config summary ───────────────────────────────────────────────────────────
-
-function configSummary(trigger: PipelineTrigger): string {
-  switch (trigger.type) {
-    case "webhook":
-      return trigger.webhookUrl
-        ? `POST ${trigger.webhookUrl}`
-        : "Webhook endpoint auto-assigned";
-    case "schedule": {
-      const cfg = trigger.config as ScheduleTriggerConfig;
-      return cfg.cron;
-    }
-    case "github_event": {
-      const cfg = trigger.config as GitHubEventTriggerConfig;
-      return `${cfg.repository} · ${cfg.events.join(", ")}`;
-    }
-    case "file_change": {
-      const cfg = trigger.config as FileChangeTriggerConfig;
-      return `${cfg.watchPath} · ${cfg.patterns.join(", ")}`;
-    }
-  }
-}
 
 // ─── Fired-loop helpers ───────────────────────────────────────────────────────
 

--- a/client/src/components/triggers/TriggerForm.tsx
+++ b/client/src/components/triggers/TriggerForm.tsx
@@ -528,7 +528,11 @@ export function TriggerForm({
     );
     setGhEvents(
       trigger?.type === "github_event"
-        ? (trigger.config as GitHubEventTriggerConfig).events
+        ? // `events` is typed string[] but an API-created trigger can omit it;
+          // fall back to [] (mirrors the `patterns ?? []` guard below) so editing a
+          // malformed github trigger renders the noEvents warning instead of crashing
+          // on `events.includes`/`events.length`.
+          (trigger.config as GitHubEventTriggerConfig).events ?? []
         : [...GITHUB_DEFAULT_EVENTS],
     );
     setWatchPath(

--- a/client/src/components/triggers/trigger-form-logic.ts
+++ b/client/src/components/triggers/trigger-form-logic.ts
@@ -11,6 +11,9 @@ import type {
   TriggerType,
   ConsiliumReviewPreset,
   ConsiliumReviewTriggerAction,
+  ScheduleTriggerConfig,
+  GitHubEventTriggerConfig,
+  FileChangeTriggerConfig,
 } from "@shared/types";
 
 /** Trigger types whose firing creates a consilium loop (carry a loop template). */
@@ -140,6 +143,41 @@ export function buildLoopTemplate(state: LoopTemplateState): ConsiliumReviewTrig
   }
   if (Number.isFinite(rounds) && rounds >= 1 && rounds <= 6) action.maxRounds = rounds;
   return action;
+}
+
+/**
+ * One-line, human-readable summary of a trigger's config — the mono line on the
+ * trigger card. Extracted here (from TriggerCard.tsx) so it is node-testable and
+ * has a single source of truth.
+ *
+ * ROBUSTNESS: `events`/`patterns` are typed `string[]` but a trigger created via
+ * the API can omit them entirely (e.g. the spec-watch demo file_change trigger is
+ * just `{ watchPath, action }`). An unguarded `cfg.events.join`/`cfg.patterns.join`
+ * on `undefined` throws and takes the WHOLE TriggersPage into its error boundary.
+ * We coalesce to `[]` and, when the array is empty/absent, fall back to a sensible
+ * summary (repository / watchPath alone) rather than a trailing " · ".
+ */
+export function configSummary(trigger: PipelineTrigger): string {
+  switch (trigger.type) {
+    case "webhook":
+      return trigger.webhookUrl
+        ? `POST ${trigger.webhookUrl}`
+        : "Webhook endpoint auto-assigned";
+    case "schedule": {
+      const cfg = trigger.config as ScheduleTriggerConfig;
+      return cfg.cron;
+    }
+    case "github_event": {
+      const cfg = trigger.config as GitHubEventTriggerConfig;
+      const events = (cfg.events ?? []).join(", ");
+      return events ? `${cfg.repository} · ${events}` : cfg.repository;
+    }
+    case "file_change": {
+      const cfg = trigger.config as FileChangeTriggerConfig;
+      const patterns = (cfg.patterns ?? []).join(", ");
+      return patterns ? `${cfg.watchPath} · ${patterns}` : cfg.watchPath;
+    }
+  }
 }
 
 /**

--- a/server/config-sync/git-wrapper.ts
+++ b/server/config-sync/git-wrapper.ts
@@ -26,6 +26,11 @@ export type GitErrorKind =
   | "no-upstream"
   | "merge-conflict"
   | "offline"
+  // A required revision (a commit sha or a branch/tag ref) could not be resolved
+  // in the local checkout even after a bounded fetch attempt — git reports this as
+  // "fatal: Needed a single revision". DETERMINISTIC (a retry cannot fix it), so
+  // callers must fail closed to a terminal state rather than re-drive forever.
+  | "unresolved-ref"
   | "unknown";
 
 // ─── Result types ─────────────────────────────────────────────────────────────

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -1285,6 +1285,10 @@ export class ConsiliumLoopController {
     this.log(loop.id, `re-drive CLAIMED stranded ${loop.state} (age ${ageMs}ms > grace) — running side effect`);
     if (claimed.state === "reviewing") {
       const extra = await this.startReviewRound(claimed);
+      // Fail-closed on a deterministic unresolved ref rather than re-stranding it.
+      if (extra.terminal) {
+        return this.failUnresolvedReview(claimed, String(extra.error ?? "diff ref unresolvable"));
+      }
       return Object.keys(extra).length === 0 ? claimed : this.storage.updateLoop(claimed.id, extra);
     }
     // developing
@@ -1395,10 +1399,14 @@ export class ConsiliumLoopController {
       `review stall — re-launching round ${claimed.round} (attempt ${attempt}/${max}) after ${idleMin}m idle`,
     );
     const extra = await this.startReviewRound(claimed, { relaunch: true });
+    if (extra.terminal) {
+      // Deterministic unresolved ref on re-launch — fail closed (do NOT re-strand).
+      return this.failUnresolvedReview(claimed, String(extra.error ?? "diff ref unresolvable"));
+    }
     if (extra.error) {
-      // The re-launch itself failed to build (e.g. git) — record it and leave the
-      // loop reviewing with a null child ref; the null-ref redrive re-attempts it
-      // after the grace window (bounded overall by maxRounds).
+      // The re-launch itself failed to build (e.g. a transient git error) — record
+      // it and leave the loop reviewing with a null child ref; the null-ref redrive
+      // re-attempts it after the grace window (bounded overall by maxRounds).
       return this.storage.updateLoop(claimed.id, extra);
     }
     return this.storage.updateLoop(claimed.id, {
@@ -1536,7 +1544,17 @@ export class ConsiliumLoopController {
     transition: LoopTransition,
     event: LoopEvent,
   ): Promise<Record<string, unknown>> {
-    if (transition.to === "reviewing") return this.startReviewRound(loop);
+    if (transition.to === "reviewing") {
+      const extra = await this.startReviewRound(loop);
+      // Fail-closed: a DETERMINISTIC unresolved-ref failure must not strand the
+      // loop in `reviewing` (loop-73fddadc). Drive it terminal WITH the reason and
+      // return no extra columns (the terminal CAS already persisted the reason).
+      if (extra.terminal) {
+        await this.failUnresolvedReview(loop, String(extra.error ?? "diff ref unresolvable"));
+        return {};
+      }
+      return extra;
+    }
     if (transition.to === "developing" && event.kind === "decided") {
       return this.startDevHandoff(loop, event.verdict);
     }
@@ -1855,6 +1873,31 @@ export class ConsiliumLoopController {
    * KICKOFF (milliseconds) — `deriveReviewEvent` then polls the settle (§14.5).
    * `round` only ever increments here (M-2).
    */
+  /**
+   * Fail a review round CLOSED to a terminal state with an operator-readable
+   * reason (the #486 status-explanation style). Used when `startReviewRound`
+   * reports a DETERMINISTIC unresolved-ref failure (`terminal: true`): the diff
+   * baseline/head sha is not in the local checkout and a retry cannot fix it, so
+   * the loop MUST NOT sit in `reviewing` re-driving the same missing sha forever.
+   *
+   * The loop is already in `reviewing` at every call site (the CAS to reviewing
+   * ran before the side effect). We commit `reviewing → failed` via the EXISTING
+   * `review_failed` edge (no new FSM state), which records the reason on
+   * `loop.error` + sets `completedAt`, so the UI shows the explanation instead of a
+   * bare git string. Single-flight: it is a CAS, so a concurrent tick that already
+   * advanced the loop loses the race and no-ops (the reason is never double-written
+   * or lost — the winning transition carries it atomically).
+   */
+  private async failUnresolvedReview(
+    loop: ConsiliumLoopRow,
+    reason: string,
+  ): Promise<ConsiliumLoopRow | null> {
+    const transition = reduce("reviewing", { kind: "review_failed", error: reason });
+    if (!transition) return null; // loop no longer reviewing (a concurrent tick won).
+    this.log(loop.id, `review ref unresolvable → failing loop closed: ${reason}`);
+    return this.commit(loop, transition);
+  }
+
   private async startReviewRound(
     loop: ConsiliumLoopRow,
     opts?: { relaunch?: boolean },
@@ -1898,6 +1941,16 @@ export class ConsiliumLoopController {
       repoMap,
     });
     if (!ctx.ok) {
+      // A DETERMINISTIC unresolved ref (the diff baseline/head sha is absent from
+      // the local checkout even after a bounded fetch — e.g. a PR fired from GitHub
+      // polling whose commit was never fetched, or an empty repo) can NEVER be fixed
+      // by re-driving the same round. Signal it as TERMINAL so the caller fails the
+      // loop closed WITH this reason instead of stranding it in `reviewing` forever
+      // (the loop-73fddadc bug). Any OTHER (transient) git failure keeps the legacy
+      // strand-and-redrive behaviour (null child ref → redriveStranded re-attempts).
+      if (ctx.errorKind === "unresolved-ref") {
+        return { error: ctx.message, terminal: true };
+      }
       // Surface the (scrubbed) git failure as a loop error; the next tick from
       // REVIEWING with no iteration will not advance — recorded for the human.
       return { error: ctx.message };

--- a/server/services/consilium/diff-context.ts
+++ b/server/services/consilium/diff-context.ts
@@ -39,6 +39,15 @@ import { validateReviewRef } from "./ref-validator.js";
 export interface GitDiffClient {
   revparse(args: string[]): Promise<string>;
   diff(args: string[]): Promise<string>;
+  /**
+   * OPTIONAL, best-effort single fetch of a specific ref from origin — used to
+   * recover a PR head/base sha that fired from GitHub/polling and was never
+   * fetched into the local checkout. Absent on a fake ⇒ resolution stays local
+   * only (the pre-fetch behaviour). Bounded by the client's own block timeout
+   * (see `buildDiffContext`). Args are passed straight through as a git arg-array
+   * (no shell), e.g. `["origin", "<sha>"]`.
+   */
+  fetch?(args: string[]): Promise<unknown>;
 }
 
 export interface DiffContextRequest {
@@ -103,6 +112,13 @@ export interface DiffContextResult {
 const SHA_RE = /^[0-9a-f]{7,64}$/;
 
 /**
+ * Block-timeout (ms) for the DEFAULT simple-git client: git is killed if it emits
+ * no output for this long. Bounds the best-effort `git fetch` (and every other git
+ * call) so an unreachable remote or a wedged fetch can never hang a review round.
+ */
+const GIT_BLOCK_TIMEOUT_MS = 15_000;
+
+/**
  * Char cap on the caller-supplied `testSummary` before it enters the LLM input.
  * The DEV pipeline produces it opaquely, so it is untrusted/unbounded here — a
  * 10MB summary would otherwise flow straight into every debater + judge prompt.
@@ -124,38 +140,98 @@ function fail(errorKind: GitErrorKind, rawMessage: string): GitFail {
 }
 
 /**
- * B-1/H-2: strict-hex gate + `revparse --verify --end-of-options <sha>^{commit}`.
- * Returns the RESOLVED sha (used downstream), or a scrubbed GitFail.
+ * Fail-closed for a revision that could not be resolved LOCALLY even after a
+ * bounded fetch. Distinct `errorKind: "unresolved-ref"` (DETERMINISTIC — a retry
+ * cannot fix it) so the loop controller drives the loop to a TERMINAL state with
+ * this reason instead of leaving it stuck in `reviewing` re-driving the same
+ * missing sha forever. `repoLabel` is the repo BASENAME (no `/`), and a hex sha
+ * has no `/`, so both survive `scrubMessage` and reach the operator intact; a
+ * slash-bearing branch ref is path-scrubbed (the security guarantee) but the
+ * remediation ("fetch the PR ref / point at a local branch") still lands.
  */
-async function resolveCommit(git: GitDiffClient, ref: string): Promise<string | GitFail> {
+function unresolvedRef(role: "baseline" | "head", ref: string, repoLabel: string): GitFail {
+  return fail(
+    "unresolved-ref",
+    `diff ${role} ${ref} is not present in the local checkout of ${repoLabel}; ` +
+      `fetch the PR ref or point the review at a local branch`,
+  );
+}
+
+/**
+ * B-1/H-2: `revparse --verify --end-of-options <ref>^{commit}` — resolve a ref to
+ * a concrete sha WITHOUT trusting git's exit path. Returns the resolved sha, or
+ * null when git cannot resolve it (a missing object → "fatal: Needed a single
+ * revision"; the raw error is swallowed, never bubbled). `--end-of-options`
+ * precedes the ref so a leading-dash/option-looking ref can never be parsed as a
+ * git flag.
+ */
+async function verifyLocally(git: GitDiffClient, ref: string): Promise<string | null> {
+  try {
+    const out = (await git.revparse(["--verify", "--end-of-options", `${ref}^{commit}`])).trim();
+    return SHA_RE.test(out) ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Bounded, best-effort SINGLE fetch of `ref` from origin — recovers a PR head/base
+ * sha that fired from GitHub/polling and was never fetched locally. Failures (a
+ * server that disallows fetch-by-sha, an offline box, a gone ref) are swallowed:
+ * the caller re-verifies and fails closed. Never fetches the symbolic "HEAD". The
+ * ref is already gated upstream (baseline strict-hex; head via `validateReviewRef`,
+ * which rejects leading `-`), so it is a safe git arg-array element.
+ */
+async function fetchRefOnce(git: GitDiffClient, ref: string): Promise<void> {
+  if (typeof git.fetch !== "function" || ref === "HEAD") return;
+  try {
+    await git.fetch(["origin", ref]);
+  } catch {
+    // best-effort — fall through to the fail-closed unresolved-ref below.
+  }
+}
+
+/**
+ * B-1/H-2: strict-hex gate → resolve the diff baseline. If it is not present
+ * locally, attempt ONE bounded fetch, then re-verify; still missing ⇒ a
+ * DETERMINISTIC `unresolved-ref` GitFail (never a raw git error).
+ */
+async function resolveCommit(
+  git: GitDiffClient,
+  ref: string,
+  repoLabel: string,
+): Promise<string | GitFail> {
   if (!SHA_RE.test(ref)) {
     return fail("unknown", "baseline commit is not a 7-64 char hex sha");
   }
-  try {
-    const out = await git.revparse(["--verify", "--end-of-options", `${ref}^{commit}`]);
-    const resolved = out.trim();
-    if (!SHA_RE.test(resolved)) return fail("unknown", "resolved commit is not a valid sha");
-    return resolved;
-  } catch (err) {
-    return fail("not-a-repo", err instanceof Error ? err.message : String(err));
-  }
+  const local = await verifyLocally(git, ref);
+  if (local) return local;
+  await fetchRefOnce(git, ref);
+  const refetched = await verifyLocally(git, ref);
+  if (refetched) return refetched;
+  return unresolvedRef("baseline", ref, repoLabel);
 }
 
 /**
  * B-1: resolve the review HEAD to a concrete sha (server-derived, still
  * pinned/validated). `ref` defaults to "HEAD" (working-tree HEAD); a
- * BRANCH-targeted review passes the loop's `reviewRef` so the resolved tip is the
- * chosen branch's, WITHOUT any checkout. `--end-of-options` precedes the ref so a
- * leading-dash/option-looking ref can never be parsed as a git flag.
+ * BRANCH-targeted / diff-pr review passes the loop's `reviewRef` (a PR head sha or
+ * branch) so the resolved tip is the chosen ref's, WITHOUT any checkout. A missing
+ * ref is fetched once then re-verified; still missing ⇒ a DETERMINISTIC
+ * `unresolved-ref` GitFail (an EMPTY repo — zero commits — also lands here for
+ * "HEAD"), never a raw "Needed a single revision".
  */
-async function resolveHead(git: GitDiffClient, ref: string): Promise<string | GitFail> {
-  try {
-    const head = (await git.revparse(["--verify", "--end-of-options", `${ref}^{commit}`])).trim();
-    if (!SHA_RE.test(head)) return fail("unknown", "resolved HEAD is not a valid sha");
-    return head;
-  } catch (err) {
-    return fail("not-a-repo", err instanceof Error ? err.message : String(err));
-  }
+async function resolveHead(
+  git: GitDiffClient,
+  ref: string,
+  repoLabel: string,
+): Promise<string | GitFail> {
+  const local = await verifyLocally(git, ref);
+  if (local) return local;
+  await fetchRefOnce(git, ref);
+  const refetched = await verifyLocally(git, ref);
+  if (refetched) return refetched;
+  return unresolvedRef("head", ref, repoLabel);
 }
 
 interface DiffParts {
@@ -320,7 +396,12 @@ export async function buildDiffContext(
     return fail("not-a-repo", err instanceof Error ? err.message : String(err));
   }
 
-  const git: GitDiffClient = req.gitClient ?? simpleGit(resolvedRepo);
+  // Default client is bounded by a block timeout so the best-effort fetch (and any
+  // git call) can never hang the review round; a fake injected by a test is used
+  // as-is. `repoLabel` is the basename — safe to embed in an operator-facing error.
+  const git: GitDiffClient =
+    req.gitClient ?? simpleGit({ baseDir: resolvedRepo, timeout: { block: GIT_BLOCK_TIMEOUT_MS } });
+  const repoLabel = resolvedRepo.split("/").filter(Boolean).pop() ?? "the target repo";
 
   // LOW-1 (defense-in-depth): reviewRef is write-once and strict-validated at the
   // factory boundary, but on later rounds the controller reads it back from the DB
@@ -338,7 +419,7 @@ export async function buildDiffContext(
 
   // BRANCH-targeted review: resolve the chosen ref's tip (loop.reviewRef) as the
   // HEAD side; null/undefined ⇒ working-tree "HEAD" (full back-compat).
-  const head = await resolveHead(git, req.ref ?? "HEAD");
+  const head = await resolveHead(git, req.ref ?? "HEAD", repoLabel);
   if (typeof head !== "string") return head;
 
   if (req.baselineCommit === null) {
@@ -351,7 +432,7 @@ export async function buildDiffContext(
     return { ok: true, input: built.input, headCommit: head, baselineCommit: null, truncated: built.truncated };
   }
 
-  const baseline = await resolveCommit(git, req.baselineCommit);
+  const baseline = await resolveCommit(git, req.baselineCommit, repoLabel);
   if (typeof baseline !== "string") return baseline;
 
   const parts = await collectDiff(git, baseline, head, req.maxDiffBytes);

--- a/tests/integration/consilium/diff-context-realgit.test.ts
+++ b/tests/integration/consilium/diff-context-realgit.test.ts
@@ -88,4 +88,75 @@ describe("buildDiffContext — real git", () => {
     const res = await buildDiffContext({ repoPath: repo, baselineCommit: null, objective: "O", allowedRepoPaths: ["/nonexistent-root"], maxDiffBytes: 1024 });
     expect(res.ok).toBe(false);
   });
+
+  // ─── BUG 2: unresolved-ref fail-closed (loop-73fddadc class) ───────────────
+  // A PR sha fired from GitHub/polling is frequently NOT present locally →
+  // `git rev-parse` throws "fatal: Needed a single revision". The resolver must
+  // fail closed with a DETERMINISTIC `unresolved-ref` + an operator-readable
+  // reason, never bubble the raw git string (which stranded the loop in
+  // `reviewing`). No `fetch` on this client, and the sha is absent, so the
+  // best-effort fetch is a no-op and resolution stays local.
+
+  it("baseline sha absent from the local checkout → unresolved-ref, not a raw git error", async () => {
+    const absent = "0".repeat(40); // valid hex shape, but no such object here
+    const res = await buildDiffContext({ repoPath: repo, baselineCommit: absent, objective: "O", allowedRepoPaths: [allow], maxDiffBytes: 1024 });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.errorKind).toBe("unresolved-ref");
+    expect(res.message).toContain("not present in the local checkout");
+    expect(res.message).toContain("fetch the PR ref");
+    // The raw git wording must never leak through as the operator reason.
+    expect(res.message).not.toContain("Needed a single revision");
+  });
+
+  it("EMPTY repo (zero commits) resolving HEAD → unresolved-ref, never stuck", async () => {
+    // An empty repo also yields "Needed a single revision" for HEAD — the same
+    // fail-closed path must catch it (round 1, null baseline, so HEAD is resolved).
+    const emptyRepo = path.join(allow, "empty");
+    await fs.mkdir(emptyRepo, { recursive: true });
+    await execFileAsync("git", ["-C", emptyRepo, "init", "-q", "-b", "main"]);
+    const res = await buildDiffContext({ repoPath: emptyRepo, baselineCommit: null, objective: "Standing objective", allowedRepoPaths: [allow], maxDiffBytes: 1024 });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.errorKind).toBe("unresolved-ref");
+    expect(res.message).toContain("head");
+  });
+
+  it("fetch-then-resolve happy path: a sha missing locally is fetched ONCE from origin, then diffs", async () => {
+    // `origin` is a clone that HAS the commit; the consumer clone does NOT (never
+    // fetched it). buildDiffContext's bounded fetchRefOnce("origin", <sha>) pulls
+    // it, then the re-verify resolves and the diff builds. Proves the recovery, not
+    // just the fail-closed. Uses the real default client (real git, real fetch).
+    const consumer = path.join(allow, "consumer");
+    // origin = our seeded `repo`; clone it, then add a NEW commit to origin only.
+    await execFileAsync("git", ["clone", "-q", repo, consumer]);
+    // Allow the consumer to fetch by exact object name across git versions (a raw
+    // PR head sha). GitHub enables this server-side; a file:// origin needs it set.
+    await git(["config", "uploadpack.allowAnySHA1InWant", "true"]);
+    await git(["config", "uploadpack.allowReachableSHA1InWant", "true"]);
+    await fs.writeFile(path.join(repo, "a.txt"), "one\ntwo\nthree\n");
+    await git(["add", "."]);
+    await git(["commit", "-q", "-m", "third (origin-only)"]);
+    const originOnlySha = await git(["rev-parse", "HEAD"]);
+    // Point the consumer's `origin` at the seeded repo (clone already does), and
+    // confirm the commit is genuinely absent in the consumer before the fetch.
+    await execFileAsync("git", ["-C", consumer, "remote", "set-url", "origin", repo]);
+    await expect(
+      execFileAsync("git", ["-C", consumer, "cat-file", "-e", `${originOnlySha}^{commit}`]),
+    ).rejects.toBeTruthy();
+    // Review the origin-only sha (as reviewRef/head) against the base it branched
+    // from; the consumer must fetch it to resolve, then produce the diff.
+    const res = await buildDiffContext({
+      repoPath: consumer,
+      baselineCommit: firstSha,
+      ref: originOnlySha,
+      objective: "O",
+      allowedRepoPaths: [allow],
+      maxDiffBytes: 100_000,
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.headCommit).toBe(originOnlySha);
+    expect(res.input).toContain("+three");
+  });
 });

--- a/tests/unit/consilium/diff-context.test.ts
+++ b/tests/unit/consilium/diff-context.test.ts
@@ -121,13 +121,53 @@ describe("buildDiffContext — B-1 git argument injection (BINDING)", () => {
 });
 
 describe("buildDiffContext — failures & H-1 allowlist", () => {
-  it("git failure → GitFail with scrubbed (no-path) message", async () => {
-    const git = fakeGit({ revparse: vi.fn(async () => { throw new Error("fatal: /home/secret/.git not a repository"); }) });
+  it("unresolvable HEAD (git throws) → unresolved-ref GitFail, raw git string NOT leaked", async () => {
+    // The resolver never embeds git's raw error for a resolution failure — it fails
+    // closed with a crafted, path-free operator reason. So a leaked path/secret in
+    // the underlying "fatal: ..." can NEVER reach the message (structural guarantee).
+    const git = fakeGit({ revparse: vi.fn(async () => { throw new Error("fatal: /home/secret/.git Needed a single revision"); }) });
     const res = await buildDiffContext({ repoPath: REPO, baselineCommit: null, objective: "O", allowedRepoPaths: ALLOW, maxDiffBytes: 1000, gitClient: git });
     expect(res.ok).toBe(false);
     if (res.ok) return;
+    expect(res.errorKind).toBe("unresolved-ref");
     expect(res.message).not.toContain("/home/secret");
-    expect(res.message).toContain("<path>");
+    expect(res.message).not.toContain("Needed a single revision");
+    expect(res.message).toContain("not present in the local checkout");
+  });
+
+  it("no fetch client on the injected git → resolution stays local, still fails closed", async () => {
+    // A fake without `fetch` must not throw when the sha is missing — the optional
+    // fetch is skipped and the resolver returns unresolved-ref (never a raw error).
+    const git = fakeGit({ revparse: vi.fn(async () => { throw new Error("fatal: bad object"); }) });
+    expect(git.fetch).toBeUndefined();
+    const res = await buildDiffContext({ repoPath: REPO, baselineCommit: BASE_SHA, objective: "O", allowedRepoPaths: ALLOW, maxDiffBytes: 1000, gitClient: git });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.errorKind).toBe("unresolved-ref");
+  });
+
+  it("fetch-then-resolve (unit): a sha absent on first verify resolves after ONE fetch", async () => {
+    // First revparse throws (missing); fetch is invoked ONCE; the second revparse
+    // succeeds. Proves the recovery seam calls fetch exactly once and re-verifies.
+    let verifyCalls = 0;
+    const fetch = vi.fn(async () => undefined);
+    const git = fakeGit({
+      revparse: vi.fn(async (args: string[]) => {
+        const ref = args[args.length - 1];
+        verifyCalls += 1;
+        // HEAD resolves normally; the baseline sha is "missing" until fetched.
+        if (ref === "HEAD^{commit}") return HEAD_SHA + "\n";
+        if (verifyCalls <= 2) throw new Error("fatal: Needed a single revision");
+        return BASE_SHA + "\n";
+      }),
+      fetch,
+    });
+    const res = await buildDiffContext({ repoPath: REPO, baselineCommit: BASE_SHA, objective: "O", allowedRepoPaths: ALLOW, maxDiffBytes: 10_000, gitClient: git });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(["origin", BASE_SHA]);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.baselineCommit).toBe(BASE_SHA);
   });
 
   it("empty allowlist → GitFail (fail-closed), no git call", async () => {

--- a/tests/unit/consilium/loop-unresolved-ref.test.ts
+++ b/tests/unit/consilium/loop-unresolved-ref.test.ts
@@ -1,0 +1,226 @@
+/**
+ * loop-unresolved-ref.test.ts — BUG 2 fail-closed for an unresolvable diff ref.
+ *
+ * Live evidence: loop 73fddadc — a github_event trigger fired via polling on an
+ * Omniscience PR ran a diff-pr-review; the round errored with
+ * `fatal: Needed a single revision` (the PR head/base sha was never fetched into
+ * the local checkout) and the loop sat in `state=reviewing, round=0/1` FOREVER.
+ *
+ * Root cause: `startReviewRound`'s `buildDiffContext` failure returned `{ error }`,
+ * which left the loop in `reviewing` with a NULL child ref. `redriveStranded` then
+ * re-attempted the SAME missing sha every grace window — a deterministic failure
+ * that a retry can never fix, so the round never advanced and `maxRounds` never
+ * tripped. Stuck reviewing.
+ *
+ * Fix: a DETERMINISTIC `unresolved-ref` GitFail is signalled `terminal: true` and
+ * the controller drives the loop `reviewing → failed` via the EXISTING
+ * `review_failed` edge, recording the operator-readable reason on `loop.error` —
+ * NOT stranded. These tests assert the primary entry path (building_context →
+ * reviewing → failed) AND the stranded-redrive path both land terminal-with-reason
+ * and then no-op (never re-drive), and that a TRANSIENT git failure is unchanged.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The unresolved-ref reason the resolver produces (see diff-context.ts).
+const UNRESOLVED_REASON =
+  "diff head 0000000 is not present in the local checkout of omniscience; " +
+  "fetch the PR ref or point the review at a local branch";
+
+// Per-test control over what buildDiffContext returns.
+const buildDiffContextMock = vi.fn();
+vi.mock("../../../server/services/consilium/diff-context.js", () => ({
+  buildDiffContext: (...args: unknown[]) => buildDiffContextMock(...args),
+}));
+
+import { ConsiliumLoopController } from "../../../server/services/consilium/consilium-loop-controller.js";
+import type { ConsiliumLoopRow, ConsiliumLoopState } from "@shared/schema";
+
+const MIN = 60_000;
+
+function makeLoop(over: Partial<ConsiliumLoopRow>): ConsiliumLoopRow {
+  return {
+    id: "loop-73fddadc",
+    projectId: "proj1",
+    groupId: "grp1",
+    state: "building_context",
+    round: 0,
+    maxRounds: 1,
+    repoPath: process.cwd(),
+    // A diff-pr-review: base sha (baseline) + PR head sha (reviewRef), both absent
+    // from the local checkout in the live case.
+    lastReviewedCommit: "b".repeat(40),
+    reviewRef: "0".repeat(40),
+    currentIterationNumber: null,
+    reviewRedrive: null,
+    devGroupId: null,
+    prRef: null,
+    headCommitAtReview: null,
+    openP0: null,
+    error: null,
+    createdBy: "user1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    completedAt: null,
+    ...over,
+  } as ConsiliumLoopRow;
+}
+
+const makeConfig = () => () =>
+  ({
+    pipeline: {
+      consiliumLoop: {
+        enabled: true,
+        maxRounds: 1,
+        pollIntervalMs: 5000,
+        maxDiffBytes: 200_000,
+        allowedRepoPaths: [process.cwd()],
+        reviewStallTimeoutMs: 900_000,
+        reviewMaxRedrives: 3,
+        implement: {
+          enabled: false,
+          verification: { enabled: false },
+          maxFixIterations: 3,
+          testCommand: null,
+          testRunTimeoutMs: 300_000,
+          research: { enabled: false, maxResearchIterations: 3, model: "claude-sonnet" },
+        },
+      },
+    },
+  }) as never;
+
+function fakeStorage(loop: ConsiliumLoopRow) {
+  let current = loop;
+  const casLoopState = vi.fn(
+    async (id: string, expected: ConsiliumLoopState, next: ConsiliumLoopState, extra?: Record<string, unknown>) => {
+      if (id !== current.id || current.state !== expected) return undefined;
+      current = { ...current, ...(extra ?? {}), state: next };
+      return current;
+    },
+  );
+  const updateLoop = vi.fn(async (_id: string, extra?: Record<string, unknown>) => {
+    current = { ...current, ...(extra ?? {}) };
+    return current;
+  });
+  const startGroupAsync = vi.fn(async () => ({ group: {}, iteration: { iterationNumber: 1 } }));
+  const storage = {
+    getLoop: vi.fn(async () => current),
+    getLoops: vi.fn(async () => [current]),
+    getLoopRounds: vi.fn(async () => []),
+    getTaskGroup: vi.fn(async () => ({ id: current.groupId, input: "objective", projectId: current.projectId })),
+    updateTaskGroup: vi.fn(async () => ({})),
+    getIteration: vi.fn(async () => undefined),
+    updateIteration: vi.fn(async () => ({})),
+    getExecutionsByIteration: vi.fn(async () => []),
+    getLlmRequests: vi.fn(async () => ({ rows: [], total: 0 })),
+    claimReviewRedrive: vi.fn(async () => undefined),
+    // Faithful redrive claim: null child ref in `reviewing`, past grace → winner.
+    claimRedrive: vi.fn(async (id: string, expected: ConsiliumLoopState) => {
+      if (id !== current.id || current.state !== expected) return undefined;
+      current = { ...current, updatedAt: new Date() };
+      return current;
+    }),
+    casLoopState,
+    updateLoop,
+    appendLoopRound: vi.fn(async () => ({})),
+  };
+  return { storage, casLoopState, updateLoop, startGroupAsync, get: () => current };
+}
+
+function makeController(storage: unknown, startGroupAsync: unknown, config: () => unknown) {
+  return new ConsiliumLoopController({
+    storage: storage as never,
+    taskOrchestrator: {
+      startGroup: startGroupAsync,
+      startGroupAsync,
+      createTaskGroup: vi.fn(),
+      cancelGroup: vi.fn(),
+    } as never,
+    config: config as never,
+    readRepoHead: async () => "abc1234",
+  });
+}
+
+const unresolvedFail = () => ({ ok: false, errorKind: "unresolved-ref", message: UNRESOLVED_REASON });
+
+describe("BUG 2 — unresolvable diff ref fails CLOSED (loop-73fddadc class)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    buildDiffContextMock.mockReset();
+  });
+
+  it("primary path: building_context → reviewing → FAILED with the operator reason (not stuck)", async () => {
+    buildDiffContextMock.mockResolvedValue(unresolvedFail());
+    const loop = makeLoop({ state: "building_context" });
+    const { storage, casLoopState, startGroupAsync, get } = fakeStorage(loop);
+    const controller = makeController(storage, startGroupAsync, makeConfig());
+
+    await controller.tick(loop.id);
+
+    // The review was never dispatched (the ref could not be resolved)…
+    expect(startGroupAsync).not.toHaveBeenCalled();
+    // …and the loop was driven to a TERMINAL state, carrying the reason.
+    expect(casLoopState).toHaveBeenCalledWith("loop-73fddadc", "reviewing", "failed", expect.any(Object));
+    const final = get();
+    expect(final.state).toBe("failed");
+    expect(final.error).toBe(UNRESOLVED_REASON);
+    expect(final.error).not.toContain("Needed a single revision");
+    expect(final.completedAt).toBeInstanceOf(Date);
+  });
+
+  it("a FAILED loop is terminal: the next tick is a no-op (never re-drives the missing sha)", async () => {
+    buildDiffContextMock.mockResolvedValue(unresolvedFail());
+    const loop = makeLoop({ state: "building_context" });
+    const { storage, startGroupAsync, get } = fakeStorage(loop);
+    const controller = makeController(storage, startGroupAsync, makeConfig());
+
+    await controller.tick(loop.id); // → failed
+    buildDiffContextMock.mockClear();
+    const res = await controller.tick(loop.id); // terminal → no-op
+
+    expect(res).toBeNull();
+    expect(buildDiffContextMock).not.toHaveBeenCalled(); // no re-attempt of the ref
+    expect(get().state).toBe("failed");
+  });
+
+  it("stranded-redrive path: a reviewing loop with a null child ref also fails closed", async () => {
+    // Simulate a loop already parked in `reviewing` with a null iteration ref, past
+    // the grace window — redriveStranded re-runs startReviewRound, which now returns
+    // the terminal unresolved-ref and must FAIL the loop instead of re-stranding it.
+    buildDiffContextMock.mockResolvedValue(unresolvedFail());
+    const loop = makeLoop({
+      state: "reviewing",
+      round: 0,
+      currentIterationNumber: null,
+      updatedAt: new Date(Date.now() - 30 * MIN),
+    });
+    const { storage, casLoopState, get } = fakeStorage(loop);
+    const controller = makeController(storage, storage.startGroupAsync ?? vi.fn(), makeConfig());
+
+    await controller.tick(loop.id);
+
+    expect(casLoopState).toHaveBeenCalledWith("loop-73fddadc", "reviewing", "failed", expect.any(Object));
+    expect(get().state).toBe("failed");
+    expect(get().error).toBe(UNRESOLVED_REASON);
+  });
+
+  it("a TRANSIENT git failure is UNCHANGED: stays reviewing (redrive path), not failed", async () => {
+    // Only `unresolved-ref` is terminal. A non-deterministic failure keeps the
+    // legacy strand-and-redrive behaviour so a transient blip is retried.
+    buildDiffContextMock.mockResolvedValue({ ok: false, errorKind: "unknown", message: "transient git blip" });
+    const loop = makeLoop({ state: "building_context" });
+    const { storage, casLoopState, startGroupAsync, get } = fakeStorage(loop);
+    const controller = makeController(storage, startGroupAsync, makeConfig());
+
+    await controller.tick(loop.id);
+
+    // NOT driven terminal — no reviewing→failed CAS.
+    expect(casLoopState).not.toHaveBeenCalledWith(
+      "loop-73fddadc",
+      "reviewing",
+      "failed",
+      expect.any(Object),
+    );
+    expect(get().state).toBe("reviewing");
+    expect(get().error).toBe("transient git blip");
+  });
+});

--- a/tests/unit/triggers-ui.test.ts
+++ b/tests/unit/triggers-ui.test.ts
@@ -16,6 +16,7 @@ import {
   isTriggerFormValid,
   canAddTrigger,
   buildLoopTemplate,
+  configSummary,
   loopTargetSummary,
   isGitHubRepoValid,
   formatValidationIssues,
@@ -24,27 +25,8 @@ import {
 
 // ─── Helpers duplicated from TriggerCard / TriggerForm ──────────────────────
 // (keeping them in test scope avoids re-exporting implementation details)
-
-function configSummary(trigger: PipelineTrigger): string {
-  switch (trigger.type) {
-    case "webhook":
-      return trigger.webhookUrl
-        ? `POST ${trigger.webhookUrl}`
-        : "Webhook endpoint auto-assigned";
-    case "schedule": {
-      const cfg = trigger.config as ScheduleTriggerConfig;
-      return cfg.cron;
-    }
-    case "github_event": {
-      const cfg = trigger.config as GitHubEventTriggerConfig;
-      return `${cfg.repository} · ${cfg.events.join(", ")}`;
-    }
-    case "file_change": {
-      const cfg = trigger.config as FileChangeTriggerConfig;
-      return `${cfg.watchPath} · ${cfg.patterns.join(", ")}`;
-    }
-  }
-}
+// NOTE: `configSummary` is imported from the module above (single source of
+// truth) so these tests exercise the real render logic the card uses.
 
 function parseCronHuman(cron: string): string {
   const parts = cron.trim().split(/\s+/);
@@ -131,6 +113,48 @@ describe("configSummary", () => {
       } as FileChangeTriggerConfig,
     });
     expect(configSummary(trigger)).toBe("/workspace/src · **/*.ts, !node_modules/**");
+  });
+
+  // ─── ROBUSTNESS: API-created triggers can omit `events`/`patterns` ──────────
+  // Regression guard for "Cannot read properties of undefined (reading 'join')"
+  // which took the whole /triggers page into its error boundary.
+
+  it("file_change with NO patterns (spec-watch demo shape) renders without throwing", () => {
+    // The spec-watch demo trigger is exactly { watchPath, action } — no patterns.
+    const trigger = buildTrigger({
+      type: "file_change",
+      config: {
+        watchPath: "/workspace/specs",
+        action: { kind: "consilium_review", preset: "sdlc-cross-review" },
+      } as unknown as FileChangeTriggerConfig,
+    });
+    expect(() => configSummary(trigger)).not.toThrow();
+    expect(configSummary(trigger)).toBe("/workspace/specs");
+  });
+
+  it("file_change with empty patterns array falls back to watchPath alone", () => {
+    const trigger = buildTrigger({
+      type: "file_change",
+      config: { watchPath: "/workspace/src", patterns: [] } as FileChangeTriggerConfig,
+    });
+    expect(configSummary(trigger)).toBe("/workspace/src");
+  });
+
+  it("github_event with NO events renders repository alone without throwing", () => {
+    const trigger = buildTrigger({
+      type: "github_event",
+      config: { repository: "acme/app" } as unknown as GitHubEventTriggerConfig,
+    });
+    expect(() => configSummary(trigger)).not.toThrow();
+    expect(configSummary(trigger)).toBe("acme/app");
+  });
+
+  it("github_event with empty events array falls back to repository alone", () => {
+    const trigger = buildTrigger({
+      type: "github_event",
+      config: { repository: "acme/app", events: [] } as GitHubEventTriggerConfig,
+    });
+    expect(configSummary(trigger)).toBe("acme/app");
   });
 });
 


### PR DESCRIPTION
Two real robustness bugs the operator hit live, both reproduced.

## BUG 1 — `/triggers` page crashes: "Cannot read properties of undefined (reading 'join')"

`TriggerCard.configSummary()` did `cfg.events.join(", ")` (`github_event`) and `cfg.patterns.join(", ")` (`file_change`) unguarded. A `file_change` trigger created via the API with only `{ watchPath, action }` and **no `patterns`** (exactly the spec-watch demo trigger shape) makes `cfg.patterns` `undefined` → `.join` throws → the whole `TriggersPage` renders the "Something went wrong" error boundary.

**Fix**
- Promoted `configSummary` into the pure, node-testable `trigger-form-logic.ts` (single source of truth; the old unit test duplicated the function, so a fix in the component alone would not have been exercised).
- Guarded both arrays: `(cfg.events ?? []).join(", ")`, `(cfg.patterns ?? []).join(", ")`, and render a sensible summary (repository / watchPath alone) when the array is empty or absent — no trailing " · ".
- Hardened `TriggerForm`'s `github_event` `events` read to `?? []` (mirrors the already-guarded `patterns ?? []`) so editing a malformed trigger cannot crash the form on `events.includes`/`events.length`.
- `loopTargetSummary` audited — already safe (uses `filter/pop`, no unguarded `.join`).

**Tests** — a `file_change` trigger with `{watchPath, action}` and no `patterns` renders without throwing (falls back to the watchPath); a `github_event` with no `events` likewise (repository alone); empty-vs-absent array both covered.

## BUG 2 — a polling/GitHub-fired diff-pr-review dies with "fatal: Needed a single revision" and hangs in `reviewing`

**Live case:** loop `73fddadc` — a `github_event` trigger (id `8ed4f87e`) fired via polling on an Omniscience PR, ran a `diff-pr-review`, the round errored with `fatal: Needed a single revision`, then the loop sat in `state=reviewing, round=0/1` forever.

**Root cause** — `diff-pr-review` resolves the PR head/base sha against the **local** checkout, but a PR commit fired from GitHub/polling is often never fetched locally, so `git rev-parse` cannot resolve it. `startReviewRound`'s `buildDiffContext` failure returned `{ error }`, leaving the loop in `reviewing` with a **null child ref**; `redriveStranded` then re-attempted the same missing sha every grace window. Because the round never advanced, `maxRounds` never tripped → stuck reviewing forever.

**Fix**
1. **Resolve the ref safely** (`diff-context.ts`): verify the head/base sha locally (`revparse --verify --end-of-options <ref>^{commit}`, reusing the vbm-argv pattern); if missing, attempt **one bounded** `git fetch origin <ref>` (default client created with a block timeout so it can never hang), then re-verify. The ref is already gated (baseline strict-hex; head via `validateReviewRef`, which rejects leading `-`), so the fetch arg-array is safe.
2. **Fail closed with an explanation, never hang**: an unresolvable ref becomes a deterministic `unresolved-ref` `GitFail` with an operator-readable reason — `diff <role> <sha> is not present in the local checkout of <repo>; fetch the PR ref or point the review at a local branch` — never the raw git string. The controller now drives the loop `reviewing → failed` via the **existing** `review_failed` edge (reason recorded on `loop.error`, `completedAt` set), so the UI shows the explanation instead of a bare git error. Transient (non-deterministic) git failures keep the legacy strand-and-redrive behaviour.

**Tests**
- diff-context unit: fetch-then-resolve (fetch called exactly once, then diffs); fail-closed with no `fetch` client; the raw "Needed a single revision" is never leaked into the operator reason.
- diff-context real-git: baseline sha absent → `unresolved-ref`; **empty repo** (zero commits) resolving HEAD → `unresolved-ref`; **fetch-then-resolve happy path** against a real `origin` that has the commit the consumer clone lacks.
- FSM (`loop-unresolved-ref.test.ts`): the primary `building_context → reviewing → failed` path lands terminal-with-reason (review never dispatched); a `failed` loop is terminal and the next tick is a no-op (never re-attempts the sha); the stranded-redrive path also fails closed; a transient failure stays `reviewing` (unchanged).

## Validation
- `tsc` clean (client + server, incl. new tests).
- Full unit project green: **5073 passed**. Consilium + trigger integration green.
- Confirms loop-73fddadc-class failures now land **terminal (`failed`) with an operator reason** instead of stuck-reviewing.

Adversarial self-review covered: empty vs absent trigger arrays; a diff-pr-review on a zero-commit repo; the fetch is block-timeout-bounded (cannot hang); the terminal transition is a CAS (single-flight — never double-fires or loses the reason).