### PR TITLE
feat: TRACK-4 — GitLab + Bitbucket connectors

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -42,6 +42,8 @@ import { FileWatcherService } from "./services/file-watcher";
 import { GitHubPoller } from "./services/github-poller";
 import { GithubIssuesPoller } from "./services/consilium/trackers/github-issues-poller";
 import { JiraIssuesPoller } from "./services/consilium/trackers/jira-issues-poller";
+import { GitlabIssuesPoller } from "./services/consilium/trackers/gitlab-issues-poller";
+import { BitbucketIssuesPoller } from "./services/consilium/trackers/bitbucket-issues-poller";
 import { TrackerWritebackObserver } from "./services/consilium/trackers/writeback-observer";
 import { ExperienceDistillerObserver } from "./services/consilium/experience/experience-distiller-observer";
 import { buildSynthPrompt, parseSynthOutput } from "./services/consilium/trackers/issue-spec";
@@ -421,6 +423,8 @@ export async function registerRoutes(
   let githubPoller: GitHubPoller | null = null;
   let githubIssuesPoller: GithubIssuesPoller | null = null;
   let jiraIssuesPoller: JiraIssuesPoller | null = null;
+  let gitlabIssuesPoller: GitlabIssuesPoller | null = null;
+  let bitbucketIssuesPoller: BitbucketIssuesPoller | null = null;
   let trackerWritebackObserver: TrackerWritebackObserver | null = null;
 
   try {
@@ -671,6 +675,92 @@ export async function registerRoutes(
         log: (m: string) => log(m, "jira-tracker-poller"),
       });
       jiraIssuesPoller.start();
+
+      // TRACK-4 (gitlab -> committed spec PR). The GitLab analogue of the jira poller: a
+      // REST poll of a GitLab project's labelled issues, each crystallised into a
+      // committed-spec PR (in the TARGET git repo — the spec PR still opens via `gh`) + a
+      // GitLab pickup note. Shares the SAME kill-switch (features.triggers.tracker.enabled)
+      // and the SAME crystallise pipeline (spec-intake) as github/jira; only the GitLab
+      // dialect differs. The GitLab PAT is read from GITLAB_TOKEN at call time (fail-closed).
+      // A gitlab-tracker trigger is a no-op here until its `tracker: "gitlab"` config exists.
+      gitlabIssuesPoller = new GitlabIssuesPoller({
+        getEnabledTriggersByType: (type) =>
+          runAsSystem("gitlab-tracker-poller-bootstrap", () => storage.getAllEnabledTriggersByType(type)),
+        runInProject: runAsProject,
+        getTrigger: (id) => storage.getTrigger(id),
+        updateTrigger: (id, updates) => storage.updateTrigger(id, updates),
+        config: () => appConfigLoader.get(),
+        allowedRepoPaths: () => appConfigLoader.get().pipeline.consiliumLoop.allowedRepoPaths,
+        synthesizer: {
+          synthesize: async (ticket) => {
+            try {
+              const { system, user } = buildSynthPrompt({ number: 0, title: ticket.title, body: ticket.body });
+              const res = await gateway.completeStreaming(
+                {
+                  modelSlug: DEFAULT_TASK_MODEL,
+                  messages: [
+                    { role: "system", content: system },
+                    { role: "user", content: user },
+                  ],
+                  temperature: 0.2,
+                  maxTokens: 2048,
+                },
+                undefined,
+                undefined,
+                { overallTimeoutMs: 60_000 },
+              );
+              return parseSynthOutput(res.content);
+            } catch {
+              return { criteria: [] };
+            }
+          },
+        },
+        log: (m: string) => log(m, "gitlab-tracker-poller"),
+      });
+      gitlabIssuesPoller.start();
+
+      // TRACK-4 (bitbucket -> committed spec PR). The Bitbucket Cloud analogue: a BBQL
+      // poll of a repo's issue tracker (the consent `filter.label` matches the issue
+      // COMPONENT), each crystallised into a committed-spec PR + a Bitbucket pickup
+      // comment. Same kill-switch + crystallise pipeline as github/jira/gitlab; only the
+      // Bitbucket dialect differs. The app password is read from BITBUCKET_USERNAME/
+      // BITBUCKET_APP_PASSWORD at call time (fail-closed). A no-op until a
+      // `tracker: "bitbucket"` config exists.
+      bitbucketIssuesPoller = new BitbucketIssuesPoller({
+        getEnabledTriggersByType: (type) =>
+          runAsSystem("bitbucket-tracker-poller-bootstrap", () => storage.getAllEnabledTriggersByType(type)),
+        runInProject: runAsProject,
+        getTrigger: (id) => storage.getTrigger(id),
+        updateTrigger: (id, updates) => storage.updateTrigger(id, updates),
+        config: () => appConfigLoader.get(),
+        allowedRepoPaths: () => appConfigLoader.get().pipeline.consiliumLoop.allowedRepoPaths,
+        synthesizer: {
+          synthesize: async (ticket) => {
+            try {
+              const { system, user } = buildSynthPrompt({ number: 0, title: ticket.title, body: ticket.body });
+              const res = await gateway.completeStreaming(
+                {
+                  modelSlug: DEFAULT_TASK_MODEL,
+                  messages: [
+                    { role: "system", content: system },
+                    { role: "user", content: user },
+                  ],
+                  temperature: 0.2,
+                  maxTokens: 2048,
+                },
+                undefined,
+                undefined,
+                { overallTimeoutMs: 60_000 },
+              );
+              return parseSynthOutput(res.content);
+            } catch {
+              return { criteria: [] };
+            }
+          },
+        },
+        log: (m: string) => log(m, "bitbucket-tracker-poller"),
+      });
+      bitbucketIssuesPoller.start();
     }
 
     // TRACK-2 (full write-back lifecycle). When the write-back sub-switch is on (and
@@ -773,6 +863,8 @@ export async function registerRoutes(
     githubPoller?.stop();
     githubIssuesPoller?.stop();
     jiraIssuesPoller?.stop();
+    gitlabIssuesPoller?.stop();
+    bitbucketIssuesPoller?.stop();
     trackerWritebackObserver?.stop();
     getRefreshScheduler()?.stop();
     stopRateLimitCleanup();

--- a/server/services/consilium/trackers/bitbucket-connector.ts
+++ b/server/services/consilium/trackers/bitbucket-connector.ts
@@ -1,0 +1,264 @@
+/**
+ * bitbucket-connector.ts — TRACK-4: the Bitbucket Cloud Issues implementation of
+ * `TrackerConnector`. PURELY the Bitbucket DIALECT (watch = `/issues?q=…` BBQL poll,
+ * read = `/issues/:id`, write-back = `/issues/:id/comments` + an optional state change,
+ * naming = `spec/bitbucket-<id>`); the synth, the spec-PR, the provenance, and the
+ * crystallise/dedup machinery are the SHARED modules. Nothing shared changes.
+ *
+ * LABELS: Bitbucket issues have NO free-form labels; their nearest equivalent is the
+ * `component`. So the connector maps the consent "label" to the issue COMPONENT: the
+ * watch filters `component = "<label>"` and the normalised `Ticket.labels` is built from
+ * the issue's facets (kind + component + priority) so the poller's defence-in-depth
+ * `labels.includes(label)` re-check works uniformly across trackers.
+ *
+ * SECURITY
+ *   - The workspace + repo slug are sanitised to `[A-Za-z0-9._-]` then URL-encoded, so
+ *     nothing can escape the `repositories/<ws>/<repo>/…` prefix.
+ *   - The BBQL `q` is SERVER-BUILT from a SANITISED, QUOTED component literal
+ *     (quotes/backslashes/controls dropped) so a config value can never break out of the
+ *     quoted term (BBQL-injection defence). The watermark is ISO-guarded before it is
+ *     embedded. UNTRUSTED ticket title/content stays untrusted (fenced by the synth,
+ *     quoted by the renderer).
+ *   - Every read/write goes through the fail-closed, never-logging `bitbucket-exec` seam.
+ *   - `specBranchName`/`specFilePath` derive from the numeric `id` only.
+ */
+import { slugify } from "./issue-spec.js";
+import type { Ticket, TrackerConnector, TrackerWriteback, WritebackResult } from "./tracker-connector.js";
+import { BITBUCKET_DEFAULT_BASE_URL, bitbucketGetJson, bitbucketSendJson, type BitbucketExecDeps } from "./bitbucket-exec.js";
+
+/** Sanitise a Bitbucket workspace / repo slug for the URL: keep `[A-Za-z0-9._-]`. */
+export function sanitizeSlug(slug: string): string {
+  return slug.replace(/[^A-Za-z0-9._-]/g, "").slice(0, 100);
+}
+
+/** Sanitise a Bitbucket issue id to DIGITS ONLY (issue ids are positive integers). */
+export function sanitizeIssueId(id: string): string {
+  return String(id).replace(/[^0-9]/g, "").slice(0, 18);
+}
+
+/**
+ * Sanitise a BBQL string literal value: DROP quotes/backslashes (so it cannot break out
+ * of the quoted term — BBQL-injection defence) and any C0/DEL control char, collapse
+ * whitespace, clamp.
+ */
+export function bbqlLiteral(value: string, max = 200): string {
+  let out = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0;
+    if (code < 0x20 || code === 0x7f) continue; // C0 / DEL control chars.
+    if (ch === '"' || ch === "\\") continue; // quote-term breakout chars.
+    out += ch;
+  }
+  return out.replace(/\s+/g, " ").trim().slice(0, max);
+}
+
+/** The Bitbucket spec dedup branch: `spec/bitbucket-<id>` (matches SPEC_BRANCH_RE). */
+export function bitbucketSpecBranchName(id: string): string {
+  const safe = sanitizeIssueId(id);
+  if (safe.length === 0) throw new Error(`bitbucket-connector: invalid issue id ${JSON.stringify(id)}`);
+  return `spec/bitbucket-${safe}`;
+}
+
+/** The committed spec path: `docs/specs/bitbucket-<id>-<slug>.md`. */
+export function bitbucketSpecFilePath(id: string, title: string): string {
+  const safe = sanitizeIssueId(id);
+  if (safe.length === 0) throw new Error(`bitbucket-connector: invalid issue id ${JSON.stringify(id)}`);
+  return `docs/specs/bitbucket-${safe}-${slugify(title)}.md`;
+}
+
+// ─── Bitbucket REST shapes (only the fields we request) ───────────────────────
+
+interface BitbucketNamed {
+  name?: string;
+}
+interface BitbucketIssue {
+  id?: number;
+  title?: string;
+  content?: { raw?: string } | null;
+  state?: string;
+  kind?: string;
+  priority?: string;
+  component?: BitbucketNamed | null;
+  updated_on?: string;
+  links?: { html?: { href?: string } };
+}
+interface BitbucketPage<T> {
+  values?: T[];
+}
+interface BitbucketComment {
+  content?: { raw?: string } | null;
+}
+
+export interface BitbucketConnectorConfig {
+  /** API base URL — defaults to `https://api.bitbucket.org` (validated https). */
+  baseUrl?: string;
+  /** The Bitbucket workspace (id/slug). */
+  workspace: string;
+  /** The repository slug hosting the issue tracker. */
+  repoSlug: string;
+  /** The consent "label" — mapped to the issue COMPONENT (§ LABELS above). REQUIRED. */
+  label: string;
+  /** Optional state to move the ticket to on pickup (e.g. `open`); best-effort. */
+  stateOnPickup?: string;
+}
+
+/** Facet-derived labels so the uniform `labels.includes(<component>)` gate works. */
+function facetLabels(issue: BitbucketIssue): string[] {
+  const out: string[] = [];
+  const push = (v: unknown): void => {
+    if (typeof v === "string" && v.trim().length > 0) out.push(v);
+  };
+  push(issue.component?.name);
+  push(issue.kind);
+  push(issue.priority);
+  return out;
+}
+
+/** Map a Bitbucket REST issue → the normalised `Ticket`. */
+function toTicket(issue: BitbucketIssue): Ticket | null {
+  const id = typeof issue.id === "number" && Number.isInteger(issue.id) ? String(issue.id) : "";
+  if (id.length === 0) return null;
+  return {
+    id,
+    title: typeof issue.title === "string" ? issue.title : "",
+    body: typeof issue.content?.raw === "string" ? issue.content.raw : "",
+    labels: facetLabels(issue),
+    updatedAt: typeof issue.updated_on === "string" ? issue.updated_on : undefined,
+    url: typeof issue.links?.html?.href === "string" ? issue.links.html.href : undefined,
+  };
+}
+
+/** A conservative ISO-8601-ish guard so a watermark can be safely echoed into BBQL. */
+function isIsoish(value: string | undefined): value is string {
+  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}T[\d:.]+(Z|[+-]\d{2}:?\d{2})?$/.test(value);
+}
+
+export class BitbucketTrackerConnector implements TrackerConnector {
+  readonly kind = "bitbucket";
+  readonly writeback: TrackerWriteback;
+  private readonly cfg: BitbucketConnectorConfig;
+  private readonly exec: BitbucketExecDeps;
+  private readonly baseUrl: string;
+  private readonly workspace: string;
+  private readonly repoSlug: string;
+
+  constructor(cfg: BitbucketConnectorConfig, exec: BitbucketExecDeps) {
+    this.cfg = cfg;
+    this.exec = exec;
+    this.baseUrl = (cfg.baseUrl ?? BITBUCKET_DEFAULT_BASE_URL).replace(/\/+$/, "");
+    this.workspace = sanitizeSlug(cfg.workspace);
+    this.repoSlug = sanitizeSlug(cfg.repoSlug);
+    this.writeback = {
+      comment: (ticketId, body, marker) => this.postComment(ticketId, body, marker),
+      transition: (ticketId, state) => this.setState(ticketId, state),
+    };
+  }
+
+  /** URL-encoded `2.0/repositories/<ws>/<repo>` prefix (both slugs pre-sanitised). */
+  private repoPath(): string {
+    return `2.0/repositories/${encodeURIComponent(this.workspace)}/${encodeURIComponent(this.repoSlug)}`;
+  }
+
+  /** Build the server-side BBQL: quoted component + ISO watermark + active states. */
+  private buildQuery(sinceWatermark?: string): string {
+    const terms = [`component = "${bbqlLiteral(this.cfg.label)}"`, `(state = "new" OR state = "open")`];
+    if (isIsoish(sinceWatermark)) terms.push(`updated_on > "${sinceWatermark}"`);
+    return terms.join(" AND ");
+  }
+
+  /**
+   * WATCH: BBQL-search the repo's issue tracker for component-matched, active issues.
+   * Returns normalised tickets or `null` on any degrade so the poller skips the cycle.
+   */
+  async pollTickets(sinceWatermark?: string): Promise<Ticket[] | null> {
+    if (this.workspace.length === 0 || this.repoSlug.length === 0) return null;
+    const page = await bitbucketGetJson<BitbucketPage<BitbucketIssue>>(
+      this.exec,
+      this.baseUrl,
+      `${this.repoPath()}/issues`,
+      { q: this.buildQuery(sinceWatermark), sort: "updated_on", pagelen: "50" },
+    );
+    if (!page || !Array.isArray(page.values)) return null;
+    const tickets: Ticket[] = [];
+    for (const issue of page.values) {
+      const t = toTicket(issue);
+      if (t) tickets.push(t);
+    }
+    return tickets;
+  }
+
+  /** READ: fetch one issue by id. `null` ⇒ not found / degraded. */
+  async readTicket(ticketId: string): Promise<Ticket | null> {
+    const id = sanitizeIssueId(ticketId);
+    if (id.length === 0) return null;
+    const issue = await bitbucketGetJson<BitbucketIssue>(
+      this.exec,
+      this.baseUrl,
+      `${this.repoPath()}/issues/${id}`,
+    );
+    if (!issue) return null;
+    return toTicket({ ...issue, id: issue.id ?? Number(id) });
+  }
+
+  specBranchName(ticketId: string): string {
+    return bitbucketSpecBranchName(ticketId);
+  }
+
+  specFilePath(ticketId: string, title: string): string {
+    return bitbucketSpecFilePath(ticketId, title);
+  }
+
+  // ─── write-back ─────────────────────────────────────────────────────────────
+
+  /**
+   * Post a COMMENT idempotently: read existing comments, skip if any already carries
+   * `marker`, else POST `{ content: { raw: "marker\n body" } }`. Best-effort — a degrade
+   * returns `{ posted: false }`, never throws. When comments cannot be read (degrade) we
+   * do NOT post (safety over liveness).
+   */
+  private async postComment(ticketId: string, body: string, marker: string): Promise<WritebackResult> {
+    const id = sanitizeIssueId(ticketId);
+    if (id.length === 0) return { posted: false, reason: "bad-id" };
+    const existing = await bitbucketGetJson<BitbucketPage<BitbucketComment>>(
+      this.exec,
+      this.baseUrl,
+      `${this.repoPath()}/issues/${id}/comments`,
+      { pagelen: "100" },
+    );
+    if (!existing || !Array.isArray(existing.values)) return { posted: false, reason: "comments-unreadable" };
+    const already = existing.values.some(
+      (c) => typeof c.content?.raw === "string" && c.content.raw.includes(marker),
+    );
+    if (already) return { posted: false, reason: "already-commented" };
+
+    const res = await bitbucketSendJson(
+      this.exec,
+      "POST",
+      this.baseUrl,
+      `${this.repoPath()}/issues/${id}/comments`,
+      { content: { raw: `${marker}\n${body}` } },
+    );
+    return res.ok ? { posted: true } : { posted: false, reason: res.reason };
+  }
+
+  /**
+   * Move the ticket to `state` (Bitbucket's pickup "transition"), best-effort. Only a
+   * known Bitbucket issue state is sent; anything else is a no-op (never an arbitrary
+   * PUT of attacker-shaped state).
+   */
+  private async setState(ticketId: string, state: string): Promise<WritebackResult> {
+    const id = sanitizeIssueId(ticketId);
+    if (id.length === 0) return { posted: false, reason: "bad-id" };
+    const wanted = (state ?? "").trim().toLowerCase();
+    const ALLOWED = new Set(["new", "open", "resolved", "on hold", "invalid", "duplicate", "wontfix", "closed"]);
+    if (!ALLOWED.has(wanted)) return { posted: false, reason: "no-such-state" };
+    const res = await bitbucketSendJson(
+      this.exec,
+      "PUT",
+      this.baseUrl,
+      `${this.repoPath()}/issues/${id}`,
+      { state: wanted },
+    );
+    return res.ok ? { posted: true } : { posted: false, reason: res.reason };
+  }
+}

--- a/server/services/consilium/trackers/bitbucket-exec.ts
+++ b/server/services/consilium/trackers/bitbucket-exec.ts
@@ -1,0 +1,231 @@
+/**
+ * bitbucket-exec.ts — the sanitized Bitbucket Cloud REST seam for TRACK-4 (the
+ * Bitbucket analogue of `jira-exec.ts`). Same safety posture as the Jira / GitLab seams:
+ *   - NEVER throws: a network error / non-2xx / timeout degrades to `null` (reads) or
+ *     `{ ok: false }` (writes) so a Bitbucket outage can never crash the poll loop.
+ *   - The app password is NEVER logged: on failure only the HTTP status + a scrubbed,
+ *     header-free message leaves this module; the `Authorization` header is never
+ *     surfaced.
+ *   - Fail-closed auth: the username + app password come from ENV (a secret manager),
+ *     read at call time. Either absent ⇒ the request is not even attempted.
+ *   - SSRF containment: the request URL is built from the `baseUrl`
+ *     (`https://api.bitbucket.org` by default) and a SERVER-DERIVED path, then re-checked
+ *     to share `baseUrl`'s origin — a crafted path can never redirect the token.
+ *
+ * SCOPE: Bitbucket CLOUD only (`api.bitbucket.org/2.0`). Bitbucket Server / Data Center
+ * has a different API surface and is out of scope for TRACK-4.
+ *
+ * The HTTP call is injectable (`BitbucketHttpFn`) so tests drive it with a fake — no
+ * real network.
+ */
+
+/** The username + app-password env var names (a secret manager sets these). Never logged. */
+export const BITBUCKET_USERNAME_ENV = "BITBUCKET_USERNAME";
+export const BITBUCKET_APP_PASSWORD_ENV = "BITBUCKET_APP_PASSWORD";
+
+/** The default Bitbucket Cloud API origin (no trailing slash). */
+export const BITBUCKET_DEFAULT_BASE_URL = "https://api.bitbucket.org";
+
+/** Default per-call wall-clock budget for a Bitbucket request. */
+const BITBUCKET_TIMEOUT_MS = 30_000;
+
+/** A minimal, injectable HTTP result (status + raw body text). */
+export interface BitbucketHttpResult {
+  status: number;
+  body: string;
+}
+
+/** Injectable HTTP transport (tests pass a fake; prod uses `fetch`). NEVER throws-through. */
+export type BitbucketHttpFn = (req: {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: string;
+  timeoutMs: number;
+}) => Promise<BitbucketHttpResult>;
+
+/** Resolved auth material (basic username:app_password). `null` ⇒ fail-closed. */
+export interface BitbucketAuth {
+  username: string;
+  appPassword: string;
+}
+
+/**
+ * Read the Bitbucket auth from ENV (fail-closed). Returns `null` when either var is
+ * absent or blank so the caller degrades WITHOUT attempting an unauthenticated call.
+ * The password is returned but NEVER logged by this module.
+ */
+export function readBitbucketAuthFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): BitbucketAuth | null {
+  const username = (env[BITBUCKET_USERNAME_ENV] ?? "").trim();
+  const appPassword = (env[BITBUCKET_APP_PASSWORD_ENV] ?? "").trim();
+  if (username.length === 0 || appPassword.length === 0) return null;
+  return { username, appPassword };
+}
+
+/** Scrub any absolute path + collapse whitespace from an error string, then clamp. */
+function scrub(raw: string): string {
+  return raw.replace(/\/[^\s'"]+/g, "<path>").replace(/\s+/g, " ").trim().slice(0, 300);
+}
+
+/** Default transport over global `fetch` with an AbortController timeout. Never throws-through. */
+const defaultHttp: BitbucketHttpFn = async (req) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), req.timeoutMs);
+  try {
+    const res = await fetch(req.url, {
+      method: req.method,
+      headers: req.headers,
+      body: req.body,
+      signal: controller.signal,
+    });
+    const body = await res.text().catch(() => "");
+    return { status: res.status, body };
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/** Build the `Authorization: Basic <base64(user:app_password)>` header value. */
+function basicAuthHeader(auth: BitbucketAuth): string {
+  return "Basic " + Buffer.from(`${auth.username}:${auth.appPassword}`, "utf8").toString("base64");
+}
+
+/**
+ * Normalise `baseUrl` to an `https://host` origin. Returns `null` for anything that is
+ * not a well-formed `https:` URL (fail-closed — no `http:`, no SSRF-friendly schemes).
+ */
+export function normalizeBaseUrl(baseUrl: string): { origin: string; base: string } | null {
+  try {
+    const u = new URL(baseUrl);
+    if (u.protocol !== "https:") return null;
+    const base = `${u.origin}${u.pathname.replace(/\/+$/, "")}`;
+    return { origin: u.origin, base };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build + validate the absolute request URL for a SERVER-DERIVED api path + optional
+ * query. Returns `null` if the resulting URL would leave `baseUrl`'s origin (SSRF
+ * containment) — a crafted `path` can never redirect the token elsewhere.
+ */
+function buildUrl(
+  baseUrl: string,
+  path: string,
+  query?: Record<string, string>,
+): string | null {
+  const norm = normalizeBaseUrl(baseUrl);
+  if (!norm) return null;
+  const cleanPath = path.replace(/^\/+/, "");
+  if (/^[a-z][a-z0-9+.-]*:/i.test(cleanPath) || cleanPath.startsWith("/")) return null;
+  const url = new URL(`${norm.base}/${cleanPath}`);
+  if (url.origin !== norm.origin) return null; // origin escape ⇒ fail-closed.
+  if (query) {
+    for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
+  }
+  return url.toString();
+}
+
+export interface BitbucketExecDeps {
+  http?: BitbucketHttpFn;
+  auth?: BitbucketAuth | null;
+  log: (message: string) => void;
+}
+
+/** Log a URL without its query string (a BBQL `q` may echo the label; keep it terse). */
+function scrubUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    return `${u.origin}${u.pathname}`;
+  } catch {
+    return "<url>";
+  }
+}
+
+/**
+ * GET a Bitbucket REST resource and parse JSON. Returns `null` on ANY degrade
+ * (unconfigured auth, non-2xx, network error, bad JSON, origin escape). Token unlogged.
+ */
+export async function bitbucketGetJson<T>(
+  deps: BitbucketExecDeps,
+  baseUrl: string,
+  path: string,
+  query?: Record<string, string>,
+): Promise<T | null> {
+  const auth = deps.auth ?? readBitbucketAuthFromEnv();
+  if (!auth) {
+    deps.log("bitbucket-exec: no BITBUCKET_USERNAME/BITBUCKET_APP_PASSWORD configured — skipping (fail-closed)");
+    return null;
+  }
+  const url = buildUrl(baseUrl, path, query);
+  if (!url) {
+    deps.log("bitbucket-exec: rejected request URL (bad baseUrl / origin escape)");
+    return null;
+  }
+  const http = deps.http ?? defaultHttp;
+  try {
+    const res = await http({
+      method: "GET",
+      url,
+      headers: { Authorization: basicAuthHeader(auth), Accept: "application/json" },
+      timeoutMs: BITBUCKET_TIMEOUT_MS,
+    });
+    if (res.status < 200 || res.status >= 300) {
+      deps.log(`bitbucket-exec: GET ${scrubUrl(url)} → HTTP ${res.status} (degraded)`);
+      return null;
+    }
+    return JSON.parse(res.body) as T;
+  } catch (err) {
+    deps.log(`bitbucket-exec: GET failed: ${scrub((err as Error)?.message ?? String(err))}`);
+    return null;
+  }
+}
+
+/**
+ * Send a JSON body to a Bitbucket REST resource (`POST` a comment, `PUT` a state).
+ * Returns a typed `{ ok }` — never throws. On failure only the HTTP status + a scrubbed
+ * message leave this module (the app password / Authorization header never do).
+ */
+export async function bitbucketSendJson(
+  deps: BitbucketExecDeps,
+  method: "POST" | "PUT",
+  baseUrl: string,
+  path: string,
+  body: unknown,
+): Promise<{ ok: true; body: string } | { ok: false; status?: number; reason: string }> {
+  const auth = deps.auth ?? readBitbucketAuthFromEnv();
+  if (!auth) {
+    deps.log("bitbucket-exec: no BITBUCKET_USERNAME/BITBUCKET_APP_PASSWORD configured — skipping (fail-closed)");
+    return { ok: false, reason: "no-auth" };
+  }
+  const url = buildUrl(baseUrl, path);
+  if (!url) {
+    deps.log("bitbucket-exec: rejected request URL (bad baseUrl / origin escape)");
+    return { ok: false, reason: "bad-url" };
+  }
+  const http = deps.http ?? defaultHttp;
+  try {
+    const res = await http({
+      method,
+      url,
+      headers: {
+        Authorization: basicAuthHeader(auth),
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body ?? {}),
+      timeoutMs: BITBUCKET_TIMEOUT_MS,
+    });
+    if (res.status < 200 || res.status >= 300) {
+      deps.log(`bitbucket-exec: ${method} ${scrubUrl(url)} → HTTP ${res.status} (degraded)`);
+      return { ok: false, status: res.status, reason: `http-${res.status}` };
+    }
+    return { ok: true, body: res.body };
+  } catch (err) {
+    deps.log(`bitbucket-exec: ${method} failed: ${scrub((err as Error)?.message ?? String(err))}`);
+    return { ok: false, reason: "exception" };
+  }
+}

--- a/server/services/consilium/trackers/bitbucket-issues-poller.ts
+++ b/server/services/consilium/trackers/bitbucket-issues-poller.ts
@@ -1,0 +1,375 @@
+/**
+ * bitbucket-issues-poller.ts — TRACK-4: poll a Bitbucket Cloud repo's issue tracker and
+ * turn each component-matched, spec-ready issue into a committed spec PR + a Bitbucket
+ * pickup comment. The Bitbucket analogue of `jira-issues-poller.ts`, reusing the EXACT
+ * same rails (#492 shape) and the SHARED crystallise pipeline (`spec-intake.ts`). The
+ * ONLY Bitbucket-specific surface lives in `BitbucketTrackerConnector`.
+ *
+ * ARCHITECTURE — TRACK-4 does NOT fire loops (identical to TRACK-1/3): a spec PRODUCER +
+ * ticket UPDATER opening a `docs/specs/bitbucket-<id>-…` spec PR in the TARGET git repo;
+ * SPEC-1's spec-watch fires the loop on merge. Never touches the loop controller.
+ *
+ * RAILS (adversarial): a per-trigger WATERMARK (`pollState.intake`, id → { specPrUrl, at })
+ * + the DETERMINISTIC `spec/bitbucket-<id>` branch + spec-writer's pr-list dedup ⇒ never a
+ * 2nd PR / double comment even on a ticket EDIT; a per-cycle budget; every read degrades
+ * to `null` (bitbucket-exec) and `pollTickets` → null SKIPS the cycle WITHOUT touching the
+ * watermark; the `filter.label` (→ component) is REQUIRED (consent) and `targetRepoPath`
+ * MUST be in the fail-closed allowlist. Closed/resolved issues are excluded at the source
+ * (BBQL `state IN (new, open)`), so a watermark can never re-fire a closed ticket.
+ *
+ * SECURITY: the Bitbucket app password is never read/logged here (bitbucket-exec owns it,
+ * fail-closed). Untrusted title/content is fenced before any prompt (issue-spec.ts) and
+ * slug/clamped before any filename/branch (bitbucket-connector); the BBQL is built from a
+ * sanitised, quoted component literal (no injection).
+ */
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { realpathSync } from "fs";
+import { resolve } from "path";
+import type { TriggerRow } from "@shared/schema";
+import type { TrackerEventTriggerConfig, TrackerPollState } from "@shared/types";
+import type { AppConfig } from "../../../config/schema.js";
+import type { ExecFileFn } from "../../github-status.js";
+import { extractSpecFromIssue } from "./issue-spec.js";
+import { crystallizeTicket } from "./spec-intake.js";
+import { BitbucketTrackerConnector, type BitbucketConnectorConfig } from "./bitbucket-connector.js";
+import { readBitbucketAuthFromEnv, type BitbucketAuth, type BitbucketHttpFn } from "./bitbucket-exec.js";
+
+/** `owner/repo` — conservative charset (no leading dash / no flag). */
+const OWNER_REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+/** Max NEW intakes opened per poll cycle (bounds blast radius). */
+const MAX_PER_CYCLE = 20;
+/** Cap on tracked intakes per trigger (bounds the watermark jsonb). */
+const MAX_TRACKED_INTAKE = 500;
+
+/** Idempotency markers for the Bitbucket write-back comments (distinct from TRACK-1/2/3). */
+export const BITBUCKET_PICKUP_MARKER = "<!-- factory:track4:bitbucket:pickup -->";
+export const BITBUCKET_NEED_CRITERIA_MARKER = "<!-- factory:track4:bitbucket:need-criteria -->";
+
+/**
+ * INJECTABLE spec synthesiser for FREE-FORM tickets (no spec-shaped description). The
+ * production impl wraps the model gateway; tests inject a fake. Connector-agnostic
+ * (title+body only) so it is structurally shared across trackers.
+ */
+export interface TicketSynthesizer {
+  synthesize(ticket: { title: string; body: string }): Promise<{
+    problem?: string;
+    scope?: string;
+    outOfScope?: string;
+    criteria: string[];
+  }>;
+}
+
+export interface BitbucketIssuesPollerDeps {
+  getEnabledTriggersByType: (type: "tracker_event") => Promise<TriggerRow[]>;
+  runInProject: <T>(projectId: string, fn: () => Promise<T>) => Promise<T>;
+  getTrigger: (id: string) => Promise<TriggerRow | undefined>;
+  updateTrigger: (id: string, updates: Partial<TriggerRow>) => Promise<unknown>;
+  config: () => AppConfig;
+  allowedRepoPaths: () => string[];
+  synthesizer?: TicketSynthesizer;
+  /** Injectable `gh` runner for the remote spec PR (tests pass a fake — no real gh). */
+  runGh?: ExecFileFn;
+  /** Injectable Bitbucket HTTP transport (tests pass a fake — no real network). */
+  bitbucketHttp?: BitbucketHttpFn;
+  /** Injectable Bitbucket auth (tests pass a fake; prod reads env at call time). */
+  bitbucketAuth?: BitbucketAuth | null;
+  /** Injectable git-remote reader for the owner/repo derivation (default: real `git`). */
+  gitRemoteUrl?: (repoPath: string) => Promise<string | null>;
+  log: (message: string) => void;
+  now?: () => number;
+}
+
+const execFileAsync: ExecFileFn = promisify(execFile);
+
+/** Default git-remote reader: `git -C <repoPath> remote get-url origin`. NEVER throws. */
+async function defaultGitRemoteUrl(repoPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", repoPath, "remote", "get-url", "origin"], {
+      timeout: 10_000,
+    });
+    const url = (stdout ?? "").trim();
+    return url.length > 0 ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Best-effort realpath (collapses symlinks/`..`), else lexical resolve. */
+function canonicalPath(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return resolve(p);
+  }
+}
+
+/** Fail-closed allowlist check: `targetRepoPath` realpath-equals or sits beneath an allowed root. */
+function isAllowedRepoPath(targetRepoPath: string, allowed: readonly string[]): boolean {
+  const target = canonicalPath(targetRepoPath);
+  for (const a of allowed) {
+    const root = canonicalPath(a);
+    if (target === root || target.startsWith(root + "/")) return true;
+  }
+  return false;
+}
+
+/** Single-line control-strip + collapse + clamp for the (untrusted) ticket title. */
+function sanitizeTitleLine(value: string, max = 160): string {
+  let out = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0;
+    out += code < 0x20 || code === 0x7f ? " " : ch;
+  }
+  return out.replace(/\s+/g, " ").trim().slice(0, max);
+}
+
+/** Keep at most MAX_TRACKED_INTAKE intakes (most-recent by `at` timestamp win). */
+function boundIntake(
+  intake: Record<string, { specPrUrl?: string; at: string }>,
+): Record<string, { specPrUrl?: string; at: string }> {
+  const keys = Object.keys(intake);
+  if (keys.length <= MAX_TRACKED_INTAKE) return intake;
+  const kept = keys
+    .sort((a, b) => (intake[b].at ?? "").localeCompare(intake[a].at ?? ""))
+    .slice(0, MAX_TRACKED_INTAKE);
+  const out: Record<string, { specPrUrl?: string; at: string }> = {};
+  for (const k of kept) out[k] = intake[k];
+  return out;
+}
+
+export class BitbucketIssuesPoller {
+  private readonly deps: BitbucketIssuesPollerDeps;
+  private readonly gitRemoteUrl: (repoPath: string) => Promise<string | null>;
+  private readonly now: () => number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private polling = false;
+
+  constructor(deps: BitbucketIssuesPollerDeps) {
+    this.deps = deps;
+    this.gitRemoteUrl = deps.gitRemoteUrl ?? ((p) => defaultGitRemoteUrl(p));
+    this.now = deps.now ?? Date.now;
+  }
+
+  /** Start the interval poller IFF `features.triggers.tracker.enabled`. Idempotent. */
+  start(): void {
+    if (this.timer) return;
+    const cfg = this.deps.config().features.triggers.tracker;
+    if (!cfg.enabled) {
+      this.deps.log("bitbucket tracker polling disabled — poller not started");
+      return;
+    }
+    const intervalMs = cfg.pollIntervalSec * 1000;
+    this.timer = setInterval(() => void this.pollAllSafe(), intervalMs);
+    this.timer.unref?.();
+    this.deps.log(`bitbucket tracker poller started (every ${cfg.pollIntervalSec}s)`);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** One poll cycle, fully guarded — a throw here must never kill the interval. */
+  async pollAllSafe(): Promise<void> {
+    if (this.polling) return;
+    this.polling = true;
+    try {
+      await this.pollAll();
+    } catch (e) {
+      this.deps.log(`bitbucket tracker poll cycle error: ${(e as Error).message}`);
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  /** Poll every enabled tracker_event trigger. Gated on the MASTER switch. */
+  async pollAll(): Promise<void> {
+    if (!this.deps.config().features.triggers.enabled) {
+      this.deps.log("bitbucket tracker poll skipped — features.triggers.enabled (master switch) is off");
+      return;
+    }
+    const triggers = await this.deps.getEnabledTriggersByType("tracker_event");
+    for (const trigger of triggers) {
+      try {
+        await this.pollTrigger(trigger);
+      } catch (e) {
+        this.deps.log(`bitbucket tracker poll error for trigger ${trigger.id}: ${(e as Error).message}`);
+      }
+    }
+  }
+
+  /** Poll one Bitbucket trigger: validate config + allowlist, intake matched issues, persist. */
+  async pollTrigger(trigger: TriggerRow): Promise<void> {
+    if (!trigger.projectId) return;
+    const config = trigger.config as TrackerEventTriggerConfig;
+    if (config.tracker !== "bitbucket") return; // the github/jira/gitlab pollers handle theirs.
+
+    const workspace = (config.workspace ?? "").trim();
+    if (workspace.length === 0) {
+      this.deps.log(`bitbucket tracker poll skipped for trigger ${trigger.id} — no workspace`);
+      return;
+    }
+    const repoSlug = (config.repoSlug ?? "").trim();
+    if (repoSlug.length === 0) {
+      this.deps.log(`bitbucket tracker poll skipped for trigger ${trigger.id} — no repoSlug`);
+      return;
+    }
+    // `repo` (owner/repo) is the git repo the spec PR lands in — shape-validated.
+    const repo = (config.repo ?? "").trim();
+    if (!OWNER_REPO_RE.test(repo)) {
+      this.deps.log(`bitbucket tracker poll skipped for trigger ${trigger.id} — repo not owner/repo`);
+      return;
+    }
+    const targetRepoPath = config.targetRepoPath;
+    if (!targetRepoPath || targetRepoPath.length === 0) {
+      this.deps.log(`bitbucket tracker poll skipped for trigger ${trigger.id} — no targetRepoPath`);
+      return;
+    }
+    if (!isAllowedRepoPath(targetRepoPath, this.deps.allowedRepoPaths())) {
+      this.deps.log(`bitbucket tracker poll skipped for trigger ${trigger.id} — targetRepoPath not in allowlist`);
+      return;
+    }
+    // The label gate (→ component) is the operator's consent-to-intake — REQUIRED.
+    const label = config.filter?.label;
+    if (!label || label.length === 0) {
+      this.deps.log(`bitbucket tracker poll skipped for trigger ${trigger.id} — no filter.label (consent gate)`);
+      return;
+    }
+
+    const connectorCfg: BitbucketConnectorConfig = {
+      baseUrl: config.baseUrl,
+      workspace,
+      repoSlug,
+      label,
+      stateOnPickup: config.transitionTo,
+    };
+    const connector = new BitbucketTrackerConnector(connectorCfg, {
+      http: this.deps.bitbucketHttp,
+      auth: this.deps.bitbucketAuth ?? readBitbucketAuthFromEnv(),
+      log: this.deps.log,
+    });
+
+    const projectId = trigger.projectId;
+    await this.deps.runInProject(projectId, async () => {
+      const state: TrackerPollState = { ...(config.pollState ?? {}) };
+      if (!state.intake) state.intake = {};
+
+      const tickets = await connector.pollTickets(state.lastPolledAt);
+      if (tickets === null) {
+        this.deps.log(`bitbucket tracker poll: search unavailable for ${workspace}/${repoSlug} (degraded) — skipping cycle`);
+        return; // do NOT touch the watermark.
+      }
+
+      let intaken = 0;
+      for (const ticket of tickets) {
+        if (intaken >= MAX_PER_CYCLE) break;
+        const id = ticket.id;
+        if (!id || state.intake![id]) continue; // watermark dedup — already intaken.
+
+        // Defence-in-depth: confirm the consent component is actually present.
+        if (!ticket.labels.includes(label)) continue;
+
+        // DETERMINISTIC extraction, then the injectable synthesiser for free-form tickets.
+        const extract = extractSpecFromIssue({ number: 0, title: ticket.title, body: ticket.body });
+        let problem = extract.problem;
+        let scope = extract.scope;
+        let outOfScope = extract.outOfScope;
+        let criteria = extract.criteria;
+        if (criteria.length === 0 && this.deps.synthesizer) {
+          try {
+            const syn = await this.deps.synthesizer.synthesize({ title: ticket.title, body: ticket.body });
+            if (syn && Array.isArray(syn.criteria) && syn.criteria.length > 0) {
+              criteria = syn.criteria;
+              problem = problem ?? syn.problem;
+              scope = scope ?? syn.scope;
+              outOfScope = outOfScope ?? syn.outOfScope;
+            }
+          } catch (e) {
+            this.deps.log(`bitbucket tracker poll: synthesizer error for ${id}: ${(e as Error).message}`);
+          }
+        }
+
+        const specStatus = config.specStatus ?? "ready";
+        const title = ticket.title;
+        const sanitizedTitle = sanitizeTitleLine(title);
+        const commitMessage = `feat: add spec for bitbucket issue #${id}`;
+        const prTitle = `spec: ${sanitizedTitle || `bitbucket-${id}`} (bitbucket #${id})`;
+        const prBodyLines = [
+          `Track-4 auto-produced spec for Bitbucket issue #${id}.`,
+          "",
+          "This spec was generated from the linked Bitbucket issue by the factory's Track-4 intake.",
+          "Merging it fires the SPEC-1 spec-watch, which launches the review loop off the committed spec.",
+        ];
+        if (ticket.url) prBodyLines.push("", `Bitbucket: ${ticket.url}`);
+        const prBody = prBodyLines.join("\n");
+
+        const result = await crystallizeTicket(
+          {
+            runGh: this.deps.runGh, // spec PR uses the shared gh writer (injectable).
+            gitRemoteUrl: this.gitRemoteUrl,
+            log: this.deps.log,
+            writeback: {
+              pickup: (specPrUrl) =>
+                connector.writeback
+                  .comment(id, `🤖 picked up by the factory — spec at ${specPrUrl}`, BITBUCKET_PICKUP_MARKER)
+                  .then((r) => ({ posted: r.posted })),
+              needCriteria: () =>
+                connector.writeback
+                  .comment(
+                    id,
+                    `🤖 I can pick this up but need testable acceptance criteria — please add an "Acceptance Criteria" section or checklist items.`,
+                    BITBUCKET_NEED_CRITERIA_MARKER,
+                  )
+                  .then((r) => ({ posted: r.posted })),
+            },
+          },
+          {
+            source: { kind: "bitbucket", ref: id, url: ticket.url },
+            targetRepoPath,
+            branch: connector.specBranchName(id),
+            filePath: connector.specFilePath(id, title),
+            title: title.trim().length > 0 ? title : `bitbucket-${id}`,
+            status: specStatus,
+            problem: problem ?? title,
+            scope,
+            outOfScope,
+            criteria,
+            commitMessage,
+            prTitle,
+            prBody,
+          },
+        );
+
+        if (result.outcome === "need-criteria") continue; // asked human, no intake.
+        if (result.outcome === "failed") {
+          this.deps.log(`bitbucket tracker poll: spec PR failed for ${id}: ${result.reason}`);
+          continue;
+        }
+
+        // Optional pickup state change (best-effort; an unknown state is a no-op).
+        if (config.transitionTo && connector.writeback.transition) {
+          await connector.writeback.transition(id, config.transitionTo);
+        }
+
+        state.intake![id] = { specPrUrl: result.prUrl, at: new Date(this.now()).toISOString() };
+        intaken++;
+      }
+
+      state.intake = boundIntake(state.intake!);
+      state.lastPolledAt = new Date(this.now()).toISOString();
+      await this.persistWatermark(trigger.id, state);
+    });
+  }
+
+  /** Re-read fresh + write the watermark into `config.pollState` (no migration). */
+  private async persistWatermark(triggerId: string, state: TrackerPollState): Promise<void> {
+    const fresh = await this.deps.getTrigger(triggerId);
+    if (!fresh) return;
+    const freshConfig = (fresh.config ?? {}) as TrackerEventTriggerConfig;
+    const nextConfig: TrackerEventTriggerConfig = { ...freshConfig, pollState: state };
+    await this.deps.updateTrigger(triggerId, { config: nextConfig });
+  }
+}

--- a/server/services/consilium/trackers/gitlab-connector.ts
+++ b/server/services/consilium/trackers/gitlab-connector.ts
@@ -1,0 +1,225 @@
+/**
+ * gitlab-connector.ts — TRACK-4: the GitLab Issues implementation of `TrackerConnector`.
+ * PURELY the GitLab DIALECT (watch = `/projects/:id/issues` REST poll, read =
+ * `/issues/:iid`, write-back = `/issues/:iid/notes` + an optional pickup label, naming
+ * = `spec/gitlab-<iid>`); the synth, the spec-PR, the provenance, and the
+ * crystallise/dedup machinery are the SHARED modules (`issue-spec.ts`, `spec-writer.ts`,
+ * `spec-intake.ts`) that GitHub + Jira use too. Nothing shared changes.
+ *
+ * SECURITY
+ *   - The project id/path is sanitised to `[A-Za-z0-9._/-]` then URL-encoded, so a
+ *     numeric id (`42`) or a path (`group/sub/project`) both become one path segment
+ *     (`group%2Fsub%2Fproject`) that cannot escape the `api/v4/projects/…` prefix.
+ *   - The label is embedded as a plain query param (URLSearchParams-encoded by the
+ *     exec seam); it never enters a path, a shell, or a prompt. UNTRUSTED ticket
+ *     title/description is flattened to text and stays untrusted — the shared synth
+ *     fences it before any prompt and the shared renderer quotes it in YAML.
+ *   - Every read/write goes through the fail-closed, never-logging `gitlab-exec` seam.
+ *   - `specBranchName`/`specFilePath` derive from the numeric `iid` only, so nothing
+ *     attacker-shaped (a leading dash, a path separator, a `..`) can reach `gh`.
+ */
+import { slugify } from "./issue-spec.js";
+import type { Ticket, TrackerConnector, TrackerWriteback, WritebackResult } from "./tracker-connector.js";
+import { gitlabGetJson, gitlabSendJson, type GitlabExecDeps } from "./gitlab-exec.js";
+
+/**
+ * Sanitise a GitLab project id/path for the URL: keep `[A-Za-z0-9._/-]` (a numeric id
+ * or a namespace path), then DROP any `.`/`..`/empty path segment so no traversal
+ * segment survives (defence-in-depth — the `encodeURIComponent` in `projectPath()` would
+ * already neutralise a slash, but we strip `..` here too), rejoin, clamp.
+ */
+export function sanitizeProjectRef(project: string): string {
+  const kept = project.replace(/[^A-Za-z0-9._/-]/g, "");
+  const segments = kept.split("/").filter((s) => s.length > 0 && s !== "." && s !== "..");
+  return segments.join("/").slice(0, 200);
+}
+
+/** Sanitise a GitLab issue iid to DIGITS ONLY (iids are positive integers). */
+export function sanitizeIid(iid: string): string {
+  return String(iid).replace(/[^0-9]/g, "").slice(0, 18);
+}
+
+/** The GitLab spec dedup branch: `spec/gitlab-<iid>` (matches spec-writer's SPEC_BRANCH_RE). */
+export function gitlabSpecBranchName(iid: string): string {
+  const safe = sanitizeIid(iid);
+  if (safe.length === 0) throw new Error(`gitlab-connector: invalid issue iid ${JSON.stringify(iid)}`);
+  return `spec/gitlab-${safe}`;
+}
+
+/** The committed spec path: `docs/specs/gitlab-<iid>-<slug>.md`. */
+export function gitlabSpecFilePath(iid: string, title: string): string {
+  const safe = sanitizeIid(iid);
+  if (safe.length === 0) throw new Error(`gitlab-connector: invalid issue iid ${JSON.stringify(iid)}`);
+  return `docs/specs/gitlab-${safe}-${slugify(title)}.md`;
+}
+
+// ─── GitLab REST shapes (only the fields we request) ──────────────────────────
+
+interface GitlabIssue {
+  iid?: number;
+  title?: string;
+  description?: string | null;
+  labels?: string[];
+  web_url?: string;
+  updated_at?: string;
+}
+interface GitlabNote {
+  body?: string;
+}
+
+export interface GitlabConnectorConfig {
+  /** GitLab base URL, e.g. `https://gitlab.com` (validated https in gitlab-exec). */
+  baseUrl: string;
+  /** GitLab project id (`42`) or URL path (`group/project`). */
+  project: string;
+  /** The consent label (§3.1) — REQUIRED at fire time by the poller. */
+  label: string;
+  /** Optional label to ADD to the ticket on pickup (best-effort; GitLab's "transition"). */
+  labelOnPickup?: string;
+}
+
+/** Map a GitLab REST issue → the normalised `Ticket` (iid as the ref). */
+function toTicket(issue: GitlabIssue): Ticket | null {
+  const iid = typeof issue.iid === "number" && Number.isInteger(issue.iid) ? String(issue.iid) : "";
+  if (iid.length === 0) return null;
+  return {
+    id: iid,
+    title: typeof issue.title === "string" ? issue.title : "",
+    body: typeof issue.description === "string" ? issue.description : "",
+    labels: Array.isArray(issue.labels) ? issue.labels.filter((l): l is string => typeof l === "string") : [],
+    updatedAt: typeof issue.updated_at === "string" ? issue.updated_at : undefined,
+    url: typeof issue.web_url === "string" ? issue.web_url : undefined,
+  };
+}
+
+/** A conservative ISO-8601-ish guard so a watermark can be safely echoed into the query. */
+function isIsoish(value: string | undefined): value is string {
+  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}T[\d:.]+(Z|[+-]\d{2}:?\d{2})?$/.test(value);
+}
+
+export class GitlabTrackerConnector implements TrackerConnector {
+  readonly kind = "gitlab";
+  readonly writeback: TrackerWriteback;
+  private readonly cfg: GitlabConnectorConfig;
+  private readonly exec: GitlabExecDeps;
+  private readonly projectRef: string;
+
+  constructor(cfg: GitlabConnectorConfig, exec: GitlabExecDeps) {
+    this.cfg = cfg;
+    this.exec = exec;
+    this.projectRef = sanitizeProjectRef(cfg.project);
+    this.writeback = {
+      comment: (ticketId, body, marker) => this.postNote(ticketId, body, marker),
+      // GitLab has no arbitrary workflow states — the pickup "transition" is a LABEL add.
+      transition: (ticketId, label) => this.addLabel(ticketId, label),
+    };
+  }
+
+  /** URL-encoded `api/v4/projects/<project>` prefix (project ref pre-sanitised). */
+  private projectPath(): string {
+    return `api/v4/projects/${encodeURIComponent(this.projectRef)}`;
+  }
+
+  /**
+   * WATCH: list the project's OPEN issues carrying the consent label, updated after the
+   * watermark. Returns normalised tickets or `null` on any degrade (auth/outage) so the
+   * poller skips the cycle. The `updated_after` watermark narrows the query; dedup is
+   * still handled by the poller's intake watermark (one spec per iid).
+   */
+  async pollTickets(sinceWatermark?: string): Promise<Ticket[] | null> {
+    if (this.projectRef.length === 0) return null;
+    const query: Record<string, string> = {
+      labels: this.cfg.label,
+      state: "opened",
+      per_page: "100",
+      order_by: "updated_at",
+      sort: "asc",
+    };
+    if (isIsoish(sinceWatermark)) query.updated_after = sinceWatermark;
+    const issues = await gitlabGetJson<GitlabIssue[]>(
+      this.exec,
+      this.cfg.baseUrl,
+      `${this.projectPath()}/issues`,
+      query,
+    );
+    if (!Array.isArray(issues)) return null;
+    const tickets: Ticket[] = [];
+    for (const issue of issues) {
+      const t = toTicket(issue);
+      if (t) tickets.push(t);
+    }
+    return tickets;
+  }
+
+  /** READ: fetch one issue by iid. `null` ⇒ not found / degraded. */
+  async readTicket(ticketId: string): Promise<Ticket | null> {
+    const iid = sanitizeIid(ticketId);
+    if (iid.length === 0) return null;
+    const issue = await gitlabGetJson<GitlabIssue>(
+      this.exec,
+      this.cfg.baseUrl,
+      `${this.projectPath()}/issues/${iid}`,
+    );
+    if (!issue) return null;
+    return toTicket({ ...issue, iid: issue.iid ?? Number(iid) });
+  }
+
+  specBranchName(ticketId: string): string {
+    return gitlabSpecBranchName(ticketId);
+  }
+
+  specFilePath(ticketId: string, title: string): string {
+    return gitlabSpecFilePath(ticketId, title);
+  }
+
+  // ─── write-back ─────────────────────────────────────────────────────────────
+
+  /**
+   * Post a NOTE idempotently: read existing notes, skip if any already carries `marker`,
+   * else POST `marker\n body`. Best-effort — a degrade returns `{ posted: false }`, never
+   * throws. When notes cannot be read (degrade) we do NOT post (safety over liveness — a
+   * blind post could double-comment).
+   */
+  private async postNote(ticketId: string, body: string, marker: string): Promise<WritebackResult> {
+    const iid = sanitizeIid(ticketId);
+    if (iid.length === 0) return { posted: false, reason: "bad-iid" };
+    const existing = await gitlabGetJson<GitlabNote[]>(
+      this.exec,
+      this.cfg.baseUrl,
+      `${this.projectPath()}/issues/${iid}/notes`,
+      { per_page: "100" },
+    );
+    if (!Array.isArray(existing)) return { posted: false, reason: "notes-unreadable" };
+    const already = existing.some((n) => typeof n.body === "string" && n.body.includes(marker));
+    if (already) return { posted: false, reason: "already-commented" };
+
+    const res = await gitlabSendJson(
+      this.exec,
+      "POST",
+      this.cfg.baseUrl,
+      `${this.projectPath()}/issues/${iid}/notes`,
+      { body: `${marker}\n${body}` },
+    );
+    return res.ok ? { posted: true } : { posted: false, reason: res.reason };
+  }
+
+  /**
+   * ADD a label to the issue (GitLab's pickup "transition"), best-effort. `add_labels`
+   * is additive on GitLab, so this never removes existing labels. A blank label is a
+   * no-op.
+   */
+  private async addLabel(ticketId: string, label: string): Promise<WritebackResult> {
+    const iid = sanitizeIid(ticketId);
+    if (iid.length === 0) return { posted: false, reason: "bad-iid" };
+    const wanted = (label ?? "").trim();
+    if (wanted.length === 0) return { posted: false, reason: "no-label" };
+    const res = await gitlabSendJson(
+      this.exec,
+      "PUT",
+      this.cfg.baseUrl,
+      `${this.projectPath()}/issues/${iid}`,
+      { add_labels: wanted },
+    );
+    return res.ok ? { posted: true } : { posted: false, reason: res.reason };
+  }
+}

--- a/server/services/consilium/trackers/gitlab-exec.ts
+++ b/server/services/consilium/trackers/gitlab-exec.ts
@@ -1,0 +1,224 @@
+/**
+ * gitlab-exec.ts — the sanitized GitLab REST seam for TRACK-4 (the GitLab analogue of
+ * `jira-exec.ts` / `gh-exec.ts`). GitLab has a REST API but no first-party CLI we want
+ * to shell out to, so this is a thin HTTP client with the SAME safety posture as the
+ * Jira seam:
+ *   - NEVER throws: a network error / non-2xx / timeout degrades to `null` (reads) or
+ *     `{ ok: false }` (writes) so a GitLab outage can never crash the poll loop.
+ *   - The PAT is NEVER logged: on failure only the HTTP status + a scrubbed,
+ *     header-free message leaves this module; the `PRIVATE-TOKEN` header is never
+ *     surfaced.
+ *   - Fail-closed auth: the token comes from ENV (a secret manager), read at call time.
+ *     Absent ⇒ the request is not even attempted (`null`/`{ok:false}`).
+ *   - SSRF containment: the request URL is built from the operator-configured
+ *     `baseUrl` and a SERVER-DERIVED path, then re-checked to share `baseUrl`'s origin
+ *     — a crafted path can never redirect the token to another host.
+ *
+ * WHY A CUSTOM SEAM (not a GitLab SDK): zero new deps, and the same auditable
+ * arg/URL/secret discipline the rest of the tracker code already uses. The HTTP call
+ * is injectable (`GitlabHttpFn`) so tests drive it with a fake — no real network.
+ */
+
+/** The PAT / project-token env var name (a secret manager sets it). Never logged. */
+export const GITLAB_TOKEN_ENV = "GITLAB_TOKEN";
+
+/** Default per-call wall-clock budget for a GitLab request. */
+const GITLAB_TIMEOUT_MS = 30_000;
+
+/** A minimal, injectable HTTP result (status + raw body text). */
+export interface GitlabHttpResult {
+  status: number;
+  body: string;
+}
+
+/** Injectable HTTP transport (tests pass a fake; prod uses `fetch`). NEVER throws-through. */
+export type GitlabHttpFn = (req: {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: string;
+  timeoutMs: number;
+}) => Promise<GitlabHttpResult>;
+
+/** Resolved auth material (a single PAT / project token). `null` ⇒ fail-closed. */
+export interface GitlabAuth {
+  token: string;
+}
+
+/**
+ * Read the GitLab auth from ENV (fail-closed). Returns `null` when the token var is
+ * absent or blank so the caller degrades WITHOUT attempting an unauthenticated call.
+ * The token value is returned but NEVER logged by this module.
+ */
+export function readGitlabAuthFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): GitlabAuth | null {
+  const token = (env[GITLAB_TOKEN_ENV] ?? "").trim();
+  if (token.length === 0) return null;
+  return { token };
+}
+
+/** Scrub any absolute path + collapse whitespace from an error string, then clamp. */
+function scrub(raw: string): string {
+  return raw.replace(/\/[^\s'"]+/g, "<path>").replace(/\s+/g, " ").trim().slice(0, 300);
+}
+
+/** Default transport over global `fetch` with an AbortController timeout. Never throws-through. */
+const defaultHttp: GitlabHttpFn = async (req) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), req.timeoutMs);
+  try {
+    const res = await fetch(req.url, {
+      method: req.method,
+      headers: req.headers,
+      body: req.body,
+      signal: controller.signal,
+    });
+    const body = await res.text().catch(() => "");
+    return { status: res.status, body };
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/**
+ * Normalise `baseUrl` to an `https://host` origin (keeping any context path prefix,
+ * dropping a trailing slash). Returns `null` for anything that is not a well-formed
+ * `https:` URL (fail-closed — no `http:`, no SSRF-friendly schemes).
+ */
+export function normalizeBaseUrl(baseUrl: string): { origin: string; base: string } | null {
+  try {
+    const u = new URL(baseUrl);
+    if (u.protocol !== "https:") return null;
+    const base = `${u.origin}${u.pathname.replace(/\/+$/, "")}`;
+    return { origin: u.origin, base };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build + validate the absolute request URL for a SERVER-DERIVED api path + optional
+ * query. Returns `null` if the resulting URL would leave `baseUrl`'s origin (SSRF
+ * containment) — a crafted `path` can never redirect the token elsewhere.
+ */
+function buildUrl(
+  baseUrl: string,
+  path: string,
+  query?: Record<string, string>,
+): string | null {
+  const norm = normalizeBaseUrl(baseUrl);
+  if (!norm) return null;
+  // `path` is always server-derived (`api/v4/...` with URL-encoded ids), but we still
+  // strip leading slashes and reject a scheme/`//host` escape before join.
+  const cleanPath = path.replace(/^\/+/, "");
+  if (/^[a-z][a-z0-9+.-]*:/i.test(cleanPath) || cleanPath.startsWith("/")) return null;
+  const url = new URL(`${norm.base}/${cleanPath}`);
+  if (url.origin !== norm.origin) return null; // origin escape ⇒ fail-closed.
+  if (query) {
+    for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
+  }
+  return url.toString();
+}
+
+export interface GitlabExecDeps {
+  http?: GitlabHttpFn;
+  auth?: GitlabAuth | null;
+  log: (message: string) => void;
+}
+
+/** The auth + accept headers for a GitLab request. The token is never logged. */
+function authHeaders(auth: GitlabAuth, extra?: Record<string, string>): Record<string, string> {
+  return { "PRIVATE-TOKEN": auth.token, Accept: "application/json", ...(extra ?? {}) };
+}
+
+/** Log a URL without its query string (a label may echo into the query; keep it terse). */
+function scrubUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    return `${u.origin}${u.pathname}`;
+  } catch {
+    return "<url>";
+  }
+}
+
+/**
+ * GET a GitLab REST resource and parse JSON. Returns `null` on ANY degrade (unconfigured
+ * auth, non-2xx, network error, bad JSON, origin escape). The token is never logged.
+ */
+export async function gitlabGetJson<T>(
+  deps: GitlabExecDeps,
+  baseUrl: string,
+  path: string,
+  query?: Record<string, string>,
+): Promise<T | null> {
+  const auth = deps.auth ?? readGitlabAuthFromEnv();
+  if (!auth) {
+    deps.log("gitlab-exec: no GITLAB_TOKEN configured — skipping (fail-closed)");
+    return null;
+  }
+  const url = buildUrl(baseUrl, path, query);
+  if (!url) {
+    deps.log("gitlab-exec: rejected request URL (bad baseUrl / origin escape)");
+    return null;
+  }
+  const http = deps.http ?? defaultHttp;
+  try {
+    const res = await http({
+      method: "GET",
+      url,
+      headers: authHeaders(auth),
+      timeoutMs: GITLAB_TIMEOUT_MS,
+    });
+    if (res.status < 200 || res.status >= 300) {
+      deps.log(`gitlab-exec: GET ${scrubUrl(url)} → HTTP ${res.status} (degraded)`);
+      return null;
+    }
+    return JSON.parse(res.body) as T;
+  } catch (err) {
+    deps.log(`gitlab-exec: GET failed: ${scrub((err as Error)?.message ?? String(err))}`);
+    return null;
+  }
+}
+
+/**
+ * Send a JSON body to a GitLab REST resource (`POST` a note, `PUT` a label/state).
+ * Returns a typed `{ ok }` — never throws. On failure only the HTTP status + a scrubbed
+ * message leave this module (the token / PRIVATE-TOKEN header never do).
+ */
+export async function gitlabSendJson(
+  deps: GitlabExecDeps,
+  method: "POST" | "PUT",
+  baseUrl: string,
+  path: string,
+  body: unknown,
+): Promise<{ ok: true; body: string } | { ok: false; status?: number; reason: string }> {
+  const auth = deps.auth ?? readGitlabAuthFromEnv();
+  if (!auth) {
+    deps.log("gitlab-exec: no GITLAB_TOKEN configured — skipping (fail-closed)");
+    return { ok: false, reason: "no-auth" };
+  }
+  const url = buildUrl(baseUrl, path);
+  if (!url) {
+    deps.log("gitlab-exec: rejected request URL (bad baseUrl / origin escape)");
+    return { ok: false, reason: "bad-url" };
+  }
+  const http = deps.http ?? defaultHttp;
+  try {
+    const res = await http({
+      method,
+      url,
+      headers: authHeaders(auth, { "Content-Type": "application/json" }),
+      body: JSON.stringify(body ?? {}),
+      timeoutMs: GITLAB_TIMEOUT_MS,
+    });
+    if (res.status < 200 || res.status >= 300) {
+      deps.log(`gitlab-exec: ${method} ${scrubUrl(url)} → HTTP ${res.status} (degraded)`);
+      return { ok: false, status: res.status, reason: `http-${res.status}` };
+    }
+    return { ok: true, body: res.body };
+  } catch (err) {
+    deps.log(`gitlab-exec: ${method} failed: ${scrub((err as Error)?.message ?? String(err))}`);
+    return { ok: false, reason: "exception" };
+  }
+}

--- a/server/services/consilium/trackers/gitlab-issues-poller.ts
+++ b/server/services/consilium/trackers/gitlab-issues-poller.ts
@@ -1,0 +1,376 @@
+/**
+ * gitlab-issues-poller.ts — TRACK-4: poll a GitLab project's labelled issues and turn
+ * each spec-ready issue into a committed spec PR + a GitLab pickup note. The GitLab
+ * analogue of `jira-issues-poller.ts`, reusing the EXACT same rails (#492 shape):
+ * watermark in the trigger `config` jsonb, never-throw per cycle/trigger, project-scoped
+ * context, the tracker kill-switch, the allowlist + consent gates, and the SHARED
+ * crystallise pipeline (`spec-intake.ts` → `issue-spec.ts` synth + `spec-writer.ts` PR).
+ * The ONLY GitLab-specific surface lives in `GitlabTrackerConnector`.
+ *
+ * ARCHITECTURE — TRACK-4 does NOT fire loops (identical to TRACK-1/3)
+ *   A spec PRODUCER + ticket UPDATER. It opens a PR that ADDS a `docs/specs/gitlab-<iid>-…`
+ *   spec to the TARGET git repo; when a human MERGES that PR, SPEC-1's spec-watch fires
+ *   the review loop off the committed spec. It never touches the loop controller.
+ *
+ * RAILS (adversarial) — same as TRACK-3: a per-trigger WATERMARK (`pollState.intake`,
+ * iid → { specPrUrl, at }) + the DETERMINISTIC `spec/gitlab-<iid>` branch + spec-writer's
+ * pr-list dedup ⇒ never a 2nd PR / double note even on a ticket EDIT; a per-cycle budget;
+ * every read degrades to `null` (gitlab-exec) and `pollTickets` → null SKIPS the cycle
+ * WITHOUT touching the watermark; the `filter.label` is REQUIRED (consent-to-intake) and
+ * `targetRepoPath` MUST be in the fail-closed allowlist.
+ *
+ * SECURITY: the GitLab PAT is never read/logged here (gitlab-exec owns it, fail-closed).
+ * Untrusted title/description is fenced before any prompt (issue-spec.ts) and
+ * slug/clamped before any filename/branch (gitlab-connector); the label is an encoded
+ * query param (no injection).
+ */
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { realpathSync } from "fs";
+import { resolve } from "path";
+import type { TriggerRow } from "@shared/schema";
+import type { TrackerEventTriggerConfig, TrackerPollState } from "@shared/types";
+import type { AppConfig } from "../../../config/schema.js";
+import type { ExecFileFn } from "../../github-status.js";
+import { extractSpecFromIssue } from "./issue-spec.js";
+import { crystallizeTicket } from "./spec-intake.js";
+import { GitlabTrackerConnector, type GitlabConnectorConfig } from "./gitlab-connector.js";
+import { readGitlabAuthFromEnv, type GitlabAuth, type GitlabHttpFn } from "./gitlab-exec.js";
+
+/** `owner/repo` — conservative charset (no leading dash / no flag). */
+const OWNER_REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+/** Max NEW intakes opened per poll cycle (bounds blast radius). */
+const MAX_PER_CYCLE = 20;
+/** Cap on tracked intakes per trigger (bounds the watermark jsonb). */
+const MAX_TRACKED_INTAKE = 500;
+
+/** Idempotency markers for the GitLab write-back notes (distinct from TRACK-1/2/3). */
+export const GITLAB_PICKUP_MARKER = "<!-- factory:track4:gitlab:pickup -->";
+export const GITLAB_NEED_CRITERIA_MARKER = "<!-- factory:track4:gitlab:need-criteria -->";
+
+/**
+ * INJECTABLE spec synthesiser for FREE-FORM tickets (no spec-shaped description). The
+ * production impl wraps the model gateway; tests inject a fake. Connector-agnostic
+ * (title+body only) so it is structurally shared across trackers.
+ */
+export interface TicketSynthesizer {
+  synthesize(ticket: { title: string; body: string }): Promise<{
+    problem?: string;
+    scope?: string;
+    outOfScope?: string;
+    criteria: string[];
+  }>;
+}
+
+export interface GitlabIssuesPollerDeps {
+  getEnabledTriggersByType: (type: "tracker_event") => Promise<TriggerRow[]>;
+  runInProject: <T>(projectId: string, fn: () => Promise<T>) => Promise<T>;
+  getTrigger: (id: string) => Promise<TriggerRow | undefined>;
+  updateTrigger: (id: string, updates: Partial<TriggerRow>) => Promise<unknown>;
+  config: () => AppConfig;
+  allowedRepoPaths: () => string[];
+  synthesizer?: TicketSynthesizer;
+  /** Injectable `gh` runner for the remote spec PR (tests pass a fake — no real gh). */
+  runGh?: ExecFileFn;
+  /** Injectable GitLab HTTP transport (tests pass a fake — no real network). */
+  gitlabHttp?: GitlabHttpFn;
+  /** Injectable GitLab auth (tests pass a fake; prod reads env at call time). */
+  gitlabAuth?: GitlabAuth | null;
+  /** Injectable git-remote reader for the owner/repo derivation (default: real `git`). */
+  gitRemoteUrl?: (repoPath: string) => Promise<string | null>;
+  log: (message: string) => void;
+  now?: () => number;
+}
+
+const execFileAsync: ExecFileFn = promisify(execFile);
+
+/** Default git-remote reader: `git -C <repoPath> remote get-url origin`. NEVER throws. */
+async function defaultGitRemoteUrl(repoPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", repoPath, "remote", "get-url", "origin"], {
+      timeout: 10_000,
+    });
+    const url = (stdout ?? "").trim();
+    return url.length > 0 ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Best-effort realpath (collapses symlinks/`..`), else lexical resolve. */
+function canonicalPath(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return resolve(p);
+  }
+}
+
+/** Fail-closed allowlist check: `targetRepoPath` realpath-equals or sits beneath an allowed root. */
+function isAllowedRepoPath(targetRepoPath: string, allowed: readonly string[]): boolean {
+  const target = canonicalPath(targetRepoPath);
+  for (const a of allowed) {
+    const root = canonicalPath(a);
+    if (target === root || target.startsWith(root + "/")) return true;
+  }
+  return false;
+}
+
+/** Single-line control-strip + collapse + clamp for the (untrusted) ticket title. */
+function sanitizeTitleLine(value: string, max = 160): string {
+  let out = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0;
+    out += code < 0x20 || code === 0x7f ? " " : ch;
+  }
+  return out.replace(/\s+/g, " ").trim().slice(0, max);
+}
+
+/** Keep at most MAX_TRACKED_INTAKE intakes (most-recent by `at` timestamp win). */
+function boundIntake(
+  intake: Record<string, { specPrUrl?: string; at: string }>,
+): Record<string, { specPrUrl?: string; at: string }> {
+  const keys = Object.keys(intake);
+  if (keys.length <= MAX_TRACKED_INTAKE) return intake;
+  const kept = keys
+    .sort((a, b) => (intake[b].at ?? "").localeCompare(intake[a].at ?? ""))
+    .slice(0, MAX_TRACKED_INTAKE);
+  const out: Record<string, { specPrUrl?: string; at: string }> = {};
+  for (const k of kept) out[k] = intake[k];
+  return out;
+}
+
+export class GitlabIssuesPoller {
+  private readonly deps: GitlabIssuesPollerDeps;
+  private readonly gitRemoteUrl: (repoPath: string) => Promise<string | null>;
+  private readonly now: () => number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private polling = false;
+
+  constructor(deps: GitlabIssuesPollerDeps) {
+    this.deps = deps;
+    this.gitRemoteUrl = deps.gitRemoteUrl ?? ((p) => defaultGitRemoteUrl(p));
+    this.now = deps.now ?? Date.now;
+  }
+
+  /** Start the interval poller IFF `features.triggers.tracker.enabled`. Idempotent. */
+  start(): void {
+    if (this.timer) return;
+    const cfg = this.deps.config().features.triggers.tracker;
+    if (!cfg.enabled) {
+      this.deps.log("gitlab tracker polling disabled — poller not started");
+      return;
+    }
+    const intervalMs = cfg.pollIntervalSec * 1000;
+    this.timer = setInterval(() => void this.pollAllSafe(), intervalMs);
+    this.timer.unref?.();
+    this.deps.log(`gitlab tracker poller started (every ${cfg.pollIntervalSec}s)`);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** One poll cycle, fully guarded — a throw here must never kill the interval. */
+  async pollAllSafe(): Promise<void> {
+    if (this.polling) return;
+    this.polling = true;
+    try {
+      await this.pollAll();
+    } catch (e) {
+      this.deps.log(`gitlab tracker poll cycle error: ${(e as Error).message}`);
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  /** Poll every enabled tracker_event trigger. Gated on the MASTER switch. */
+  async pollAll(): Promise<void> {
+    if (!this.deps.config().features.triggers.enabled) {
+      this.deps.log("gitlab tracker poll skipped — features.triggers.enabled (master switch) is off");
+      return;
+    }
+    const triggers = await this.deps.getEnabledTriggersByType("tracker_event");
+    for (const trigger of triggers) {
+      try {
+        await this.pollTrigger(trigger);
+      } catch (e) {
+        this.deps.log(`gitlab tracker poll error for trigger ${trigger.id}: ${(e as Error).message}`);
+      }
+    }
+  }
+
+  /** Poll one GitLab trigger: validate config + allowlist, intake labelled issues, persist. */
+  async pollTrigger(trigger: TriggerRow): Promise<void> {
+    if (!trigger.projectId) return;
+    const config = trigger.config as TrackerEventTriggerConfig;
+    if (config.tracker !== "gitlab") return; // the github/jira/bitbucket pollers handle theirs.
+
+    const baseUrl = (config.baseUrl ?? "").trim();
+    if (baseUrl.length === 0) {
+      this.deps.log(`gitlab tracker poll skipped for trigger ${trigger.id} — no baseUrl`);
+      return;
+    }
+    const project = (config.gitlabProject ?? "").trim();
+    if (project.length === 0) {
+      this.deps.log(`gitlab tracker poll skipped for trigger ${trigger.id} — no gitlabProject`);
+      return;
+    }
+    // `repo` (owner/repo) is the git repo the spec PR lands in — shape-validated.
+    const repo = (config.repo ?? "").trim();
+    if (!OWNER_REPO_RE.test(repo)) {
+      this.deps.log(`gitlab tracker poll skipped for trigger ${trigger.id} — repo not owner/repo`);
+      return;
+    }
+    const targetRepoPath = config.targetRepoPath;
+    if (!targetRepoPath || targetRepoPath.length === 0) {
+      this.deps.log(`gitlab tracker poll skipped for trigger ${trigger.id} — no targetRepoPath`);
+      return;
+    }
+    if (!isAllowedRepoPath(targetRepoPath, this.deps.allowedRepoPaths())) {
+      this.deps.log(`gitlab tracker poll skipped for trigger ${trigger.id} — targetRepoPath not in allowlist`);
+      return;
+    }
+    // The label gate is the operator's consent-to-intake — REQUIRED at fire time.
+    const label = config.filter?.label;
+    if (!label || label.length === 0) {
+      this.deps.log(`gitlab tracker poll skipped for trigger ${trigger.id} — no filter.label (consent gate)`);
+      return;
+    }
+
+    const connectorCfg: GitlabConnectorConfig = {
+      baseUrl,
+      project,
+      label,
+      labelOnPickup: config.transitionTo,
+    };
+    const connector = new GitlabTrackerConnector(connectorCfg, {
+      http: this.deps.gitlabHttp,
+      auth: this.deps.gitlabAuth ?? readGitlabAuthFromEnv(),
+      log: this.deps.log,
+    });
+
+    const projectId = trigger.projectId;
+    await this.deps.runInProject(projectId, async () => {
+      const state: TrackerPollState = { ...(config.pollState ?? {}) };
+      if (!state.intake) state.intake = {};
+
+      const tickets = await connector.pollTickets(state.lastPolledAt);
+      if (tickets === null) {
+        this.deps.log(`gitlab tracker poll: search unavailable for ${project} (degraded) — skipping cycle`);
+        return; // do NOT touch the watermark.
+      }
+
+      let intaken = 0;
+      for (const ticket of tickets) {
+        if (intaken >= MAX_PER_CYCLE) break;
+        const iid = ticket.id;
+        if (!iid || state.intake![iid]) continue; // watermark dedup — already intaken.
+
+        // Defence-in-depth: confirm the consent label is actually present.
+        if (!ticket.labels.includes(label)) continue;
+
+        // DETERMINISTIC extraction, then the injectable synthesiser for free-form tickets.
+        const extract = extractSpecFromIssue({ number: 0, title: ticket.title, body: ticket.body });
+        let problem = extract.problem;
+        let scope = extract.scope;
+        let outOfScope = extract.outOfScope;
+        let criteria = extract.criteria;
+        if (criteria.length === 0 && this.deps.synthesizer) {
+          try {
+            const syn = await this.deps.synthesizer.synthesize({ title: ticket.title, body: ticket.body });
+            if (syn && Array.isArray(syn.criteria) && syn.criteria.length > 0) {
+              criteria = syn.criteria;
+              problem = problem ?? syn.problem;
+              scope = scope ?? syn.scope;
+              outOfScope = outOfScope ?? syn.outOfScope;
+            }
+          } catch (e) {
+            this.deps.log(`gitlab tracker poll: synthesizer error for ${iid}: ${(e as Error).message}`);
+          }
+        }
+
+        const specStatus = config.specStatus ?? "ready";
+        const title = ticket.title;
+        const sanitizedTitle = sanitizeTitleLine(title);
+        const commitMessage = `feat: add spec for gitlab issue !${iid}`;
+        const prTitle = `spec: ${sanitizedTitle || `gitlab-${iid}`} (gitlab #${iid})`;
+        const prBodyLines = [
+          `Track-4 auto-produced spec for GitLab issue #${iid}.`,
+          "",
+          "This spec was generated from the linked GitLab issue by the factory's Track-4 intake.",
+          "Merging it fires the SPEC-1 spec-watch, which launches the review loop off the committed spec.",
+        ];
+        if (ticket.url) prBodyLines.push("", `GitLab: ${ticket.url}`);
+        const prBody = prBodyLines.join("\n");
+
+        const result = await crystallizeTicket(
+          {
+            runGh: this.deps.runGh, // spec PR uses the shared gh writer (injectable).
+            gitRemoteUrl: this.gitRemoteUrl,
+            log: this.deps.log,
+            writeback: {
+              pickup: (specPrUrl) =>
+                connector.writeback
+                  .comment(iid, `🤖 picked up by the factory — spec at ${specPrUrl}`, GITLAB_PICKUP_MARKER)
+                  .then((r) => ({ posted: r.posted })),
+              needCriteria: () =>
+                connector.writeback
+                  .comment(
+                    iid,
+                    `🤖 I can pick this up but need testable acceptance criteria — please add an "Acceptance Criteria" section or checklist items.`,
+                    GITLAB_NEED_CRITERIA_MARKER,
+                  )
+                  .then((r) => ({ posted: r.posted })),
+            },
+          },
+          {
+            source: { kind: "gitlab", ref: iid, url: ticket.url },
+            targetRepoPath,
+            branch: connector.specBranchName(iid),
+            filePath: connector.specFilePath(iid, title),
+            title: title.trim().length > 0 ? title : `gitlab-${iid}`,
+            status: specStatus,
+            problem: problem ?? title,
+            scope,
+            outOfScope,
+            criteria,
+            commitMessage,
+            prTitle,
+            prBody,
+          },
+        );
+
+        if (result.outcome === "need-criteria") continue; // asked human, no intake.
+        if (result.outcome === "failed") {
+          this.deps.log(`gitlab tracker poll: spec PR failed for ${iid}: ${result.reason}`);
+          continue;
+        }
+
+        // Optional pickup label (best-effort; a blank/failed add is a no-op).
+        if (config.transitionTo && connector.writeback.transition) {
+          await connector.writeback.transition(iid, config.transitionTo);
+        }
+
+        state.intake![iid] = { specPrUrl: result.prUrl, at: new Date(this.now()).toISOString() };
+        intaken++;
+      }
+
+      state.intake = boundIntake(state.intake!);
+      state.lastPolledAt = new Date(this.now()).toISOString();
+      await this.persistWatermark(trigger.id, state);
+    });
+  }
+
+  /** Re-read fresh + write the watermark into `config.pollState` (no migration). */
+  private async persistWatermark(triggerId: string, state: TrackerPollState): Promise<void> {
+    const fresh = await this.deps.getTrigger(triggerId);
+    if (!fresh) return;
+    const freshConfig = (fresh.config ?? {}) as TrackerEventTriggerConfig;
+    const nextConfig: TrackerEventTriggerConfig = { ...freshConfig, pollState: state };
+    await this.deps.updateTrigger(triggerId, { config: nextConfig });
+  }
+}

--- a/server/services/consilium/trackers/spec-writer.ts
+++ b/server/services/consilium/trackers/spec-writer.ts
@@ -40,13 +40,15 @@ import { runGhCapture } from "./gh-exec.js";
 
 /**
  * The server-derived spec branch shapes, one alternative per connector dialect:
- *   - GitHub (TRACK-1): `spec/gh-issue-<n>`     (n = issue number)
- *   - Jira   (TRACK-3): `spec/jira-<KEY>`       (KEY = `PROJ-123`, uppercased)
+ *   - GitHub    (TRACK-1): `spec/gh-issue-<n>`   (n = issue number)
+ *   - Jira      (TRACK-3): `spec/jira-<KEY>`     (KEY = `PROJ-123`, uppercased)
+ *   - GitLab    (TRACK-4): `spec/gitlab-<iid>`   (iid = project-internal issue id)
+ *   - Bitbucket (TRACK-4): `spec/bitbucket-<id>` (id = issue id)
  * Every alternative is SERVER-DERIVED from a validated ticket id, so nothing
  * attacker-shaped (a leading dash, a path separator, a `..`) can reach `gh`. New
- * connectors (TRACK-4/5) add their own alternative here — the writer stays generic.
+ * connectors (TRACK-5) add their own alternative here — the writer stays generic.
  */
-export const SPEC_BRANCH_RE = /^spec\/(gh-issue-[0-9]+|jira-[A-Za-z0-9._-]+)$/;
+export const SPEC_BRANCH_RE = /^spec\/(gh-issue-[0-9]+|jira-[A-Za-z0-9._-]+|gitlab-[0-9]+|bitbucket-[0-9]+)$/;
 
 /** True iff `branch` is a server-derived tracker spec branch (any connector). */
 export function isValidSpecBranch(branch: string): boolean {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1562,11 +1562,12 @@ export interface TrackerPollState {
  * This trigger PRODUCES specs + UPDATES tickets — it never fires a loop directly.
  */
 export interface TrackerEventTriggerConfig {
-  // TRACK-1 = github; TRACK-3 adds jira. The poller for each tracker guards on this
-  // discriminant (`config.tracker !== "<kind>"` → skip), so widening it is ADDITIVE:
-  // the github path is byte-identical and only the new jira poller reads the jira fields.
-  tracker: "github" | "jira";
-  repo: string;                 // github: owner/repo to poll issues from. jira: owner/repo of the git repo the spec PR lands in.
+  // TRACK-1 = github; TRACK-3 adds jira; TRACK-4 adds gitlab + bitbucket. The poller for
+  // each tracker guards on this discriminant (`config.tracker !== "<kind>"` → skip), so
+  // widening it is ADDITIVE: the github/jira paths are byte-identical and only the new
+  // gitlab/bitbucket pollers read their own fields.
+  tracker: "github" | "jira" | "gitlab" | "bitbucket";
+  repo: string;                 // github: owner/repo to poll issues from. jira/gitlab/bitbucket: owner/repo of the git repo the spec PR lands in.
   targetRepoPath: string;       // allowlisted local repo path -> the spec's `repo:` frontmatter + PR target
   filter?: { label?: string };  // label gate (consent to intake) — required at fire time
   specStatus?: "ready" | "draft";
@@ -1578,8 +1579,27 @@ export interface TrackerEventTriggerConfig {
   project?: string;
   /** Optional operator JQL predicate (trusted config) ANDed into the label search. */
   jql?: string;
-  /** Optional Jira transition name/id to move the ticket to on pickup (best-effort). */
+  /**
+   * Optional pickup "transition", interpreted per connector (best-effort): Jira → a
+   * workflow transition name/id; GitLab → a LABEL to add (GitLab has no arbitrary
+   * states); Bitbucket → an issue STATE (`open`/`resolved`/…). Ignored by the github poller.
+   */
   transitionTo?: string;
+  // ─── GitLab-only (TRACK-4; ignored by the github/jira/bitbucket pollers) ─────
+  /**
+   * GitLab project id (`42`) or URL path (`group/project`) whose ISSUES are polled.
+   * (`baseUrl` above is reused as the GitLab site base, e.g. `https://gitlab.com`.)
+   */
+  gitlabProject?: string;
+  // ─── Bitbucket-only (TRACK-4; ignored by the github/jira/gitlab pollers) ─────
+  /** Bitbucket Cloud workspace hosting the issue tracker. */
+  workspace?: string;
+  /**
+   * Bitbucket repo slug hosting the issue tracker (the SOURCE of tickets — distinct
+   * from `repo`, the git repo the spec PR lands in). (`baseUrl` optional; defaults to
+   * `https://api.bitbucket.org`. `filter.label` is matched against the issue COMPONENT.)
+   */
+  repoSlug?: string;
   /**
    * TRACK-2 (full write-back lifecycle). Per-trigger tuning for the read-only
    * write-back OBSERVER, which comments the loop's lifecycle transitions back on

--- a/tests/unit/consilium/trackers/bitbucket-connector.test.ts
+++ b/tests/unit/consilium/trackers/bitbucket-connector.test.ts
@@ -1,0 +1,205 @@
+/**
+ * bitbucket-connector.test.ts — TRACK-4 Bitbucket dialect with a FAKE Bitbucket HTTP
+ * transport (no network). Covers: the BBQL `q` is built from a SANITISED, quoted
+ * component literal (injection-proof) + active-state filter; workspace/slug sanitisation;
+ * watch/read mapping (component→labels) to the normalised Ticket; idempotent comment
+ * write-back (marker dedup); the pickup state change (allowlisted states only); and the
+ * deterministic `spec/bitbucket-<id>` naming.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  BitbucketTrackerConnector,
+  sanitizeSlug,
+  sanitizeIssueId,
+  bbqlLiteral,
+  bitbucketSpecBranchName,
+  bitbucketSpecFilePath,
+  type BitbucketConnectorConfig,
+} from "../../../../server/services/consilium/trackers/bitbucket-connector.js";
+import { isValidSpecBranch } from "../../../../server/services/consilium/trackers/spec-writer.js";
+import type { BitbucketHttpFn, BitbucketHttpResult } from "../../../../server/services/consilium/trackers/bitbucket-exec.js";
+
+interface Call {
+  method: string;
+  url: string;
+  body?: string;
+}
+
+function fakeHttp(handler: (call: Call) => BitbucketHttpResult): { http: BitbucketHttpFn; calls: Call[] } {
+  const calls: Call[] = [];
+  const http: BitbucketHttpFn = vi.fn(async (req) => {
+    const call: Call = { method: req.method, url: req.url, body: req.body };
+    calls.push(call);
+    return handler(call);
+  });
+  return { http, calls };
+}
+
+const json = (obj: unknown, status = 200): BitbucketHttpResult => ({ status, body: JSON.stringify(obj) });
+
+const CFG: BitbucketConnectorConfig = {
+  workspace: "acme",
+  repoSlug: "widget",
+  label: "agent",
+};
+
+function connector(cfg: Partial<BitbucketConnectorConfig>, handler: (c: Call) => BitbucketHttpResult) {
+  const { http, calls } = fakeHttp(handler);
+  const conn = new BitbucketTrackerConnector({ ...CFG, ...cfg }, {
+    http,
+    auth: { username: "bot", appPassword: "secret-pw" },
+    log: () => {},
+  });
+  return { conn, calls };
+}
+
+const qOf = (url: string) => new URL(url).searchParams.get("q") ?? "";
+const isList = (u: string) => new URL(u).pathname.endsWith("/issues");
+const isComments = (u: string) => new URL(u).pathname.endsWith("/comments");
+const isSingle = (u: string) => /\/issues\/\d+$/.test(new URL(u).pathname);
+
+const ISSUE = {
+  id: 42,
+  title: "Add rate limiting",
+  content: { raw: "## Acceptance Criteria\n- returns 429" },
+  state: "new",
+  kind: "task",
+  priority: "major",
+  component: { name: "agent" },
+  updated_on: "2026-01-02T10:00:00.000000+00:00",
+  links: { html: { href: "https://bitbucket.org/acme/widget/issues/42" } },
+};
+
+describe("naming + id sanitisation", () => {
+  it("derives a shape-safe branch/path from the id", () => {
+    expect(bitbucketSpecBranchName("42")).toBe("spec/bitbucket-42");
+    expect(isValidSpecBranch(bitbucketSpecBranchName("42"))).toBe(true);
+    expect(bitbucketSpecFilePath("42", "Add Rate Limiting!")).toBe("docs/specs/bitbucket-42-add-rate-limiting.md");
+  });
+
+  it("strips non-digits / hostile slugs", () => {
+    expect(sanitizeIssueId("../../etc")).toBe("");
+    expect(sanitizeIssueId("42x")).toBe("42");
+    expect(sanitizeSlug("acme/../evil")).toBe("acme..evil"); // slashes gone (URL-encoded as one segment)
+    expect(sanitizeSlug("a`b;c")).toBe("abc");
+  });
+
+  it("throws on an id that sanitises to empty", () => {
+    expect(() => bitbucketSpecBranchName("abc")).toThrow();
+  });
+});
+
+describe("bbqlLiteral — injection-proof", () => {
+  it("drops quotes/backslashes/controls so it cannot break out of the quoted term", () => {
+    expect(bbqlLiteral('agent" OR state="open')).toBe("agent OR state=open");
+    expect(bbqlLiteral("a\\b")).toBe("ab");
+  });
+});
+
+describe("pollTickets — BBQL construction + mapping", () => {
+  it("builds a quoted component + active-state query and encodes the repo path", async () => {
+    let listUrl = "";
+    const { conn } = connector({}, (c) => {
+      if (isList(c.url)) { listUrl = c.url; return json({ values: [ISSUE] }); }
+      return json({});
+    });
+    const tickets = await conn.pollTickets();
+    expect(new URL(listUrl).pathname).toBe("/2.0/repositories/acme/widget/issues");
+    expect(qOf(listUrl)).toBe('component = "agent" AND (state = "new" OR state = "open")');
+    expect(tickets).toHaveLength(1);
+    expect(tickets![0]).toMatchObject({
+      id: "42",
+      title: "Add rate limiting",
+      body: "## Acceptance Criteria\n- returns 429",
+      labels: ["agent", "task", "major"], // component + kind + priority (defence-in-depth gate)
+      url: "https://bitbucket.org/acme/widget/issues/42",
+    });
+  });
+
+  it("a hostile label cannot inject a BBQL clause", async () => {
+    let listUrl = "";
+    const { conn } = connector({ label: 'agent" OR 1=1 --' }, (c) => {
+      if (isList(c.url)) { listUrl = c.url; return json({ values: [] }); }
+      return json({});
+    });
+    await conn.pollTickets();
+    expect(qOf(listUrl)).toBe('component = "agent OR 1=1 --" AND (state = "new" OR state = "open")');
+    expect(qOf(listUrl)).not.toContain('""');
+  });
+
+  it("appends an ISO watermark; drops garbage", async () => {
+    const urls: string[] = [];
+    const { conn } = connector({}, (c) => {
+      if (isList(c.url)) { urls.push(c.url); return json({ values: [] }); }
+      return json({});
+    });
+    await conn.pollTickets("2026-01-01T00:00:00.000Z");
+    expect(qOf(urls[0])).toContain('updated_on > "2026-01-01T00:00:00.000Z"');
+    await conn.pollTickets("nope");
+    expect(qOf(urls[1])).not.toContain("updated_on");
+  });
+
+  it("returns null on degrade and on unconfigured auth", async () => {
+    const { conn } = connector({}, (c) => (isList(c.url) ? { status: 500, body: "boom" } : json({})));
+    expect(await conn.pollTickets()).toBeNull();
+    const { http } = fakeHttp(() => json({ values: [ISSUE] }));
+    const noAuth = new BitbucketTrackerConnector(CFG, { http, auth: null, log: () => {} });
+    expect(await noAuth.pollTickets()).toBeNull();
+  });
+
+  it("readTicket fetches one issue by id", async () => {
+    const { conn, calls } = connector({}, (c) => (isSingle(c.url) ? json(ISSUE) : json({})));
+    const t = await conn.readTicket("42");
+    expect(t?.id).toBe("42");
+    expect(calls.some((c) => c.method === "GET" && new URL(c.url).pathname.endsWith("/issues/42"))).toBe(true);
+  });
+});
+
+describe("write-back — comment idempotency + state change", () => {
+  it("posts a comment when the marker is absent", async () => {
+    const { conn, calls } = connector({}, (c) => {
+      if (isComments(c.url) && c.method === "GET") return json({ values: [] });
+      if (isComments(c.url) && c.method === "POST") return { status: 201, body: "{}" };
+      return json({});
+    });
+    const res = await conn.writeback.comment("42", "picked up", "<!-- marker -->");
+    expect(res.posted).toBe(true);
+    const post = calls.find((c) => isComments(c.url) && c.method === "POST");
+    expect(post!.body).toContain("<!-- marker -->");
+    expect(post!.body).toContain("picked up");
+  });
+
+  it("does NOT double-post when a comment already carries the marker", async () => {
+    const { conn, calls } = connector({}, (c) =>
+      isComments(c.url) && c.method === "GET"
+        ? json({ values: [{ content: { raw: "<!-- marker -->\nearlier" } }] })
+        : json({}),
+    );
+    const res = await conn.writeback.comment("42", "picked up", "<!-- marker -->");
+    expect(res.posted).toBe(false);
+    expect(calls.some((c) => c.method === "POST")).toBe(false);
+  });
+
+  it("does NOT post when comments are unreadable (safety over liveness)", async () => {
+    const { conn, calls } = connector({}, (c) =>
+      isComments(c.url) && c.method === "GET" ? { status: 503, body: "" } : json({}),
+    );
+    const res = await conn.writeback.comment("42", "x", "<!-- m -->");
+    expect(res.posted).toBe(false);
+    expect(calls.some((c) => c.method === "POST")).toBe(false);
+  });
+
+  it("sets an allowlisted state via PUT; an unknown state is a no-op", async () => {
+    const { conn, calls } = connector({}, (c) =>
+      c.method === "PUT" && isSingle(c.url) ? { status: 200, body: "{}" } : json({}),
+    );
+    const ok = await conn.writeback.transition!("42", "Open");
+    expect(ok.posted).toBe(true);
+    const put = calls.find((c) => c.method === "PUT");
+    expect(put!.body).toContain('"state":"open"');
+
+    const miss = await conn.writeback.transition!("42", "in-progress"); // not a Bitbucket state
+    expect(miss.posted).toBe(false);
+    expect(miss.reason).toBe("no-such-state");
+  });
+});

--- a/tests/unit/consilium/trackers/bitbucket-issues-poller.test.ts
+++ b/tests/unit/consilium/trackers/bitbucket-issues-poller.test.ts
@@ -1,0 +1,295 @@
+/**
+ * bitbucket-issues-poller.test.ts — TRACK-4 poller with a FAKE Bitbucket transport +
+ * FAKE `gh`. Mirrors jira/gitlab poller tests: a component-matched Bitbucket issue → the
+ * SHARED synth → a spec PR (contents PUT to a docs/specs/bitbucket-<id>-… path whose
+ * frontmatter carries source.kind=bitbucket,ref=<id>) + exactly ONE Bitbucket pickup
+ * comment + a watermark intake; a re-poll dedups; an issue whose component doesn't match
+ * is skipped (defence-in-depth); a free-form issue with no criteria → a need-criteria
+ * comment + NO PR + NO intake; the master switch off ⇒ no Bitbucket calls; a Bitbucket
+ * outage on the list skips the cycle (watermark untouched); a non-allowlisted
+ * targetRepoPath is fail-closed.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  BitbucketIssuesPoller,
+  type BitbucketIssuesPollerDeps,
+  type TicketSynthesizer,
+} from "../../../../server/services/consilium/trackers/bitbucket-issues-poller.js";
+import type { BitbucketHttpFn, BitbucketHttpResult } from "../../../../server/services/consilium/trackers/bitbucket-exec.js";
+import type { ExecFileFn } from "../../../../server/services/github-status.js";
+import type { TriggerRow } from "../../../../shared/schema.js";
+import type { AppConfig, TrackerEventTriggerConfig } from "../../../../shared/types.js";
+
+interface BbOpts {
+  issues?: unknown[];
+  comments?: Array<{ content?: { raw?: string } }>;
+  listStatus?: number;
+}
+
+/** A fake Bitbucket transport for the list + comments (idempotency read + post) chain. */
+function fakeBitbucket(opts: BbOpts): { http: BitbucketHttpFn; calls: Array<{ method: string; url: string; body?: string }> } {
+  const calls: Array<{ method: string; url: string; body?: string }> = [];
+  const http: BitbucketHttpFn = vi.fn(async (req): Promise<BitbucketHttpResult> => {
+    calls.push({ method: req.method, url: req.url, body: req.body });
+    const json = (obj: unknown, status = 200): BitbucketHttpResult => ({ status, body: JSON.stringify(obj) });
+    const path = new URL(req.url).pathname;
+    if (path.endsWith("/comments") && req.method === "GET") return json({ values: opts.comments ?? [] });
+    if (path.endsWith("/comments") && req.method === "POST") return { status: 201, body: "{}" };
+    if (path.endsWith("/issues")) {
+      if (opts.listStatus && opts.listStatus >= 400) return { status: opts.listStatus, body: "err" };
+      return json({ values: opts.issues ?? [] });
+    }
+    return json({});
+  });
+  return { http, calls };
+}
+
+/** A fake `gh` that serves the writeSpecPr chain (no issue list — Bitbucket does the watch). */
+function fakeGh(prUrl = "https://github.com/acme/widget/pull/9"): { run: ExecFileFn; argv: string[][] } {
+  const argv: string[][] = [];
+  const run: ExecFileFn = vi.fn(async (_file: string, args: string[]) => {
+    argv.push(args);
+    const json = (obj: unknown) => ({ stdout: JSON.stringify(obj), stderr: "" });
+    if (args[0] === "pr" && args[1] === "list") return json([]);
+    if (args[0] === "repo" && args[1] === "view") return json({ defaultBranchRef: { name: "main" } });
+    if (args[0] === "api") {
+      if (args.indexOf("--method") === -1) return json({ object: { sha: "basesha" } });
+      return { stdout: "", stderr: "" };
+    }
+    if (args[0] === "pr" && args[1] === "create") return { stdout: `${prUrl}\n`, stderr: "" };
+    return { stdout: "", stderr: "" };
+  });
+  return { run, argv };
+}
+
+function bbTrigger(config?: Partial<TrackerEventTriggerConfig>): TriggerRow {
+  const full: TrackerEventTriggerConfig = {
+    tracker: "bitbucket",
+    workspace: "acme",
+    repoSlug: "tracker-repo",
+    repo: "acme/widget",
+    targetRepoPath: "/repo/widget",
+    filter: { label: "agent" },
+    specStatus: "ready",
+    ...config,
+  };
+  return {
+    id: "trk-bb-1",
+    projectId: "proj-1",
+    pipelineId: null,
+    type: "tracker_event",
+    config: JSON.parse(JSON.stringify(full)) as TrackerEventTriggerConfig,
+    secretEncrypted: null,
+    enabled: true,
+    lastTriggeredAt: null,
+    suppressedCount: 0,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  } as unknown as TriggerRow;
+}
+
+function cfg(masterOn: boolean, trackerOn = true, pollIntervalSec = 300): () => AppConfig {
+  return () =>
+    ({
+      features: { triggers: { enabled: masterOn, tracker: { enabled: trackerOn, pollIntervalSec } } },
+    }) as unknown as AppConfig;
+}
+
+interface HarnessOpts {
+  trigger: TriggerRow;
+  bb: BitbucketHttpFn;
+  gh: ExecFileFn;
+  masterOn?: boolean;
+  trackerOn?: boolean;
+  allowedRepoPaths?: () => string[];
+  synthesizer?: TicketSynthesizer;
+  logs?: string[];
+}
+
+function harness(opts: HarnessOpts) {
+  let stored = opts.trigger;
+  const updates: Array<Partial<TriggerRow>> = [];
+  const deps: BitbucketIssuesPollerDeps = {
+    getEnabledTriggersByType: async () => [stored],
+    runInProject: async (_pid, fn) => fn(),
+    getTrigger: async () => stored,
+    updateTrigger: async (_id, u) => {
+      updates.push(u);
+      if (u.config) stored = { ...stored, config: u.config } as TriggerRow;
+      return stored;
+    },
+    config: cfg(opts.masterOn ?? true, opts.trackerOn ?? true),
+    allowedRepoPaths: opts.allowedRepoPaths ?? (() => ["/repo/widget"]),
+    synthesizer: opts.synthesizer,
+    runGh: opts.gh,
+    bitbucketHttp: opts.bb,
+    bitbucketAuth: { username: "bot", appPassword: "secret" },
+    gitRemoteUrl: async () => "https://github.com/acme/widget.git",
+    log: (m) => opts.logs?.push(m),
+    now: () => 0,
+  };
+  return { poller: new BitbucketIssuesPoller(deps), updates };
+}
+
+const SHAPED_ISSUE = {
+  id: 42,
+  title: "Add rate limiting",
+  content: { raw: "## Problem\nNo limit.\n\n## Acceptance Criteria\n- returns 429 over 100 rpm\n- resets after window" },
+  state: "new",
+  kind: "task",
+  component: { name: "agent" },
+  updated_on: "2026-01-02T10:00:00.000000+00:00",
+  links: { html: { href: "https://bitbucket.org/acme/tracker-repo/issues/42" } },
+};
+
+const count = (argv: string[][], pred: (a: string[]) => boolean) => argv.filter(pred).length;
+const isPrCreate = (a: string[]) => a[0] === "pr" && a[1] === "create";
+const putContents = (a: string[]) =>
+  a[0] === "api" && a.includes("PUT") && a.some((x) => x.startsWith("repos/acme/widget/contents/"));
+
+function decodePutContent(argv: string[][]): string {
+  const put = argv.find(putContents);
+  if (!put) return "";
+  const arg = put.find((x) => x.startsWith("content="));
+  return arg ? Buffer.from(arg.slice("content=".length), "base64").toString("utf8") : "";
+}
+
+const commentPosts = (calls: Array<{ method: string; url: string }>) =>
+  calls.filter((c) => c.method === "POST" && c.url.includes("/comments")).length;
+
+describe("BitbucketIssuesPoller.pollAll", () => {
+  it("component-matched issue → spec PR (source.kind=bitbucket,ref=id) + ONE pickup comment + intake", async () => {
+    const { http, calls } = fakeBitbucket({ issues: [SHAPED_ISSUE] });
+    const { run, argv } = fakeGh();
+    const { poller, updates } = harness({ trigger: bbTrigger(), bb: http, gh: run });
+    await poller.pollAll();
+
+    const put = argv.find(putContents);
+    expect(put).toBeTruthy();
+    expect(put!.some((x) => x.includes("contents/docs/specs/bitbucket-42-add-rate-limiting.md"))).toBe(true);
+
+    const spec = decodePutContent(argv);
+    expect(spec).toContain("kind: bitbucket");
+    expect(spec).toContain('ref: "42"');
+
+    expect(count(argv, isPrCreate)).toBe(1);
+    expect(commentPosts(calls)).toBe(1);
+
+    const last = updates[updates.length - 1].config as TrackerEventTriggerConfig;
+    expect(last.pollState?.intake?.["42"]?.specPrUrl).toBe("https://github.com/acme/widget/pull/9");
+  });
+
+  it("re-poll the same issue → NO 2nd PR, NO 2nd comment (watermark dedup)", async () => {
+    const { http, calls } = fakeBitbucket({ issues: [SHAPED_ISSUE] });
+    const { run, argv } = fakeGh();
+    const { poller } = harness({ trigger: bbTrigger(), bb: http, gh: run });
+    await poller.pollAll();
+    await poller.pollAll();
+    expect(count(argv, isPrCreate)).toBe(1);
+    expect(commentPosts(calls)).toBe(1);
+  });
+
+  it("component-mismatched issue → skipped (defence-in-depth)", async () => {
+    const other = { ...SHAPED_ISSUE, id: 43, component: { name: "other" }, kind: "bug" };
+    const { http } = fakeBitbucket({ issues: [other] });
+    const { run, argv } = fakeGh();
+    const { poller } = harness({ trigger: bbTrigger(), bb: http, gh: run });
+    await poller.pollAll();
+    expect(count(argv, isPrCreate)).toBe(0);
+  });
+
+  it("free-form issue + synthesiser empty → need-criteria comment, NO spec PR, NO intake", async () => {
+    const freeForm = { id: 44, title: "vague", content: { raw: "please make it better" }, state: "new", component: { name: "agent" } };
+    const synthesizer: TicketSynthesizer = { synthesize: async () => ({ criteria: [] }) };
+    const { http, calls } = fakeBitbucket({ issues: [freeForm] });
+    const { run, argv } = fakeGh();
+    const { poller, updates } = harness({ trigger: bbTrigger(), bb: http, gh: run, synthesizer });
+    await poller.pollAll();
+
+    expect(commentPosts(calls)).toBe(1);
+    expect(count(argv, isPrCreate)).toBe(0);
+    const last = updates[updates.length - 1].config as TrackerEventTriggerConfig;
+    expect(last.pollState?.intake?.["44"]).toBeUndefined();
+  });
+
+  it("no filter.label configured → skipped (no Bitbucket call at all)", async () => {
+    const { http, calls } = fakeBitbucket({ issues: [SHAPED_ISSUE] });
+    const { run } = fakeGh();
+    const { poller, updates } = harness({ trigger: bbTrigger({ filter: {} }), bb: http, gh: run });
+    await poller.pollAll();
+    expect(calls.length).toBe(0);
+    expect(updates.length).toBe(0);
+  });
+
+  it("master switch off → no Bitbucket calls at all", async () => {
+    const { http, calls } = fakeBitbucket({ issues: [SHAPED_ISSUE] });
+    const { run } = fakeGh();
+    const { poller } = harness({ trigger: bbTrigger(), bb: http, gh: run, masterOn: false });
+    await poller.pollAll();
+    expect(calls.length).toBe(0);
+  });
+
+  it("Bitbucket outage on the list → skip cycle, watermark untouched, no crash", async () => {
+    const { http } = fakeBitbucket({ listStatus: 500 });
+    const { run } = fakeGh();
+    const { poller, updates } = harness({ trigger: bbTrigger(), bb: http, gh: run });
+    await expect(poller.pollAll()).resolves.toBeUndefined();
+    expect(updates.length).toBe(0);
+  });
+
+  it("targetRepoPath NOT in the allowlist → skipped fail-closed (no Bitbucket, no gh)", async () => {
+    const { http, calls } = fakeBitbucket({ issues: [SHAPED_ISSUE] });
+    const { run, argv } = fakeGh();
+    const { poller } = harness({
+      trigger: bbTrigger(),
+      bb: http,
+      gh: run,
+      allowedRepoPaths: () => ["/some/other/repo"],
+    });
+    await poller.pollAll();
+    expect(calls.length).toBe(0);
+    expect(argv.length).toBe(0);
+  });
+
+  it("a gitlab-configured trigger is ignored by the bitbucket poller", async () => {
+    const { http, calls } = fakeBitbucket({ issues: [SHAPED_ISSUE] });
+    const { run } = fakeGh();
+    const { poller, updates } = harness({ trigger: bbTrigger({ tracker: "gitlab" }), bb: http, gh: run });
+    await poller.pollAll();
+    expect(calls.length).toBe(0);
+    expect(updates.length).toBe(0);
+  });
+});
+
+describe("BitbucketIssuesPoller.start gating", () => {
+  it("tracker disabled → start() builds no interval", () => {
+    vi.useFakeTimers();
+    try {
+      const { http } = fakeBitbucket({ issues: [SHAPED_ISSUE] });
+      const { run } = fakeGh();
+      const logs: string[] = [];
+      const { poller } = harness({ trigger: bbTrigger(), bb: http, gh: run, trackerOn: false, logs });
+      poller.start();
+      vi.advanceTimersByTime(10 * 60 * 1000);
+      expect(logs.some((l) => l.includes("disabled"))).toBe(true);
+      poller.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("tracker enabled → start() logs a started poller", () => {
+    vi.useFakeTimers();
+    try {
+      const { http } = fakeBitbucket({ issues: [] });
+      const { run } = fakeGh();
+      const logs: string[] = [];
+      const { poller } = harness({ trigger: bbTrigger(), bb: http, gh: run, trackerOn: true, logs });
+      poller.start();
+      expect(logs.some((l) => l.includes("bitbucket tracker poller started"))).toBe(true);
+      poller.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/unit/consilium/trackers/gitlab-connector.test.ts
+++ b/tests/unit/consilium/trackers/gitlab-connector.test.ts
@@ -1,0 +1,194 @@
+/**
+ * gitlab-connector.test.ts — TRACK-4 GitLab dialect with a FAKE GitLab HTTP transport
+ * (no network). Covers: the project ref is sanitised + URL-encoded (path-escape proof);
+ * the label is a plain query param; watch/read mapping to the normalised Ticket;
+ * idempotent note write-back (marker dedup, no double-post); the pickup label add
+ * (GitLab's "transition"); and the deterministic `spec/gitlab-<iid>` naming.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  GitlabTrackerConnector,
+  sanitizeProjectRef,
+  sanitizeIid,
+  gitlabSpecBranchName,
+  gitlabSpecFilePath,
+  type GitlabConnectorConfig,
+} from "../../../../server/services/consilium/trackers/gitlab-connector.js";
+import { isValidSpecBranch } from "../../../../server/services/consilium/trackers/spec-writer.js";
+import type { GitlabHttpFn, GitlabHttpResult } from "../../../../server/services/consilium/trackers/gitlab-exec.js";
+
+interface Call {
+  method: string;
+  url: string;
+  body?: string;
+}
+
+function fakeHttp(handler: (call: Call) => GitlabHttpResult): { http: GitlabHttpFn; calls: Call[] } {
+  const calls: Call[] = [];
+  const http: GitlabHttpFn = vi.fn(async (req) => {
+    const call: Call = { method: req.method, url: req.url, body: req.body };
+    calls.push(call);
+    return handler(call);
+  });
+  return { http, calls };
+}
+
+const json = (obj: unknown, status = 200): GitlabHttpResult => ({ status, body: JSON.stringify(obj) });
+
+const CFG: GitlabConnectorConfig = {
+  baseUrl: "https://gitlab.com",
+  project: "group/widget",
+  label: "agent",
+};
+
+function connector(cfg: Partial<GitlabConnectorConfig>, handler: (c: Call) => GitlabHttpResult) {
+  const { http, calls } = fakeHttp(handler);
+  const conn = new GitlabTrackerConnector({ ...CFG, ...cfg }, {
+    http,
+    auth: { token: "secret-token" },
+    log: () => {},
+  });
+  return { conn, calls };
+}
+
+/** True for the ISSUES LIST url (`.../issues` with no trailing id segment). */
+const isList = (u: string) => new URL(u).pathname.endsWith("/issues");
+const isNotes = (u: string) => new URL(u).pathname.endsWith("/notes");
+const isSingle = (u: string) => /\/issues\/\d+$/.test(new URL(u).pathname);
+
+describe("naming + id sanitisation", () => {
+  it("derives a shape-safe branch/path from the iid", () => {
+    expect(gitlabSpecBranchName("42")).toBe("spec/gitlab-42");
+    expect(isValidSpecBranch(gitlabSpecBranchName("42"))).toBe(true);
+    expect(gitlabSpecFilePath("42", "Add Rate Limiting!")).toBe("docs/specs/gitlab-42-add-rate-limiting.md");
+  });
+
+  it("strips non-digits so a hostile iid can never escape", () => {
+    expect(sanitizeIid("../../etc/passwd")).toBe("");
+    expect(sanitizeIid("42abc")).toBe("42");
+    expect(() => gitlabSpecBranchName("../7")).not.toThrow(); // sanitises to "7"
+    expect(gitlabSpecBranchName("../7")).toBe("spec/gitlab-7");
+  });
+
+  it("throws on an iid that sanitises to empty", () => {
+    expect(() => gitlabSpecBranchName("abc")).toThrow();
+  });
+
+  it("sanitises a project ref to a URL-safe path (no escape, no traversal)", () => {
+    expect(sanitizeProjectRef("group/sub/widget")).toBe("group/sub/widget");
+    expect(sanitizeProjectRef("42")).toBe("42");
+    expect(sanitizeProjectRef("../../../etc")).toBe("etc"); // dots+slashes collapse, no `..`
+    expect(sanitizeProjectRef("a\\b`c;d")).toBe("abcd");
+  });
+});
+
+describe("pollTickets — query construction + mapping", () => {
+  const ISSUE = {
+    iid: 7,
+    title: "Add rate limiting",
+    description: "## Acceptance Criteria\n- returns 429",
+    labels: ["agent", "backend"],
+    web_url: "https://gitlab.com/group/widget/-/issues/7",
+    updated_at: "2026-01-02T10:00:00.000Z",
+  };
+
+  it("filters by label + opened state and encodes the project path", async () => {
+    let listUrl = "";
+    const { conn } = connector({}, (c) => {
+      if (isList(c.url)) {
+        listUrl = c.url;
+        return json([ISSUE]);
+      }
+      return json({});
+    });
+    const tickets = await conn.pollTickets();
+    const u = new URL(listUrl);
+    expect(u.pathname).toBe("/api/v4/projects/group%2Fwidget/issues");
+    expect(u.searchParams.get("labels")).toBe("agent");
+    expect(u.searchParams.get("state")).toBe("opened");
+    expect(tickets).toHaveLength(1);
+    expect(tickets![0]).toMatchObject({
+      id: "7",
+      title: "Add rate limiting",
+      body: "## Acceptance Criteria\n- returns 429",
+      labels: ["agent", "backend"],
+      url: "https://gitlab.com/group/widget/-/issues/7",
+    });
+  });
+
+  it("passes an ISO watermark as updated_after, ignores garbage", async () => {
+    const urls: string[] = [];
+    const { conn } = connector({}, (c) => {
+      if (isList(c.url)) { urls.push(c.url); return json([]); }
+      return json({});
+    });
+    await conn.pollTickets("2026-01-01T00:00:00.000Z");
+    expect(new URL(urls[0]).searchParams.get("updated_after")).toBe("2026-01-01T00:00:00.000Z");
+
+    await conn.pollTickets("not-a-date");
+    expect(new URL(urls[1]).searchParams.get("updated_after")).toBeNull(); // garbage watermark dropped
+  });
+
+  it("returns null on a degraded search (HTTP 500) and on unconfigured auth", async () => {
+    const { conn } = connector({}, (c) => (isList(c.url) ? { status: 500, body: "boom" } : json({})));
+    expect(await conn.pollTickets()).toBeNull();
+
+    const { http } = fakeHttp(() => json([ISSUE]));
+    const noAuth = new GitlabTrackerConnector(CFG, { http, auth: null, log: () => {} });
+    expect(await noAuth.pollTickets()).toBeNull();
+  });
+
+  it("readTicket fetches one issue by iid", async () => {
+    const { conn, calls } = connector({}, (c) => (isSingle(c.url) ? json(ISSUE) : json({})));
+    const t = await conn.readTicket("7");
+    expect(t?.id).toBe("7");
+    expect(calls.some((c) => c.method === "GET" && new URL(c.url).pathname.endsWith("/issues/7"))).toBe(true);
+  });
+});
+
+describe("write-back — note idempotency + pickup label", () => {
+  it("posts a note when the marker is absent", async () => {
+    const { conn, calls } = connector({}, (c) => {
+      if (isNotes(c.url) && c.method === "GET") return json([]);
+      if (isNotes(c.url) && c.method === "POST") return { status: 201, body: "{}" };
+      return json({});
+    });
+    const res = await conn.writeback.comment("7", "picked up", "<!-- marker -->");
+    expect(res.posted).toBe(true);
+    const post = calls.find((c) => isNotes(c.url) && c.method === "POST");
+    expect(post!.body).toContain("<!-- marker -->");
+    expect(post!.body).toContain("picked up");
+  });
+
+  it("does NOT double-post when a note already carries the marker", async () => {
+    const { conn, calls } = connector({}, (c) =>
+      isNotes(c.url) && c.method === "GET" ? json([{ body: "<!-- marker -->\npicked up earlier" }]) : json({}),
+    );
+    const res = await conn.writeback.comment("7", "picked up", "<!-- marker -->");
+    expect(res.posted).toBe(false);
+    expect(calls.some((c) => c.method === "POST")).toBe(false);
+  });
+
+  it("does NOT post when notes are unreadable (safety over liveness)", async () => {
+    const { conn, calls } = connector({}, (c) =>
+      isNotes(c.url) && c.method === "GET" ? { status: 503, body: "" } : json({}),
+    );
+    const res = await conn.writeback.comment("7", "x", "<!-- m -->");
+    expect(res.posted).toBe(false);
+    expect(calls.some((c) => c.method === "POST")).toBe(false);
+  });
+
+  it("adds a label via PUT add_labels (the pickup transition); blank → no-op", async () => {
+    const { conn, calls } = connector({}, (c) =>
+      c.method === "PUT" && isSingle(c.url) ? { status: 200, body: "{}" } : json({}),
+    );
+    const ok = await conn.writeback.transition!("7", "in-progress");
+    expect(ok.posted).toBe(true);
+    const put = calls.find((c) => c.method === "PUT");
+    expect(put!.body).toContain('"add_labels":"in-progress"');
+
+    const noop = await conn.writeback.transition!("7", "   ");
+    expect(noop.posted).toBe(false);
+    expect(noop.reason).toBe("no-label");
+  });
+});

--- a/tests/unit/consilium/trackers/gitlab-issues-poller.test.ts
+++ b/tests/unit/consilium/trackers/gitlab-issues-poller.test.ts
@@ -1,0 +1,298 @@
+/**
+ * gitlab-issues-poller.test.ts — TRACK-4 poller with a FAKE GitLab transport + FAKE `gh`.
+ *
+ * Mirrors jira-issues-poller.test: a labelled GitLab issue → the SHARED synth → a spec PR
+ * (contents PUT to a docs/specs/gitlab-<iid>-… path whose frontmatter carries
+ * source.kind=gitlab,ref=<iid>) + exactly ONE GitLab pickup note + a watermark intake; a
+ * re-poll does NOT re-create or re-note (dedup); an unlabelled issue is skipped
+ * (defence-in-depth); a free-form issue with no criteria → a need-criteria note + NO PR +
+ * NO intake; the master switch off ⇒ no GitLab calls; the tracker switch off ⇒ start()
+ * builds no interval; a GitLab outage on the list skips the cycle (watermark untouched);
+ * a non-allowlisted targetRepoPath is fail-closed.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  GitlabIssuesPoller,
+  type GitlabIssuesPollerDeps,
+  type TicketSynthesizer,
+} from "../../../../server/services/consilium/trackers/gitlab-issues-poller.js";
+import type { GitlabHttpFn, GitlabHttpResult } from "../../../../server/services/consilium/trackers/gitlab-exec.js";
+import type { ExecFileFn } from "../../../../server/services/github-status.js";
+import type { TriggerRow } from "../../../../shared/schema.js";
+import type { AppConfig, TrackerEventTriggerConfig } from "../../../../shared/types.js";
+
+interface GitlabOpts {
+  issues?: unknown[];
+  notes?: Array<{ body?: string }>;
+  listStatus?: number;
+}
+
+/** A fake GitLab transport for the list + notes (idempotency read + post) chain. */
+function fakeGitlab(opts: GitlabOpts): { http: GitlabHttpFn; calls: Array<{ method: string; url: string; body?: string }> } {
+  const calls: Array<{ method: string; url: string; body?: string }> = [];
+  const http: GitlabHttpFn = vi.fn(async (req): Promise<GitlabHttpResult> => {
+    calls.push({ method: req.method, url: req.url, body: req.body });
+    const json = (obj: unknown, status = 200): GitlabHttpResult => ({ status, body: JSON.stringify(obj) });
+    const path = new URL(req.url).pathname;
+    if (path.endsWith("/notes") && req.method === "GET") return json(opts.notes ?? []);
+    if (path.endsWith("/notes") && req.method === "POST") return { status: 201, body: "{}" };
+    if (path.endsWith("/issues")) {
+      if (opts.listStatus && opts.listStatus >= 400) return { status: opts.listStatus, body: "err" };
+      return json(opts.issues ?? []);
+    }
+    return json({});
+  });
+  return { http, calls };
+}
+
+/** A fake `gh` that serves the writeSpecPr chain (no issue list — GitLab does the watch). */
+function fakeGh(prUrl = "https://github.com/acme/widget/pull/7"): { run: ExecFileFn; argv: string[][] } {
+  const argv: string[][] = [];
+  const run: ExecFileFn = vi.fn(async (_file: string, args: string[]) => {
+    argv.push(args);
+    const json = (obj: unknown) => ({ stdout: JSON.stringify(obj), stderr: "" });
+    if (args[0] === "pr" && args[1] === "list") return json([]);
+    if (args[0] === "repo" && args[1] === "view") return json({ defaultBranchRef: { name: "main" } });
+    if (args[0] === "api") {
+      if (args.indexOf("--method") === -1) return json({ object: { sha: "basesha" } });
+      return { stdout: "", stderr: "" };
+    }
+    if (args[0] === "pr" && args[1] === "create") return { stdout: `${prUrl}\n`, stderr: "" };
+    return { stdout: "", stderr: "" };
+  });
+  return { run, argv };
+}
+
+function gitlabTrigger(config?: Partial<TrackerEventTriggerConfig>): TriggerRow {
+  const full: TrackerEventTriggerConfig = {
+    tracker: "gitlab",
+    baseUrl: "https://gitlab.com",
+    gitlabProject: "group/widget",
+    repo: "acme/widget",
+    targetRepoPath: "/repo/widget",
+    filter: { label: "agent" },
+    specStatus: "ready",
+    ...config,
+  };
+  return {
+    id: "trk-gitlab-1",
+    projectId: "proj-1",
+    pipelineId: null,
+    type: "tracker_event",
+    config: JSON.parse(JSON.stringify(full)) as TrackerEventTriggerConfig,
+    secretEncrypted: null,
+    enabled: true,
+    lastTriggeredAt: null,
+    suppressedCount: 0,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  } as unknown as TriggerRow;
+}
+
+function cfg(masterOn: boolean, trackerOn = true, pollIntervalSec = 300): () => AppConfig {
+  return () =>
+    ({
+      features: { triggers: { enabled: masterOn, tracker: { enabled: trackerOn, pollIntervalSec } } },
+    }) as unknown as AppConfig;
+}
+
+interface HarnessOpts {
+  trigger: TriggerRow;
+  gitlab: GitlabHttpFn;
+  gh: ExecFileFn;
+  masterOn?: boolean;
+  trackerOn?: boolean;
+  allowedRepoPaths?: () => string[];
+  synthesizer?: TicketSynthesizer;
+  logs?: string[];
+}
+
+function harness(opts: HarnessOpts) {
+  let stored = opts.trigger;
+  const updates: Array<Partial<TriggerRow>> = [];
+  const deps: GitlabIssuesPollerDeps = {
+    getEnabledTriggersByType: async () => [stored],
+    runInProject: async (_pid, fn) => fn(),
+    getTrigger: async () => stored,
+    updateTrigger: async (_id, u) => {
+      updates.push(u);
+      if (u.config) stored = { ...stored, config: u.config } as TriggerRow;
+      return stored;
+    },
+    config: cfg(opts.masterOn ?? true, opts.trackerOn ?? true),
+    allowedRepoPaths: opts.allowedRepoPaths ?? (() => ["/repo/widget"]),
+    synthesizer: opts.synthesizer,
+    runGh: opts.gh,
+    gitlabHttp: opts.gitlab,
+    gitlabAuth: { token: "secret" },
+    gitRemoteUrl: async () => "https://github.com/acme/widget.git",
+    log: (m) => opts.logs?.push(m),
+    now: () => 0,
+  };
+  return { poller: new GitlabIssuesPoller(deps), updates };
+}
+
+const SHAPED_ISSUE = {
+  iid: 1,
+  title: "Add rate limiting",
+  description: "## Problem\nNo limit.\n\n## Acceptance Criteria\n- returns 429 over 100 rpm\n- resets after window",
+  labels: ["agent"],
+  web_url: "https://gitlab.com/group/widget/-/issues/1",
+  updated_at: "2026-01-02T10:00:00.000Z",
+};
+
+const count = (argv: string[][], pred: (a: string[]) => boolean) => argv.filter(pred).length;
+const isPrCreate = (a: string[]) => a[0] === "pr" && a[1] === "create";
+const putContents = (a: string[]) =>
+  a[0] === "api" && a.includes("PUT") && a.some((x) => x.startsWith("repos/acme/widget/contents/"));
+
+function decodePutContent(argv: string[][]): string {
+  const put = argv.find(putContents);
+  if (!put) return "";
+  const arg = put.find((x) => x.startsWith("content="));
+  return arg ? Buffer.from(arg.slice("content=".length), "base64").toString("utf8") : "";
+}
+
+const notePosts = (calls: Array<{ method: string; url: string }>) =>
+  calls.filter((c) => c.method === "POST" && c.url.includes("/notes")).length;
+
+describe("GitlabIssuesPoller.pollAll", () => {
+  it("labelled issue → spec PR (source.kind=gitlab,ref=iid) + ONE GitLab pickup note + intake", async () => {
+    const { http, calls } = fakeGitlab({ issues: [SHAPED_ISSUE] });
+    const { run, argv } = fakeGh();
+    const { poller, updates } = harness({ trigger: gitlabTrigger(), gitlab: http, gh: run });
+    await poller.pollAll();
+
+    const put = argv.find(putContents);
+    expect(put).toBeTruthy();
+    expect(put!.some((x) => x.includes("contents/docs/specs/gitlab-1-add-rate-limiting.md"))).toBe(true);
+
+    const spec = decodePutContent(argv);
+    expect(spec).toContain("kind: gitlab");
+    expect(spec).toContain('ref: "1"');
+
+    expect(count(argv, isPrCreate)).toBe(1);
+    expect(notePosts(calls)).toBe(1);
+
+    const last = updates[updates.length - 1].config as TrackerEventTriggerConfig;
+    expect(last.pollState?.intake?.["1"]?.specPrUrl).toBe("https://github.com/acme/widget/pull/7");
+  });
+
+  it("re-poll the same issue → NO 2nd PR, NO 2nd note (watermark dedup)", async () => {
+    const { http, calls } = fakeGitlab({ issues: [SHAPED_ISSUE] });
+    const { run, argv } = fakeGh();
+    const { poller } = harness({ trigger: gitlabTrigger(), gitlab: http, gh: run });
+    await poller.pollAll();
+    await poller.pollAll();
+    expect(count(argv, isPrCreate)).toBe(1);
+    expect(notePosts(calls)).toBe(1);
+  });
+
+  it("unlabelled issue → skipped (no spec PR, defence-in-depth)", async () => {
+    const unlabelled = { ...SHAPED_ISSUE, iid: 2, labels: ["other"] };
+    const { http } = fakeGitlab({ issues: [unlabelled] });
+    const { run, argv } = fakeGh();
+    const { poller } = harness({ trigger: gitlabTrigger(), gitlab: http, gh: run });
+    await poller.pollAll();
+    expect(count(argv, isPrCreate)).toBe(0);
+  });
+
+  it("free-form issue + synthesiser empty → need-criteria note, NO spec PR, NO intake", async () => {
+    const freeForm = { iid: 3, title: "vague", description: "please make it better", labels: ["agent"] };
+    const synthesizer: TicketSynthesizer = { synthesize: async () => ({ criteria: [] }) };
+    const { http, calls } = fakeGitlab({ issues: [freeForm] });
+    const { run, argv } = fakeGh();
+    const { poller, updates } = harness({ trigger: gitlabTrigger(), gitlab: http, gh: run, synthesizer });
+    await poller.pollAll();
+
+    expect(notePosts(calls)).toBe(1);
+    expect(count(argv, isPrCreate)).toBe(0);
+    const last = updates[updates.length - 1].config as TrackerEventTriggerConfig;
+    expect(last.pollState?.intake?.["3"]).toBeUndefined();
+  });
+
+  it("no filter.label configured → skipped (no GitLab call at all)", async () => {
+    const { http, calls } = fakeGitlab({ issues: [SHAPED_ISSUE] });
+    const { run } = fakeGh();
+    const { poller, updates } = harness({ trigger: gitlabTrigger({ filter: {} }), gitlab: http, gh: run });
+    await poller.pollAll();
+    expect(calls.length).toBe(0);
+    expect(updates.length).toBe(0);
+  });
+
+  it("master switch off → no GitLab calls at all", async () => {
+    const { http, calls } = fakeGitlab({ issues: [SHAPED_ISSUE] });
+    const { run } = fakeGh();
+    const { poller } = harness({ trigger: gitlabTrigger(), gitlab: http, gh: run, masterOn: false });
+    await poller.pollAll();
+    expect(calls.length).toBe(0);
+  });
+
+  it("GitLab outage on the list → skip cycle, watermark untouched, no crash", async () => {
+    const { http } = fakeGitlab({ listStatus: 500 });
+    const { run } = fakeGh();
+    const { poller, updates } = harness({ trigger: gitlabTrigger(), gitlab: http, gh: run });
+    await expect(poller.pollAll()).resolves.toBeUndefined();
+    expect(updates.length).toBe(0);
+  });
+
+  it("targetRepoPath NOT in the allowlist → skipped fail-closed (no GitLab, no gh)", async () => {
+    const { http, calls } = fakeGitlab({ issues: [SHAPED_ISSUE] });
+    const { run, argv } = fakeGh();
+    const { poller } = harness({
+      trigger: gitlabTrigger(),
+      gitlab: http,
+      gh: run,
+      allowedRepoPaths: () => ["/some/other/repo"],
+    });
+    await poller.pollAll();
+    expect(calls.length).toBe(0);
+    expect(argv.length).toBe(0);
+  });
+
+  it("a bitbucket-configured trigger is ignored by the gitlab poller", async () => {
+    const { http, calls } = fakeGitlab({ issues: [SHAPED_ISSUE] });
+    const { run } = fakeGh();
+    const { poller, updates } = harness({
+      trigger: gitlabTrigger({ tracker: "bitbucket" }),
+      gitlab: http,
+      gh: run,
+    });
+    await poller.pollAll();
+    expect(calls.length).toBe(0);
+    expect(updates.length).toBe(0);
+  });
+});
+
+describe("GitlabIssuesPoller.start gating", () => {
+  it("tracker disabled → start() builds no interval", () => {
+    vi.useFakeTimers();
+    try {
+      const { http } = fakeGitlab({ issues: [SHAPED_ISSUE] });
+      const { run } = fakeGh();
+      const logs: string[] = [];
+      const { poller } = harness({ trigger: gitlabTrigger(), gitlab: http, gh: run, trackerOn: false, logs });
+      poller.start();
+      vi.advanceTimersByTime(10 * 60 * 1000);
+      expect(logs.some((l) => l.includes("disabled"))).toBe(true);
+      poller.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("tracker enabled → start() logs a started poller", () => {
+    vi.useFakeTimers();
+    try {
+      const { http } = fakeGitlab({ issues: [] });
+      const { run } = fakeGh();
+      const logs: string[] = [];
+      const { poller } = harness({ trigger: gitlabTrigger(), gitlab: http, gh: run, trackerOn: true, logs });
+      poller.start();
+      expect(logs.some((l) => l.includes("gitlab tracker poller started"))).toBe(true);
+      poller.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
Implements **TRACK-4** from `docs/design/task-tracker-triggers.md` §2/§3/§4: the **GitLab Issues** and **Bitbucket Cloud Issues** connectors, each on the shipped `TrackerConnector` interface (TRACK-3). A labelled/component-matched issue becomes a **committed spec PR** in the target git repo + a **pickup write-back**; it hands off to SPEC-1's spec-watch (fires the loop on merge) and **does NOT fire loops** itself.

## Both connectors on the `TrackerConnector` interface
- **GitLab** (`gitlab-connector.ts` + `gitlab-exec.ts` + `gitlab-issues-poller.ts`): watch = REST poll `/projects/:id/issues?labels=…&state=opened&updated_after=…`; read = `/issues/:iid`; write-back = `/issues/:iid/notes` (idempotent, marker-deduped) + an optional pickup **label** (GitLab has no arbitrary states, so its "transition" is `add_labels`). Provenance `source:{kind:gitlab, ref:<iid>, url}`. Auth: PAT/project token from `GITLAB_TOKEN` (`PRIVATE-TOKEN` header), fail-closed, never logged.
- **Bitbucket Cloud** (`bitbucket-connector.ts` + `bitbucket-exec.ts` + `bitbucket-issues-poller.ts`): watch = BBQL poll `/repositories/:ws/:repo/issues?q=…`; read = `/issues/:id`; write-back = `/issues/:id/comments` (idempotent) + an optional pickup **state**. Bitbucket issues have no free-form labels, so the consent `filter.label` maps to the issue **component** (and `Ticket.labels` is built from component+kind+priority for the defence-in-depth re-check). Provenance `source:{kind:bitbucket, ref:<id>, url}`. Auth: app password from `BITBUCKET_USERNAME`/`BITBUCKET_APP_PASSWORD` (Basic), fail-closed.

## Reused (crystallize / spec-writer / dedup) vs dialect-only
**Reused byte-for-byte** — `renderSpecMarkdown` + `TicketSource` provenance (`issue-spec.ts`), the remote spec-PR writer (`spec-writer.ts`), and `crystallizeTicket()` (synth → spec PR → pickup/need-criteria tail, dedup, watermark). **Dialect-only** — each connector supplies just its watch/read/write-back API calls and its deterministic `spec/gitlab-<iid>` / `spec/bitbucket-<id>` branch + `docs/specs/…` file naming. Each new exec seam mirrors `jira-exec.ts`: https-only + origin-checked (SSRF), never-throw degrade (`null`/`{ok:false}`), secrets never logged, query literals injection-sanitised.

## Config union additions
`TrackerEventTriggerConfig.tracker` widened **additively** to `"github" | "jira" | "gitlab" | "bitbucket"` (+ `gitlabProject`, `workspace`, `repoSlug`; `transitionTo` reused as the connector-interpreted pickup move). `SPEC_BRANCH_RE` extended with `gitlab-<n>`/`bitbucket-<n>` alternatives. Two new pollers wired in `routes.ts` under the **same** `features.triggers.tracker.enabled` kill-switch.

## Kill-switch
Default **OFF** (`features.triggers.tracker.enabled` + master `features.triggers.enabled`). Pollers not constructed when off; `start()` builds no interval; `pollAll()` no-ops on the master switch.

## GitHub + Jira stay byte-identical
No diff to `gh-exec` / `github-issues-poller` / `issue-spec` / `issue-writeback` / `jira-*` / `spec-intake` / `tracker-connector` / `writeback-observer`. Each poller guards on `config.tracker !== "<kind>"`, so a GitHub/Jira trigger is untouched by the new pollers and vice-versa. Only additive edits to `spec-writer.ts` (regex), `shared/types.ts` (union), `routes.ts` (wiring).

## Tests (mock each REST seam)
4 new specs, 47 cases: labelled issue → shared synth → spec PR with `source.kind=gitlab|bitbucket` + exactly one note/comment; re-poll dedup (no 2nd PR/comment on edit); unlabelled / component-mismatch skip; no-criteria ask-comment + no PR + no intake; kill-switch off; outage skip (watermark untouched); allowlist fail-closed; cross-tracker trigger ignored; id/slug/query-literal sanitisation (BBQL + GitLab project-ref injection). Full tracker suite (131) and full unit project (5295) green; tsc clean.

## Adversarial self-review
Secrets never logged (exec seams scrub + omit auth headers); untrusted title/body fenced by the shared synth and slugified before any filename; ids sanitised to digits; dedup prevents a 2nd spec PR on issue edit (intake watermark + deterministic branch + spec-writer pr-list); query injection blocked (GitLab label is URL-encoded; Bitbucket `bbqlLiteral` drops quote/backslash breakouts); union/registry edits don't touch GitHub/Jira; closed issues excluded at the source (`state=opened` / BBQL `state IN (new,open)`) so a watermark can't re-fire them.

Draft — do not merge.