### PR TITLE
feat: StandingRole concerns + trigger-wake (ROLE-2)

### DIFF
--- a/client/src/hooks/use-roles.ts
+++ b/client/src/hooks/use-roles.ts
@@ -7,7 +7,11 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/hooks/use-pipeline";
 import type { StandingRoleRow } from "@shared/schema";
-import type { StandingRoleLoopTemplate } from "@shared/types";
+import type {
+  StandingRoleLoopTemplate,
+  StandingRolePolicy,
+  StandingRoleConcernTrigger,
+} from "@shared/types";
 
 const ROLES_KEY = ["/api/roles"] as const;
 
@@ -18,6 +22,16 @@ export interface CreateRolePayload {
   persona: string;
   skills: string[];
   loopTemplate: StandingRoleLoopTemplate;
+  policy?: StandingRolePolicy;
+  enabled?: boolean;
+}
+
+/** ROLE-2: a concern to add to a role (materialises a backing trigger server-side). */
+export interface AddConcernPayload {
+  roleId: string;
+  repoPath: string;
+  focus: string;
+  trigger: StandingRoleConcernTrigger;
   enabled?: boolean;
 }
 
@@ -78,5 +92,39 @@ export function useWakeRole() {
         { id?: string } & Record<string, unknown>
       >,
     onSuccess: () => qc.invalidateQueries({ queryKey: ["/api/consilium-loops"] }),
+  });
+}
+
+// ─── ROLE-2: concern hooks ────────────────────────────────────────────────────
+
+/** Add a concern to a role → binds a trigger; a firing wakes the role. */
+export function useAddConcern() {
+  const qc = useQueryClient();
+  return useMutation<StandingRoleRow, Error, AddConcernPayload>({
+    mutationFn: ({ roleId, ...body }) =>
+      apiRequest("POST", `/api/roles/${roleId}/concerns`, body) as Promise<StandingRoleRow>,
+    onSuccess: () => qc.invalidateQueries({ queryKey: ROLES_KEY }),
+  });
+}
+
+/** Remove a concern from a role → tears down its backing trigger. */
+export function useDeleteConcern() {
+  const qc = useQueryClient();
+  return useMutation<StandingRoleRow, Error, { roleId: string; concernId: string }>({
+    mutationFn: ({ roleId, concernId }) =>
+      apiRequest("DELETE", `/api/roles/${roleId}/concerns/${concernId}`) as Promise<StandingRoleRow>,
+    onSuccess: () => qc.invalidateQueries({ queryKey: ROLES_KEY }),
+  });
+}
+
+/** The loops a role has woken (trigger wakes + manual wakes) — for the role card. */
+export function useWokenLoops(roleId: string, enabled = true) {
+  return useQuery<Array<{ id: string; state?: string; repoPath?: string }>>({
+    queryKey: ["/api/roles", roleId, "woken-loops"],
+    queryFn: () =>
+      apiRequest("GET", `/api/roles/${roleId}/woken-loops`) as Promise<
+        Array<{ id: string; state?: string; repoPath?: string }>
+      >,
+    enabled,
   });
 }

--- a/client/src/pages/Roles.tsx
+++ b/client/src/pages/Roles.tsx
@@ -9,9 +9,9 @@
  */
 import { useState } from "react";
 import { useLocation } from "wouter";
-import { UserCog, Plus, Trash2, Zap } from "lucide-react";
+import { UserCog, Plus, Trash2, Zap, Eye, Radio } from "lucide-react";
 import { CONSILIUM_REVIEW_PRESETS, REVIEW_MODES } from "@shared/types";
-import type { ConsiliumReviewPreset, ReviewMode } from "@shared/types";
+import type { ConsiliumReviewPreset, ReviewMode, StandingRoleConcern } from "@shared/types";
 import type { StandingRoleRow } from "@shared/schema";
 import { useSkills } from "@/hooks/use-skills";
 import {
@@ -19,6 +19,9 @@ import {
   useCreateRole,
   useDeleteRole,
   useWakeRole,
+  useAddConcern,
+  useDeleteConcern,
+  useWokenLoops,
 } from "@/hooks/use-roles";
 import { useToast } from "@/hooks/use-toast";
 import { Button } from "@/components/ui/button";
@@ -340,11 +343,237 @@ function WakeRoleDialog({ role }: { role: StandingRoleRow }) {
   );
 }
 
+// ─── Add-concern dialog (ROLE-2) ──────────────────────────────────────────────
+
+function AddConcernDialog({ role }: { role: StandingRoleRow }) {
+  const [open, setOpen] = useState(false);
+  const [triggerType, setTriggerType] = useState<"file_change" | "github_event">("file_change");
+  const [repoPath, setRepoPath] = useState("");
+  const [focus, setFocus] = useState("");
+  const [watchPath, setWatchPath] = useState("");
+  const [patterns, setPatterns] = useState("");
+  const [repository, setRepository] = useState("");
+  const [events, setEvents] = useState("pull_request");
+  const { toast } = useToast();
+  const add = useAddConcern();
+
+  const reset = () => {
+    setTriggerType("file_change");
+    setRepoPath("");
+    setFocus("");
+    setWatchPath("");
+    setPatterns("");
+    setRepository("");
+    setEvents("pull_request");
+  };
+
+  const submit = async () => {
+    if (!repoPath.trim() || !focus.trim()) {
+      toast({ title: "Repo path and focus are required", variant: "destructive" });
+      return;
+    }
+    const trigger =
+      triggerType === "file_change"
+        ? {
+            type: "file_change" as const,
+            filter: {
+              watchPath: watchPath.trim() || repoPath.trim(),
+              patterns: patterns.trim() ? patterns.split(",").map((p) => p.trim()).filter(Boolean) : undefined,
+            },
+          }
+        : {
+            type: "github_event" as const,
+            filter: {
+              repository: repository.trim(),
+              events: events.trim() ? events.split(",").map((e) => e.trim()).filter(Boolean) : undefined,
+            },
+          };
+    if (triggerType === "file_change" && !(watchPath.trim() || repoPath.trim())) {
+      toast({ title: "A watch path is required", variant: "destructive" });
+      return;
+    }
+    if (triggerType === "github_event" && !repository.trim()) {
+      toast({ title: "A repository (owner/repo) is required", variant: "destructive" });
+      return;
+    }
+    try {
+      await add.mutateAsync({ roleId: role.id, repoPath: repoPath.trim(), focus: focus.trim(), trigger });
+      toast({ title: "Concern added — trigger bound" });
+      reset();
+      setOpen(false);
+    } catch (e) {
+      toast({
+        title: "Failed to add concern",
+        description: e instanceof Error ? e.message : undefined,
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="outline" data-testid={`add-concern-${role.id}`}>
+          <Radio className="h-4 w-4 mr-2" />
+          Add concern
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Watch a concern</DialogTitle>
+          <DialogDescription>
+            Bind a trigger to "{role.name}". When it fires, the role wakes and spawns a
+            review-only loop on the target repo using this focus.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>Trigger type</Label>
+            <Select value={triggerType} onValueChange={(v) => setTriggerType(v as "file_change" | "github_event")}>
+              <SelectTrigger data-testid="concern-trigger-type">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="file_change">file change</SelectItem>
+                <SelectItem value="github_event">github event</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {triggerType === "file_change" ? (
+            <>
+              <div className="space-y-1.5">
+                <Label htmlFor="concern-watch">Watch path</Label>
+                <Input
+                  id="concern-watch"
+                  data-testid="concern-watch-input"
+                  value={watchPath}
+                  onChange={(e) => setWatchPath(e.target.value)}
+                  placeholder="/repos/iac/modules"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="concern-patterns">Patterns (comma-separated, optional)</Label>
+                <Input
+                  id="concern-patterns"
+                  value={patterns}
+                  onChange={(e) => setPatterns(e.target.value)}
+                  placeholder="**/*.tf, !**/.terraform/**"
+                />
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="space-y-1.5">
+                <Label htmlFor="concern-repo">Repository (owner/repo)</Label>
+                <Input
+                  id="concern-repo"
+                  data-testid="concern-repository-input"
+                  value={repository}
+                  onChange={(e) => setRepository(e.target.value)}
+                  placeholder="my-org/iac"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="concern-events">Events (comma-separated)</Label>
+                <Input
+                  id="concern-events"
+                  value={events}
+                  onChange={(e) => setEvents(e.target.value)}
+                  placeholder="pull_request, push"
+                />
+              </div>
+            </>
+          )}
+
+          <div className="space-y-1.5">
+            <Label htmlFor="concern-repopath">Target repo path</Label>
+            <Input
+              id="concern-repopath"
+              data-testid="concern-repopath-input"
+              value={repoPath}
+              onChange={(e) => setRepoPath(e.target.value)}
+              placeholder="/repos/iac"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="concern-focus">Focus</Label>
+            <Textarea
+              id="concern-focus"
+              data-testid="concern-focus-input"
+              value={focus}
+              onChange={(e) => setFocus(e.target.value)}
+              rows={2}
+              placeholder="A new or changed Terraform module version — review for CIS/security regressions."
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button onClick={submit} disabled={add.isPending} data-testid="concern-submit">
+            {add.isPending ? "Adding…" : "Add concern"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─── Concern list + woken loops (ROLE-2) ──────────────────────────────────────
+
+function ConcernRow({ role, concern }: { role: StandingRoleRow; concern: StandingRoleConcern }) {
+  const { toast } = useToast();
+  const del = useDeleteConcern();
+  const remove = async () => {
+    try {
+      await del.mutateAsync({ roleId: role.id, concernId: concern.id });
+      toast({ title: "Concern removed" });
+    } catch (e) {
+      toast({ title: "Failed to remove concern", description: e instanceof Error ? e.message : undefined, variant: "destructive" });
+    }
+  };
+  return (
+    <div className="flex items-start justify-between gap-2 rounded-md border p-2" data-testid={`concern-${concern.id}`}>
+      <div className="min-w-0 space-y-0.5">
+        <div className="flex items-center gap-1.5">
+          <Badge variant="outline" className="text-xs">{concern.trigger.type}</Badge>
+          {concern.enabled === false && <Badge variant="outline" className="text-xs">disabled</Badge>}
+          <span className="font-mono text-xs truncate">{concern.repoPath}</span>
+        </div>
+        <p className="text-xs text-muted-foreground line-clamp-2">{concern.focus}</p>
+      </div>
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={remove}
+        disabled={del.isPending}
+        data-testid={`delete-concern-${concern.id}`}
+      >
+        <Trash2 className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+}
+
+function WokenLoops({ roleId }: { roleId: string }) {
+  const { data } = useWokenLoops(roleId);
+  const loops = data ?? [];
+  if (loops.length === 0) {
+    return <p className="text-xs text-muted-foreground">No loops woken yet.</p>;
+  }
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      <Eye className="h-3.5 w-3.5" />
+      <span data-testid={`woken-count-${roleId}`}>{loops.length} loop{loops.length === 1 ? "" : "s"} woken</span>
+    </div>
+  );
+}
+
 // ─── Role card ──────────────────────────────────────────────────────────────
 
 function RoleCard({ role }: { role: StandingRoleRow }) {
   const { toast } = useToast();
   const del = useDeleteRole();
+  const concerns = (role.concerns ?? []) as StandingRoleConcern[];
 
   const remove = async () => {
     try {
@@ -387,6 +616,26 @@ function RoleCard({ role }: { role: StandingRoleRow }) {
         <p className="text-xs text-muted-foreground">
           maxRounds: {tpl.maxRounds ?? "default"} · reviewMode: {tpl.reviewMode ?? "operator default"}
         </p>
+
+        {/* ROLE-2: concerns the role watches (each bound to a trigger) + woken loops. */}
+        <div className="space-y-1.5 pt-1">
+          <div className="flex items-center justify-between">
+            <Label className="text-xs">Concerns ({concerns.length})</Label>
+            <AddConcernDialog role={role} />
+          </div>
+          {concerns.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              No concerns. Add one to bind a trigger — a firing wakes this role.
+            </p>
+          ) : (
+            <div className="space-y-1.5">
+              {concerns.map((c) => (
+                <ConcernRow key={c.id} role={role} concern={c} />
+              ))}
+            </div>
+          )}
+          <WokenLoops roleId={role.id} />
+        </div>
       </CardContent>
       <CardFooter className="gap-2">
         <WakeRoleDialog role={role} />

--- a/migrations/0048_standing_roles_concerns.sql
+++ b/migrations/0048_standing_roles_concerns.sql
@@ -1,0 +1,23 @@
+-- ROLE-2 (standing-role.md §3/§8): a Standing Role's CONCERNS + per-role rails.
+--
+-- Bind triggers to a role's concerns so a firing WAKES the role → spawns its loop
+-- (ROLE-1 shipped the record + manual wake). This migration is ADDITIVE only:
+--
+--   * `concerns` — jsonb array of { id, repoPath, trigger:{type,filter}, focus,
+--     enabled?, triggerId? }. WHAT the role watches + WHERE + the wake focus. Each
+--     concern's runtime footprint is a BACKING trigger row whose `config.roleConcern`
+--     names { roleId, concernId }; when that trigger fires the dispatch wakes the role.
+--     Defaults to '[]' so every ROLE-1 row reads back as "no concerns" (byte-identical).
+--
+--   * `policy` — jsonb { budgetPerDay?, cascadeDepth? }. The per-role rails
+--     (loop-triggers.md §4): a daily budget + a concurrent-loop cascade ceiling so a
+--     misfiring concern can't spawn unbounded loops. NULL ⇒ server default constants.
+--     `enabled` (unchanged) stays the role's primary kill-switch.
+--
+-- A role is a DEFINITION not a process (§6): no new runtime is added — the concern's
+-- backing trigger rides the EXISTING file-watcher / github poller.
+ALTER TABLE "standing_roles"
+  ADD COLUMN IF NOT EXISTS "concerns" jsonb DEFAULT '[]'::jsonb NOT NULL;
+
+ALTER TABLE "standing_roles"
+  ADD COLUMN IF NOT EXISTS "policy" jsonb;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -64,7 +64,7 @@ import { registerConsiliumLoopRoutes } from "./routes/consilium-loops";
 import { registerConsiliumReviewRoutes } from "./routes/consilium-reviews";
 import { registerStandingRoleRoutes } from "./routes/standing-roles";
 import { createConsiliumReview } from "./services/consilium/review-factory";
-import { maybeLaunchConsiliumReview, maybeLaunchGitHubReview, resolveSpecWatchConfig, deriveRepoRoot } from "./services/consilium/trigger-dispatch";
+import { maybeLaunchConsiliumReview, maybeLaunchGitHubReview, maybeLaunchRoleWake, resolveSpecWatchConfig, deriveRepoRoot } from "./services/consilium/trigger-dispatch";
 import { ConsiliumLoopController, ConsiliumLoopPoller } from "./services/consilium/consilium-loop-controller";
 import {
   writeSpecStatusRemote,
@@ -449,14 +449,21 @@ export async function registerRoutes(
         await storage.updateTrigger(trigger.id, { lastTriggeredAt: new Date() });
         log(`[triggers] Fired trigger ${trigger.id} (type ${trigger.type})`, "triggers");
 
-        // T1 KILL-SWITCH (loop-triggers.md §4.5): a SCHEDULE or GITHUB_EVENT trigger
-        // only fires a loop when `features.triggers.enabled` is on — a running server
-        // never silently starts firing scheduled OR github-event loops (a github
-        // webhook could otherwise start disputing PRs the moment it is wired). The
-        // pre-existing file_change binding is NOT gated here (it stays under
-        // consiliumLoop.enabled), so the one live prototype binding is unchanged.
+        // ROLE-2: is this the BACKING trigger of a Standing Role's concern? (config
+        // carries `roleConcern`). A role wake is a NEW autonomous behaviour → it is
+        // gated by the SAME master switch as schedule/github below, regardless of the
+        // underlying trigger class (so a role-bound file_change also requires the
+        // switch — default-off until an operator both defines a concern AND flips it).
+        const roleBinding = (trigger.config as { roleConcern?: unknown } | null)?.roleConcern;
+
+        // T1 KILL-SWITCH (loop-triggers.md §4.5): a SCHEDULE / GITHUB_EVENT trigger, or
+        // ANY role-bound trigger (ROLE-2), only fires a loop when
+        // `features.triggers.enabled` is on — a running server never silently starts
+        // firing scheduled / github-event / role-wake loops. The pre-existing NON-role
+        // file_change binding is NOT gated here (it stays under consiliumLoop.enabled),
+        // so the one live prototype binding is unchanged.
         if (
-          (trigger.type === "schedule" || trigger.type === "github_event") &&
+          (trigger.type === "schedule" || trigger.type === "github_event" || roleBinding) &&
           !appConfigLoader.get().features.triggers.enabled
         ) {
           log(`[triggers] ${trigger.type} trigger ${trigger.id} not fired — features.triggers.enabled is off`, "triggers");
@@ -518,15 +525,21 @@ export async function registerRoutes(
           log: (m: string) => log(m, "triggers"),
         };
 
-        const result =
-          trigger.type === "github_event"
+        // ROLE-2: a role-bound trigger WAKES the role (compose the loop from the role)
+        // instead of the legacy action — a single new seam that reuses the SAME
+        // dedup/owner/factory core. A trigger with NO role binding is byte-identical to
+        // before (the roleBinding branch is never taken).
+        const result = roleBinding
+          ? await maybeLaunchRoleWake(dispatchDeps, trigger, payload)
+          : trigger.type === "github_event"
             ? await maybeLaunchGitHubReview(dispatchDeps, trigger, payload)
             : await maybeLaunchConsiliumReview(dispatchDeps, trigger, payload);
 
-        // T1 policy rail (§4): a fire suppressed by dedup bumps the trigger's
+        // T1 policy rail (§4): a fire suppressed by a rail bumps the trigger's
         // suppressed counter (surfaced on the triggers page) instead of blindly
-        // creating a second active loop for the same repo.
-        if (result === "skipped-dedup") {
+        // creating a second active loop. ROLE-2 adds the per-role budget/cascade rails
+        // alongside dedup — all three count as suppressed.
+        if (result === "skipped-dedup" || result === "skipped-budget" || result === "skipped-cascade") {
           await storage.incrementTriggerSuppressed(trigger.id);
         }
         // The github POLLER reads this result to decide whether to advance its

--- a/server/routes/standing-roles.ts
+++ b/server/routes/standing-roles.ts
@@ -36,9 +36,11 @@
  *     them (untrustedExtraBlock) before they enter the objective — no injection seam.
  *   - A DISABLED role cannot wake (409 before the factory is ever called — §6).
  */
+import { randomUUID } from "node:crypto";
 import type { Express, Request, Response } from "express";
 import { z } from "zod";
 import { CONSILIUM_REVIEW_PRESETS, REVIEW_MODES } from "@shared/types";
+import type { StandingRoleConcern, TriggerConfig, TriggerType } from "@shared/types";
 import type { IStorage } from "../storage.js";
 import type { InsertStandingRole } from "@shared/schema";
 import { validateBody } from "../middleware/validate.js";
@@ -46,6 +48,11 @@ import {
   createConsiliumReview,
   type CreateConsiliumReviewDeps,
 } from "../services/consilium/review-factory.js";
+// ROLE-2: the compose seam moved to a shared pure helper (role-compose.ts) so the
+// manual wake (here) and the trigger wake (trigger-dispatch.ts) cannot drift. Re-export
+// keeps `composeWakeInstruction`'s existing import path/tests intact.
+import { composeWakeInstruction } from "../services/consilium/role-compose.js";
+export { composeWakeInstruction };
 
 /** Max skills a role may carry — mirrors the review factory's MAX_REVIEW_SKILLS. */
 const MAX_ROLE_SKILLS = 5;
@@ -55,6 +62,16 @@ const LoopTemplateSchema = z.object({
   preset: z.enum(CONSILIUM_REVIEW_PRESETS),
   maxRounds: z.coerce.number().int().min(1).max(6).optional(),
   reviewMode: z.enum(REVIEW_MODES).optional(),
+});
+
+/**
+ * ROLE-2 (standing-role.md §6, loop-triggers.md §4): the per-role rails. Bounds only —
+ * an omitted field falls back to the server default constant in role-wake.ts. `enabled`
+ * (below) stays the primary kill-switch; this is the quantitative budget/cascade rails.
+ */
+const PolicySchema = z.object({
+  budgetPerDay: z.coerce.number().int().min(1).max(1000).optional(),
+  cascadeDepth: z.coerce.number().int().min(1).max(20).optional(),
 });
 
 const CreateRoleSchema = z.object({
@@ -67,7 +84,40 @@ const CreateRoleSchema = z.object({
   // in the handler (fail-closed); the zod cap keeps a >5 body a clean 400.
   skills: z.array(z.string().min(1).max(200)).max(MAX_ROLE_SKILLS).default([]),
   loopTemplate: LoopTemplateSchema,
+  // ROLE-2: the per-role rails. Concerns are NOT set here — they are managed via the
+  // dedicated concern endpoints (which also materialise the backing trigger).
+  policy: PolicySchema.optional(),
   enabled: z.boolean().default(true),
+});
+
+/** file_change concern filter — the watched path + optional glob patterns. */
+const FileChangeConcernFilterSchema = z.object({
+  watchPath: z.string().min(1).max(4096),
+  patterns: z.array(z.string().min(1).max(500)).max(50).optional(),
+});
+
+/** github_event concern filter — the polled repo + event set + optional ref filter. */
+const GitHubConcernFilterSchema = z.object({
+  repository: z.string().min(1).max(200),
+  events: z.array(z.string().min(1).max(50)).max(20).optional(),
+  refFilter: z.string().min(1).max(300).optional(),
+});
+
+/**
+ * ROLE-2 (standing-role.md §3/§8): a concern to ADD to a role. `repoPath` is
+ * re-validated fail-closed by the factory at wake (not here). `focus` is UNTRUSTED —
+ * fenced by the factory. The `trigger` is a file_change | github_event discriminated
+ * union; tracker_event is a documented follow-up (TRACK-6) so it is intentionally NOT
+ * accepted here.
+ */
+const AddConcernSchema = z.object({
+  repoPath: z.string().min(1).max(4096),
+  focus: z.string().min(1).max(8000),
+  enabled: z.boolean().optional(),
+  trigger: z.discriminatedUnion("type", [
+    z.object({ type: z.literal("file_change"), filter: FileChangeConcernFilterSchema }),
+    z.object({ type: z.literal("github_event"), filter: GitHubConcernFilterSchema }),
+  ]),
 });
 
 /** PATCH is a partial of create (every field optional). */
@@ -82,18 +132,6 @@ const WakeSchema = z.object({
   repoPath: z.string().min(1).max(4096),
   focus: z.string().min(1).max(8000),
 });
-
-/**
- * Compose the wake's engineer instruction from the role's persona + the wake focus.
- * PURE (unit-testable). We ONLY JOIN here — the review factory does ALL sanitization:
- * it control-strips + byte-clamps + wraps the whole string in a strictly-longer
- * backtick fence (untrustedExtraBlock) before it enters the objective, so neither the
- * stored persona nor the per-wake focus can break out to inject instructions. The
- * fencing is a SINGLE seam (the factory), not re-done here.
- */
-export function composeWakeInstruction(persona: string, focus: string): string {
-  return `${persona}\n\n## Focus\n${focus}`;
-}
 
 /**
  * Validate that every skill id exists in the PROJECT-SCOPED registry (fail-closed).
@@ -135,6 +173,40 @@ function mapFactoryError(err: unknown, repoPath: string, res: Response): boolean
   return false;
 }
 
+/**
+ * ROLE-2: build the BACKING trigger's `config` for a concern — the concern's filter
+ * fields (so the existing file-watcher / github poller runtime picks it up) PLUS the
+ * `roleConcern` binding the dispatch reads to route the fire to the role-wake path. No
+ * `action` is set — a role-bound trigger's behaviour comes ENTIRELY from the role.
+ */
+function buildConcernTriggerConfig(
+  concern: StandingRoleConcern,
+  roleId: string,
+): { type: TriggerType; config: TriggerConfig } {
+  const binding = { roleId, concernId: concern.id };
+  if (concern.trigger.type === "file_change") {
+    const f = concern.trigger.filter as { watchPath: string; patterns?: string[] };
+    return {
+      type: "file_change",
+      config: {
+        watchPath: f.watchPath,
+        patterns: f.patterns ?? [],
+        roleConcern: binding,
+      } as TriggerConfig,
+    };
+  }
+  const f = concern.trigger.filter as { repository: string; events?: string[]; refFilter?: string };
+  return {
+    type: "github_event",
+    config: {
+      repository: f.repository,
+      events: f.events ?? [],
+      ...(f.refFilter ? { refFilter: f.refFilter } : {}),
+      roleConcern: binding,
+    } as TriggerConfig,
+  };
+}
+
 export function registerStandingRoleRoutes(app: Express, deps: CreateConsiliumReviewDeps): void {
   const { storage } = deps;
 
@@ -164,6 +236,9 @@ export function registerStandingRoleRoutes(app: Express, deps: CreateConsiliumRe
       persona: body.persona,
       skills: body.skills,
       loopTemplate: body.loopTemplate,
+      // ROLE-2: concerns start empty (added via the concern endpoints); policy optional.
+      concerns: [],
+      policy: body.policy ?? null,
       enabled: body.enabled,
       createdBy: req.user.id,
     } as InsertStandingRole);
@@ -253,5 +328,84 @@ export function registerStandingRoleRoutes(app: Express, deps: CreateConsiliumRe
       console.error("[roles] wake failed:", err instanceof Error ? err.message : String(err));
       return res.status(500).json({ error: "Failed to wake the role" });
     }
+  });
+
+  // ─── ROLE-2: ADD a concern — materialises a BACKING trigger ────────────────
+  // A concern is WHAT the role watches + WHERE + the wake focus. Adding one creates a
+  // backing trigger (config carries `roleConcern={roleId,concernId}`) in the EXISTING
+  // trigger runtime; when it fires the dispatch wakes the role. No new runtime is added
+  // (§6). The concern is appended to the role's `concerns` (the durable declaration).
+  app.post("/api/roles/:id/concerns", validateBody(AddConcernSchema), async (req: Request, res: Response) => {
+    if (!req.user?.id) return res.status(401).json({ error: "Authentication required" });
+    if (!req.projectId) return res.status(400).json({ error: "x-project-id header is required" });
+    const body = req.body as z.infer<typeof AddConcernSchema>;
+
+    const role = await storage.getStandingRole(String(req.params.id));
+    if (!role) return res.status(404).json({ error: "Role not found" });
+
+    const concern: StandingRoleConcern = {
+      id: randomUUID(),
+      repoPath: body.repoPath,
+      focus: body.focus,
+      trigger: body.trigger as StandingRoleConcern["trigger"],
+      ...(body.enabled !== undefined ? { enabled: body.enabled } : {}),
+    };
+
+    // Materialise the backing trigger FIRST so its id can be stored on the concern for
+    // lifecycle (delete concern → delete trigger). createTrigger sets projectId from the
+    // request ALS (project-scoped). enabled mirrors the concern (default on).
+    const { type, config } = buildConcernTriggerConfig(concern, role.id);
+    const trigger = await storage.createTrigger({
+      pipelineId: null,
+      type,
+      config,
+      enabled: concern.enabled !== false,
+    } as Parameters<IStorage["createTrigger"]>[0]);
+    concern.triggerId = trigger.id;
+
+    const concerns = [...((role.concerns ?? []) as StandingRoleConcern[]), concern];
+    const updated = await storage.updateStandingRole(String(req.params.id), {
+      concerns,
+    } as Partial<InsertStandingRole>);
+    return res.status(201).json(updated);
+  });
+
+  // ─── ROLE-2: DELETE a concern — tears down its backing trigger ─────────────
+  app.delete("/api/roles/:id/concerns/:concernId", async (req: Request, res: Response) => {
+    if (!req.user?.id) return res.status(401).json({ error: "Authentication required" });
+    if (!req.projectId) return res.status(400).json({ error: "x-project-id header is required" });
+
+    const role = await storage.getStandingRole(String(req.params.id));
+    if (!role) return res.status(404).json({ error: "Role not found" });
+    const concerns = (role.concerns ?? []) as StandingRoleConcern[];
+    const concern = concerns.find((c) => c.id === String(req.params.concernId));
+    if (!concern) return res.status(404).json({ error: "Concern not found" });
+
+    // Best-effort tear down the backing trigger so a removed concern stops firing.
+    if (concern.triggerId) {
+      try {
+        await storage.deleteTrigger(concern.triggerId);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error("[roles] backing trigger delete failed:", err instanceof Error ? err.message : String(err));
+      }
+    }
+    const updated = await storage.updateStandingRole(String(req.params.id), {
+      concerns: concerns.filter((c) => c.id !== concern.id),
+    } as Partial<InsertStandingRole>);
+    return res.json(updated);
+  });
+
+  // ─── ROLE-2: the loops this role has WOKEN (trigger wakes + manual wakes) ───
+  // Reads the project-scoped loop list and returns those whose provenance names this
+  // role — so the UI can show "which triggers are bound and the loops a role has woken".
+  app.get("/api/roles/:id/woken-loops", async (req: Request, res: Response) => {
+    if (!req.user?.id) return res.status(401).json({ error: "Authentication required" });
+    if (!req.projectId) return res.status(400).json({ error: "x-project-id header is required" });
+    const role = await storage.getStandingRole(String(req.params.id));
+    if (!role) return res.status(404).json({ error: "Role not found" });
+    const loops = await storage.getLoops();
+    const woken = loops.filter((l) => l.triggerProvenance?.role?.roleId === role.id);
+    return res.json(woken);
   });
 }

--- a/server/services/consilium/role-compose.ts
+++ b/server/services/consilium/role-compose.ts
@@ -1,0 +1,43 @@
+/**
+ * role-compose.ts — the ONE pure seam that composes a Standing Role wake's engineer
+ * instruction (standing-role.md §3). Shared by BOTH wake paths so they cannot drift:
+ *   - ROLE-1 manual wake  (routes/standing-roles.ts, POST /api/roles/:id/wake)
+ *   - ROLE-2 trigger wake (services/consilium/trigger-dispatch.ts, maybeLaunchRoleWake)
+ *
+ * PURE + unit-testable. It ONLY JOINS text — ALL sanitisation happens in the review
+ * factory (`untrustedExtraBlock`: control-strip + byte-clamp + a strictly-longer
+ * backtick fence) before the string enters the loop objective. Neither the stored
+ * persona nor the (per-wake / per-concern) focus can break out to inject instructions;
+ * the fence is a SINGLE downstream seam, never re-done here.
+ */
+
+/** The literal token a concern focus may embed to interpolate the firing event (§3). */
+const EVENT_TOKEN = "${event}";
+
+/**
+ * Compose a wake's engineer instruction = `persona + focus`. The factory fences the
+ * whole string as data. Used verbatim by the ROLE-1 manual wake.
+ */
+export function composeWakeInstruction(persona: string, focus: string): string {
+  return `${persona}\n\n## Focus\n${focus}`;
+}
+
+/**
+ * ROLE-2: compose a TRIGGER wake's instruction = `persona + concern.focus + the fired
+ * event`. If the focus embeds the literal `${event}` token it is interpolated in place
+ * (mirrors the trigger action's `${event}` seam); otherwise a short, inert
+ * "(triggered by: …)" line is appended so the loop knows what woke it. The event
+ * description is UNTRUSTED (embeds fs paths / a PR title) — safe to join here because
+ * the factory fences the composed string. Split/join replaces EVERY `${event}` without
+ * invoking regex `$`-pattern semantics on the untrusted description.
+ */
+export function composeRoleTriggerInstruction(
+  persona: string,
+  focus: string,
+  eventDescription: string,
+): string {
+  const focusWithEvent = focus.includes(EVENT_TOKEN)
+    ? focus.split(EVENT_TOKEN).join(eventDescription)
+    : `${focus}\n\n(triggered by: ${eventDescription})`;
+  return composeWakeInstruction(persona, focusWithEvent);
+}

--- a/server/services/consilium/trigger-dispatch.ts
+++ b/server/services/consilium/trigger-dispatch.ts
@@ -76,15 +76,21 @@ import {
   CONSILIUM_LOOP_TERMINAL_STATES,
   type TriggerRow,
   type ConsiliumLoopRow,
+  type StandingRoleRow,
 } from "@shared/schema";
 import type {
   ConsiliumReviewTriggerAction,
   ConsiliumReviewPreset,
   GitHubEventTriggerConfig,
   TriggerProvenance,
+  RoleProvenance,
   SpecProvenance,
+  ReviewMode,
+  RoleConcernBinding,
+  StandingRoleConcern,
 } from "@shared/types";
 import { mapGitHubEventToReview } from "./github-event-map.js";
+import { composeRoleTriggerInstruction } from "./role-compose.js";
 import {
   readSpecFile,
   evaluateReadyGate,
@@ -201,9 +207,20 @@ export type ConsiliumDispatchResult =
   | "launched"
   | "skipped"
   | "skipped-dedup"
+  // ROLE-2 rails (loop-triggers.md §4): a role wake suppressed by the per-role daily
+  // budget / concurrent-loop cascade ceiling. Both are counted as suppressed on the
+  // trigger row (like dedup) and factory is NOT called.
+  | "skipped-budget"
+  | "skipped-cascade"
   | "noop"
   | "noop-event"
   | "failed";
+
+/** ROLE-2: the per-role rails, defaulted from `role.policy` (role-wake path). */
+export const DEFAULT_ROLE_BUDGET_PER_DAY = 20;
+export const DEFAULT_ROLE_CASCADE_CEILING = 3;
+/** The trailing window the per-role/day budget counts over. */
+const ROLE_BUDGET_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 /**
  * The value `fireTrigger` (server/routes.ts) resolves with. It is the dispatch
@@ -604,6 +621,26 @@ export interface ReviewLaunchPlan {
   specDedupKey?: string;
   /** SPEC-1: spec origin folded into the loop's provenance (`{specPath,source,status}`). */
   specProvenance?: SpecProvenance;
+  /**
+   * ROLE-2: when a Standing Role wake launched this loop — folded into the loop's
+   * provenance as `role: { roleId, name, concernId, cascadeDepth }`. Absent for every
+   * legacy/spec/github fire (byte-identical). Its presence ALSO selects the role dedup
+   * key (per-(role,concern), see `roleRails`) over the historical per-repoPath dedup.
+   */
+  roleProvenance?: RoleProvenance;
+  /**
+   * ROLE-2 (loop-triggers.md §4): the per-role rails evaluated in the dedup block —
+   * one active loop per (role, concern) [dedup], a concurrent-loop ceiling [cascade],
+   * and a trailing-24h launch cap [budget]. Present IFF `roleProvenance` is — a role
+   * wake always carries both. Absent ⇒ the legacy repo/spec dedup is unchanged.
+   */
+  roleRails?: { roleId: string; concernId: string; budgetPerDay: number; cascadeCeiling: number };
+  /**
+   * ROLE-2: the role's `loopTemplate.reviewMode` (server enum), passed through to the
+   * factory so a role wake's re-review rounds honour the role template. Undefined for
+   * every non-role path (byte-identical — the factory resolves the operator default).
+   */
+  reviewMode?: ReviewMode;
   payload: unknown;
 }
 
@@ -643,6 +680,9 @@ export async function launchReviewWithDedup(
     // SPEC-1 (§3): carry the spec origin so the per-spec dedup below and a future
     // write-back can find it. Inert jsonb; never a prompt/shell sink.
     ...(plan.specProvenance ? { spec: plan.specProvenance } : {}),
+    // ROLE-2: a role wake also stamps WHICH role + concern woke the loop — the second
+    // half of the (role, concern) dedup key and the launch-passport identity. Inert.
+    ...(plan.roleProvenance ? { role: plan.roleProvenance } : {}),
   };
 
   // T5: dedup key — match against the CANONICAL path the factory persists.
@@ -655,6 +695,9 @@ export async function launchReviewWithDedup(
   // (a real `users.id`). Inside the try so a lookup throw is caught (T4) rather
   // than crashing the watcher/webhook loop.
   let dedupLoopId: string | undefined;
+  // ROLE-2: which per-role rail suppressed the launch (dedup | budget | cascade), set
+  // inside the runInProject block so the post-block branch returns the right result.
+  let roleSuppress: "dedup" | "budget" | "cascade" | undefined;
   try {
     const createdBy = await deps.resolveOwnerId(plan.projectId);
     if (!createdBy) {
@@ -671,33 +714,51 @@ export async function launchReviewWithDedup(
       // a spec-write burst) must not fan out into unbounded heavy-model disputes.
       // (The explicit UI endpoint calls the factory directly and is NOT deduped.)
       const existing = await reviewDeps.storage.getLoops();
-      const active = existing.find((l) => {
-        if (TERMINAL_LOOP_STATES.has(l.state)) return false;
-        // SPEC-1: a spec fire dedups PURELY on the spec path (a distinct spec, even
-        // in the same repo, is a DIFFERENT unit of work → its own loop). A non-spec
-        // fire keeps the historical per-repoPath dedup.
-        if (specDedupKey !== undefined) {
-          return l.triggerProvenance?.spec?.specPath === specDedupKey;
+
+      // ROLE-2 (loop-triggers.md §4): the per-role rails REPLACE the repo/spec dedup
+      // when this is a role wake — dedup on (role, concern), then a concurrent-loop
+      // cascade ceiling, then a trailing-24h budget. Evaluated over the SAME
+      // project-scoped loop list so a misfiring concern can never spawn unbounded loops.
+      if (plan.roleRails) {
+        const rail = evaluateRoleRails(existing, plan.roleRails, firedAt);
+        if (rail.suppress) {
+          roleSuppress = rail.suppress;
+          dedupLoopId = rail.loopId;
+          return null; // signal: a rail suppressed, do NOT launch the factory
         }
-        return l.repoPath === resolvedRepo || l.repoPath === plan.repoPath;
-      });
-      if (active) {
-        dedupLoopId = active.id;
-        return null; // signal: deduped, do NOT launch the factory
+      } else {
+        const active = existing.find((l) => {
+          if (TERMINAL_LOOP_STATES.has(l.state)) return false;
+          // SPEC-1: a spec fire dedups PURELY on the spec path (a distinct spec, even
+          // in the same repo, is a DIFFERENT unit of work → its own loop). A non-spec
+          // fire keeps the historical per-repoPath dedup.
+          if (specDedupKey !== undefined) {
+            return l.triggerProvenance?.spec?.specPath === specDedupKey;
+          }
+          return l.repoPath === resolvedRepo || l.repoPath === plan.repoPath;
+        });
+        if (active) {
+          dedupLoopId = active.id;
+          return null; // signal: deduped, do NOT launch the factory
+        }
       }
 
       return deps.createReview(reviewDeps, {
         projectId: plan.projectId,
         repoPath: plan.repoPath,
         preset: plan.preset,
-        // SPEC-1: spec-selected skills (resolved project-scoped in the factory);
-        // undefined for every non-spec path (byte-identical).
+        // SPEC-1 / ROLE-2: spec- or role-selected skills (resolved project-scoped in
+        // the factory); undefined for every non-spec/non-role path (byte-identical).
         skillIds: plan.skillIds,
         // FK FIX: real `users.id` (project owner), NOT the literal "system".
         createdBy,
-        // T6 (FIX MED-2): FORCE review-only on EVERY trigger path. An unattended,
-        // automatically-fired run must NEVER reach DEVELOPING / the SDLC coder.
+        // T6 (FIX MED-2): FORCE review-only on EVERY trigger path — INCLUDING a role
+        // wake. An unattended, automatically-fired run must NEVER reach DEVELOPING /
+        // the SDLC coder; escalation to develop is a human (UI / manual-wake) action.
         maxRounds: 1,
+        // ROLE-2: honour the role template's reviewMode (moot at maxRounds=1, but kept
+        // faithful + forward-compatible); undefined elsewhere (factory resolves default).
+        reviewMode: plan.reviewMode,
         // github diff-pr-review targets the PR head vs the PR base; absent for the
         // action path (working-tree HEAD). Both re-validated at the factory.
         ref: plan.ref,
@@ -705,16 +766,28 @@ export async function launchReviewWithDedup(
         // Exactly one of these is set (engineerInstruction wins in the factory).
         engineerInstruction: plan.engineerInstruction,
         objectiveExtra: plan.objectiveExtra,
-        // §6: record which trigger + event started the loop.
+        // §6: record which trigger + event (+ role) started the loop.
         triggerProvenance: provenance,
       });
     });
 
     if (loop === null) {
+      // ROLE-2: a per-role rail suppressed the launch — return the specific result so
+      // the caller can surface it (all three count as suppressed on the trigger row).
+      if (roleSuppress === "budget") {
+        deps.log(`role wake skipped-budget for trigger ${trigger.id} — role ${plan.roleRails?.roleId} over daily budget`);
+        return "skipped-budget";
+      }
+      if (roleSuppress === "cascade") {
+        deps.log(`role wake skipped-cascade for trigger ${trigger.id} — role ${plan.roleRails?.roleId} at concurrent-loop ceiling`);
+        return "skipped-cascade";
+      }
       deps.log(
-        specDedupKey !== undefined
-          ? `review skipped-dedup:spec for trigger ${trigger.id} — active loop ${dedupLoopId} already running for spec ${specDedupKey}`
-          : `review skipped-dedup for trigger ${trigger.id} — active loop ${dedupLoopId} already running for ${resolvedRepo}`,
+        plan.roleRails
+          ? `role wake skipped-dedup for trigger ${trigger.id} — active loop ${dedupLoopId} already running for (role ${plan.roleRails.roleId}, concern ${plan.roleRails.concernId})`
+          : specDedupKey !== undefined
+            ? `review skipped-dedup:spec for trigger ${trigger.id} — active loop ${dedupLoopId} already running for spec ${specDedupKey}`
+            : `review skipped-dedup for trigger ${trigger.id} — active loop ${dedupLoopId} already running for ${resolvedRepo}`,
       );
       // WATERMARK DISCIPLINE: a dedup-suppressed fire must NOT touch lastFiredAt /
       // firedCount — the caller counts it via `incrementTriggerSuppressed` instead.
@@ -838,6 +911,198 @@ export async function maybeLaunchGitHubReview(
     objectiveExtra,
     // §6: a human passport label so #457 shows "fired by github trigger: PR #N".
     eventSummary: eventLabel,
+    payload,
+  });
+}
+
+// ─── ROLE-2: Standing Role wake (standing-role.md §3/§8, loop-triggers.md §4) ───
+//
+// A BACKING trigger whose `config.roleConcern = { roleId, concernId }` FIRES → instead
+// of the legacy action, WAKE the role: compose the loop FROM THE ROLE (persona +
+// concern.focus + the fired event, the role's skills + loop template) on the CONCERN's
+// repoPath, and stamp `role` provenance. Reuses the SAME `launchReviewWithDedup` core
+// (owner FK, factory, T4 catch, recordFire) and the SAME `createConsiliumReview` factory
+// as every other path — NO reimplemented loop creation, and the controller is untouched.
+//
+// SECURITY (flagged for the adversarial reviewer):
+//   R1. A role wake CANNOT bypass the allowlist — `concern.repoPath` is re-validated
+//       fail-closed INSIDE the factory (never trusted from the stored concern), same
+//       gate as the manual wake / UI review button. A bad repoPath → factory throw → T4
+//       "failed", never a review of an unallowed repo.
+//   R2. A DISABLED role never wakes (checked BEFORE the factory is touched — §6), and a
+//       disabled concern is skipped. The role's `enabled` column is the authoritative gate.
+//   R3. The per-role RAILS (evaluateRoleRails) bound a misfiring concern: one active loop
+//       per (role, concern) [dedup], a concurrent-loop ceiling [cascade], a trailing-24h
+//       cap [budget] — all read over the project-scoped loop list, so a burst of fires or
+//       a role-loop that re-fires its own concern can never spawn unbounded loops.
+//   R4. persona + concern.focus are UNTRUSTED at wake: composed here (join only) and
+//       fenced/clamped by the factory (untrustedExtraBlock) before entering the objective.
+//   R5. `skillIds = role.skills` is re-resolved PROJECT-SCOPED by the factory (a foreign
+//       id throws → T4 "failed", no cross-tenant leak).
+//   R6. maxRounds is FORCED to 1 (review-only, T6) — an unattended fire never reaches the
+//       SDLC coder; escalation to develop is a human action (manual wake / UI).
+
+/**
+ * Evaluate the per-role rails over the (project-scoped) loop list. PURE + unit-testable.
+ * Order: DEDUP (one active loop per (role, concern)) → CASCADE (concurrent active loops
+ * across ALL the role's concerns ≥ ceiling) → BUDGET (loops launched by the role in the
+ * trailing 24h ≥ budgetPerDay). Returns the first rail that suppresses (with the blocking
+ * loop id for dedup), else `{}` (launch permitted).
+ */
+export function evaluateRoleRails(
+  existing: readonly ConsiliumLoopRow[],
+  rails: { roleId: string; concernId: string; budgetPerDay: number; cascadeCeiling: number },
+  now: Date,
+): { suppress?: "dedup" | "budget" | "cascade"; loopId?: string } {
+  const roleLoops = existing.filter((l) => l.triggerProvenance?.role?.roleId === rails.roleId);
+
+  // DEDUP: an active loop already running for this EXACT (role, concern).
+  const dup = roleLoops.find(
+    (l) => !TERMINAL_LOOP_STATES.has(l.state) && l.triggerProvenance?.role?.concernId === rails.concernId,
+  );
+  if (dup) return { suppress: "dedup", loopId: dup.id };
+
+  // CASCADE: too many concurrent active loops for this role across ALL its concerns.
+  const activeCount = roleLoops.filter((l) => !TERMINAL_LOOP_STATES.has(l.state)).length;
+  if (activeCount >= rails.cascadeCeiling) return { suppress: "cascade" };
+
+  // BUDGET: too many launched by this role in the trailing 24h (LLM cost is real money).
+  const windowStart = now.getTime() - ROLE_BUDGET_WINDOW_MS;
+  const recent = roleLoops.filter((l) => {
+    const t = l.createdAt instanceof Date ? l.createdAt.getTime() : new Date(l.createdAt as unknown as string).getTime();
+    return Number.isFinite(t) && t >= windowStart;
+  }).length;
+  if (recent >= rails.budgetPerDay) return { suppress: "budget" };
+
+  return {};
+}
+
+/** Read the role-concern binding off any trigger config without trusting its shape. */
+function readRoleConcernBinding(config: unknown): RoleConcernBinding | undefined {
+  if (typeof config !== "object" || config === null) return undefined;
+  const rc = (config as Record<string, unknown>).roleConcern;
+  if (typeof rc !== "object" || rc === null) return undefined;
+  const { roleId, concernId } = rc as Record<string, unknown>;
+  if (typeof roleId === "string" && roleId.length > 0 && typeof concernId === "string" && concernId.length > 0) {
+    return { roleId, concernId };
+  }
+  return undefined;
+}
+
+/** Locate a concern on a role by id (defensive — the stored array is jsonb). */
+function findConcern(role: StandingRoleRow, concernId: string): StandingRoleConcern | undefined {
+  const concerns = (role.concerns ?? []) as StandingRoleConcern[];
+  return concerns.find((c) => c && c.id === concernId);
+}
+
+/**
+ * WAKE a Standing Role because its concern's BACKING trigger fired. The route calls
+ * this (instead of `maybeLaunchConsiliumReview` / `maybeLaunchGitHubReview`) when the
+ * trigger config carries `roleConcern`. Discriminants mirror the other dispatch paths:
+ *   - "noop"          → the trigger carries no role binding (defensive; route pre-checks)
+ *   - "noop-event"    → a github concern whose event does not map to a review
+ *   - "skipped"       → subsystem off / no project / role missing / role or concern
+ *                       DISABLED / concern missing / no resolvable owner — logged, safe
+ *   - "skipped-dedup" / "skipped-budget" / "skipped-cascade" → a per-role rail suppressed
+ *   - "launched"      → the factory was invoked (role loop, review-only)
+ *   - "failed"        → the factory threw (allowlist/workspace/skill rejection) — T4 caught
+ */
+export async function maybeLaunchRoleWake(
+  deps: ConsiliumTriggerDispatchDeps,
+  trigger: TriggerRow,
+  payload: unknown,
+): Promise<ConsiliumDispatchResult> {
+  const binding = readRoleConcernBinding(trigger.config);
+  if (!binding) return "noop"; // not a role-bound trigger (route only routes here when it is)
+
+  const reviewDeps = deps.reviewDeps;
+  if (!reviewDeps) {
+    deps.log(`role wake skipped for trigger ${trigger.id} — consilium loop disabled`);
+    return "skipped";
+  }
+  const projectId = trigger.projectId;
+  if (!projectId) {
+    deps.log(`role wake skipped for trigger ${trigger.id} — trigger has no projectId`);
+    return "skipped";
+  }
+
+  // Load the role PROJECT-SCOPED (same ALS the dedup read uses). A role/concern lookup
+  // that fails is a safe skip, never a throw.
+  const role = await deps.runInProject(projectId, () => reviewDeps.storage.getStandingRole(binding.roleId));
+  if (!role) {
+    deps.log(`role wake skipped for trigger ${trigger.id} — role ${binding.roleId} not found`);
+    return "skipped";
+  }
+  // R2 (§6): a DISABLED role can never spawn work — refuse BEFORE the factory is touched.
+  if (!role.enabled) {
+    deps.log(`role wake skipped for trigger ${trigger.id} — role ${role.id} is disabled`);
+    return "skipped";
+  }
+  const concern = findConcern(role, binding.concernId);
+  if (!concern) {
+    deps.log(`role wake skipped for trigger ${trigger.id} — concern ${binding.concernId} not on role ${role.id}`);
+    return "skipped";
+  }
+  // Per-concern kill (default on): a disabled concern's backing trigger never wakes.
+  if (concern.enabled === false) {
+    deps.log(`role wake skipped for trigger ${trigger.id} — concern ${concern.id} is disabled`);
+    return "skipped";
+  }
+
+  // Resolve WHAT the fired event is, per trigger class. For github_event we reuse the
+  // PURE event→review mapping to target the PR head (ref/baseline); the review SHAPE
+  // (preset/rounds/mode) still comes from the ROLE template, not the mapping.
+  let ref: string | null | undefined;
+  let baselineCommit: string | undefined;
+  let eventDescription: string;
+  if (trigger.type === "github_event") {
+    const eventType = payloadString(payload, "event") ?? "";
+    const mapped = mapGitHubEventToReview(eventType, githubBody(payload));
+    if (mapped.kind === "noop") {
+      deps.log(`role wake no-op for trigger ${trigger.id} — github ${eventType || "?"}: ${mapped.reason}`);
+      return "noop-event";
+    }
+    ref = mapped.mapping.ref;
+    baselineCommit = mapped.mapping.baselineCommit;
+    eventDescription = mapped.mapping.eventLabel;
+  } else {
+    // file_change (and any other concern class riding the file/schedule runtime).
+    eventDescription = describeEvent(trigger, payload);
+  }
+
+  // Compose the loop payload FROM THE ROLE (§3): persona + concern.focus + the event.
+  const engineerInstruction = composeRoleTriggerInstruction(role.persona, concern.focus, eventDescription);
+  const policy = role.policy ?? {};
+  const roleProvenance: RoleProvenance = {
+    roleId: role.id,
+    name: role.name,
+    concernId: concern.id,
+    cascadeDepth: 1, // a trigger-born role wake is depth 1 (loop-triggers.md §4.4)
+  };
+
+  return launchReviewWithDedup(deps, trigger, {
+    projectId,
+    // R1: the concern's repoPath — re-validated fail-closed against the allowlist +
+    // the project's workspaces INSIDE the factory (never trusted from the stored config).
+    repoPath: concern.repoPath,
+    preset: role.loopTemplate.preset,
+    ref,
+    baselineCommit,
+    // R4: persona + focus + event, fenced by the factory.
+    engineerInstruction,
+    // R5: role skills, re-resolved project-scoped by the factory.
+    skillIds: role.skills && role.skills.length > 0 ? role.skills : undefined,
+    reviewMode: role.loopTemplate.reviewMode,
+    roleProvenance,
+    // R3: the per-role rails (defaults from server constants when policy omits them).
+    roleRails: {
+      roleId: role.id,
+      concernId: concern.id,
+      budgetPerDay: policy.budgetPerDay ?? DEFAULT_ROLE_BUDGET_PER_DAY,
+      cascadeCeiling: policy.cascadeDepth ?? DEFAULT_ROLE_CASCADE_CEILING,
+    },
+    // §6: a human passport label (e.g. "PR #12: …" / "file change at …").
+    eventSummary: eventDescription,
     payload,
   });
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -3200,6 +3200,9 @@ export class MemStorage implements IStorage {
       persona: data.persona,
       skills: (data.skills as string[] | undefined) ?? [],
       loopTemplate: data.loopTemplate,
+      // ROLE-2: additive — default to no concerns / no policy overrides.
+      concerns: (data.concerns as StandingRoleRow["concerns"] | undefined) ?? [],
+      policy: (data.policy as StandingRoleRow["policy"] | undefined) ?? null,
       enabled: data.enabled ?? true,
       createdBy: data.createdBy ?? null,
       createdAt: now,
@@ -3217,6 +3220,10 @@ export class MemStorage implements IStorage {
       ...updates,
       skills: (updates.skills as string[] | undefined) ?? existing.skills,
       loopTemplate: updates.loopTemplate ?? existing.loopTemplate,
+      // ROLE-2: concerns/policy are additive — an update that omits them preserves the
+      // existing value (a PATCH that sets `policy: null` explicitly still clears it).
+      concerns: (updates.concerns as StandingRoleRow["concerns"] | undefined) ?? existing.concerns,
+      policy: updates.policy !== undefined ? (updates.policy as StandingRoleRow["policy"]) : existing.policy,
       updatedAt: new Date(),
     };
     this.standingRolesMap.set(id, updated);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -2256,7 +2256,7 @@ export type InsertCredentialAccessLog = typeof credentialAccessLog.$inferInsert;
 // existing isolation + human-merge gate). Separate import (localized/append-only) so
 // the shared `./types.js` import line stays a single merge point for other teams.
 // eslint-disable-next-line @typescript-eslint/no-duplicate-imports -- localized append
-import type { StandingRoleLoopTemplate } from "./types.js";
+import type { StandingRoleLoopTemplate, StandingRoleConcern, StandingRolePolicy } from "./types.js";
 
 export const standingRoles = pgTable(
   "standing_roles",
@@ -2278,8 +2278,19 @@ export const standingRoles = pgTable(
     // How the role's ephemeral loops run: { preset, maxRounds?, reviewMode? }. `preset`
     // + `reviewMode` are server enums; `maxRounds` is bounded 1..6 by the factory.
     loopTemplate: jsonb("loop_template").$type<StandingRoleLoopTemplate>().notNull(),
+    // ROLE-2 (standing-role.md §3, migration 0048): the concerns this role WATCHES —
+    // each `{ id, repoPath, trigger:{type,filter}, focus, enabled?, triggerId? }`. A
+    // concern is a DECLARATION; its runtime footprint is a BACKING trigger row whose
+    // `config.roleConcern` names `{ roleId, concernId }`. Additive default '[]' so
+    // every ROLE-1 row reads back as "no concerns" (byte-identical). jsonb array.
+    concerns: jsonb("concerns").$type<StandingRoleConcern[]>().notNull().default(sql`'[]'::jsonb`),
+    // ROLE-2 (§6, loop-triggers.md §4): the per-ROLE rails { budgetPerDay?, cascadeDepth? }.
+    // Nullable ⇒ the server default constants apply (role-wake.ts). `enabled` (below)
+    // stays the primary kill-switch; this is the quantitative budget/cascade rails.
+    policy: jsonb("policy").$type<StandingRolePolicy>(),
     // A DISABLED role is inert — the wake endpoint refuses it (safety §6): a role can
-    // never spawn work while disabled.
+    // never spawn work while disabled. ROLE-2: a disabled role's backing triggers also
+    // never wake it (the dispatch enabled-gate is the authoritative check).
     enabled: boolean("enabled").notNull().default(true),
     createdBy: text("created_by").references(() => users.id, { onDelete: "set null" }),
     createdAt: timestamp("created_at").notNull().defaultNow(),

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1377,6 +1377,14 @@ export interface GitHubEventTriggerConfig {
    * still receives + records events but launches nothing (record-only, back-compat).
    */
   action?: ConsiliumReviewTriggerAction;
+  /**
+   * ROLE-2 (standing-role.md §8): when present, this github trigger is the BACKING
+   * trigger of a Standing Role's concern. On fire the dispatch WAKES the named role
+   * (compose the loop from the role) instead of the legacy `action` — see
+   * trigger-dispatch.ts `maybeLaunchRoleWake`. Absent ⇒ the legacy github path is
+   * BYTE-IDENTICAL.
+   */
+  roleConcern?: RoleConcernBinding;
 }
 
 export interface FileChangeTriggerConfig {
@@ -1392,6 +1400,14 @@ export interface FileChangeTriggerConfig {
    * `createConsiliumReview` under `runAsProject(trigger.projectId)`.
    */
   action?: ConsiliumReviewTriggerAction;
+  /**
+   * ROLE-2 (standing-role.md §8): when present, this file_change trigger is the
+   * BACKING trigger of a Standing Role's concern. On fire the dispatch WAKES the
+   * named role (compose the loop from the role) instead of the legacy `action` — see
+   * trigger-dispatch.ts `maybeLaunchRoleWake`. Absent ⇒ the legacy file_change path
+   * is BYTE-IDENTICAL.
+   */
+  roleConcern?: RoleConcernBinding;
 }
 
 /**
@@ -1441,6 +1457,86 @@ export interface StandingRoleLoopTemplate {
 }
 
 /**
+ * ROLE-2 (standing-role.md §3): a CONCERN a Standing Role watches — "WHAT it watches
+ * + WHERE + the wake focus". A concern binds ONE trigger (file_change | github_event)
+ * on ONE `repoPath` to a `focus` that is folded into the wake instruction. It is a
+ * DECLARATION on the role; the actual runtime footprint is a BACKING trigger row
+ * (materialised in the existing trigger runtime — file-watcher / github poller) whose
+ * `config.roleConcern` names `{ roleId, concernId }`. When that trigger fires, the
+ * dispatch WAKES the role instead of running a legacy action (trigger-dispatch.ts).
+ *
+ * `tracker_event` concerns are a documented follow-up (TRACK-6) — ROLE-2 covers only
+ * the two mechanics that already have a runtime + a review mapping.
+ *
+ * `focus`/`repoPath` are UNTRUSTED at wake: the focus is fenced by the review factory
+ * (untrustedExtraBlock), the repoPath is re-validated fail-closed against the
+ * allowlist inside the factory. Neither is trusted from the stored role config.
+ */
+export interface StandingRoleConcern {
+  /** Stable id (server-generated) — the dedup key half `(role, concern)` + the UI key. */
+  id: string;
+  /** Target repo — MUST resolve inside the allowlist (re-validated INSIDE the factory). */
+  repoPath: string;
+  /** WHEN it wakes — a file_change or github_event trigger + its filter. */
+  trigger: StandingRoleConcernTrigger;
+  /** WHAT to look at — folded into the wake instruction (UNTRUSTED; factory-fenced). */
+  focus: string;
+  /** Per-concern kill (default true). A disabled concern's backing trigger never wakes. */
+  enabled?: boolean;
+  /** The backing trigger row id materialised for this concern (lifecycle bookkeeping). */
+  triggerId?: string;
+}
+
+/** A concern's trigger: the class (file_change | github_event) + its filter shape. */
+export interface StandingRoleConcernTrigger {
+  type: "file_change" | "github_event";
+  filter: FileChangeConcernFilter | GitHubConcernFilter;
+}
+
+/** file_change concern filter — the path watched + optional glob patterns. */
+export interface FileChangeConcernFilter {
+  watchPath: string;
+  patterns?: string[];
+}
+
+/** github_event concern filter — the repo polled + the event set + optional ref filter. */
+export interface GitHubConcernFilter {
+  repository: string;
+  events?: string[];
+  refFilter?: string;
+}
+
+/**
+ * ROLE-2 (standing-role.md §6, loop-triggers.md §4): the per-ROLE rails. Bind at the
+ * ROLE level so a MISFIRING concern cannot spawn unbounded loops. All OPTIONAL — an
+ * absent field falls back to the server default constant (role-wake.ts). `enabled`
+ * stays the role's top-level column (the primary kill-switch); this block is the
+ * quantitative rails only.
+ */
+export interface StandingRolePolicy {
+  /** Max trigger-born loops this role may launch per trailing 24h (budget rail §4.3). */
+  budgetPerDay?: number;
+  /**
+   * Cascade ceiling — the max number of SIMULTANEOUSLY-ACTIVE (non-terminal) loops a
+   * role may hold across ALL its concerns (§4.4). Bounds a burst of concurrent fires
+   * / a role-loop that re-fires its own concern. Distinct from per-(role,concern)
+   * dedup (which caps ONE active loop per concern).
+   */
+  cascadeDepth?: number;
+}
+
+/**
+ * ROLE-2: the binding a BACKING trigger carries in its `config.roleConcern` to name
+ * the role + concern it wakes. When the dispatch sees this on a firing trigger it
+ * routes to the role-wake path (compose the loop from the role) INSTEAD of the legacy
+ * action — so a role-bound trigger and a legacy trigger never cross paths.
+ */
+export interface RoleConcernBinding {
+  roleId: string;
+  concernId: string;
+}
+
+/**
  * A file-change trigger ACTION that launches a consilium review. Embedded in the
  * trigger's `config` JSONB. `repoPath`, when present, MUST resolve inside the
  * consilium-loop allowlist (re-validated INSIDE the factory — never trusted from
@@ -1480,6 +1576,18 @@ export interface ConsiliumReviewTriggerAction {
 export interface RoleProvenance {
   roleId: string;
   name: string;
+  /**
+   * ROLE-2: the concern that woke the role (present on a trigger-fired role wake;
+   * absent on a ROLE-1 manual wake). It is the SECOND half of the per-(role,concern)
+   * dedup key and drives the budget/cascade rails (role-wake.ts). Inert audit data.
+   */
+  concernId?: string;
+  /**
+   * ROLE-2 (§6, loop-triggers.md §4.4): the cascade depth of this loop — a
+   * trigger-born role wake is depth 1. Recorded so the cascade rail is auditable and
+   * a future loop-lifecycle trigger (depth ≥ 1 never re-fires) can read it. Inert.
+   */
+  cascadeDepth?: number;
 }
 
 /**

--- a/tests/unit/consilium/role-wake.test.ts
+++ b/tests/unit/consilium/role-wake.test.ts
@@ -1,0 +1,369 @@
+/**
+ * role-wake.test.ts — ROLE-2 (standing-role.md §3/§8, loop-triggers.md §4): a
+ * role-bound trigger firing WAKES the Standing Role → spawns its loop.
+ *
+ * The factory + storage are INJECTED so we assert the wake decision + the role→loop
+ * composition + the per-role rails without a DB / Express / ALS:
+ *   - a role-bound file_change trigger fires → factory called once on the CONCERN's
+ *     repoPath, with persona+focus+event, role skills, template reviewMode, role
+ *     provenance {roleId,name,concernId,cascadeDepth:1}, maxRounds forced review-only.
+ *   - a role-bound github_event concern → factory called with the PR head/base ref +
+ *     the ROLE template preset (not the event's default).
+ *   - per-(role,concern) DEDUP, per-role CASCADE ceiling, per-role/day BUDGET.
+ *   - a DISABLED role never wakes; a disabled concern never wakes.
+ *   - allowlist fail-closed: a factory throw → "failed" (never a review of a bad repo).
+ *   - the legacy (non-role) dispatch is untouched (maybeLaunchConsiliumReview ignores
+ *     a roleConcern-less trigger — covered by trigger-dispatch.test.ts).
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { TriggerRow, ConsiliumLoopRow, StandingRoleRow } from "@shared/schema";
+import type { StandingRoleConcern } from "@shared/types";
+import {
+  maybeLaunchRoleWake,
+  evaluateRoleRails,
+  DEFAULT_ROLE_BUDGET_PER_DAY,
+  DEFAULT_ROLE_CASCADE_CEILING,
+  type ConsiliumTriggerDispatchDeps,
+} from "../../../server/services/consilium/trigger-dispatch.js";
+
+const HEAD = "a".repeat(40);
+const BASE = "b".repeat(40);
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function fileConcern(over: Partial<StandingRoleConcern> = {}): StandingRoleConcern {
+  return {
+    id: "concern-1",
+    repoPath: "/allowed/iac",
+    focus: "a new or changed Terraform module version",
+    trigger: { type: "file_change", filter: { watchPath: "/allowed/iac/modules" } },
+    ...over,
+  };
+}
+
+function githubConcern(over: Partial<StandingRoleConcern> = {}): StandingRoleConcern {
+  return {
+    id: "concern-gh",
+    repoPath: "/allowed/iac",
+    focus: "review this module PR",
+    trigger: { type: "github_event", filter: { repository: "owner/repo", events: ["pull_request"] } },
+    ...over,
+  };
+}
+
+function makeRole(over: Partial<StandingRoleRow> = {}): StandingRoleRow {
+  return {
+    id: "role-1",
+    projectId: "proj-1",
+    name: "devops-reviewer",
+    persona: "You are a senior DevOps reviewer. Prioritise CIS/security and cost.",
+    skills: ["skill-a", "skill-b"],
+    loopTemplate: { preset: "diff-pr-review", maxRounds: 3, reviewMode: "single-verifier" },
+    concerns: [fileConcern()],
+    policy: null,
+    enabled: true,
+    createdBy: "owner-1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...over,
+  } as unknown as StandingRoleRow;
+}
+
+function makeTrigger(
+  binding: { roleId: string; concernId: string },
+  over: Partial<TriggerRow> = {},
+): TriggerRow {
+  return {
+    id: "trig-role-1",
+    projectId: "proj-1",
+    pipelineId: null,
+    type: "file_change",
+    config: { watchPath: "/allowed/iac/modules", roleConcern: binding },
+    ...over,
+  } as unknown as TriggerRow;
+}
+
+function envelope(event: string, ghPayload: unknown) {
+  return { event, delivery: "d-1", payload: ghPayload };
+}
+
+function prPayload(over: Record<string, unknown> = {}) {
+  return {
+    action: "opened",
+    number: 12,
+    pull_request: { title: "Add module", head: { sha: HEAD }, base: { sha: BASE } },
+    repository: { full_name: "owner/repo", default_branch: "main" },
+    ...over,
+  };
+}
+
+function makeDeps(
+  role: StandingRoleRow | undefined,
+  over: Partial<ConsiliumTriggerDispatchDeps> = {},
+  loops: ConsiliumLoopRow[] = [],
+) {
+  const createReview = vi
+    .fn()
+    .mockResolvedValue({ id: "loop-1", repoPath: "/allowed/iac", state: "reviewing" } as ConsiliumLoopRow);
+  const runInProject = vi.fn().mockImplementation((_pid: string, fn: () => Promise<unknown>) => fn());
+  const log = vi.fn();
+  const getLoops = vi.fn().mockResolvedValue(loops);
+  const getStandingRole = vi.fn().mockResolvedValue(role);
+  const resolveOwnerId = vi.fn().mockResolvedValue("owner-1");
+  const recordFire = vi.fn().mockResolvedValue(undefined);
+  const deps: ConsiliumTriggerDispatchDeps = {
+    reviewDeps: { storage: { getLoops, getStandingRole } } as unknown as ConsiliumTriggerDispatchDeps["reviewDeps"],
+    createReview,
+    runInProject,
+    resolveOwnerId,
+    recordFire,
+    log,
+    ...over,
+  };
+  return { deps, createReview, runInProject, log, getLoops, getStandingRole, resolveOwnerId, recordFire };
+}
+
+/** A non-terminal loop woken by a given (role, concern) — for the rails tests. */
+function roleLoop(roleId: string, concernId: string, over: Partial<ConsiliumLoopRow> = {}): ConsiliumLoopRow {
+  return {
+    id: `loop-${roleId}-${concernId}-${Math.random().toString(36).slice(2, 6)}`,
+    repoPath: "/allowed/iac",
+    state: "reviewing",
+    createdAt: new Date(),
+    triggerProvenance: { firedAt: new Date().toISOString(), role: { roleId, name: "r", concernId } },
+    ...over,
+  } as unknown as ConsiliumLoopRow;
+}
+
+// ─── file_change wake ─────────────────────────────────────────────────────────
+
+describe("maybeLaunchRoleWake — file_change concern", () => {
+  it("wakes the role → factory once on the concern repo, with role composition + provenance", async () => {
+    const role = makeRole();
+    const { deps, createReview, runInProject, recordFire } = makeDeps(role);
+    const trigger = makeTrigger({ roleId: "role-1", concernId: "concern-1" });
+
+    const result = await maybeLaunchRoleWake(deps, trigger, {
+      filePath: "/allowed/iac/modules/vpc/main.tf",
+      watchPath: "/allowed/iac/modules",
+    });
+
+    expect(result).toBe("launched");
+    expect(runInProject).toHaveBeenCalledWith("proj-1", expect.any(Function));
+    expect(createReview).toHaveBeenCalledTimes(1);
+    expect(recordFire).toHaveBeenCalledTimes(1);
+
+    const [, params] = createReview.mock.calls[0];
+    // WHERE: the CONCERN's repoPath (not the trigger's watchPath) — factory re-validates.
+    expect(params.repoPath).toBe("/allowed/iac");
+    // SHAPE: the ROLE template.
+    expect(params.preset).toBe("diff-pr-review");
+    expect(params.reviewMode).toBe("single-verifier");
+    // T6: review-only forced even for a role wake (template maxRounds:3 is NOT honoured
+    // on the automated path — escalation to develop is a human action).
+    expect(params.maxRounds).toBe(1);
+    // WHAT: persona + concern.focus + the fired event, all in the engineerInstruction.
+    expect(params.engineerInstruction).toContain(role.persona);
+    expect(params.engineerInstruction).toContain("Terraform module version");
+    expect(params.engineerInstruction).toContain("/allowed/iac/modules/vpc/main.tf");
+    // CAPABILITY: the role's skills (re-resolved project-scoped by the factory).
+    expect(params.skillIds).toEqual(["skill-a", "skill-b"]);
+    // OWNER: the resolved project owner (never the literal "system").
+    expect(params.createdBy).toBe("owner-1");
+    // PROVENANCE: the originating role + concern + cascade depth.
+    expect(params.triggerProvenance.role).toMatchObject({
+      roleId: "role-1",
+      name: "devops-reviewer",
+      concernId: "concern-1",
+      cascadeDepth: 1,
+    });
+    expect(params.triggerProvenance.triggerId).toBe("trig-role-1");
+  });
+
+  it("interpolates ${event} in the concern focus when the operator embedded the token", async () => {
+    const role = makeRole({ concerns: [fileConcern({ focus: "watch: ${event}" })] });
+    const { deps, createReview } = makeDeps(role);
+    const trigger = makeTrigger({ roleId: "role-1", concernId: "concern-1" });
+
+    await maybeLaunchRoleWake(deps, trigger, { filePath: "/allowed/iac/modules/x.tf" });
+    const [, params] = createReview.mock.calls[0];
+    expect(params.engineerInstruction).toContain("watch: file change at /allowed/iac/modules/x.tf");
+  });
+});
+
+// ─── github_event wake ────────────────────────────────────────────────────────
+
+describe("maybeLaunchRoleWake — github_event concern", () => {
+  it("wakes the role on a PR → PR head/base ref, ROLE template preset (not the event default)", async () => {
+    const role = makeRole({
+      concerns: [githubConcern()],
+      loopTemplate: { preset: "sdlc-cross-review", reviewMode: "full-dispute" },
+    });
+    const { deps, createReview } = makeDeps(role);
+    const trigger = makeTrigger(
+      { roleId: "role-1", concernId: "concern-gh" },
+      { type: "github_event", config: { repository: "owner/repo", events: ["pull_request"], roleConcern: { roleId: "role-1", concernId: "concern-gh" } } as unknown as TriggerRow["config"] },
+    );
+
+    const result = await maybeLaunchRoleWake(deps, trigger, envelope("pull_request", prPayload()));
+
+    expect(result).toBe("launched");
+    const [, params] = createReview.mock.calls[0];
+    expect(params.ref).toBe(HEAD);
+    expect(params.baselineCommit).toBe(BASE);
+    // The ROLE template's preset wins over the github event mapping's diff-pr-review.
+    expect(params.preset).toBe("sdlc-cross-review");
+    expect(params.engineerInstruction).toContain("PR #12: Add module");
+    expect(params.triggerProvenance.role.concernId).toBe("concern-gh");
+  });
+
+  it("an unmapped github event (issues) → noop-event, factory NOT called", async () => {
+    const role = makeRole({ concerns: [githubConcern()] });
+    const { deps, createReview } = makeDeps(role);
+    const trigger = makeTrigger(
+      { roleId: "role-1", concernId: "concern-gh" },
+      { type: "github_event", config: { repository: "owner/repo", events: ["issues"], roleConcern: { roleId: "role-1", concernId: "concern-gh" } } as unknown as TriggerRow["config"] },
+    );
+    expect(await maybeLaunchRoleWake(deps, trigger, envelope("issues", { action: "opened" }))).toBe("noop-event");
+    expect(createReview).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Safety: disabled role / concern, missing role / concern ──────────────────
+
+describe("maybeLaunchRoleWake — enabled gate + resolution (§6)", () => {
+  it("a DISABLED role never wakes → skipped, factory NOT called", async () => {
+    const { deps, createReview } = makeDeps(makeRole({ enabled: false }));
+    const trigger = makeTrigger({ roleId: "role-1", concernId: "concern-1" });
+    expect(await maybeLaunchRoleWake(deps, trigger, { filePath: "/allowed/iac/modules/x.tf" })).toBe("skipped");
+    expect(createReview).not.toHaveBeenCalled();
+  });
+
+  it("a DISABLED concern never wakes → skipped, factory NOT called", async () => {
+    const { deps, createReview } = makeDeps(makeRole({ concerns: [fileConcern({ enabled: false })] }));
+    const trigger = makeTrigger({ roleId: "role-1", concernId: "concern-1" });
+    expect(await maybeLaunchRoleWake(deps, trigger, { filePath: "/allowed/iac/modules/x.tf" })).toBe("skipped");
+    expect(createReview).not.toHaveBeenCalled();
+  });
+
+  it("an unknown role id → skipped, factory NOT called", async () => {
+    const { deps, createReview } = makeDeps(undefined);
+    const trigger = makeTrigger({ roleId: "ghost", concernId: "concern-1" });
+    expect(await maybeLaunchRoleWake(deps, trigger, {})).toBe("skipped");
+    expect(createReview).not.toHaveBeenCalled();
+  });
+
+  it("a concern id not on the role → skipped, factory NOT called", async () => {
+    const { deps, createReview } = makeDeps(makeRole());
+    const trigger = makeTrigger({ roleId: "role-1", concernId: "ghost-concern" });
+    expect(await maybeLaunchRoleWake(deps, trigger, {})).toBe("skipped");
+    expect(createReview).not.toHaveBeenCalled();
+  });
+
+  it("a trigger with no roleConcern binding → noop (defensive; the route pre-checks)", async () => {
+    const { deps, createReview } = makeDeps(makeRole());
+    const trigger = { id: "t", projectId: "proj-1", type: "file_change", config: { watchPath: "/w" } } as unknown as TriggerRow;
+    expect(await maybeLaunchRoleWake(deps, trigger, {})).toBe("noop");
+    expect(createReview).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Allowlist fail-closed (R1) ───────────────────────────────────────────────
+
+describe("maybeLaunchRoleWake — allowlist fail-closed", () => {
+  it("a factory throw (repoPath outside the allowlist) → failed, never a review", async () => {
+    const role = makeRole({ concerns: [fileConcern({ repoPath: "/etc/evil" })] });
+    const createReview = vi.fn().mockRejectedValue(new Error("repoPath is outside every allowed root (fail-closed)"));
+    const { deps } = makeDeps(role, { createReview });
+    const trigger = makeTrigger({ roleId: "role-1", concernId: "concern-1" });
+    expect(await maybeLaunchRoleWake(deps, trigger, { filePath: "/etc/evil/x" })).toBe("failed");
+  });
+});
+
+// ─── Per-role rails: dedup / cascade / budget ─────────────────────────────────
+
+describe("maybeLaunchRoleWake — per-role rails (loop-triggers.md §4)", () => {
+  it("DEDUP: an active loop for the SAME (role, concern) → skipped-dedup, factory NOT called", async () => {
+    const role = makeRole();
+    const { deps, createReview } = makeDeps(role, {}, [roleLoop("role-1", "concern-1")]);
+    const trigger = makeTrigger({ roleId: "role-1", concernId: "concern-1" });
+    expect(await maybeLaunchRoleWake(deps, trigger, { filePath: "/allowed/iac/modules/x.tf" })).toBe("skipped-dedup");
+    expect(createReview).not.toHaveBeenCalled();
+  });
+
+  it("a loop for a DIFFERENT concern of the SAME role does NOT dedup (per-(role,concern))", async () => {
+    const role = makeRole({ concerns: [fileConcern(), fileConcern({ id: "concern-2" })] });
+    const { deps, createReview } = makeDeps(role, {}, [roleLoop("role-1", "concern-2")]);
+    const trigger = makeTrigger({ roleId: "role-1", concernId: "concern-1" });
+    expect(await maybeLaunchRoleWake(deps, trigger, { filePath: "/allowed/iac/modules/x.tf" })).toBe("launched");
+    expect(createReview).toHaveBeenCalledTimes(1);
+  });
+
+  it("CASCADE: active loops for the role at the ceiling → skipped-cascade, factory NOT called", async () => {
+    const role = makeRole({
+      concerns: [fileConcern(), fileConcern({ id: "c2" }), fileConcern({ id: "c3" }), fileConcern({ id: "c4" })],
+      policy: { cascadeDepth: 2 },
+    });
+    // Two active loops across OTHER concerns → at the ceiling of 2 → the new concern is
+    // suppressed by cascade (before dedup would even apply, since it's a different concern).
+    const { deps, createReview } = makeDeps(role, {}, [roleLoop("role-1", "c2"), roleLoop("role-1", "c3")]);
+    const trigger = makeTrigger({ roleId: "role-1", concernId: "concern-1" });
+    expect(await maybeLaunchRoleWake(deps, trigger, { filePath: "/allowed/iac/modules/x.tf" })).toBe("skipped-cascade");
+    expect(createReview).not.toHaveBeenCalled();
+  });
+
+  it("BUDGET: role at its daily cap → skipped-budget, factory NOT called", async () => {
+    const role = makeRole({ policy: { budgetPerDay: 2, cascadeDepth: 10 } });
+    // Two TERMINAL loops for the role within 24h → budget spent (2/2), but not active so
+    // cascade (concurrent) does not trip; budget does.
+    const terminal = (concernId: string) =>
+      roleLoop("role-1", concernId, { state: "converged", createdAt: new Date() });
+    const { deps, createReview } = makeDeps(role, {}, [terminal("c-old-1"), terminal("c-old-2")]);
+    const trigger = makeTrigger({ roleId: "role-1", concernId: "concern-1" });
+    expect(await maybeLaunchRoleWake(deps, trigger, { filePath: "/allowed/iac/modules/x.tf" })).toBe("skipped-budget");
+    expect(createReview).not.toHaveBeenCalled();
+  });
+});
+
+// ─── evaluateRoleRails (pure) ─────────────────────────────────────────────────
+
+describe("evaluateRoleRails — pure rail evaluation", () => {
+  const rails = { roleId: "r", concernId: "c", budgetPerDay: 5, cascadeCeiling: 3 };
+  const now = new Date("2026-07-06T12:00:00Z");
+
+  it("empty loop list → no suppression", () => {
+    expect(evaluateRoleRails([], rails, now)).toEqual({});
+  });
+
+  it("dedup wins over cascade/budget when the SAME concern is active", () => {
+    const loops = [roleLoop("r", "c", { id: "dup-1" })];
+    expect(evaluateRoleRails(loops, rails, now)).toEqual({ suppress: "dedup", loopId: "dup-1" });
+  });
+
+  it("cascade trips when concurrent active role loops reach the ceiling", () => {
+    const loops = [roleLoop("r", "x"), roleLoop("r", "y"), roleLoop("r", "z")];
+    expect(evaluateRoleRails(loops, rails, now).suppress).toBe("cascade");
+  });
+
+  it("budget trips on recent (24h) loops when none are concurrently active", () => {
+    const recent = (c: string) => roleLoop("r", c, { state: "converged", createdAt: new Date("2026-07-06T06:00:00Z") });
+    const loops = [recent("a"), recent("b"), recent("c"), recent("d"), recent("e")];
+    expect(evaluateRoleRails(loops, rails, now).suppress).toBe("budget");
+  });
+
+  it("loops OLDER than the 24h window do not count against budget", () => {
+    const old = (c: string) => roleLoop("r", c, { state: "converged", createdAt: new Date("2026-07-04T00:00:00Z") });
+    const loops = [old("a"), old("b"), old("c"), old("d"), old("e"), old("f")];
+    expect(evaluateRoleRails(loops, rails, now)).toEqual({});
+  });
+
+  it("loops of OTHER roles are ignored entirely", () => {
+    const loops = [roleLoop("other", "c"), roleLoop("other", "c"), roleLoop("other", "c")];
+    expect(evaluateRoleRails(loops, rails, now)).toEqual({});
+  });
+
+  it("exposes sane server defaults", () => {
+    expect(DEFAULT_ROLE_BUDGET_PER_DAY).toBeGreaterThan(0);
+    expect(DEFAULT_ROLE_CASCADE_CEILING).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/consilium/standing-roles-route.test.ts
+++ b/tests/unit/consilium/standing-roles-route.test.ts
@@ -40,6 +40,9 @@ interface FakeRole {
   persona: string;
   skills: string[];
   loopTemplate: { preset: string; maxRounds?: number; reviewMode?: string };
+  // ROLE-2: additive.
+  concerns?: unknown[];
+  policy?: unknown;
   enabled: boolean;
   createdBy: string | null;
   createdAt: Date;
@@ -50,7 +53,9 @@ function makeStorage(seed: FakeRole[] = [], knownSkills: string[] = []) {
   const roles = new Map<string, FakeRole>();
   seed.forEach((r) => roles.set(r.id, r));
   const skillSet = new Set(knownSkills);
+  const triggers = new Map<string, { id: string; type: string; config: unknown; enabled: boolean }>();
   let seq = seed.length;
+  let trigSeq = 0;
   return {
     getStandingRoles: vi.fn(async () => Array.from(roles.values())),
     getStandingRole: vi.fn(async (id: string) => roles.get(id)),
@@ -63,6 +68,8 @@ function makeStorage(seed: FakeRole[] = [], knownSkills: string[] = []) {
         persona: data.persona ?? "",
         skills: data.skills ?? [],
         loopTemplate: data.loopTemplate ?? { preset: "sdlc-cross-review" },
+        concerns: data.concerns ?? [],
+        policy: data.policy ?? null,
         enabled: data.enabled ?? true,
         createdBy: data.createdBy ?? null,
         createdAt: new Date(),
@@ -82,7 +89,19 @@ function makeStorage(seed: FakeRole[] = [], knownSkills: string[] = []) {
       roles.delete(id);
     }),
     getSkill: vi.fn(async (id: string) => (skillSet.has(id) ? { id, name: id } : undefined)),
+    // ROLE-2: the concern endpoints materialise / tear down a backing trigger + read loops.
+    createTrigger: vi.fn(async (data: { type: string; config: unknown; enabled?: boolean }) => {
+      trigSeq += 1;
+      const row = { id: `trig-${trigSeq}`, type: data.type, config: data.config, enabled: data.enabled ?? true };
+      triggers.set(row.id, row);
+      return row;
+    }),
+    deleteTrigger: vi.fn(async (id: string) => {
+      triggers.delete(id);
+    }),
+    getLoops: vi.fn(async () => [] as unknown[]),
     _roles: roles,
+    _triggers: triggers,
   };
 }
 
@@ -282,5 +301,91 @@ describe("POST /api/roles/:id/wake", () => {
       .send({ repoPath: "/repos/iac", focus: "f" });
     expect(res.status).toBe(404);
     expect(mockedCreate).not.toHaveBeenCalled();
+  });
+});
+
+// ─── ROLE-2: concern endpoints (bind a trigger to a role's concern) ───────────
+
+describe("ROLE-2 concern endpoints", () => {
+  const FILE_CONCERN = {
+    repoPath: "/repos/iac",
+    focus: "a new Terraform module version",
+    trigger: { type: "file_change", filter: { watchPath: "/repos/iac/modules", patterns: ["**/*.tf"] } },
+  };
+
+  it("POST /api/roles/:id/concerns adds a concern AND materialises a backing trigger", async () => {
+    const storage = makeStorage([seedRole()], ["sk-1"]);
+    const res = await request(makeApp(storage)).post("/api/roles/role-1/concerns").send(FILE_CONCERN);
+
+    expect(res.status).toBe(201);
+    // The backing trigger was created with the roleConcern binding + the concern filter.
+    expect(storage.createTrigger).toHaveBeenCalledTimes(1);
+    const trig = storage.createTrigger.mock.calls[0][0] as { type: string; config: Record<string, unknown> };
+    expect(trig.type).toBe("file_change");
+    expect(trig.config.watchPath).toBe("/repos/iac/modules");
+    expect(trig.config.roleConcern).toMatchObject({ roleId: "role-1" });
+    // The concern is appended to the role, carrying the backing triggerId.
+    const concerns = res.body.concerns as Array<Record<string, unknown>>;
+    expect(concerns).toHaveLength(1);
+    expect(concerns[0]).toMatchObject({ repoPath: "/repos/iac", focus: "a new Terraform module version" });
+    expect(typeof concerns[0].id).toBe("string");
+    expect(concerns[0].triggerId).toBe((storage.createTrigger.mock.results[0].value as { id: string } | undefined)?.id ?? concerns[0].triggerId);
+    // The roleConcern binding names the SAME concern id that was stored.
+    expect((trig.config.roleConcern as { concernId: string }).concernId).toBe(concerns[0].id);
+  });
+
+  it("POST a github_event concern builds a github backing trigger", async () => {
+    const storage = makeStorage([seedRole()], ["sk-1"]);
+    const res = await request(makeApp(storage)).post("/api/roles/role-1/concerns").send({
+      repoPath: "/repos/iac",
+      focus: "review the PR",
+      trigger: { type: "github_event", filter: { repository: "owner/repo", events: ["pull_request"] } },
+    });
+    expect(res.status).toBe(201);
+    const trig = storage.createTrigger.mock.calls[0][0] as { type: string; config: Record<string, unknown> };
+    expect(trig.type).toBe("github_event");
+    expect(trig.config.repository).toBe("owner/repo");
+    expect(trig.config.roleConcern).toBeTruthy();
+  });
+
+  it("POST a concern with an invalid trigger type (tracker_event → TRACK-6) → 400", async () => {
+    const storage = makeStorage([seedRole()], ["sk-1"]);
+    const res = await request(makeApp(storage)).post("/api/roles/role-1/concerns").send({
+      repoPath: "/repos/iac",
+      focus: "f",
+      trigger: { type: "tracker_event", filter: {} },
+    });
+    expect(res.status).toBe(400);
+    expect(storage.createTrigger).not.toHaveBeenCalled();
+  });
+
+  it("POST a concern to an unknown role → 404 (no trigger created)", async () => {
+    const storage = makeStorage([], []);
+    const res = await request(makeApp(storage)).post("/api/roles/ghost/concerns").send(FILE_CONCERN);
+    expect(res.status).toBe(404);
+    expect(storage.createTrigger).not.toHaveBeenCalled();
+  });
+
+  it("DELETE /api/roles/:id/concerns/:concernId removes the concern AND its backing trigger", async () => {
+    const storage = makeStorage([seedRole()], ["sk-1"]);
+    const add = await request(makeApp(storage)).post("/api/roles/role-1/concerns").send(FILE_CONCERN);
+    const concernId = (add.body.concerns as Array<{ id: string }>)[0].id;
+
+    const del = await request(makeApp(storage)).delete(`/api/roles/role-1/concerns/${concernId}`);
+    expect(del.status).toBe(200);
+    expect(storage.deleteTrigger).toHaveBeenCalledTimes(1);
+    expect((del.body.concerns as unknown[]).length).toBe(0);
+  });
+
+  it("GET /api/roles/:id/woken-loops returns loops whose provenance names the role", async () => {
+    const storage = makeStorage([seedRole()], ["sk-1"]);
+    storage.getLoops.mockResolvedValueOnce([
+      { id: "loop-a", triggerProvenance: { role: { roleId: "role-1", name: "x" } } },
+      { id: "loop-b", triggerProvenance: { role: { roleId: "other", name: "y" } } },
+      { id: "loop-c", triggerProvenance: { triggerId: "t" } },
+    ]);
+    const res = await request(makeApp(storage)).get("/api/roles/role-1/woken-loops");
+    expect(res.status).toBe(200);
+    expect(res.body.map((l: { id: string }) => l.id)).toEqual(["loop-a"]);
   });
 });


### PR DESCRIPTION
## ROLE-2 — bind triggers to a StandingRole's concerns; a firing wakes the role

Implements ROLE-2 from `docs/design/standing-role.md` (§3 concern anatomy, §6 safety, §8 scope). ROLE-1 shipped the record + manual `POST /api/roles/:id/wake`; this adds **concerns** and the **trigger → role-wake** binding so a firing trigger spawns the role's loop automatically. Inert-by-default and kill-switched.

### The Concern entity (`shared/types.ts`, `shared/schema.ts`)
Added `concerns: Concern[]` + `policy` to `StandingRole` (additive migration `0048`, jsonb `'[]'` / nullable — every ROLE-1 row reads back byte-identical):

```
Concern = { id, repoPath, trigger: { type: file_change | github_event, filter }, focus, enabled?, triggerId? }
```
A concern is **WHAT the role watches + WHERE + the wake focus**. `tracker_event` concerns are the documented follow-up **TRACK-6** — ROLE-2 covers the two mechanics that already have a runtime + a review mapping.

### The trigger → role-wake binding (`server/services/consilium/trigger-dispatch.ts`)
A **backing trigger** carries `config.roleConcern = { roleId, concernId }` (materialised when a concern is added). On fire the route routes to **`maybeLaunchRoleWake`** instead of the legacy action:
- Composes the loop **from the role** — `persona + concern.focus + the fired event` (via the shared `role-compose.ts` seam, reused from ROLE-1's wake), `skillIds = role.skills`, preset/reviewMode from `role.loopTemplate`, on **`concern.repoPath`**.
- For a `github_event` concern it reuses the pure event→review mapping for the PR head/base `ref`; the review **shape** still comes from the role template.
- Records provenance `role: { roleId, name, concernId, cascadeDepth: 1 }` + the trigger event.
- **Reuses `launchReviewWithDedup` + `createConsiliumReview`** — no reimplemented loop creation, the consilium controller is **untouched** (DREAM-2's `plan()` is not in this diff).

### Per-role rails (§6, loop-triggers §4) — bind at the ROLE level
- **Dedup**: one active loop per `(role, concern)`.
- **Cascade**: a concurrent-active-loop ceiling per role across all concerns (`policy.cascadeDepth`, default 3) — bounds a burst / a role-loop re-firing its own concern.
- **Budget**: trailing-24h launch cap per role (`policy.budgetPerDay`, default 20).
- **Enabled gate**: a disabled role never wakes (checked before the factory); per-concern kill too.
- `repoPath` re-validated fail-closed by the factory; `maxRounds` forced review-only (T6); the whole role-wake path is gated behind `features.triggers.enabled`. Suppressions bump the trigger's suppressed counter.

### UI (`client/src/pages/Roles.tsx`, `use-roles.ts`)
The Roles card now lets you **add/remove a concern** (trigger type + filter, target repo, focus — which creates/tears down the backing trigger) and shows **how many loops the role has woken** (`GET /api/roles/:id/woken-loops`).

### Boundary
- `tracker_event` concerns → **TRACK-6**.
- Runtime-created backing triggers are picked up by the file-watcher / github poller on their normal bootstrap cadence (no new long-lived runtime is added — a role is a definition, §6).

### Tests
`tests/unit/consilium/role-wake.test.ts` (+ extended `standing-roles-route.test.ts`):
- a role-bound **file_change** trigger firing wakes the role → loop with role provenance + concern focus + skills/template;
- a **github_event** concern likewise (PR head ref, role template preset);
- per-`(role,concern)` **dedup**, per-role **cascade** + **budget** rails, **disabled role never wakes**, **allowlist fail-closed** (factory throw → `failed`);
- the legacy (non-role) trigger path unchanged; pure `evaluateRoleRails`.
- Concern endpoints materialise/tear down the backing trigger; woken-loops filter.

### Adversarial self-review
Verified: a role wake cannot bypass the allowlist (factory re-validates `concern.repoPath`), the dedup, or the budget/cascade caps; a disabled role/concern cannot wake; a misfiring concern is bounded by cascade + budget; loop creation is **not** reimplemented (factory reused); the legacy trigger action path is byte-identical when no `roleConcern` is present.

`tsc` clean; full unit suite green (5275 passed).

Do not merge — draft for review.
