### PR TITLE
fix: New consilium review dialog overflow (fields spill past the window)

### DIFF
--- a/client/src/components/consilium/new-review-dialog.tsx
+++ b/client/src/components/consilium/new-review-dialog.tsx
@@ -446,11 +446,11 @@ export function NewConsiliumReviewDialog({
           New consilium review
         </Button>
       </DialogTrigger>
-      <DialogContent>
+      <DialogContent className="max-h-[85vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>New consilium review</DialogTitle>
         </DialogHeader>
-        <div className="space-y-4 py-4">
+        <div className="min-w-0 space-y-4 py-4">
           {/* PRESET — the review "shape". Prominent, with a one-line description of
               each option in the dropdown AND a live description of the current choice
               below the control, so the operator always sees WHAT they picked. */}


### PR DESCRIPTION
**Operator-reported:** the *New consilium review* dialog's input fields protrude beyond the dialog window.

**Cause:** the form (preset / repo / branch / instruction / acceptance-criteria) is taller than the viewport, but `DialogContent` only sets `max-w-lg` — no `max-height`/`overflow`, so content overflows vertically.

**Fix:** `max-h-[85vh] overflow-y-auto` on DialogContent (form scrolls inside the dialog) + `min-w-0` on the inner container (horizontal-overflow guard). One-line layout fix, no behavior change.