### PR TITLE
feat: spec auto-commit policy + ADR intake (SPEC-3, SPEC-4)

### DIFF
--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -604,6 +604,32 @@ export const ConfigSchema = z.object({
          * config.yaml only (arrays are not env-mapped — matches allowedRepoPaths).
          */
         globs: z.array(z.string()).default(["docs/specs/**/*.md", "docs/adr/**/*.md"]),
+        /**
+         * SPEC-3 (spec-as-task.md §4/§5/§7): the HIGH-TRUST auto-commit policy. When
+         * enabled for a repo, a connector- or draft-produced spec may be committed
+         * DIRECTLY to the default branch as `status: ready` — SKIPPING GATE 1, the spec
+         * PR where a human reviews the *intent*. This does NOT touch the SPEC-1 watch
+         * (which only ever sees already-committed specs); it is the POLICY a spec
+         * PRODUCER (a TRACK-1+ connector) consults via `shouldAutoCommitSpec` to choose
+         * "open a spec PR" vs "direct-commit ready". GATE 2 (the code PR merge) is
+         * UNAFFECTED. Default OFF everywhere, FAIL-CLOSED: an empty `repos` list means
+         * NOTHING is auto-committed (it NEVER means "all repos"). config.yaml only
+         * (arrays are not env-mapped — matches `globs`/`allowedRepoPaths`). Also gated
+         * by the parent `specWatch.enabled` + `consiliumLoop.enabled`.
+         *
+         * SECURITY: auto-commit SKIPS the human intent-review gate — enable it ONLY for
+         * repos whose spec producers are trusted (spec-as-task §5).
+         */
+        autoCommit: z.object({
+          /** Kill-switch: false (default) → every spec opens a spec PR (Gate 1 stands). */
+          enabled: z.boolean().default(false),
+          /**
+           * EXPLICIT allowlist of repos (paths/slugs) permitted to auto-commit. Empty
+           * (default) ⇒ nothing is trusted even when `enabled` — the flag can NEVER
+           * widen beyond this list.
+           */
+          repos: z.array(z.string()).default([]),
+        }).default({}),
       }).default({}),
       /**
        * Stage 2a (design §3.C/§4): the SKILLED, archetype-branched implement

--- a/server/services/consilium/spec-parser.ts
+++ b/server/services/consilium/spec-parser.ts
@@ -73,6 +73,13 @@ export interface SpecFrontmatter {
   role?: string;
   skills?: string[];
   acceptanceCriteria: string[];
+  /**
+   * SPEC-4 (spec-as-task.md §2/§7): a path-independent ADR marker. True when the
+   * frontmatter carries an `adr:` (truthy) or `decision:` key — an ADR living outside
+   * `docs/adr/`. Absent for a normal spec (so SPEC-1/2 behavior is byte-identical —
+   * only the SPEC-4 ADR-intake code reads this field).
+   */
+  adr?: boolean;
 }
 
 /** Why a candidate file is NOT a fireable spec (logged, never thrown). */
@@ -128,6 +135,19 @@ function asStringArray(v: unknown): string[] {
     if (s !== undefined) out.push(s);
   }
   return out;
+}
+
+/**
+ * SPEC-4: detect the path-independent ADR marker in raw frontmatter. An `adr:` key
+ * with ANY truthy value (`adr: true`, `adr: "0001"`) or a present `decision:` key
+ * marks the file as an ADR regardless of its path. Returns undefined (field absent)
+ * for a normal spec so the parsed shape is byte-identical for the SPEC-1/2 paths.
+ */
+function asAdrMarker(rec: Record<string, unknown>): boolean | undefined {
+  if (rec.adr === true) return true;
+  if (asString(rec.adr) !== undefined) return true; // e.g. `adr: "0001"`
+  if (rec.decision !== undefined && rec.decision !== null) return true;
+  return undefined;
 }
 
 /** Coerce the `source` field to a SpecSource (best-effort; kind is required). */
@@ -186,6 +206,7 @@ export function parseSpecContent(
     role: asString(rec.role),
     skills: asStringArray(rec.skills),
     acceptanceCriteria: asStringArray(rec.acceptanceCriteria),
+    adr: asAdrMarker(rec),
   };
   return { kind: "spec", frontmatter, body };
 }
@@ -401,4 +422,111 @@ export function pathMatchesSpecGlobs(absPath: string, globs: readonly string[]):
     if (globToRegExp(glob).test(normalized)) return true;
   }
   return false;
+}
+
+// ─── SPEC-3: auto-commit policy (spec-as-task.md §4/§7) ─────────────────────────
+
+/**
+ * The per-repo auto-commit policy (spec-as-task.md §4 "Default = spec PR"). This is
+ * the HIGH-TRUST setting: when enabled for a repo, a connector- or draft-produced spec
+ * may be committed DIRECTLY to the default branch as `status: ready` — SKIPPING GATE 1
+ * (the spec PR where a human reviews the *intent*). Off by default everywhere.
+ */
+export interface SpecAutoCommitConfig {
+  /** Master switch for auto-commit. false (default) ⇒ every spec opens a spec PR. */
+  enabled: boolean;
+  /** The EXPLICIT allowlist of repos trusted to auto-commit. Empty ⇒ nothing trusted. */
+  repos?: string[];
+}
+
+/**
+ * SPEC-3 (spec-as-task.md §4/§5/§7): decide whether a spec destined for `repo` may be
+ * auto-committed directly to the default branch as `status: ready` — skipping GATE 1,
+ * the spec PR (human intent-review). This is the seam a spec PRODUCER (a TRACK-1+
+ * connector, or a `draft`-spec author) consults to choose "open a spec PR" vs
+ * "direct-commit ready". GATE 2 (the code PR merge) is UNAFFECTED — this governs ONLY
+ * whether the *intent* review is skipped.
+ *
+ * FAIL-CLOSED (the safe default is a spec PR). Returns `true` ONLY when auto-commit is
+ * EXPLICITLY enabled AND `repo` is in the EXPLICIT allowlist:
+ *   - config absent / `enabled !== true` ⇒ false (flag off ⇒ spec PR).
+ *   - `repo` undefined / empty            ⇒ false (unknown repo ⇒ spec PR).
+ *   - `repos` absent / empty              ⇒ false (enabled but NOTHING trusted — an
+ *                                           empty allowlist NEVER means "all repos", so
+ *                                           the flag can never widen beyond its list).
+ *   - `repo` not in `repos`               ⇒ false (a repo outside the list ⇒ spec PR).
+ * A caller MUST treat `false` as "open the spec PR" — never as "block".
+ */
+export function shouldAutoCommitSpec(
+  repo: string | undefined,
+  config: SpecAutoCommitConfig | undefined,
+): boolean {
+  if (!config || config.enabled !== true) return false;
+  if (repo === undefined) return false;
+  const target = repo.trim();
+  if (target.length === 0) return false;
+  const repos = config.repos;
+  if (!Array.isArray(repos) || repos.length === 0) return false;
+  return repos.some((r) => typeof r === "string" && r.trim() === target);
+}
+
+// ─── SPEC-4: ADR intake (spec-as-task.md §2/§7) ────────────────────────────────
+
+/**
+ * The implicit Definition-of-Done synthesised for an ADR that declares NO explicit
+ * `acceptanceCriteria` (spec-as-task.md §2: "an ADR is a spec whose acceptanceCriteria
+ * are 'the decision is implemented + …'"). Gives an ADR-fired loop a concrete DoD so it
+ * NEVER fires without criteria to verify against.
+ */
+export const ADR_IMPLICIT_CRITERIA: readonly string[] = [
+  "The decision described in this ADR is implemented in the codebase.",
+  "Automated tests cover the implemented decision.",
+  "Documentation affected by the decision is updated to reflect it.",
+];
+
+/** Anchored `docs/adr/` directory match (the ADR path convention, §2). */
+const ADR_PATH_RE = /(?:^|\/)docs\/adr\//;
+
+/**
+ * SPEC-4: is this candidate an ADR? True when the file lives under `docs/adr/` OR its
+ * frontmatter carries the path-independent `adr:`/`decision:` marker (§2/§7).
+ */
+export function isAdrCandidate(filePath: string, frontmatter: SpecFrontmatter): boolean {
+  if (ADR_PATH_RE.test(filePath.replace(/\\/g, "/"))) return true;
+  return frontmatter.adr === true;
+}
+
+/**
+ * SPEC-4 (spec-as-task.md §2/§7): make an ADR a valid task by producing an ADR-aware
+ * "effective" parse result the SAME ready-gate/dispatch consume — extend, don't
+ * duplicate. A non-ADR result is returned UNCHANGED (byte-identical for SPEC-1/2). For
+ * an ADR:
+ *   - the accepted-state (`status: accepted`) is normalised to the spec ready-state
+ *     (`ready`) so the ONE ready-gate fires it — an ADR is "approved to execute" when
+ *     accepted. Only `accepted` is remapped; `proposed`/`draft`/others stay
+ *     non-firing (the gate rejects them exactly as before).
+ *   - when it declares NO explicit `acceptanceCriteria`, the implicit decision-DoD
+ *     ({@link ADR_IMPLICIT_CRITERIA}) is synthesised so the loop has criteria to verify
+ *     (an ADR NEVER fires with an empty DoD). An explicit criteria set is preserved.
+ * Pure; never throws. `isAdr` lets the caller stamp ADR provenance.
+ */
+export function applyAdrIntake(
+  parsed: SpecParseResult,
+  filePath: string,
+): { parsed: SpecParseResult; isAdr: boolean } {
+  if (parsed.kind !== "spec") return { parsed, isAdr: false };
+  if (!isAdrCandidate(filePath, parsed.frontmatter)) return { parsed, isAdr: false };
+
+  const fm = parsed.frontmatter;
+  const status = fm.status === "accepted" ? "ready" : fm.status;
+  const acceptanceCriteria =
+    fm.acceptanceCriteria.length > 0 ? fm.acceptanceCriteria : [...ADR_IMPLICIT_CRITERIA];
+  return {
+    parsed: {
+      kind: "spec",
+      frontmatter: { ...fm, status, acceptanceCriteria },
+      body: parsed.body,
+    },
+    isAdr: true,
+  };
 }

--- a/server/services/consilium/trigger-dispatch.ts
+++ b/server/services/consilium/trigger-dispatch.ts
@@ -90,6 +90,7 @@ import {
   evaluateReadyGate,
   buildSpecInstruction,
   pathMatchesSpecGlobs,
+  applyAdrIntake,
 } from "./spec-parser.js";
 import type {
   CreateConsiliumReviewDeps,
@@ -481,7 +482,13 @@ export async function maybeLaunchSpecReview(
 
   // Parse + ready-gate. readSpecFile is size/binary/error-guarded and NEVER throws,
   // so a malformed/huge/binary/deleted file under the globs degrades to a no-op.
-  const parsed = readSpecFile(filePath, (s) => jsYamlLoad(s));
+  // SPEC-4 (spec-as-task.md §2/§7): applyAdrIntake makes an ADR a valid task — for a
+  // file under docs/adr/ (or with an `adr:`/`decision:` marker) it normalises the
+  // accepted-state → ready and synthesises the implicit decision-DoD when the ADR
+  // declares no explicit criteria, so the SAME ready-gate fires it. A non-ADR spec is
+  // returned UNCHANGED (byte-identical SPEC-1/2). `isAdr` stamps the provenance.
+  const rawParsed = readSpecFile(filePath, (s) => jsYamlLoad(s));
+  const { parsed, isAdr } = applyAdrIntake(rawParsed, filePath);
   const gate = evaluateReadyGate(parsed);
   if (!gate.fire) {
     deps.log(`spec-watch no-op for ${filePath} — ${gate.reason}`);
@@ -531,6 +538,8 @@ export async function maybeLaunchSpecReview(
       specPath: filePath,
       status: frontmatter.status ?? "ready",
       ...(frontmatter.source ? { source: frontmatter.source } : {}),
+      // SPEC-4: record that this loop was fired by an ADR (not a docs/specs spec).
+      ...(isAdr ? { artifact: "adr" as const } : {}),
     },
     // H2: use the SANITIZED title (single-line, control-stripped, length-clamped) —
     // NOT the raw frontmatter title — for the inert provenance passport label.

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1498,6 +1498,14 @@ export interface SpecProvenance {
   specPath: string;
   status: string;
   source?: { kind: string; ref?: string; url?: string };
+  /**
+   * SPEC-4 (spec-as-task.md §2/§7): `"adr"` when the unit of work is an ADR (a file
+   * under `docs/adr/**`, or one carrying an `adr:`/`decision:` frontmatter marker) —
+   * so the provenance records that this loop was fired by an ADR, not a `docs/specs`
+   * spec. Absent ⇒ a normal spec (byte-identical provenance for the SPEC-1/2 paths).
+   * Inert provenance metadata; never a prompt/shell sink.
+   */
+  artifact?: "adr";
 }
 
 /**

--- a/tests/unit/consilium/adr-intake.test.ts
+++ b/tests/unit/consilium/adr-intake.test.ts
@@ -1,0 +1,251 @@
+/**
+ * adr-intake.test.ts — SPEC-4 (spec-as-task.md §2/§7): an ADR under the watched globs
+ * is a valid task. Covers the pure parser surface (`isAdrCandidate` / `applyAdrIntake`
+ * — ADR detection, accepted→ready normalisation, the implicit decision-DoD) AND the
+ * dispatch seam (`maybeLaunchSpecReview` firing an ADR, its provenance marker, and the
+ * per-spec dedup holding). Reuses the SPEC-1 parser/ready-gate/dedup — it extends them.
+ */
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { load as jsYamlLoad } from "js-yaml";
+import type { TriggerRow, ConsiliumLoopRow } from "@shared/schema";
+import {
+  parseSpecContent,
+  applyAdrIntake,
+  isAdrCandidate,
+  evaluateReadyGate,
+  ADR_IMPLICIT_CRITERIA,
+} from "../../../server/services/consilium/spec-parser.js";
+import {
+  maybeLaunchSpecReview,
+  type ConsiliumTriggerDispatchDeps,
+} from "../../../server/services/consilium/trigger-dispatch.js";
+
+const load = (s: string) => jsYamlLoad(s);
+
+// ─── Pure: ADR detection + normalisation (applyAdrIntake / isAdrCandidate) ──────
+
+/** Build a spec parse result from raw markdown (through the real parser). */
+function parse(md: string) {
+  return parseSpecContent(md, load);
+}
+
+const ADR_ACCEPTED_NO_CRIT = `---
+title: "Adopt event sourcing for the ledger"
+status: accepted
+source: { kind: human, ref: "adr-0007" }
+---
+## Decision
+We will store ledger mutations as an append-only event log.
+`;
+
+describe("isAdrCandidate — detection", () => {
+  it("a file under docs/adr/ is an ADR (path convention)", () => {
+    const p = parse(ADR_ACCEPTED_NO_CRIT);
+    expect(p.kind).toBe("spec");
+    if (p.kind !== "spec") return;
+    expect(isAdrCandidate("/repo/docs/adr/0007-event-sourcing.md", p.frontmatter)).toBe(true);
+  });
+
+  it("a docs/specs file is NOT an ADR (no path/marker)", () => {
+    const p = parse(`---\nstatus: ready\nsource: {kind: human}\nacceptanceCriteria: ["c"]\n---\nb`);
+    if (p.kind !== "spec") throw new Error("expected spec");
+    expect(isAdrCandidate("/repo/docs/specs/foo.md", p.frontmatter)).toBe(false);
+  });
+
+  it("an `adr:` / `decision:` frontmatter marks an ADR OUTSIDE docs/adr/", () => {
+    const withAdr = parse(`---\nstatus: accepted\nadr: true\nsource: {kind: human}\n---\nbody`);
+    const withDecision = parse(`---\nstatus: accepted\ndecision: "use X"\nsource: {kind: human}\n---\nbody`);
+    if (withAdr.kind !== "spec" || withDecision.kind !== "spec") throw new Error("expected spec");
+    expect(isAdrCandidate("/repo/docs/notes/x.md", withAdr.frontmatter)).toBe(true);
+    expect(isAdrCandidate("/repo/docs/notes/y.md", withDecision.frontmatter)).toBe(true);
+  });
+
+  it("`docs/adr` mid-segment does NOT falsely match (boundary-anchored)", () => {
+    const p = parse(`---\nstatus: ready\nsource: {kind: human}\nacceptanceCriteria: ["c"]\n---\nb`);
+    if (p.kind !== "spec") throw new Error("expected spec");
+    expect(isAdrCandidate("/repo/mydocs/adrs/x.md", p.frontmatter)).toBe(false);
+  });
+});
+
+describe("applyAdrIntake — normalisation + implicit DoD", () => {
+  it("ADR accepted + NO criteria → status normalised to ready + implicit decision-DoD; FIRES", () => {
+    const raw = parse(ADR_ACCEPTED_NO_CRIT);
+    const { parsed, isAdr } = applyAdrIntake(raw, "/repo/docs/adr/0007.md");
+    expect(isAdr).toBe(true);
+    if (parsed.kind !== "spec") throw new Error("expected spec");
+    expect(parsed.frontmatter.status).toBe("ready"); // accepted → ready
+    expect(parsed.frontmatter.acceptanceCriteria).toEqual([...ADR_IMPLICIT_CRITERIA]);
+    // The SAME ready-gate now fires it (an ADR NEVER fires with an empty DoD).
+    const gate = evaluateReadyGate(parsed);
+    expect(gate.fire).toBe(true);
+  });
+
+  it("ADR with EXPLICIT criteria keeps them (implicit DoD not injected)", () => {
+    const raw = parse(
+      `---\nstatus: accepted\nsource: {kind: human}\nacceptanceCriteria:\n  - "Ledger writes are append-only"\n---\n## Decision\nx`,
+    );
+    const { parsed, isAdr } = applyAdrIntake(raw, "/repo/docs/adr/9.md");
+    expect(isAdr).toBe(true);
+    if (parsed.kind !== "spec") throw new Error("expected spec");
+    expect(parsed.frontmatter.acceptanceCriteria).toEqual(["Ledger writes are append-only"]);
+    expect(evaluateReadyGate(parsed).fire).toBe(true);
+  });
+
+  it("a PROPOSED ADR does NOT fire (only accepted/ready is the go-state)", () => {
+    const raw = parse(`---\nstatus: proposed\nsource: {kind: human}\n---\n## Decision\nx`);
+    const { parsed, isAdr } = applyAdrIntake(raw, "/repo/docs/adr/1.md");
+    expect(isAdr).toBe(true);
+    if (parsed.kind !== "spec") throw new Error("expected spec");
+    expect(parsed.frontmatter.status).toBe("proposed"); // NOT normalised
+    expect(evaluateReadyGate(parsed).fire).toBe(false);
+  });
+
+  it("a DRAFT ADR does NOT fire", () => {
+    const raw = parse(`---\nstatus: draft\nsource: {kind: human}\n---\n## Decision\nx`);
+    const { parsed } = applyAdrIntake(raw, "/repo/docs/adr/2.md");
+    expect(evaluateReadyGate(parsed).fire).toBe(false);
+  });
+
+  it("a NON-ADR spec is returned UNCHANGED (byte-identical SPEC-1/2)", () => {
+    const raw = parse(`---\nstatus: accepted\nsource: {kind: human}\n---\nbody`);
+    const { parsed, isAdr } = applyAdrIntake(raw, "/repo/docs/specs/foo.md");
+    expect(isAdr).toBe(false);
+    expect(parsed).toBe(raw); // same reference — no normalisation applied
+    // A docs/specs file with `accepted` (a non-spec status) still does NOT fire.
+    expect(evaluateReadyGate(parsed).fire).toBe(false);
+  });
+
+  it("a not-a-spec input is passed through untouched", () => {
+    const raw = parse(`# just markdown, no frontmatter`);
+    const { parsed, isAdr } = applyAdrIntake(raw, "/repo/docs/adr/x.md");
+    expect(isAdr).toBe(false);
+    expect(parsed.kind).toBe("not-a-spec");
+  });
+});
+
+// ─── Dispatch: an ADR fires a loop, marks provenance, and dedups ───────────────
+
+let root: string;
+let adrDir: string;
+
+function adrFile(name: string, content: string): string {
+  const p = join(adrDir, name);
+  writeFileSync(p, content, "utf8");
+  return p;
+}
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "adr-intake-"));
+  adrDir = join(root, "docs", "adr");
+  mkdirSync(adrDir, { recursive: true });
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function makeTrigger(over: Partial<TriggerRow> = {}): TriggerRow {
+  return {
+    id: "trig-adr",
+    projectId: "proj-1",
+    pipelineId: null,
+    type: "file_change",
+    config: { watchPath: adrDir, patterns: ["**/*.md"] },
+    ...over,
+  } as unknown as TriggerRow;
+}
+
+function makeDeps(loops: ConsiliumLoopRow[] = []) {
+  const createReview = vi
+    .fn()
+    .mockImplementation((_deps, params) =>
+      Promise.resolve({ id: "loop-new", repoPath: params.repoPath, state: "reviewing" } as ConsiliumLoopRow),
+    );
+  const runInProject = vi.fn().mockImplementation((_pid: string, fn: () => Promise<unknown>) => fn());
+  const log = vi.fn();
+  const getLoops = vi.fn().mockResolvedValue(loops);
+  const resolveOwnerId = vi.fn().mockResolvedValue("owner-1");
+  const recordFire = vi.fn().mockResolvedValue(undefined);
+  const deps: ConsiliumTriggerDispatchDeps = {
+    reviewDeps: { storage: { getLoops } } as unknown as ConsiliumTriggerDispatchDeps["reviewDeps"],
+    createReview,
+    runInProject,
+    resolveOwnerId,
+    recordFire,
+    specWatch: () => ({ enabled: true, globs: ["docs/adr/**/*.md"], allowedRepoPaths: [] }),
+    log,
+  };
+  return { deps, createReview, log, recordFire };
+}
+
+function activeSpecLoop(specPath: string, repoPath: string): ConsiliumLoopRow {
+  return {
+    id: `loop-${specPath}`,
+    state: "reviewing",
+    repoPath,
+    triggerProvenance: { spec: { specPath } },
+  } as unknown as ConsiliumLoopRow;
+}
+
+describe("maybeLaunchSpecReview — ADR intake", () => {
+  it("an ADR under docs/adr (accepted, no explicit criteria) FIRES with the implicit DoD + ADR provenance", async () => {
+    const p = adrFile("0007.md", ADR_ACCEPTED_NO_CRIT);
+    const { deps, createReview } = makeDeps();
+    const result = await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: adrDir }, p, ["/whatever"]);
+
+    expect(result).toBe("launched");
+    const [, params] = createReview.mock.calls[0];
+    // The decision is the objective; the implicit criteria are the fenced DoD.
+    expect(params.engineerInstruction).toContain("append-only event log");
+    expect(params.engineerInstruction).toContain(
+      "The decision described in this ADR is implemented in the codebase.",
+    );
+    // Provenance records it is an ADR (status reflects the normalised ready).
+    expect(params.triggerProvenance.spec).toEqual(
+      expect.objectContaining({ specPath: p, status: "ready", artifact: "adr" }),
+    );
+  });
+
+  it("an ADR with status:ready + explicit criteria fires with those criteria", async () => {
+    const p = adrFile("ready-explicit.md", `---\nstatus: ready\nsource: {kind: human}\nacceptanceCriteria:\n  - "The cache is invalidated on write"\n---\n## Decision\nWrite-through cache.`);
+    const { deps, createReview } = makeDeps();
+    expect(await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: adrDir }, p, [])).toBe("launched");
+    expect(createReview.mock.calls[0][1].engineerInstruction).toContain("The cache is invalidated on write");
+    expect(createReview.mock.calls[0][1].triggerProvenance.spec.artifact).toBe("adr");
+  });
+
+  it("a PROPOSED ADR is a NO-OP (does not fire)", async () => {
+    const p = adrFile("proposed.md", `---\nstatus: proposed\nsource: {kind: human}\n---\n## Decision\nx`);
+    const { deps, createReview, log } = makeDeps();
+    expect(await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: adrDir }, p, [])).toBe("skipped");
+    expect(createReview).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/no-op.*(unknown-status|draft)/));
+  });
+
+  it("a DRAFT ADR is a NO-OP (does not fire)", async () => {
+    const p = adrFile("draft.md", `---\nstatus: draft\nsource: {kind: human}\n---\n## Decision\nx`);
+    const { deps, createReview } = makeDeps();
+    expect(await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: adrDir }, p, [])).toBe("skipped");
+    expect(createReview).not.toHaveBeenCalled();
+  });
+
+  it("PER-SPEC dedup holds for ADRs: an ACTIVE loop for the SAME ADR → skipped-dedup", async () => {
+    const p = adrFile("dedup.md", ADR_ACCEPTED_NO_CRIT);
+    const { deps, createReview, log } = makeDeps([activeSpecLoop(p, adrDir)]);
+    const result = await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: adrDir }, p, []);
+    expect(result).toBe("skipped-dedup");
+    expect(createReview).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringMatching(/skipped-dedup:spec/));
+  });
+
+  it("two DISTINCT ADRs in the same dir each fire their own loop", async () => {
+    const a = adrFile("a.md", ADR_ACCEPTED_NO_CRIT);
+    const b = adrFile("b.md", ADR_ACCEPTED_NO_CRIT.replace("event sourcing", "CQRS"));
+    const { deps, createReview } = makeDeps([activeSpecLoop(a, adrDir)]);
+    expect(await maybeLaunchSpecReview(deps, makeTrigger(), { watchPath: adrDir }, b, [])).toBe("launched");
+    expect(createReview.mock.calls[0][1].triggerProvenance.spec.specPath).toBe(b);
+  });
+});

--- a/tests/unit/consilium/spec-autocommit.test.ts
+++ b/tests/unit/consilium/spec-autocommit.test.ts
@@ -1,0 +1,96 @@
+/**
+ * spec-autocommit.test.ts — SPEC-3 (spec-as-task.md §4/§5/§7): the auto-commit
+ * POLICY that lets a trusted repo skip GATE 1 (the spec PR) and direct-commit a spec
+ * as `status: ready`. Covers the pure decision helper `shouldAutoCommitSpec` (the
+ * connector seam) and the `specWatch.autoCommit` config surface + validation.
+ *
+ * The headline invariant is FAIL-CLOSED: the helper returns `true` ONLY for a repo
+ * EXPLICITLY on an ENABLED allowlist; every other case falls back to `false` (= open
+ * a spec PR, the safe default). It can NEVER widen beyond the configured repos.
+ */
+import { describe, it, expect } from "vitest";
+import { shouldAutoCommitSpec } from "../../../server/services/consilium/spec-parser.js";
+import { ConfigSchema } from "../../../server/config/schema.js";
+
+// ─── shouldAutoCommitSpec (the connector seam, pure + fail-closed) ─────────────
+
+describe("shouldAutoCommitSpec — the trusted-flow decision (fail-closed)", () => {
+  it("TRUE only for an ENABLED repo that is EXPLICITLY on the allowlist", () => {
+    const config = { enabled: true, repos: ["omnius", "multiqlti"] };
+    expect(shouldAutoCommitSpec("omnius", config)).toBe(true);
+    expect(shouldAutoCommitSpec("multiqlti", config)).toBe(true);
+  });
+
+  it("a repo NOT on the allowlist → false (spec PR — the flag never widens)", () => {
+    const config = { enabled: true, repos: ["omnius"] };
+    expect(shouldAutoCommitSpec("platform-design", config)).toBe(false);
+  });
+
+  it("flag OFF (enabled:false) → false even for a listed repo (Gate 1 stands)", () => {
+    expect(shouldAutoCommitSpec("omnius", { enabled: false, repos: ["omnius"] })).toBe(false);
+  });
+
+  it("flag ABSENT (undefined config) → false (safe default = spec PR)", () => {
+    expect(shouldAutoCommitSpec("omnius", undefined)).toBe(false);
+  });
+
+  it("enabled but EMPTY allowlist → false (empty ≠ 'all repos' — nothing trusted)", () => {
+    expect(shouldAutoCommitSpec("omnius", { enabled: true, repos: [] })).toBe(false);
+    // repos omitted entirely is likewise fail-closed.
+    expect(shouldAutoCommitSpec("omnius", { enabled: true })).toBe(false);
+  });
+
+  it("unknown/empty repo → false (unknown repo ⇒ spec PR)", () => {
+    const config = { enabled: true, repos: ["omnius"] };
+    expect(shouldAutoCommitSpec(undefined, config)).toBe(false);
+    expect(shouldAutoCommitSpec("", config)).toBe(false);
+    expect(shouldAutoCommitSpec("   ", config)).toBe(false);
+  });
+
+  it("whitespace around repo / allowlist entries is tolerated (trimmed match)", () => {
+    expect(shouldAutoCommitSpec("  omnius  ", { enabled: true, repos: [" omnius "] })).toBe(true);
+  });
+
+  it("a truthy-but-not-true `enabled` is treated as OFF (strict === true)", () => {
+    // Defensive: only a real boolean true opens the gate.
+    const cfg = { enabled: 1 as unknown as boolean, repos: ["omnius"] };
+    expect(shouldAutoCommitSpec("omnius", cfg)).toBe(false);
+  });
+});
+
+// ─── config surface + validation (specWatch.autoCommit) ────────────────────────
+
+describe("specWatch.autoCommit — config schema surface + defaults", () => {
+  const specWatchOf = (over: Record<string, unknown> = {}) =>
+    ConfigSchema.parse({
+      pipeline: { consiliumLoop: { specWatch: over } },
+    }).pipeline.consiliumLoop.specWatch;
+
+  it("DEFAULT is OFF + empty allowlist (byte-identical inert default)", () => {
+    const sw = specWatchOf();
+    expect(sw.autoCommit).toEqual({ enabled: false, repos: [] });
+  });
+
+  it("an operator can enable + allowlist specific repos", () => {
+    const sw = specWatchOf({ autoCommit: { enabled: true, repos: ["omnius"] } });
+    expect(sw.autoCommit).toEqual({ enabled: true, repos: ["omnius"] });
+  });
+
+  it("the folded config drives the helper end-to-end (only listed repo passes)", () => {
+    const sw = specWatchOf({ autoCommit: { enabled: true, repos: ["omnius"] } });
+    expect(shouldAutoCommitSpec("omnius", sw.autoCommit)).toBe(true);
+    expect(shouldAutoCommitSpec("ghost", sw.autoCommit)).toBe(false);
+  });
+
+  it("rejects a malformed autoCommit (non-boolean enabled / non-array repos)", () => {
+    expect(() => specWatchOf({ autoCommit: { enabled: "yes" } })).toThrow();
+    expect(() => specWatchOf({ autoCommit: { repos: "omnius" } })).toThrow();
+  });
+
+  it("GATE 2 is unaffected: autoCommit lives ONLY under specWatch (no code-PR key)", () => {
+    // The policy is scoped to the spec-PR gate — it introduces no field that could
+    // touch the code-PR merge. Assert the shape is exactly {enabled, repos}.
+    const sw = specWatchOf({ autoCommit: { enabled: true, repos: ["omnius"] } });
+    expect(Object.keys(sw.autoCommit).sort()).toEqual(["enabled", "repos"]);
+  });
+});


### PR DESCRIPTION
Two small spec-substrate extensions on top of the shipped SPEC-1 (watch) and SPEC-2 (status lifecycle), per `docs/design/spec-as-task.md` §4/§7 (and §2 for the ADR criteria shape). Both are additive, localized, and default-inert.

## SPEC-3 — auto-commit policy (skip Gate 1 for trusted flows)

`docs/design/spec-as-task.md` §4 makes the **spec PR the default** — a human reviews the *intent* before the factory builds. For trusted, low-stakes flows an operator may allow **auto-commit**: a connector- or `draft`-produced spec is committed **directly to the default branch as `status: ready`**, skipping Gate 1 (the spec PR) so the SPEC-1 watch fires immediately.

- **Config surface** (`server/config/schema.ts`): `pipeline.consiliumLoop.specWatch.autoCommit: { enabled: false, repos: [] }`. Default **OFF + empty allowlist** everywhere — byte-identical when off. config.yaml-only arrays (matches `globs`/`allowedRepoPaths`); rejects non-boolean `enabled` / non-array `repos` at load.
- **Decision helper** (`shouldAutoCommitSpec(repo, config)` in `spec-parser.ts`): the seam a spec **producer** consults to choose "open a spec PR" vs "direct-commit ready". Because SPEC-1 watches already-committed specs, SPEC-3 is (a) the config + validation and (b) this documented seam; the connector-side use (TRACK-1+) is additive.
- **Fail-closed** (the safe default is a spec PR): returns `true` **only** when auto-commit is explicitly enabled **and** `repo` is on the explicit allowlist. Flag absent/off, unknown/empty repo, or an empty `repos` list ⇒ `false`. **An empty allowlist never means "all repos"** — the flag can never widen beyond its list.
- **Gate 2 stands.** Auto-commit only skips the *intent* review (Gate 1); the **code PR merge (Gate 2)** is unaffected — the policy introduces no field outside `specWatch` that could touch it (asserted in the tests).

> Safety: auto-commit is the HIGH-TRUST setting (spec-as-task §5) — it **skips human intent-review**. Enable it only for repos whose spec producers are trusted. Documented loudly in the schema + helper doc-comments.

**Connector seam note:** a TRACK-1+ connector (in `trackers/`, untouched here) imports `shouldAutoCommitSpec`, passes the resolved `specWatch.autoCommit` + the target repo, and branches: `true` → direct-commit the spec `ready`; `false` → open the spec PR. No connector code is changed in this PR — only the flag, its validation, and the helper are wired.

## SPEC-4 — ADR intake (docs/adr entries are tasks)

The SPEC-1 watch already globs `docs/adr/**/*.md`. SPEC-4 makes an ADR a **valid task** — an ADR with an accepted/ready state + criteria fires a loop like a spec (§2: "an ADR is a spec whose acceptanceCriteria are 'the decision is implemented + …'").

- **ADR-awareness in the parser** (`spec-parser.ts`): `isAdrCandidate(path, frontmatter)` recognises an ADR by **path under `docs/adr/`** (boundary-anchored) **or** an `adr:`/`decision:` frontmatter marker. `applyAdrIntake(parsed, path)`:
  - normalises the ADR **accepted-state → `ready`** so the **same SPEC-1 ready-gate** fires it (only `accepted` is remapped; `proposed`/`draft` stay non-firing);
  - when the ADR declares **no explicit `acceptanceCriteria`**, synthesises the **implicit decision-DoD** (`ADR_IMPLICIT_CRITERIA`: decision implemented + tests + docs) so the loop always has a DoD to verify — **an ADR never fires with an empty DoD**;
  - returns a **non-ADR spec unchanged** (byte-identical SPEC-1/2), and passes `not-a-spec` straight through.
- **Fires** with the ADR body as the objective + the implicit/explicit criteria as the fenced DoD (via the existing `buildSpecInstruction`).
- **Provenance** stamps `artifact: "adr"` on `SpecProvenance` (`shared/types.ts`, additive/optional — absent for normal specs).
- **Obeys the existing rails:** ready-gate, per-spec dedup (keyed by spec path), and provenance — all reused, not duplicated. A **proposed/draft ADR is a no-op**.

## How both build on SPEC-1/2

- **Reuse, don't duplicate:** SPEC-4 threads through the SPEC-1 `readSpecFile` → ready-gate → `buildSpecInstruction` → per-spec-dedup pipeline; it only pre-normalises the parse result. SPEC-3 adds a pure helper + config, consumed at the spec-producer boundary.
- **SPEC-2 untouched:** the status-lifecycle writer and terminal/PR-merge hooks are built on, not rewritten. (Boundary: an ADR authored with `status: ready` gets the full SPEC-2 `ready → in-progress` durable flip; an ADR authored `accepted` fires and relies on the in-memory active-loop dedup for the launch window — the CAS flip from `ready` is a best-effort no-op against an `accepted` file. Recommend `status: ready` for ADRs intended to auto-execute.)

## Kill-switch

Both sit behind the existing `specWatch` kill-switch (itself behind `features.triggers.enabled` + `consiliumLoop.enabled`). Auto-commit is **additionally** default-off per-repo. With `specWatch` off, the dispatch is byte-identical to pre-SPEC-3/4.

## Tests

New unit suites (`tests/unit/consilium/spec-autocommit.test.ts`, `adr-intake.test.ts`):

- **SPEC-3:** `shouldAutoCommitSpec` true **only** for an enabled+allowlisted repo; false for off/absent/unknown-repo/empty-allowlist/not-listed; whitespace-trimmed match; config default OFF+empty; validation rejects malformed; Gate-2 shape assertion (autoCommit is `{enabled, repos}` only).
- **SPEC-4:** ADR under `docs/adr` with ready+criteria fires; ADR with no explicit criteria gets the implicit decision-DoD and fires; accepted→ready normalisation; a proposed/draft ADR no-ops; ADR provenance marks `artifact: "adr"`; per-spec dedup holds; `adr:`/`decision:` marker detection; boundary-anchored path match; non-ADR spec unchanged.

`tsc` clean; full consilium unit suite green (837). Full unit suite green except two pre-existing, unrelated env flakes (`gateway.test.ts` — passes in isolation, parallel global-state; `sandbox-api` integration — needs Docker); neither imports the touched files. pull_request CI is authoritative.

## Adversarial self-review

- **auto-commit defaulting on / widening beyond the configured repos** → default OFF; empty allowlist ⇒ nothing trusted (never "all"); strict `=== true` on `enabled`; not-listed ⇒ spec PR. Covered.
- **an ADR firing without any DoD** → implicit decision-DoD always synthesised when criteria absent; the ready-gate still rejects a criteria-less result. Covered.
- **a proposed/draft ADR firing** → only `accepted` is normalised to ready; `proposed`/`draft` stay non-firing. Covered.
- **implicit criteria being untestable noise** → the §2 decision-DoD shape (implemented + tests + docs), the documented ADR criteria contract, not free text.
- **auto-commit weakening Gate 2** → the policy is scoped to `specWatch` and consumed only at the spec-PR decision; no code-PR field is introduced. Asserted.
