### PR TITLE
feat: spec status lifecycle draft→ready→in-progress→done (SPEC-2)

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -59,8 +59,13 @@ import { registerTaskGroupResolveRoute } from "./routes/task-group-resolve";
 import { registerConsiliumLoopRoutes } from "./routes/consilium-loops";
 import { registerConsiliumReviewRoutes } from "./routes/consilium-reviews";
 import { createConsiliumReview } from "./services/consilium/review-factory";
-import { maybeLaunchConsiliumReview, maybeLaunchGitHubReview, resolveSpecWatchConfig } from "./services/consilium/trigger-dispatch";
+import { maybeLaunchConsiliumReview, maybeLaunchGitHubReview, resolveSpecWatchConfig, deriveRepoRoot } from "./services/consilium/trigger-dispatch";
 import { ConsiliumLoopController, ConsiliumLoopPoller } from "./services/consilium/consilium-loop-controller";
+import {
+  writeSpecStatusRemote,
+  specStatusForTerminalLoop,
+  type SpecStatusValue,
+} from "./services/consilium/spec-status-writer";
 import { registerModelSkillBindingRoutes } from "./routes/model-skill-bindings";
 import { registerTaskTraceRoutes } from "./routes/task-traces";
 import { registerTaskIterationRoutes } from "./routes/task-iterations";
@@ -256,6 +261,29 @@ export async function registerRoutes(
   // SAME controller. Stays null when the kill-switch is off — fireTrigger then
   // treats a consilium_review action as an inert no-op (logs + skips).
   let consiliumLoopController: ConsiliumLoopController | null = null;
+  // SPEC-2 (spec-as-task.md §4): the ONE spec-status write seam, GATED behind
+  // spec-watch. BOTH lifecycle flips route through here — the launch flip
+  // (`ready → in-progress`, via the trigger dispatch) and the terminal flip
+  // (`in-progress → blocked`, via the loop controller) — so the kill-switch is
+  // enforced in a SINGLE place and the write is BEST-EFFORT + never-throw. When
+  // spec-watch is OFF, this returns immediately: no `gh` call, no commit, byte-
+  // identical to before. It commits REMOTELY (never the operator's local tree).
+  const flipSpecStatus = async (args: {
+    specPath: string;
+    specRepoPath: string;
+    from: SpecStatusValue;
+    to: SpecStatusValue;
+    reason?: string;
+  }): Promise<void> => {
+    if (!resolveSpecWatchConfig(appConfigLoader.get()).enabled) return; // kill-switch OFF ⇒ no write.
+    const res = await writeSpecStatusRemote(
+      { log: (m) => log(m, "triggers") },
+      { specRepoPath: args.specRepoPath, specPath: args.specPath, expectedFrom: args.from, to: args.to, reason: args.reason },
+    );
+    if (!res.ok) {
+      log(`[spec-status] ${args.from}->${args.to} not written for ${args.specPath}: ${res.reason}`, "triggers");
+    }
+  };
   if (appConfigLoader.get().pipeline.consiliumLoop.enabled) {
     consiliumLoopController = new ConsiliumLoopController({
       storage,
@@ -268,6 +296,22 @@ export async function registerRoutes(
       // §14.4: the DEVELOPING→AWAITING_MERGE close-out runs the SDLC executor
       // (isolated worktree + agentic coder + Draft PR) by default — no manager
       // seam needed here. Push/PR go through pr-wrapper (B-3/H-6/H-7/M-6/M-7).
+      //
+      // SPEC-2 (§4): on a SPEC-FIRED loop reaching a TERMINAL state, flip the spec's
+      // `status:`. `converged` leaves it `in-progress` (the code PR is the next gate,
+      // spec→done comes from the merge — reconcileSpecStatusOnPrMerge); a stalled
+      // terminal (`failed`/`stopped_cap`/`escalated`/`cancelled`) → `blocked` so it
+      // does NOT re-fire the watch trigger (only `ready` fires). CAS-guarded on
+      // `in-progress`, so a spec a human already moved is never clobbered.
+      onSpecLoopTerminal: async (loop, terminalState) => {
+        const specPath = loop.triggerProvenance?.spec?.specPath;
+        if (!specPath) return;
+        const target = specStatusForTerminalLoop(terminalState);
+        if (!target) return; // converged / non-terminal → leave in-progress.
+        const specRepoPath = deriveRepoRoot(specPath);
+        if (!specRepoPath) return;
+        await flipSpecStatus({ specPath, specRepoPath, from: "in-progress", to: target.to, reason: target.reason });
+      },
     });
     registerConsiliumLoopRoutes(app, storage, consiliumLoopController, () => appConfigLoader.get());
     // POST /api/consilium-reviews — the UI "New consilium review" button. Same
@@ -418,6 +462,12 @@ export async function registerRoutes(
           // byte-identical. The parent consiliumLoop.enabled gate is enforced downstream
           // (reviewDeps null). The fold lives in one tested helper (see its unit test).
           specWatch: () => resolveSpecWatchConfig(appConfigLoader.get()),
+          // SPEC-2 (§4): flip a just-launched spec `ready → in-progress`. The shared
+          // `flipSpecStatus` helper is spec-watch-gated + best-effort + never-throw, so
+          // a status-commit hiccup can never turn a real loop launch into a failure. The
+          // dispatch only calls it on a genuine `launched` (not dedup/skip), from inside
+          // the spec path (which itself runs only when spec-watch is enabled).
+          flipSpecStatus,
           log: (m: string) => log(m, "triggers"),
         };
 

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -658,6 +658,18 @@ export interface ConsiliumLoopControllerDeps {
    * gateway. NEVER reached for non-research loops.
    */
   runResearch?: typeof runResearchHandoff;
+  /**
+   * SPEC-2 (spec-as-task.md §4): notify that a SPEC-FIRED loop (one carrying
+   * `triggerProvenance.spec`) reached a TERMINAL state, so the spec's frontmatter
+   * `status:` can be flipped accordingly (a stalled terminal → `blocked`; `converged`
+   * leaves it `in-progress` — the code PR is the next gate). The route wires this to
+   * the spec-status writer, GATED behind `specWatch`; absent for every non-route
+   * caller / test ⇒ no write (byte-identical, no new default-on behaviour). Invoked
+   * ONLY on the CAS WINNER for a terminal transition, so a status flip fires at most
+   * once per loop terminal. Best-effort + never-throw: a status-write failure must
+   * never crash a `tick`/`cancel` nor undo the (already-committed) FSM transition.
+   */
+  onSpecLoopTerminal?: (loop: ConsiliumLoopRow, terminalState: ConsiliumLoopState) => Promise<void>;
 }
 
 export class ConsiliumLoopController {
@@ -1226,9 +1238,21 @@ export class ConsiliumLoopController {
     extra?: Record<string, unknown>,
   ): Promise<ConsiliumLoopRow | null> {
     const merged = { ...(transition.extra ?? {}), ...(extra ?? {}) };
-    return (
-      (await this.storage.casLoopState(loop.id, transition.from, transition.to, merged)) ?? null
-    );
+    const won =
+      (await this.storage.casLoopState(loop.id, transition.from, transition.to, merged)) ?? null;
+    // SPEC-2 (spec-as-task.md §4): a SPEC-FIRED loop reaching a TERMINAL state flips
+    // the spec's `status:` (terminal-stall → `blocked`; `converged` stays
+    // `in-progress`). Runs ONLY on the CAS winner (`won !== null`), so exactly one
+    // terminal flip fires per loop even under multi-instance ticks. Best-effort +
+    // never-throw: a status-write failure must not undo the (already-persisted)
+    // transition nor crash the tick/cancel. The mapping/gating live in the injected
+    // hook (`onSpecLoopTerminal`); absent ⇒ no-op (byte-identical).
+    if (won && this.deps.onSpecLoopTerminal && isTerminal(won.state) && won.triggerProvenance?.spec) {
+      await this.deps
+        .onSpecLoopTerminal(won, won.state)
+        .catch((e) => this.log(won.id, `spec-status terminal flip errored: ${scrubErr(String(e))}`));
+    }
+    return won;
   }
 
   /**

--- a/server/services/consilium/spec-parser.ts
+++ b/server/services/consilium/spec-parser.ts
@@ -97,6 +97,7 @@ export type ReadyGateReason =
   | "no-acceptance-criteria"
   | "status:in-progress"
   | "status:done"
+  | "status:blocked"
   | "unknown-status";
 
 export type ReadyGateResult =
@@ -225,7 +226,11 @@ export function readSpecFile(
 
 // ─── Ready-gate (spec-as-task §3/§5) ────────────────────────────────────────────
 
-const RECOGNIZED_STATUSES = new Set(["draft", "ready", "in-progress", "done"]);
+// SPEC-2 (spec-as-task.md §4): `blocked` is a recognized, INERT terminal status —
+// a spec-fired loop that fails/escalates/caps/cancels is flipped `in-progress →
+// blocked` (see spec-status-writer.specStatusForTerminalLoop) so it never RE-FIRES
+// (only `ready` fires). A human moves `blocked → ready` after fixing to re-trigger.
+const RECOGNIZED_STATUSES = new Set(["draft", "ready", "in-progress", "done", "blocked"]);
 
 /**
  * Decide whether a parsed candidate FIRES a loop. Fires ONLY when
@@ -247,6 +252,9 @@ export function evaluateReadyGate(parsed: SpecParseResult): ReadyGateResult {
   if (status === "draft") return { fire: false, reason: "draft" };
   if (status === "in-progress") return { fire: false, reason: "status:in-progress" };
   if (status === "done") return { fire: false, reason: "status:done" };
+  // SPEC-2: a `blocked` spec is inert — it stalled and needs a human to move it back
+  // to `ready`. NEVER fires (that would re-launch the same failing loop unbounded).
+  if (status === "blocked") return { fire: false, reason: "status:blocked" };
 
   // status === "ready": REQUIRES non-empty acceptanceCriteria (the DoD the loop
   // verifies against — no criteria ⇒ nothing to verify ⇒ not ready).

--- a/server/services/consilium/spec-status-writer.ts
+++ b/server/services/consilium/spec-status-writer.ts
@@ -1,0 +1,388 @@
+/**
+ * spec-status-writer.ts — SPEC-2 (spec-as-task.md §4): commit the spec's
+ * `status:` frontmatter lifecycle flip (draft→ready→in-progress→done, plus the
+ * terminal `blocked`) back to the repo the spec lives in.
+ *
+ * WHY A REMOTE (gh api) COMMIT — never a local git checkout/commit
+ *   The watcher runs in the operator's server process against a LIVE working tree
+ *   they may be editing. Flipping the status LOCALLY (checkout/add/commit) would
+ *   mutate that tree — a destructive side effect an unattended trigger must never
+ *   inflict. So every status write goes through the SAME safe `gh` HTTP seam
+ *   SPEC-1/TRACK-1 use (spec-writer.ts): read the file's current blob on the
+ *   default branch, rewrite the one status line, PUT it back on the default
+ *   branch. The operator's tree is never touched; branch-protection, if any, makes
+ *   the PUT fail — which degrades to a logged best-effort no-op, never a crash.
+ *
+ * WHY FRONTMATTER (not a sidecar) — spec-as-task.md §8 open question
+ *   The status lives IN the spec's frontmatter (not a sidecar / loop-state row) so
+ *   it is HUMAN-VISIBLE in the diff and on GitHub: a reviewer sees `in-progress`
+ *   the moment the loop starts and `done` when the code PR merges, with the commit
+ *   history as the audit trail. The cost is a small churn commit per transition —
+ *   accepted for visibility. The `status:` value is the single source of truth for
+ *   "is this being worked / done" (§7: no silent drift).
+ *
+ * RACE / SAFETY (flagged for the adversarial reviewer)
+ *   R1. TWO ticks racing to flip the same spec: the pure {@link rewriteSpecStatus}
+ *       is CAS-GUARDED on `expectedFrom` — it only rewrites when the file STILL
+ *       reads the expected prior status. The second writer reads the already-flipped
+ *       value → `status-mismatch` → no-op. Belt-and-braces: the GitHub contents PUT
+ *       carries the blob `sha` we read; a concurrent write changes the sha → 409 →
+ *       typed `sha-conflict` no-op. Two independent guards, no lost update, no clobber.
+ *   R2. The status commit FAILING must never crash the loop/dispatch: every path is
+ *       never-throw (`{ ok:false, reason }`); the callers invoke it best-effort.
+ *   R3. Never clobber a HUMAN edit: because the flip is CAS-guarded on `expectedFrom`,
+ *       a spec a human moved elsewhere (e.g. back to `draft`) is left untouched.
+ *   R4. Fenced path: the spec's repo-relative path is derived + validated to stay
+ *       INSIDE the spec repo (no `..`, not absolute) before it reaches `gh`.
+ */
+import { relative, isAbsolute } from "path";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { runGhJson, type ExecFileFn } from "../github-status.js";
+import { parseOwnerRepo } from "../github-poller.js";
+import { runGhCapture } from "./trackers/gh-exec.js";
+
+const execFileAsync: ExecFileFn = promisify(execFile);
+
+/** The spec lifecycle values (spec-as-task.md §2 + SPEC-2's terminal `blocked`). */
+export type SpecStatusValue = "draft" | "ready" | "in-progress" | "done" | "blocked";
+
+// ─── Pure: terminal loop state → target spec status (SPEC-2 §4 policy) ──────────
+
+/**
+ * Map a spec-fired loop's TERMINAL state to the spec status it should be flipped to,
+ * or `null` to LEAVE the status unchanged (spec-as-task.md §4):
+ *
+ *   - `converged`  → null. The loop reached a positive terminal (a review converged,
+ *     or a develop run's PR was merge-approved). The spec STAYS `in-progress`: the
+ *     CODE PR is the next gate, and the spec goes `done` ONLY when that PR merges
+ *     (never auto-`done` from a loop verdict — see {@link specStatusForPrMerge}).
+ *   - `failed` / `stopped_cap` / `escalated` / `cancelled` → `blocked`. The unit of
+ *     work stalled and needs a human. We flip to `blocked` (NOT back to `ready`) on
+ *     purpose: `ready` would RE-FIRE the watch trigger (transition-to-ready) →
+ *     another loop → likely the same failure → an unbounded re-fire loop + budget
+ *     burn. `blocked` is inert (the ready-gate never fires on it), so recovery is an
+ *     explicit human edit `blocked→ready` after fixing — which re-fires exactly once.
+ *
+ * This is the recoverability guarantee: a spec whose loop DIES is never stuck
+ * `in-progress` forever — the terminal hook moves it to `blocked` (human-visible,
+ * re-triggerable), and if the write itself fails the dedup already released so a
+ * human can re-drive.
+ */
+export function specStatusForTerminalLoop(
+  state: string,
+): { to: SpecStatusValue; reason: string } | null {
+  switch (state) {
+    case "converged":
+      return null; // stays in-progress — the code PR is the next gate.
+    case "failed":
+      return { to: "blocked", reason: "loop failed" };
+    case "stopped_cap":
+      return { to: "blocked", reason: "loop hit round cap" };
+    case "escalated":
+      return { to: "blocked", reason: "loop escalated to human" };
+    case "cancelled":
+      return { to: "blocked", reason: "loop cancelled" };
+    default:
+      return null; // non-terminal / unknown → never touch the spec.
+  }
+}
+
+/**
+ * Map an observed GitHub PR status for a spec-fired loop's CODE PR to the spec
+ * status flip, or `null` for no change (spec-as-task.md §4 GATE 2). ONLY a `MERGED`
+ * code PR closes the spec (`in-progress → done`). `OPEN`/`DRAFT` (still in review),
+ * `CLOSED` (abandoned — a human re-opens/re-specs), and `unknown` (GitHub degraded)
+ * all leave the spec untouched — we NEVER auto-`done` without a real merge.
+ */
+export function specStatusForPrMerge(
+  prStatus: string,
+): { to: SpecStatusValue; reason: string } | null {
+  return prStatus === "MERGED" ? { to: "done", reason: "code PR merged" } : null;
+}
+
+/**
+ * The minimal shape of a loop the code-PR→done reconciler reads (a structural slice
+ * of `ConsiliumLoopRow` — kept local so the writer never imports the heavy schema).
+ */
+export interface SpecLoopView {
+  state: string;
+  prRef: string | null;
+  triggerProvenance?: { spec?: { specPath?: string } } | null;
+}
+
+/**
+ * SPEC-2 GATE-2 (spec-as-task.md §4): the code-PR-merge → `done` RECONCILER (the
+ * documented hook). Given a spec-fired loop and an OBSERVED GitHub PR status for its
+ * code PR (`prRef`), flip the spec `in-progress → done` IFF the PR is `MERGED`.
+ *
+ * This is deliberately the ONLY path to `done` — a spec is closed by a MERGED CODE
+ * PR, never auto-`done` from a loop verdict (§4: "only a merged code PR closes the
+ * spec"). It acts only when:
+ *   - the loop is SPEC-FIRED (`triggerProvenance.spec.specPath` present), AND
+ *   - it carries a `prRef` (a real code PR was opened by a develop run), AND
+ *   - the loop is at a PR-bearing terminal/awaiting state (`converged`/`awaiting_merge`), AND
+ *   - the observed PR status is `MERGED`.
+ * Everything else is a typed no-op. Never throws (delegates to the never-throw writer).
+ * The `in-progress → done` write is CAS-guarded (a spec a human already closed/moved
+ * is left untouched).
+ *
+ * WIRING (the hook): the existing PR-status seam (`github-status.ts`
+ * `fetchPrStatus`/`githubStatusCache`, #474) already observes `MERGED` for a loop's
+ * `prRef` in the `/api/pr-queue` reconcile. This function is what that observation
+ * point calls to close the spec. See the SPEC-2 boundary note in the PR body:
+ * periodic invocation INDEPENDENT of a queue view (a terminal `converged` loop is not
+ * ticked by the poller) is the piece deferred to a follow-up.
+ */
+export async function reconcileSpecStatusOnPrMerge(
+  deps: SpecStatusWriterDeps,
+  loop: SpecLoopView,
+  observedPrStatus: string,
+  specRepoPath: string,
+): Promise<WriteSpecStatusResult | { ok: false; reason: string }> {
+  const specPath = loop.triggerProvenance?.spec?.specPath;
+  if (!specPath) return { ok: false, reason: "not-spec-fired" };
+  if (!loop.prRef) return { ok: false, reason: "no-pr-ref" };
+  if (loop.state !== "converged" && loop.state !== "awaiting_merge") {
+    return { ok: false, reason: "not-pr-bearing-state" };
+  }
+  const target = specStatusForPrMerge(observedPrStatus);
+  if (!target) return { ok: false, reason: "pr-not-merged" };
+  return writeSpecStatusRemote(deps, {
+    specRepoPath,
+    specPath,
+    expectedFrom: "in-progress",
+    to: target.to,
+    reason: target.reason,
+  });
+}
+
+// ─── Pure: repo-relative, fenced spec path (R4) ────────────────────────────────
+
+/**
+ * Derive the spec's repo-relative path for the `gh` contents API, fenced INSIDE the
+ * spec repo. Returns `null` (caller no-ops) when the spec is not under the repo root
+ * (escapes via `..`, is absolute after relativisation, or is empty) — a path that
+ * could target a file outside the repo must never reach a write.
+ */
+export function specRelPath(repoRoot: string, specPath: string): string | null {
+  if (repoRoot.length === 0 || specPath.length === 0) return null;
+  const rel = relative(repoRoot, specPath).replace(/\\/g, "/");
+  if (rel.length === 0) return null;
+  if (rel === ".." || rel.startsWith("../") || isAbsolute(rel)) return null;
+  return rel;
+}
+
+// ─── Pure: CAS-guarded status rewrite (R1/R3) ──────────────────────────────────
+
+/** Matches the leading `---\n` fence so we can splice at an EXACT byte offset. */
+const OPEN_FENCE_RE = /^\uFEFF?---[ \t]*\r?\n/;
+/** Matches the whole frontmatter block; group 1 is the YAML text (mirror of spec-parser). */
+const FRONTMATTER_RE = /^\uFEFF?---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n[\s\S]*)?$/;
+/**
+ * A single frontmatter `status:` line: prefix, optional quote, value (no quote /
+ * comment / newline), same quote, optional trailing whitespace + `#` comment.
+ */
+const STATUS_LINE_RE =
+  /^([ \t]*status[ \t]*:[ \t]*)(["']?)([^"'\r\n#]*?)\2([ \t]*(?:#[^\r\n]*)?)$/m;
+
+export type SpecRewriteResult =
+  | { changed: true; content: string; from: SpecStatusValue }
+  | {
+      changed: false;
+      reason: "no-frontmatter" | "no-status-field" | "status-mismatch" | "unchanged";
+      /** The current status found (for `status-mismatch`/`unchanged` logging). */
+      current?: string;
+    };
+
+/**
+ * Rewrite ONLY the frontmatter `status:` value, IFF it currently reads
+ * `expectedFrom` (case-insensitive). Everything else — body, other frontmatter
+ * keys, line endings, indentation, a trailing `# comment` on the status line — is
+ * preserved byte-for-byte (the value is spliced at its exact offset, not re-emitted
+ * via a YAML round-trip). Pure + never throws.
+ *
+ *   - no frontmatter fence            → `no-frontmatter`
+ *   - frontmatter but no status line  → `no-status-field`
+ *   - status is not `expectedFrom`    → `status-mismatch` (the R1/R3 guard: a racing
+ *                                       writer or a human already moved it — no-op)
+ *   - status is already `to`          → `unchanged` (idempotent re-run)
+ */
+export function rewriteSpecStatus(
+  content: string,
+  expectedFrom: SpecStatusValue,
+  to: SpecStatusValue,
+): SpecRewriteResult {
+  const fm = FRONTMATTER_RE.exec(content);
+  if (fm === null) return { changed: false, reason: "no-frontmatter" };
+  const open = OPEN_FENCE_RE.exec(content);
+  if (open === null) return { changed: false, reason: "no-frontmatter" };
+  const yamlStart = open[0].length;
+  const yaml = fm[1];
+
+  const sm = STATUS_LINE_RE.exec(yaml);
+  if (sm === null) return { changed: false, reason: "no-status-field" };
+
+  const current = sm[3].trim().toLowerCase();
+  if (current === to) return { changed: false, reason: "unchanged", current };
+  if (current !== expectedFrom) return { changed: false, reason: "status-mismatch", current };
+
+  // Rebuild the line unquoted (status values are simple slugs), preserving the
+  // prefix (indent + `status:` + spacing) and any trailing `# comment`.
+  const newLine = `${sm[1]}${to}${sm[4]}`;
+  const absStart = yamlStart + sm.index;
+  const absEnd = absStart + sm[0].length;
+  const newContent = content.slice(0, absStart) + newLine + content.slice(absEnd);
+  return { changed: true, content: newContent, from: expectedFrom };
+}
+
+// ─── Remote write (never throws) ───────────────────────────────────────────────
+
+/** Default git-remote reader (spec-writer/github-poller parity; NEVER throws). */
+export async function defaultGitRemoteUrl(
+  repoPath: string,
+  run: ExecFileFn = execFileAsync,
+): Promise<string | null> {
+  try {
+    const { stdout } = await run(
+      "git",
+      ["-C", repoPath, "remote", "get-url", "origin"],
+      { timeout: 10_000 },
+    );
+    const url = (stdout ?? "").trim();
+    return url.length > 0 ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface SpecStatusWriterDeps {
+  /** Injectable `gh` runner (tests pass a fake — no real `gh`/network). */
+  runGh?: ExecFileFn;
+  /** Read the spec repo's `origin` URL (→ owner/repo). Defaults to the git seam. */
+  gitRemoteUrl?: (repoPath: string) => Promise<string | null>;
+  /** Structured logger. */
+  log: (message: string) => void;
+}
+
+export interface WriteSpecStatusParams {
+  /** The repo the SPEC FILE lives in (its OWN repo — may differ from the loop's target `repo:`). */
+  specRepoPath: string;
+  /** Absolute path of the spec file. */
+  specPath: string;
+  /** CAS guard: only flip when the file still reads this (R1/R3). */
+  expectedFrom: SpecStatusValue;
+  /** The new status. */
+  to: SpecStatusValue;
+  /** Short audit note folded into the commit message (e.g. the terminal reason). */
+  reason?: string;
+}
+
+export type WriteSpecStatusResult =
+  | { ok: true; from: SpecStatusValue; to: SpecStatusValue }
+  | { ok: false; reason: string };
+
+/** Decode a GitHub contents API base64 blob (newline-wrapped) to UTF-8 text. */
+function decodeContentsBlob(raw: unknown): string | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const rec = raw as { content?: unknown; encoding?: unknown; sha?: unknown };
+  if (typeof rec.content !== "string") return null;
+  if (rec.encoding !== undefined && rec.encoding !== "base64") return null;
+  try {
+    return Buffer.from(rec.content.replace(/\s+/g, ""), "base64").toString("utf8");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Commit the spec's `status:` flip REMOTELY on the default branch via `gh` (see the
+ * module header). NEVER throws — every failure is a typed `{ ok:false, reason }` the
+ * caller logs. The default-branch read-then-PUT is CAS-guarded twice (R1): the pure
+ * rewrite only acts when the remote file still reads `expectedFrom`, and the PUT
+ * carries the read blob `sha` so a concurrent write 409s instead of clobbering.
+ */
+export async function writeSpecStatusRemote(
+  deps: SpecStatusWriterDeps,
+  params: WriteSpecStatusParams,
+): Promise<WriteSpecStatusResult> {
+  const { runGh, log } = deps;
+  const gitRemoteUrl = deps.gitRemoteUrl ?? ((p: string) => defaultGitRemoteUrl(p, runGh));
+  const { specRepoPath, specPath, expectedFrom, to, reason } = params;
+
+  try {
+    // R4: repo-relative, fenced path.
+    const relPath = specRelPath(specRepoPath, specPath);
+    if (relPath === null) {
+      log(`spec-status: refusing out-of-repo spec path ${specPath} (repo ${specRepoPath})`);
+      return { ok: false, reason: "bad-path" };
+    }
+
+    // Origin-derived, validated owner/repo (reuse github-poller's parser).
+    const remoteUrl = await gitRemoteUrl(specRepoPath);
+    const ownerRepo = remoteUrl ? parseOwnerRepo(remoteUrl) : null;
+    if (!ownerRepo) {
+      log(`spec-status: no github owner/repo for ${specRepoPath} — skip`);
+      return { ok: false, reason: "bad-origin" };
+    }
+
+    // Default branch (where a `ready` spec lives — §3/§4).
+    const repoMeta = await runGhJson<{ defaultBranchRef?: { name?: string } }>(
+      ["repo", "view", ownerRepo, "--json", "defaultBranchRef"],
+      runGh,
+    );
+    const base = repoMeta?.defaultBranchRef?.name;
+    if (!base || typeof base !== "string" || base.length === 0) {
+      log(`spec-status: no default branch for ${ownerRepo} (gh degraded) — skip`);
+      return { ok: false, reason: "no-default-branch" };
+    }
+
+    // Read the file's current blob (content + sha) on the default branch.
+    const fileInfo = await runGhJson<{ content?: string; encoding?: string; sha?: string }>(
+      ["api", `repos/${ownerRepo}/contents/${relPath}?ref=${base}`],
+      runGh,
+    );
+    const sha = fileInfo?.sha;
+    const decoded = decodeContentsBlob(fileInfo);
+    if (!sha || typeof sha !== "string" || decoded === null) {
+      log(`spec-status: could not read ${relPath}@${base} on ${ownerRepo} (gh degraded) — skip`);
+      return { ok: false, reason: "read-failed" };
+    }
+
+    // R1/R3 CAS: only flip when the REMOTE file still reads `expectedFrom`.
+    const rewrite = rewriteSpecStatus(decoded, expectedFrom, to);
+    if (!rewrite.changed) {
+      log(
+        `spec-status: no-op ${expectedFrom}→${to} for ${relPath}@${base} — ${rewrite.reason}` +
+          (rewrite.current ? ` (current=${rewrite.current})` : ""),
+      );
+      return { ok: false, reason: rewrite.reason };
+    }
+
+    // PUT the rewritten file on the default branch. The read `sha` makes a
+    // concurrent write 409 (sha-conflict) rather than clobber (R1 second guard).
+    const message = `chore(spec): status ${expectedFrom} -> ${to}${reason ? ` (${reason})` : ""}`;
+    const base64 = Buffer.from(rewrite.content, "utf8").toString("base64");
+    const putRes = await runGhCapture(
+      [
+        "api", "--method", "PUT", `repos/${ownerRepo}/contents/${relPath}`,
+        "-f", `message=${message}`, "-f", `content=${base64}`, "-f", `sha=${sha}`, "-f", `branch=${base}`,
+      ],
+      runGh,
+    );
+    if (!putRes.ok) {
+      // A 409 / sha mismatch means a concurrent write beat us — best-effort no-op.
+      if (/409|sha.*(mismatch|does not match|wasn)|conflict/i.test(putRes.stderr)) {
+        log(`spec-status: sha-conflict flipping ${relPath}@${base} (concurrent write) — no-op`);
+        return { ok: false, reason: "sha-conflict" };
+      }
+      log(`spec-status: PUT failed for ${relPath}@${base} on ${ownerRepo}: ${putRes.stderr}`);
+      return { ok: false, reason: "put-failed" };
+    }
+    log(`spec-status: flipped ${relPath}@${base} on ${ownerRepo}: ${expectedFrom} → ${to}`);
+    return { ok: true, from: expectedFrom, to };
+  } catch (err) {
+    log(`spec-status: unexpected error: ${(err as Error).message}`);
+    return { ok: false, reason: "exception" };
+  }
+}

--- a/server/services/consilium/trigger-dispatch.ts
+++ b/server/services/consilium/trigger-dispatch.ts
@@ -259,6 +259,25 @@ export interface ConsiliumTriggerDispatchDeps {
    * is the consilium-loop repo allowlist (used to resolve a spec's `repo:` field).
    */
   specWatch?: () => SpecWatchDispatchView;
+  /**
+   * SPEC-2 (spec-as-task.md §4, GATE-1→work): flip the just-fired spec's frontmatter
+   * `status: ready → in-progress` (a small remote commit to the spec file, via the
+   * SAME safe `gh` seam SPEC-1/TRACK-1 use — never the operator's local tree). Called
+   * BEST-EFFORT and ONLY on a real `launched` (not dedup-suppress / skip): a failed
+   * status commit must NEVER flip the launch result or crash the watcher. This is the
+   * DURABLE "this spec is being worked" signal that replaces reliance on the in-memory
+   * active-loop dedup (which still guards the window before the commit lands). Absent
+   * for every non-route caller / test ⇒ NO write (byte-identical). Gated by the route
+   * behind `specWatch.enabled`, and only reached from inside the spec path (which only
+   * runs when spec-watch is enabled) — so a disabled spec-watch never writes.
+   */
+  flipSpecStatus?: (args: {
+    specPath: string;
+    specRepoPath: string;
+    from: "ready" | "in-progress" | "done" | "blocked" | "draft";
+    to: "ready" | "in-progress" | "done" | "blocked" | "draft";
+    reason?: string;
+  }) => Promise<void>;
   /** Structured logger (the route passes `(m) => log(m, "triggers")`). */
   log: (message: string) => void;
 }
@@ -500,7 +519,7 @@ export async function maybeLaunchSpecReview(
     .trim()
     .slice(0, 120);
 
-  return launchReviewWithDedup(deps, trigger, {
+  const result = await launchReviewWithDedup(deps, trigger, {
     projectId,
     repoPath,
     preset,
@@ -518,6 +537,28 @@ export async function maybeLaunchSpecReview(
     eventSummary: `spec ready: ${titleLabel}`,
     payload,
   });
+
+  // SPEC-2 (§3/§4): a spec that ACTUALLY launched a loop transitions `ready →
+  // in-progress` — the durable "being worked" marker that stops a re-fire once the
+  // in-memory dedup expires (a `blocked`/`done`/`in-progress` spec no longer passes
+  // the ready-gate). ONLY on a real `launched` (never dedup-suppress: that means a
+  // loop is ALREADY running — its OWN launch already flipped the status, or is about
+  // to; re-flipping would be a redundant no-op the CAS guard rejects anyway). The
+  // spec file lives in ITS OWN repo (the watched repo), which may differ from the
+  // loop's target `repo:` — so the write targets `deriveRepoRoot(watchPath)`, not
+  // `repoPath`. Best-effort: the closure never throws; the extra catch is belt-and-
+  // braces so a status-write hiccup can never turn a real launch into a crash.
+  if (result === "launched" && deps.flipSpecStatus) {
+    const specRepoPath = deriveRepoRoot(watchPath);
+    if (specRepoPath) {
+      await deps
+        .flipSpecStatus({ specPath: filePath, specRepoPath, from: "ready", to: "in-progress" })
+        .catch((e) => deps.log(`spec-status flip (launch) errored for ${filePath}: ${(e as Error).message}`));
+    } else {
+      deps.log(`spec-status flip (launch) skipped for ${filePath} — no spec repo root`);
+    }
+  }
+  return result;
 }
 
 /**

--- a/tests/unit/consilium/spec-parser.test.ts
+++ b/tests/unit/consilium/spec-parser.test.ts
@@ -189,6 +189,29 @@ describe("evaluateReadyGate", () => {
       reason: "not-a-spec",
     });
   });
+
+  // SPEC-2 (spec-as-task.md §4): `blocked` is a recognized INERT status — the target
+  // a stalled terminal loop flips the spec to. It must NEVER fire (only `ready`
+  // fires); a human moves `blocked → ready` after fixing to re-trigger.
+  it("blocked → no-op(status:blocked) — an inert stalled spec never re-fires", () => {
+    expect(gate(`---\nstatus: blocked\nacceptanceCriteria: ["c"]\n---\nb`)).toEqual({
+      fire: false,
+      reason: "status:blocked",
+    });
+  });
+
+  // SPEC-2 re-run discipline (§4 #4) — the SAFE subset, enforced entirely by the
+  // ready-gate: the system never AUTO-reopens; re-opening is a HUMAN status edit.
+  it("re-run discipline: an in-progress/done/blocked spec whose BODY is edited still does NOT fire", () => {
+    // Editing the prose of a spec already being worked / closed changes nothing —
+    // the gate keys on `status`, so a 2nd loop is never spawned (per-spec dedup
+    // also holds for in-progress). Only a human status flip to `ready` re-opens.
+    expect(gate(`---\nstatus: in-progress\nacceptanceCriteria: ["c"]\n---\nEDITED BODY`).fire).toBe(false);
+    expect(gate(`---\nstatus: done\nacceptanceCriteria: ["c"]\n---\nMATERIALLY CHANGED`).fire).toBe(false);
+    expect(gate(`---\nstatus: blocked\nacceptanceCriteria: ["c"]\n---\nEDITED`).fire).toBe(false);
+    // The re-open: a human moves a done spec back to `ready` → it fires again.
+    expect(gate(`---\nstatus: ready\nacceptanceCriteria: ["c"]\n---\nreopened`).fire).toBe(true);
+  });
 });
 
 // ─── buildSpecInstruction ──────────────────────────────────────────────────────

--- a/tests/unit/consilium/spec-status-terminal.test.ts
+++ b/tests/unit/consilium/spec-status-terminal.test.ts
@@ -1,0 +1,104 @@
+/**
+ * spec-status-terminal.test.ts — SPEC-2 (spec-as-task.md §4): the loop-controller
+ * side of the spec status lifecycle. On a SPEC-FIRED loop reaching a TERMINAL state,
+ * the controller invokes the injected `onSpecLoopTerminal` hook (the route wires it
+ * to the spec-status writer). Asserts:
+ *   - a terminal transition of a spec-fired loop fires the hook once, with the state,
+ *   - a NON-spec loop never fires it (no triggerProvenance.spec),
+ *   - a hook throw never crashes the terminal transition (best-effort).
+ *
+ * Driven via `cancel()` (the simplest terminal path: reviewing → cancelled), which
+ * commits through the SAME `commit()`/casLoopState seam every terminal transition
+ * uses, so the hook fires for failed/stopped_cap/escalated/converged identically.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { ConsiliumLoopController } from "../../../server/services/consilium/consilium-loop-controller.js";
+import type { ConsiliumLoopRow, ConsiliumLoopState } from "@shared/schema";
+
+function makeLoop(over: Partial<ConsiliumLoopRow>): ConsiliumLoopRow {
+  return {
+    id: "loop-1",
+    projectId: "proj1",
+    groupId: "grp1",
+    state: "reviewing",
+    round: 1,
+    maxRounds: 1,
+    repoPath: "/repo/widget",
+    lastReviewedCommit: null,
+    currentIterationNumber: 1,
+    devGroupId: null,
+    prRef: null,
+    headCommitAtReview: null,
+    openP0: null,
+    error: null,
+    triggerProvenance: null,
+    createdBy: "user1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    completedAt: null,
+    ...over,
+  } as ConsiliumLoopRow;
+}
+
+function fakeStorage(loop: ConsiliumLoopRow) {
+  let current = loop;
+  const storage = {
+    getLoop: vi.fn(async () => current),
+    casLoopState: vi.fn(
+      async (id: string, expected: ConsiliumLoopState, next: ConsiliumLoopState, extra?: Record<string, unknown>) => {
+        if (id !== current.id || current.state !== expected) return undefined;
+        current = { ...current, ...(extra ?? {}), state: next };
+        return current;
+      },
+    ),
+  };
+  return storage;
+}
+
+function makeController(loop: ConsiliumLoopRow, onSpecLoopTerminal?: ReturnType<typeof vi.fn>) {
+  const storage = fakeStorage(loop);
+  const controller = new ConsiliumLoopController({
+    storage: storage as never,
+    taskOrchestrator: { cancelGroup: vi.fn(async () => undefined) } as never,
+    config: () => ({}) as never,
+    onSpecLoopTerminal,
+  });
+  return { controller, storage };
+}
+
+const SPEC_PROV = { spec: { specPath: "/repo/widget/docs/specs/x.md", status: "ready" } };
+
+describe("controller terminal → onSpecLoopTerminal (SPEC-2)", () => {
+  it("a SPEC-FIRED loop reaching terminal fires the hook once with the terminal state", async () => {
+    const hook = vi.fn(async () => undefined);
+    const loop = makeLoop({ triggerProvenance: SPEC_PROV as never });
+    const { controller } = makeController(loop, hook);
+
+    const out = await controller.cancel("loop-1", { reason: "operator" });
+    expect(out?.state).toBe("cancelled");
+    expect(hook).toHaveBeenCalledTimes(1);
+    expect(hook).toHaveBeenCalledWith(expect.objectContaining({ id: "loop-1", state: "cancelled" }), "cancelled");
+  });
+
+  it("a NON-spec loop reaching terminal NEVER fires the hook", async () => {
+    const hook = vi.fn(async () => undefined);
+    const loop = makeLoop({ triggerProvenance: null }); // human/API launched
+    const { controller } = makeController(loop, hook);
+
+    const out = await controller.cancel("loop-1");
+    expect(out?.state).toBe("cancelled");
+    expect(hook).not.toHaveBeenCalled();
+  });
+
+  it("a hook throw is swallowed — the terminal transition still commits", async () => {
+    const hook = vi.fn(async () => {
+      throw new Error("gh down");
+    });
+    const loop = makeLoop({ triggerProvenance: SPEC_PROV as never });
+    const { controller } = makeController(loop, hook);
+
+    const out = await controller.cancel("loop-1");
+    expect(out?.state).toBe("cancelled"); // transition survived the hook failure.
+    expect(hook).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/consilium/spec-status-writer.test.ts
+++ b/tests/unit/consilium/spec-status-writer.test.ts
@@ -1,0 +1,266 @@
+/**
+ * spec-status-writer.test.ts — SPEC-2 (spec-as-task.md §4) status lifecycle writer.
+ *
+ * Covers the pure core + the remote (`gh`) write with a FAKE gh (no real gh/network):
+ *   - rewriteSpecStatus: CAS-guard on expectedFrom (race/human-edit safety), exact
+ *     formatting preservation, malformed/absent status handled safely, idempotence.
+ *   - specStatusForTerminalLoop: converged stays in-progress; failed/cap/escalated/
+ *     cancelled → blocked (never `ready` — no re-fire); never auto-`done`.
+ *   - specStatusForPrMerge / reconcileSpecStatusOnPrMerge: ONLY a MERGED code PR → done.
+ *   - specRelPath: fenced inside the spec repo (rejects `..`/absolute escapes).
+ *   - writeSpecStatusRemote: ready→in-progress happy path; sha-conflict + status-
+ *     mismatch = best-effort no-op; bad-origin/read-failure never throw.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  rewriteSpecStatus,
+  specStatusForTerminalLoop,
+  specStatusForPrMerge,
+  specRelPath,
+  writeSpecStatusRemote,
+  reconcileSpecStatusOnPrMerge,
+} from "../../../server/services/consilium/spec-status-writer.js";
+import type { ExecFileFn } from "../../../server/services/github-status.js";
+
+const SPEC = (status: string) => `---
+title: "Add rate limiting"
+status: ${status}
+source: { kind: human }
+acceptanceCriteria:
+  - "429 on overflow"
+---
+## Problem
+No rate limit.
+`;
+
+// ─── rewriteSpecStatus (pure, CAS-guarded) ─────────────────────────────────────
+
+describe("rewriteSpecStatus", () => {
+  it("flips ready → in-progress, changing ONLY the status line", () => {
+    const r = rewriteSpecStatus(SPEC("ready"), "ready", "in-progress");
+    expect(r.changed).toBe(true);
+    if (!r.changed) return;
+    expect(r.content).toBe(SPEC("in-progress"));
+    // Body + other frontmatter keys untouched.
+    expect(r.content).toContain('title: "Add rate limiting"');
+    expect(r.content).toContain("## Problem");
+  });
+
+  it("CAS guard: refuses to flip when the file is not the expected `from` (race/human edit)", () => {
+    // Two ticks racing: the file already reads in-progress → second writer no-ops.
+    const r = rewriteSpecStatus(SPEC("in-progress"), "ready", "in-progress");
+    expect(r).toEqual({ changed: false, reason: "unchanged", current: "in-progress" });
+
+    const human = rewriteSpecStatus(SPEC("draft"), "ready", "in-progress");
+    expect(human).toEqual({ changed: false, reason: "status-mismatch", current: "draft" });
+  });
+
+  it("preserves quotes-independent formatting, indentation, and a trailing comment", () => {
+    const withComment = `---\nstatus:   ready   # gate\ntitle: x\n---\nbody\n`;
+    const r = rewriteSpecStatus(withComment, "ready", "in-progress");
+    expect(r.changed).toBe(true);
+    if (!r.changed) return;
+    expect(r.content).toBe(`---\nstatus:   in-progress   # gate\ntitle: x\n---\nbody\n`);
+  });
+
+  it("handles a quoted status value", () => {
+    const q = `---\nstatus: "ready"\n---\nbody\n`;
+    const r = rewriteSpecStatus(q, "ready", "blocked");
+    expect(r.changed).toBe(true);
+    if (!r.changed) return;
+    expect(r.content).toBe(`---\nstatus: blocked\n---\nbody\n`);
+  });
+
+  it("safely no-ops on absent frontmatter / absent status (never throws)", () => {
+    expect(rewriteSpecStatus("no frontmatter here\n", "ready", "done")).toEqual({
+      changed: false,
+      reason: "no-frontmatter",
+    });
+    expect(rewriteSpecStatus(`---\ntitle: x\n---\nbody\n`, "ready", "done")).toEqual({
+      changed: false,
+      reason: "no-status-field",
+    });
+  });
+
+  it("does not match a `status:` line in the BODY (only frontmatter)", () => {
+    const bodyOnly = `---\ntitle: x\n---\nstatus: ready in prose\n`;
+    expect(rewriteSpecStatus(bodyOnly, "ready", "in-progress")).toEqual({
+      changed: false,
+      reason: "no-status-field",
+    });
+  });
+});
+
+// ─── terminal-loop → spec status mapping (SPEC-2 §4) ───────────────────────────
+
+describe("specStatusForTerminalLoop", () => {
+  it("converged leaves the spec in-progress (code PR is the next gate — no auto-done)", () => {
+    expect(specStatusForTerminalLoop("converged")).toBeNull();
+  });
+  it("stalled terminals → blocked (NOT ready — blocked never re-fires the watch)", () => {
+    expect(specStatusForTerminalLoop("failed")?.to).toBe("blocked");
+    expect(specStatusForTerminalLoop("stopped_cap")?.to).toBe("blocked");
+    expect(specStatusForTerminalLoop("escalated")?.to).toBe("blocked");
+    expect(specStatusForTerminalLoop("cancelled")?.to).toBe("blocked");
+    // Never `ready`, never `done`.
+    for (const s of ["failed", "stopped_cap", "escalated", "cancelled"]) {
+      expect(specStatusForTerminalLoop(s)?.to).not.toBe("ready");
+      expect(specStatusForTerminalLoop(s)?.to).not.toBe("done");
+    }
+  });
+  it("non-terminal / unknown states never touch the spec", () => {
+    expect(specStatusForTerminalLoop("reviewing")).toBeNull();
+    expect(specStatusForTerminalLoop("awaiting_merge")).toBeNull();
+  });
+});
+
+// ─── code-PR merge → done (SPEC-2 §4, GATE 2) ──────────────────────────────────
+
+describe("specStatusForPrMerge", () => {
+  it("ONLY a MERGED PR closes the spec → done", () => {
+    expect(specStatusForPrMerge("MERGED")?.to).toBe("done");
+    for (const s of ["OPEN", "DRAFT", "CLOSED", "unknown"]) {
+      expect(specStatusForPrMerge(s)).toBeNull(); // never auto-done without a merge.
+    }
+  });
+});
+
+// ─── specRelPath (fenced) ──────────────────────────────────────────────────────
+
+describe("specRelPath", () => {
+  it("derives a repo-relative path inside the repo", () => {
+    expect(specRelPath("/repo", "/repo/docs/specs/x.md")).toBe("docs/specs/x.md");
+  });
+  it("rejects paths that escape the repo (../ or absolute)", () => {
+    expect(specRelPath("/repo", "/etc/passwd")).toBeNull();
+    expect(specRelPath("/repo/a", "/repo/b/x.md")).toBeNull();
+    expect(specRelPath("/repo", "/repo")).toBeNull();
+  });
+});
+
+// ─── writeSpecStatusRemote (fake gh) ───────────────────────────────────────────
+
+interface FakeOpts {
+  defaultBranch?: string;
+  fileStatus?: string; // the status in the remote file the GET returns
+  sha?: string;
+  putStderr?: string; // set → PUT throws this stderr (runGhCapture → {ok:false})
+  contentsNull?: boolean; // GET returns null (gh degraded)
+}
+
+function fakeGh(opts: FakeOpts): { run: ExecFileFn; argv: string[][]; puts: string[][] } {
+  const argv: string[][] = [];
+  const puts: string[][] = [];
+  const run: ExecFileFn = vi.fn(async (_file: string, args: string[]) => {
+    argv.push(args);
+    const json = (o: unknown) => ({ stdout: JSON.stringify(o), stderr: "" });
+    if (args[0] === "repo" && args[1] === "view") {
+      return json({ defaultBranchRef: { name: opts.defaultBranch ?? "main" } });
+    }
+    if (args[0] === "api" && args.indexOf("--method") === -1) {
+      // GET contents.
+      if (opts.contentsNull) return { stdout: "", stderr: "" };
+      const content = Buffer.from(SPEC(opts.fileStatus ?? "ready"), "utf8").toString("base64");
+      return json({ content, encoding: "base64", sha: opts.sha ?? "sha-abc" });
+    }
+    if (args[0] === "api" && args.indexOf("--method") !== -1) {
+      puts.push(args);
+      if (opts.putStderr !== undefined) throw Object.assign(new Error("gh failed"), { stderr: opts.putStderr });
+      return { stdout: "", stderr: "" };
+    }
+    return { stdout: "", stderr: "" };
+  });
+  return { run, argv, puts };
+}
+
+const DEPS = (run: ExecFileFn) => ({
+  runGh: run,
+  gitRemoteUrl: async () => "https://github.com/acme/widget.git",
+  log: () => undefined,
+});
+
+const PARAMS = {
+  specRepoPath: "/repo/widget",
+  specPath: "/repo/widget/docs/specs/rate-limit.md",
+  expectedFrom: "ready" as const,
+  to: "in-progress" as const,
+};
+
+describe("writeSpecStatusRemote", () => {
+  it("ready→in-progress: reads the blob then PUTs the flipped file with the read sha", async () => {
+    const gh = fakeGh({ fileStatus: "ready", sha: "sha-xyz" });
+    const res = await writeSpecStatusRemote(DEPS(gh.run), PARAMS);
+    expect(res).toEqual({ ok: true, from: "ready", to: "in-progress" });
+    // The PUT targets the repo-relative path on the default branch, carrying the sha.
+    expect(gh.puts).toHaveLength(1);
+    const put = gh.puts[0];
+    expect(put.join(" ")).toContain("repos/acme/widget/contents/docs/specs/rate-limit.md");
+    expect(put).toContain("sha=sha-xyz");
+    expect(put).toContain("branch=main");
+    // The committed content decodes to the in-progress spec.
+    const contentArg = put.find((a) => a.startsWith("content="))!.slice("content=".length);
+    expect(Buffer.from(contentArg, "base64").toString("utf8")).toBe(SPEC("in-progress"));
+    // Commit message carries no AI mention.
+    const msg = put.find((a) => a.startsWith("message="))!;
+    expect(msg).toMatch(/status ready -> in-progress/);
+    expect(msg.toLowerCase()).not.toMatch(/claude|anthropic|co-authored/);
+  });
+
+  it("status-mismatch (remote already moved) → no PUT, typed no-op", async () => {
+    const gh = fakeGh({ fileStatus: "in-progress" }); // human/other tick already flipped
+    const res = await writeSpecStatusRemote(DEPS(gh.run), PARAMS);
+    expect(res).toEqual({ ok: false, reason: "unchanged" });
+    expect(gh.puts).toHaveLength(0);
+  });
+
+  it("sha-conflict on PUT (concurrent write) → best-effort no-op, never throws", async () => {
+    const gh = fakeGh({ fileStatus: "ready", putStderr: "HTTP 409: sha does not match" });
+    const res = await writeSpecStatusRemote(DEPS(gh.run), PARAMS);
+    expect(res).toEqual({ ok: false, reason: "sha-conflict" });
+  });
+
+  it("degrades safely when gh cannot read the file / origin is not github", async () => {
+    const gh = fakeGh({ contentsNull: true });
+    expect(await writeSpecStatusRemote(DEPS(gh.run), PARAMS)).toEqual({ ok: false, reason: "read-failed" });
+
+    const badOrigin = { runGh: gh.run, gitRemoteUrl: async () => null, log: () => undefined };
+    expect(await writeSpecStatusRemote(badOrigin, PARAMS)).toEqual({ ok: false, reason: "bad-origin" });
+  });
+});
+
+// ─── reconcileSpecStatusOnPrMerge (code-PR → done hook) ────────────────────────
+
+describe("reconcileSpecStatusOnPrMerge", () => {
+  const specLoop = {
+    state: "converged",
+    prRef: "https://github.com/acme/widget/pull/9",
+    triggerProvenance: { spec: { specPath: "/repo/widget/docs/specs/rate-limit.md" } },
+  };
+
+  it("MERGED code PR flips the spec in-progress → done", async () => {
+    const gh = fakeGh({ fileStatus: "in-progress" });
+    const res = await reconcileSpecStatusOnPrMerge(DEPS(gh.run), specLoop, "MERGED", "/repo/widget");
+    expect(res).toEqual({ ok: true, from: "in-progress", to: "done" });
+    expect(gh.puts).toHaveLength(1);
+    expect(gh.puts[0].join(" ")).toContain("status in-progress -> done");
+  });
+
+  it("a non-merged PR never auto-dones the spec (no write)", async () => {
+    const gh = fakeGh({ fileStatus: "in-progress" });
+    expect(await reconcileSpecStatusOnPrMerge(DEPS(gh.run), specLoop, "OPEN", "/repo/widget")).toEqual({
+      ok: false,
+      reason: "pr-not-merged",
+    });
+    expect(gh.puts).toHaveLength(0);
+  });
+
+  it("ignores non-spec-fired loops / loops without a code PR", async () => {
+    const gh = fakeGh({ fileStatus: "in-progress" });
+    expect(
+      await reconcileSpecStatusOnPrMerge(DEPS(gh.run), { ...specLoop, prRef: null }, "MERGED", "/repo/widget"),
+    ).toEqual({ ok: false, reason: "no-pr-ref" });
+    expect(
+      await reconcileSpecStatusOnPrMerge(DEPS(gh.run), { ...specLoop, triggerProvenance: null }, "MERGED", "/repo/widget"),
+    ).toEqual({ ok: false, reason: "not-spec-fired" });
+  });
+});

--- a/tests/unit/consilium/spec-watch-dispatch.test.ts
+++ b/tests/unit/consilium/spec-watch-dispatch.test.ts
@@ -318,6 +318,55 @@ describe("maybeLaunchSpecReview — per-SPEC dedup", () => {
   });
 });
 
+// ─── SPEC-2: ready → in-progress flip on launch ────────────────────────────────
+
+describe("maybeLaunchSpecReview — SPEC-2 launch flip (ready → in-progress)", () => {
+  it("a real launch flips the spec ready → in-progress via the injected writer", async () => {
+    const p = specFile("s2-flip.md", READY);
+    const flipSpecStatus = vi.fn().mockResolvedValue(undefined);
+    const { deps } = makeDeps({ flipSpecStatus });
+    const result = await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: specsDir }, p, []);
+    expect(result).toBe("launched");
+    expect(flipSpecStatus).toHaveBeenCalledTimes(1);
+    expect(flipSpecStatus).toHaveBeenCalledWith(
+      // The spec file lives in ITS OWN repo (derived from watchPath), not the loop's `repo:`.
+      expect.objectContaining({ specPath: p, specRepoPath: specsDir, from: "ready", to: "in-progress" }),
+    );
+  });
+
+  it("a dedup-suppressed fire does NOT flip (a loop is already running for this spec)", async () => {
+    const p = specFile("s2-dedup.md", READY);
+    const flipSpecStatus = vi.fn().mockResolvedValue(undefined);
+    const { deps } = makeDeps({ flipSpecStatus }, [activeSpecLoop(p, specsDir)]);
+    const result = await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: specsDir }, p, []);
+    expect(result).toBe("skipped-dedup");
+    expect(flipSpecStatus).not.toHaveBeenCalled();
+  });
+
+  it("a non-firing (draft) spec does NOT flip", async () => {
+    const p = specFile("s2-draft.md", READY.replace("status: ready", "status: draft"));
+    const flipSpecStatus = vi.fn().mockResolvedValue(undefined);
+    const { deps } = makeDeps({ flipSpecStatus });
+    expect(await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: specsDir }, p, [])).toBe("skipped");
+    expect(flipSpecStatus).not.toHaveBeenCalled();
+  });
+
+  it("a status-write throw NEVER turns a real launch into a failure (best-effort)", async () => {
+    const p = specFile("s2-throw.md", READY);
+    const flipSpecStatus = vi.fn().mockRejectedValue(new Error("gh down"));
+    const { deps } = makeDeps({ flipSpecStatus });
+    // The launch still succeeds; the flip error is swallowed + logged.
+    expect(await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: specsDir }, p, [])).toBe("launched");
+    expect(flipSpecStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("spec-watch UNWIRED writer (flipSpecStatus absent) → launches, no flip (byte-identical)", async () => {
+    const p = specFile("s2-nowriter.md", READY);
+    const { deps } = makeDeps(); // no flipSpecStatus dep
+    expect(await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: specsDir }, p, [])).toBe("launched");
+  });
+});
+
 // ─── Kill-switch + glob routing via maybeLaunchConsiliumReview ──────────────────
 
 describe("maybeLaunchConsiliumReview — spec pre-check routing", () => {


### PR DESCRIPTION
## SPEC-2 — spec status lifecycle (spec-as-task.md §2/§3/§4)

Builds the status lifecycle on top of the shipped SPEC-1 watch. A committed spec's frontmatter `status:` is now the single, human-visible source of truth for "is this being worked / done" (§7, no silent drift), flipped by the factory at the two-gate flow's seams. **Humans still own both gates** — approve the spec (GATE 1) and merge the code PR (GATE 2). Draft; do not merge.

### The transitions — where each flip fires

| Transition | Fires in | Trigger |
|---|---|---|
| `ready → in-progress` | `trigger-dispatch.ts` `maybeLaunchSpecReview` (after a real `launched`) | a spec fires a loop |
| terminal → `blocked` | `consilium-loop-controller.ts` `commit()` (CAS winner, terminal + spec-fired) | loop `failed`/`stopped_cap`/`escalated`/`cancelled` |
| terminal → *(stay `in-progress`)* | same hook, mapped to no-op | loop `converged` (code PR is the next gate) |
| `in-progress → done` | `spec-status-writer.ts` `reconcileSpecStatusOnPrMerge` | the loop's **code PR observed MERGED** |

- **`ready → in-progress` on launch** — the durable "being worked" marker that replaces reliance on the in-memory active-loop dedup (which still guards the window before the commit lands). Only on a genuine `launched` (never dedup-suppress/skip). The write targets the spec file's **own** repo (`deriveRepoRoot(watchPath)`), which may differ from the loop's target `repo:`.
- **loop terminal → spec status** — `converged`/PR-ready leaves the spec `in-progress` (only a merged code PR closes it). A stalled terminal goes to a new inert **`blocked`** status, **not** `ready`: flipping to `ready` and committing it would re-fire the watch trigger → another loop → the same failure → an unbounded re-fire loop + budget burn. `blocked` never fires (only `ready` does); a human moves `blocked → ready` after fixing to re-trigger exactly once. Reason recorded in the commit message.
- **code PR merge → done** — the ONLY path to `done` (never auto-`done` from a loop verdict). `reconcileSpecStatusOnPrMerge` flips `in-progress → done` only when the code PR is observed `MERGED` via the `github-status.ts` `fetchPrStatus`/`githubStatusCache` seam (#474).

### The status-write mechanism (frontmatter commit)

A **remote** commit to the spec file on the **default branch** via the same safe `gh` seam SPEC-1/TRACK-1 use — **never** the operator's local working tree (TRACK-1's precedent: an unattended trigger must not mutate a tree the operator may be editing). Flow: `gh repo view` → default branch, `gh api …/contents/<rel>?ref=<base>` → current blob + sha, rewrite the one status line, `gh api PUT …/contents/<rel>` with the read sha on the default branch.

**Frontmatter over sidecar** (spec-as-task §8 open question): chosen for human visibility — a reviewer sees `in-progress`/`done` in the diff and on GitHub, with commit history as the audit trail. Cost is a small churn commit per transition; accepted and documented in the module header.

### code-PR → done: the documented boundary

The `→done` reconciler is **code-complete and unit-tested** and wired to the existing PR-status observation seam. What is **deferred** (noted per the task): a *dedicated background reconcile* that polls converged spec-loops' PRs **independently of a queue view** — a terminal `converged` loop is not ticked by the poller, and `/api/pr-queue` is a per-user GET (a poor place for a system-context write). The minimal-viable hook (`reconcileSpecStatusOnPrMerge`) is ready for that poller to call. Deferred to a SPEC-2 follow-up / SPEC-3.

### Re-run discipline (§4 #4) — the safe subset

Enforced entirely by the ready-gate: the system **never auto-reopens**. An `in-progress`/`done`/`blocked` spec whose body is edited does **not** fire a 2nd loop (the gate keys on `status`; per-spec dedup also holds for `in-progress`). Re-opening a `done` spec is a **human** status edit back to `ready`, which fires again.

### Kill-switch

Every write is gated behind the existing `specWatch` config in **one** place (the `flipSpecStatus` helper in `routes.ts`). When spec-watch is off: no `gh` call, no commit, byte-identical. No new default-on behaviour.

### Adversarial self-review

- **Status-write race (two ticks flipping the same spec):** the pure `rewriteSpecStatus` is CAS-guarded on `expectedFrom` (only flips when the file still reads the expected prior status); the contents PUT carries the read blob `sha` so a concurrent write 409s instead of clobbering. Two independent guards, no lost update.
- **Status commit failing must not crash the loop:** every path is never-throw (`{ok:false, reason}`), callers invoke best-effort + catch. A hook/writer failure never flips a launch to `failed` nor breaks a `tick`/`cancel` (tested).
- **A spec flipped to in-progress whose loop dies is recoverable:** the terminal hook moves it to `blocked` (human-visible, re-triggerable); if the write itself fails, the dedup already released so a human can re-drive.
- **Never auto-`done` without a merged PR:** `done` comes solely from a `MERGED` observation; `converged`/`OPEN`/`DRAFT`/`CLOSED`/`unknown` never close the spec.

### Tests

`tsc` clean; full unit suite green (272 files / 5144 tests; none of the known flakes flaked). New/extended: `spec-status-writer.test.ts` (rewrite CAS + exact-formatting + malformed/absent; terminal & PR-merge mappings; remote write happy-path + sha-conflict/status-mismatch/bad-origin no-ops; reconciler MERGED→done + guards), `spec-status-terminal.test.ts` (controller fires the hook once on a spec-fired terminal, never for non-spec, hook throw survives the transition), `spec-watch-dispatch.test.ts` (ready→in-progress on launch; no flip on dedup/draft; writer-throw never fails the launch), `spec-parser.test.ts` (`blocked` inert; re-run discipline).
