### PR TITLE
feat: StandingRole record + manual wake (ROLE-1)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -36,6 +36,7 @@ import ConfigSync from "@/pages/ConfigSync";
 import Activity from "@/pages/Activity";
 import ConsiliumLoopList from "@/pages/ConsiliumLoopList";
 import ConsiliumLoopDetail from "@/pages/ConsiliumLoopDetail";
+import Roles from "@/pages/Roles";
 import PrReviewQueue from "@/pages/PrReviewQueue";
 import TrustTelemetry from "@/pages/TrustTelemetry";
 import ContourObservability from "@/pages/ContourObservability";
@@ -83,6 +84,9 @@ function ProtectedRouter() {
         )} />
         <Route path="/triggers" component={() => (
           <ErrorBoundary><TriggersPage /></ErrorBoundary>
+        )} />
+        <Route path="/roles" component={() => (
+          <ErrorBoundary><Roles /></ErrorBoundary>
         )} />
         <Route path="/consilium-loops/:id" component={() => (
           <ErrorBoundary><ConsiliumLoopDetail /></ErrorBoundary>

--- a/client/src/components/layout/MainLayout.tsx
+++ b/client/src/components/layout/MainLayout.tsx
@@ -18,6 +18,7 @@ import {
   GitPullRequest,
   ShieldCheck,
   KeyRound,
+  UserCog,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/hooks/use-auth";
@@ -55,6 +56,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
 
   const navItems = [
     { icon: Zap, label: "Triggers", href: "/triggers" },
+    { icon: UserCog, label: "Roles", href: "/roles" },
     { icon: Repeat, label: "Consilium Loops", href: "/consilium-loops" },
     { icon: GitPullRequest, label: "PR Queue", href: "/pr-queue" },
     { icon: ShieldCheck, label: "Trust", href: "/trust" },

--- a/client/src/hooks/use-roles.ts
+++ b/client/src/hooks/use-roles.ts
@@ -1,0 +1,82 @@
+/**
+ * use-roles.ts — React Query hooks for the ROLE-1 StandingRole surface
+ * (standing-role.md §3/§8). Mirrors use-skills.ts but goes through the shared
+ * `apiRequest` transport (use-pipeline) so every call carries auth + `x-project-id`
+ * (the project-scoped `/api/roles` mount returns 401/400 without them).
+ */
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiRequest } from "@/hooks/use-pipeline";
+import type { StandingRoleRow } from "@shared/schema";
+import type { StandingRoleLoopTemplate } from "@shared/types";
+
+const ROLES_KEY = ["/api/roles"] as const;
+
+// ─── Payload types ────────────────────────────────────────────────────────────
+
+export interface CreateRolePayload {
+  name: string;
+  persona: string;
+  skills: string[];
+  loopTemplate: StandingRoleLoopTemplate;
+  enabled?: boolean;
+}
+
+export type UpdateRolePayload = Partial<CreateRolePayload> & { id: string };
+
+export interface WakeRolePayload {
+  id: string;
+  repoPath: string;
+  focus: string;
+}
+
+// ─── Read hooks ─────────────────────────────────────────────────────────────
+
+export function useRoles() {
+  return useQuery<StandingRoleRow[]>({
+    queryKey: ROLES_KEY,
+    queryFn: () => apiRequest("GET", "/api/roles") as Promise<StandingRoleRow[]>,
+  });
+}
+
+// ─── Mutation hooks ─────────────────────────────────────────────────────────
+
+export function useCreateRole() {
+  const qc = useQueryClient();
+  return useMutation<StandingRoleRow, Error, CreateRolePayload>({
+    mutationFn: (data) => apiRequest("POST", "/api/roles", data) as Promise<StandingRoleRow>,
+    onSuccess: () => qc.invalidateQueries({ queryKey: ROLES_KEY }),
+  });
+}
+
+export function useUpdateRole() {
+  const qc = useQueryClient();
+  return useMutation<StandingRoleRow, Error, UpdateRolePayload>({
+    mutationFn: ({ id, ...updates }) =>
+      apiRequest("PATCH", `/api/roles/${id}`, updates) as Promise<StandingRoleRow>,
+    onSuccess: () => qc.invalidateQueries({ queryKey: ROLES_KEY }),
+  });
+}
+
+export function useDeleteRole() {
+  const qc = useQueryClient();
+  return useMutation<null, Error, string>({
+    mutationFn: (id) => apiRequest("DELETE", `/api/roles/${id}`) as Promise<null>,
+    onSuccess: () => qc.invalidateQueries({ queryKey: ROLES_KEY }),
+  });
+}
+
+/**
+ * Wake a role → spawns ONE ephemeral consilium loop. Resolves to the created loop
+ * (the caller links to `/consilium-loops/:id`). Invalidates the loop list so the new
+ * loop shows immediately.
+ */
+export function useWakeRole() {
+  const qc = useQueryClient();
+  return useMutation<{ id?: string } & Record<string, unknown>, Error, WakeRolePayload>({
+    mutationFn: ({ id, repoPath, focus }) =>
+      apiRequest("POST", `/api/roles/${id}/wake`, { repoPath, focus }) as Promise<
+        { id?: string } & Record<string, unknown>
+      >,
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["/api/consilium-loops"] }),
+  });
+}

--- a/client/src/pages/Roles.tsx
+++ b/client/src/pages/Roles.tsx
@@ -1,0 +1,437 @@
+/**
+ * Roles.tsx — the ROLE-1 Standing Roles page (standing-role.md §3/§8).
+ *
+ * Lists the project's Standing Roles, lets you DEFINE one (name + persona + a skills
+ * multi-select from the project registry + a loop template), and manually WAKE a role
+ * (asks repoPath + focus) — which spawns ONE ephemeral consilium loop and links to it.
+ * No triggers/concerns (ROLE-2) and no role-scoped experience (ROLE-3) here — a wake
+ * is an explicit user action (§6).
+ */
+import { useState } from "react";
+import { useLocation } from "wouter";
+import { UserCog, Plus, Trash2, Zap } from "lucide-react";
+import { CONSILIUM_REVIEW_PRESETS, REVIEW_MODES } from "@shared/types";
+import type { ConsiliumReviewPreset, ReviewMode } from "@shared/types";
+import type { StandingRoleRow } from "@shared/schema";
+import { useSkills } from "@/hooks/use-skills";
+import {
+  useRoles,
+  useCreateRole,
+  useDeleteRole,
+  useWakeRole,
+} from "@/hooks/use-roles";
+import { useToast } from "@/hooks/use-toast";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Switch } from "@/components/ui/switch";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const MAX_ROLE_SKILLS = 5;
+
+// ─── Create-role dialog ───────────────────────────────────────────────────────
+
+function CreateRoleDialog() {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [persona, setPersona] = useState("");
+  const [preset, setPreset] = useState<ConsiliumReviewPreset>("sdlc-cross-review");
+  const [maxRounds, setMaxRounds] = useState("1");
+  const [reviewMode, setReviewMode] = useState<"" | ReviewMode>("");
+  const [enabled, setEnabled] = useState(true);
+  const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>([]);
+
+  const { toast } = useToast();
+  const createRole = useCreateRole();
+  const skillsQuery = useSkills({ isBuiltin: false });
+  const availableSkills = skillsQuery.data ?? [];
+
+  const toggleSkill = (id: string) => {
+    setSelectedSkillIds((cur) => {
+      if (cur.includes(id)) return cur.filter((s) => s !== id);
+      if (cur.length >= MAX_ROLE_SKILLS) return cur;
+      return [...cur, id];
+    });
+  };
+
+  const reset = () => {
+    setName("");
+    setPersona("");
+    setPreset("sdlc-cross-review");
+    setMaxRounds("1");
+    setReviewMode("");
+    setEnabled(true);
+    setSelectedSkillIds([]);
+  };
+
+  const submit = async () => {
+    if (!name.trim() || !persona.trim()) {
+      toast({ title: "Name and persona are required", variant: "destructive" });
+      return;
+    }
+    const rounds = Number(maxRounds);
+    try {
+      await createRole.mutateAsync({
+        name: name.trim(),
+        persona: persona.trim(),
+        skills: selectedSkillIds,
+        loopTemplate: {
+          preset,
+          ...(Number.isInteger(rounds) && rounds > 0 ? { maxRounds: rounds } : {}),
+          ...(reviewMode ? { reviewMode } : {}),
+        },
+        enabled,
+      });
+      toast({ title: "Role created" });
+      reset();
+      setOpen(false);
+    } catch (e) {
+      toast({
+        title: "Failed to create role",
+        description: e instanceof Error ? e.message : undefined,
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" data-testid="new-role-button">
+          <Plus className="h-4 w-4 mr-2" />
+          New Role
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Define a Standing Role</DialogTitle>
+          <DialogDescription>
+            A named identity (persona + skills + loop template) you can later wake to
+            spawn a consilium loop.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="role-name">Name</Label>
+            <Input
+              id="role-name"
+              data-testid="role-name-input"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="devops-reviewer"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="role-persona">Persona (standing instruction)</Label>
+            <Textarea
+              id="role-persona"
+              data-testid="role-persona-input"
+              value={persona}
+              onChange={(e) => setPersona(e.target.value)}
+              rows={4}
+              placeholder="You are a senior DevOps reviewer. Prioritise CIS/security, cost, and breaking-change surface…"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Skills {selectedSkillIds.length > 0 && `(${selectedSkillIds.length}/${MAX_ROLE_SKILLS})`}</Label>
+            {availableSkills.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No project skills available. Create skills first to give the role a capability.
+              </p>
+            ) : (
+              <div className="max-h-40 overflow-y-auto rounded-md border p-2 space-y-1.5">
+                {availableSkills.map((s) => {
+                  const checked = selectedSkillIds.includes(s.id);
+                  const disabled = !checked && selectedSkillIds.length >= MAX_ROLE_SKILLS;
+                  return (
+                    <label
+                      key={s.id}
+                      className="flex items-center gap-2 text-sm cursor-pointer"
+                      data-testid={`role-skill-${s.id}`}
+                    >
+                      <Checkbox
+                        checked={checked}
+                        disabled={disabled}
+                        onCheckedChange={() => toggleSkill(s.id)}
+                      />
+                      <span>{s.name}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label>Preset</Label>
+              <Select value={preset} onValueChange={(v) => setPreset(v as ConsiliumReviewPreset)}>
+                <SelectTrigger data-testid="role-preset-select">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {CONSILIUM_REVIEW_PRESETS.map((p) => (
+                    <SelectItem key={p} value={p}>
+                      {p}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="role-max-rounds">Max rounds</Label>
+              <Input
+                id="role-max-rounds"
+                type="number"
+                min={1}
+                max={6}
+                value={maxRounds}
+                onChange={(e) => setMaxRounds(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Review mode</Label>
+            <Select
+              value={reviewMode || "default"}
+              onValueChange={(v) => setReviewMode(v === "default" ? "" : (v as ReviewMode))}
+            >
+              <SelectTrigger data-testid="role-review-mode-select">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="default">Operator default</SelectItem>
+                {REVIEW_MODES.map((m) => (
+                  <SelectItem key={m} value={m}>
+                    {m}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Switch id="role-enabled" checked={enabled} onCheckedChange={setEnabled} />
+            <Label htmlFor="role-enabled">Enabled</Label>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            onClick={submit}
+            disabled={createRole.isPending}
+            data-testid="role-create-submit"
+          >
+            {createRole.isPending ? "Creating…" : "Create Role"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─── Wake dialog ────────────────────────────────────────────────────────────
+
+function WakeRoleDialog({ role }: { role: StandingRoleRow }) {
+  const [open, setOpen] = useState(false);
+  const [repoPath, setRepoPath] = useState("");
+  const [focus, setFocus] = useState("");
+  const [, navigate] = useLocation();
+  const { toast } = useToast();
+  const wake = useWakeRole();
+
+  const submit = async () => {
+    if (!repoPath.trim() || !focus.trim()) {
+      toast({ title: "Repo path and focus are required", variant: "destructive" });
+      return;
+    }
+    try {
+      const loop = await wake.mutateAsync({ id: role.id, repoPath: repoPath.trim(), focus: focus.trim() });
+      toast({ title: `Woke "${role.name}" — loop started` });
+      setOpen(false);
+      const id = typeof loop?.id === "string" ? loop.id : undefined;
+      if (id) navigate(`/consilium-loops/${id}`);
+    } catch (e) {
+      // apiRequest threads the server's 400 message (e.g. "…not in the allowed repo
+      // paths") verbatim into Error.message.
+      toast({
+        title: "Failed to wake role",
+        description: e instanceof Error ? e.message : undefined,
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="secondary" data-testid={`wake-role-${role.id}`} disabled={!role.enabled}>
+          <Zap className="h-4 w-4 mr-2" />
+          Wake
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Wake "{role.name}"</DialogTitle>
+          <DialogDescription>
+            Spawns one consilium loop using this role's persona, skills, and loop template.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="wake-repo">Repo path</Label>
+            <Input
+              id="wake-repo"
+              data-testid="wake-repo-input"
+              value={repoPath}
+              onChange={(e) => setRepoPath(e.target.value)}
+              placeholder="/repos/my-iac"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="wake-focus">Focus</Label>
+            <Textarea
+              id="wake-focus"
+              data-testid="wake-focus-input"
+              value={focus}
+              onChange={(e) => setFocus(e.target.value)}
+              rows={3}
+              placeholder="Review the new Terraform module version for CIS/security regressions."
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button onClick={submit} disabled={wake.isPending} data-testid="wake-submit">
+            {wake.isPending ? "Waking…" : "Wake"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─── Role card ──────────────────────────────────────────────────────────────
+
+function RoleCard({ role }: { role: StandingRoleRow }) {
+  const { toast } = useToast();
+  const del = useDeleteRole();
+
+  const remove = async () => {
+    try {
+      await del.mutateAsync(role.id);
+      toast({ title: "Role deleted" });
+    } catch (e) {
+      toast({
+        title: "Failed to delete role",
+        description: e instanceof Error ? e.message : undefined,
+        variant: "destructive",
+      });
+    }
+  };
+
+  const tpl = role.loopTemplate;
+  return (
+    <Card data-testid={`role-card-${role.id}`}>
+      <CardHeader>
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="flex items-center gap-2">
+            {role.name}
+            {!role.enabled && <Badge variant="outline">disabled</Badge>}
+          </CardTitle>
+          <Badge variant="secondary">{tpl.preset}</Badge>
+        </div>
+        <CardDescription className="line-clamp-3">{role.persona}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div className="flex flex-wrap gap-1">
+          {role.skills.length === 0 ? (
+            <span className="text-sm text-muted-foreground">No skills</span>
+          ) : (
+            role.skills.map((sid) => (
+              <Badge key={sid} variant="outline" className="font-mono text-xs">
+                {sid}
+              </Badge>
+            ))
+          )}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          maxRounds: {tpl.maxRounds ?? "default"} · reviewMode: {tpl.reviewMode ?? "operator default"}
+        </p>
+      </CardContent>
+      <CardFooter className="gap-2">
+        <WakeRoleDialog role={role} />
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={remove}
+          disabled={del.isPending}
+          data-testid={`delete-role-${role.id}`}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+
+// ─── Page ───────────────────────────────────────────────────────────────────
+
+export default function Roles() {
+  const { data: roles, isLoading, isError } = useRoles();
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <UserCog className="h-5 w-5" />
+          <h1 className="text-xl font-semibold">Standing Roles</h1>
+        </div>
+        <CreateRoleDialog />
+      </div>
+
+      {isLoading && <p className="text-muted-foreground">Loading roles…</p>}
+      {isError && <p className="text-destructive">Failed to load roles.</p>}
+      {!isLoading && !isError && (roles?.length ?? 0) === 0 && (
+        <p className="text-muted-foreground">
+          No roles yet. Define one to save a persona + skills + loop template you can wake on demand.
+        </p>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {(roles ?? []).map((role) => (
+          <RoleCard key={role.id} role={role} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/migrations/0046_standing_roles.sql
+++ b/migrations/0046_standing_roles.sql
@@ -1,0 +1,41 @@
+-- ROLE-1 (standing-role.md §3/§8): the StandingRole record.
+--
+-- A named, persistent identity (persona + skills + loop template) an operator can
+-- manually "wake" (POST /api/roles/:id/wake) to spawn ONE ephemeral consilium loop.
+-- ROLE-1 is JUST the record + manual wake — NO triggers/concerns (ROLE-2), NO
+-- role-scoped experience (ROLE-3). A role is a definition, not a running process (§6).
+--
+-- Project-scoped (owner/member isolation via the app's withProject helper), cascades
+-- with the owning project. `skills` = skill ids validated against the project's skill
+-- registry. `loop_template` = { preset, maxRounds?, reviewMode? } (server enums).
+CREATE TABLE IF NOT EXISTS "standing_roles" (
+  "id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "project_id" text,
+  "name" text NOT NULL,
+  "persona" text NOT NULL,
+  "skills" jsonb DEFAULT '[]'::jsonb NOT NULL,
+  "loop_template" jsonb NOT NULL,
+  "enabled" boolean DEFAULT true NOT NULL,
+  "created_by" text,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+DO $$ BEGIN
+  ALTER TABLE "standing_roles"
+    ADD CONSTRAINT "standing_roles_project_id_projects_id_fk"
+    FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "standing_roles"
+    ADD CONSTRAINT "standing_roles_created_by_users_id_fk"
+    FOREIGN KEY ("created_by") REFERENCES "users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "standing_roles_project_id_idx" ON "standing_roles" ("project_id");
+CREATE INDEX IF NOT EXISTS "standing_roles_created_by_idx" ON "standing_roles" ("created_by");

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -58,6 +58,7 @@ import { registerTaskGroupRoutes } from "./routes/task-groups";
 import { registerTaskGroupResolveRoute } from "./routes/task-group-resolve";
 import { registerConsiliumLoopRoutes } from "./routes/consilium-loops";
 import { registerConsiliumReviewRoutes } from "./routes/consilium-reviews";
+import { registerStandingRoleRoutes } from "./routes/standing-roles";
 import { createConsiliumReview } from "./services/consilium/review-factory";
 import { maybeLaunchConsiliumReview, maybeLaunchGitHubReview, resolveSpecWatchConfig, deriveRepoRoot } from "./services/consilium/trigger-dispatch";
 import { ConsiliumLoopController, ConsiliumLoopPoller } from "./services/consilium/consilium-loop-controller";
@@ -167,6 +168,10 @@ export async function registerRoutes(
   // route is unauthenticated (the /api/pr-queue class of bug). Do not drop it.
   app.use("/api/telemetry", requireAuth, requireProject);
   app.use("/api/consilium-reviews", requireAuth, requireProject);
+  // ROLE-1 (standing-role.md §3/§8): StandingRole CRUD + manual wake. Project-scoped
+  // — the mount carries auth (the /api/pr-queue 401 lesson); the routes register
+  // inside the consiliumLoop.enabled kill-switch (wake reuses the review factory).
+  app.use("/api/roles", requireAuth, requireProject);
   app.use("/api/lmstudio", requireAuth, requireProject);       // UNCERTAIN — see note above
   app.use("/api/tracker-connections", requireAuth, requireProject);
   app.use("/api/remote-agents", requireAuth, requireProject);
@@ -325,6 +330,16 @@ export async function registerRoutes(
       config: () => appConfigLoader.get(),
       // "Magic mode" reformulate endpoint uses the SAME gateway path (completeStreaming)
       // direct_llm/planner use. Gated by consiliumLoop.reformulate.enabled in the route.
+      gateway,
+    });
+    // ROLE-1 — StandingRole CRUD + manual wake. Registered inside the SAME kill-switch
+    // (inert otherwise) and given the SAME deps as the review routes: wake reuses the
+    // `createConsiliumReview` factory (no reimplemented loop creation; dispatch untouched).
+    registerStandingRoleRoutes(app, {
+      storage,
+      orchestrator: taskOrchestrator,
+      controller: consiliumLoopController,
+      config: () => appConfigLoader.get(),
       gateway,
     });
     // NOTE: the standalone POST /api/task-groups/:groupId/execute-sdlc surface was

--- a/server/routes/standing-roles.ts
+++ b/server/routes/standing-roles.ts
@@ -1,0 +1,257 @@
+/**
+ * standing-roles.ts — the ROLE-1 HTTP surface (standing-role.md §3/§8).
+ *
+ * A StandingRole is a named, persistent identity — a SAVED COMPOSITION of a persona
+ * (standing instruction) + skills + a loop template — that an operator defines once
+ * and can manually "WAKE" to spawn ONE ephemeral consilium loop. This file is the
+ * project-scoped CRUD (`/api/roles`) plus the manual wake (`/api/roles/:id/wake`).
+ *
+ * SCOPE (ROLE-1 only): the record + manual wake. NO triggers/concerns binding
+ * (ROLE-2) and NO role-scoped experience (ROLE-3) — a wake here is an EXPLICIT
+ * user/API action, never a background runtime (a role is a definition, not a
+ * process — §6).
+ *
+ * Auth: the whole router is mounted behind `requireAuth + requireProject` in
+ * `routes.ts` (the /api/pr-queue 401 lesson — never a per-route auth to forget), so
+ * every handler already runs inside the request's project ALS. Each handler ALSO
+ * re-checks `req.user?.id` / `req.projectId` as defense-in-depth (mirrors
+ * consilium-reviews.ts). The router is registered ONLY inside the
+ * `config.consiliumLoop.enabled` kill-switch block (inert otherwise), same as the
+ * consilium-review routes it reuses.
+ *
+ * WAKE reuses the SINGLE review-launch factory (`createConsiliumReview`) — the SAME
+ * code `POST /api/consilium-reviews` uses — so a wake does NOT reimplement loop
+ * creation and does NOT touch trigger-dispatch's tracker/spec paths. The factory
+ * re-validates `repoPath` against the fail-closed allowlist (S1) + per-project
+ * workspace confinement (S5) and re-resolves `skillIds` PROJECT-SCOPED (fail-closed)
+ * — the wake trusts NONE of the stored role config blindly.
+ *
+ * SECURITY (flagged for the adversarial reviewer):
+ *   - Wake CANNOT bypass the allowlist: `repoPath` is re-validated INSIDE the factory
+ *     (never trusted from the request), same gate as the UI review button.
+ *   - Skills are validated against the PROJECT-SCOPED registry at create/update
+ *     (fail-closed — unknown id → 400) AND re-resolved by the factory at wake.
+ *   - persona + focus are UNTRUSTED at wake: they are joined here and handed to the
+ *     factory as `engineerInstruction`, which control-strips + byte-clamps + fences
+ *     them (untrustedExtraBlock) before they enter the objective — no injection seam.
+ *   - A DISABLED role cannot wake (409 before the factory is ever called — §6).
+ */
+import type { Express, Request, Response } from "express";
+import { z } from "zod";
+import { CONSILIUM_REVIEW_PRESETS, REVIEW_MODES } from "@shared/types";
+import type { IStorage } from "../storage.js";
+import type { InsertStandingRole } from "@shared/schema";
+import { validateBody } from "../middleware/validate.js";
+import {
+  createConsiliumReview,
+  type CreateConsiliumReviewDeps,
+} from "../services/consilium/review-factory.js";
+
+/** Max skills a role may carry — mirrors the review factory's MAX_REVIEW_SKILLS. */
+const MAX_ROLE_SKILLS = 5;
+
+/** The role's loop template — HOW its ephemeral loops run (server enums + bounds). */
+const LoopTemplateSchema = z.object({
+  preset: z.enum(CONSILIUM_REVIEW_PRESETS),
+  maxRounds: z.coerce.number().int().min(1).max(6).optional(),
+  reviewMode: z.enum(REVIEW_MODES).optional(),
+});
+
+const CreateRoleSchema = z.object({
+  name: z.string().min(1).max(200),
+  // The standing instruction. Bounded at the same 8000 the review engineerInstruction
+  // uses (the factory's OBJECTIVE_EXTRA_MAX_BYTES) so a too-long persona is a clean 400
+  // here rather than a silent downstream truncation.
+  persona: z.string().min(1).max(8000),
+  // Skill ids (<= MAX_ROLE_SKILLS). Existence is validated against the project registry
+  // in the handler (fail-closed); the zod cap keeps a >5 body a clean 400.
+  skills: z.array(z.string().min(1).max(200)).max(MAX_ROLE_SKILLS).default([]),
+  loopTemplate: LoopTemplateSchema,
+  enabled: z.boolean().default(true),
+});
+
+/** PATCH is a partial of create (every field optional). */
+const UpdateRoleSchema = CreateRoleSchema.partial();
+
+/**
+ * Wake body: WHERE (repoPath — re-validated fail-closed by the factory) and WHAT to
+ * look at (focus — UNTRUSTED, folded into the loop instruction + fenced downstream).
+ * The persona/skills/template come from the ROLE, not the request.
+ */
+const WakeSchema = z.object({
+  repoPath: z.string().min(1).max(4096),
+  focus: z.string().min(1).max(8000),
+});
+
+/**
+ * Compose the wake's engineer instruction from the role's persona + the wake focus.
+ * PURE (unit-testable). We ONLY JOIN here — the review factory does ALL sanitization:
+ * it control-strips + byte-clamps + wraps the whole string in a strictly-longer
+ * backtick fence (untrustedExtraBlock) before it enters the objective, so neither the
+ * stored persona nor the per-wake focus can break out to inject instructions. The
+ * fencing is a SINGLE seam (the factory), not re-done here.
+ */
+export function composeWakeInstruction(persona: string, focus: string): string {
+  return `${persona}\n\n## Focus\n${focus}`;
+}
+
+/**
+ * Validate that every skill id exists in the PROJECT-SCOPED registry (fail-closed).
+ * Returns the FIRST offending id (safe to echo — it is the caller's own input), or
+ * null when all resolve. Mirrors the factory's `resolveSkillDirectives` gate so a
+ * role can never be SAVED referencing a skill a wake would then reject.
+ */
+async function firstUnknownSkillId(storage: IStorage, skillIds: readonly string[]): Promise<string | null> {
+  for (const id of skillIds) {
+    const skill = await storage.getSkill(id);
+    if (!skill) return id;
+  }
+  return null;
+}
+
+/**
+ * Map a factory error to an actionable 4xx (shared by wake). Mirrors the
+ * consilium-reviews route mapping so the allowlist / workspace / skill boundaries
+ * surface distinct, fixable messages. Returns true when it handled the response.
+ */
+function mapFactoryError(err: unknown, repoPath: string, res: Response): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  if (message.includes("[skill-not-found]")) {
+    res.status(400).json({ error: message.replace("[skill-not-found] ", "") });
+    return true;
+  }
+  if (/is not a workspace of this project/i.test(message)) {
+    res.status(400).json({
+      error: `repoPath "${repoPath}" is not registered as a workspace of the selected project — pick one of its workspaces or add it as a workspace.`,
+    });
+    return true;
+  }
+  if (/allowlist|outside every allowed|denied system|traversal|fail-closed/i.test(message)) {
+    res.status(400).json({
+      error: `repoPath "${repoPath}" is not in the allowed repo paths. Add it to consiliumLoop.allowedRepoPaths in config.yaml (then restart), or pick an already-allowed workspace.`,
+    });
+    return true;
+  }
+  return false;
+}
+
+export function registerStandingRoleRoutes(app: Express, deps: CreateConsiliumReviewDeps): void {
+  const { storage } = deps;
+
+  // ─── LIST ───────────────────────────────────────────────────────────────
+  app.get("/api/roles", async (req: Request, res: Response) => {
+    if (!req.user?.id) return res.status(401).json({ error: "Authentication required" });
+    if (!req.projectId) return res.status(400).json({ error: "x-project-id header is required" });
+    const roles = await storage.getStandingRoles();
+    return res.json(roles);
+  });
+
+  // ─── CREATE ─────────────────────────────────────────────────────────────
+  app.post("/api/roles", validateBody(CreateRoleSchema), async (req: Request, res: Response) => {
+    if (!req.user?.id) return res.status(401).json({ error: "Authentication required" });
+    if (!req.projectId) return res.status(400).json({ error: "x-project-id header is required" });
+    const body = req.body as z.infer<typeof CreateRoleSchema>;
+
+    // Fail-closed: a role may not be saved referencing a skill that does not exist in
+    // THIS project (so a wake can never reference a phantom capability).
+    const unknown = await firstUnknownSkillId(storage, body.skills);
+    if (unknown) {
+      return res.status(400).json({ error: `skill "${unknown}" was not found in this project` });
+    }
+
+    const created = await storage.createStandingRole({
+      name: body.name,
+      persona: body.persona,
+      skills: body.skills,
+      loopTemplate: body.loopTemplate,
+      enabled: body.enabled,
+      createdBy: req.user.id,
+    } as InsertStandingRole);
+    return res.status(201).json(created);
+  });
+
+  // ─── GET ONE ────────────────────────────────────────────────────────────
+  app.get("/api/roles/:id", async (req: Request, res: Response) => {
+    if (!req.user?.id) return res.status(401).json({ error: "Authentication required" });
+    if (!req.projectId) return res.status(400).json({ error: "x-project-id header is required" });
+    const role = await storage.getStandingRole(String(req.params.id));
+    if (!role) return res.status(404).json({ error: "Role not found" });
+    return res.json(role);
+  });
+
+  // ─── UPDATE ─────────────────────────────────────────────────────────────
+  app.patch("/api/roles/:id", validateBody(UpdateRoleSchema), async (req: Request, res: Response) => {
+    if (!req.user?.id) return res.status(401).json({ error: "Authentication required" });
+    if (!req.projectId) return res.status(400).json({ error: "x-project-id header is required" });
+    const body = req.body as z.infer<typeof UpdateRoleSchema>;
+
+    const existing = await storage.getStandingRole(String(req.params.id));
+    if (!existing) return res.status(404).json({ error: "Role not found" });
+
+    if (body.skills !== undefined) {
+      const unknown = await firstUnknownSkillId(storage, body.skills);
+      if (unknown) {
+        return res.status(400).json({ error: `skill "${unknown}" was not found in this project` });
+      }
+    }
+
+    const updated = await storage.updateStandingRole(String(req.params.id), body as Partial<InsertStandingRole>);
+    return res.json(updated);
+  });
+
+  // ─── DELETE ─────────────────────────────────────────────────────────────
+  app.delete("/api/roles/:id", async (req: Request, res: Response) => {
+    if (!req.user?.id) return res.status(401).json({ error: "Authentication required" });
+    if (!req.projectId) return res.status(400).json({ error: "x-project-id header is required" });
+    const existing = await storage.getStandingRole(String(req.params.id));
+    if (!existing) return res.status(404).json({ error: "Role not found" });
+    await storage.deleteStandingRole(String(req.params.id));
+    return res.status(204).end();
+  });
+
+  // ─── WAKE — spawn ONE ephemeral consilium loop from the role ─────────────
+  app.post("/api/roles/:id/wake", validateBody(WakeSchema), async (req: Request, res: Response) => {
+    if (!req.user?.id) return res.status(401).json({ error: "Authentication required" });
+    if (!req.projectId) return res.status(400).json({ error: "x-project-id header is required" });
+    const body = req.body as z.infer<typeof WakeSchema>;
+
+    const role = await storage.getStandingRole(String(req.params.id));
+    if (!role) return res.status(404).json({ error: "Role not found" });
+
+    // §6 safety: a role is a definition, not a live process — a DISABLED role can
+    // never spawn work. Refuse BEFORE the factory is touched.
+    if (!role.enabled) {
+      return res.status(409).json({ error: "This role is disabled and cannot be woken. Enable it first." });
+    }
+
+    try {
+      // Compose the loop payload FROM THE ROLE (standing-role.md §3):
+      //   engineerInstruction = persona + focus  (UNTRUSTED — fenced by the factory)
+      //   skillIds            = role.skills       (re-resolved fail-closed by the factory)
+      //   preset/maxRounds/reviewMode = role.loopTemplate
+      // on `repoPath` (re-validated fail-closed against the allowlist by the factory).
+      const loop = await createConsiliumReview(deps, {
+        projectId: req.projectId,
+        repoPath: body.repoPath,
+        preset: role.loopTemplate.preset,
+        createdBy: req.user.id,
+        maxRounds: role.loopTemplate.maxRounds,
+        reviewMode: role.loopTemplate.reviewMode,
+        engineerInstruction: composeWakeInstruction(role.persona, body.focus),
+        skillIds: role.skills,
+        // Provenance: record the originating role so a wake is TRACEABLE on the
+        // launch passport (a wake is not a trigger fire — no trigger trio, just role).
+        triggerProvenance: {
+          firedAt: new Date().toISOString(),
+          role: { roleId: role.id, name: role.name },
+        },
+      });
+      return res.status(201).json(loop);
+    } catch (err) {
+      if (mapFactoryError(err, body.repoPath, res)) return;
+      // eslint-disable-next-line no-console
+      console.error("[roles] wake failed:", err instanceof Error ? err.message : String(err));
+      return res.status(500).json({ error: "Failed to wake the role" });
+    }
+  });
+}

--- a/server/routes/triggers.ts
+++ b/server/routes/triggers.ts
@@ -414,7 +414,11 @@ export function registerTriggerRoutes(app: Express, triggerService: TriggerServi
             state: l.state,
             prRef: l.prRef ?? null,
             eventSummary: prov.eventSummary ?? null,
-            eventDigest: prov.eventDigest,
+            // `eventDigest` is now optional on TriggerProvenance (a ROLE-1 wake has
+            // none) — but these loops are already filtered to trigger fires
+            // (`triggerId === trigger.id`), which always carry a digest; `?? ""` is
+            // a defensive fallback that keeps the field a string.
+            eventDigest: prov.eventDigest ?? "",
             firedAt: prov.firedAt ?? new Date(l.createdAt).toISOString(),
           };
         });

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -106,6 +106,9 @@ import {
   type SessionConflictRow,
   type DecisionLogRow,
 } from "@shared/schema";
+// ROLE-1 (standing-role.md §3/§8): the StandingRole table + types. Separate localized
+// import so the shared `@shared/schema` import block above stays a single merge point.
+import { standingRoles, type StandingRoleRow, type InsertStandingRole } from "@shared/schema";
 import type { LessonRecallFilter } from "./memory/lessons/types";
 import type { TraceSpan, SkillVersionRecord, InsertSkillVersion, SharedSession, CreateSharedSessionInput, ShareRole, WorkspaceConnection, CreateWorkspaceConnectionInput, UpdateWorkspaceConnectionInput, McpToolCall, ConnectionUsageMetrics, RecordMcpToolCallInput, SessionConflict, DecisionLogEntry, RaiseConflictInput, CastConflictVoteInput, DebateJudgement, ExperimentBranchResult, ResolutionOutcome, ResearchReport, ExecutionTrace, ActionPoint } from "@shared/types";
 
@@ -2606,6 +2609,45 @@ export class PgStorage implements IStorage {
           eq(taskTraces.groupId, groupId),
         ),));
     return row ?? null;
+  }
+
+  // ─── Standing Roles (ROLE-1 — standing-role.md §3/§8) ──────────────────────
+  // All queries are PROJECT-scoped via withProject/withProjectList/withProjectInsert
+  // (owner/member isolation from the caller's ALS) — mirrors the skills CRUD exactly.
+
+  async getStandingRoles(): Promise<StandingRoleRow[]> {
+    return db.select().from(standingRoles).where(withProjectList(standingRoles)).orderBy(standingRoles.name);
+  }
+
+  async getStandingRole(id: string): Promise<StandingRoleRow | undefined> {
+    const [row] = await db
+      .select()
+      .from(standingRoles)
+      .where(withProject(standingRoles, eq(standingRoles.id, id)));
+    return row;
+  }
+
+  async createStandingRole(data: InsertStandingRole): Promise<StandingRoleRow> {
+    type RoleInsert = Parameters<ReturnType<typeof db.insert<typeof standingRoles>>["values"]>[0];
+    const [row] = await db
+      .insert(standingRoles)
+      .values(withProjectInsert(standingRoles, data as unknown as RoleInsert))
+      .returning();
+    return row;
+  }
+
+  async updateStandingRole(id: string, updates: Partial<InsertStandingRole>): Promise<StandingRoleRow> {
+    const [row] = await db
+      .update(standingRoles)
+      .set({ ...(updates as Record<string, unknown>), updatedAt: new Date() } as Parameters<ReturnType<typeof db.update<typeof standingRoles>>["set"]>[0])
+      .where(withProject(standingRoles, eq(standingRoles.id, id)))
+      .returning();
+    if (!row) throw new Error(`Standing role not found: ${id}`);
+    return row;
+  }
+
+  async deleteStandingRole(id: string): Promise<void> {
+    await db.delete(standingRoles).where(withProject(standingRoles, eq(standingRoles.id, id)));
   }
 
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -76,6 +76,9 @@ import {
 } from "@shared/schema";
 import type { Memory, InsertMemory, MemoryScope, MemoryType, McpServerConfig, TraceSpan, TaskTraceSpan, SkillVersionRecord, InsertSkillVersion as InsertSkillVersionType, SharedSession, CreateSharedSessionInput, SharePermissions, ShareRole, WorkspaceConnection, CreateWorkspaceConnectionInput, UpdateWorkspaceConnectionInput, McpToolCall, ConnectionUsageMetrics, RecordMcpToolCallInput, SessionConflict, DecisionLogEntry, RaiseConflictInput, CastConflictVoteInput, DebateJudgement, ExperimentBranchResult, ResolutionOutcome, ResearchReport, ExecutionTrace, ActionPoint } from "@shared/types";
 import type { LessonRecallFilter } from "./memory/lessons/types";
+// ROLE-1 (standing-role.md §3/§8): the StandingRole record types. Separate localized
+// import so the shared `@shared/schema` import block above stays a single merge point.
+import type { StandingRoleRow, InsertStandingRole } from "@shared/schema";
 import { randomUUID } from "crypto";
 import { PgStorage } from "./storage-pg";
 import { configLoader } from "./config/loader";
@@ -658,6 +661,16 @@ export interface IStorage {
   getSessionConflicts(sessionId: string): Promise<SessionConflict[]>;
   appendDecisionLog(entry: DecisionLogEntry): Promise<void>;
   getDecisionLog(sessionId?: string): Promise<DecisionLogEntry[]>;
+
+  // ─── Standing Roles (ROLE-1 — standing-role.md §3/§8) ──────────────────────
+  // Project-scoped CRUD for the StandingRole record. All reads/writes are
+  // owner/member-scoped by the caller's ALS project (PgStorage withProject);
+  // MemStorage keeps a flat map for tests/dev parity.
+  getStandingRoles(): Promise<StandingRoleRow[]>;
+  getStandingRole(id: string): Promise<StandingRoleRow | undefined>;
+  createStandingRole(data: InsertStandingRole): Promise<StandingRoleRow>;
+  updateStandingRole(id: string, updates: Partial<InsertStandingRole>): Promise<StandingRoleRow>;
+  deleteStandingRole(id: string): Promise<void>;
 }
 
 /**
@@ -3106,6 +3119,54 @@ export class MemStorage implements IStorage {
       if (tr.iterationId === iterationId && tr.groupId === groupId) return tr;
     }
     return null;
+  }
+
+  // ─── Standing Roles (ROLE-1 — standing-role.md §3/§8) ──────────────────────
+  private standingRolesMap: Map<string, StandingRoleRow> = new Map();
+
+  async getStandingRoles(): Promise<StandingRoleRow[]> {
+    return Array.from(this.standingRolesMap.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  async getStandingRole(id: string): Promise<StandingRoleRow | undefined> {
+    return this.standingRolesMap.get(id);
+  }
+
+  async createStandingRole(data: InsertStandingRole): Promise<StandingRoleRow> {
+    const id = (data.id as string | undefined) ?? randomUUID();
+    const now = new Date();
+    const row: StandingRoleRow = {
+      id,
+      projectId: data.projectId ?? null,
+      name: data.name,
+      persona: data.persona,
+      skills: (data.skills as string[] | undefined) ?? [],
+      loopTemplate: data.loopTemplate,
+      enabled: data.enabled ?? true,
+      createdBy: data.createdBy ?? null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.standingRolesMap.set(id, row);
+    return row;
+  }
+
+  async updateStandingRole(id: string, updates: Partial<InsertStandingRole>): Promise<StandingRoleRow> {
+    const existing = this.standingRolesMap.get(id);
+    if (!existing) throw new Error(`Standing role not found: ${id}`);
+    const updated: StandingRoleRow = {
+      ...existing,
+      ...updates,
+      skills: (updates.skills as string[] | undefined) ?? existing.skills,
+      loopTemplate: updates.loopTemplate ?? existing.loopTemplate,
+      updatedAt: new Date(),
+    };
+    this.standingRolesMap.set(id, updated);
+    return updated;
+  }
+
+  async deleteStandingRole(id: string): Promise<void> {
+    this.standingRolesMap.delete(id);
   }
 
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -2244,3 +2244,57 @@ export const credentialAccessLog = pgTable(
 
 export type CredentialAccessLogRow = typeof credentialAccessLog.$inferSelect;
 export type InsertCredentialAccessLog = typeof credentialAccessLog.$inferInsert;
+
+// ─── Standing Roles (ROLE-1 — standing-role.md §3/§8) ────────────────────────
+//
+// A StandingRole is a named, persistent identity — a saved COMPOSITION of a persona
+// (standing instruction) + skills + a loop template — that an operator can manually
+// "wake" (POST /api/roles/:id/wake) to spawn ONE ephemeral consilium loop. ROLE-1 is
+// JUST the record + manual wake: NO triggers/concerns (ROLE-2) and NO role-scoped
+// experience (ROLE-3) yet. A role is a DEFINITION, not a running process (§6) — its
+// only runtime footprint is the ephemeral loops a wake spawns (which keep every
+// existing isolation + human-merge gate). Separate import (localized/append-only) so
+// the shared `./types.js` import line stays a single merge point for other teams.
+// eslint-disable-next-line @typescript-eslint/no-duplicate-imports -- localized append
+import type { StandingRoleLoopTemplate } from "./types.js";
+
+export const standingRoles = pgTable(
+  "standing_roles",
+  {
+    id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+    // Project-scoped (owner/member isolation via withProject); cascades with project.
+    projectId: text("project_id").references(() => projects.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    // The standing instruction / persona that grounds every wake. Human-authored on
+    // create, but UNTRUSTED at wake time: it (with the wake `focus`) is fed through
+    // the review factory's `untrustedExtraBlock` (control-strip + byte-clamp + a
+    // strictly-longer backtick fence) before it enters the loop objective. Inert in
+    // storage; never a shell/branch/PR sink.
+    persona: text("persona").notNull(),
+    // The role's capability: skill ids (shared `skills.id`). Validated against the
+    // PROJECT-SCOPED skill registry at create/update (fail-closed — an unknown id is
+    // a 400) AND re-resolved project-scoped by the review factory at wake. jsonb string[].
+    skills: jsonb("skills").$type<string[]>().notNull().default(sql`'[]'::jsonb`),
+    // How the role's ephemeral loops run: { preset, maxRounds?, reviewMode? }. `preset`
+    // + `reviewMode` are server enums; `maxRounds` is bounded 1..6 by the factory.
+    loopTemplate: jsonb("loop_template").$type<StandingRoleLoopTemplate>().notNull(),
+    // A DISABLED role is inert — the wake endpoint refuses it (safety §6): a role can
+    // never spawn work while disabled.
+    enabled: boolean("enabled").notNull().default(true),
+    createdBy: text("created_by").references(() => users.id, { onDelete: "set null" }),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => ({
+    projectIdIdx: index("standing_roles_project_id_idx").on(table.projectId),
+    createdByIdx: index("standing_roles_created_by_idx").on(table.createdBy),
+  }),
+);
+
+export const insertStandingRoleSchema = createInsertSchema(standingRoles).omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+export type InsertStandingRole = typeof standingRoles.$inferInsert;
+export type StandingRoleRow = typeof standingRoles.$inferSelect;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1428,6 +1428,19 @@ export const REVIEW_MODES = ["full-dispute", "single-verifier"] as const;
 export type ReviewMode = (typeof REVIEW_MODES)[number];
 
 /**
+ * ROLE-1 (standing-role.md §3): the "how its loops run" slice of a Standing Role —
+ * the loop template. A wake composes exactly the `POST /api/consilium-reviews`
+ * payload from the role, using this template for the loop shape. `preset` +
+ * `reviewMode` are server enums (`CONSILIUM_REVIEW_PRESETS` / `REVIEW_MODES`);
+ * `maxRounds` is bounded 1..6 by the review factory (`clampRounds`).
+ */
+export interface StandingRoleLoopTemplate {
+  preset: ConsiliumReviewPreset;
+  maxRounds?: number;
+  reviewMode?: ReviewMode;
+}
+
+/**
  * A file-change trigger ACTION that launches a consilium review. Embedded in the
  * trigger's `config` JSONB. `repoPath`, when present, MUST resolve inside the
  * consilium-loop allowlist (re-validated INSIDE the factory — never trusted from
@@ -1456,18 +1469,42 @@ export interface ConsiliumReviewTriggerAction {
 }
 
 /**
- * T1 (loop-triggers.md §2, hard-rail §6): provenance recorded on EVERY
- * trigger-fired consilium loop so the launch passport (#457) can show which
- * trigger + which event started it. Persisted INERT as jsonb on the loop
- * (`consilium_loops.trigger_provenance`); display/audit only, never a prompt or
- * shell sink. `eventDigest` is a short hex hash of the firing payload — enough to
- * correlate a loop to the event without storing the (untrusted) payload verbatim.
+ * ROLE-1 (standing-role.md §3/§8): provenance recorded on a consilium loop that a
+ * Standing Role WAKE launched (POST /api/roles/:id/wake). A wake is NOT a trigger
+ * fire — it has no triggerId/triggerType/eventDigest — so those launch fields are
+ * ABSENT on a wake and this `role` block identifies the originating role instead.
+ * Persisted INERT as jsonb on `consilium_loops.trigger_provenance`; display/audit
+ * only, never a prompt/shell sink. `name` is the role's stored (human-authored)
+ * name, rendered as inert text.
+ */
+export interface RoleProvenance {
+  roleId: string;
+  name: string;
+}
+
+/**
+ * LAUNCH provenance recorded on a consilium loop for the launch passport (#457):
+ * WHICH trigger + event started it, OR (ROLE-1) which Standing Role wake did.
+ * Persisted INERT as jsonb on the loop (`consilium_loops.trigger_provenance`);
+ * display/audit only, never a prompt or shell sink.
+ *
+ * T1 (loop-triggers.md §2, hard-rail §6): the `triggerId`/`triggerType`/
+ * `eventDigest` trio identifies a trigger fire (`eventDigest` is a short hex hash of
+ * the firing payload — enough to correlate a loop to the event without storing the
+ * untrusted payload verbatim). The trio is OPTIONAL because a Standing Role wake
+ * (ROLE-1) has no trigger; a wake sets `firedAt` + `role` and OMITS the trio. A
+ * human/API-initiated loop with neither trigger nor role leaves the whole column null.
  */
 export interface TriggerProvenance {
-  triggerId: string;
-  triggerType: TriggerType;
-  eventDigest: string;
+  triggerId?: string;
+  triggerType?: TriggerType;
+  eventDigest?: string;
   firedAt: string; // ISO-8601
+  /**
+   * ROLE-1: present when a Standing Role wake launched this loop (absent for every
+   * trigger/human fire). Identifies the role for the launch passport / traceability.
+   */
+  role?: RoleProvenance;
   /**
    * OPTIONAL short, human-readable description of the firing event for the launch
    * passport (#457) — e.g. `PR #123: <title>` or `post-merge push to main (abc1234)`.

--- a/tests/unit/consilium/standing-roles-route.test.ts
+++ b/tests/unit/consilium/standing-roles-route.test.ts
@@ -1,0 +1,286 @@
+/**
+ * standing-roles-route.test.ts — ROLE-1 (standing-role.md §3/§8).
+ *
+ * Covers the StandingRole CRUD + manual wake surface:
+ *   - CRUD (create / list / get / update / delete) against a fake project-scoped storage.
+ *   - AUTH: a handler with no `req.user` → 401 (the /api/pr-queue 401 lesson — the route
+ *     re-checks auth as defense-in-depth even though the mount applies requireAuth).
+ *   - WAKE composes the CORRECT review payload FROM the role (persona+focus instruction,
+ *     skills, loop template) and passes it to the REUSED `createConsiliumReview` factory.
+ *   - WAKE records ROLE provenance on the loop's triggerProvenance.
+ *   - WAKE surfaces the factory's fail-closed allowlist rejection as an actionable 400.
+ *   - Skills are validated against the registry at CREATE (unknown id → 400, no persist).
+ *   - A DISABLED role cannot wake (409, factory NEVER called).
+ *
+ * The factory is mocked (same resolved module the route imports) — we assert the route's
+ * COMPOSITION + wiring, not the factory internals (covered by review-factory.test.ts).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+vi.mock("../../../server/services/consilium/review-factory.js", () => ({
+  createConsiliumReview: vi.fn(),
+}));
+
+import {
+  registerStandingRoleRoutes,
+  composeWakeInstruction,
+} from "../../../server/routes/standing-roles.js";
+import { createConsiliumReview } from "../../../server/services/consilium/review-factory.js";
+
+const mockedCreate = vi.mocked(createConsiliumReview);
+
+// ─── Fake project-scoped storage (only the methods the route touches) ─────────
+
+interface FakeRole {
+  id: string;
+  projectId: string | null;
+  name: string;
+  persona: string;
+  skills: string[];
+  loopTemplate: { preset: string; maxRounds?: number; reviewMode?: string };
+  enabled: boolean;
+  createdBy: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function makeStorage(seed: FakeRole[] = [], knownSkills: string[] = []) {
+  const roles = new Map<string, FakeRole>();
+  seed.forEach((r) => roles.set(r.id, r));
+  const skillSet = new Set(knownSkills);
+  let seq = seed.length;
+  return {
+    getStandingRoles: vi.fn(async () => Array.from(roles.values())),
+    getStandingRole: vi.fn(async (id: string) => roles.get(id)),
+    createStandingRole: vi.fn(async (data: Partial<FakeRole>) => {
+      seq += 1;
+      const row: FakeRole = {
+        id: `role-${seq}`,
+        projectId: "project-1",
+        name: data.name ?? "",
+        persona: data.persona ?? "",
+        skills: data.skills ?? [],
+        loopTemplate: data.loopTemplate ?? { preset: "sdlc-cross-review" },
+        enabled: data.enabled ?? true,
+        createdBy: data.createdBy ?? null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      roles.set(row.id, row);
+      return row;
+    }),
+    updateStandingRole: vi.fn(async (id: string, updates: Partial<FakeRole>) => {
+      const ex = roles.get(id);
+      if (!ex) throw new Error(`Standing role not found: ${id}`);
+      const up = { ...ex, ...updates, updatedAt: new Date() };
+      roles.set(id, up);
+      return up;
+    }),
+    deleteStandingRole: vi.fn(async (id: string) => {
+      roles.delete(id);
+    }),
+    getSkill: vi.fn(async (id: string) => (skillSet.has(id) ? { id, name: id } : undefined)),
+    _roles: roles,
+  };
+}
+
+function makeApp(storage: ReturnType<typeof makeStorage>, opts?: { auth?: boolean }) {
+  const app = express();
+  app.use(express.json());
+  if (opts?.auth !== false) {
+    app.use((req, _res, next) => {
+      (req as unknown as { user: { id: string } }).user = { id: "user-1" };
+      (req as unknown as { projectId: string }).projectId = "project-1";
+      next();
+    });
+  }
+  registerStandingRoleRoutes(app, { storage } as never);
+  return app;
+}
+
+function seedRole(over: Partial<FakeRole> = {}): FakeRole {
+  return {
+    id: "role-1",
+    projectId: "project-1",
+    name: "devops-reviewer",
+    persona: "You are a senior DevOps reviewer.",
+    skills: ["sk-1"],
+    loopTemplate: { preset: "sdlc-cross-review", maxRounds: 3, reviewMode: "single-verifier" },
+    enabled: true,
+    createdBy: "user-1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...over,
+  };
+}
+
+const VALID_CREATE = {
+  name: "devops-reviewer",
+  persona: "You are a senior DevOps reviewer.",
+  skills: ["sk-1"],
+  loopTemplate: { preset: "sdlc-cross-review", maxRounds: 3, reviewMode: "single-verifier" },
+};
+
+// ─── composeWakeInstruction (pure) ────────────────────────────────────────────
+
+describe("composeWakeInstruction", () => {
+  it("joins persona + focus under a Focus heading (fencing is the factory's job)", () => {
+    expect(composeWakeInstruction("PERSONA", "FOCUS")).toBe("PERSONA\n\n## Focus\nFOCUS");
+  });
+});
+
+// ─── CRUD ─────────────────────────────────────────────────────────────────────
+
+describe("StandingRole CRUD", () => {
+  beforeEach(() => mockedCreate.mockReset());
+
+  it("POST /api/roles creates a role (201) with the caller as owner", async () => {
+    const storage = makeStorage([], ["sk-1"]);
+    const res = await request(makeApp(storage)).post("/api/roles").send(VALID_CREATE);
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe("devops-reviewer");
+    expect(storage.createStandingRole).toHaveBeenCalledTimes(1);
+    expect(storage.createStandingRole.mock.calls[0][0]).toMatchObject({ createdBy: "user-1" });
+  });
+
+  it("GET /api/roles lists the project's roles", async () => {
+    const storage = makeStorage([seedRole()]);
+    const res = await request(makeApp(storage)).get("/api/roles");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].name).toBe("devops-reviewer");
+  });
+
+  it("GET /api/roles/:id returns 404 for an unknown id", async () => {
+    const res = await request(makeApp(makeStorage())).get("/api/roles/nope");
+    expect(res.status).toBe(404);
+  });
+
+  it("PATCH /api/roles/:id updates a role", async () => {
+    const storage = makeStorage([seedRole()], ["sk-1"]);
+    const res = await request(makeApp(storage)).patch("/api/roles/role-1").send({ name: "renamed" });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe("renamed");
+  });
+
+  it("DELETE /api/roles/:id removes a role (204)", async () => {
+    const storage = makeStorage([seedRole()]);
+    const res = await request(makeApp(storage)).delete("/api/roles/role-1");
+    expect(res.status).toBe(204);
+    expect(storage.deleteStandingRole).toHaveBeenCalledWith("role-1");
+  });
+
+  it("CREATE fails-closed on a skill id that is NOT in the project registry (400, no persist)", async () => {
+    const storage = makeStorage([], []); // registry empty ⇒ sk-1 unknown
+    const res = await request(makeApp(storage)).post("/api/roles").send(VALID_CREATE);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/sk-1/);
+    expect(res.body.error).toMatch(/was not found in this project/);
+    expect(storage.createStandingRole).not.toHaveBeenCalled();
+  });
+});
+
+// ─── AUTH (the /api/pr-queue 401 lesson) ──────────────────────────────────────
+
+describe("StandingRole routes — auth guard", () => {
+  it("GET /api/roles without an authenticated user → 401", async () => {
+    const res = await request(makeApp(makeStorage(), { auth: false })).get("/api/roles");
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /api/roles/:id/wake without auth → 401 (factory never called)", async () => {
+    mockedCreate.mockReset();
+    const storage = makeStorage([seedRole()], ["sk-1"]);
+    const res = await request(makeApp(storage, { auth: false }))
+      .post("/api/roles/role-1/wake")
+      .send({ repoPath: "/repos/x", focus: "f" });
+    expect(res.status).toBe(401);
+    expect(mockedCreate).not.toHaveBeenCalled();
+  });
+});
+
+// ─── WAKE ─────────────────────────────────────────────────────────────────────
+
+describe("POST /api/roles/:id/wake", () => {
+  beforeEach(() => mockedCreate.mockReset());
+
+  it("composes the review payload FROM the role and returns 201 with the loop", async () => {
+    mockedCreate.mockResolvedValueOnce({ id: "loop-1", state: "pending" } as never);
+    const storage = makeStorage([seedRole()], ["sk-1"]);
+    const res = await request(makeApp(storage))
+      .post("/api/roles/role-1/wake")
+      .send({ repoPath: "/repos/iac", focus: "Review the new module version" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe("loop-1");
+    expect(mockedCreate).toHaveBeenCalledTimes(1);
+    const params = mockedCreate.mock.calls[0][1] as Record<string, unknown>;
+    expect(params).toMatchObject({
+      projectId: "project-1",
+      repoPath: "/repos/iac",
+      preset: "sdlc-cross-review",
+      createdBy: "user-1",
+      maxRounds: 3,
+      reviewMode: "single-verifier",
+      skillIds: ["sk-1"],
+      engineerInstruction: "You are a senior DevOps reviewer.\n\n## Focus\nReview the new module version",
+    });
+  });
+
+  it("records ROLE provenance on the loop (roleId + name)", async () => {
+    mockedCreate.mockResolvedValueOnce({ id: "loop-1" } as never);
+    const storage = makeStorage([seedRole()], ["sk-1"]);
+    await request(makeApp(storage))
+      .post("/api/roles/role-1/wake")
+      .send({ repoPath: "/repos/iac", focus: "f" });
+
+    const params = mockedCreate.mock.calls[0][1] as { triggerProvenance?: { role?: unknown; firedAt?: string } };
+    expect(params.triggerProvenance?.role).toEqual({ roleId: "role-1", name: "devops-reviewer" });
+    expect(typeof params.triggerProvenance?.firedAt).toBe("string");
+  });
+
+  it("a DISABLED role cannot wake → 409, factory NEVER called (§6 safety)", async () => {
+    const storage = makeStorage([seedRole({ enabled: false })], ["sk-1"]);
+    const res = await request(makeApp(storage))
+      .post("/api/roles/role-1/wake")
+      .send({ repoPath: "/repos/iac", focus: "f" });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/disabled/i);
+    expect(mockedCreate).not.toHaveBeenCalled();
+  });
+
+  it("maps the factory's fail-closed allowlist rejection to an actionable 400", async () => {
+    mockedCreate.mockRejectedValueOnce(
+      new Error('[repo-allowlist] Path "/repos/evil" is outside every allowed repo root'),
+    );
+    const storage = makeStorage([seedRole()], ["sk-1"]);
+    const res = await request(makeApp(storage))
+      .post("/api/roles/role-1/wake")
+      .send({ repoPath: "/repos/evil", focus: "f" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/is not in the allowed repo paths/i);
+  });
+
+  it("maps a factory skill-not-found (skill deleted after role save) to a 400 naming the id", async () => {
+    mockedCreate.mockRejectedValueOnce(
+      new Error('[skill-not-found] skill "sk-1" was not found in this project'),
+    );
+    const storage = makeStorage([seedRole()], ["sk-1"]);
+    const res = await request(makeApp(storage))
+      .post("/api/roles/role-1/wake")
+      .send({ repoPath: "/repos/iac", focus: "f" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/sk-1/);
+    expect(res.body.error).not.toMatch(/\[skill-not-found\]/);
+  });
+
+  it("waking an unknown role → 404 (factory never called)", async () => {
+    const res = await request(makeApp(makeStorage()))
+      .post("/api/roles/ghost/wake")
+      .send({ repoPath: "/repos/iac", focus: "f" });
+    expect(res.status).toBe(404);
+    expect(mockedCreate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Implements **ROLE-1** from `docs/design/standing-role.md` §3 (anatomy) + §8 (staging): the **StandingRole record** — a named, persistent identity (persona + skills + loop template) you define once and can manually **wake** to spawn one ephemeral consilium loop. Deliberately scoped: **no** triggers/concerns binding (ROLE-2), **no** role-scoped experience (ROLE-3).

## The entity + migration
`StandingRole { id, name, persona (standing instruction), skills: string[] (skill ids), loopTemplate: { preset, maxRounds?, reviewMode? }, enabled, createdAt }` — a project-scoped `standing_roles` table (`shared/schema.ts`, appended additively) + migration `0046_standing_roles.sql`. Storage methods added to `IStorage`, `PgStorage` (project-scoped via `withProject`), and `MemStorage`.

## CRUD API — `/api/roles`
`list / create / get / update / delete`, mounted behind `requireAuth + requireProject` (the /api/pr-queue 401 lesson) and registered inside the `consiliumLoop.enabled` kill-switch (inert otherwise). On create/update, `skills` are validated **fail-closed** against the project-scoped skill registry (`storage.getSkill`) — a role can never be saved referencing a phantom capability.

## Wake → loop composition (reuses the review path)
`POST /api/roles/:id/wake { repoPath, focus }` composes exactly the `POST /api/consilium-reviews` payload **from the role** and hands it to the **same** `createConsiliumReview` factory:

- `engineerInstruction = persona + focus`
- `skillIds = role.skills`
- `preset / maxRounds / reviewMode = role.loopTemplate`
- on `repoPath`

It does **not** reimplement loop creation and does **not** modify trigger-dispatch's tracker/spec paths. The factory re-validates `repoPath` against the fail-closed allowlist + per-project workspace confinement, and re-resolves `skillIds` project-scoped — the wake trusts none of the stored config blindly. `persona`/`focus` are UNTRUSTED and are control-stripped + byte-clamped + backtick-fenced by the factory (`untrustedExtraBlock`) before they enter the objective. A **disabled** role refuses to wake (`409`) before the factory is touched (§6: a role is a definition, not a process).

## Provenance
A wake records `{ role: { roleId, name } }` on the loop's `triggerProvenance` (launch passport traceability). Since a wake is not a trigger fire, the trigger-identity trio (`triggerId/triggerType/eventDigest`) was widened to optional **additively**; a wake sets `firedAt` + `role` and omits the trio. Trigger-scoped queries (`triggerProvenance.triggerId === trigger.id`) correctly exclude role-waked loops.

## UI
A **Roles** page (`/roles`, nav item added): lists roles, a create form (name, persona, skills multi-select from the project registry, loop-template fields), and a **Wake** button (asks repoPath + focus) that calls the wake endpoint and navigates to the created loop.

## Tests
`tests/unit/consilium/standing-roles-route.test.ts` (15 tests): role CRUD, auth mount (401 without auth), wake payload composition (persona+focus instruction, skills, template), role provenance on the loop, allowlist fail-closed on a bad repoPath, skill-registry validation, disabled-role can't wake (409, factory never called), and the pure `composeWakeInstruction`.

## Verification
- `tsc` clean (client + server; test files excluded from tsc, green under vitest).
- Full unit suite green: **274 files / 5175 tests** passing (incl. the historically flaky files this run).

## ROLE-2 boundary (deferred)
Triggers/concerns binding — wiring a trigger to a role's concerns so a firing wakes the role — is **ROLE-2** and is intentionally out of scope here. Role-scoped experience (the Dream keyed by role/concern) is **ROLE-3**. This PR ships only the record + explicit manual wake.
