### PR TITLE
feat: TRACK-3 — Jira connector + generalised tracker interface

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -41,6 +41,7 @@ import { CronScheduler } from "./services/cron-scheduler";
 import { FileWatcherService } from "./services/file-watcher";
 import { GitHubPoller } from "./services/github-poller";
 import { GithubIssuesPoller } from "./services/consilium/trackers/github-issues-poller";
+import { JiraIssuesPoller } from "./services/consilium/trackers/jira-issues-poller";
 import { TrackerWritebackObserver } from "./services/consilium/trackers/writeback-observer";
 import { ExperienceDistillerObserver } from "./services/consilium/experience/experience-distiller-observer";
 import { buildSynthPrompt, parseSynthOutput } from "./services/consilium/trackers/issue-spec";
@@ -419,6 +420,7 @@ export async function registerRoutes(
   let fileWatcherService: FileWatcherService | null = null;
   let githubPoller: GitHubPoller | null = null;
   let githubIssuesPoller: GithubIssuesPoller | null = null;
+  let jiraIssuesPoller: JiraIssuesPoller | null = null;
   let trackerWritebackObserver: TrackerWritebackObserver | null = null;
 
   try {
@@ -623,6 +625,52 @@ export async function registerRoutes(
         log: (m: string) => log(m, "tracker-poller"),
       });
       githubIssuesPoller.start();
+
+      // TRACK-3 (jira -> committed spec PR). The Jira analogue of the github-issues
+      // poller: a JQL poll of a Jira project's labelled issues, each crystallised into
+      // a committed-spec PR (in the TARGET git repo — Jira has no git) + a Jira pickup
+      // comment. Shares the SAME kill-switch (features.triggers.tracker.enabled) and the
+      // SAME crystallise pipeline (spec-intake) as github; only the Jira dialect differs.
+      // The Jira token is read from JIRA_EMAIL/JIRA_API_TOKEN at call time (fail-closed).
+      // A jira-tracker trigger is a no-op here until its `tracker: "jira"` config exists.
+      jiraIssuesPoller = new JiraIssuesPoller({
+        getEnabledTriggersByType: (type) =>
+          runAsSystem("jira-tracker-poller-bootstrap", () => storage.getAllEnabledTriggersByType(type)),
+        runInProject: runAsProject,
+        getTrigger: (id) => storage.getTrigger(id),
+        updateTrigger: (id, updates) => storage.updateTrigger(id, updates),
+        config: () => appConfigLoader.get(),
+        allowedRepoPaths: () => appConfigLoader.get().pipeline.consiliumLoop.allowedRepoPaths,
+        // Gateway-backed synthesiser for FREE-FORM tickets — connector-agnostic
+        // (title+body only). Any error degrades to no-criteria (never throws into the
+        // poll loop) -> the poller posts an ask-for-criteria comment instead of a PR.
+        synthesizer: {
+          synthesize: async (ticket) => {
+            try {
+              const { system, user } = buildSynthPrompt({ number: 0, title: ticket.title, body: ticket.body });
+              const res = await gateway.completeStreaming(
+                {
+                  modelSlug: DEFAULT_TASK_MODEL,
+                  messages: [
+                    { role: "system", content: system },
+                    { role: "user", content: user },
+                  ],
+                  temperature: 0.2,
+                  maxTokens: 2048,
+                },
+                undefined,
+                undefined,
+                { overallTimeoutMs: 60_000 },
+              );
+              return parseSynthOutput(res.content);
+            } catch {
+              return { criteria: [] };
+            }
+          },
+        },
+        log: (m: string) => log(m, "jira-tracker-poller"),
+      });
+      jiraIssuesPoller.start();
     }
 
     // TRACK-2 (full write-back lifecycle). When the write-back sub-switch is on (and
@@ -724,6 +772,7 @@ export async function registerRoutes(
     fileWatcherService?.stopAll();
     githubPoller?.stop();
     githubIssuesPoller?.stop();
+    jiraIssuesPoller?.stop();
     trackerWritebackObserver?.stop();
     getRefreshScheduler()?.stop();
     stopRateLimitCleanup();

--- a/server/routes/triggers.ts
+++ b/server/routes/triggers.ts
@@ -112,13 +112,34 @@ const FileChangeConfigSchema = z.object({
   action: LoopTemplateActionSchema.optional(),
 });
 
-const TrackerConfigSchema = z.object({
+// TRACK-1 (github) — byte-identical shape, now the `github` arm of the union.
+const GithubTrackerConfigSchema = z.object({
   tracker: z.literal("github"),
   repo: z.string().min(1).max(500).regex(/^[^/]+\/[^/]+$/, "Must be owner/repo"),
   targetRepoPath: z.string().min(1).max(4096),
   filter: z.object({ label: z.string().min(1).max(200).optional() }).optional(),
   specStatus: z.enum(["ready", "draft"]).optional(),
 });
+
+// TRACK-3 (jira) — JQL poll → committed spec PR in `repo` (the git repo) + Jira pickup.
+const JiraTrackerConfigSchema = z.object({
+  tracker: z.literal("jira"),
+  baseUrl: z.string().min(1).max(500).url().startsWith("https://", "Jira baseUrl must be https"),
+  project: z.string().min(1).max(64).regex(/^[A-Za-z0-9_]+$/, "Jira project key: alnum/underscore"),
+  jql: z.string().max(2000).optional(),
+  transitionTo: z.string().min(1).max(200).optional(),
+  repo: z.string().min(1).max(500).regex(/^[^/]+\/[^/]+$/, "Must be owner/repo (the git repo the spec PR lands in)"),
+  targetRepoPath: z.string().min(1).max(4096),
+  filter: z.object({ label: z.string().min(1).max(200).optional() }).optional(),
+  specStatus: z.enum(["ready", "draft"]).optional(),
+});
+
+// Discriminated on `tracker` so a bad/absent kind yields a precise 400 (additive: the
+// github arm is unchanged, so existing github trigger creation validates identically).
+const TrackerConfigSchema = z.discriminatedUnion("tracker", [
+  GithubTrackerConfigSchema,
+  JiraTrackerConfigSchema,
+]);
 
 type TriggerTypeValue = "webhook" | "schedule" | "github_event" | "file_change" | "tracker_event";
 

--- a/server/services/consilium/trackers/github-issues-poller.ts
+++ b/server/services/consilium/trackers/github-issues-poller.ts
@@ -52,10 +52,9 @@ import {
   extractSpecFromIssue,
   specBranchName,
   specFilePath,
-  buildSpecMarkdown,
   type GhIssue,
 } from "./issue-spec.js";
-import { writeSpecPr } from "./spec-writer.js";
+import { crystallizeTicket } from "./spec-intake.js";
 import { postPickupComment, postNeedCriteriaComment } from "./issue-writeback.js";
 
 const execFileAsync: ExecFileFn = promisify(execFile);
@@ -335,32 +334,13 @@ export class GithubIssuesPoller {
           }
         }
 
-        if (criteria.length === 0) {
-          // No testable criteria — ask the human (idempotent), open NO spec PR, and
-          // do NOT record intake so a re-poll re-checks after they edit the issue.
-          await postNeedCriteriaComment(
-            { runGh: this.deps.runGh, log: this.deps.log },
-            { repo, issueNumber: number },
-          );
-          continue;
-        }
-
+        // Crystallise via the SHARED spec-intake (same renderer + spec-writer + order
+        // as Jira/TRACK-4/5). GitHub supplies only its dialect: the `github` source,
+        // the `spec/gh-issue-<n>` branch/path, the `closes #n` copy, and the pickup /
+        // need-criteria GitHub-comment write-backs. Byte-identical to the original
+        // inline tail (same gh calls, same order) — github-issues-poller.test asserts it.
         const specStatus = config.specStatus ?? "ready";
         const title = typeof issue.title === "string" ? issue.title : "";
-        const filePath = specFilePath(number, title);
-        const branch = specBranchName(number);
-        const markdown = buildSpecMarkdown({
-          title: title.trim().length > 0 ? title : `Issue #${number}`,
-          issueNumber: number,
-          issueUrl: issue.url,
-          repo: targetRepoPath, // the allowlisted local path → SPEC-1's resolveSpecRepo maps it.
-          status: specStatus,
-          problem: problem ?? title,
-          scope,
-          outOfScope,
-          criteria,
-        });
-
         const sanitizedTitle = sanitizeTitleLine(title);
         const commitMessage = `feat: add spec for issue #${number} (closes #${number})`;
         const prTitle = `spec: ${sanitizedTitle || `issue #${number}`} (closes #${number})`;
@@ -373,33 +353,50 @@ export class GithubIssuesPoller {
           `Closes #${number}`,
         ].join("\n");
 
-        const res = await writeSpecPr(
-          { runGh: this.deps.runGh, gitRemoteUrl: this.gitRemoteUrl, log: this.deps.log },
+        const result = await crystallizeTicket(
           {
-            targetRepoPath,
-            issueNumber: number,
-            branch,
-            filePath,
-            fileContent: markdown,
+            runGh: this.deps.runGh,
+            gitRemoteUrl: this.gitRemoteUrl,
+            log: this.deps.log,
+            writeback: {
+              pickup: (specPrUrl) =>
+                postPickupComment(
+                  { runGh: this.deps.runGh, log: this.deps.log },
+                  { repo, issueNumber: number, specPrUrl },
+                ),
+              needCriteria: () =>
+                postNeedCriteriaComment(
+                  { runGh: this.deps.runGh, log: this.deps.log },
+                  { repo, issueNumber: number },
+                ),
+            },
+          },
+          {
+            source: { kind: "github", ref: String(number), url: issue.url },
+            targetRepoPath, // the allowlisted local path → SPEC-1's resolveSpecRepo maps it.
+            branch: specBranchName(number),
+            filePath: specFilePath(number, title),
+            title: title.trim().length > 0 ? title : `Issue #${number}`,
+            status: specStatus,
+            problem: problem ?? title,
+            scope,
+            outOfScope,
+            criteria,
             commitMessage,
             prTitle,
             prBody,
           },
         );
-        if (!res.ok) {
+
+        if (result.outcome === "need-criteria") continue; // asked human, no intake.
+        if (result.outcome === "failed") {
           // Do NOT record intake → retried next cycle.
-          this.deps.log(`tracker poll: spec PR failed for ${repo}#${number}: ${res.reason}`);
+          this.deps.log(`tracker poll: spec PR failed for ${repo}#${number}: ${result.reason}`);
           continue;
         }
 
-        // WRITE-BACK (mandatory, idempotent, non-fatal): comment the pickup + PR link.
-        await postPickupComment(
-          { runGh: this.deps.runGh, log: this.deps.log },
-          { repo, issueNumber: number, specPrUrl: res.prUrl },
-        );
-
         // Record intake in the watermark (bound the map to the most-recent entries).
-        state.intake![key] = { specPrUrl: res.prUrl, at: new Date(this.now()).toISOString() };
+        state.intake![key] = { specPrUrl: result.prUrl, at: new Date(this.now()).toISOString() };
         intaken++;
       }
 

--- a/server/services/consilium/trackers/issue-spec.ts
+++ b/server/services/consilium/trackers/issue-spec.ts
@@ -331,10 +331,25 @@ function yamlQuote(value: string): string {
   return `"${escaped}"`;
 }
 
-export interface BuildSpecMarkdownInput {
+/**
+ * Provenance of the ticket a spec was crystallised from. `kind` is a server-chosen
+ * connector literal ("github" | "jira" | …) and is REQUIRED — it is what write-back
+ * (and the round-trip ready-gate) keys off. `ref` is the tracker-native ticket id
+ * (a GitHub issue number as a string, or a Jira key like `ACME-123`).
+ *
+ * GENERALISATION (TRACK-3): this is the shared provenance shape every connector
+ * emits, so ONE renderer (`renderSpecMarkdown`) + ONE synthesis feeds all trackers.
+ */
+export interface TicketSource {
+  kind: string;
+  ref: string;
+  url?: string;
+}
+
+export interface RenderSpecMarkdownInput {
   title: string;
-  issueNumber: number;
-  issueUrl?: string;
+  /** Provenance — `{ kind: <connector>, ref: <ticket-id>[, url] }`. */
+  source: TicketSource;
   repo: string;
   status: "ready" | "draft";
   problem: string;
@@ -345,25 +360,35 @@ export interface BuildSpecMarkdownInput {
   skills?: string[];
 }
 
+/** A `kind` safe to emit as a BARE YAML scalar (server literal); else it is quoted. */
+const SAFE_KIND_RE = /^[a-z][a-z0-9-]*$/;
+
 /**
- * Render a committed spec markdown that spec-parser.ts reads cleanly (see the
- * ROUND-TRIP CONTRACT at the top). Frontmatter: quoted `title`, bare `status`,
- * a `source` flow map `{ kind: github, ref: "<n>"[, url: "<url>"] }` (ref is the
- * issue number as a QUOTED string), quoted `repo`, optional `role`/`skills`, and a
- * block list of quoted `acceptanceCriteria`. Body: `## Problem / ## Scope / ## Out
- * of scope` (defaults `TBD` / `None specified.`). All untrusted text is control-
- * stripped; scalars are double-quote-escaped, so a title with quotes/newlines can
- * never break the YAML.
+ * SHARED (connector-agnostic) renderer for a committed spec markdown that
+ * spec-parser.ts reads cleanly (see the ROUND-TRIP CONTRACT at the top). Frontmatter:
+ * quoted `title`, bare `status`, a `source` flow map `{ kind: <connector>, ref:
+ * "<id>"[, url: "<url>"] }` (ref QUOTED), quoted `repo`, optional `role`/`skills`, and
+ * a block list of quoted `acceptanceCriteria`. Body: `## Problem / ## Scope / ## Out
+ * of scope`. All untrusted text is control-stripped; scalars are double-quote-escaped,
+ * so a title with quotes/newlines can never break the YAML. Every tracker connector
+ * (GitHub, Jira, …) renders through THIS function — the only per-connector difference
+ * is the `source.kind`/`ref` it passes in.
  */
-export function buildSpecMarkdown(input: BuildSpecMarkdownInput): string {
+export function renderSpecMarkdown(input: RenderSpecMarkdownInput): string {
   const lines: string[] = ["---"];
   lines.push(`title: ${yamlQuote(input.title)}`);
   // status is a server-chosen literal ("ready"|"draft") — safe bare scalar.
   lines.push(`status: ${input.status}`);
 
-  const srcParts = ["kind: github", `ref: ${yamlQuote(String(input.issueNumber))}`];
-  if (input.issueUrl && input.issueUrl.trim().length > 0) {
-    srcParts.push(`url: ${yamlQuote(input.issueUrl)}`);
+  // `kind` is a server literal; bare when it matches SAFE_KIND_RE, else quoted so a
+  // hostile kind can never break the flow map (defence-in-depth — kind is never
+  // attacker-authored today).
+  const kindScalar = SAFE_KIND_RE.test(input.source.kind)
+    ? input.source.kind
+    : yamlQuote(input.source.kind);
+  const srcParts = [`kind: ${kindScalar}`, `ref: ${yamlQuote(input.source.ref)}`];
+  if (input.source.url && input.source.url.trim().length > 0) {
+    srcParts.push(`url: ${yamlQuote(input.source.url)}`);
   }
   lines.push(`source: { ${srcParts.join(", ")} }`);
 
@@ -396,4 +421,39 @@ export function buildSpecMarkdown(input: BuildSpecMarkdownInput): string {
   lines.push("");
 
   return lines.join("\n");
+}
+
+export interface BuildSpecMarkdownInput {
+  title: string;
+  issueNumber: number;
+  issueUrl?: string;
+  repo: string;
+  status: "ready" | "draft";
+  problem: string;
+  scope?: string;
+  outOfScope?: string;
+  criteria: string[];
+  role?: string;
+  skills?: string[];
+}
+
+/**
+ * GitHub-specific thin wrapper over `renderSpecMarkdown` (TRACK-1 compat). Maps the
+ * issue number/url into the shared `source: { kind: github, ref: "<n>" }` provenance.
+ * Output is BYTE-IDENTICAL to the pre-generalisation renderer — issue-spec.test.ts's
+ * round-trip asserts `source.kind === "github"` + `ref === String(n)` unchanged.
+ */
+export function buildSpecMarkdown(input: BuildSpecMarkdownInput): string {
+  return renderSpecMarkdown({
+    title: input.title,
+    source: { kind: "github", ref: String(input.issueNumber), url: input.issueUrl },
+    repo: input.repo,
+    status: input.status,
+    problem: input.problem,
+    scope: input.scope,
+    outOfScope: input.outOfScope,
+    criteria: input.criteria,
+    role: input.role,
+    skills: input.skills,
+  });
 }

--- a/server/services/consilium/trackers/jira-connector.ts
+++ b/server/services/consilium/trackers/jira-connector.ts
@@ -1,0 +1,299 @@
+/**
+ * jira-connector.ts — TRACK-3: the Jira Cloud implementation of `TrackerConnector`.
+ * It is PURELY the Jira DIALECT (watch = JQL search, read = `/issue/{key}`, write-back
+ * = `/issue/{key}/comment` + optional transition, naming = `spec/jira-<KEY>`); the
+ * synth, the spec-PR, the provenance, and the crystallise/dedup machinery are the
+ * SHARED modules (`issue-spec.ts`, `spec-writer.ts`, `spec-intake.ts`) that GitHub
+ * uses too. Adding TRACK-4/5 is another file like this — nothing shared changes.
+ *
+ * SECURITY
+ *   - JQL is SERVER-BUILT: `project`/`label` are sanitised to a safe charset and
+ *     embedded as QUOTED literals (double-quotes/backslashes stripped) so a config
+ *     value can never break out of the quoted term (JQL-injection defence). The optional
+ *     operator `extraJql` is TRUSTED config (a saved filter), wrapped in parens. The
+ *     UNTRUSTED ticket title/body never touches JQL.
+ *   - Every read/write goes through the fail-closed, never-logging `jira-exec` seam.
+ *   - `specBranchName`/`specFilePath` sanitise the Jira key to `[A-Za-z0-9._-]` so it is
+ *     shape-safe for the branch (matches `SPEC_BRANCH_RE`) and the filename.
+ *   - The ticket description is flattened from ADF and stays UNTRUSTED — the shared
+ *     synth fences it before any prompt and the shared renderer quotes it in YAML.
+ */
+import { slugify } from "./issue-spec.js";
+import type { Ticket, TrackerConnector, TrackerWriteback, WritebackResult } from "./tracker-connector.js";
+import { jiraGetJson, jiraPostJson, type JiraExecDeps } from "./jira-exec.js";
+
+/**
+ * Sanitise a JQL string literal value: DROP quotes/backslashes (so it cannot break
+ * out of the quoted term — JQL-injection defence) and any C0/DEL control char,
+ * collapse whitespace, clamp. Char-code filtered (no control-char regex literal).
+ */
+function jqlLiteral(value: string, max = 200): string {
+  let out = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0;
+    if (code < 0x20 || code === 0x7f) continue; // C0 / DEL control chars.
+    if (ch === '"' || ch === "\\") continue; // quote-term breakout chars.
+    out += ch;
+  }
+  return out.replace(/\s+/g, " ").trim().slice(0, max);
+}
+
+/** A valid Jira project key charset (upper alnum + underscore); rejects anything else. */
+function sanitizeProjectKey(project: string): string {
+  return project.replace(/[^A-Za-z0-9_]/g, "").slice(0, 64);
+}
+
+/**
+ * Sanitise a Jira issue key for a branch/filename (`ACME-123` → `ACME-123`). Jira keys
+ * are `PROJ-<n>` (alnum + underscore + one dash), so DOTS are dropped — that also keeps
+ * the branch free of a `..` sequence git would reject as an invalid ref, and free of
+ * any path separator / leading dash (flag-injection / traversal defence).
+ */
+export function sanitizeIssueKey(key: string): string {
+  return key.replace(/[^A-Za-z0-9_-]/g, "").replace(/^-+/, "").slice(0, 80);
+}
+
+/** The Jira spec dedup branch: `spec/jira-<KEY>` (matches spec-writer's SPEC_BRANCH_RE). */
+export function jiraSpecBranchName(key: string): string {
+  const safe = sanitizeIssueKey(key);
+  if (safe.length === 0) throw new Error(`jira-connector: invalid issue key ${JSON.stringify(key)}`);
+  return `spec/jira-${safe}`;
+}
+
+/** The committed spec path: `docs/specs/jira-<KEY>-<slug>.md`. */
+export function jiraSpecFilePath(key: string, title: string): string {
+  const safe = sanitizeIssueKey(key);
+  if (safe.length === 0) throw new Error(`jira-connector: invalid issue key ${JSON.stringify(key)}`);
+  return `docs/specs/jira-${safe}-${slugify(title)}.md`;
+}
+
+// ─── ADF (Atlassian Document Format) → plain text ─────────────────────────────
+
+/**
+ * Flatten a Jira Cloud ADF `description` (a nested `{ type, content, text }` doc) into
+ * plain text. A string description (Jira Server / v2) passes through. Bounded so a
+ * pathological doc cannot blow the stack / memory (depth + total length caps).
+ */
+export function adfToText(description: unknown, maxLen = 16_000): string {
+  if (typeof description === "string") return description.slice(0, maxLen);
+  if (!description || typeof description !== "object") return "";
+  const out: string[] = [];
+  let total = 0;
+  const walk = (node: unknown, depth: number): void => {
+    if (total >= maxLen || depth > 50 || !node || typeof node !== "object") return;
+    const n = node as { type?: string; text?: string; content?: unknown };
+    if (typeof n.text === "string") {
+      out.push(n.text);
+      total += n.text.length;
+    }
+    if (n.type === "paragraph" || n.type === "hardBreak" || n.type === "heading") {
+      out.push("\n");
+      total += 1;
+    }
+    if (Array.isArray(n.content)) {
+      for (const child of n.content) walk(child, depth + 1);
+    }
+  };
+  walk(description, 0);
+  return out.join("").slice(0, maxLen).trim();
+}
+
+/** Wrap plain-text lines into a minimal ADF doc (one paragraph per line). */
+export function textToAdf(lines: string[]): unknown {
+  return {
+    type: "doc",
+    version: 1,
+    content: lines.map((line) => ({
+      type: "paragraph",
+      content: line.length > 0 ? [{ type: "text", text: line }] : [],
+    })),
+  };
+}
+
+// ─── Jira REST shapes (only the fields we request) ────────────────────────────
+
+interface JiraIssue {
+  key?: string;
+  fields?: {
+    summary?: string;
+    description?: unknown;
+    labels?: string[];
+    updated?: string;
+  };
+}
+interface JiraSearchResult {
+  issues?: JiraIssue[];
+}
+interface JiraComment {
+  body?: unknown;
+}
+interface JiraCommentsResult {
+  comments?: JiraComment[];
+}
+interface JiraTransition {
+  id?: string;
+  name?: string;
+}
+interface JiraTransitionsResult {
+  transitions?: JiraTransition[];
+}
+
+export interface JiraConnectorConfig {
+  /** `https://your-domain.atlassian.net` (validated https in jira-exec). */
+  baseUrl: string;
+  /** Jira project key, e.g. `ACME`. */
+  project: string;
+  /** The consent label (§3.1) — REQUIRED at fire time by the poller. */
+  label: string;
+  /** Optional operator JQL predicate (TRUSTED config) ANDed into the search. */
+  extraJql?: string;
+  /** Optional transition name/id to move the ticket to on pickup (best-effort). */
+  transitionTo?: string;
+}
+
+/** Map a Jira REST issue → the normalised `Ticket` (description flattened from ADF). */
+function toTicket(issue: JiraIssue, browseBase: string): Ticket | null {
+  const key = typeof issue.key === "string" ? issue.key : "";
+  if (key.length === 0) return null;
+  const f = issue.fields ?? {};
+  return {
+    id: key,
+    title: typeof f.summary === "string" ? f.summary : "",
+    body: adfToText(f.description),
+    labels: Array.isArray(f.labels) ? f.labels.filter((l): l is string => typeof l === "string") : [],
+    updatedAt: typeof f.updated === "string" ? f.updated : undefined,
+    url: `${browseBase}/browse/${encodeURIComponent(key)}`,
+  };
+}
+
+export class JiraTrackerConnector implements TrackerConnector {
+  readonly kind = "jira";
+  readonly writeback: TrackerWriteback;
+  private readonly cfg: JiraConnectorConfig;
+  private readonly exec: JiraExecDeps;
+  private readonly browseBase: string;
+
+  constructor(cfg: JiraConnectorConfig, exec: JiraExecDeps) {
+    this.cfg = cfg;
+    this.exec = exec;
+    // Human browse links live at the site origin (strip any trailing slash).
+    this.browseBase = cfg.baseUrl.replace(/\/+$/, "");
+    this.writeback = {
+      comment: (ticketId, body, marker) => this.postComment(ticketId, body, marker),
+      transition: (ticketId, state) => this.doTransition(ticketId, state),
+    };
+  }
+
+  /** Build the server-side JQL (quoted, sanitised literals; trusted extra ANDed). */
+  private buildJql(): string {
+    const project = sanitizeProjectKey(this.cfg.project);
+    const label = jqlLiteral(this.cfg.label);
+    const terms = [`project = "${project}"`, `labels = "${label}"`];
+    const extra = (this.cfg.extraJql ?? "").trim();
+    if (extra.length > 0) terms.push(`(${extra})`);
+    return `${terms.join(" AND ")} ORDER BY updated ASC`;
+  }
+
+  /**
+   * WATCH: JQL-search the project for labelled tickets. Returns normalised tickets or
+   * `null` on any degrade (auth/outage) so the poller skips the cycle. `sinceWatermark`
+   * is accepted for interface parity but dedup is handled by the poller's intake
+   * watermark (one spec per ticket), exactly as the GitHub path does.
+   */
+  async pollTickets(_sinceWatermark?: string): Promise<Ticket[] | null> {
+    const result = await jiraGetJson<JiraSearchResult>(this.exec, this.cfg.baseUrl, "rest/api/3/search", {
+      jql: this.buildJql(),
+      fields: "summary,description,labels,updated",
+      maxResults: "100",
+    });
+    if (!result || !Array.isArray(result.issues)) return null;
+    const tickets: Ticket[] = [];
+    for (const issue of result.issues) {
+      const t = toTicket(issue, this.browseBase);
+      if (t) tickets.push(t);
+    }
+    return tickets;
+  }
+
+  /** READ: fetch one issue by key. `null` ⇒ not found / degraded. */
+  async readTicket(ticketId: string): Promise<Ticket | null> {
+    const key = sanitizeIssueKey(ticketId);
+    if (key.length === 0) return null;
+    const issue = await jiraGetJson<JiraIssue>(
+      this.exec,
+      this.cfg.baseUrl,
+      `rest/api/3/issue/${encodeURIComponent(key)}`,
+      { fields: "summary,description,labels,updated" },
+    );
+    if (!issue) return null;
+    return toTicket({ ...issue, key: issue.key ?? key }, this.browseBase);
+  }
+
+  specBranchName(ticketId: string): string {
+    return jiraSpecBranchName(ticketId);
+  }
+
+  specFilePath(ticketId: string, title: string): string {
+    return jiraSpecFilePath(ticketId, title);
+  }
+
+  // ─── write-back ─────────────────────────────────────────────────────────────
+
+  /**
+   * Post a comment IDEMPOTENTLY: read existing comments, skip if any already carries
+   * `marker`, else POST an ADF comment `marker\n body`. Best-effort — a degrade returns
+   * `{ posted: false }`, never throws. When comments cannot be read (degrade) we do NOT
+   * post (safety over liveness — a blind post could double-comment).
+   */
+  private async postComment(ticketId: string, body: string, marker: string): Promise<WritebackResult> {
+    const key = sanitizeIssueKey(ticketId);
+    if (key.length === 0) return { posted: false, reason: "bad-key" };
+    const existing = await jiraGetJson<JiraCommentsResult>(
+      this.exec,
+      this.cfg.baseUrl,
+      `rest/api/3/issue/${encodeURIComponent(key)}/comment`,
+      { maxResults: "200" },
+    );
+    if (!existing || !Array.isArray(existing.comments)) {
+      return { posted: false, reason: "comments-unreadable" };
+    }
+    const already = existing.comments.some((c) => adfToText(c.body).includes(marker));
+    if (already) return { posted: false, reason: "already-commented" };
+
+    const res = await jiraPostJson(
+      this.exec,
+      this.cfg.baseUrl,
+      `rest/api/3/issue/${encodeURIComponent(key)}/comment`,
+      { body: textToAdf([marker, body]) },
+    );
+    return res.ok ? { posted: true } : { posted: false, reason: res.reason };
+  }
+
+  /**
+   * Move the ticket to `state` (name or id), best-effort. Resolves the transition id
+   * from the issue's available transitions (a state not offered ⇒ no-op) then POSTs it.
+   */
+  private async doTransition(ticketId: string, state: string): Promise<WritebackResult> {
+    const key = sanitizeIssueKey(ticketId);
+    if (key.length === 0) return { posted: false, reason: "bad-key" };
+    const wanted = state.trim();
+    if (wanted.length === 0) return { posted: false, reason: "no-state" };
+    const avail = await jiraGetJson<JiraTransitionsResult>(
+      this.exec,
+      this.cfg.baseUrl,
+      `rest/api/3/issue/${encodeURIComponent(key)}/transitions`,
+    );
+    if (!avail || !Array.isArray(avail.transitions)) return { posted: false, reason: "transitions-unreadable" };
+    const match = avail.transitions.find(
+      (t) => t.id === wanted || (t.name ?? "").toLowerCase() === wanted.toLowerCase(),
+    );
+    if (!match?.id) return { posted: false, reason: "no-such-transition" };
+    const res = await jiraPostJson(
+      this.exec,
+      this.cfg.baseUrl,
+      `rest/api/3/issue/${encodeURIComponent(key)}/transitions`,
+      { transition: { id: match.id } },
+    );
+    return res.ok ? { posted: true } : { posted: false, reason: res.reason };
+  }
+}

--- a/server/services/consilium/trackers/jira-exec.ts
+++ b/server/services/consilium/trackers/jira-exec.ts
@@ -1,0 +1,230 @@
+/**
+ * jira-exec.ts — the sanitized Jira Cloud REST seam for TRACK-3 (the Jira analogue of
+ * `gh-exec.ts`). Jira has no CLI, so this is a thin HTTP client with the SAME safety
+ * posture as the `gh` seam:
+ *   - NEVER throws: a network error / non-2xx / timeout degrades to `null` (reads) or
+ *     `{ ok: false }` (writes) so a Jira outage can never crash the poll loop.
+ *   - The API token is NEVER logged: on failure only the HTTP status + a scrubbed,
+ *     header-free message leaves this module; the `Authorization` header is never
+ *     surfaced.
+ *   - Fail-closed auth: the email + API token come from ENV (a secret manager), read
+ *     at call time. Absent ⇒ the request is not even attempted (`null`/`{ok:false}`).
+ *   - SSRF containment: the request URL is built from the operator-configured
+ *     `baseUrl` and a SERVER-DERIVED path, then re-checked to share `baseUrl`'s origin
+ *     — a crafted path can never redirect the token to another host.
+ *
+ * WHY A CUSTOM SEAM (not a Jira SDK): zero new deps, and the same auditable
+ * arg/URL/secret discipline the rest of the tracker code already uses. The HTTP call
+ * is injectable (`JiraHttpFn`) so tests drive it with a fake — no real network.
+ */
+
+/** The token/email env var names (a secret manager sets these). Never logged. */
+export const JIRA_EMAIL_ENV = "JIRA_EMAIL";
+export const JIRA_TOKEN_ENV = "JIRA_API_TOKEN";
+
+/** Default per-call wall-clock budget for a Jira request. */
+const JIRA_TIMEOUT_MS = 30_000;
+
+/** A minimal, injectable HTTP result (status + raw body text). */
+export interface JiraHttpResult {
+  status: number;
+  body: string;
+}
+
+/** Injectable HTTP transport (tests pass a fake; prod uses `fetch`). NEVER throws-through. */
+export type JiraHttpFn = (req: {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: string;
+  timeoutMs: number;
+}) => Promise<JiraHttpResult>;
+
+/** Resolved auth material (basic email:token). `null` ⇒ fail-closed (not configured). */
+export interface JiraAuth {
+  email: string;
+  token: string;
+}
+
+/**
+ * Read the Jira auth from ENV (fail-closed). Returns `null` when either var is absent
+ * or blank so the caller degrades WITHOUT attempting an unauthenticated call. The
+ * token value is returned but NEVER logged by this module.
+ */
+export function readJiraAuthFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): JiraAuth | null {
+  const email = (env[JIRA_EMAIL_ENV] ?? "").trim();
+  const token = (env[JIRA_TOKEN_ENV] ?? "").trim();
+  if (email.length === 0 || token.length === 0) return null;
+  return { email, token };
+}
+
+/** Scrub any absolute path + collapse whitespace from an error string, then clamp. */
+function scrub(raw: string): string {
+  return raw.replace(/\/[^\s'"]+/g, "<path>").replace(/\s+/g, " ").trim().slice(0, 300);
+}
+
+/** Default transport over global `fetch` with an AbortController timeout. Never throws-through. */
+const defaultHttp: JiraHttpFn = async (req) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), req.timeoutMs);
+  try {
+    const res = await fetch(req.url, {
+      method: req.method,
+      headers: req.headers,
+      body: req.body,
+      signal: controller.signal,
+    });
+    const body = await res.text().catch(() => "");
+    return { status: res.status, body };
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/** Build the `Authorization: Basic <base64(email:token)>` header value. */
+function basicAuthHeader(auth: JiraAuth): string {
+  return "Basic " + Buffer.from(`${auth.email}:${auth.token}`, "utf8").toString("base64");
+}
+
+/**
+ * Normalise `baseUrl` to an `https://host` origin. Returns `null` for anything that is
+ * not a well-formed `https:` URL (fail-closed — no `http:`, no SSRF-friendly schemes).
+ */
+export function normalizeBaseUrl(baseUrl: string): { origin: string; base: string } | null {
+  try {
+    const u = new URL(baseUrl);
+    if (u.protocol !== "https:") return null;
+    // Keep any path prefix (some Jira DC installs live under a context path) but drop
+    // a trailing slash so we can join a server-derived path cleanly.
+    const base = `${u.origin}${u.pathname.replace(/\/+$/, "")}`;
+    return { origin: u.origin, base };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build + validate the absolute request URL for a SERVER-DERIVED api path + optional
+ * query. Returns `null` if the resulting URL would leave `baseUrl`'s origin (SSRF
+ * containment) — a crafted `path` can never redirect the token elsewhere.
+ */
+function buildUrl(
+  baseUrl: string,
+  path: string,
+  query?: Record<string, string>,
+): string | null {
+  const norm = normalizeBaseUrl(baseUrl);
+  if (!norm) return null;
+  // `path` is always server-derived (`/rest/api/3/...` with a shape-validated key),
+  // but we still strip leading slashes and reject a scheme/`//host` escape before join.
+  const cleanPath = path.replace(/^\/+/, "");
+  if (/^[a-z][a-z0-9+.-]*:/i.test(cleanPath) || cleanPath.startsWith("/")) return null;
+  const url = new URL(`${norm.base}/${cleanPath}`);
+  if (url.origin !== norm.origin) return null; // origin escape ⇒ fail-closed.
+  if (query) {
+    for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
+  }
+  return url.toString();
+}
+
+export interface JiraExecDeps {
+  http?: JiraHttpFn;
+  auth?: JiraAuth | null;
+  log: (message: string) => void;
+}
+
+/**
+ * GET a Jira REST resource and parse JSON. Returns `null` on ANY degrade (unconfigured
+ * auth, non-2xx, network error, bad JSON, origin escape). The token is never logged.
+ */
+export async function jiraGetJson<T>(
+  deps: JiraExecDeps,
+  baseUrl: string,
+  path: string,
+  query?: Record<string, string>,
+): Promise<T | null> {
+  const auth = deps.auth ?? readJiraAuthFromEnv();
+  if (!auth) {
+    deps.log("jira-exec: no JIRA_EMAIL/JIRA_API_TOKEN configured — skipping (fail-closed)");
+    return null;
+  }
+  const url = buildUrl(baseUrl, path, query);
+  if (!url) {
+    deps.log("jira-exec: rejected request URL (bad baseUrl / origin escape)");
+    return null;
+  }
+  const http = deps.http ?? defaultHttp;
+  try {
+    const res = await http({
+      method: "GET",
+      url,
+      headers: { Authorization: basicAuthHeader(auth), Accept: "application/json" },
+      timeoutMs: JIRA_TIMEOUT_MS,
+    });
+    if (res.status < 200 || res.status >= 300) {
+      deps.log(`jira-exec: GET ${scrubUrl(url)} → HTTP ${res.status} (degraded)`);
+      return null;
+    }
+    return JSON.parse(res.body) as T;
+  } catch (err) {
+    deps.log(`jira-exec: GET failed: ${scrub((err as Error)?.message ?? String(err))}`);
+    return null;
+  }
+}
+
+/**
+ * POST a JSON body to a Jira REST resource (comment / transition / remote link).
+ * Returns a typed `{ ok }` — never throws. On failure only the HTTP status + a scrubbed
+ * message leave this module (the token / Authorization header never do).
+ */
+export async function jiraPostJson(
+  deps: JiraExecDeps,
+  baseUrl: string,
+  path: string,
+  body: unknown,
+): Promise<{ ok: true; body: string } | { ok: false; status?: number; reason: string }> {
+  const auth = deps.auth ?? readJiraAuthFromEnv();
+  if (!auth) {
+    deps.log("jira-exec: no JIRA_EMAIL/JIRA_API_TOKEN configured — skipping (fail-closed)");
+    return { ok: false, reason: "no-auth" };
+  }
+  const url = buildUrl(baseUrl, path);
+  if (!url) {
+    deps.log("jira-exec: rejected request URL (bad baseUrl / origin escape)");
+    return { ok: false, reason: "bad-url" };
+  }
+  const http = deps.http ?? defaultHttp;
+  try {
+    const res = await http({
+      method: "POST",
+      url,
+      headers: {
+        Authorization: basicAuthHeader(auth),
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body ?? {}),
+      timeoutMs: JIRA_TIMEOUT_MS,
+    });
+    if (res.status < 200 || res.status >= 300) {
+      deps.log(`jira-exec: POST ${scrubUrl(url)} → HTTP ${res.status} (degraded)`);
+      return { ok: false, status: res.status, reason: `http-${res.status}` };
+    }
+    return { ok: true, body: res.body };
+  } catch (err) {
+    deps.log(`jira-exec: POST failed: ${scrub((err as Error)?.message ?? String(err))}`);
+    return { ok: false, reason: "exception" };
+  }
+}
+
+/** Log a URL without its query string (a JQL/label may echo the label; keep it terse). */
+function scrubUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    return `${u.origin}${u.pathname}`;
+  } catch {
+    return "<url>";
+  }
+}

--- a/server/services/consilium/trackers/jira-issues-poller.ts
+++ b/server/services/consilium/trackers/jira-issues-poller.ts
@@ -1,0 +1,385 @@
+/**
+ * jira-issues-poller.ts — TRACK-3: poll a Jira project (JQL) and turn each labelled,
+ * spec-ready issue into a committed spec PR + a Jira pickup comment. The Jira analogue
+ * of `github-issues-poller.ts`, reusing the EXACT same rails (#492 shape): watermark in
+ * the trigger `config` jsonb, never-throw per cycle/trigger, project-scoped context,
+ * the tracker kill-switch, the allowlist + consent gates, and the SHARED crystallise
+ * pipeline (`spec-intake.ts` → `issue-spec.ts` synth + `spec-writer.ts` PR). The ONLY
+ * Jira-specific surface lives in `JiraTrackerConnector` (JQL watch / REST read /
+ * comment+transition write-back / `spec/jira-<KEY>` naming).
+ *
+ * ARCHITECTURE — TRACK-3 does NOT fire loops (identical to TRACK-1)
+ *   A spec PRODUCER + ticket UPDATER. It opens a PR that ADDS a `docs/specs/jira-<KEY>-…`
+ *   spec to the TARGET git repo (Jira has no git); when a human MERGES that PR, SPEC-1's
+ *   spec-watch fires the review loop off the committed spec. It never touches the loop
+ *   controller and never launches a loop itself.
+ *
+ * RAILS (adversarial)
+ *   (a) RE-INTAKE — a per-trigger WATERMARK (`pollState.intake`, issue KEY → { specPrUrl,
+ *       at }) is persisted in `config` jsonb; an already-intaken key is skipped.
+ *       Combined with the DETERMINISTIC `spec/jira-<KEY>` branch + spec-writer's pr-list
+ *       dedup ⇒ never a 2nd PR, never a double comment — even on a ticket EDIT.
+ *   (b) INTAKE STORM — a per-cycle budget (MAX_PER_CYCLE) bounds new specs per poll.
+ *   (c) JIRA OUTAGE — every read degrades to `null` (jira-exec) and `pollTickets` → null
+ *       SKIPS the cycle WITHOUT touching the watermark; each trigger + cycle is wrapped.
+ *   (d) CONSENT + BLAST RADIUS — the `filter.label` is REQUIRED (consent-to-intake);
+ *       `targetRepoPath` MUST be in the fail-closed allowlist (realpath-normalised).
+ *
+ * SECURITY
+ *   The Jira token is never read/logged here (jira-exec owns it, fail-closed). Untrusted
+ *   summary/description is fenced before any prompt (issue-spec.ts), slug/clamped before
+ *   any filename/branch (jira-connector), and the JQL is built from sanitised, quoted
+ *   literals (no injection). `targetRepoPath` is the allowlisted local path that becomes
+ *   the spec's `repo:` frontmatter, validated HERE and re-validated by SPEC-1 on merge.
+ */
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { realpathSync } from "fs";
+import { resolve } from "path";
+import type { TriggerRow } from "@shared/schema";
+import type { TrackerEventTriggerConfig, TrackerPollState } from "@shared/types";
+import type { AppConfig } from "../../../config/schema.js";
+import type { ExecFileFn } from "../../github-status.js";
+import { extractSpecFromIssue } from "./issue-spec.js";
+import { crystallizeTicket } from "./spec-intake.js";
+import { JiraTrackerConnector, type JiraConnectorConfig } from "./jira-connector.js";
+import { readJiraAuthFromEnv, type JiraAuth, type JiraHttpFn } from "./jira-exec.js";
+
+/** `owner/repo` — conservative charset (no leading dash / no flag). */
+const OWNER_REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+/** Max NEW intakes opened per poll cycle (bounds blast radius). */
+const MAX_PER_CYCLE = 20;
+/** Cap on tracked intakes per trigger (bounds the watermark jsonb). */
+const MAX_TRACKED_INTAKE = 500;
+
+/** Idempotency markers for the Jira write-back comments (distinct from TRACK-1/2). */
+export const JIRA_PICKUP_MARKER = "<!-- factory:track3:pickup -->";
+export const JIRA_NEED_CRITERIA_MARKER = "<!-- factory:track3:need-criteria -->";
+
+/**
+ * INJECTABLE spec synthesiser for FREE-FORM tickets (no spec-shaped description). The
+ * production impl wraps the model gateway; tests inject a fake. Connector-agnostic
+ * (takes only title+body) so it is SHARED across trackers.
+ */
+export interface TicketSynthesizer {
+  synthesize(ticket: { title: string; body: string }): Promise<{
+    problem?: string;
+    scope?: string;
+    outOfScope?: string;
+    criteria: string[];
+  }>;
+}
+
+export interface JiraIssuesPollerDeps {
+  getEnabledTriggersByType: (type: "tracker_event") => Promise<TriggerRow[]>;
+  runInProject: <T>(projectId: string, fn: () => Promise<T>) => Promise<T>;
+  getTrigger: (id: string) => Promise<TriggerRow | undefined>;
+  updateTrigger: (id: string, updates: Partial<TriggerRow>) => Promise<unknown>;
+  config: () => AppConfig;
+  allowedRepoPaths: () => string[];
+  synthesizer?: TicketSynthesizer;
+  /** Injectable `gh` runner for the remote spec PR (tests pass a fake — no real gh). */
+  runGh?: ExecFileFn;
+  /** Injectable Jira HTTP transport (tests pass a fake — no real network). */
+  jiraHttp?: JiraHttpFn;
+  /** Injectable Jira auth (tests pass a fake; prod reads env at call time). */
+  jiraAuth?: JiraAuth | null;
+  /** Injectable git-remote reader for the owner/repo derivation (default: real `git`). */
+  gitRemoteUrl?: (repoPath: string) => Promise<string | null>;
+  log: (message: string) => void;
+  now?: () => number;
+}
+
+const execFileAsync: ExecFileFn = promisify(execFile);
+
+/** Default git-remote reader: `git -C <repoPath> remote get-url origin`. NEVER throws. */
+async function defaultGitRemoteUrl(repoPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", repoPath, "remote", "get-url", "origin"], {
+      timeout: 10_000,
+    });
+    const url = (stdout ?? "").trim();
+    return url.length > 0 ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Best-effort realpath (collapses symlinks/`..`), else lexical resolve. */
+function canonicalPath(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return resolve(p);
+  }
+}
+
+/** Fail-closed allowlist check: `targetRepoPath` realpath-equals or sits beneath an allowed root. */
+function isAllowedRepoPath(targetRepoPath: string, allowed: readonly string[]): boolean {
+  const target = canonicalPath(targetRepoPath);
+  for (const a of allowed) {
+    const root = canonicalPath(a);
+    if (target === root || target.startsWith(root + "/")) return true;
+  }
+  return false;
+}
+
+/** Single-line control-strip + collapse + clamp for the (untrusted) ticket summary. */
+function sanitizeTitleLine(value: string, max = 160): string {
+  let out = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0;
+    out += code < 0x20 || code === 0x7f ? " " : ch;
+  }
+  return out.replace(/\s+/g, " ").trim().slice(0, max);
+}
+
+/** Keep at most MAX_TRACKED_INTAKE intakes (most-recent by `at` timestamp win). */
+function boundIntake(
+  intake: Record<string, { specPrUrl?: string; at: string }>,
+): Record<string, { specPrUrl?: string; at: string }> {
+  const keys = Object.keys(intake);
+  if (keys.length <= MAX_TRACKED_INTAKE) return intake;
+  const kept = keys
+    .sort((a, b) => (intake[b].at ?? "").localeCompare(intake[a].at ?? ""))
+    .slice(0, MAX_TRACKED_INTAKE);
+  const out: Record<string, { specPrUrl?: string; at: string }> = {};
+  for (const k of kept) out[k] = intake[k];
+  return out;
+}
+
+export class JiraIssuesPoller {
+  private readonly deps: JiraIssuesPollerDeps;
+  private readonly gitRemoteUrl: (repoPath: string) => Promise<string | null>;
+  private readonly now: () => number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private polling = false;
+
+  constructor(deps: JiraIssuesPollerDeps) {
+    this.deps = deps;
+    this.gitRemoteUrl = deps.gitRemoteUrl ?? ((p) => defaultGitRemoteUrl(p));
+    this.now = deps.now ?? Date.now;
+  }
+
+  /** Start the interval poller IFF `features.triggers.tracker.enabled`. Idempotent. */
+  start(): void {
+    if (this.timer) return;
+    const cfg = this.deps.config().features.triggers.tracker;
+    if (!cfg.enabled) {
+      this.deps.log("jira tracker polling disabled — poller not started");
+      return;
+    }
+    const intervalMs = cfg.pollIntervalSec * 1000;
+    this.timer = setInterval(() => void this.pollAllSafe(), intervalMs);
+    this.timer.unref?.();
+    this.deps.log(`jira tracker poller started (every ${cfg.pollIntervalSec}s)`);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** One poll cycle, fully guarded — a throw here must never kill the interval. */
+  async pollAllSafe(): Promise<void> {
+    if (this.polling) return;
+    this.polling = true;
+    try {
+      await this.pollAll();
+    } catch (e) {
+      this.deps.log(`jira tracker poll cycle error: ${(e as Error).message}`);
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  /** Poll every enabled tracker_event trigger. Gated on the MASTER switch. */
+  async pollAll(): Promise<void> {
+    if (!this.deps.config().features.triggers.enabled) {
+      this.deps.log("jira tracker poll skipped — features.triggers.enabled (master switch) is off");
+      return;
+    }
+    const triggers = await this.deps.getEnabledTriggersByType("tracker_event");
+    for (const trigger of triggers) {
+      try {
+        await this.pollTrigger(trigger);
+      } catch (e) {
+        this.deps.log(`jira tracker poll error for trigger ${trigger.id}: ${(e as Error).message}`);
+      }
+    }
+  }
+
+  /** Poll one Jira trigger: validate config + allowlist, intake labelled issues, persist. */
+  async pollTrigger(trigger: TriggerRow): Promise<void> {
+    if (!trigger.projectId) return;
+    const config = trigger.config as TrackerEventTriggerConfig;
+    if (config.tracker !== "jira") return; // the GitHub poller handles "github".
+
+    const baseUrl = (config.baseUrl ?? "").trim();
+    if (baseUrl.length === 0) {
+      this.deps.log(`jira tracker poll skipped for trigger ${trigger.id} — no baseUrl`);
+      return;
+    }
+    const project = (config.project ?? "").trim();
+    if (project.length === 0) {
+      this.deps.log(`jira tracker poll skipped for trigger ${trigger.id} — no project`);
+      return;
+    }
+    // `repo` (owner/repo) is the git repo the spec PR lands in — shape-validated.
+    const repo = (config.repo ?? "").trim();
+    if (!OWNER_REPO_RE.test(repo)) {
+      this.deps.log(`jira tracker poll skipped for trigger ${trigger.id} — repo not owner/repo`);
+      return;
+    }
+    const targetRepoPath = config.targetRepoPath;
+    if (!targetRepoPath || targetRepoPath.length === 0) {
+      this.deps.log(`jira tracker poll skipped for trigger ${trigger.id} — no targetRepoPath`);
+      return;
+    }
+    if (!isAllowedRepoPath(targetRepoPath, this.deps.allowedRepoPaths())) {
+      this.deps.log(`jira tracker poll skipped for trigger ${trigger.id} — targetRepoPath not in allowlist`);
+      return;
+    }
+    // The label gate is the operator's consent-to-intake — REQUIRED at fire time.
+    const label = config.filter?.label;
+    if (!label || label.length === 0) {
+      this.deps.log(`jira tracker poll skipped for trigger ${trigger.id} — no filter.label (consent gate)`);
+      return;
+    }
+
+    const connectorCfg: JiraConnectorConfig = {
+      baseUrl,
+      project,
+      label,
+      extraJql: config.jql,
+      transitionTo: config.transitionTo,
+    };
+    const connector = new JiraTrackerConnector(connectorCfg, {
+      http: this.deps.jiraHttp,
+      auth: this.deps.jiraAuth ?? readJiraAuthFromEnv(),
+      log: this.deps.log,
+    });
+
+    const projectId = trigger.projectId;
+    await this.deps.runInProject(projectId, async () => {
+      const state: TrackerPollState = { ...(config.pollState ?? {}) };
+      if (!state.intake) state.intake = {};
+
+      const tickets = await connector.pollTickets(state.lastPolledAt);
+      if (tickets === null) {
+        this.deps.log(`jira tracker poll: search unavailable for ${project} (degraded) — skipping cycle`);
+        return; // do NOT touch the watermark.
+      }
+
+      let intaken = 0;
+      for (const ticket of tickets) {
+        if (intaken >= MAX_PER_CYCLE) break;
+        const key = ticket.id;
+        if (!key || state.intake![key]) continue; // watermark dedup — already intaken.
+
+        // Defence-in-depth: confirm the consent label is actually present.
+        if (!ticket.labels.includes(label)) continue;
+
+        // DETERMINISTIC extraction, then the injectable synthesiser for free-form tickets.
+        const extract = extractSpecFromIssue({ number: 0, title: ticket.title, body: ticket.body });
+        let problem = extract.problem;
+        let scope = extract.scope;
+        let outOfScope = extract.outOfScope;
+        let criteria = extract.criteria;
+        if (criteria.length === 0 && this.deps.synthesizer) {
+          try {
+            const syn = await this.deps.synthesizer.synthesize({ title: ticket.title, body: ticket.body });
+            if (syn && Array.isArray(syn.criteria) && syn.criteria.length > 0) {
+              criteria = syn.criteria;
+              problem = problem ?? syn.problem;
+              scope = scope ?? syn.scope;
+              outOfScope = outOfScope ?? syn.outOfScope;
+            }
+          } catch (e) {
+            this.deps.log(`jira tracker poll: synthesizer error for ${key}: ${(e as Error).message}`);
+          }
+        }
+
+        const specStatus = config.specStatus ?? "ready";
+        const title = ticket.title;
+        const sanitizedTitle = sanitizeTitleLine(title);
+        const commitMessage = `feat: add spec for ${key}`;
+        const prTitle = `spec: ${sanitizedTitle || key} (${key})`;
+        const prBodyLines = [
+          `Track-3 auto-produced spec for Jira issue ${key}.`,
+          "",
+          "This spec was generated from the linked Jira issue by the factory's Track-3 intake.",
+          "Merging it fires the SPEC-1 spec-watch, which launches the review loop off the committed spec.",
+        ];
+        if (ticket.url) prBodyLines.push("", `Jira: ${ticket.url}`);
+        const prBody = prBodyLines.join("\n");
+
+        const result = await crystallizeTicket(
+          {
+            runGh: this.deps.runGh, // spec PR uses the shared gh writer (injectable).
+            gitRemoteUrl: this.gitRemoteUrl,
+            log: this.deps.log,
+            writeback: {
+              pickup: (specPrUrl) =>
+                connector.writeback
+                  .comment(key, `🤖 picked up by the factory — spec at ${specPrUrl}`, JIRA_PICKUP_MARKER)
+                  .then((r) => ({ posted: r.posted })),
+              needCriteria: () =>
+                connector.writeback
+                  .comment(
+                    key,
+                    `🤖 I can pick this up but need testable acceptance criteria — please add an "Acceptance Criteria" section or checklist items.`,
+                    JIRA_NEED_CRITERIA_MARKER,
+                  )
+                  .then((r) => ({ posted: r.posted })),
+            },
+          },
+          {
+            source: { kind: "jira", ref: key, url: ticket.url },
+            targetRepoPath,
+            branch: connector.specBranchName(key),
+            filePath: connector.specFilePath(key, title),
+            title: title.trim().length > 0 ? title : key,
+            status: specStatus,
+            problem: problem ?? title,
+            scope,
+            outOfScope,
+            criteria,
+            commitMessage,
+            prTitle,
+            prBody,
+          },
+        );
+
+        if (result.outcome === "need-criteria") continue; // asked human, no intake.
+        if (result.outcome === "failed") {
+          this.deps.log(`jira tracker poll: spec PR failed for ${key}: ${result.reason}`);
+          continue;
+        }
+
+        // Optional pickup transition (best-effort; a missing transition is a no-op).
+        if (config.transitionTo && connector.writeback.transition) {
+          await connector.writeback.transition(key, config.transitionTo);
+        }
+
+        state.intake![key] = { specPrUrl: result.prUrl, at: new Date(this.now()).toISOString() };
+        intaken++;
+      }
+
+      state.intake = boundIntake(state.intake!);
+      state.lastPolledAt = new Date(this.now()).toISOString();
+      await this.persistWatermark(trigger.id, state);
+    });
+  }
+
+  /** Re-read fresh + write the watermark into `config.pollState` (no migration). */
+  private async persistWatermark(triggerId: string, state: TrackerPollState): Promise<void> {
+    const fresh = await this.deps.getTrigger(triggerId);
+    if (!fresh) return;
+    const freshConfig = (fresh.config ?? {}) as TrackerEventTriggerConfig;
+    const nextConfig: TrackerEventTriggerConfig = { ...freshConfig, pollState: state };
+    await this.deps.updateTrigger(triggerId, { config: nextConfig });
+  }
+}

--- a/server/services/consilium/trackers/spec-intake.ts
+++ b/server/services/consilium/trackers/spec-intake.ts
@@ -1,0 +1,125 @@
+/**
+ * spec-intake.ts — the SHARED "crystallise a ticket into a committed spec PR" step,
+ * used by EVERY tracker poller (GitHub TRACK-1, Jira TRACK-3, TRACK-4/5). This is the
+ * single place the synth output becomes (a) a rendered spec markdown, (b) a remote
+ * spec PR, and (c) a pickup write-back — so all connectors share ONE spec renderer
+ * (`issue-spec.ts renderSpecMarkdown`), ONE spec-PR writer (`spec-writer.ts`), and ONE
+ * provenance shape (`TicketSource`). A connector differs ONLY in the dialect it feeds
+ * in (source, branch/file names, copy strings) and the write-back it supplies.
+ *
+ * WHAT STAYS IN THE POLLER (not here)
+ *   The WATCH loop, the per-trigger WATERMARK (dedup — one spec per ticket), the
+ *   MAX_PER_CYCLE budget, the allowlist + consent gates, and the extract/synth of
+ *   criteria. This module is the crystallise TAIL only: it assumes the caller has
+ *   already resolved the spec fields (criteria may be empty → ask-for-criteria).
+ *
+ * ORDER (identical to TRACK-1's original inline tail, so GitHub stays byte-identical)
+ *   1. no testable criteria ⇒ post the ask-for-criteria write-back, open NO PR,
+ *      return `need-criteria` (the caller does NOT record intake ⇒ re-checked next poll);
+ *   2. else render the spec markdown (shared) and open the spec PR (shared, remote);
+ *   3. PR failed ⇒ return `failed` (caller does NOT record intake ⇒ retried next cycle);
+ *   4. PR ok ⇒ post the pickup write-back (mandatory, idempotent) and return `spec-pr`.
+ */
+import type { ExecFileFn } from "../../github-status.js";
+import { renderSpecMarkdown, type TicketSource } from "./issue-spec.js";
+import { writeSpecPr } from "./spec-writer.js";
+
+/** The two write-back actions the crystallise step needs, supplied per connector. */
+export interface CrystallizeWriteback {
+  /** "picked up → spec at <PR>" (idempotent, best-effort). */
+  pickup(specPrUrl: string): Promise<{ posted: boolean }>;
+  /** "add testable acceptance criteria" (idempotent, best-effort). */
+  needCriteria(): Promise<{ posted: boolean }>;
+}
+
+export interface CrystallizeDeps {
+  /** Injectable `gh` runner for the remote spec PR (tests pass a fake). */
+  runGh?: ExecFileFn;
+  /** Read the TARGET git repo's `origin` URL (→ owner/repo for the PR). */
+  gitRemoteUrl: (repoPath: string) => Promise<string | null>;
+  /** The connector's pickup / need-criteria write-back. */
+  writeback: CrystallizeWriteback;
+  /** Structured logger. */
+  log: (message: string) => void;
+}
+
+export interface CrystallizeTicketInput {
+  /** Provenance the spec records (`{ kind, ref, url }`) — REQUIRED. */
+  source: TicketSource;
+  /** Allowlisted local git repo path → the spec's `repo:` frontmatter + PR target. */
+  targetRepoPath: string;
+  /** The deterministic dedup branch (`connector.specBranchName`). */
+  branch: string;
+  /** The committed spec path (`connector.specFilePath`). */
+  filePath: string;
+  /** The spec title (untrusted — rendered as a quoted YAML scalar). */
+  title: string;
+  status: "ready" | "draft";
+  /** Resolved spec fields. `criteria` EMPTY ⇒ the ask-for-criteria path. */
+  problem: string;
+  scope?: string;
+  outOfScope?: string;
+  criteria: string[];
+  role?: string;
+  skills?: string[];
+  /** Connector-specific PR/commit copy (GitHub carries `closes #n`; Jira does not). */
+  commitMessage: string;
+  prTitle: string;
+  prBody: string;
+}
+
+export type CrystallizeOutcome =
+  | { outcome: "spec-pr"; prUrl: string; reused: boolean }
+  | { outcome: "need-criteria" }
+  | { outcome: "failed"; reason: string };
+
+/**
+ * Crystallise one ticket (see the ORDER contract above). NEVER throws — every failure
+ * path is a typed outcome the poller logs and (for `failed`/`need-criteria`) leaves
+ * OUT of the watermark so it is retried/re-checked.
+ */
+export async function crystallizeTicket(
+  deps: CrystallizeDeps,
+  input: CrystallizeTicketInput,
+): Promise<CrystallizeOutcome> {
+  // 1) No testable criteria — ask the human (idempotent), open NO spec PR.
+  if (input.criteria.length === 0) {
+    await deps.writeback.needCriteria();
+    return { outcome: "need-criteria" };
+  }
+
+  // 2) Render the committed spec (SHARED renderer → identical bytes for every connector).
+  const markdown = renderSpecMarkdown({
+    title: input.title,
+    source: input.source,
+    repo: input.targetRepoPath,
+    status: input.status,
+    problem: input.problem,
+    scope: input.scope,
+    outOfScope: input.outOfScope,
+    criteria: input.criteria,
+    role: input.role,
+    skills: input.skills,
+  });
+
+  // 3) Open the spec PR remotely (SHARED writer; never touches the working tree).
+  const res = await writeSpecPr(
+    { runGh: deps.runGh, gitRemoteUrl: deps.gitRemoteUrl, log: deps.log },
+    {
+      targetRepoPath: input.targetRepoPath,
+      branch: input.branch,
+      filePath: input.filePath,
+      fileContent: markdown,
+      commitMessage: input.commitMessage,
+      prTitle: input.prTitle,
+      prBody: input.prBody,
+    },
+  );
+  if (!res.ok) {
+    return { outcome: "failed", reason: res.reason };
+  }
+
+  // 4) WRITE-BACK (mandatory, idempotent, non-fatal): comment the pickup + PR link.
+  await deps.writeback.pickup(res.prUrl);
+  return { outcome: "spec-pr", prUrl: res.prUrl, reused: res.reused };
+}

--- a/server/services/consilium/trackers/spec-writer.ts
+++ b/server/services/consilium/trackers/spec-writer.ts
@@ -38,10 +38,17 @@ import { runGhJson, type ExecFileFn } from "../../github-status.js";
 import { parseOwnerRepo } from "../../github-poller.js";
 import { runGhCapture } from "./gh-exec.js";
 
-/** The server-derived spec branch shape (`spec/gh-issue-<n>`). */
-export const SPEC_BRANCH_RE = /^spec\/gh-issue-[0-9]+$/;
+/**
+ * The server-derived spec branch shapes, one alternative per connector dialect:
+ *   - GitHub (TRACK-1): `spec/gh-issue-<n>`     (n = issue number)
+ *   - Jira   (TRACK-3): `spec/jira-<KEY>`       (KEY = `PROJ-123`, uppercased)
+ * Every alternative is SERVER-DERIVED from a validated ticket id, so nothing
+ * attacker-shaped (a leading dash, a path separator, a `..`) can reach `gh`. New
+ * connectors (TRACK-4/5) add their own alternative here — the writer stays generic.
+ */
+export const SPEC_BRANCH_RE = /^spec\/(gh-issue-[0-9]+|jira-[A-Za-z0-9._-]+)$/;
 
-/** True iff `branch` is a server-derived TRACK-1 spec branch. */
+/** True iff `branch` is a server-derived tracker spec branch (any connector). */
 export function isValidSpecBranch(branch: string): boolean {
   return SPEC_BRANCH_RE.test(branch);
 }
@@ -57,7 +64,12 @@ export interface SpecWriterDeps {
 
 export interface WriteSpecPrParams {
   targetRepoPath: string;
-  issueNumber: number;
+  /**
+   * The origin ticket id, for logging/traceability only (NOT used to build any
+   * `gh` arg — the branch/path/title are pre-derived by the caller). Optional
+   * because a Jira key is not a number; the GitHub caller still passes its number.
+   */
+  issueNumber?: number;
   branch: string;
   filePath: string;
   fileContent: string;

--- a/server/services/consilium/trackers/tracker-connector.ts
+++ b/server/services/consilium/trackers/tracker-connector.ts
@@ -1,0 +1,94 @@
+/**
+ * tracker-connector.ts — the UNIFORM tracker-connector surface (task-tracker-triggers
+ * §2). A connector is a small per-system adapter doing exactly three things:
+ *   1. WATCH  — learn of new/changed tickets   (`pollTickets(sinceWatermark)`)
+ *   2. READ   — fetch a ticket's fields        (`readTicket(id)`)
+ *   3. WRITE-BACK — comment / transition / link (`writeback.*`)
+ * plus the two deterministic NAMING helpers the shared spec-intake needs to dedup and
+ * to place the committed spec (`specBranchName`/`specFilePath`).
+ *
+ * WHY THIS EXISTS (TRACK-3 generalisation)
+ *   TRACK-1/2 shipped a GitHub-only path. TRACK-3 adds Jira and, per §2, EVERY tracker
+ *   (GitHub, Jira, GitLab, Bitbucket, Linear, Azure DevOps, ClickUp) "reduces to the
+ *   same interface; only the API dialect differs." So the synth (`issue-spec.ts`), the
+ *   spec-PR writer (`spec-writer.ts`), the provenance (`TicketSource`), and the
+ *   crystallise pipeline (`spec-intake.ts`) are SHARED; a connector supplies ONLY the
+ *   dialect (how to watch/read/write-back + how it names its spec branch/file).
+ *   TRACK-4/5 are then a new `*-connector.ts` implementing this interface — no change
+ *   to the shared machinery.
+ *
+ * SECURITY CONTRACT (every implementer MUST honour)
+ *   - `pollTickets`/`readTicket` NEVER throw — a tracker outage returns `null` (skip the
+ *     cycle, watermark untouched) so a degraded tracker can never crash the poll loop.
+ *   - Ticket `title`/`body` are UNTRUSTED (anyone may file a ticket): the shared synth
+ *     fences them before any prompt and slugifies/clamps them before any filename.
+ *   - Credentials come from a secret manager / env, are NEVER logged, and are scoped to
+ *     one tracker site/project (fail-closed).
+ *   - `specBranchName`/`specFilePath` are SERVER-DERIVED from the validated ticket id;
+ *     they must be shape-safe (no leading dash, no path separator, no `..`) and match
+ *     the writer's `SPEC_BRANCH_RE`.
+ */
+
+/** A lightweight reference to a ticket (id + change cursor), from a watch/poll. */
+export interface TicketRef {
+  /** Tracker-native id: a GitHub issue number as a string, or a Jira key `PROJ-123`. */
+  id: string;
+  /** ISO timestamp of the ticket's last update (the poll watermark cursor). */
+  updatedAt?: string;
+  /** Canonical human URL of the ticket (for provenance + write-back links). */
+  url?: string;
+}
+
+/** A ticket's read fields, normalised across trackers (what synthesis consumes). */
+export interface Ticket extends TicketRef {
+  /** The ticket title / summary (UNTRUSTED). */
+  title: string;
+  /** The ticket body / description as PLAIN TEXT (UNTRUSTED; ADF etc. flattened). */
+  body: string;
+  /** The ticket's labels / tags (used for the defence-in-depth consent re-check). */
+  labels: string[];
+}
+
+/** Outcome of a write-back attempt — best-effort, never throws. */
+export interface WritebackResult {
+  posted: boolean;
+  reason?: string;
+}
+
+/**
+ * The write-back dialect (§4). `comment` is MANDATORY (the pickup record); `transition`
+ * and `link` are OPTIONAL (a tracker without them omits them). Every method is
+ * IDEMPOTENT (keyed by the caller-supplied `marker`) and best-effort.
+ */
+export interface TrackerWriteback {
+  /** Post `body` as a ticket comment IFF no existing comment carries `marker`. */
+  comment(ticketId: string, body: string, marker: string): Promise<WritebackResult>;
+  /** Move the ticket to `state` (name or id). Absent on trackers without transitions. */
+  transition?(ticketId: string, state: string): Promise<WritebackResult>;
+  /** Attach a remote link (e.g. the spec/PR URL). Absent on trackers without links. */
+  link?(ticketId: string, url: string, title?: string): Promise<WritebackResult>;
+}
+
+/**
+ * A tracker connector: watch + read + write-back + naming, per §2. Implemented once
+ * per tracker (`github-connector.ts`, `jira-connector.ts`, …); the shared poller +
+ * `crystallizeTicket` drive it.
+ */
+export interface TrackerConnector {
+  /** The connector's provenance kind ("github" | "jira" | …) — the spec's `source.kind`. */
+  readonly kind: string;
+  /**
+   * WATCH: return the tickets matching the connector's filter that changed since
+   * `sinceWatermark` (ISO), already normalised. `null` ⇒ the tracker is degraded
+   * (outage / auth) — the poller SKIPS the cycle without touching its watermark.
+   */
+  pollTickets(sinceWatermark?: string): Promise<Ticket[] | null>;
+  /** READ: fetch one ticket's fields by id. `null` ⇒ not found / degraded. */
+  readTicket(ticketId: string): Promise<Ticket | null>;
+  /** WRITE-BACK dialect. */
+  readonly writeback: TrackerWriteback;
+  /** The deterministic dedup spec branch for a ticket (matches `SPEC_BRANCH_RE`). */
+  specBranchName(ticketId: string): string;
+  /** The committed spec file path for a ticket (`docs/specs/<connector>-<id>-<slug>.md`). */
+  specFilePath(ticketId: string, title: string): string;
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1562,12 +1562,24 @@ export interface TrackerPollState {
  * This trigger PRODUCES specs + UPDATES tickets — it never fires a loop directly.
  */
 export interface TrackerEventTriggerConfig {
-  tracker: "github";            // TRACK-1 = github only
-  repo: string;                 // owner/repo to poll issues from
+  // TRACK-1 = github; TRACK-3 adds jira. The poller for each tracker guards on this
+  // discriminant (`config.tracker !== "<kind>"` → skip), so widening it is ADDITIVE:
+  // the github path is byte-identical and only the new jira poller reads the jira fields.
+  tracker: "github" | "jira";
+  repo: string;                 // github: owner/repo to poll issues from. jira: owner/repo of the git repo the spec PR lands in.
   targetRepoPath: string;       // allowlisted local repo path -> the spec's `repo:` frontmatter + PR target
   filter?: { label?: string };  // label gate (consent to intake) — required at fire time
   specStatus?: "ready" | "draft";
   pollState?: TrackerPollState;  // owned by the poller (watermark)
+  // ─── Jira-only (TRACK-3; ignored by the github poller) ──────────────────────
+  /** Jira site base URL, e.g. `https://acme.atlassian.net` (validated https). */
+  baseUrl?: string;
+  /** Jira project key to poll, e.g. `ACME`. */
+  project?: string;
+  /** Optional operator JQL predicate (trusted config) ANDed into the label search. */
+  jql?: string;
+  /** Optional Jira transition name/id to move the ticket to on pickup (best-effort). */
+  transitionTo?: string;
   /**
    * TRACK-2 (full write-back lifecycle). Per-trigger tuning for the read-only
    * write-back OBSERVER, which comments the loop's lifecycle transitions back on

--- a/tests/unit/consilium/trackers/jira-connector.test.ts
+++ b/tests/unit/consilium/trackers/jira-connector.test.ts
@@ -1,0 +1,236 @@
+/**
+ * jira-connector.test.ts — TRACK-3 Jira dialect with a FAKE Jira HTTP transport (no
+ * network). Covers: JQL is built from SANITISED, quoted literals (injection-proof);
+ * ADF description flattening; watch/read mapping to the normalised Ticket; idempotent
+ * comment write-back (marker dedup, no double-post); transition name→id resolution;
+ * and the deterministic `spec/jira-<KEY>` naming.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  JiraTrackerConnector,
+  adfToText,
+  textToAdf,
+  sanitizeIssueKey,
+  jiraSpecBranchName,
+  jiraSpecFilePath,
+  type JiraConnectorConfig,
+} from "../../../../server/services/consilium/trackers/jira-connector.js";
+import { isValidSpecBranch } from "../../../../server/services/consilium/trackers/spec-writer.js";
+import type { JiraHttpFn, JiraHttpResult } from "../../../../server/services/consilium/trackers/jira-exec.js";
+
+interface Call {
+  method: string;
+  url: string;
+  body?: string;
+}
+
+/** A fake Jira transport routed by method + url path; records every call. */
+function fakeHttp(
+  handler: (call: Call) => JiraHttpResult,
+): { http: JiraHttpFn; calls: Call[] } {
+  const calls: Call[] = [];
+  const http: JiraHttpFn = vi.fn(async (req) => {
+    const call: Call = { method: req.method, url: req.url, body: req.body };
+    calls.push(call);
+    return handler(call);
+  });
+  return { http, calls };
+}
+
+const json = (obj: unknown, status = 200): JiraHttpResult => ({ status, body: JSON.stringify(obj) });
+
+const CFG: JiraConnectorConfig = {
+  baseUrl: "https://acme.atlassian.net",
+  project: "ACME",
+  label: "agent",
+};
+
+function connector(cfg: Partial<JiraConnectorConfig>, handler: (c: Call) => JiraHttpResult) {
+  const { http, calls } = fakeHttp(handler);
+  const conn = new JiraTrackerConnector({ ...CFG, ...cfg }, {
+    http,
+    auth: { email: "a@b.co", token: "secret-token" },
+    log: () => {},
+  });
+  return { conn, calls };
+}
+
+const jqlOf = (url: string) => new URL(url).searchParams.get("jql") ?? "";
+
+describe("adfToText", () => {
+  it("flattens an ADF doc to plain text with paragraph breaks", () => {
+    const doc = {
+      type: "doc",
+      version: 1,
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "Hello " }, { type: "text", text: "world" }] },
+        { type: "paragraph", content: [{ type: "text", text: "line2" }] },
+      ],
+    };
+    expect(adfToText(doc)).toBe("Hello world\nline2");
+  });
+
+  it("passes a string description through (Jira Server / v2)", () => {
+    expect(adfToText("## Acceptance Criteria\n- a")).toBe("## Acceptance Criteria\n- a");
+  });
+
+  it("returns empty for null/garbage and is depth/length bounded", () => {
+    expect(adfToText(null)).toBe("");
+    expect(adfToText({ type: "doc" })).toBe("");
+    const big = { type: "doc", content: [{ type: "text", text: "x".repeat(50_000) }] };
+    expect(adfToText(big, 100).length).toBeLessThanOrEqual(100);
+  });
+});
+
+describe("naming + key sanitisation", () => {
+  it("derives a shape-safe branch/path from the Jira key", () => {
+    expect(jiraSpecBranchName("ACME-123")).toBe("spec/jira-ACME-123");
+    expect(isValidSpecBranch(jiraSpecBranchName("ACME-123"))).toBe(true);
+    expect(jiraSpecFilePath("ACME-123", "Add Rate Limiting!")).toBe(
+      "docs/specs/jira-ACME-123-add-rate-limiting.md",
+    );
+  });
+
+  it("strips path separators / leading dots so a hostile key can never escape", () => {
+    expect(sanitizeIssueKey("../../etc/passwd")).toBe("etcpasswd");
+    expect(sanitizeIssueKey("-ACME/../x")).toBe("ACMEx");
+    expect(isValidSpecBranch(jiraSpecBranchName("ACME-9"))).toBe(true);
+  });
+
+  it("throws on a key that sanitises to empty", () => {
+    expect(() => jiraSpecBranchName("///")).toThrow();
+  });
+});
+
+describe("buildJql (via pollTickets) — injection-proof", () => {
+  it("embeds sanitised, quoted literals (quotes/controls stripped)", async () => {
+    let seen = "";
+    const { conn } = connector({ project: "ACME", label: 'agent"; DROP' }, (c) => {
+      if (c.url.includes("/search")) {
+        seen = jqlOf(c.url);
+        return json({ issues: [] });
+      }
+      return json({});
+    });
+    await conn.pollTickets();
+    // The injected double-quote is gone → cannot break out of the quoted term.
+    expect(seen).toBe('project = "ACME" AND labels = "agent; DROP" ORDER BY updated ASC');
+    expect(seen).not.toContain('""');
+  });
+
+  it("ANDs a trusted operator extraJql in parens", async () => {
+    let seen = "";
+    const { conn } = connector({ extraJql: "priority = High" }, (c) => {
+      if (c.url.includes("/search")) {
+        seen = jqlOf(c.url);
+        return json({ issues: [] });
+      }
+      return json({});
+    });
+    await conn.pollTickets();
+    expect(seen).toBe('project = "ACME" AND labels = "agent" AND (priority = High) ORDER BY updated ASC');
+  });
+});
+
+describe("pollTickets / readTicket mapping", () => {
+  const ISSUE = {
+    key: "ACME-7",
+    fields: {
+      summary: "Add rate limiting",
+      description: "## Acceptance Criteria\n- returns 429",
+      labels: ["agent", "backend"],
+      updated: "2026-01-02T10:00:00.000+0000",
+    },
+  };
+
+  it("maps a JQL result to normalised tickets (browse url + flattened body)", async () => {
+    const { conn } = connector({}, (c) =>
+      c.url.includes("/search") ? json({ issues: [ISSUE] }) : json({}),
+    );
+    const tickets = await conn.pollTickets();
+    expect(tickets).toHaveLength(1);
+    expect(tickets![0]).toMatchObject({
+      id: "ACME-7",
+      title: "Add rate limiting",
+      body: "## Acceptance Criteria\n- returns 429",
+      labels: ["agent", "backend"],
+      url: "https://acme.atlassian.net/browse/ACME-7",
+    });
+  });
+
+  it("returns null when the search is degraded (HTTP 500)", async () => {
+    const { conn } = connector({}, (c) =>
+      c.url.includes("/search") ? { status: 500, body: "boom" } : json({}),
+    );
+    expect(await conn.pollTickets()).toBeNull();
+  });
+
+  it("returns null when auth is unconfigured (fail-closed)", async () => {
+    const { http } = fakeHttp(() => json({ issues: [ISSUE] }));
+    const conn = new JiraTrackerConnector(CFG, { http, auth: null, log: () => {} });
+    expect(await conn.pollTickets()).toBeNull();
+  });
+
+  it("readTicket fetches one issue by key", async () => {
+    const { conn, calls } = connector({}, (c) =>
+      c.url.includes("/issue/ACME-7") ? json(ISSUE) : json({}),
+    );
+    const t = await conn.readTicket("ACME-7");
+    expect(t?.id).toBe("ACME-7");
+    expect(calls.some((c) => c.method === "GET" && c.url.includes("/rest/api/3/issue/ACME-7"))).toBe(true);
+  });
+});
+
+describe("write-back — comment idempotency + transition", () => {
+  it("posts an ADF comment when the marker is absent", async () => {
+    const { conn, calls } = connector({}, (c) => {
+      if (c.method === "GET" && c.url.includes("/comment")) return json({ comments: [] });
+      if (c.method === "POST" && c.url.includes("/comment")) return { status: 201, body: "{}" };
+      return json({});
+    });
+    const res = await conn.writeback.comment("ACME-7", "picked up", "<!-- marker -->");
+    expect(res.posted).toBe(true);
+    const post = calls.find((c) => c.method === "POST" && c.url.includes("/comment"));
+    expect(post).toBeTruthy();
+    expect(post!.body).toContain("<!-- marker -->");
+    expect(post!.body).toContain("picked up");
+  });
+
+  it("does NOT double-post when a comment already carries the marker", async () => {
+    const existing = { body: textToAdf(["<!-- marker -->", "picked up earlier"]) };
+    const { conn, calls } = connector({}, (c) => {
+      if (c.method === "GET" && c.url.includes("/comment")) return json({ comments: [existing] });
+      return json({});
+    });
+    const res = await conn.writeback.comment("ACME-7", "picked up", "<!-- marker -->");
+    expect(res.posted).toBe(false);
+    expect(calls.some((c) => c.method === "POST")).toBe(false);
+  });
+
+  it("does NOT post when comments are unreadable (safety over liveness)", async () => {
+    const { conn, calls } = connector({}, (c) =>
+      c.method === "GET" && c.url.includes("/comment") ? { status: 503, body: "" } : json({}),
+    );
+    const res = await conn.writeback.comment("ACME-7", "x", "<!-- m -->");
+    expect(res.posted).toBe(false);
+    expect(calls.some((c) => c.method === "POST")).toBe(false);
+  });
+
+  it("resolves a transition by name and POSTs its id; unknown → no-op", async () => {
+    const { conn, calls } = connector({}, (c) => {
+      if (c.method === "GET" && c.url.includes("/transitions")) {
+        return json({ transitions: [{ id: "31", name: "In Progress" }] });
+      }
+      if (c.method === "POST" && c.url.includes("/transitions")) return { status: 204, body: "" };
+      return json({});
+    });
+    const ok = await conn.writeback.transition!("ACME-7", "in progress");
+    expect(ok.posted).toBe(true);
+    const post = calls.find((c) => c.method === "POST" && c.url.includes("/transitions"));
+    expect(post!.body).toContain('"id":"31"');
+
+    const miss = await conn.writeback.transition!("ACME-7", "Done");
+    expect(miss.posted).toBe(false);
+    expect(miss.reason).toBe("no-such-transition");
+  });
+});

--- a/tests/unit/consilium/trackers/jira-issues-poller.test.ts
+++ b/tests/unit/consilium/trackers/jira-issues-poller.test.ts
@@ -1,0 +1,294 @@
+/**
+ * jira-issues-poller.test.ts — TRACK-3 poller with a FAKE Jira transport + FAKE `gh`.
+ *
+ * Covers the rails, mirroring github-issues-poller.test: a JQL-matched issue → the
+ * SHARED synth → a spec PR (contents PUT to a docs/specs/jira-<KEY>-… path whose
+ * frontmatter carries source.kind=jira,ref=<KEY>) + exactly ONE Jira pickup comment +
+ * a watermark intake; a re-poll does NOT re-create or re-comment; an unlabelled issue
+ * is skipped (defence-in-depth); a free-form issue with no criteria (synth empty) gets
+ * a need-criteria comment + NO spec PR + NO intake; the master switch off ⇒ no Jira
+ * calls; the tracker switch off ⇒ start() builds no interval; a Jira outage on search
+ * skips the cycle (watermark untouched).
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  JiraIssuesPoller,
+  type JiraIssuesPollerDeps,
+  type TicketSynthesizer,
+} from "../../../../server/services/consilium/trackers/jira-issues-poller.js";
+import type { JiraHttpFn, JiraHttpResult } from "../../../../server/services/consilium/trackers/jira-exec.js";
+import type { ExecFileFn } from "../../../../server/services/github-status.js";
+import type { TriggerRow } from "../../../../shared/schema.js";
+import type { AppConfig, TrackerEventTriggerConfig } from "../../../../shared/types.js";
+
+// ─── fakes ───────────────────────────────────────────────────────────────────
+
+interface JiraOpts {
+  issues?: unknown[];
+  comments?: Array<{ body?: unknown }>;
+  searchStatus?: number;
+}
+
+/** A fake Jira transport for the search + comment (idempotency read + post) chain. */
+function fakeJira(opts: JiraOpts): { http: JiraHttpFn; calls: Array<{ method: string; url: string; body?: string }> } {
+  const calls: Array<{ method: string; url: string; body?: string }> = [];
+  const http: JiraHttpFn = vi.fn(async (req): Promise<JiraHttpResult> => {
+    calls.push({ method: req.method, url: req.url, body: req.body });
+    const json = (obj: unknown, status = 200): JiraHttpResult => ({ status, body: JSON.stringify(obj) });
+    if (req.url.includes("/rest/api/3/search")) {
+      if (opts.searchStatus && opts.searchStatus >= 400) return { status: opts.searchStatus, body: "err" };
+      return json({ issues: opts.issues ?? [] });
+    }
+    if (req.url.includes("/comment") && req.method === "GET") return json({ comments: opts.comments ?? [] });
+    if (req.url.includes("/comment") && req.method === "POST") return { status: 201, body: "{}" };
+    return json({});
+  });
+  return { http, calls };
+}
+
+/** A fake `gh` that serves the writeSpecPr chain (no issue list — Jira does the watch). */
+function fakeGh(prUrl = "https://github.com/acme/widget/pull/7"): { run: ExecFileFn; argv: string[][] } {
+  const argv: string[][] = [];
+  const run: ExecFileFn = vi.fn(async (_file: string, args: string[]) => {
+    argv.push(args);
+    const json = (obj: unknown) => ({ stdout: JSON.stringify(obj), stderr: "" });
+    if (args[0] === "pr" && args[1] === "list") return json([]);
+    if (args[0] === "repo" && args[1] === "view") return json({ defaultBranchRef: { name: "main" } });
+    if (args[0] === "api") {
+      if (args.indexOf("--method") === -1) return json({ object: { sha: "basesha" } });
+      return { stdout: "", stderr: "" };
+    }
+    if (args[0] === "pr" && args[1] === "create") return { stdout: `${prUrl}\n`, stderr: "" };
+    return { stdout: "", stderr: "" };
+  });
+  return { run, argv };
+}
+
+function jiraTrigger(config?: Partial<TrackerEventTriggerConfig>): TriggerRow {
+  const full: TrackerEventTriggerConfig = {
+    tracker: "jira",
+    baseUrl: "https://acme.atlassian.net",
+    project: "ACME",
+    repo: "acme/widget",
+    targetRepoPath: "/repo/widget",
+    filter: { label: "agent" },
+    specStatus: "ready",
+    ...config,
+  };
+  return {
+    id: "trk-jira-1",
+    projectId: "proj-1",
+    pipelineId: null,
+    type: "tracker_event",
+    config: JSON.parse(JSON.stringify(full)) as TrackerEventTriggerConfig,
+    secretEncrypted: null,
+    enabled: true,
+    lastTriggeredAt: null,
+    suppressedCount: 0,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  } as unknown as TriggerRow;
+}
+
+function cfg(masterOn: boolean, trackerOn = true, pollIntervalSec = 300): () => AppConfig {
+  return () =>
+    ({
+      features: { triggers: { enabled: masterOn, tracker: { enabled: trackerOn, pollIntervalSec } } },
+    }) as unknown as AppConfig;
+}
+
+interface HarnessOpts {
+  trigger: TriggerRow;
+  jira: JiraHttpFn;
+  gh: ExecFileFn;
+  masterOn?: boolean;
+  trackerOn?: boolean;
+  allowedRepoPaths?: () => string[];
+  synthesizer?: TicketSynthesizer;
+  logs?: string[];
+}
+
+function harness(opts: HarnessOpts) {
+  let stored = opts.trigger;
+  const updates: Array<Partial<TriggerRow>> = [];
+  const deps: JiraIssuesPollerDeps = {
+    getEnabledTriggersByType: async () => [stored],
+    runInProject: async (_pid, fn) => fn(),
+    getTrigger: async () => stored,
+    updateTrigger: async (_id, u) => {
+      updates.push(u);
+      if (u.config) stored = { ...stored, config: u.config } as TriggerRow;
+      return stored;
+    },
+    config: cfg(opts.masterOn ?? true, opts.trackerOn ?? true),
+    allowedRepoPaths: opts.allowedRepoPaths ?? (() => ["/repo/widget"]),
+    synthesizer: opts.synthesizer,
+    runGh: opts.gh,
+    jiraHttp: opts.jira,
+    jiraAuth: { email: "a@b.co", token: "secret" },
+    gitRemoteUrl: async () => "https://github.com/acme/widget.git",
+    log: (m) => opts.logs?.push(m),
+    now: () => 0,
+  };
+  return { poller: new JiraIssuesPoller(deps), updates };
+}
+
+const SHAPED_ISSUE = {
+  key: "ACME-1",
+  fields: {
+    summary: "Add rate limiting",
+    description: "## Problem\nNo limit.\n\n## Acceptance Criteria\n- returns 429 over 100 rpm\n- resets after window",
+    labels: ["agent"],
+    updated: "2026-01-02T10:00:00.000+0000",
+  },
+};
+
+const count = (argv: string[][], pred: (a: string[]) => boolean) => argv.filter(pred).length;
+const isPrCreate = (a: string[]) => a[0] === "pr" && a[1] === "create";
+const putContents = (a: string[]) =>
+  a[0] === "api" && a.includes("PUT") && a.some((x) => x.startsWith("repos/acme/widget/contents/"));
+
+function decodePutContent(argv: string[][]): string {
+  const put = argv.find(putContents);
+  if (!put) return "";
+  const arg = put.find((x) => x.startsWith("content="));
+  return arg ? Buffer.from(arg.slice("content=".length), "base64").toString("utf8") : "";
+}
+
+const jiraPosts = (calls: Array<{ method: string; url: string }>, needle: string) =>
+  calls.filter((c) => c.method === "POST" && c.url.includes(needle)).length;
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+describe("JiraIssuesPoller.pollAll", () => {
+  it("JQL-matched issue → spec PR (source.kind=jira,ref=KEY) + ONE Jira pickup comment + intake", async () => {
+    const { http, calls } = fakeJira({ issues: [SHAPED_ISSUE] });
+    const { run, argv } = fakeGh();
+    const { poller, updates } = harness({ trigger: jiraTrigger(), jira: http, gh: run });
+    await poller.pollAll();
+
+    // Spec PR contents PUT to the deterministic jira docs/specs path.
+    const put = argv.find(putContents);
+    expect(put).toBeTruthy();
+    expect(put!.some((x) => x.includes("contents/docs/specs/jira-ACME-1-add-rate-limiting.md"))).toBe(true);
+
+    // The committed spec frontmatter carries JIRA provenance.
+    const spec = decodePutContent(argv);
+    expect(spec).toContain("kind: jira");
+    expect(spec).toContain('ref: "ACME-1"');
+
+    expect(count(argv, isPrCreate)).toBe(1);
+    expect(jiraPosts(calls, "/comment")).toBe(1); // exactly one pickup comment
+
+    const last = updates[updates.length - 1].config as TrackerEventTriggerConfig;
+    expect(last.pollState?.intake?.["ACME-1"]?.specPrUrl).toBe("https://github.com/acme/widget/pull/7");
+  });
+
+  it("re-poll the same issue → NO 2nd PR, NO 2nd Jira comment (watermark dedup)", async () => {
+    const { http, calls } = fakeJira({ issues: [SHAPED_ISSUE] });
+    const { run, argv } = fakeGh();
+    const { poller } = harness({ trigger: jiraTrigger(), jira: http, gh: run });
+    await poller.pollAll();
+    await poller.pollAll();
+    expect(count(argv, isPrCreate)).toBe(1);
+    expect(jiraPosts(calls, "/comment")).toBe(1);
+  });
+
+  it("unlabelled issue → skipped (no spec PR, defence-in-depth)", async () => {
+    const unlabelled = { ...SHAPED_ISSUE, key: "ACME-2", fields: { ...SHAPED_ISSUE.fields, labels: ["other"] } };
+    const { http } = fakeJira({ issues: [unlabelled] });
+    const { run, argv } = fakeGh();
+    const { poller } = harness({ trigger: jiraTrigger(), jira: http, gh: run });
+    await poller.pollAll();
+    expect(count(argv, isPrCreate)).toBe(0);
+  });
+
+  it("free-form issue + synthesiser empty → need-criteria comment, NO spec PR, NO intake", async () => {
+    const freeForm = {
+      key: "ACME-3",
+      fields: { summary: "vague", description: "please make it better", labels: ["agent"] },
+    };
+    const synthesizer: TicketSynthesizer = { synthesize: async () => ({ criteria: [] }) };
+    const { http, calls } = fakeJira({ issues: [freeForm] });
+    const { run, argv } = fakeGh();
+    const { poller, updates } = harness({ trigger: jiraTrigger(), jira: http, gh: run, synthesizer });
+    await poller.pollAll();
+
+    expect(jiraPosts(calls, "/comment")).toBe(1); // the ask-for-criteria comment
+    expect(count(argv, isPrCreate)).toBe(0);
+    const last = updates[updates.length - 1].config as TrackerEventTriggerConfig;
+    expect(last.pollState?.intake?.["ACME-3"]).toBeUndefined();
+  });
+
+  it("no filter.label configured → skipped (no Jira search at all)", async () => {
+    const { http, calls } = fakeJira({ issues: [SHAPED_ISSUE] });
+    const { run } = fakeGh();
+    const { poller, updates } = harness({ trigger: jiraTrigger({ filter: {} }), jira: http, gh: run });
+    await poller.pollAll();
+    expect(calls.length).toBe(0);
+    expect(updates.length).toBe(0);
+  });
+
+  it("master switch off → no Jira calls at all", async () => {
+    const { http, calls } = fakeJira({ issues: [SHAPED_ISSUE] });
+    const { run } = fakeGh();
+    const { poller } = harness({ trigger: jiraTrigger(), jira: http, gh: run, masterOn: false });
+    await poller.pollAll();
+    expect(calls.length).toBe(0);
+  });
+
+  it("Jira outage on search → skip cycle, watermark untouched, no crash", async () => {
+    const { http } = fakeJira({ searchStatus: 500 });
+    const { run } = fakeGh();
+    const { poller, updates } = harness({ trigger: jiraTrigger(), jira: http, gh: run });
+    await expect(poller.pollAll()).resolves.toBeUndefined();
+    expect(updates.length).toBe(0);
+  });
+
+  it("targetRepoPath NOT in the allowlist → skipped fail-closed (no Jira, no gh)", async () => {
+    const { http, calls } = fakeJira({ issues: [SHAPED_ISSUE] });
+    const { run, argv } = fakeGh();
+    const { poller } = harness({
+      trigger: jiraTrigger(),
+      jira: http,
+      gh: run,
+      allowedRepoPaths: () => ["/some/other/repo"],
+    });
+    await poller.pollAll();
+    expect(calls.length).toBe(0);
+    expect(argv.length).toBe(0);
+  });
+});
+
+describe("JiraIssuesPoller.start gating", () => {
+  it("tracker disabled → start() builds no interval", () => {
+    vi.useFakeTimers();
+    try {
+      const { http } = fakeJira({ issues: [SHAPED_ISSUE] });
+      const { run } = fakeGh();
+      const logs: string[] = [];
+      const { poller } = harness({ trigger: jiraTrigger(), jira: http, gh: run, trackerOn: false, logs });
+      poller.start();
+      vi.advanceTimersByTime(10 * 60 * 1000);
+      expect(logs.some((l) => l.includes("disabled"))).toBe(true);
+      poller.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("tracker enabled → start() logs a started poller", () => {
+    vi.useFakeTimers();
+    try {
+      const { http } = fakeJira({ issues: [] });
+      const { run } = fakeGh();
+      const logs: string[] = [];
+      const { poller } = harness({ trigger: jiraTrigger(), jira: http, gh: run, trackerOn: true, logs });
+      poller.start();
+      expect(logs.some((l) => l.includes("jira tracker poller started"))).toBe(true);
+      poller.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
Implements **TRACK-3** from `docs/design/task-tracker-triggers.md` (v2): a **Jira connector** — and, since it's the second tracker after GitHub, **generalises the tracker-connector interface** so TRACK-4/5 (GitLab / Bitbucket / Linear / Azure DevOps / ClickUp) are drop-in.

A Jira ticket → a **committed spec PR** (in the target git repo — Jira has no git) + a **Jira pickup write-back**. Like TRACK-1, it hands off to SPEC-1's spec-watch on merge; it **does not fire loops**.

## The `TrackerConnector` interface (so TRACK-4/5 drop in)
`server/services/consilium/trackers/tracker-connector.ts` — the uniform §2 surface every tracker reduces to:

```ts
interface TrackerConnector {
  readonly kind: string;                                   // spec source.kind
  pollTickets(sinceWatermark?): Promise<Ticket[] | null>;  // WATCH (null = degraded → skip cycle)
  readTicket(id): Promise<Ticket | null>;                  // READ
  readonly writeback: {                                    // WRITE-BACK dialect
    comment(id, body, marker): Promise<WritebackResult>;   // idempotent (marker-keyed)
    transition?(id, state): Promise<WritebackResult>;
    link?(id, url, title?): Promise<WritebackResult>;
  };
  specBranchName(id): string;                              // deterministic dedup branch
  specFilePath(id, title): string;                         // docs/specs/<kind>-<id>-<slug>.md
}
```

## Shared vs per-connector
**Shared (one impl, all connectors):**
- `issue-spec.ts` — `renderSpecMarkdown({ source: {kind,ref,url}, … })` (extracted from the old GitHub-only `buildSpecMarkdown`, now a byte-identical wrapper) + the extract/synth (`extractSpecFromIssue` / `buildSynthPrompt` / `parseSynthOutput`).
- `spec-writer.ts` — the remote `gh`-api spec PR (working tree never touched). `SPEC_BRANCH_RE` widened to also accept `spec/jira-<KEY>`.
- `spec-intake.ts` — **`crystallizeTicket()`**: the single crystallise tail (render → spec PR → pickup / need-criteria), shared by both pollers, so dedup + provenance + spec-PR machinery lives in one place.

**Per-connector (dialect only):**
| | watch | read | write-back | naming |
|---|---|---|---|---|
| GitHub | `gh issue list` | inline | `gh issue comment` | `spec/gh-issue-<n>` |
| Jira | JQL `search?jql=…` | `/issue/{key}` | `/issue/{key}/comment` + transition | `spec/jira-<KEY>` |

## Jira connector
- **watch** — `JiraTrackerConnector.pollTickets()` runs a server-built JQL (`project = "X" AND labels = "Y" [AND (extraJql)] ORDER BY updated ASC`) through the sanitized `jira-exec.ts` REST seam (the Jira analogue of `gh-exec.ts`: never-throws → degrade, no secret logging, `https`-only + origin-checked URLs, fail-closed auth). ADF descriptions are flattened to text.
- **read** — `/rest/api/3/issue/{key}`.
- **ticket → spec** — reuses the shared synth (`Jira description → Problem/Scope/acceptanceCriteria`, untrusted text fenced) with `source: { kind: jira, ref: <KEY>, url }`. The spec lands in the **target git repo's** `docs/specs/` and the PR opens there via `gh` (exactly like GitHub-issues when the spec repo ≠ the tracker).
- **write-back** — `/issue/{key}/comment` pickup ("picked up → spec at `<PR>`") + optional transition, idempotent via a hidden marker in the ADF comment body.
- **auth** — `JIRA_EMAIL` / `JIRA_API_TOKEN` (basic email:token) from env, read at call time, fail-closed.

## Config + kill-switch
- `tracker_event` widened to `tracker: "github" | "jira"` **additively** (github fields unchanged; jira fields optional) in `shared/types.ts`; zod validation is now a `z.discriminatedUnion("tracker", …)` in `routes/triggers.ts`. Jira variant: `{ tracker:"jira", baseUrl, project, jql?, transitionTo?, repo, targetRepoPath, filter:{label}, specStatus }`.
- The existing `features.triggers.tracker.enabled` gates the Jira poller too — **default OFF ⇒ byte-identical**, not constructed. Also folded under the master `features.triggers.enabled`.

## GitHub stays byte-identical
The GitHub path was refactored onto the shared `crystallizeTicket()` (same `gh` calls, same order, same rendered bytes). **All 58 pre-existing tracker tests pass unchanged**, and the full suite is green (6191 passed / 5 skipped / 0 failed). `tsc --noEmit` clean.

## Tests (mock the Jira REST seam + `gh`)
- JQL-matched issue → shared synth → spec PR with `source:{kind:jira,ref:KEY}` + one Jira pickup comment + watermark intake.
- Re-poll the same issue → **no 2nd PR / comment** (watermark + deterministic branch + comment marker).
- Unlabelled/unmatched → skipped (defence-in-depth label re-check).
- Free-form, no criteria → ask-for-criteria comment, **no PR**, **no intake**.
- Kill-switch off / master off → no Jira calls; Jira outage on search → skip cycle, watermark untouched, no crash; targetRepoPath outside the allowlist → fail-closed.
- Connector units: ADF flatten, injection-proof JQL (quotes/controls stripped), comment idempotency, transition name→id, `spec/jira-<KEY>` naming.

## Adversarial self-review
- **Interface extraction changing GitHub** → tests assert byte-identical (argv + rendered spec + logs).
- **Secrets** → `jira-exec` never logs the token; errors surface only status + a scrubbed, header-free message; auth fail-closed.
- **Prompt/filename injection** → untrusted Jira text is fenced before the synth prompt and slug/clamped before any filename; key sanitised to `[A-Za-z0-9_-]` (no `..`, no separator, no leading dash).
- **2nd spec PR on edit** → dedup via intake watermark (Jira key) + deterministic branch + `gh pr list` + comment marker.
- **JQL injection via config** → `jqlLiteral` drops quotes/backslashes/control chars; project sanitised; values embedded as quoted literals; `extraJql` is trusted config in parens.
- **Wrong-repo spec PR** → the PR target is derived from the **allowlisted** `targetRepoPath`'s git origin (allowlist re-checked here and by SPEC-1 on merge).

**Do not merge** — Draft for review.
