### PR TITLE
feat: TRACK-5 — Linear + Azure DevOps + ClickUp connectors

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -44,6 +44,9 @@ import { GithubIssuesPoller } from "./services/consilium/trackers/github-issues-
 import { JiraIssuesPoller } from "./services/consilium/trackers/jira-issues-poller";
 import { GitlabIssuesPoller } from "./services/consilium/trackers/gitlab-issues-poller";
 import { BitbucketIssuesPoller } from "./services/consilium/trackers/bitbucket-issues-poller";
+import { LinearIssuesPoller } from "./services/consilium/trackers/linear-issues-poller";
+import { AzureIssuesPoller } from "./services/consilium/trackers/azure-issues-poller";
+import { ClickUpIssuesPoller } from "./services/consilium/trackers/clickup-issues-poller";
 import { TrackerWritebackObserver } from "./services/consilium/trackers/writeback-observer";
 import { ExperienceDistillerObserver } from "./services/consilium/experience/experience-distiller-observer";
 import { buildSynthPrompt, parseSynthOutput } from "./services/consilium/trackers/issue-spec";
@@ -425,6 +428,9 @@ export async function registerRoutes(
   let jiraIssuesPoller: JiraIssuesPoller | null = null;
   let gitlabIssuesPoller: GitlabIssuesPoller | null = null;
   let bitbucketIssuesPoller: BitbucketIssuesPoller | null = null;
+  let linearIssuesPoller: LinearIssuesPoller | null = null;
+  let azureIssuesPoller: AzureIssuesPoller | null = null;
+  let clickupIssuesPoller: ClickUpIssuesPoller | null = null;
   let trackerWritebackObserver: TrackerWritebackObserver | null = null;
 
   try {
@@ -774,6 +780,68 @@ export async function registerRoutes(
         log: (m: string) => log(m, "bitbucket-tracker-poller"),
       });
       bitbucketIssuesPoller.start();
+      // TRACK-5 (linear / azure / clickup -> committed spec PR). Each is the same spec
+      // PRODUCER + ticket UPDATER as github/jira — a labelled/tagged ticket becomes a
+      // committed-spec PR (in the TARGET git repo) + a pickup comment, firing NO loop
+      // itself. They share the SAME kill-switch (features.triggers.tracker.enabled) and
+      // the SAME crystallise pipeline; only the watch/read/write-back dialect differs
+      // (Linear GraphQL / Azure WIQL / ClickUp REST). Tokens are read from LINEAR_API_KEY
+      // / AZURE_DEVOPS_PAT / CLICKUP_API_TOKEN at call time (fail-closed). A trigger is a
+      // no-op in each poller until its `tracker: "<kind>"` config exists. The synthesiser
+      // is connector-agnostic (title+body only), so all three share ONE instance.
+      const track5Synthesizer = {
+        synthesize: async (ticket: { title: string; body: string }) => {
+          try {
+            const { system, user } = buildSynthPrompt({ number: 0, title: ticket.title, body: ticket.body });
+            const res = await gateway.completeStreaming(
+              {
+                modelSlug: DEFAULT_TASK_MODEL,
+                messages: [
+                  { role: "system", content: system },
+                  { role: "user", content: user },
+                ],
+                temperature: 0.2,
+                maxTokens: 2048,
+              },
+              undefined,
+              undefined,
+              { overallTimeoutMs: 60_000 },
+            );
+            return parseSynthOutput(res.content);
+          } catch {
+            return { criteria: [] };
+          }
+        },
+      };
+      const track5CommonDeps = {
+        getEnabledTriggersByType: (type: "tracker_event") =>
+          runAsSystem("track5-tracker-poller-bootstrap", () => storage.getAllEnabledTriggersByType(type)),
+        runInProject: runAsProject,
+        getTrigger: (id: string) => storage.getTrigger(id),
+        updateTrigger: (id: string, updates: Partial<import("@shared/schema").TriggerRow>) =>
+          storage.updateTrigger(id, updates),
+        config: () => appConfigLoader.get(),
+        allowedRepoPaths: () => appConfigLoader.get().pipeline.consiliumLoop.allowedRepoPaths,
+        synthesizer: track5Synthesizer,
+      };
+
+      linearIssuesPoller = new LinearIssuesPoller({
+        ...track5CommonDeps,
+        log: (m: string) => log(m, "linear-tracker-poller"),
+      });
+      linearIssuesPoller.start();
+
+      azureIssuesPoller = new AzureIssuesPoller({
+        ...track5CommonDeps,
+        log: (m: string) => log(m, "azure-tracker-poller"),
+      });
+      azureIssuesPoller.start();
+
+      clickupIssuesPoller = new ClickUpIssuesPoller({
+        ...track5CommonDeps,
+        log: (m: string) => log(m, "clickup-tracker-poller"),
+      });
+      clickupIssuesPoller.start();
     }
 
     // TRACK-2 (full write-back lifecycle). When the write-back sub-switch is on (and
@@ -878,6 +946,9 @@ export async function registerRoutes(
     jiraIssuesPoller?.stop();
     gitlabIssuesPoller?.stop();
     bitbucketIssuesPoller?.stop();
+    linearIssuesPoller?.stop();
+    azureIssuesPoller?.stop();
+    clickupIssuesPoller?.stop();
     trackerWritebackObserver?.stop();
     getRefreshScheduler()?.stop();
     stopRateLimitCleanup();

--- a/server/routes/triggers.ts
+++ b/server/routes/triggers.ts
@@ -134,11 +134,53 @@ const JiraTrackerConfigSchema = z.object({
   specStatus: z.enum(["ready", "draft"]).optional(),
 });
 
+// TRACK-5 (linear) — GraphQL poll → committed spec PR in `repo` (the git repo) + pickup.
+const LinearTrackerConfigSchema = z.object({
+  tracker: z.literal("linear"),
+  baseUrl: z.string().min(1).max(500).url().startsWith("https://", "Linear baseUrl must be https").optional(),
+  linearTeamId: z.string().min(1).max(200).optional(),
+  transitionTo: z.string().min(1).max(200).optional(),
+  repo: z.string().min(1).max(500).regex(/^[^/]+\/[^/]+$/, "Must be owner/repo (the git repo the spec PR lands in)"),
+  targetRepoPath: z.string().min(1).max(4096),
+  filter: z.object({ label: z.string().min(1).max(200).optional() }).optional(),
+  specStatus: z.enum(["ready", "draft"]).optional(),
+});
+
+// TRACK-5 (azure) — WIQL poll → committed spec PR in `repo` (the git repo) + pickup.
+const AzureTrackerConfigSchema = z.object({
+  tracker: z.literal("azure"),
+  baseUrl: z.string().min(1).max(500).url().startsWith("https://", "Azure baseUrl must be https").optional(),
+  azureOrg: z.string().min(1).max(100),
+  project: z.string().min(1).max(100),
+  azureAreaPath: z.string().min(1).max(400).optional(),
+  transitionTo: z.string().min(1).max(200).optional(),
+  repo: z.string().min(1).max(500).regex(/^[^/]+\/[^/]+$/, "Must be owner/repo (the git repo the spec PR lands in)"),
+  targetRepoPath: z.string().min(1).max(4096),
+  filter: z.object({ label: z.string().min(1).max(200).optional() }).optional(),
+  specStatus: z.enum(["ready", "draft"]).optional(),
+});
+
+// TRACK-5 (clickup) — REST poll → committed spec PR in `repo` (the git repo) + pickup.
+const ClickUpTrackerConfigSchema = z.object({
+  tracker: z.literal("clickup"),
+  baseUrl: z.string().min(1).max(500).url().startsWith("https://", "ClickUp baseUrl must be https").optional(),
+  clickupListId: z.string().min(1).max(64).regex(/^[A-Za-z0-9._-]+$/, "ClickUp list id: alnum/._-"),
+  transitionTo: z.string().min(1).max(200).optional(),
+  repo: z.string().min(1).max(500).regex(/^[^/]+\/[^/]+$/, "Must be owner/repo (the git repo the spec PR lands in)"),
+  targetRepoPath: z.string().min(1).max(4096),
+  filter: z.object({ label: z.string().min(1).max(200).optional() }).optional(),
+  specStatus: z.enum(["ready", "draft"]).optional(),
+});
+
 // Discriminated on `tracker` so a bad/absent kind yields a precise 400 (additive: the
-// github arm is unchanged, so existing github trigger creation validates identically).
+// github + jira arms are unchanged, so existing trigger creation validates identically;
+// TRACK-5 adds the linear/azure/clickup arms).
 const TrackerConfigSchema = z.discriminatedUnion("tracker", [
   GithubTrackerConfigSchema,
   JiraTrackerConfigSchema,
+  LinearTrackerConfigSchema,
+  AzureTrackerConfigSchema,
+  ClickUpTrackerConfigSchema,
 ]);
 
 type TriggerTypeValue = "webhook" | "schedule" | "github_event" | "file_change" | "tracker_event";

--- a/server/services/consilium/trackers/azure-connector.ts
+++ b/server/services/consilium/trackers/azure-connector.ts
@@ -1,0 +1,333 @@
+/**
+ * azure-connector.ts — TRACK-5: the Azure DevOps implementation of `TrackerConnector`. It
+ * is PURELY the Azure DIALECT (watch = WIQL query, read = `/wit/workitems/{id}`, write-back
+ * = `/comments` + `System.State` field patch + hyperlink relation, naming =
+ * `spec/azure-<id>`); the synth, the spec-PR, the provenance, and the crystallise/dedup
+ * machinery are the SHARED modules (`issue-spec.ts`, `spec-writer.ts`, `spec-intake.ts`).
+ *
+ * SECURITY
+ *   - WIQL is SERVER-BUILT: `[System.TeamProject] = @project` uses the WIQL MACRO (no
+ *     project interpolation); the `tag` and optional `areaPath` are sanitised to a safe
+ *     charset and embedded as QUOTED literals (single-quotes/backslashes stripped) so a
+ *     config value can never break out of the quoted term (WIQL-injection defence). The
+ *     `changedDate` watermark is a server-generated ISO string. The UNTRUSTED work-item
+ *     title/description NEVER touches WIQL.
+ *   - Path segments (org/project/id) are shape-validated then `encodeURIComponent`-d;
+ *     `azure-exec` re-checks the final URL stays on `baseUrl`'s origin.
+ *   - Every read/write goes through the fail-closed, never-logging `azure-exec` seam.
+ *   - `System.Description` is HTML → flattened to plain text and stays UNTRUSTED (the
+ *     shared synth fences it before any prompt; the renderer quotes it in YAML).
+ *   - `specBranchName`/`specFilePath` reduce the id to DIGITS so the branch matches
+ *     `SPEC_BRANCH_RE` (`azure-[0-9]+`) and the filename is traversal-free.
+ */
+import { slugify } from "./issue-spec.js";
+import type { Ticket, TrackerConnector, TrackerWriteback, WritebackResult } from "./tracker-connector.js";
+import { azureGetJson, azureSendJson, type AzureExecDeps } from "./azure-exec.js";
+
+const API_VERSION = "7.0";
+const COMMENTS_API_VERSION = "7.0-preview.3";
+const DESCRIPTION_MAX = 16_000;
+
+/**
+ * Sanitise a WIQL single-quoted literal: DROP the single-quote (the ONLY term-breakout
+ * char in a WIQL quoted string — WIQL-injection defence) and any C0/DEL control char,
+ * collapse whitespace, clamp. Backslash is KEPT: WIQL treats it literally (no escape
+ * sequences) and area paths legitimately use it as a hierarchy separator
+ * (`Project\Area\Sub`). Char-code filtered (no control-char regex literal).
+ */
+function wiqlLiteral(value: string, max = 200): string {
+  let out = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0;
+    if (code < 0x20 || code === 0x7f) continue;
+    if (ch === "'") continue; // quote-term breakout char.
+    out += ch;
+  }
+  return out.replace(/\s+/g, " ").trim().slice(0, max);
+}
+
+/** Reduce a work-item id to DIGITS (Azure ids are positive integers). */
+export function sanitizeWorkItemId(id: string): string {
+  return String(id).replace(/[^0-9]/g, "").slice(0, 18);
+}
+
+/** Sanitise an org/project path segment: drop separators/control/`..`, clamp (encoded later). */
+function sanitizeSegment(value: string, max = 100): string {
+  let out = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0;
+    if (code < 0x20 || code === 0x7f) continue;
+    if (ch === "/" || ch === "\\") continue;
+    out += ch;
+  }
+  return out.replace(/\.\.+/g, ".").trim().slice(0, max);
+}
+
+/** The Azure spec dedup branch: `spec/azure-<id>` (matches spec-writer's SPEC_BRANCH_RE). */
+export function azureSpecBranchName(id: string): string {
+  const safe = sanitizeWorkItemId(id);
+  if (safe.length === 0) throw new Error(`azure-connector: invalid work-item id ${JSON.stringify(id)}`);
+  return `spec/azure-${safe}`;
+}
+
+/** The committed spec path: `docs/specs/azure-<id>-<slug>.md`. */
+export function azureSpecFilePath(id: string, title: string): string {
+  const safe = sanitizeWorkItemId(id);
+  if (safe.length === 0) throw new Error(`azure-connector: invalid work-item id ${JSON.stringify(id)}`);
+  return `docs/specs/azure-${safe}-${slugify(title)}.md`;
+}
+
+/**
+ * Flatten a work-item HTML `System.Description` to plain text: drop tags, decode the
+ * common named/numeric entities, collapse whitespace, clamp. Bounded (never runs a
+ * catastrophic regex over an unbounded string — the input is clamped first).
+ */
+export function htmlToText(html: unknown, maxLen = DESCRIPTION_MAX): string {
+  if (typeof html !== "string") return "";
+  const clamped = html.slice(0, maxLen * 2);
+  const noTags = clamped
+    .replace(/<\s*br\s*\/?\s*>/gi, "\n")
+    // Render list items as markdown bullets so the shared criteria extractor
+    // (`- text`) still recognises an Azure "Acceptance Criteria" HTML list.
+    .replace(/<\s*li[^>]*>/gi, "\n- ")
+    .replace(/<\s*\/\s*(p|div|li|h[1-6])\s*>/gi, "\n")
+    .replace(/<[^>]*>/g, "");
+  const decoded = noTags
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&#(\d+);/g, (_m, d) => {
+      const code = Number(d);
+      return code > 0 && code < 0x110000 ? String.fromCodePoint(code) : "";
+    });
+  return decoded.replace(/[ \t]+\n/g, "\n").replace(/\n{3,}/g, "\n\n").trim().slice(0, maxLen);
+}
+
+/** Split the `System.Tags` string (`"a; b; c"`) into a normalised label array. */
+export function parseTags(tags: unknown): string[] {
+  if (typeof tags !== "string") return [];
+  return tags
+    .split(";")
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+}
+
+// ─── Azure REST shapes (only the fields we request) ───────────────────────────
+
+interface AzureFields {
+  "System.Title"?: string;
+  "System.Description"?: string;
+  "System.Tags"?: string;
+  "System.ChangedDate"?: string;
+}
+interface AzureWorkItem {
+  id?: number;
+  fields?: AzureFields;
+}
+interface AzureWiqlResult {
+  workItems?: Array<{ id?: number }>;
+}
+interface AzureBatchResult {
+  value?: AzureWorkItem[];
+}
+interface AzureCommentsResult {
+  comments?: Array<{ text?: string }>;
+}
+
+export interface AzureConnectorConfig {
+  /** Azure organization (the `dev.azure.com/<org>` segment) — REQUIRED. */
+  org: string;
+  /** Azure project name — REQUIRED. */
+  project: string;
+  /** The consent tag (§3.1) — REQUIRED at fire time by the poller. */
+  tag: string;
+  /** Optional area-path filter ANDed into the WIQL (`[System.AreaPath] UNDER '<path>'`). */
+  areaPath?: string;
+  /** Optional `System.State` value to move the work item to on pickup (best-effort). */
+  transitionTo?: string;
+}
+
+export class AzureTrackerConnector implements TrackerConnector {
+  readonly kind = "azure";
+  readonly writeback: TrackerWriteback;
+  private readonly cfg: AzureConnectorConfig;
+  private readonly exec: AzureExecDeps;
+  private readonly org: string;
+  private readonly project: string;
+  private readonly apiBase: string;
+  private readonly webBase: string;
+
+  constructor(cfg: AzureConnectorConfig, exec: AzureExecDeps) {
+    this.cfg = cfg;
+    this.exec = exec;
+    this.org = encodeURIComponent(sanitizeSegment(cfg.org));
+    this.project = encodeURIComponent(sanitizeSegment(cfg.project));
+    this.apiBase = `${this.org}/${this.project}/_apis/wit`;
+    const host = (exec.baseUrl && exec.baseUrl.trim().length > 0 ? exec.baseUrl : "https://dev.azure.com").replace(/\/+$/, "");
+    this.webBase = `${host}/${this.org}/${this.project}/_workitems/edit`;
+    this.writeback = {
+      comment: (ticketId, body, marker) => this.postComment(ticketId, body, marker),
+      transition: (ticketId, state) => this.setState(ticketId, state),
+      link: (ticketId, url, title) => this.addLink(ticketId, url, title),
+    };
+  }
+
+  /** Build the server-side WIQL (macro project; sanitised, quoted tag/areaPath literals). */
+  private buildWiql(sinceWatermark?: string): string {
+    const tag = wiqlLiteral(this.cfg.tag);
+    const terms = [
+      "[System.TeamProject] = @project",
+      `[System.Tags] CONTAINS '${tag}'`,
+    ];
+    const area = (this.cfg.areaPath ?? "").trim();
+    if (area.length > 0) terms.push(`[System.AreaPath] UNDER '${wiqlLiteral(area)}'`);
+    if (sinceWatermark && sinceWatermark.trim().length > 0) {
+      terms.push(`[System.ChangedDate] > '${wiqlLiteral(sinceWatermark, 40)}'`);
+    }
+    return `SELECT [System.Id] FROM WorkItems WHERE ${terms.join(" AND ")} ORDER BY [System.ChangedDate] ASC`;
+  }
+
+  /** Map an Azure work item → the normalised `Ticket`. */
+  private toTicket(wi: AzureWorkItem): Ticket | null {
+    const id = typeof wi.id === "number" && Number.isFinite(wi.id) ? String(wi.id) : "";
+    if (id.length === 0) return null;
+    const f = wi.fields ?? {};
+    return {
+      id,
+      title: typeof f["System.Title"] === "string" ? f["System.Title"]! : "",
+      body: htmlToText(f["System.Description"]),
+      labels: parseTags(f["System.Tags"]),
+      updatedAt: typeof f["System.ChangedDate"] === "string" ? f["System.ChangedDate"] : undefined,
+      url: `${this.webBase}/${id}`,
+    };
+  }
+
+  /**
+   * WATCH: WIQL-query the project for tagged work items, then batch-read their fields.
+   * `null` on any degrade (auth/outage) so the poller skips the cycle.
+   */
+  async pollTickets(sinceWatermark?: string): Promise<Ticket[] | null> {
+    const wiql = await azureSendJson(
+      this.exec,
+      "POST",
+      `${this.apiBase}/wiql`,
+      { query: this.buildWiql(sinceWatermark) },
+      { query: { "api-version": API_VERSION } },
+    );
+    if (!wiql.ok) return null;
+    let ids: number[] = [];
+    try {
+      const parsed = JSON.parse(wiql.body) as AzureWiqlResult;
+      ids = (parsed.workItems ?? [])
+        .map((w) => w.id)
+        .filter((n): n is number => typeof n === "number" && Number.isFinite(n))
+        .slice(0, 200);
+    } catch {
+      return null;
+    }
+    if (ids.length === 0) return [];
+    const batch = await azureGetJson<AzureBatchResult>(this.exec, `${this.apiBase}/workitems`, {
+      ids: ids.join(","),
+      fields: "System.Title,System.Description,System.Tags,System.ChangedDate",
+      "api-version": API_VERSION,
+    });
+    if (!batch || !Array.isArray(batch.value)) return null;
+    const tickets: Ticket[] = [];
+    for (const wi of batch.value) {
+      const t = this.toTicket(wi);
+      if (t) tickets.push(t);
+    }
+    return tickets;
+  }
+
+  /** READ: fetch one work item by id. `null` ⇒ not found / degraded. */
+  async readTicket(ticketId: string): Promise<Ticket | null> {
+    const id = sanitizeWorkItemId(ticketId);
+    if (id.length === 0) return null;
+    const wi = await azureGetJson<AzureWorkItem>(this.exec, `${this.apiBase}/workitems/${id}`, {
+      fields: "System.Title,System.Description,System.Tags,System.ChangedDate",
+      "api-version": API_VERSION,
+    });
+    if (!wi) return null;
+    return this.toTicket({ ...wi, id: typeof wi.id === "number" ? wi.id : Number(id) });
+  }
+
+  specBranchName(ticketId: string): string {
+    return azureSpecBranchName(ticketId);
+  }
+
+  specFilePath(ticketId: string, title: string): string {
+    return azureSpecFilePath(ticketId, title);
+  }
+
+  // ─── write-back ─────────────────────────────────────────────────────────────
+
+  /**
+   * Post a comment IDEMPOTENTLY: read existing comments, skip if any already carries
+   * `marker`, else POST `{ text }`. Best-effort; when comments cannot be read we do NOT
+   * post (safety over liveness).
+   */
+  private async postComment(ticketId: string, body: string, marker: string): Promise<WritebackResult> {
+    const id = sanitizeWorkItemId(ticketId);
+    if (id.length === 0) return { posted: false, reason: "bad-id" };
+    const existing = await azureGetJson<AzureCommentsResult>(this.exec, `${this.apiBase}/workItems/${id}/comments`, {
+      "api-version": COMMENTS_API_VERSION,
+    });
+    if (!existing || !Array.isArray(existing.comments)) {
+      return { posted: false, reason: "comments-unreadable" };
+    }
+    const already = existing.comments.some((c) => typeof c.text === "string" && c.text.includes(marker));
+    if (already) return { posted: false, reason: "already-commented" };
+    const res = await azureSendJson(
+      this.exec,
+      "POST",
+      `${this.apiBase}/workItems/${id}/comments`,
+      { text: `${marker}\n${body}` },
+      { query: { "api-version": COMMENTS_API_VERSION } },
+    );
+    return res.ok ? { posted: true } : { posted: false, reason: res.reason };
+  }
+
+  /**
+   * Move the work item to `state` via a `System.State` JSON-patch, best-effort. The value
+   * is the operator-configured state (trusted); no resolution needed.
+   */
+  private async setState(ticketId: string, state: string): Promise<WritebackResult> {
+    const id = sanitizeWorkItemId(ticketId);
+    if (id.length === 0) return { posted: false, reason: "bad-id" };
+    const wanted = state.trim();
+    if (wanted.length === 0) return { posted: false, reason: "no-state" };
+    const res = await azureSendJson(
+      this.exec,
+      "PATCH",
+      `${this.apiBase}/workitems/${id}`,
+      [{ op: "add", path: "/fields/System.State", value: wanted }],
+      { query: { "api-version": API_VERSION }, contentType: "application/json-patch+json" },
+    );
+    return res.ok ? { posted: true } : { posted: false, reason: res.reason };
+  }
+
+  /** Attach a hyperlink relation to the work item (e.g. the spec/PR URL), best-effort. */
+  private async addLink(ticketId: string, url: string, title?: string): Promise<WritebackResult> {
+    const id = sanitizeWorkItemId(ticketId);
+    if (id.length === 0) return { posted: false, reason: "bad-id" };
+    if (!/^https?:\/\//i.test(url)) return { posted: false, reason: "bad-url" };
+    const res = await azureSendJson(
+      this.exec,
+      "PATCH",
+      `${this.apiBase}/workitems/${id}`,
+      [
+        {
+          op: "add",
+          path: "/relations/-",
+          value: { rel: "Hyperlink", url, attributes: title ? { comment: title } : {} },
+        },
+      ],
+      { query: { "api-version": API_VERSION }, contentType: "application/json-patch+json" },
+    );
+    return res.ok ? { posted: true } : { posted: false, reason: res.reason };
+  }
+}

--- a/server/services/consilium/trackers/azure-exec.ts
+++ b/server/services/consilium/trackers/azure-exec.ts
@@ -1,0 +1,221 @@
+/**
+ * azure-exec.ts — the sanitized Azure DevOps REST seam for TRACK-5 (the Azure analogue of
+ * `gh-exec.ts` / `jira-exec.ts`). A thin HTTP client with the SAME safety posture:
+ *   - NEVER throws: a network error / non-2xx / timeout degrades to `null` (reads) or
+ *     `{ ok: false }` (writes) so an Azure outage can never crash the poll loop.
+ *   - The PAT is NEVER logged: on failure only the HTTP status + a scrubbed, header-free
+ *     message leaves this module; the `Authorization` header is never surfaced.
+ *   - Fail-closed auth: the PAT comes from ENV (a secret manager), read at call time.
+ *     Absent ⇒ the request is not even attempted (`null` / `{ ok: false }`).
+ *   - SSRF containment: the request URL is built from the operator-configured `baseUrl`
+ *     (default `https://dev.azure.com`) + a SERVER-DERIVED path (`<org>/<project>/_apis/…`
+ *     with shape-validated org/project/id), then re-checked to share `baseUrl`'s origin —
+ *     a crafted path can never redirect the PAT to another host.
+ *
+ * Azure PAT auth is HTTP Basic with an EMPTY username and the PAT as the password. The
+ * HTTP call is injectable (`AzureHttpFn`) so tests drive it with a fake — no real network.
+ */
+
+/** The PAT env var name (a secret manager sets this). Never logged. */
+export const AZURE_PAT_ENV = "AZURE_DEVOPS_PAT";
+
+/** The default Azure DevOps host (overridable by validated https config, e.g. a server install). */
+export const AZURE_DEFAULT_BASE_URL = "https://dev.azure.com";
+
+/** Default per-call wall-clock budget for an Azure request. */
+const AZURE_TIMEOUT_MS = 30_000;
+
+/** A minimal, injectable HTTP result (status + raw body text). */
+export interface AzureHttpResult {
+  status: number;
+  body: string;
+}
+
+/** Injectable HTTP transport (tests pass a fake; prod uses `fetch`). NEVER throws-through. */
+export type AzureHttpFn = (req: {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: string;
+  timeoutMs: number;
+}) => Promise<AzureHttpResult>;
+
+/** Resolved auth material (a PAT). `null` ⇒ fail-closed (not configured). */
+export interface AzureAuth {
+  pat: string;
+}
+
+/**
+ * Read the Azure auth from ENV (fail-closed). Returns `null` when the var is absent or
+ * blank so the caller degrades WITHOUT attempting an unauthenticated call. The PAT is
+ * returned but NEVER logged by this module.
+ */
+export function readAzureAuthFromEnv(env: NodeJS.ProcessEnv = process.env): AzureAuth | null {
+  const pat = (env[AZURE_PAT_ENV] ?? "").trim();
+  if (pat.length === 0) return null;
+  return { pat };
+}
+
+/** Scrub any absolute path + collapse whitespace from an error string, then clamp. */
+function scrub(raw: string): string {
+  return raw.replace(/\/[^\s'"]+/g, "<path>").replace(/\s+/g, " ").trim().slice(0, 300);
+}
+
+/** Default transport over global `fetch` with an AbortController timeout. Never throws-through. */
+const defaultHttp: AzureHttpFn = async (req) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), req.timeoutMs);
+  try {
+    const res = await fetch(req.url, {
+      method: req.method,
+      headers: req.headers,
+      body: req.body,
+      signal: controller.signal,
+    });
+    const body = await res.text().catch(() => "");
+    return { status: res.status, body };
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/** The `Authorization: Basic <base64(:PAT)>` header (empty user, PAT as password). */
+function basicAuthHeader(auth: AzureAuth): string {
+  return "Basic " + Buffer.from(`:${auth.pat}`, "utf8").toString("base64");
+}
+
+/** Normalise `baseUrl` to an `https://host[/path]` origin. `null` for non-https / malformed. */
+export function normalizeBaseUrl(baseUrl: string): { origin: string; base: string } | null {
+  try {
+    const u = new URL(baseUrl);
+    if (u.protocol !== "https:") return null;
+    const base = `${u.origin}${u.pathname.replace(/\/+$/, "")}`;
+    return { origin: u.origin, base };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build + validate the absolute request URL for a SERVER-DERIVED api path + optional
+ * query. `null` if the URL would leave `baseUrl`'s origin (SSRF containment).
+ */
+function buildUrl(baseUrl: string, path: string, query?: Record<string, string>): string | null {
+  const norm = normalizeBaseUrl(baseUrl);
+  if (!norm) return null;
+  const cleanPath = path.replace(/^\/+/, "");
+  if (/^[a-z][a-z0-9+.-]*:/i.test(cleanPath) || cleanPath.startsWith("/")) return null;
+  const url = new URL(`${norm.base}/${cleanPath}`);
+  if (url.origin !== norm.origin) return null; // origin escape ⇒ fail-closed.
+  if (query) {
+    for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
+  }
+  return url.toString();
+}
+
+export interface AzureExecDeps {
+  http?: AzureHttpFn;
+  auth?: AzureAuth | null;
+  /** The Azure host base (default `AZURE_DEFAULT_BASE_URL`). */
+  baseUrl?: string;
+  log: (message: string) => void;
+}
+
+/** Log a URL without its query string (a WIQL/tag might echo in a query param). */
+function scrubUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    return `${u.origin}${u.pathname}`;
+  } catch {
+    return "<url>";
+  }
+}
+
+function resolveBase(deps: AzureExecDeps): string {
+  return deps.baseUrl && deps.baseUrl.trim().length > 0 ? deps.baseUrl : AZURE_DEFAULT_BASE_URL;
+}
+
+/**
+ * GET an Azure REST resource and parse JSON. Returns `null` on ANY degrade (unconfigured
+ * auth, non-2xx, network error, bad JSON, origin escape). The PAT is never logged.
+ */
+export async function azureGetJson<T>(
+  deps: AzureExecDeps,
+  path: string,
+  query?: Record<string, string>,
+): Promise<T | null> {
+  const auth = deps.auth ?? readAzureAuthFromEnv();
+  if (!auth) {
+    deps.log("azure-exec: no AZURE_DEVOPS_PAT configured — skipping (fail-closed)");
+    return null;
+  }
+  const url = buildUrl(resolveBase(deps), path, query);
+  if (!url) {
+    deps.log("azure-exec: rejected request URL (bad baseUrl / origin escape)");
+    return null;
+  }
+  const http = deps.http ?? defaultHttp;
+  try {
+    const res = await http({
+      method: "GET",
+      url,
+      headers: { Authorization: basicAuthHeader(auth), Accept: "application/json" },
+      timeoutMs: AZURE_TIMEOUT_MS,
+    });
+    if (res.status < 200 || res.status >= 300) {
+      deps.log(`azure-exec: GET ${scrubUrl(url)} → HTTP ${res.status} (degraded)`);
+      return null;
+    }
+    return JSON.parse(res.body) as T;
+  } catch (err) {
+    deps.log(`azure-exec: GET failed: ${scrub((err as Error)?.message ?? String(err))}`);
+    return null;
+  }
+}
+
+/**
+ * Send a JSON body (POST for WIQL / comments; PATCH for JSON-patch field updates) to an
+ * Azure REST resource. `contentType` lets the caller pass `application/json-patch+json`
+ * for work-item field patches. Returns a typed `{ ok }` — never throws; the PAT never
+ * leaves this module.
+ */
+export async function azureSendJson(
+  deps: AzureExecDeps,
+  method: "POST" | "PATCH",
+  path: string,
+  body: unknown,
+  opts?: { query?: Record<string, string>; contentType?: string },
+): Promise<{ ok: true; body: string } | { ok: false; status?: number; reason: string }> {
+  const auth = deps.auth ?? readAzureAuthFromEnv();
+  if (!auth) {
+    deps.log("azure-exec: no AZURE_DEVOPS_PAT configured — skipping (fail-closed)");
+    return { ok: false, reason: "no-auth" };
+  }
+  const url = buildUrl(resolveBase(deps), path, opts?.query);
+  if (!url) {
+    deps.log("azure-exec: rejected request URL (bad baseUrl / origin escape)");
+    return { ok: false, reason: "bad-url" };
+  }
+  const http = deps.http ?? defaultHttp;
+  try {
+    const res = await http({
+      method,
+      url,
+      headers: {
+        Authorization: basicAuthHeader(auth),
+        Accept: "application/json",
+        "Content-Type": opts?.contentType ?? "application/json",
+      },
+      body: JSON.stringify(body ?? {}),
+      timeoutMs: AZURE_TIMEOUT_MS,
+    });
+    if (res.status < 200 || res.status >= 300) {
+      deps.log(`azure-exec: ${method} ${scrubUrl(url)} → HTTP ${res.status} (degraded)`);
+      return { ok: false, status: res.status, reason: `http-${res.status}` };
+    }
+    return { ok: true, body: res.body };
+  } catch (err) {
+    deps.log(`azure-exec: ${method} failed: ${scrub((err as Error)?.message ?? String(err))}`);
+    return { ok: false, reason: "exception" };
+  }
+}

--- a/server/services/consilium/trackers/azure-issues-poller.ts
+++ b/server/services/consilium/trackers/azure-issues-poller.ts
@@ -1,0 +1,335 @@
+/**
+ * azure-issues-poller.ts — TRACK-5: poll an Azure DevOps project (WIQL) and turn each
+ * tagged, spec-ready work item into a committed spec PR + an Azure pickup comment. The
+ * Azure analogue of `jira-issues-poller.ts`, reusing the EXACT same rails: watermark in
+ * the trigger `config` jsonb, never-throw per cycle/trigger, project-scoped context, the
+ * shared tracker kill-switch, the allowlist + consent gates, and the SHARED crystallise
+ * pipeline. The ONLY Azure-specific surface lives in `AzureTrackerConnector` (WIQL watch /
+ * REST read / comment+state+link write-back / `spec/azure-<id>` naming).
+ *
+ * DOES NOT FIRE LOOPS (identical to TRACK-1/3): a spec PRODUCER + ticket UPDATER opening a
+ * PR that ADDS `docs/specs/azure-<id>-…` to the TARGET git repo (Azure has no git in this
+ * flow). RAILS: per-trigger watermark + deterministic `spec/azure-<id>` branch + spec-writer
+ * pr-list dedup ⇒ never a 2nd PR / double comment even on an edit; per-cycle budget; every
+ * read degrades to `null` (azure-exec) so an outage SKIPS the cycle; `filter.label` (tag)
+ * REQUIRED (consent); `targetRepoPath` MUST be in the allowlist. The PAT is never
+ * read/logged here (azure-exec owns it); WIQL is built from sanitised, quoted literals.
+ */
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { realpathSync } from "fs";
+import { resolve } from "path";
+import type { TriggerRow } from "@shared/schema";
+import type { TrackerEventTriggerConfig, TrackerPollState } from "@shared/types";
+import type { AppConfig } from "../../../config/schema.js";
+import type { ExecFileFn } from "../../github-status.js";
+import { extractSpecFromIssue } from "./issue-spec.js";
+import { crystallizeTicket } from "./spec-intake.js";
+import { AzureTrackerConnector, type AzureConnectorConfig } from "./azure-connector.js";
+import { readAzureAuthFromEnv, type AzureAuth, type AzureHttpFn } from "./azure-exec.js";
+import type { TicketSynthesizer } from "./jira-issues-poller.js";
+
+const OWNER_REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+const MAX_PER_CYCLE = 20;
+const MAX_TRACKED_INTAKE = 500;
+
+export const AZURE_PICKUP_MARKER = "<!-- factory:track5:azure:pickup -->";
+export const AZURE_NEED_CRITERIA_MARKER = "<!-- factory:track5:azure:need-criteria -->";
+
+export interface AzureIssuesPollerDeps {
+  getEnabledTriggersByType: (type: "tracker_event") => Promise<TriggerRow[]>;
+  runInProject: <T>(projectId: string, fn: () => Promise<T>) => Promise<T>;
+  getTrigger: (id: string) => Promise<TriggerRow | undefined>;
+  updateTrigger: (id: string, updates: Partial<TriggerRow>) => Promise<unknown>;
+  config: () => AppConfig;
+  allowedRepoPaths: () => string[];
+  synthesizer?: TicketSynthesizer;
+  runGh?: ExecFileFn;
+  /** Injectable Azure HTTP transport (tests pass a fake — no real network). */
+  azureHttp?: AzureHttpFn;
+  /** Injectable Azure auth (tests pass a fake; prod reads env at call time). */
+  azureAuth?: AzureAuth | null;
+  gitRemoteUrl?: (repoPath: string) => Promise<string | null>;
+  log: (message: string) => void;
+  now?: () => number;
+}
+
+const execFileAsync: ExecFileFn = promisify(execFile);
+
+async function defaultGitRemoteUrl(repoPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", repoPath, "remote", "get-url", "origin"], {
+      timeout: 10_000,
+    });
+    const url = (stdout ?? "").trim();
+    return url.length > 0 ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function canonicalPath(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return resolve(p);
+  }
+}
+
+function isAllowedRepoPath(targetRepoPath: string, allowed: readonly string[]): boolean {
+  const target = canonicalPath(targetRepoPath);
+  for (const a of allowed) {
+    const root = canonicalPath(a);
+    if (target === root || target.startsWith(root + "/")) return true;
+  }
+  return false;
+}
+
+function sanitizeTitleLine(value: string, max = 160): string {
+  let out = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0;
+    out += code < 0x20 || code === 0x7f ? " " : ch;
+  }
+  return out.replace(/\s+/g, " ").trim().slice(0, max);
+}
+
+function boundIntake(
+  intake: Record<string, { specPrUrl?: string; at: string }>,
+): Record<string, { specPrUrl?: string; at: string }> {
+  const keys = Object.keys(intake);
+  if (keys.length <= MAX_TRACKED_INTAKE) return intake;
+  const kept = keys
+    .sort((a, b) => (intake[b].at ?? "").localeCompare(intake[a].at ?? ""))
+    .slice(0, MAX_TRACKED_INTAKE);
+  const out: Record<string, { specPrUrl?: string; at: string }> = {};
+  for (const k of kept) out[k] = intake[k];
+  return out;
+}
+
+export class AzureIssuesPoller {
+  private readonly deps: AzureIssuesPollerDeps;
+  private readonly gitRemoteUrl: (repoPath: string) => Promise<string | null>;
+  private readonly now: () => number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private polling = false;
+
+  constructor(deps: AzureIssuesPollerDeps) {
+    this.deps = deps;
+    this.gitRemoteUrl = deps.gitRemoteUrl ?? ((p) => defaultGitRemoteUrl(p));
+    this.now = deps.now ?? Date.now;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    const cfg = this.deps.config().features.triggers.tracker;
+    if (!cfg.enabled) {
+      this.deps.log("azure tracker polling disabled — poller not started");
+      return;
+    }
+    const intervalMs = cfg.pollIntervalSec * 1000;
+    this.timer = setInterval(() => void this.pollAllSafe(), intervalMs);
+    this.timer.unref?.();
+    this.deps.log(`azure tracker poller started (every ${cfg.pollIntervalSec}s)`);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  async pollAllSafe(): Promise<void> {
+    if (this.polling) return;
+    this.polling = true;
+    try {
+      await this.pollAll();
+    } catch (e) {
+      this.deps.log(`azure tracker poll cycle error: ${(e as Error).message}`);
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  async pollAll(): Promise<void> {
+    if (!this.deps.config().features.triggers.enabled) {
+      this.deps.log("azure tracker poll skipped — features.triggers.enabled (master switch) is off");
+      return;
+    }
+    const triggers = await this.deps.getEnabledTriggersByType("tracker_event");
+    for (const trigger of triggers) {
+      try {
+        await this.pollTrigger(trigger);
+      } catch (e) {
+        this.deps.log(`azure tracker poll error for trigger ${trigger.id}: ${(e as Error).message}`);
+      }
+    }
+  }
+
+  async pollTrigger(trigger: TriggerRow): Promise<void> {
+    if (!trigger.projectId) return;
+    const config = trigger.config as TrackerEventTriggerConfig;
+    if (config.tracker !== "azure") return; // other pollers handle other kinds.
+
+    const org = (config.azureOrg ?? "").trim();
+    if (org.length === 0) {
+      this.deps.log(`azure tracker poll skipped for trigger ${trigger.id} — no azureOrg`);
+      return;
+    }
+    const project = (config.project ?? "").trim();
+    if (project.length === 0) {
+      this.deps.log(`azure tracker poll skipped for trigger ${trigger.id} — no project`);
+      return;
+    }
+    const repo = (config.repo ?? "").trim();
+    if (!OWNER_REPO_RE.test(repo)) {
+      this.deps.log(`azure tracker poll skipped for trigger ${trigger.id} — repo not owner/repo`);
+      return;
+    }
+    const targetRepoPath = config.targetRepoPath;
+    if (!targetRepoPath || targetRepoPath.length === 0) {
+      this.deps.log(`azure tracker poll skipped for trigger ${trigger.id} — no targetRepoPath`);
+      return;
+    }
+    if (!isAllowedRepoPath(targetRepoPath, this.deps.allowedRepoPaths())) {
+      this.deps.log(`azure tracker poll skipped for trigger ${trigger.id} — targetRepoPath not in allowlist`);
+      return;
+    }
+    const tag = config.filter?.label;
+    if (!tag || tag.length === 0) {
+      this.deps.log(`azure tracker poll skipped for trigger ${trigger.id} — no filter.label (consent gate)`);
+      return;
+    }
+
+    const connectorCfg: AzureConnectorConfig = {
+      org,
+      project,
+      tag,
+      areaPath: config.azureAreaPath,
+      transitionTo: config.transitionTo,
+    };
+    const connector = new AzureTrackerConnector(connectorCfg, {
+      http: this.deps.azureHttp,
+      auth: this.deps.azureAuth ?? readAzureAuthFromEnv(),
+      baseUrl: config.baseUrl,
+      log: this.deps.log,
+    });
+
+    const projectId = trigger.projectId;
+    await this.deps.runInProject(projectId, async () => {
+      const state: TrackerPollState = { ...(config.pollState ?? {}) };
+      if (!state.intake) state.intake = {};
+
+      const tickets = await connector.pollTickets(state.lastPolledAt);
+      if (tickets === null) {
+        this.deps.log(`azure tracker poll: WIQL unavailable for ${project} (degraded) — skipping cycle`);
+        return;
+      }
+
+      let intaken = 0;
+      for (const ticket of tickets) {
+        if (intaken >= MAX_PER_CYCLE) break;
+        const key = ticket.id;
+        if (!key || state.intake![key]) continue;
+
+        if (!ticket.labels.includes(tag)) continue; // defence-in-depth consent re-check.
+
+        const extract = extractSpecFromIssue({ number: 0, title: ticket.title, body: ticket.body });
+        let problem = extract.problem;
+        let scope = extract.scope;
+        let outOfScope = extract.outOfScope;
+        let criteria = extract.criteria;
+        if (criteria.length === 0 && this.deps.synthesizer) {
+          try {
+            const syn = await this.deps.synthesizer.synthesize({ title: ticket.title, body: ticket.body });
+            if (syn && Array.isArray(syn.criteria) && syn.criteria.length > 0) {
+              criteria = syn.criteria;
+              problem = problem ?? syn.problem;
+              scope = scope ?? syn.scope;
+              outOfScope = outOfScope ?? syn.outOfScope;
+            }
+          } catch (e) {
+            this.deps.log(`azure tracker poll: synthesizer error for ${key}: ${(e as Error).message}`);
+          }
+        }
+
+        const specStatus = config.specStatus ?? "ready";
+        const title = ticket.title;
+        const sanitizedTitle = sanitizeTitleLine(title);
+        const commitMessage = `feat: add spec for azure-${key}`;
+        const prTitle = `spec: ${sanitizedTitle || key} (azure ${key})`;
+        const prBodyLines = [
+          `Track-5 auto-produced spec for Azure DevOps work item ${key}.`,
+          "",
+          "This spec was generated from the linked Azure DevOps work item by the factory's Track-5 intake.",
+          "Merging it fires the SPEC-1 spec-watch, which launches the review loop off the committed spec.",
+        ];
+        if (ticket.url) prBodyLines.push("", `Azure DevOps: ${ticket.url}`);
+        const prBody = prBodyLines.join("\n");
+
+        const result = await crystallizeTicket(
+          {
+            runGh: this.deps.runGh,
+            gitRemoteUrl: this.gitRemoteUrl,
+            log: this.deps.log,
+            writeback: {
+              pickup: (specPrUrl) =>
+                connector.writeback
+                  .comment(key, `🤖 picked up by the factory — spec at ${specPrUrl}`, AZURE_PICKUP_MARKER)
+                  .then((r) => ({ posted: r.posted })),
+              needCriteria: () =>
+                connector.writeback
+                  .comment(
+                    key,
+                    `🤖 I can pick this up but need testable acceptance criteria — please add an "Acceptance Criteria" section or checklist items.`,
+                    AZURE_NEED_CRITERIA_MARKER,
+                  )
+                  .then((r) => ({ posted: r.posted })),
+            },
+          },
+          {
+            source: { kind: "azure", ref: key, url: ticket.url },
+            targetRepoPath,
+            branch: connector.specBranchName(key),
+            filePath: connector.specFilePath(key, title),
+            title: title.trim().length > 0 ? title : key,
+            status: specStatus,
+            problem: problem ?? title,
+            scope,
+            outOfScope,
+            criteria,
+            commitMessage,
+            prTitle,
+            prBody,
+          },
+        );
+
+        if (result.outcome === "need-criteria") continue;
+        if (result.outcome === "failed") {
+          this.deps.log(`azure tracker poll: spec PR failed for ${key}: ${result.reason}`);
+          continue;
+        }
+
+        if (config.transitionTo && connector.writeback.transition) {
+          await connector.writeback.transition(key, config.transitionTo);
+        }
+
+        state.intake![key] = { specPrUrl: result.prUrl, at: new Date(this.now()).toISOString() };
+        intaken++;
+      }
+
+      state.intake = boundIntake(state.intake!);
+      state.lastPolledAt = new Date(this.now()).toISOString();
+      await this.persistWatermark(trigger.id, state);
+    });
+  }
+
+  private async persistWatermark(triggerId: string, state: TrackerPollState): Promise<void> {
+    const fresh = await this.deps.getTrigger(triggerId);
+    if (!fresh) return;
+    const freshConfig = (fresh.config ?? {}) as TrackerEventTriggerConfig;
+    const nextConfig: TrackerEventTriggerConfig = { ...freshConfig, pollState: state };
+    await this.deps.updateTrigger(triggerId, { config: nextConfig });
+  }
+}

--- a/server/services/consilium/trackers/clickup-connector.ts
+++ b/server/services/consilium/trackers/clickup-connector.ts
@@ -1,0 +1,201 @@
+/**
+ * clickup-connector.ts — TRACK-5: the ClickUp implementation of `TrackerConnector`. It is
+ * PURELY the ClickUp DIALECT (watch = `/list/{id}/task?date_updated_gt=…` filtered by tag,
+ * read = `/task/{id}`, write-back = `/task/{id}/comment` + status update, naming =
+ * `spec/clickup-<id>`); the synth, the spec-PR, the provenance, and the crystallise/dedup
+ * machinery are the SHARED modules (`issue-spec.ts`, `spec-writer.ts`, `spec-intake.ts`).
+ *
+ * SECURITY
+ *   - Query params travel through `URLSearchParams` in `clickup-exec` (a value can never
+ *     inject an extra param); the tag/date/id are also shape-sanitised. The UNTRUSTED task
+ *     name/description never reaches a query or a path.
+ *   - Every read/write goes through the fail-closed, never-logging `clickup-exec` seam.
+ *   - `specBranchName`/`specFilePath` sanitise the task id to `[A-Za-z0-9._-]` so the
+ *     branch matches `SPEC_BRANCH_RE` (`clickup-…`) and the filename is traversal-free.
+ *   - The task name/description are UNTRUSTED — the shared synth fences them before any
+ *     prompt; the shared renderer quotes them in YAML.
+ */
+import { slugify } from "./issue-spec.js";
+import type { Ticket, TrackerConnector, TrackerWriteback, WritebackResult } from "./tracker-connector.js";
+import { clickupGetJson, clickupSendJson, type ClickUpExecDeps } from "./clickup-exec.js";
+
+const DESCRIPTION_MAX = 16_000;
+
+/** Sanitise a ClickUp id (list/task) to `[A-Za-z0-9._-]`, drop leading dash / `..`, clamp. */
+export function sanitizeClickUpId(id: string): string {
+  return String(id)
+    .replace(/[^A-Za-z0-9._-]/g, "")
+    .replace(/\.\.+/g, ".")
+    .replace(/^[-.]+/, "")
+    .slice(0, 64);
+}
+
+/** Control-strip + clamp a tag value before it becomes a query param (defence in depth). */
+function cleanTag(value: string, max = 100): string {
+  let out = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0;
+    if (code < 0x20 || code === 0x7f) continue;
+    out += ch;
+  }
+  return out.trim().slice(0, max);
+}
+
+/** The ClickUp spec dedup branch: `spec/clickup-<id>` (matches spec-writer's SPEC_BRANCH_RE). */
+export function clickupSpecBranchName(id: string): string {
+  const safe = sanitizeClickUpId(id);
+  if (safe.length === 0) throw new Error(`clickup-connector: invalid task id ${JSON.stringify(id)}`);
+  return `spec/clickup-${safe}`;
+}
+
+/** The committed spec path: `docs/specs/clickup-<id>-<slug>.md`. */
+export function clickupSpecFilePath(id: string, title: string): string {
+  const safe = sanitizeClickUpId(id);
+  if (safe.length === 0) throw new Error(`clickup-connector: invalid task id ${JSON.stringify(id)}`);
+  return `docs/specs/clickup-${safe}-${slugify(title)}.md`;
+}
+
+// ─── ClickUp REST shapes (only the fields we request) ─────────────────────────
+
+interface ClickUpTask {
+  id?: string;
+  name?: string;
+  description?: string;
+  text_content?: string;
+  tags?: Array<{ name?: string }>;
+  date_updated?: string;
+  url?: string;
+}
+interface ClickUpTasksResult {
+  tasks?: ClickUpTask[];
+}
+interface ClickUpCommentsResult {
+  comments?: Array<{ comment_text?: string }>;
+}
+
+export interface ClickUpConnectorConfig {
+  /** The ClickUp list id whose tasks are polled — REQUIRED. */
+  listId: string;
+  /** The consent tag (§3.1) — REQUIRED at fire time by the poller. */
+  tag: string;
+  /** Optional status name to move the task to on pickup (best-effort). */
+  transitionTo?: string;
+}
+
+/** Map a ClickUp task → the normalised `Ticket`. `null` if it has no id. */
+function toTicket(task: ClickUpTask | null | undefined): Ticket | null {
+  if (!task) return null;
+  const id = typeof task.id === "string" ? task.id : "";
+  if (id.length === 0) return null;
+  const body =
+    typeof task.text_content === "string" && task.text_content.length > 0
+      ? task.text_content
+      : typeof task.description === "string"
+        ? task.description
+        : "";
+  const labels = Array.isArray(task.tags)
+    ? task.tags.map((t) => t?.name).filter((n): n is string => typeof n === "string")
+    : [];
+  return {
+    id,
+    title: typeof task.name === "string" ? task.name : "",
+    body: body.slice(0, DESCRIPTION_MAX),
+    labels,
+    updatedAt: typeof task.date_updated === "string" ? task.date_updated : undefined,
+    url: typeof task.url === "string" && task.url.length > 0 ? task.url : `https://app.clickup.com/t/${id}`,
+  };
+}
+
+export class ClickUpTrackerConnector implements TrackerConnector {
+  readonly kind = "clickup";
+  readonly writeback: TrackerWriteback;
+  private readonly cfg: ClickUpConnectorConfig;
+  private readonly exec: ClickUpExecDeps;
+  private readonly listId: string;
+
+  constructor(cfg: ClickUpConnectorConfig, exec: ClickUpExecDeps) {
+    this.cfg = cfg;
+    this.exec = exec;
+    this.listId = sanitizeClickUpId(cfg.listId);
+    this.writeback = {
+      comment: (ticketId, body, marker) => this.postComment(ticketId, body, marker),
+      transition: (ticketId, state) => this.setStatus(ticketId, state),
+      // `link` intentionally omitted: ClickUp attachment upload is multipart (out of scope
+      // for the JSON seam); the pickup URL already lands as a comment. The interface makes
+      // `link` optional, so the crystallise pipeline (comment-only) is unaffected.
+    };
+  }
+
+  /**
+   * WATCH: list tasks updated since the watermark, filtered by tag. The ISO watermark is
+   * converted to ClickUp's epoch-ms `date_updated_gt`. `null` on any degrade so the poller
+   * skips the cycle.
+   */
+  async pollTickets(sinceWatermark?: string): Promise<Ticket[] | null> {
+    if (this.listId.length === 0) return null;
+    const query: Record<string, string> = { "tags[]": cleanTag(this.cfg.tag) };
+    if (sinceWatermark && sinceWatermark.trim().length > 0) {
+      const ms = Date.parse(sinceWatermark);
+      if (Number.isFinite(ms)) query.date_updated_gt = String(ms);
+    }
+    const data = await clickupGetJson<ClickUpTasksResult>(this.exec, `list/${this.listId}/task`, query);
+    if (!data || !Array.isArray(data.tasks)) return null;
+    const tickets: Ticket[] = [];
+    for (const task of data.tasks) {
+      const t = toTicket(task);
+      if (t) tickets.push(t);
+    }
+    return tickets;
+  }
+
+  /** READ: fetch one task by id. `null` ⇒ not found / degraded. */
+  async readTicket(ticketId: string): Promise<Ticket | null> {
+    const id = sanitizeClickUpId(ticketId);
+    if (id.length === 0) return null;
+    const task = await clickupGetJson<ClickUpTask>(this.exec, `task/${id}`);
+    if (!task) return null;
+    return toTicket({ ...task, id: task.id ?? id });
+  }
+
+  specBranchName(ticketId: string): string {
+    return clickupSpecBranchName(ticketId);
+  }
+
+  specFilePath(ticketId: string, title: string): string {
+    return clickupSpecFilePath(ticketId, title);
+  }
+
+  // ─── write-back ─────────────────────────────────────────────────────────────
+
+  /**
+   * Post a comment IDEMPOTENTLY: read existing comments, skip if any already carries
+   * `marker`, else POST `{ comment_text }`. Best-effort; when comments cannot be read we
+   * do NOT post (safety over liveness).
+   */
+  private async postComment(ticketId: string, body: string, marker: string): Promise<WritebackResult> {
+    const id = sanitizeClickUpId(ticketId);
+    if (id.length === 0) return { posted: false, reason: "bad-id" };
+    const existing = await clickupGetJson<ClickUpCommentsResult>(this.exec, `task/${id}/comment`);
+    if (!existing || !Array.isArray(existing.comments)) {
+      return { posted: false, reason: "comments-unreadable" };
+    }
+    const already = existing.comments.some(
+      (c) => typeof c.comment_text === "string" && c.comment_text.includes(marker),
+    );
+    if (already) return { posted: false, reason: "already-commented" };
+    const res = await clickupSendJson(this.exec, "POST", `task/${id}/comment`, {
+      comment_text: `${marker}\n${body}`,
+    });
+    return res.ok ? { posted: true } : { posted: false, reason: res.reason };
+  }
+
+  /** Move the task to `status` (name), best-effort. The value is trusted config. */
+  private async setStatus(ticketId: string, status: string): Promise<WritebackResult> {
+    const id = sanitizeClickUpId(ticketId);
+    if (id.length === 0) return { posted: false, reason: "bad-id" };
+    const wanted = status.trim();
+    if (wanted.length === 0) return { posted: false, reason: "no-status" };
+    const res = await clickupSendJson(this.exec, "PUT", `task/${id}`, { status: wanted });
+    return res.ok ? { posted: true } : { posted: false, reason: res.reason };
+  }
+}

--- a/server/services/consilium/trackers/clickup-exec.ts
+++ b/server/services/consilium/trackers/clickup-exec.ts
@@ -1,0 +1,215 @@
+/**
+ * clickup-exec.ts — the sanitized ClickUp REST seam for TRACK-5 (the ClickUp analogue of
+ * `gh-exec.ts` / `jira-exec.ts`). A thin HTTP client with the SAME safety posture:
+ *   - NEVER throws: a network error / non-2xx / timeout degrades to `null` (reads) or
+ *     `{ ok: false }` (writes) so a ClickUp outage can never crash the poll loop.
+ *   - The API token is NEVER logged: on failure only the HTTP status + a scrubbed,
+ *     header-free message leaves this module; the `Authorization` header is never
+ *     surfaced.
+ *   - Fail-closed auth: the token comes from ENV (a secret manager), read at call time.
+ *     Absent ⇒ the request is not even attempted (`null` / `{ ok: false }`).
+ *   - SSRF containment: the request URL is built from the operator-configured `baseUrl`
+ *     (default the public ClickUp v2 API) + a SERVER-DERIVED path (`/list/{id}/task`,
+ *     `/task/{id}` with a shape-validated id), then re-checked to share `baseUrl`'s origin.
+ *
+ * ClickUp personal tokens are sent RAW in the `Authorization` header (no `Bearer`). The
+ * HTTP call is injectable (`ClickUpHttpFn`) so tests drive it with a fake — no real network.
+ * (The inbound webhook `X-Signature` HMAC path, #494, is a documented follow-up.)
+ */
+
+/** The API token env var name (a secret manager sets this). Never logged. */
+export const CLICKUP_TOKEN_ENV = "CLICKUP_API_TOKEN";
+
+/** The default public ClickUp v2 API base (overridable by validated https config). */
+export const CLICKUP_DEFAULT_BASE_URL = "https://api.clickup.com/api/v2";
+
+/** Default per-call wall-clock budget for a ClickUp request. */
+const CLICKUP_TIMEOUT_MS = 30_000;
+
+/** A minimal, injectable HTTP result (status + raw body text). */
+export interface ClickUpHttpResult {
+  status: number;
+  body: string;
+}
+
+/** Injectable HTTP transport (tests pass a fake; prod uses `fetch`). NEVER throws-through. */
+export type ClickUpHttpFn = (req: {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: string;
+  timeoutMs: number;
+}) => Promise<ClickUpHttpResult>;
+
+/** Resolved auth material (a personal API token or OAuth access token). `null` ⇒ fail-closed. */
+export interface ClickUpAuth {
+  token: string;
+}
+
+/**
+ * Read the ClickUp auth from ENV (fail-closed). Returns `null` when the var is absent or
+ * blank so the caller degrades WITHOUT attempting an unauthenticated call. The token is
+ * returned but NEVER logged by this module.
+ */
+export function readClickUpAuthFromEnv(env: NodeJS.ProcessEnv = process.env): ClickUpAuth | null {
+  const token = (env[CLICKUP_TOKEN_ENV] ?? "").trim();
+  if (token.length === 0) return null;
+  return { token };
+}
+
+/** Scrub any absolute path + collapse whitespace from an error string, then clamp. */
+function scrub(raw: string): string {
+  return raw.replace(/\/[^\s'"]+/g, "<path>").replace(/\s+/g, " ").trim().slice(0, 300);
+}
+
+/** Default transport over global `fetch` with an AbortController timeout. Never throws-through. */
+const defaultHttp: ClickUpHttpFn = async (req) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), req.timeoutMs);
+  try {
+    const res = await fetch(req.url, {
+      method: req.method,
+      headers: req.headers,
+      body: req.body,
+      signal: controller.signal,
+    });
+    const body = await res.text().catch(() => "");
+    return { status: res.status, body };
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/** Normalise `baseUrl` to an `https://host[/path]` origin. `null` for non-https / malformed. */
+export function normalizeBaseUrl(baseUrl: string): { origin: string; base: string } | null {
+  try {
+    const u = new URL(baseUrl);
+    if (u.protocol !== "https:") return null;
+    const base = `${u.origin}${u.pathname.replace(/\/+$/, "")}`;
+    return { origin: u.origin, base };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build + validate the absolute request URL for a SERVER-DERIVED api path + optional
+ * query. `null` if the URL would leave `baseUrl`'s origin (SSRF containment). `query`
+ * values are set via `URLSearchParams` so a value can never inject extra params.
+ */
+function buildUrl(baseUrl: string, path: string, query?: Record<string, string>): string | null {
+  const norm = normalizeBaseUrl(baseUrl);
+  if (!norm) return null;
+  const cleanPath = path.replace(/^\/+/, "");
+  if (/^[a-z][a-z0-9+.-]*:/i.test(cleanPath) || cleanPath.startsWith("/")) return null;
+  const url = new URL(`${norm.base}/${cleanPath}`);
+  if (url.origin !== norm.origin) return null; // origin escape ⇒ fail-closed.
+  if (query) {
+    for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
+  }
+  return url.toString();
+}
+
+export interface ClickUpExecDeps {
+  http?: ClickUpHttpFn;
+  auth?: ClickUpAuth | null;
+  /** The ClickUp API base (default `CLICKUP_DEFAULT_BASE_URL`). */
+  baseUrl?: string;
+  log: (message: string) => void;
+}
+
+/** Log a URL without its query string (a tag might echo in a query param). */
+function scrubUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    return `${u.origin}${u.pathname}`;
+  } catch {
+    return "<url>";
+  }
+}
+
+function resolveBase(deps: ClickUpExecDeps): string {
+  return deps.baseUrl && deps.baseUrl.trim().length > 0 ? deps.baseUrl : CLICKUP_DEFAULT_BASE_URL;
+}
+
+/**
+ * GET a ClickUp REST resource and parse JSON. Returns `null` on ANY degrade (unconfigured
+ * auth, non-2xx, network error, bad JSON, origin escape). The token is never logged.
+ */
+export async function clickupGetJson<T>(
+  deps: ClickUpExecDeps,
+  path: string,
+  query?: Record<string, string>,
+): Promise<T | null> {
+  const auth = deps.auth ?? readClickUpAuthFromEnv();
+  if (!auth) {
+    deps.log("clickup-exec: no CLICKUP_API_TOKEN configured — skipping (fail-closed)");
+    return null;
+  }
+  const url = buildUrl(resolveBase(deps), path, query);
+  if (!url) {
+    deps.log("clickup-exec: rejected request URL (bad baseUrl / origin escape)");
+    return null;
+  }
+  const http = deps.http ?? defaultHttp;
+  try {
+    const res = await http({
+      method: "GET",
+      url,
+      headers: { Authorization: auth.token, Accept: "application/json" },
+      timeoutMs: CLICKUP_TIMEOUT_MS,
+    });
+    if (res.status < 200 || res.status >= 300) {
+      deps.log(`clickup-exec: GET ${scrubUrl(url)} → HTTP ${res.status} (degraded)`);
+      return null;
+    }
+    return JSON.parse(res.body) as T;
+  } catch (err) {
+    deps.log(`clickup-exec: GET failed: ${scrub((err as Error)?.message ?? String(err))}`);
+    return null;
+  }
+}
+
+/**
+ * Send a JSON body (POST for a comment; PUT for a status update) to a ClickUp REST
+ * resource. Returns a typed `{ ok }` — never throws; the token never leaves this module.
+ */
+export async function clickupSendJson(
+  deps: ClickUpExecDeps,
+  method: "POST" | "PUT",
+  path: string,
+  body: unknown,
+): Promise<{ ok: true; body: string } | { ok: false; status?: number; reason: string }> {
+  const auth = deps.auth ?? readClickUpAuthFromEnv();
+  if (!auth) {
+    deps.log("clickup-exec: no CLICKUP_API_TOKEN configured — skipping (fail-closed)");
+    return { ok: false, reason: "no-auth" };
+  }
+  const url = buildUrl(resolveBase(deps), path);
+  if (!url) {
+    deps.log("clickup-exec: rejected request URL (bad baseUrl / origin escape)");
+    return { ok: false, reason: "bad-url" };
+  }
+  const http = deps.http ?? defaultHttp;
+  try {
+    const res = await http({
+      method,
+      url,
+      headers: {
+        Authorization: auth.token,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body ?? {}),
+      timeoutMs: CLICKUP_TIMEOUT_MS,
+    });
+    if (res.status < 200 || res.status >= 300) {
+      deps.log(`clickup-exec: ${method} ${scrubUrl(url)} → HTTP ${res.status} (degraded)`);
+      return { ok: false, status: res.status, reason: `http-${res.status}` };
+    }
+    return { ok: true, body: res.body };
+  } catch (err) {
+    deps.log(`clickup-exec: ${method} failed: ${scrub((err as Error)?.message ?? String(err))}`);
+    return { ok: false, reason: "exception" };
+  }
+}

--- a/server/services/consilium/trackers/clickup-issues-poller.ts
+++ b/server/services/consilium/trackers/clickup-issues-poller.ts
@@ -1,0 +1,326 @@
+/**
+ * clickup-issues-poller.ts — TRACK-5: poll a ClickUp list (REST) and turn each tagged,
+ * spec-ready task into a committed spec PR + a ClickUp pickup comment. The ClickUp analogue
+ * of `jira-issues-poller.ts`, reusing the EXACT same rails: watermark in the trigger
+ * `config` jsonb, never-throw per cycle/trigger, project-scoped context, the shared tracker
+ * kill-switch, the allowlist + consent gates, and the SHARED crystallise pipeline. The ONLY
+ * ClickUp-specific surface lives in `ClickUpTrackerConnector` (REST watch / read /
+ * comment+status write-back / `spec/clickup-<id>` naming).
+ *
+ * DOES NOT FIRE LOOPS (identical to TRACK-1/3). RAILS: per-trigger watermark + deterministic
+ * `spec/clickup-<id>` branch + spec-writer pr-list dedup ⇒ never a 2nd PR / double comment
+ * even on a task edit; per-cycle budget; every read degrades to `null` (clickup-exec) so an
+ * outage SKIPS the cycle; `filter.label` (tag) REQUIRED (consent); `targetRepoPath` MUST be
+ * in the allowlist. The token is never read/logged here (clickup-exec owns it).
+ */
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { realpathSync } from "fs";
+import { resolve } from "path";
+import type { TriggerRow } from "@shared/schema";
+import type { TrackerEventTriggerConfig, TrackerPollState } from "@shared/types";
+import type { AppConfig } from "../../../config/schema.js";
+import type { ExecFileFn } from "../../github-status.js";
+import { extractSpecFromIssue } from "./issue-spec.js";
+import { crystallizeTicket } from "./spec-intake.js";
+import { ClickUpTrackerConnector, type ClickUpConnectorConfig } from "./clickup-connector.js";
+import { readClickUpAuthFromEnv, type ClickUpAuth, type ClickUpHttpFn } from "./clickup-exec.js";
+import type { TicketSynthesizer } from "./jira-issues-poller.js";
+
+const OWNER_REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+const MAX_PER_CYCLE = 20;
+const MAX_TRACKED_INTAKE = 500;
+
+export const CLICKUP_PICKUP_MARKER = "<!-- factory:track5:clickup:pickup -->";
+export const CLICKUP_NEED_CRITERIA_MARKER = "<!-- factory:track5:clickup:need-criteria -->";
+
+export interface ClickUpIssuesPollerDeps {
+  getEnabledTriggersByType: (type: "tracker_event") => Promise<TriggerRow[]>;
+  runInProject: <T>(projectId: string, fn: () => Promise<T>) => Promise<T>;
+  getTrigger: (id: string) => Promise<TriggerRow | undefined>;
+  updateTrigger: (id: string, updates: Partial<TriggerRow>) => Promise<unknown>;
+  config: () => AppConfig;
+  allowedRepoPaths: () => string[];
+  synthesizer?: TicketSynthesizer;
+  runGh?: ExecFileFn;
+  /** Injectable ClickUp HTTP transport (tests pass a fake — no real network). */
+  clickupHttp?: ClickUpHttpFn;
+  /** Injectable ClickUp auth (tests pass a fake; prod reads env at call time). */
+  clickupAuth?: ClickUpAuth | null;
+  gitRemoteUrl?: (repoPath: string) => Promise<string | null>;
+  log: (message: string) => void;
+  now?: () => number;
+}
+
+const execFileAsync: ExecFileFn = promisify(execFile);
+
+async function defaultGitRemoteUrl(repoPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", repoPath, "remote", "get-url", "origin"], {
+      timeout: 10_000,
+    });
+    const url = (stdout ?? "").trim();
+    return url.length > 0 ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function canonicalPath(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return resolve(p);
+  }
+}
+
+function isAllowedRepoPath(targetRepoPath: string, allowed: readonly string[]): boolean {
+  const target = canonicalPath(targetRepoPath);
+  for (const a of allowed) {
+    const root = canonicalPath(a);
+    if (target === root || target.startsWith(root + "/")) return true;
+  }
+  return false;
+}
+
+function sanitizeTitleLine(value: string, max = 160): string {
+  let out = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0;
+    out += code < 0x20 || code === 0x7f ? " " : ch;
+  }
+  return out.replace(/\s+/g, " ").trim().slice(0, max);
+}
+
+function boundIntake(
+  intake: Record<string, { specPrUrl?: string; at: string }>,
+): Record<string, { specPrUrl?: string; at: string }> {
+  const keys = Object.keys(intake);
+  if (keys.length <= MAX_TRACKED_INTAKE) return intake;
+  const kept = keys
+    .sort((a, b) => (intake[b].at ?? "").localeCompare(intake[a].at ?? ""))
+    .slice(0, MAX_TRACKED_INTAKE);
+  const out: Record<string, { specPrUrl?: string; at: string }> = {};
+  for (const k of kept) out[k] = intake[k];
+  return out;
+}
+
+export class ClickUpIssuesPoller {
+  private readonly deps: ClickUpIssuesPollerDeps;
+  private readonly gitRemoteUrl: (repoPath: string) => Promise<string | null>;
+  private readonly now: () => number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private polling = false;
+
+  constructor(deps: ClickUpIssuesPollerDeps) {
+    this.deps = deps;
+    this.gitRemoteUrl = deps.gitRemoteUrl ?? ((p) => defaultGitRemoteUrl(p));
+    this.now = deps.now ?? Date.now;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    const cfg = this.deps.config().features.triggers.tracker;
+    if (!cfg.enabled) {
+      this.deps.log("clickup tracker polling disabled — poller not started");
+      return;
+    }
+    const intervalMs = cfg.pollIntervalSec * 1000;
+    this.timer = setInterval(() => void this.pollAllSafe(), intervalMs);
+    this.timer.unref?.();
+    this.deps.log(`clickup tracker poller started (every ${cfg.pollIntervalSec}s)`);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  async pollAllSafe(): Promise<void> {
+    if (this.polling) return;
+    this.polling = true;
+    try {
+      await this.pollAll();
+    } catch (e) {
+      this.deps.log(`clickup tracker poll cycle error: ${(e as Error).message}`);
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  async pollAll(): Promise<void> {
+    if (!this.deps.config().features.triggers.enabled) {
+      this.deps.log("clickup tracker poll skipped — features.triggers.enabled (master switch) is off");
+      return;
+    }
+    const triggers = await this.deps.getEnabledTriggersByType("tracker_event");
+    for (const trigger of triggers) {
+      try {
+        await this.pollTrigger(trigger);
+      } catch (e) {
+        this.deps.log(`clickup tracker poll error for trigger ${trigger.id}: ${(e as Error).message}`);
+      }
+    }
+  }
+
+  async pollTrigger(trigger: TriggerRow): Promise<void> {
+    if (!trigger.projectId) return;
+    const config = trigger.config as TrackerEventTriggerConfig;
+    if (config.tracker !== "clickup") return; // other pollers handle other kinds.
+
+    const listId = (config.clickupListId ?? "").trim();
+    if (listId.length === 0) {
+      this.deps.log(`clickup tracker poll skipped for trigger ${trigger.id} — no clickupListId`);
+      return;
+    }
+    const repo = (config.repo ?? "").trim();
+    if (!OWNER_REPO_RE.test(repo)) {
+      this.deps.log(`clickup tracker poll skipped for trigger ${trigger.id} — repo not owner/repo`);
+      return;
+    }
+    const targetRepoPath = config.targetRepoPath;
+    if (!targetRepoPath || targetRepoPath.length === 0) {
+      this.deps.log(`clickup tracker poll skipped for trigger ${trigger.id} — no targetRepoPath`);
+      return;
+    }
+    if (!isAllowedRepoPath(targetRepoPath, this.deps.allowedRepoPaths())) {
+      this.deps.log(`clickup tracker poll skipped for trigger ${trigger.id} — targetRepoPath not in allowlist`);
+      return;
+    }
+    const tag = config.filter?.label;
+    if (!tag || tag.length === 0) {
+      this.deps.log(`clickup tracker poll skipped for trigger ${trigger.id} — no filter.label (consent gate)`);
+      return;
+    }
+
+    const connectorCfg: ClickUpConnectorConfig = {
+      listId,
+      tag,
+      transitionTo: config.transitionTo,
+    };
+    const connector = new ClickUpTrackerConnector(connectorCfg, {
+      http: this.deps.clickupHttp,
+      auth: this.deps.clickupAuth ?? readClickUpAuthFromEnv(),
+      baseUrl: config.baseUrl,
+      log: this.deps.log,
+    });
+
+    const projectId = trigger.projectId;
+    await this.deps.runInProject(projectId, async () => {
+      const state: TrackerPollState = { ...(config.pollState ?? {}) };
+      if (!state.intake) state.intake = {};
+
+      const tickets = await connector.pollTickets(state.lastPolledAt);
+      if (tickets === null) {
+        this.deps.log(`clickup tracker poll: list unavailable (degraded) — skipping cycle`);
+        return;
+      }
+
+      let intaken = 0;
+      for (const ticket of tickets) {
+        if (intaken >= MAX_PER_CYCLE) break;
+        const key = ticket.id;
+        if (!key || state.intake![key]) continue;
+
+        if (!ticket.labels.includes(tag)) continue; // defence-in-depth consent re-check.
+
+        const extract = extractSpecFromIssue({ number: 0, title: ticket.title, body: ticket.body });
+        let problem = extract.problem;
+        let scope = extract.scope;
+        let outOfScope = extract.outOfScope;
+        let criteria = extract.criteria;
+        if (criteria.length === 0 && this.deps.synthesizer) {
+          try {
+            const syn = await this.deps.synthesizer.synthesize({ title: ticket.title, body: ticket.body });
+            if (syn && Array.isArray(syn.criteria) && syn.criteria.length > 0) {
+              criteria = syn.criteria;
+              problem = problem ?? syn.problem;
+              scope = scope ?? syn.scope;
+              outOfScope = outOfScope ?? syn.outOfScope;
+            }
+          } catch (e) {
+            this.deps.log(`clickup tracker poll: synthesizer error for ${key}: ${(e as Error).message}`);
+          }
+        }
+
+        const specStatus = config.specStatus ?? "ready";
+        const title = ticket.title;
+        const sanitizedTitle = sanitizeTitleLine(title);
+        const commitMessage = `feat: add spec for clickup-${key}`;
+        const prTitle = `spec: ${sanitizedTitle || key} (clickup ${key})`;
+        const prBodyLines = [
+          `Track-5 auto-produced spec for ClickUp task ${key}.`,
+          "",
+          "This spec was generated from the linked ClickUp task by the factory's Track-5 intake.",
+          "Merging it fires the SPEC-1 spec-watch, which launches the review loop off the committed spec.",
+        ];
+        if (ticket.url) prBodyLines.push("", `ClickUp: ${ticket.url}`);
+        const prBody = prBodyLines.join("\n");
+
+        const result = await crystallizeTicket(
+          {
+            runGh: this.deps.runGh,
+            gitRemoteUrl: this.gitRemoteUrl,
+            log: this.deps.log,
+            writeback: {
+              pickup: (specPrUrl) =>
+                connector.writeback
+                  .comment(key, `🤖 picked up by the factory — spec at ${specPrUrl}`, CLICKUP_PICKUP_MARKER)
+                  .then((r) => ({ posted: r.posted })),
+              needCriteria: () =>
+                connector.writeback
+                  .comment(
+                    key,
+                    `🤖 I can pick this up but need testable acceptance criteria — please add an "Acceptance Criteria" section or checklist items.`,
+                    CLICKUP_NEED_CRITERIA_MARKER,
+                  )
+                  .then((r) => ({ posted: r.posted })),
+            },
+          },
+          {
+            source: { kind: "clickup", ref: key, url: ticket.url },
+            targetRepoPath,
+            branch: connector.specBranchName(key),
+            filePath: connector.specFilePath(key, title),
+            title: title.trim().length > 0 ? title : key,
+            status: specStatus,
+            problem: problem ?? title,
+            scope,
+            outOfScope,
+            criteria,
+            commitMessage,
+            prTitle,
+            prBody,
+          },
+        );
+
+        if (result.outcome === "need-criteria") continue;
+        if (result.outcome === "failed") {
+          this.deps.log(`clickup tracker poll: spec PR failed for ${key}: ${result.reason}`);
+          continue;
+        }
+
+        if (config.transitionTo && connector.writeback.transition) {
+          await connector.writeback.transition(key, config.transitionTo);
+        }
+
+        state.intake![key] = { specPrUrl: result.prUrl, at: new Date(this.now()).toISOString() };
+        intaken++;
+      }
+
+      state.intake = boundIntake(state.intake!);
+      state.lastPolledAt = new Date(this.now()).toISOString();
+      await this.persistWatermark(trigger.id, state);
+    });
+  }
+
+  private async persistWatermark(triggerId: string, state: TrackerPollState): Promise<void> {
+    const fresh = await this.deps.getTrigger(triggerId);
+    if (!fresh) return;
+    const freshConfig = (fresh.config ?? {}) as TrackerEventTriggerConfig;
+    const nextConfig: TrackerEventTriggerConfig = { ...freshConfig, pollState: state };
+    await this.deps.updateTrigger(triggerId, { config: nextConfig });
+  }
+}

--- a/server/services/consilium/trackers/linear-connector.ts
+++ b/server/services/consilium/trackers/linear-connector.ts
@@ -1,0 +1,262 @@
+/**
+ * linear-connector.ts — TRACK-5: the Linear implementation of `TrackerConnector`. It is
+ * PURELY the Linear DIALECT (watch = GraphQL `issues(filter:…)`, read = `issue(id)`,
+ * write-back = `commentCreate` + `issueUpdate` state + `attachmentCreate` link, naming =
+ * `spec/linear-<ID>`); the synth, the spec-PR, the provenance, and the crystallise/dedup
+ * machinery are the SHARED modules (`issue-spec.ts`, `spec-writer.ts`, `spec-intake.ts`)
+ * that GitHub + Jira use too. Adding this connector changes NOTHING shared.
+ *
+ * SECURITY
+ *   - INJECTION-PROOF BY CONSTRUCTION: every GraphQL query is a STATIC string; the label,
+ *     team id, ticket id, comment body and state all travel as GraphQL **variables**
+ *     (linear-exec sends them in a separate JSON field), so a hostile config/ticket value
+ *     can never reshape the query. Values are still control-stripped (defence in depth).
+ *   - Every read/write goes through the fail-closed, never-logging `linear-exec` seam.
+ *   - `specBranchName`/`specFilePath` sanitise the Linear identifier to `[A-Za-z0-9._-]`
+ *     so it is shape-safe for the branch (matches `SPEC_BRANCH_RE`) and the filename
+ *     (no path separator, no leading dash, no `..`).
+ *   - The ticket title/description are UNTRUSTED — the shared synth fences them before any
+ *     prompt and the shared renderer quotes them in YAML.
+ *
+ * ID MODEL: the connector's public ticket id is the human Linear **identifier**
+ * (`ENG-123`) — stable, used for the branch/path/dedup and `source.ref`. Write-back
+ * mutations need the internal UUID, so each write-back method first resolves the UUID via
+ * `issue(id: identifier)` (Linear's `issue` query accepts either form) in the same read
+ * it uses to check idempotency.
+ */
+import { slugify } from "./issue-spec.js";
+import type { Ticket, TrackerConnector, TrackerWriteback, WritebackResult } from "./tracker-connector.js";
+import { linearQuery, linearMutate, type LinearExecDeps } from "./linear-exec.js";
+
+/** Control-strip + clamp an (untrusted or config) scalar before it becomes a variable. */
+function cleanScalar(value: string, max = 200): string {
+  let out = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0;
+    if (code < 0x20 || code === 0x7f) continue; // drop C0 / DEL control chars.
+    out += ch;
+  }
+  return out.replace(/\s+/g, " ").trim().slice(0, max);
+}
+
+/**
+ * Sanitise a Linear identifier for a branch/filename (`ENG-123` → `ENG-123`). Drops any
+ * char outside `[A-Za-z0-9._-]`, then any leading dash and any `..` sequence, clamps —
+ * so the branch is free of a path separator / leading flag / traversal (matches
+ * `SPEC_BRANCH_RE`).
+ */
+export function sanitizeIdentifier(id: string): string {
+  return id
+    .replace(/[^A-Za-z0-9._-]/g, "")
+    .replace(/\.\.+/g, ".")
+    .replace(/^[-.]+/, "")
+    .slice(0, 80);
+}
+
+/** The Linear spec dedup branch: `spec/linear-<ID>` (matches spec-writer's SPEC_BRANCH_RE). */
+export function linearSpecBranchName(id: string): string {
+  const safe = sanitizeIdentifier(id);
+  if (safe.length === 0) throw new Error(`linear-connector: invalid identifier ${JSON.stringify(id)}`);
+  return `spec/linear-${safe}`;
+}
+
+/** The committed spec path: `docs/specs/linear-<ID>-<slug>.md`. */
+export function linearSpecFilePath(id: string, title: string): string {
+  const safe = sanitizeIdentifier(id);
+  if (safe.length === 0) throw new Error(`linear-connector: invalid identifier ${JSON.stringify(id)}`);
+  return `docs/specs/linear-${safe}-${slugify(title)}.md`;
+}
+
+// ─── Linear GraphQL shapes (only the fields we request) ───────────────────────
+
+interface LinearLabelConn {
+  nodes?: Array<{ name?: string }>;
+}
+interface LinearIssueNode {
+  id?: string;
+  identifier?: string;
+  title?: string;
+  description?: string | null;
+  labels?: LinearLabelConn;
+  updatedAt?: string;
+  url?: string;
+}
+interface LinearIssuesResult {
+  issues?: { nodes?: LinearIssueNode[] };
+}
+interface LinearIssueResult {
+  issue?: LinearIssueNode | null;
+}
+interface LinearIssueForWriteback {
+  issue?: {
+    id?: string;
+    comments?: { nodes?: Array<{ body?: string }> };
+    team?: { states?: { nodes?: Array<{ id?: string; name?: string }> } };
+  } | null;
+}
+
+const ISSUE_FIELDS = "id identifier title description updatedAt url labels { nodes { name } }";
+const DESCRIPTION_MAX = 16_000;
+
+export interface LinearConnectorConfig {
+  /** The consent label (§3.1) — REQUIRED at fire time by the poller. */
+  label: string;
+  /** Optional Linear team id to scope the search (workspace-wide otherwise). */
+  teamId?: string;
+  /** Optional workflow-state name/id to move the ticket to on pickup (best-effort). */
+  transitionTo?: string;
+}
+
+/** Map a Linear issue node → the normalised `Ticket`. `null` if it has no identifier. */
+function toTicket(node: LinearIssueNode | null | undefined): Ticket | null {
+  if (!node) return null;
+  const id = typeof node.identifier === "string" ? node.identifier : "";
+  if (id.length === 0) return null;
+  const labels = Array.isArray(node.labels?.nodes)
+    ? node.labels!.nodes!.map((l) => l?.name).filter((n): n is string => typeof n === "string")
+    : [];
+  return {
+    id,
+    title: typeof node.title === "string" ? node.title : "",
+    body: typeof node.description === "string" ? node.description.slice(0, DESCRIPTION_MAX) : "",
+    labels,
+    updatedAt: typeof node.updatedAt === "string" ? node.updatedAt : undefined,
+    url: typeof node.url === "string" ? node.url : undefined,
+  };
+}
+
+export class LinearTrackerConnector implements TrackerConnector {
+  readonly kind = "linear";
+  readonly writeback: TrackerWriteback;
+  private readonly cfg: LinearConnectorConfig;
+  private readonly exec: LinearExecDeps;
+
+  constructor(cfg: LinearConnectorConfig, exec: LinearExecDeps) {
+    this.cfg = cfg;
+    this.exec = exec;
+    this.writeback = {
+      comment: (ticketId, body, marker) => this.postComment(ticketId, body, marker),
+      transition: (ticketId, state) => this.doTransition(ticketId, state),
+      link: (ticketId, url, title) => this.addLink(ticketId, url, title),
+    };
+  }
+
+  /**
+   * WATCH: GraphQL-search the workspace/team for labelled issues changed since the
+   * watermark. All runtime values are VARIABLES (injection-proof). `null` on any degrade
+   * so the poller skips the cycle without touching its watermark.
+   */
+  async pollTickets(sinceWatermark?: string): Promise<Ticket[] | null> {
+    const filter: Record<string, unknown> = {
+      labels: { name: { eq: cleanScalar(this.cfg.label) } },
+    };
+    if (this.cfg.teamId && this.cfg.teamId.trim().length > 0) {
+      filter.team = { id: { eq: cleanScalar(this.cfg.teamId) } };
+    }
+    if (sinceWatermark && sinceWatermark.trim().length > 0) {
+      filter.updatedAt = { gt: sinceWatermark };
+    }
+    const query =
+      `query Issues($filter: IssueFilter) { issues(filter: $filter, first: 100, ` +
+      `orderBy: updatedAt) { nodes { ${ISSUE_FIELDS} } } }`;
+    const data = await linearQuery<LinearIssuesResult>(this.exec, query, { filter });
+    if (!data || !Array.isArray(data.issues?.nodes)) return null;
+    const tickets: Ticket[] = [];
+    for (const node of data.issues!.nodes!) {
+      const t = toTicket(node);
+      if (t) tickets.push(t);
+    }
+    return tickets;
+  }
+
+  /** READ: fetch one issue by identifier (Linear's `issue` accepts the identifier). */
+  async readTicket(ticketId: string): Promise<Ticket | null> {
+    const id = sanitizeIdentifier(ticketId);
+    if (id.length === 0) return null;
+    const query = `query Issue($id: String!) { issue(id: $id) { ${ISSUE_FIELDS} } }`;
+    const data = await linearQuery<LinearIssueResult>(this.exec, query, { id });
+    if (!data) return null;
+    return toTicket(data.issue);
+  }
+
+  specBranchName(ticketId: string): string {
+    return linearSpecBranchName(ticketId);
+  }
+
+  specFilePath(ticketId: string, title: string): string {
+    return linearSpecFilePath(ticketId, title);
+  }
+
+  // ─── write-back ─────────────────────────────────────────────────────────────
+
+  /** Resolve the internal UUID (+ comments/states) for an identifier, for a write-back. */
+  private async loadForWriteback(ticketId: string): Promise<LinearIssueForWriteback["issue"] | null> {
+    const id = sanitizeIdentifier(ticketId);
+    if (id.length === 0) return null;
+    const query =
+      `query IssueWb($id: String!) { issue(id: $id) { id ` +
+      `comments(first: 200) { nodes { body } } ` +
+      `team { states { nodes { id name } } } } }`;
+    const data = await linearQuery<LinearIssueForWriteback>(this.exec, query, { id });
+    return data?.issue ?? null;
+  }
+
+  /**
+   * Post a comment IDEMPOTENTLY: resolve the issue (uuid + existing comments), skip if any
+   * already carries `marker`, else `commentCreate`. Best-effort — a degrade returns
+   * `{ posted: false }`, never throws. When the issue cannot be read we do NOT post
+   * (safety over liveness — a blind post could double-comment).
+   */
+  private async postComment(ticketId: string, body: string, marker: string): Promise<WritebackResult> {
+    const issue = await this.loadForWriteback(ticketId);
+    if (!issue || typeof issue.id !== "string" || issue.id.length === 0) {
+      return { posted: false, reason: "issue-unreadable" };
+    }
+    const existing = issue.comments?.nodes ?? [];
+    const already = existing.some((c) => typeof c.body === "string" && c.body.includes(marker));
+    if (already) return { posted: false, reason: "already-commented" };
+    const mutation =
+      `mutation Comment($issueId: String!, $body: String!) { ` +
+      `commentCreate(input: { issueId: $issueId, body: $body }) { success } }`;
+    const res = await linearMutate(this.exec, mutation, { issueId: issue.id, body: `${marker}\n${body}` });
+    return res.ok ? { posted: true } : { posted: false, reason: res.reason };
+  }
+
+  /**
+   * Move the issue to `state` (workflow-state name or id), best-effort. Resolves the
+   * state id from the issue's team states (a state not offered ⇒ no-op) then `issueUpdate`.
+   */
+  private async doTransition(ticketId: string, state: string): Promise<WritebackResult> {
+    const wanted = cleanScalar(state);
+    if (wanted.length === 0) return { posted: false, reason: "no-state" };
+    const issue = await this.loadForWriteback(ticketId);
+    if (!issue || typeof issue.id !== "string") return { posted: false, reason: "issue-unreadable" };
+    const states = issue.team?.states?.nodes ?? [];
+    const match = states.find(
+      (s) => s.id === wanted || (s.name ?? "").toLowerCase() === wanted.toLowerCase(),
+    );
+    if (!match?.id) return { posted: false, reason: "no-such-state" };
+    const mutation =
+      `mutation Move($id: String!, $stateId: String!) { ` +
+      `issueUpdate(id: $id, input: { stateId: $stateId }) { success } }`;
+    const res = await linearMutate(this.exec, mutation, { id: issue.id, stateId: match.id });
+    return res.ok ? { posted: true } : { posted: false, reason: res.reason };
+  }
+
+  /** Attach a URL to the issue (`attachmentCreate`), best-effort. */
+  private async addLink(ticketId: string, url: string, title?: string): Promise<WritebackResult> {
+    const issue = await this.loadForWriteback(ticketId);
+    if (!issue || typeof issue.id !== "string") return { posted: false, reason: "issue-unreadable" };
+    const safeUrl = cleanScalar(url, 2000);
+    if (!/^https?:\/\//i.test(safeUrl)) return { posted: false, reason: "bad-url" };
+    const mutation =
+      `mutation Attach($issueId: String!, $url: String!, $title: String!) { ` +
+      `attachmentCreate(input: { issueId: $issueId, url: $url, title: $title }) { success } }`;
+    const res = await linearMutate(this.exec, mutation, {
+      issueId: issue.id,
+      url: safeUrl,
+      title: cleanScalar(title ?? "spec", 200) || "spec",
+    });
+    return res.ok ? { posted: true } : { posted: false, reason: res.reason };
+  }
+}

--- a/server/services/consilium/trackers/linear-exec.ts
+++ b/server/services/consilium/trackers/linear-exec.ts
@@ -1,0 +1,195 @@
+/**
+ * linear-exec.ts — the sanitized Linear GraphQL seam for TRACK-5 (the Linear analogue
+ * of `gh-exec.ts` / `jira-exec.ts`). Linear has ONE GraphQL endpoint, so this is a thin
+ * POST client with the SAME safety posture as the other seams:
+ *   - NEVER throws: a network error / non-2xx / timeout / GraphQL `errors` degrades to
+ *     `null` (reads) or `{ ok: false }` (writes) so a Linear outage can never crash the
+ *     poll loop.
+ *   - The API key is NEVER logged: on failure only the HTTP status + a scrubbed,
+ *     header-free message leaves this module; the `Authorization` header is never
+ *     surfaced.
+ *   - Fail-closed auth: the API key comes from ENV (a secret manager), read at call
+ *     time. Absent ⇒ the request is not even attempted (`null` / `{ ok: false }`).
+ *   - SSRF containment: the request URL is the operator-configured `baseUrl` (default
+ *     the public Linear GraphQL endpoint), re-validated to be `https:` and used verbatim
+ *     — there is no server-derived path to smuggle a host through.
+ *   - INJECTION-PROOF: every query is a STATIC string; all runtime values (label, id,
+ *     comment body, state) are passed as GraphQL **variables**, never interpolated into
+ *     the query text — so a hostile config/ticket value can never alter the query shape.
+ *
+ * The HTTP call is injectable (`LinearHttpFn`) so tests drive it with a fake — no real
+ * network — exactly like `jira-exec`.
+ */
+
+/** The default public Linear GraphQL endpoint (overridable by validated https config). */
+export const LINEAR_DEFAULT_API_URL = "https://api.linear.app/graphql";
+
+/** The API-key env var name (a secret manager sets this). Never logged. */
+export const LINEAR_TOKEN_ENV = "LINEAR_API_KEY";
+
+/** Default per-call wall-clock budget for a Linear request. */
+const LINEAR_TIMEOUT_MS = 30_000;
+
+/** A minimal, injectable HTTP result (status + raw body text). */
+export interface LinearHttpResult {
+  status: number;
+  body: string;
+}
+
+/** Injectable HTTP transport (tests pass a fake; prod uses `fetch`). NEVER throws-through. */
+export type LinearHttpFn = (req: {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: string;
+  timeoutMs: number;
+}) => Promise<LinearHttpResult>;
+
+/** Resolved auth material. `null` ⇒ fail-closed (not configured). */
+export interface LinearAuth {
+  /** A Linear personal API key OR an OAuth access token. Never logged. */
+  token: string;
+}
+
+/**
+ * Read the Linear auth from ENV (fail-closed). Returns `null` when the var is absent or
+ * blank so the caller degrades WITHOUT attempting an unauthenticated call. The token is
+ * returned but NEVER logged by this module.
+ */
+export function readLinearAuthFromEnv(env: NodeJS.ProcessEnv = process.env): LinearAuth | null {
+  const token = (env[LINEAR_TOKEN_ENV] ?? "").trim();
+  if (token.length === 0) return null;
+  return { token };
+}
+
+/** Scrub any absolute path + collapse whitespace from an error string, then clamp. */
+function scrub(raw: string): string {
+  return raw.replace(/\/[^\s'"]+/g, "<path>").replace(/\s+/g, " ").trim().slice(0, 300);
+}
+
+/** Default transport over global `fetch` with an AbortController timeout. Never throws-through. */
+const defaultHttp: LinearHttpFn = async (req) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), req.timeoutMs);
+  try {
+    const res = await fetch(req.url, {
+      method: req.method,
+      headers: req.headers,
+      body: req.body,
+      signal: controller.signal,
+    });
+    const body = await res.text().catch(() => "");
+    return { status: res.status, body };
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/**
+ * Validate the GraphQL endpoint URL: must be a well-formed `https:` URL (fail-closed —
+ * no `http:`, no SSRF-friendly schemes). Returns the normalised string or `null`.
+ */
+export function normalizeLinearUrl(baseUrl: string): string | null {
+  try {
+    const u = new URL(baseUrl);
+    if (u.protocol !== "https:") return null;
+    return u.toString();
+  } catch {
+    return null;
+  }
+}
+
+export interface LinearExecDeps {
+  http?: LinearHttpFn;
+  auth?: LinearAuth | null;
+  /** The GraphQL endpoint (default `LINEAR_DEFAULT_API_URL`). */
+  apiUrl?: string;
+  log: (message: string) => void;
+}
+
+/** The Linear `Authorization` header value. Personal keys pass raw; OAuth tokens use Bearer. */
+function authHeader(token: string): string {
+  // A Linear OAuth access token is `lin_oauth_…`; personal keys are `lin_api_…`. Only the
+  // OAuth form takes the `Bearer` prefix (personal keys are sent raw). Both never logged.
+  return token.startsWith("lin_oauth_") ? `Bearer ${token}` : token;
+}
+
+/**
+ * Low-level GraphQL POST. Returns the parsed `data` object on success, or `null` on ANY
+ * degrade (unconfigured auth, bad url, non-2xx, network error, bad JSON, GraphQL
+ * `errors`). The token is never logged. Variables are sent as a SEPARATE JSON field so
+ * runtime values never touch the query text (injection-proof).
+ */
+async function postGraphql<T>(
+  deps: LinearExecDeps,
+  query: string,
+  variables: Record<string, unknown>,
+): Promise<T | null> {
+  const auth = deps.auth ?? readLinearAuthFromEnv();
+  if (!auth) {
+    deps.log("linear-exec: no LINEAR_API_KEY configured — skipping (fail-closed)");
+    return null;
+  }
+  const url = normalizeLinearUrl(deps.apiUrl ?? LINEAR_DEFAULT_API_URL);
+  if (!url) {
+    deps.log("linear-exec: rejected api url (must be https)");
+    return null;
+  }
+  const http = deps.http ?? defaultHttp;
+  try {
+    const res = await http({
+      method: "POST",
+      url,
+      headers: {
+        Authorization: authHeader(auth.token),
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ query, variables }),
+      timeoutMs: LINEAR_TIMEOUT_MS,
+    });
+    if (res.status < 200 || res.status >= 300) {
+      deps.log(`linear-exec: POST → HTTP ${res.status} (degraded)`);
+      return null;
+    }
+    const parsed = JSON.parse(res.body) as { data?: T; errors?: unknown };
+    // GraphQL returns HTTP 200 even on query errors — treat any `errors` as a degrade.
+    if (parsed && Array.isArray(parsed.errors) && parsed.errors.length > 0) {
+      deps.log("linear-exec: GraphQL returned errors (degraded)");
+      return null;
+    }
+    return (parsed?.data ?? null) as T | null;
+  } catch (err) {
+    deps.log(`linear-exec: POST failed: ${scrub((err as Error)?.message ?? String(err))}`);
+    return null;
+  }
+}
+
+/** Run a READ query. `null` ⇒ degrade (outage / auth / GraphQL error). */
+export function linearQuery<T>(
+  deps: LinearExecDeps,
+  query: string,
+  variables: Record<string, unknown> = {},
+): Promise<T | null> {
+  return postGraphql<T>(deps, query, variables);
+}
+
+/**
+ * Run a MUTATION. Returns a typed `{ ok }` — never throws. On failure only a scrubbed
+ * message leaves this module (the token / Authorization header never do).
+ */
+export async function linearMutate(
+  deps: LinearExecDeps,
+  query: string,
+  variables: Record<string, unknown> = {},
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const data = await postGraphql<{ [k: string]: { success?: boolean } }>(deps, query, variables);
+  if (!data) return { ok: false, reason: "degraded" };
+  // Linear mutations return `{ <op>: { success: boolean, ... } }`; treat a missing/false
+  // success as a failure so a best-effort caller degrades rather than reports posted.
+  const op = Object.values(data)[0];
+  if (op && typeof op === "object" && op.success === false) {
+    return { ok: false, reason: "mutation-unsuccessful" };
+  }
+  return { ok: true };
+}

--- a/server/services/consilium/trackers/linear-issues-poller.ts
+++ b/server/services/consilium/trackers/linear-issues-poller.ts
@@ -1,0 +1,350 @@
+/**
+ * linear-issues-poller.ts — TRACK-5: poll a Linear workspace/team (GraphQL) and turn each
+ * labelled, spec-ready issue into a committed spec PR + a Linear pickup comment. The
+ * Linear analogue of `jira-issues-poller.ts`, reusing the EXACT same rails: watermark in
+ * the trigger `config` jsonb, never-throw per cycle/trigger, project-scoped context, the
+ * shared tracker kill-switch, the allowlist + consent gates, and the SHARED crystallise
+ * pipeline (`spec-intake.ts` → `issue-spec.ts` synth + `spec-writer.ts` PR). The ONLY
+ * Linear-specific surface lives in `LinearTrackerConnector` (GraphQL watch / read /
+ * comment+state+attachment write-back / `spec/linear-<ID>` naming).
+ *
+ * DOES NOT FIRE LOOPS (identical to TRACK-1/3): a spec PRODUCER + ticket UPDATER. It opens
+ * a PR that ADDS a `docs/specs/linear-<ID>-…` spec to the TARGET git repo (Linear has no
+ * git); when a human MERGES that PR, SPEC-1's spec-watch fires the review loop.
+ *
+ * RAILS (adversarial): (a) a per-trigger WATERMARK (identifier → { specPrUrl, at }) +
+ * the deterministic `spec/linear-<ID>` branch + spec-writer's pr-list dedup ⇒ never a 2nd
+ * PR / double comment even on a ticket EDIT; (b) a per-cycle budget bounds new specs;
+ * (c) every read degrades to `null` (linear-exec) so a Linear outage SKIPS the cycle
+ * WITHOUT touching the watermark; (d) `filter.label` is REQUIRED (consent) and
+ * `targetRepoPath` MUST be in the fail-closed allowlist. The API key is never read/logged
+ * here (linear-exec owns it, fail-closed); the GraphQL query is static + variable-bound
+ * (injection-proof).
+ */
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { realpathSync } from "fs";
+import { resolve } from "path";
+import type { TriggerRow } from "@shared/schema";
+import type { TrackerEventTriggerConfig, TrackerPollState } from "@shared/types";
+import type { AppConfig } from "../../../config/schema.js";
+import type { ExecFileFn } from "../../github-status.js";
+import { extractSpecFromIssue } from "./issue-spec.js";
+import { crystallizeTicket } from "./spec-intake.js";
+import { LinearTrackerConnector, type LinearConnectorConfig } from "./linear-connector.js";
+import { readLinearAuthFromEnv, type LinearAuth, type LinearHttpFn } from "./linear-exec.js";
+import type { TicketSynthesizer } from "./jira-issues-poller.js";
+
+/** `owner/repo` — conservative charset (no leading dash / no flag). */
+const OWNER_REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+/** Max NEW intakes opened per poll cycle (bounds blast radius). */
+const MAX_PER_CYCLE = 20;
+/** Cap on tracked intakes per trigger (bounds the watermark jsonb). */
+const MAX_TRACKED_INTAKE = 500;
+
+/** Idempotency markers for the Linear write-back comments (distinct per tracker/track). */
+export const LINEAR_PICKUP_MARKER = "<!-- factory:track5:linear:pickup -->";
+export const LINEAR_NEED_CRITERIA_MARKER = "<!-- factory:track5:linear:need-criteria -->";
+
+export interface LinearIssuesPollerDeps {
+  getEnabledTriggersByType: (type: "tracker_event") => Promise<TriggerRow[]>;
+  runInProject: <T>(projectId: string, fn: () => Promise<T>) => Promise<T>;
+  getTrigger: (id: string) => Promise<TriggerRow | undefined>;
+  updateTrigger: (id: string, updates: Partial<TriggerRow>) => Promise<unknown>;
+  config: () => AppConfig;
+  allowedRepoPaths: () => string[];
+  synthesizer?: TicketSynthesizer;
+  /** Injectable `gh` runner for the remote spec PR (tests pass a fake — no real gh). */
+  runGh?: ExecFileFn;
+  /** Injectable Linear HTTP transport (tests pass a fake — no real network). */
+  linearHttp?: LinearHttpFn;
+  /** Injectable Linear auth (tests pass a fake; prod reads env at call time). */
+  linearAuth?: LinearAuth | null;
+  /** Injectable git-remote reader for the owner/repo derivation (default: real `git`). */
+  gitRemoteUrl?: (repoPath: string) => Promise<string | null>;
+  log: (message: string) => void;
+  now?: () => number;
+}
+
+const execFileAsync: ExecFileFn = promisify(execFile);
+
+/** Default git-remote reader: `git -C <repoPath> remote get-url origin`. NEVER throws. */
+async function defaultGitRemoteUrl(repoPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", repoPath, "remote", "get-url", "origin"], {
+      timeout: 10_000,
+    });
+    const url = (stdout ?? "").trim();
+    return url.length > 0 ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Best-effort realpath (collapses symlinks/`..`), else lexical resolve. */
+function canonicalPath(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return resolve(p);
+  }
+}
+
+/** Fail-closed allowlist check: `targetRepoPath` realpath-equals or sits beneath an allowed root. */
+function isAllowedRepoPath(targetRepoPath: string, allowed: readonly string[]): boolean {
+  const target = canonicalPath(targetRepoPath);
+  for (const a of allowed) {
+    const root = canonicalPath(a);
+    if (target === root || target.startsWith(root + "/")) return true;
+  }
+  return false;
+}
+
+/** Single-line control-strip + collapse + clamp for the (untrusted) ticket title. */
+function sanitizeTitleLine(value: string, max = 160): string {
+  let out = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0;
+    out += code < 0x20 || code === 0x7f ? " " : ch;
+  }
+  return out.replace(/\s+/g, " ").trim().slice(0, max);
+}
+
+/** Keep at most MAX_TRACKED_INTAKE intakes (most-recent by `at` timestamp win). */
+function boundIntake(
+  intake: Record<string, { specPrUrl?: string; at: string }>,
+): Record<string, { specPrUrl?: string; at: string }> {
+  const keys = Object.keys(intake);
+  if (keys.length <= MAX_TRACKED_INTAKE) return intake;
+  const kept = keys
+    .sort((a, b) => (intake[b].at ?? "").localeCompare(intake[a].at ?? ""))
+    .slice(0, MAX_TRACKED_INTAKE);
+  const out: Record<string, { specPrUrl?: string; at: string }> = {};
+  for (const k of kept) out[k] = intake[k];
+  return out;
+}
+
+export class LinearIssuesPoller {
+  private readonly deps: LinearIssuesPollerDeps;
+  private readonly gitRemoteUrl: (repoPath: string) => Promise<string | null>;
+  private readonly now: () => number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private polling = false;
+
+  constructor(deps: LinearIssuesPollerDeps) {
+    this.deps = deps;
+    this.gitRemoteUrl = deps.gitRemoteUrl ?? ((p) => defaultGitRemoteUrl(p));
+    this.now = deps.now ?? Date.now;
+  }
+
+  /** Start the interval poller IFF `features.triggers.tracker.enabled`. Idempotent. */
+  start(): void {
+    if (this.timer) return;
+    const cfg = this.deps.config().features.triggers.tracker;
+    if (!cfg.enabled) {
+      this.deps.log("linear tracker polling disabled — poller not started");
+      return;
+    }
+    const intervalMs = cfg.pollIntervalSec * 1000;
+    this.timer = setInterval(() => void this.pollAllSafe(), intervalMs);
+    this.timer.unref?.();
+    this.deps.log(`linear tracker poller started (every ${cfg.pollIntervalSec}s)`);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** One poll cycle, fully guarded — a throw here must never kill the interval. */
+  async pollAllSafe(): Promise<void> {
+    if (this.polling) return;
+    this.polling = true;
+    try {
+      await this.pollAll();
+    } catch (e) {
+      this.deps.log(`linear tracker poll cycle error: ${(e as Error).message}`);
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  /** Poll every enabled tracker_event trigger. Gated on the MASTER switch. */
+  async pollAll(): Promise<void> {
+    if (!this.deps.config().features.triggers.enabled) {
+      this.deps.log("linear tracker poll skipped — features.triggers.enabled (master switch) is off");
+      return;
+    }
+    const triggers = await this.deps.getEnabledTriggersByType("tracker_event");
+    for (const trigger of triggers) {
+      try {
+        await this.pollTrigger(trigger);
+      } catch (e) {
+        this.deps.log(`linear tracker poll error for trigger ${trigger.id}: ${(e as Error).message}`);
+      }
+    }
+  }
+
+  /** Poll one Linear trigger: validate config + allowlist, intake labelled issues, persist. */
+  async pollTrigger(trigger: TriggerRow): Promise<void> {
+    if (!trigger.projectId) return;
+    const config = trigger.config as TrackerEventTriggerConfig;
+    if (config.tracker !== "linear") return; // other pollers handle other kinds.
+
+    // `repo` (owner/repo) is the git repo the spec PR lands in — shape-validated.
+    const repo = (config.repo ?? "").trim();
+    if (!OWNER_REPO_RE.test(repo)) {
+      this.deps.log(`linear tracker poll skipped for trigger ${trigger.id} — repo not owner/repo`);
+      return;
+    }
+    const targetRepoPath = config.targetRepoPath;
+    if (!targetRepoPath || targetRepoPath.length === 0) {
+      this.deps.log(`linear tracker poll skipped for trigger ${trigger.id} — no targetRepoPath`);
+      return;
+    }
+    if (!isAllowedRepoPath(targetRepoPath, this.deps.allowedRepoPaths())) {
+      this.deps.log(`linear tracker poll skipped for trigger ${trigger.id} — targetRepoPath not in allowlist`);
+      return;
+    }
+    // The label gate is the operator's consent-to-intake — REQUIRED at fire time.
+    const label = config.filter?.label;
+    if (!label || label.length === 0) {
+      this.deps.log(`linear tracker poll skipped for trigger ${trigger.id} — no filter.label (consent gate)`);
+      return;
+    }
+
+    const connectorCfg: LinearConnectorConfig = {
+      label,
+      teamId: config.linearTeamId,
+      transitionTo: config.transitionTo,
+    };
+    const connector = new LinearTrackerConnector(connectorCfg, {
+      http: this.deps.linearHttp,
+      auth: this.deps.linearAuth ?? readLinearAuthFromEnv(),
+      apiUrl: config.baseUrl,
+      log: this.deps.log,
+    });
+
+    const projectId = trigger.projectId;
+    await this.deps.runInProject(projectId, async () => {
+      const state: TrackerPollState = { ...(config.pollState ?? {}) };
+      if (!state.intake) state.intake = {};
+
+      const tickets = await connector.pollTickets(state.lastPolledAt);
+      if (tickets === null) {
+        this.deps.log(`linear tracker poll: search unavailable (degraded) — skipping cycle`);
+        return; // do NOT touch the watermark.
+      }
+
+      let intaken = 0;
+      for (const ticket of tickets) {
+        if (intaken >= MAX_PER_CYCLE) break;
+        const key = ticket.id;
+        if (!key || state.intake![key]) continue; // watermark dedup — already intaken.
+
+        // Defence-in-depth: confirm the consent label is actually present.
+        if (!ticket.labels.includes(label)) continue;
+
+        // DETERMINISTIC extraction, then the injectable synthesiser for free-form tickets.
+        const extract = extractSpecFromIssue({ number: 0, title: ticket.title, body: ticket.body });
+        let problem = extract.problem;
+        let scope = extract.scope;
+        let outOfScope = extract.outOfScope;
+        let criteria = extract.criteria;
+        if (criteria.length === 0 && this.deps.synthesizer) {
+          try {
+            const syn = await this.deps.synthesizer.synthesize({ title: ticket.title, body: ticket.body });
+            if (syn && Array.isArray(syn.criteria) && syn.criteria.length > 0) {
+              criteria = syn.criteria;
+              problem = problem ?? syn.problem;
+              scope = scope ?? syn.scope;
+              outOfScope = outOfScope ?? syn.outOfScope;
+            }
+          } catch (e) {
+            this.deps.log(`linear tracker poll: synthesizer error for ${key}: ${(e as Error).message}`);
+          }
+        }
+
+        const specStatus = config.specStatus ?? "ready";
+        const title = ticket.title;
+        const sanitizedTitle = sanitizeTitleLine(title);
+        const commitMessage = `feat: add spec for ${key}`;
+        const prTitle = `spec: ${sanitizedTitle || key} (${key})`;
+        const prBodyLines = [
+          `Track-5 auto-produced spec for Linear issue ${key}.`,
+          "",
+          "This spec was generated from the linked Linear issue by the factory's Track-5 intake.",
+          "Merging it fires the SPEC-1 spec-watch, which launches the review loop off the committed spec.",
+        ];
+        if (ticket.url) prBodyLines.push("", `Linear: ${ticket.url}`);
+        const prBody = prBodyLines.join("\n");
+
+        const result = await crystallizeTicket(
+          {
+            runGh: this.deps.runGh,
+            gitRemoteUrl: this.gitRemoteUrl,
+            log: this.deps.log,
+            writeback: {
+              pickup: (specPrUrl) =>
+                connector.writeback
+                  .comment(key, `🤖 picked up by the factory — spec at ${specPrUrl}`, LINEAR_PICKUP_MARKER)
+                  .then((r) => ({ posted: r.posted })),
+              needCriteria: () =>
+                connector.writeback
+                  .comment(
+                    key,
+                    `🤖 I can pick this up but need testable acceptance criteria — please add an "Acceptance Criteria" section or checklist items.`,
+                    LINEAR_NEED_CRITERIA_MARKER,
+                  )
+                  .then((r) => ({ posted: r.posted })),
+            },
+          },
+          {
+            source: { kind: "linear", ref: key, url: ticket.url },
+            targetRepoPath,
+            branch: connector.specBranchName(key),
+            filePath: connector.specFilePath(key, title),
+            title: title.trim().length > 0 ? title : key,
+            status: specStatus,
+            problem: problem ?? title,
+            scope,
+            outOfScope,
+            criteria,
+            commitMessage,
+            prTitle,
+            prBody,
+          },
+        );
+
+        if (result.outcome === "need-criteria") continue; // asked human, no intake.
+        if (result.outcome === "failed") {
+          this.deps.log(`linear tracker poll: spec PR failed for ${key}: ${result.reason}`);
+          continue;
+        }
+
+        // Optional pickup transition (best-effort; an unknown state is a no-op).
+        if (config.transitionTo && connector.writeback.transition) {
+          await connector.writeback.transition(key, config.transitionTo);
+        }
+
+        state.intake![key] = { specPrUrl: result.prUrl, at: new Date(this.now()).toISOString() };
+        intaken++;
+      }
+
+      state.intake = boundIntake(state.intake!);
+      state.lastPolledAt = new Date(this.now()).toISOString();
+      await this.persistWatermark(trigger.id, state);
+    });
+  }
+
+  /** Re-read fresh + write the watermark into `config.pollState` (no migration). */
+  private async persistWatermark(triggerId: string, state: TrackerPollState): Promise<void> {
+    const fresh = await this.deps.getTrigger(triggerId);
+    if (!fresh) return;
+    const freshConfig = (fresh.config ?? {}) as TrackerEventTriggerConfig;
+    const nextConfig: TrackerEventTriggerConfig = { ...freshConfig, pollState: state };
+    await this.deps.updateTrigger(triggerId, { config: nextConfig });
+  }
+}

--- a/server/services/consilium/trackers/spec-writer.ts
+++ b/server/services/consilium/trackers/spec-writer.ts
@@ -44,11 +44,15 @@ import { runGhCapture } from "./gh-exec.js";
  *   - Jira      (TRACK-3): `spec/jira-<KEY>`     (KEY = `PROJ-123`, uppercased)
  *   - GitLab    (TRACK-4): `spec/gitlab-<iid>`   (iid = project-internal issue id)
  *   - Bitbucket (TRACK-4): `spec/bitbucket-<id>` (id = issue id)
+ *   - Linear    (TRACK-5): `spec/linear-<ID>`    (ID = identifier, e.g. `ENG-123`)
+ *   - Azure     (TRACK-5): `spec/azure-<n>`      (n = work-item id)
+ *   - ClickUp   (TRACK-5): `spec/clickup-<ID>`   (ID = task id, alnum)
  * Every alternative is SERVER-DERIVED from a validated ticket id, so nothing
  * attacker-shaped (a leading dash, a path separator, a `..`) can reach `gh`. New
- * connectors (TRACK-5) add their own alternative here — the writer stays generic.
+ * connectors add their own alternative here — the writer stays generic.
  */
-export const SPEC_BRANCH_RE = /^spec\/(gh-issue-[0-9]+|jira-[A-Za-z0-9._-]+|gitlab-[0-9]+|bitbucket-[0-9]+)$/;
+export const SPEC_BRANCH_RE =
+  /^spec\/(gh-issue-[0-9]+|jira-[A-Za-z0-9._-]+|gitlab-[0-9]+|bitbucket-[0-9]+|linear-[A-Za-z0-9._-]+|azure-[0-9]+|clickup-[A-Za-z0-9._-]+)$/;
 
 /** True iff `branch` is a server-derived tracker spec branch (any connector). */
 export function isValidSpecBranch(branch: string): boolean {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1670,36 +1670,39 @@ export interface TrackerPollState {
  * This trigger PRODUCES specs + UPDATES tickets — it never fires a loop directly.
  */
 export interface TrackerEventTriggerConfig {
-  // TRACK-1 = github; TRACK-3 adds jira; TRACK-4 adds gitlab + bitbucket. The poller for
-  // each tracker guards on this discriminant (`config.tracker !== "<kind>"` → skip), so
-  // widening it is ADDITIVE: the github/jira paths are byte-identical and only the new
-  // gitlab/bitbucket pollers read their own fields.
-  tracker: "github" | "jira" | "gitlab" | "bitbucket";
-  repo: string;                 // github: owner/repo to poll issues from. jira/gitlab/bitbucket: owner/repo of the git repo the spec PR lands in.
+  // TRACK-1 = github; TRACK-3 adds jira; TRACK-4 adds gitlab + bitbucket; TRACK-5 adds
+  // linear/azure/clickup. The poller for each tracker guards on this discriminant
+  // (`config.tracker !== "<kind>"` → skip), so widening it is ADDITIVE: the github/jira
+  // paths are byte-identical and only the new poller for each kind reads its own fields.
+  tracker: "github" | "jira" | "gitlab" | "bitbucket" | "linear" | "azure" | "clickup";
+  repo: string;                 // github: owner/repo to poll issues from. other trackers: owner/repo of the git repo the spec PR lands in.
   targetRepoPath: string;       // allowlisted local repo path -> the spec's `repo:` frontmatter + PR target
-  filter?: { label?: string };  // label gate (consent to intake) — required at fire time
+  filter?: { label?: string };  // label/tag gate (consent to intake) — required at fire time (Jira label, Linear label, Azure tag, ClickUp tag)
   specStatus?: "ready" | "draft";
   pollState?: TrackerPollState;  // owned by the poller (watermark)
   // ─── Jira-only (TRACK-3; ignored by the github poller) ──────────────────────
-  /** Jira site base URL, e.g. `https://acme.atlassian.net` (validated https). */
+  /** Jira site base URL, e.g. `https://acme.atlassian.net` (validated https). Also the
+   *  optional API base override for the TRACK-5 connectors (Linear/Azure/ClickUp each
+   *  default to their own public API host when this is absent). */
   baseUrl?: string;
-  /** Jira project key to poll, e.g. `ACME`. */
+  /** Jira project key to poll, e.g. `ACME`. Also the Azure DevOps project name. */
   project?: string;
   /** Optional operator JQL predicate (trusted config) ANDed into the label search. */
   jql?: string;
   /**
    * Optional pickup "transition", interpreted per connector (best-effort): Jira → a
-   * workflow transition name/id; GitLab → a LABEL to add (GitLab has no arbitrary
-   * states); Bitbucket → an issue STATE (`open`/`resolved`/…). Ignored by the github poller.
+   * workflow transition name/id; GitLab → a LABEL to add (no arbitrary states);
+   * Bitbucket → an issue STATE; Linear → a workflow-state name; Azure → `System.State`;
+   * ClickUp → a status. Ignored by the github poller.
    */
   transitionTo?: string;
-  // ─── GitLab-only (TRACK-4; ignored by the github/jira/bitbucket pollers) ─────
+  // ─── GitLab-only (TRACK-4; ignored by other pollers) ─────────────────────────
   /**
    * GitLab project id (`42`) or URL path (`group/project`) whose ISSUES are polled.
    * (`baseUrl` above is reused as the GitLab site base, e.g. `https://gitlab.com`.)
    */
   gitlabProject?: string;
-  // ─── Bitbucket-only (TRACK-4; ignored by the github/jira/gitlab pollers) ─────
+  // ─── Bitbucket-only (TRACK-4; ignored by other pollers) ──────────────────────
   /** Bitbucket Cloud workspace hosting the issue tracker. */
   workspace?: string;
   /**
@@ -1708,6 +1711,17 @@ export interface TrackerEventTriggerConfig {
    * `https://api.bitbucket.org`. `filter.label` is matched against the issue COMPONENT.)
    */
   repoSlug?: string;
+  // ─── Linear-only (TRACK-5; ignored by other pollers) ────────────────────────
+  /** Optional Linear team id to scope the label search to a single team (workspace-wide otherwise). */
+  linearTeamId?: string;
+  // ─── Azure DevOps-only (TRACK-5; ignored by other pollers) ──────────────────
+  /** Azure DevOps organization (the `dev.azure.com/<org>` segment) — REQUIRED for azure. */
+  azureOrg?: string;
+  /** Optional Azure area-path filter ANDed into the WIQL (`[System.AreaPath] UNDER '<path>'`). */
+  azureAreaPath?: string;
+  // ─── ClickUp-only (TRACK-5; ignored by other pollers) ───────────────────────
+  /** ClickUp list id whose tasks are polled (`/list/<id>/task`) — REQUIRED for clickup. */
+  clickupListId?: string;
   /**
    * TRACK-2 (full write-back lifecycle). Per-trigger tuning for the read-only
    * write-back OBSERVER, which comments the loop's lifecycle transitions back on

--- a/tests/unit/consilium/trackers/azure-connector.test.ts
+++ b/tests/unit/consilium/trackers/azure-connector.test.ts
@@ -1,0 +1,215 @@
+/**
+ * azure-connector.test.ts — TRACK-5 Azure DevOps dialect with a FAKE Azure HTTP transport
+ * (no network). Covers: WIQL is built from the `@project` macro + SANITISED, quoted tag
+ * literals (injection-proof — a `'` in the tag is stripped, cannot break the quoted term);
+ * HTML description flattening; tag-string parsing; watch (WIQL → id list → batch read)
+ * mapping to normalised Tickets; idempotent comment write-back; `System.State` JSON-patch
+ * transition; and the deterministic `spec/azure-<id>` (digits-only) naming.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  AzureTrackerConnector,
+  htmlToText,
+  parseTags,
+  sanitizeWorkItemId,
+  azureSpecBranchName,
+  azureSpecFilePath,
+  type AzureConnectorConfig,
+} from "../../../../server/services/consilium/trackers/azure-connector.js";
+import { isValidSpecBranch } from "../../../../server/services/consilium/trackers/spec-writer.js";
+import type { AzureHttpFn, AzureHttpResult } from "../../../../server/services/consilium/trackers/azure-exec.js";
+
+interface Call {
+  method: string;
+  url: string;
+  body?: string;
+}
+
+function fakeHttp(handler: (call: Call) => AzureHttpResult): { http: AzureHttpFn; calls: Call[] } {
+  const calls: Call[] = [];
+  const http: AzureHttpFn = vi.fn(async (req) => {
+    const call: Call = { method: req.method, url: req.url, body: req.body };
+    calls.push(call);
+    return handler(call);
+  });
+  return { http, calls };
+}
+
+const json = (obj: unknown, status = 200): AzureHttpResult => ({ status, body: JSON.stringify(obj) });
+
+const CFG: AzureConnectorConfig = { org: "acme", project: "Widget", tag: "agent" };
+
+function connector(cfg: Partial<AzureConnectorConfig>, handler: (c: Call) => AzureHttpResult) {
+  const { http, calls } = fakeHttp(handler);
+  const conn = new AzureTrackerConnector({ ...CFG, ...cfg }, {
+    http,
+    auth: { pat: "secret-pat" },
+    log: () => {},
+  });
+  return { conn, calls };
+}
+
+const wiqlOf = (body?: string) => (body ? (JSON.parse(body) as { query: string }).query : "");
+
+const WORKITEM = {
+  id: 42,
+  fields: {
+    "System.Title": "Add rate limiting",
+    "System.Description": "<div>## Acceptance Criteria</div><ul><li>returns 429</li></ul>",
+    "System.Tags": "agent; backend",
+    "System.ChangedDate": "2026-01-02T10:00:00Z",
+  },
+};
+
+describe("htmlToText / parseTags", () => {
+  it("flattens HTML to text and decodes entities", () => {
+    expect(htmlToText("<p>Hello&nbsp;<b>world</b></p><p>line2</p>")).toBe("Hello world\nline2");
+    expect(htmlToText("a &amp; b &lt;c&gt;")).toBe("a & b <c>");
+    expect(htmlToText(null)).toBe("");
+  });
+  it("splits the System.Tags string into a label array", () => {
+    expect(parseTags("agent; backend ; ")).toEqual(["agent", "backend"]);
+    expect(parseTags(undefined)).toEqual([]);
+  });
+});
+
+describe("naming + id sanitisation", () => {
+  it("derives a digits-only branch/path from the work-item id", () => {
+    expect(azureSpecBranchName("42")).toBe("spec/azure-42");
+    expect(isValidSpecBranch(azureSpecBranchName("42"))).toBe(true);
+    expect(azureSpecFilePath("42", "Add Rate Limiting!")).toBe("docs/specs/azure-42-add-rate-limiting.md");
+  });
+  it("reduces a hostile id to digits (no separators / traversal)", () => {
+    expect(sanitizeWorkItemId("../../7")).toBe("7");
+    expect(sanitizeWorkItemId("42; DROP")).toBe("42");
+  });
+  it("throws on an id that sanitises to empty", () => {
+    expect(() => azureSpecBranchName("abc")).toThrow();
+  });
+});
+
+describe("buildWiql (via pollTickets) — injection-proof", () => {
+  it("uses the @project macro and a sanitised, quoted tag literal (single-quote stripped)", async () => {
+    let seen = "";
+    const { conn } = connector({ tag: "agent'; DROP" }, (c) => {
+      if (c.url.includes("/wiql")) {
+        seen = wiqlOf(c.body);
+        return json({ workItems: [] });
+      }
+      return json({});
+    });
+    await conn.pollTickets();
+    expect(seen).toContain("[System.TeamProject] = @project");
+    expect(seen).toContain("[System.Tags] CONTAINS 'agent; DROP'");
+    expect(seen).not.toContain("''"); // the injected quote is gone.
+  });
+
+  it("ANDs a ChangedDate watermark + area path when present", async () => {
+    let seen = "";
+    const { conn } = connector({ areaPath: "Widget\\Team A" }, (c) => {
+      if (c.url.includes("/wiql")) {
+        seen = wiqlOf(c.body);
+        return json({ workItems: [] });
+      }
+      return json({});
+    });
+    await conn.pollTickets("2026-01-01T00:00:00Z");
+    expect(seen).toContain("[System.AreaPath] UNDER 'Widget\\Team A'");
+    expect(seen).toContain("[System.ChangedDate] > '2026-01-01T00:00:00Z'");
+  });
+});
+
+describe("pollTickets / readTicket mapping", () => {
+  it("maps a WIQL id list + batch read to normalised tickets", async () => {
+    const { conn } = connector({}, (c) => {
+      if (c.url.includes("/wiql")) return json({ workItems: [{ id: 42 }] });
+      if (c.url.includes("/workitems") && c.method === "GET") return json({ value: [WORKITEM] });
+      return json({});
+    });
+    const tickets = await conn.pollTickets();
+    expect(tickets).toHaveLength(1);
+    expect(tickets![0]).toMatchObject({
+      id: "42",
+      title: "Add rate limiting",
+      labels: ["agent", "backend"],
+      url: "https://dev.azure.com/acme/Widget/_workitems/edit/42",
+    });
+    expect(tickets![0].body).toContain("returns 429");
+  });
+
+  it("returns [] when the WIQL matches nothing (no batch call)", async () => {
+    const { conn, calls } = connector({}, (c) =>
+      c.url.includes("/wiql") ? json({ workItems: [] }) : json({}),
+    );
+    expect(await conn.pollTickets()).toEqual([]);
+    expect(calls.some((c) => c.method === "GET" && c.url.includes("/workitems"))).toBe(false);
+  });
+
+  it("returns null when the WIQL is degraded (HTTP 500)", async () => {
+    const { conn } = connector({}, (c) =>
+      c.url.includes("/wiql") ? { status: 500, body: "boom" } : json({}),
+    );
+    expect(await conn.pollTickets()).toBeNull();
+  });
+
+  it("returns null when auth is unconfigured (fail-closed)", async () => {
+    const { http } = fakeHttp(() => json({ workItems: [{ id: 42 }] }));
+    const conn = new AzureTrackerConnector(CFG, { http, auth: null, log: () => {} });
+    expect(await conn.pollTickets()).toBeNull();
+  });
+
+  it("readTicket fetches one work item by id", async () => {
+    const { conn, calls } = connector({}, (c) =>
+      c.url.includes("/workitems/42") ? json(WORKITEM) : json({}),
+    );
+    const t = await conn.readTicket("42");
+    expect(t?.id).toBe("42");
+    expect(calls.some((c) => c.method === "GET" && c.url.includes("/_apis/wit/workitems/42"))).toBe(true);
+  });
+});
+
+describe("write-back — comment idempotency + state", () => {
+  it("posts a comment when the marker is absent", async () => {
+    const { conn, calls } = connector({}, (c) => {
+      if (c.method === "GET" && c.url.includes("/comments")) return json({ comments: [] });
+      if (c.method === "POST" && c.url.includes("/comments")) return { status: 200, body: "{}" };
+      return json({});
+    });
+    const res = await conn.writeback.comment("42", "picked up", "<!-- marker -->");
+    expect(res.posted).toBe(true);
+    const post = calls.find((c) => c.method === "POST" && c.url.includes("/comments"));
+    expect(post!.body).toContain("<!-- marker -->");
+    expect(post!.body).toContain("picked up");
+  });
+
+  it("does NOT double-post when a comment already carries the marker", async () => {
+    const { conn, calls } = connector({}, (c) =>
+      c.method === "GET" && c.url.includes("/comments")
+        ? json({ comments: [{ text: "<!-- marker -->\nearlier" }] })
+        : json({}),
+    );
+    const res = await conn.writeback.comment("42", "x", "<!-- marker -->");
+    expect(res.posted).toBe(false);
+    expect(calls.some((c) => c.method === "POST")).toBe(false);
+  });
+
+  it("does NOT post when comments are unreadable (safety over liveness)", async () => {
+    const { conn, calls } = connector({}, (c) =>
+      c.method === "GET" && c.url.includes("/comments") ? { status: 503, body: "" } : json({}),
+    );
+    const res = await conn.writeback.comment("42", "x", "<!-- m -->");
+    expect(res.posted).toBe(false);
+    expect(calls.some((c) => c.method === "POST")).toBe(false);
+  });
+
+  it("sets System.State via a JSON-patch PATCH", async () => {
+    const { conn, calls } = connector({}, (c) =>
+      c.method === "PATCH" ? { status: 200, body: "{}" } : json({}),
+    );
+    const res = await conn.writeback.transition!("42", "Active");
+    expect(res.posted).toBe(true);
+    const patch = calls.find((c) => c.method === "PATCH");
+    expect(patch!.body).toContain("/fields/System.State");
+    expect(patch!.body).toContain("Active");
+  });
+});

--- a/tests/unit/consilium/trackers/azure-issues-poller.test.ts
+++ b/tests/unit/consilium/trackers/azure-issues-poller.test.ts
@@ -1,0 +1,286 @@
+/**
+ * azure-issues-poller.test.ts — TRACK-5 poller with a FAKE Azure HTTP transport + FAKE
+ * `gh`. Mirrors jira-issues-poller.test: a tagged work item → the SHARED synth → a spec PR
+ * (docs/specs/azure-<id>-… whose frontmatter carries source.kind=azure,ref=<id>) + exactly
+ * ONE Azure pickup comment + a watermark intake; re-poll dedup; an untagged item skipped;
+ * a free-form item with no criteria → need-criteria comment + NO PR + NO intake; no
+ * filter.label / no azureOrg ⇒ skipped (no Azure calls); master switch off ⇒ no calls; a
+ * WIQL outage skips the cycle (watermark untouched); a non-allowlisted targetRepoPath skips.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  AzureIssuesPoller,
+  type AzureIssuesPollerDeps,
+} from "../../../../server/services/consilium/trackers/azure-issues-poller.js";
+import type { TicketSynthesizer } from "../../../../server/services/consilium/trackers/jira-issues-poller.js";
+import type { AzureHttpFn, AzureHttpResult } from "../../../../server/services/consilium/trackers/azure-exec.js";
+import type { ExecFileFn } from "../../../../server/services/github-status.js";
+import type { TriggerRow } from "../../../../shared/schema.js";
+import type { AppConfig, TrackerEventTriggerConfig } from "../../../../shared/types.js";
+
+interface AzureOpts {
+  workItems?: Array<{ id?: number }>;
+  value?: unknown[];
+  comments?: Array<{ text?: string }>;
+  wiqlStatus?: number;
+}
+
+function fakeAzure(opts: AzureOpts): { http: AzureHttpFn; calls: Array<{ method: string; url: string; body?: string }> } {
+  const calls: Array<{ method: string; url: string; body?: string }> = [];
+  const http: AzureHttpFn = vi.fn(async (req): Promise<AzureHttpResult> => {
+    calls.push({ method: req.method, url: req.url, body: req.body });
+    const json = (obj: unknown, status = 200): AzureHttpResult => ({ status, body: JSON.stringify(obj) });
+    if (req.url.includes("/wiql")) {
+      if (opts.wiqlStatus && opts.wiqlStatus >= 400) return { status: opts.wiqlStatus, body: "err" };
+      return json({ workItems: opts.workItems ?? [] });
+    }
+    if (req.url.includes("/workitems") && req.method === "GET") return json({ value: opts.value ?? [] });
+    if (req.url.includes("/comments") && req.method === "GET") return json({ comments: opts.comments ?? [] });
+    if (req.url.includes("/comments") && req.method === "POST") return { status: 200, body: "{}" };
+    return json({});
+  });
+  return { http, calls };
+}
+
+function fakeGh(prUrl = "https://github.com/acme/widget/pull/7"): { run: ExecFileFn; argv: string[][] } {
+  const argv: string[][] = [];
+  const run: ExecFileFn = vi.fn(async (_file: string, args: string[]) => {
+    argv.push(args);
+    const json = (obj: unknown) => ({ stdout: JSON.stringify(obj), stderr: "" });
+    if (args[0] === "pr" && args[1] === "list") return json([]);
+    if (args[0] === "repo" && args[1] === "view") return json({ defaultBranchRef: { name: "main" } });
+    if (args[0] === "api") {
+      if (args.indexOf("--method") === -1) return json({ object: { sha: "basesha" } });
+      return { stdout: "", stderr: "" };
+    }
+    if (args[0] === "pr" && args[1] === "create") return { stdout: `${prUrl}\n`, stderr: "" };
+    return { stdout: "", stderr: "" };
+  });
+  return { run, argv };
+}
+
+function azureTrigger(config?: Partial<TrackerEventTriggerConfig>): TriggerRow {
+  const full: TrackerEventTriggerConfig = {
+    tracker: "azure",
+    azureOrg: "acme",
+    project: "Widget",
+    repo: "acme/widget",
+    targetRepoPath: "/repo/widget",
+    filter: { label: "agent" },
+    specStatus: "ready",
+    ...config,
+  };
+  return {
+    id: "trk-azure-1",
+    projectId: "proj-1",
+    pipelineId: null,
+    type: "tracker_event",
+    config: JSON.parse(JSON.stringify(full)) as TrackerEventTriggerConfig,
+    secretEncrypted: null,
+    enabled: true,
+    lastTriggeredAt: null,
+    suppressedCount: 0,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  } as unknown as TriggerRow;
+}
+
+function cfg(masterOn: boolean, trackerOn = true, pollIntervalSec = 300): () => AppConfig {
+  return () =>
+    ({ features: { triggers: { enabled: masterOn, tracker: { enabled: trackerOn, pollIntervalSec } } } }) as unknown as AppConfig;
+}
+
+interface HarnessOpts {
+  trigger: TriggerRow;
+  azure: AzureHttpFn;
+  gh: ExecFileFn;
+  masterOn?: boolean;
+  trackerOn?: boolean;
+  allowedRepoPaths?: () => string[];
+  synthesizer?: TicketSynthesizer;
+  logs?: string[];
+}
+
+function harness(opts: HarnessOpts) {
+  let stored = opts.trigger;
+  const updates: Array<Partial<TriggerRow>> = [];
+  const deps: AzureIssuesPollerDeps = {
+    getEnabledTriggersByType: async () => [stored],
+    runInProject: async (_pid, fn) => fn(),
+    getTrigger: async () => stored,
+    updateTrigger: async (_id, u) => {
+      updates.push(u);
+      if (u.config) stored = { ...stored, config: u.config } as TriggerRow;
+      return stored;
+    },
+    config: cfg(opts.masterOn ?? true, opts.trackerOn ?? true),
+    allowedRepoPaths: opts.allowedRepoPaths ?? (() => ["/repo/widget"]),
+    synthesizer: opts.synthesizer,
+    runGh: opts.gh,
+    azureHttp: opts.azure,
+    azureAuth: { pat: "secret-pat" },
+    gitRemoteUrl: async () => "https://github.com/acme/widget.git",
+    log: (m) => opts.logs?.push(m),
+    now: () => 0,
+  };
+  return { poller: new AzureIssuesPoller(deps), updates };
+}
+
+const SHAPED_WORKITEM = {
+  id: 42,
+  fields: {
+    "System.Title": "Add rate limiting",
+    "System.Description": "<p>## Acceptance Criteria</p><ul><li>returns 429 over 100 rpm</li><li>resets after window</li></ul>",
+    "System.Tags": "agent; backend",
+    "System.ChangedDate": "2026-01-02T10:00:00Z",
+  },
+};
+
+const count = (argv: string[][], pred: (a: string[]) => boolean) => argv.filter(pred).length;
+const isPrCreate = (a: string[]) => a[0] === "pr" && a[1] === "create";
+const putContents = (a: string[]) =>
+  a[0] === "api" && a.includes("PUT") && a.some((x) => x.startsWith("repos/acme/widget/contents/"));
+function decodePutContent(argv: string[][]): string {
+  const put = argv.find(putContents);
+  if (!put) return "";
+  const arg = put.find((x) => x.startsWith("content="));
+  return arg ? Buffer.from(arg.slice("content=".length), "base64").toString("utf8") : "";
+}
+const azurePosts = (calls: Array<{ method: string; url: string }>, needle: string) =>
+  calls.filter((c) => c.method === "POST" && c.url.includes(needle)).length;
+
+describe("AzureIssuesPoller.pollAll", () => {
+  it("tagged work item → spec PR (source.kind=azure,ref=id) + ONE Azure pickup comment + intake", async () => {
+    const { http, calls } = fakeAzure({ workItems: [{ id: 42 }], value: [SHAPED_WORKITEM] });
+    const { run, argv } = fakeGh();
+    const { poller, updates } = harness({ trigger: azureTrigger(), azure: http, gh: run });
+    await poller.pollAll();
+
+    const put = argv.find(putContents);
+    expect(put!.some((x) => x.includes("contents/docs/specs/azure-42-add-rate-limiting.md"))).toBe(true);
+    const spec = decodePutContent(argv);
+    expect(spec).toContain("kind: azure");
+    expect(spec).toContain('ref: "42"');
+
+    expect(count(argv, isPrCreate)).toBe(1);
+    expect(azurePosts(calls, "/comments")).toBe(1);
+
+    const last = updates[updates.length - 1].config as TrackerEventTriggerConfig;
+    expect(last.pollState?.intake?.["42"]?.specPrUrl).toBe("https://github.com/acme/widget/pull/7");
+  });
+
+  it("re-poll the same item → NO 2nd PR, NO 2nd comment (watermark dedup)", async () => {
+    const { http, calls } = fakeAzure({ workItems: [{ id: 42 }], value: [SHAPED_WORKITEM] });
+    const { run, argv } = fakeGh();
+    const { poller } = harness({ trigger: azureTrigger(), azure: http, gh: run });
+    await poller.pollAll();
+    await poller.pollAll();
+    expect(count(argv, isPrCreate)).toBe(1);
+    expect(azurePosts(calls, "/comments")).toBe(1);
+  });
+
+  it("untagged item → skipped (defence-in-depth)", async () => {
+    const untagged = { ...SHAPED_WORKITEM, id: 43, fields: { ...SHAPED_WORKITEM.fields, "System.Tags": "other" } };
+    const { http } = fakeAzure({ workItems: [{ id: 43 }], value: [untagged] });
+    const { run, argv } = fakeGh();
+    const { poller } = harness({ trigger: azureTrigger(), azure: http, gh: run });
+    await poller.pollAll();
+    expect(count(argv, isPrCreate)).toBe(0);
+  });
+
+  it("free-form item + synthesiser empty → need-criteria comment, NO PR, NO intake", async () => {
+    const freeForm = {
+      id: 44,
+      fields: { "System.Title": "vague", "System.Description": "<p>please make it better</p>", "System.Tags": "agent" },
+    };
+    const synthesizer: TicketSynthesizer = { synthesize: async () => ({ criteria: [] }) };
+    const { http, calls } = fakeAzure({ workItems: [{ id: 44 }], value: [freeForm] });
+    const { run, argv } = fakeGh();
+    const { poller, updates } = harness({ trigger: azureTrigger(), azure: http, gh: run, synthesizer });
+    await poller.pollAll();
+    expect(azurePosts(calls, "/comments")).toBe(1);
+    expect(count(argv, isPrCreate)).toBe(0);
+    const last = updates[updates.length - 1].config as TrackerEventTriggerConfig;
+    expect(last.pollState?.intake?.["44"]).toBeUndefined();
+  });
+
+  it("no filter.label → skipped (no Azure calls)", async () => {
+    const { http, calls } = fakeAzure({ workItems: [{ id: 42 }], value: [SHAPED_WORKITEM] });
+    const { run } = fakeGh();
+    const { poller, updates } = harness({ trigger: azureTrigger({ filter: {} }), azure: http, gh: run });
+    await poller.pollAll();
+    expect(calls.length).toBe(0);
+    expect(updates.length).toBe(0);
+  });
+
+  it("no azureOrg → skipped (no Azure calls)", async () => {
+    const { http, calls } = fakeAzure({ workItems: [{ id: 42 }], value: [SHAPED_WORKITEM] });
+    const { run } = fakeGh();
+    const { poller } = harness({ trigger: azureTrigger({ azureOrg: "" }), azure: http, gh: run });
+    await poller.pollAll();
+    expect(calls.length).toBe(0);
+  });
+
+  it("master switch off → no Azure calls at all", async () => {
+    const { http, calls } = fakeAzure({ workItems: [{ id: 42 }], value: [SHAPED_WORKITEM] });
+    const { run } = fakeGh();
+    const { poller } = harness({ trigger: azureTrigger(), azure: http, gh: run, masterOn: false });
+    await poller.pollAll();
+    expect(calls.length).toBe(0);
+  });
+
+  it("Azure WIQL outage → skip cycle, watermark untouched, no crash", async () => {
+    const { http } = fakeAzure({ wiqlStatus: 500 });
+    const { run } = fakeGh();
+    const { poller, updates } = harness({ trigger: azureTrigger(), azure: http, gh: run });
+    await expect(poller.pollAll()).resolves.toBeUndefined();
+    expect(updates.length).toBe(0);
+  });
+
+  it("targetRepoPath NOT in the allowlist → skipped fail-closed (no Azure, no gh)", async () => {
+    const { http, calls } = fakeAzure({ workItems: [{ id: 42 }], value: [SHAPED_WORKITEM] });
+    const { run, argv } = fakeGh();
+    const { poller } = harness({
+      trigger: azureTrigger(),
+      azure: http,
+      gh: run,
+      allowedRepoPaths: () => ["/some/other/repo"],
+    });
+    await poller.pollAll();
+    expect(calls.length).toBe(0);
+    expect(argv.length).toBe(0);
+  });
+});
+
+describe("AzureIssuesPoller.start gating", () => {
+  it("tracker disabled → start() builds no interval", () => {
+    vi.useFakeTimers();
+    try {
+      const { http } = fakeAzure({ workItems: [{ id: 42 }], value: [SHAPED_WORKITEM] });
+      const { run } = fakeGh();
+      const logs: string[] = [];
+      const { poller } = harness({ trigger: azureTrigger(), azure: http, gh: run, trackerOn: false, logs });
+      poller.start();
+      vi.advanceTimersByTime(10 * 60 * 1000);
+      expect(logs.some((l) => l.includes("disabled"))).toBe(true);
+      poller.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("tracker enabled → start() logs a started poller", () => {
+    vi.useFakeTimers();
+    try {
+      const { http } = fakeAzure({ workItems: [] });
+      const { run } = fakeGh();
+      const logs: string[] = [];
+      const { poller } = harness({ trigger: azureTrigger(), azure: http, gh: run, trackerOn: true, logs });
+      poller.start();
+      expect(logs.some((l) => l.includes("azure tracker poller started"))).toBe(true);
+      poller.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/unit/consilium/trackers/clickup-connector.test.ts
+++ b/tests/unit/consilium/trackers/clickup-connector.test.ts
@@ -1,0 +1,164 @@
+/**
+ * clickup-connector.test.ts — TRACK-5 ClickUp dialect with a FAKE ClickUp HTTP transport
+ * (no network). Covers: the tag rides as a `tags[]` query param set via URLSearchParams
+ * (a value cannot inject extra params); the ISO watermark is converted to epoch-ms
+ * `date_updated_gt`; watch/read mapping to normalised Tickets; idempotent comment
+ * write-back (marker dedup, no double-post, unreadable ⇒ no post); status PUT; and the
+ * deterministic `spec/clickup-<id>` naming.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  ClickUpTrackerConnector,
+  sanitizeClickUpId,
+  clickupSpecBranchName,
+  clickupSpecFilePath,
+  type ClickUpConnectorConfig,
+} from "../../../../server/services/consilium/trackers/clickup-connector.js";
+import { isValidSpecBranch } from "../../../../server/services/consilium/trackers/spec-writer.js";
+import type { ClickUpHttpFn, ClickUpHttpResult } from "../../../../server/services/consilium/trackers/clickup-exec.js";
+
+interface Call {
+  method: string;
+  url: string;
+  body?: string;
+}
+
+function fakeHttp(handler: (call: Call) => ClickUpHttpResult): { http: ClickUpHttpFn; calls: Call[] } {
+  const calls: Call[] = [];
+  const http: ClickUpHttpFn = vi.fn(async (req) => {
+    const call: Call = { method: req.method, url: req.url, body: req.body };
+    calls.push(call);
+    return handler(call);
+  });
+  return { http, calls };
+}
+
+const json = (obj: unknown, status = 200): ClickUpHttpResult => ({ status, body: JSON.stringify(obj) });
+
+const CFG: ClickUpConnectorConfig = { listId: "9001", tag: "agent" };
+
+function connector(cfg: Partial<ClickUpConnectorConfig>, handler: (c: Call) => ClickUpHttpResult) {
+  const { http, calls } = fakeHttp(handler);
+  const conn = new ClickUpTrackerConnector({ ...CFG, ...cfg }, {
+    http,
+    auth: { token: "pk_secret" },
+    log: () => {},
+  });
+  return { conn, calls };
+}
+
+const TASK = {
+  id: "abc123",
+  name: "Add rate limiting",
+  text_content: "## Acceptance Criteria\n- returns 429",
+  tags: [{ name: "agent" }, { name: "backend" }],
+  date_updated: "1767225600000",
+  url: "https://app.clickup.com/t/abc123",
+};
+
+describe("naming + id sanitisation", () => {
+  it("derives a shape-safe branch/path from the task id", () => {
+    expect(clickupSpecBranchName("abc123")).toBe("spec/clickup-abc123");
+    expect(isValidSpecBranch(clickupSpecBranchName("abc123"))).toBe(true);
+    expect(clickupSpecFilePath("abc123", "Add Rate Limiting!")).toBe(
+      "docs/specs/clickup-abc123-add-rate-limiting.md",
+    );
+  });
+  it("strips separators / leading dash / traversal from a hostile id", () => {
+    expect(sanitizeClickUpId("a/b\\c")).toBe("abc");
+    expect(sanitizeClickUpId("-abc")).toBe("abc");
+  });
+  it("throws on an id that sanitises to empty", () => {
+    expect(() => clickupSpecBranchName("//")).toThrow();
+  });
+});
+
+describe("pollTickets — tag param + watermark", () => {
+  it("sets the tag as a tags[] query param and converts the ISO watermark to epoch ms", async () => {
+    let seenUrl = "";
+    const { conn } = connector({}, (c) => {
+      if (c.url.includes("/task")) {
+        seenUrl = c.url;
+        return json({ tasks: [] });
+      }
+      return json({});
+    });
+    await conn.pollTickets("2026-01-01T00:00:00.000Z");
+    const u = new URL(seenUrl);
+    expect(u.searchParams.get("tags[]")).toBe("agent");
+    expect(u.searchParams.get("date_updated_gt")).toBe(String(Date.parse("2026-01-01T00:00:00.000Z")));
+    expect(u.pathname).toContain("/list/9001/task");
+  });
+
+  it("maps tasks to normalised tickets", async () => {
+    const { conn } = connector({}, (c) => (c.url.includes("/task") ? json({ tasks: [TASK] }) : json({})));
+    const tickets = await conn.pollTickets();
+    expect(tickets).toHaveLength(1);
+    expect(tickets![0]).toMatchObject({
+      id: "abc123",
+      title: "Add rate limiting",
+      body: "## Acceptance Criteria\n- returns 429",
+      labels: ["agent", "backend"],
+      url: "https://app.clickup.com/t/abc123",
+    });
+  });
+
+  it("returns null on a degraded list (HTTP 500) and when auth is unconfigured", async () => {
+    const { conn } = connector({}, () => ({ status: 500, body: "boom" }));
+    expect(await conn.pollTickets()).toBeNull();
+
+    const { http } = fakeHttp(() => json({ tasks: [TASK] }));
+    const noAuth = new ClickUpTrackerConnector(CFG, { http, auth: null, log: () => {} });
+    expect(await noAuth.pollTickets()).toBeNull();
+  });
+
+  it("readTicket fetches one task by id", async () => {
+    const { conn, calls } = connector({}, (c) => (c.url.includes("/task/abc123") ? json(TASK) : json({})));
+    const t = await conn.readTicket("abc123");
+    expect(t?.id).toBe("abc123");
+    expect(calls.some((c) => c.method === "GET" && c.url.includes("/task/abc123"))).toBe(true);
+  });
+});
+
+describe("write-back — comment idempotency + status", () => {
+  it("posts a comment when the marker is absent", async () => {
+    const { conn, calls } = connector({}, (c) => {
+      if (c.method === "GET" && c.url.includes("/comment")) return json({ comments: [] });
+      if (c.method === "POST" && c.url.includes("/comment")) return { status: 200, body: "{}" };
+      return json({});
+    });
+    const res = await conn.writeback.comment("abc123", "picked up", "<!-- marker -->");
+    expect(res.posted).toBe(true);
+    const post = calls.find((c) => c.method === "POST" && c.url.includes("/comment"));
+    expect(post!.body).toContain("<!-- marker -->");
+    expect(post!.body).toContain("picked up");
+  });
+
+  it("does NOT double-post when a comment already carries the marker", async () => {
+    const { conn, calls } = connector({}, (c) =>
+      c.method === "GET" && c.url.includes("/comment")
+        ? json({ comments: [{ comment_text: "<!-- marker -->\nearlier" }] })
+        : json({}),
+    );
+    const res = await conn.writeback.comment("abc123", "x", "<!-- marker -->");
+    expect(res.posted).toBe(false);
+    expect(calls.some((c) => c.method === "POST")).toBe(false);
+  });
+
+  it("does NOT post when comments are unreadable (safety over liveness)", async () => {
+    const { conn, calls } = connector({}, (c) =>
+      c.method === "GET" && c.url.includes("/comment") ? { status: 503, body: "" } : json({}),
+    );
+    const res = await conn.writeback.comment("abc123", "x", "<!-- m -->");
+    expect(res.posted).toBe(false);
+    expect(calls.some((c) => c.method === "POST")).toBe(false);
+  });
+
+  it("sets task status via PUT", async () => {
+    const { conn, calls } = connector({}, (c) => (c.method === "PUT" ? { status: 200, body: "{}" } : json({})));
+    const res = await conn.writeback.transition!("abc123", "in progress");
+    expect(res.posted).toBe(true);
+    const put = calls.find((c) => c.method === "PUT" && c.url.includes("/task/abc123"));
+    expect(put!.body).toContain("in progress");
+  });
+});

--- a/tests/unit/consilium/trackers/clickup-issues-poller.test.ts
+++ b/tests/unit/consilium/trackers/clickup-issues-poller.test.ts
@@ -1,0 +1,280 @@
+/**
+ * clickup-issues-poller.test.ts — TRACK-5 poller with a FAKE ClickUp HTTP transport + FAKE
+ * `gh`. Mirrors jira-issues-poller.test: a tagged task → the SHARED synth → a spec PR
+ * (docs/specs/clickup-<id>-… whose frontmatter carries source.kind=clickup,ref=<id>) +
+ * exactly ONE ClickUp pickup comment + a watermark intake; re-poll dedup; an untagged task
+ * skipped; a free-form task with no criteria → need-criteria comment + NO PR + NO intake;
+ * no filter.label / no clickupListId ⇒ skipped; master switch off ⇒ no calls; a list outage
+ * skips the cycle (watermark untouched); a non-allowlisted targetRepoPath skips.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  ClickUpIssuesPoller,
+  type ClickUpIssuesPollerDeps,
+} from "../../../../server/services/consilium/trackers/clickup-issues-poller.js";
+import type { TicketSynthesizer } from "../../../../server/services/consilium/trackers/jira-issues-poller.js";
+import type { ClickUpHttpFn, ClickUpHttpResult } from "../../../../server/services/consilium/trackers/clickup-exec.js";
+import type { ExecFileFn } from "../../../../server/services/github-status.js";
+import type { TriggerRow } from "../../../../shared/schema.js";
+import type { AppConfig, TrackerEventTriggerConfig } from "../../../../shared/types.js";
+
+interface ClickUpOpts {
+  tasks?: unknown[];
+  comments?: Array<{ comment_text?: string }>;
+  listStatus?: number;
+}
+
+function fakeClickUp(opts: ClickUpOpts): { http: ClickUpHttpFn; calls: Array<{ method: string; url: string; body?: string }> } {
+  const calls: Array<{ method: string; url: string; body?: string }> = [];
+  const http: ClickUpHttpFn = vi.fn(async (req): Promise<ClickUpHttpResult> => {
+    calls.push({ method: req.method, url: req.url, body: req.body });
+    const json = (obj: unknown, status = 200): ClickUpHttpResult => ({ status, body: JSON.stringify(obj) });
+    if (req.url.includes("/comment") && req.method === "GET") return json({ comments: opts.comments ?? [] });
+    if (req.url.includes("/comment") && req.method === "POST") return { status: 200, body: "{}" };
+    if (req.url.includes("/task/") && req.method === "PUT") return { status: 200, body: "{}" };
+    if (req.url.includes("/task") && req.method === "GET") {
+      if (opts.listStatus && opts.listStatus >= 400) return { status: opts.listStatus, body: "err" };
+      return json({ tasks: opts.tasks ?? [] });
+    }
+    return json({});
+  });
+  return { http, calls };
+}
+
+function fakeGh(prUrl = "https://github.com/acme/widget/pull/7"): { run: ExecFileFn; argv: string[][] } {
+  const argv: string[][] = [];
+  const run: ExecFileFn = vi.fn(async (_file: string, args: string[]) => {
+    argv.push(args);
+    const json = (obj: unknown) => ({ stdout: JSON.stringify(obj), stderr: "" });
+    if (args[0] === "pr" && args[1] === "list") return json([]);
+    if (args[0] === "repo" && args[1] === "view") return json({ defaultBranchRef: { name: "main" } });
+    if (args[0] === "api") {
+      if (args.indexOf("--method") === -1) return json({ object: { sha: "basesha" } });
+      return { stdout: "", stderr: "" };
+    }
+    if (args[0] === "pr" && args[1] === "create") return { stdout: `${prUrl}\n`, stderr: "" };
+    return { stdout: "", stderr: "" };
+  });
+  return { run, argv };
+}
+
+function clickupTrigger(config?: Partial<TrackerEventTriggerConfig>): TriggerRow {
+  const full: TrackerEventTriggerConfig = {
+    tracker: "clickup",
+    clickupListId: "9001",
+    repo: "acme/widget",
+    targetRepoPath: "/repo/widget",
+    filter: { label: "agent" },
+    specStatus: "ready",
+    ...config,
+  };
+  return {
+    id: "trk-clickup-1",
+    projectId: "proj-1",
+    pipelineId: null,
+    type: "tracker_event",
+    config: JSON.parse(JSON.stringify(full)) as TrackerEventTriggerConfig,
+    secretEncrypted: null,
+    enabled: true,
+    lastTriggeredAt: null,
+    suppressedCount: 0,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  } as unknown as TriggerRow;
+}
+
+function cfg(masterOn: boolean, trackerOn = true, pollIntervalSec = 300): () => AppConfig {
+  return () =>
+    ({ features: { triggers: { enabled: masterOn, tracker: { enabled: trackerOn, pollIntervalSec } } } }) as unknown as AppConfig;
+}
+
+interface HarnessOpts {
+  trigger: TriggerRow;
+  clickup: ClickUpHttpFn;
+  gh: ExecFileFn;
+  masterOn?: boolean;
+  trackerOn?: boolean;
+  allowedRepoPaths?: () => string[];
+  synthesizer?: TicketSynthesizer;
+  logs?: string[];
+}
+
+function harness(opts: HarnessOpts) {
+  let stored = opts.trigger;
+  const updates: Array<Partial<TriggerRow>> = [];
+  const deps: ClickUpIssuesPollerDeps = {
+    getEnabledTriggersByType: async () => [stored],
+    runInProject: async (_pid, fn) => fn(),
+    getTrigger: async () => stored,
+    updateTrigger: async (_id, u) => {
+      updates.push(u);
+      if (u.config) stored = { ...stored, config: u.config } as TriggerRow;
+      return stored;
+    },
+    config: cfg(opts.masterOn ?? true, opts.trackerOn ?? true),
+    allowedRepoPaths: opts.allowedRepoPaths ?? (() => ["/repo/widget"]),
+    synthesizer: opts.synthesizer,
+    runGh: opts.gh,
+    clickupHttp: opts.clickup,
+    clickupAuth: { token: "pk_secret" },
+    gitRemoteUrl: async () => "https://github.com/acme/widget.git",
+    log: (m) => opts.logs?.push(m),
+    now: () => 0,
+  };
+  return { poller: new ClickUpIssuesPoller(deps), updates };
+}
+
+const SHAPED_TASK = {
+  id: "abc123",
+  name: "Add rate limiting",
+  text_content: "## Problem\nNo limit.\n\n## Acceptance Criteria\n- returns 429 over 100 rpm\n- resets after window",
+  tags: [{ name: "agent" }],
+  date_updated: "1767225600000",
+  url: "https://app.clickup.com/t/abc123",
+};
+
+const count = (argv: string[][], pred: (a: string[]) => boolean) => argv.filter(pred).length;
+const isPrCreate = (a: string[]) => a[0] === "pr" && a[1] === "create";
+const putContents = (a: string[]) =>
+  a[0] === "api" && a.includes("PUT") && a.some((x) => x.startsWith("repos/acme/widget/contents/"));
+function decodePutContent(argv: string[][]): string {
+  const put = argv.find(putContents);
+  if (!put) return "";
+  const arg = put.find((x) => x.startsWith("content="));
+  return arg ? Buffer.from(arg.slice("content=".length), "base64").toString("utf8") : "";
+}
+const clickupCommentPosts = (calls: Array<{ method: string; url: string }>) =>
+  calls.filter((c) => c.method === "POST" && c.url.includes("/comment")).length;
+
+describe("ClickUpIssuesPoller.pollAll", () => {
+  it("tagged task → spec PR (source.kind=clickup,ref=id) + ONE ClickUp pickup comment + intake", async () => {
+    const { http, calls } = fakeClickUp({ tasks: [SHAPED_TASK] });
+    const { run, argv } = fakeGh();
+    const { poller, updates } = harness({ trigger: clickupTrigger(), clickup: http, gh: run });
+    await poller.pollAll();
+
+    const put = argv.find(putContents);
+    expect(put!.some((x) => x.includes("contents/docs/specs/clickup-abc123-add-rate-limiting.md"))).toBe(true);
+    const spec = decodePutContent(argv);
+    expect(spec).toContain("kind: clickup");
+    expect(spec).toContain('ref: "abc123"');
+
+    expect(count(argv, isPrCreate)).toBe(1);
+    expect(clickupCommentPosts(calls)).toBe(1);
+
+    const last = updates[updates.length - 1].config as TrackerEventTriggerConfig;
+    expect(last.pollState?.intake?.["abc123"]?.specPrUrl).toBe("https://github.com/acme/widget/pull/7");
+  });
+
+  it("re-poll the same task → NO 2nd PR, NO 2nd comment (watermark dedup)", async () => {
+    const { http, calls } = fakeClickUp({ tasks: [SHAPED_TASK] });
+    const { run, argv } = fakeGh();
+    const { poller } = harness({ trigger: clickupTrigger(), clickup: http, gh: run });
+    await poller.pollAll();
+    await poller.pollAll();
+    expect(count(argv, isPrCreate)).toBe(1);
+    expect(clickupCommentPosts(calls)).toBe(1);
+  });
+
+  it("untagged task → skipped (defence-in-depth)", async () => {
+    const untagged = { ...SHAPED_TASK, id: "def456", tags: [{ name: "other" }] };
+    const { http } = fakeClickUp({ tasks: [untagged] });
+    const { run, argv } = fakeGh();
+    const { poller } = harness({ trigger: clickupTrigger(), clickup: http, gh: run });
+    await poller.pollAll();
+    expect(count(argv, isPrCreate)).toBe(0);
+  });
+
+  it("free-form task + synthesiser empty → need-criteria comment, NO PR, NO intake", async () => {
+    const freeForm = { id: "ghi789", name: "vague", text_content: "please make it better", tags: [{ name: "agent" }] };
+    const synthesizer: TicketSynthesizer = { synthesize: async () => ({ criteria: [] }) };
+    const { http, calls } = fakeClickUp({ tasks: [freeForm] });
+    const { run, argv } = fakeGh();
+    const { poller, updates } = harness({ trigger: clickupTrigger(), clickup: http, gh: run, synthesizer });
+    await poller.pollAll();
+    expect(clickupCommentPosts(calls)).toBe(1);
+    expect(count(argv, isPrCreate)).toBe(0);
+    const last = updates[updates.length - 1].config as TrackerEventTriggerConfig;
+    expect(last.pollState?.intake?.["ghi789"]).toBeUndefined();
+  });
+
+  it("no filter.label → skipped (no ClickUp calls)", async () => {
+    const { http, calls } = fakeClickUp({ tasks: [SHAPED_TASK] });
+    const { run } = fakeGh();
+    const { poller, updates } = harness({ trigger: clickupTrigger({ filter: {} }), clickup: http, gh: run });
+    await poller.pollAll();
+    expect(calls.length).toBe(0);
+    expect(updates.length).toBe(0);
+  });
+
+  it("no clickupListId → skipped (no ClickUp calls)", async () => {
+    const { http, calls } = fakeClickUp({ tasks: [SHAPED_TASK] });
+    const { run } = fakeGh();
+    const { poller } = harness({ trigger: clickupTrigger({ clickupListId: "" }), clickup: http, gh: run });
+    await poller.pollAll();
+    expect(calls.length).toBe(0);
+  });
+
+  it("master switch off → no ClickUp calls at all", async () => {
+    const { http, calls } = fakeClickUp({ tasks: [SHAPED_TASK] });
+    const { run } = fakeGh();
+    const { poller } = harness({ trigger: clickupTrigger(), clickup: http, gh: run, masterOn: false });
+    await poller.pollAll();
+    expect(calls.length).toBe(0);
+  });
+
+  it("ClickUp list outage → skip cycle, watermark untouched, no crash", async () => {
+    const { http } = fakeClickUp({ listStatus: 500 });
+    const { run } = fakeGh();
+    const { poller, updates } = harness({ trigger: clickupTrigger(), clickup: http, gh: run });
+    await expect(poller.pollAll()).resolves.toBeUndefined();
+    expect(updates.length).toBe(0);
+  });
+
+  it("targetRepoPath NOT in the allowlist → skipped fail-closed (no ClickUp, no gh)", async () => {
+    const { http, calls } = fakeClickUp({ tasks: [SHAPED_TASK] });
+    const { run, argv } = fakeGh();
+    const { poller } = harness({
+      trigger: clickupTrigger(),
+      clickup: http,
+      gh: run,
+      allowedRepoPaths: () => ["/some/other/repo"],
+    });
+    await poller.pollAll();
+    expect(calls.length).toBe(0);
+    expect(argv.length).toBe(0);
+  });
+});
+
+describe("ClickUpIssuesPoller.start gating", () => {
+  it("tracker disabled → start() builds no interval", () => {
+    vi.useFakeTimers();
+    try {
+      const { http } = fakeClickUp({ tasks: [SHAPED_TASK] });
+      const { run } = fakeGh();
+      const logs: string[] = [];
+      const { poller } = harness({ trigger: clickupTrigger(), clickup: http, gh: run, trackerOn: false, logs });
+      poller.start();
+      vi.advanceTimersByTime(10 * 60 * 1000);
+      expect(logs.some((l) => l.includes("disabled"))).toBe(true);
+      poller.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("tracker enabled → start() logs a started poller", () => {
+    vi.useFakeTimers();
+    try {
+      const { http } = fakeClickUp({ tasks: [] });
+      const { run } = fakeGh();
+      const logs: string[] = [];
+      const { poller } = harness({ trigger: clickupTrigger(), clickup: http, gh: run, trackerOn: true, logs });
+      poller.start();
+      expect(logs.some((l) => l.includes("clickup tracker poller started"))).toBe(true);
+      poller.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/unit/consilium/trackers/linear-connector.test.ts
+++ b/tests/unit/consilium/trackers/linear-connector.test.ts
@@ -1,0 +1,203 @@
+/**
+ * linear-connector.test.ts — TRACK-5 Linear dialect with a FAKE Linear GraphQL transport
+ * (no network). Covers: the query is STATIC + all runtime values travel as GraphQL
+ * variables (injection-proof — a hostile label lands in `variables`, never in the query
+ * text); watch/read mapping to the normalised Ticket; idempotent comment write-back (marker
+ * dedup via the issue's existing comments, no double-post; unreadable ⇒ no post); state
+ * transition name→id resolution; a GraphQL `errors` payload degrades to null; and the
+ * deterministic `spec/linear-<ID>` naming.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  LinearTrackerConnector,
+  sanitizeIdentifier,
+  linearSpecBranchName,
+  linearSpecFilePath,
+  type LinearConnectorConfig,
+} from "../../../../server/services/consilium/trackers/linear-connector.js";
+import { isValidSpecBranch } from "../../../../server/services/consilium/trackers/spec-writer.js";
+import type { LinearHttpFn, LinearHttpResult } from "../../../../server/services/consilium/trackers/linear-exec.js";
+
+interface Call {
+  method: string;
+  url: string;
+  body?: string;
+}
+
+function fakeHttp(handler: (parsed: { query: string; variables: Record<string, unknown> }) => LinearHttpResult): {
+  http: LinearHttpFn;
+  calls: Array<Call & { query: string; variables: Record<string, unknown> }>;
+} {
+  const calls: Array<Call & { query: string; variables: Record<string, unknown> }> = [];
+  const http: LinearHttpFn = vi.fn(async (req) => {
+    const parsed = JSON.parse(req.body ?? "{}") as { query: string; variables: Record<string, unknown> };
+    calls.push({ method: req.method, url: req.url, body: req.body, ...parsed });
+    return handler(parsed);
+  });
+  return { http, calls };
+}
+
+const json = (obj: unknown, status = 200): LinearHttpResult => ({ status, body: JSON.stringify(obj) });
+
+const CFG: LinearConnectorConfig = { label: "agent" };
+
+function connector(cfg: Partial<LinearConnectorConfig>, handler: Parameters<typeof fakeHttp>[0]) {
+  const { http, calls } = fakeHttp(handler);
+  const conn = new LinearTrackerConnector({ ...CFG, ...cfg }, {
+    http,
+    auth: { token: "lin_api_secret" },
+    log: () => {},
+  });
+  return { conn, calls };
+}
+
+const ISSUE_NODE = {
+  id: "uuid-1",
+  identifier: "ENG-7",
+  title: "Add rate limiting",
+  description: "## Acceptance Criteria\n- returns 429",
+  labels: { nodes: [{ name: "agent" }, { name: "backend" }] },
+  updatedAt: "2026-01-02T10:00:00.000Z",
+  url: "https://linear.app/acme/issue/ENG-7",
+};
+
+describe("naming + identifier sanitisation", () => {
+  it("derives a shape-safe branch/path from the Linear identifier", () => {
+    expect(linearSpecBranchName("ENG-123")).toBe("spec/linear-ENG-123");
+    expect(isValidSpecBranch(linearSpecBranchName("ENG-123"))).toBe(true);
+    expect(linearSpecFilePath("ENG-123", "Add Rate Limiting!")).toBe(
+      "docs/specs/linear-ENG-123-add-rate-limiting.md",
+    );
+  });
+
+  it("strips path separators / leading dashes / traversal so a hostile id can never escape", () => {
+    expect(sanitizeIdentifier("../../etc/passwd")).toBe("etcpasswd");
+    expect(sanitizeIdentifier("-ENG/../x")).toBe("ENG.x");
+    expect(isValidSpecBranch(linearSpecBranchName("ENG-9"))).toBe(true);
+  });
+
+  it("throws on an identifier that sanitises to empty", () => {
+    expect(() => linearSpecBranchName("///")).toThrow();
+  });
+});
+
+describe("pollTickets — injection-proof (variables, not interpolation)", () => {
+  it("passes a hostile label as a GraphQL variable, never into the query text", async () => {
+    let seen: { query: string; variables: Record<string, unknown> } | null = null;
+    const { conn } = connector({ label: 'agent") { evil }' }, (p) => {
+      seen = p;
+      return json({ data: { issues: { nodes: [] } } });
+    });
+    await conn.pollTickets("2026-01-01T00:00:00.000Z");
+    expect(seen).toBeTruthy();
+    // The query is static — the hostile label text is NOT in it.
+    expect(seen!.query).not.toContain("evil");
+    // The label rode in as a variable (control chars stripped, quotes preserved as data).
+    const filter = seen!.variables.filter as { labels: { name: { eq: string } }; updatedAt?: { gt: string } };
+    expect(filter.labels.name.eq).toContain("evil");
+    expect(filter.updatedAt?.gt).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("scopes to a team when teamId is configured", async () => {
+    let seen: { variables: Record<string, unknown> } | null = null;
+    const { conn } = connector({ teamId: "team-123" }, (p) => {
+      seen = p;
+      return json({ data: { issues: { nodes: [] } } });
+    });
+    await conn.pollTickets();
+    const filter = seen!.variables.filter as { team?: { id: { eq: string } } };
+    expect(filter.team?.id.eq).toBe("team-123");
+  });
+});
+
+describe("pollTickets / readTicket mapping", () => {
+  it("maps GraphQL issue nodes to normalised tickets", async () => {
+    const { conn } = connector({}, () => json({ data: { issues: { nodes: [ISSUE_NODE] } } }));
+    const tickets = await conn.pollTickets();
+    expect(tickets).toHaveLength(1);
+    expect(tickets![0]).toMatchObject({
+      id: "ENG-7",
+      title: "Add rate limiting",
+      body: "## Acceptance Criteria\n- returns 429",
+      labels: ["agent", "backend"],
+      url: "https://linear.app/acme/issue/ENG-7",
+    });
+  });
+
+  it("returns null on a GraphQL errors payload (HTTP 200 but errors)", async () => {
+    const { conn } = connector({}, () => json({ errors: [{ message: "nope" }] }));
+    expect(await conn.pollTickets()).toBeNull();
+  });
+
+  it("returns null when auth is unconfigured (fail-closed)", async () => {
+    const { http } = fakeHttp(() => json({ data: { issues: { nodes: [ISSUE_NODE] } } }));
+    const conn = new LinearTrackerConnector(CFG, { http, auth: null, log: () => {} });
+    expect(await conn.pollTickets()).toBeNull();
+  });
+
+  it("readTicket fetches one issue by identifier", async () => {
+    const { conn, calls } = connector({}, () => json({ data: { issue: ISSUE_NODE } }));
+    const t = await conn.readTicket("ENG-7");
+    expect(t?.id).toBe("ENG-7");
+    expect(calls[0].variables.id).toBe("ENG-7");
+  });
+});
+
+describe("write-back — comment idempotency + transition", () => {
+  it("posts a comment when the marker is absent (resolves uuid + no existing marker)", async () => {
+    const { conn, calls } = connector({}, (p) => {
+      if (p.query.includes("comments(")) {
+        return json({ data: { issue: { id: "uuid-1", comments: { nodes: [] }, team: { states: { nodes: [] } } } } });
+      }
+      if (p.query.includes("commentCreate")) return json({ data: { commentCreate: { success: true } } });
+      return json({ data: {} });
+    });
+    const res = await conn.writeback.comment("ENG-7", "picked up", "<!-- marker -->");
+    expect(res.posted).toBe(true);
+    const mutation = calls.find((c) => c.query.includes("commentCreate"));
+    expect(mutation).toBeTruthy();
+    expect(mutation!.variables.issueId).toBe("uuid-1");
+    expect(String(mutation!.variables.body)).toContain("<!-- marker -->");
+    expect(String(mutation!.variables.body)).toContain("picked up");
+  });
+
+  it("does NOT double-post when a comment already carries the marker", async () => {
+    const { conn, calls } = connector({}, (p) => {
+      if (p.query.includes("comments(")) {
+        return json({
+          data: { issue: { id: "uuid-1", comments: { nodes: [{ body: "<!-- marker -->\nearlier" }] } } },
+        });
+      }
+      return json({ data: {} });
+    });
+    const res = await conn.writeback.comment("ENG-7", "picked up", "<!-- marker -->");
+    expect(res.posted).toBe(false);
+    expect(calls.some((c) => c.query.includes("commentCreate"))).toBe(false);
+  });
+
+  it("does NOT post when the issue is unreadable (safety over liveness)", async () => {
+    const { conn, calls } = connector({}, () => json({ errors: [{ message: "boom" }] }));
+    const res = await conn.writeback.comment("ENG-7", "x", "<!-- m -->");
+    expect(res.posted).toBe(false);
+    expect(calls.some((c) => c.query.includes("commentCreate"))).toBe(false);
+  });
+
+  it("resolves a workflow state by name and issueUpdates it; unknown → no-op", async () => {
+    const states = { nodes: [{ id: "state-31", name: "In Progress" }] };
+    const { conn, calls } = connector({}, (p) => {
+      if (p.query.includes("comments(")) {
+        return json({ data: { issue: { id: "uuid-1", comments: { nodes: [] }, team: { states } } } });
+      }
+      if (p.query.includes("issueUpdate")) return json({ data: { issueUpdate: { success: true } } });
+      return json({ data: {} });
+    });
+    const ok = await conn.writeback.transition!("ENG-7", "in progress");
+    expect(ok.posted).toBe(true);
+    const mut = calls.find((c) => c.query.includes("issueUpdate"));
+    expect(mut!.variables.stateId).toBe("state-31");
+
+    const miss = await conn.writeback.transition!("ENG-7", "Done");
+    expect(miss.posted).toBe(false);
+    expect(miss.reason).toBe("no-such-state");
+  });
+});

--- a/tests/unit/consilium/trackers/linear-issues-poller.test.ts
+++ b/tests/unit/consilium/trackers/linear-issues-poller.test.ts
@@ -1,0 +1,283 @@
+/**
+ * linear-issues-poller.test.ts — TRACK-5 poller with a FAKE Linear GraphQL transport +
+ * FAKE `gh`. Mirrors jira-issues-poller.test: a labelled issue → the SHARED synth → a spec
+ * PR (docs/specs/linear-<ID>-… whose frontmatter carries source.kind=linear,ref=<ID>) +
+ * exactly ONE Linear pickup comment + a watermark intake; a re-poll dedups; an unlabelled
+ * issue is skipped; a free-form issue with no criteria gets a need-criteria comment + NO PR
+ * + NO intake; the master switch off ⇒ no Linear calls; the tracker switch off ⇒ no
+ * interval; a Linear outage on the poll skips the cycle (watermark untouched); a
+ * non-allowlisted targetRepoPath is skipped fail-closed.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  LinearIssuesPoller,
+  type LinearIssuesPollerDeps,
+} from "../../../../server/services/consilium/trackers/linear-issues-poller.js";
+import type { TicketSynthesizer } from "../../../../server/services/consilium/trackers/jira-issues-poller.js";
+import type { LinearHttpFn, LinearHttpResult } from "../../../../server/services/consilium/trackers/linear-exec.js";
+import type { ExecFileFn } from "../../../../server/services/github-status.js";
+import type { TriggerRow } from "../../../../shared/schema.js";
+import type { AppConfig, TrackerEventTriggerConfig } from "../../../../shared/types.js";
+
+interface LinearOpts {
+  nodes?: unknown[];
+  pollErrors?: boolean;
+  commentsNodes?: Array<{ body?: string }>;
+}
+
+function fakeLinear(opts: LinearOpts): { http: LinearHttpFn; queries: string[] } {
+  const queries: string[] = [];
+  const http: LinearHttpFn = vi.fn(async (req): Promise<LinearHttpResult> => {
+    const { query } = JSON.parse(req.body ?? "{}") as { query: string };
+    queries.push(query);
+    const json = (obj: unknown, status = 200): LinearHttpResult => ({ status, body: JSON.stringify(obj) });
+    if (query.includes("issues(")) {
+      if (opts.pollErrors) return json({ errors: [{ message: "boom" }] });
+      return json({ data: { issues: { nodes: opts.nodes ?? [] } } });
+    }
+    if (query.includes("comments(")) {
+      return json({
+        data: { issue: { id: "uuid-1", comments: { nodes: opts.commentsNodes ?? [] }, team: { states: { nodes: [] } } } },
+      });
+    }
+    if (query.includes("commentCreate")) return json({ data: { commentCreate: { success: true } } });
+    if (query.includes("issueUpdate")) return json({ data: { issueUpdate: { success: true } } });
+    return json({ data: {} });
+  });
+  return { http, queries };
+}
+
+function fakeGh(prUrl = "https://github.com/acme/widget/pull/7"): { run: ExecFileFn; argv: string[][] } {
+  const argv: string[][] = [];
+  const run: ExecFileFn = vi.fn(async (_file: string, args: string[]) => {
+    argv.push(args);
+    const json = (obj: unknown) => ({ stdout: JSON.stringify(obj), stderr: "" });
+    if (args[0] === "pr" && args[1] === "list") return json([]);
+    if (args[0] === "repo" && args[1] === "view") return json({ defaultBranchRef: { name: "main" } });
+    if (args[0] === "api") {
+      if (args.indexOf("--method") === -1) return json({ object: { sha: "basesha" } });
+      return { stdout: "", stderr: "" };
+    }
+    if (args[0] === "pr" && args[1] === "create") return { stdout: `${prUrl}\n`, stderr: "" };
+    return { stdout: "", stderr: "" };
+  });
+  return { run, argv };
+}
+
+function linearTrigger(config?: Partial<TrackerEventTriggerConfig>): TriggerRow {
+  const full: TrackerEventTriggerConfig = {
+    tracker: "linear",
+    repo: "acme/widget",
+    targetRepoPath: "/repo/widget",
+    filter: { label: "agent" },
+    specStatus: "ready",
+    ...config,
+  };
+  return {
+    id: "trk-linear-1",
+    projectId: "proj-1",
+    pipelineId: null,
+    type: "tracker_event",
+    config: JSON.parse(JSON.stringify(full)) as TrackerEventTriggerConfig,
+    secretEncrypted: null,
+    enabled: true,
+    lastTriggeredAt: null,
+    suppressedCount: 0,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  } as unknown as TriggerRow;
+}
+
+function cfg(masterOn: boolean, trackerOn = true, pollIntervalSec = 300): () => AppConfig {
+  return () =>
+    ({ features: { triggers: { enabled: masterOn, tracker: { enabled: trackerOn, pollIntervalSec } } } }) as unknown as AppConfig;
+}
+
+interface HarnessOpts {
+  trigger: TriggerRow;
+  linear: LinearHttpFn;
+  gh: ExecFileFn;
+  masterOn?: boolean;
+  trackerOn?: boolean;
+  allowedRepoPaths?: () => string[];
+  synthesizer?: TicketSynthesizer;
+  logs?: string[];
+}
+
+function harness(opts: HarnessOpts) {
+  let stored = opts.trigger;
+  const updates: Array<Partial<TriggerRow>> = [];
+  const deps: LinearIssuesPollerDeps = {
+    getEnabledTriggersByType: async () => [stored],
+    runInProject: async (_pid, fn) => fn(),
+    getTrigger: async () => stored,
+    updateTrigger: async (_id, u) => {
+      updates.push(u);
+      if (u.config) stored = { ...stored, config: u.config } as TriggerRow;
+      return stored;
+    },
+    config: cfg(opts.masterOn ?? true, opts.trackerOn ?? true),
+    allowedRepoPaths: opts.allowedRepoPaths ?? (() => ["/repo/widget"]),
+    synthesizer: opts.synthesizer,
+    runGh: opts.gh,
+    linearHttp: opts.linear,
+    linearAuth: { token: "lin_api_secret" },
+    gitRemoteUrl: async () => "https://github.com/acme/widget.git",
+    log: (m) => opts.logs?.push(m),
+    now: () => 0,
+  };
+  return { poller: new LinearIssuesPoller(deps), updates };
+}
+
+const SHAPED_NODE = {
+  id: "uuid-1",
+  identifier: "LIN-1",
+  title: "Add rate limiting",
+  description: "## Problem\nNo limit.\n\n## Acceptance Criteria\n- returns 429 over 100 rpm\n- resets after window",
+  labels: { nodes: [{ name: "agent" }] },
+  updatedAt: "2026-01-02T10:00:00.000Z",
+  url: "https://linear.app/acme/issue/LIN-1",
+};
+
+const count = (argv: string[][], pred: (a: string[]) => boolean) => argv.filter(pred).length;
+const isPrCreate = (a: string[]) => a[0] === "pr" && a[1] === "create";
+const putContents = (a: string[]) =>
+  a[0] === "api" && a.includes("PUT") && a.some((x) => x.startsWith("repos/acme/widget/contents/"));
+function decodePutContent(argv: string[][]): string {
+  const put = argv.find(putContents);
+  if (!put) return "";
+  const arg = put.find((x) => x.startsWith("content="));
+  return arg ? Buffer.from(arg.slice("content=".length), "base64").toString("utf8") : "";
+}
+const commentCreates = (queries: string[]) => queries.filter((q) => q.includes("commentCreate")).length;
+
+describe("LinearIssuesPoller.pollAll", () => {
+  it("labelled issue → spec PR (source.kind=linear,ref=ID) + ONE Linear pickup comment + intake", async () => {
+    const { http, queries } = fakeLinear({ nodes: [SHAPED_NODE] });
+    const { run, argv } = fakeGh();
+    const { poller, updates } = harness({ trigger: linearTrigger(), linear: http, gh: run });
+    await poller.pollAll();
+
+    const put = argv.find(putContents);
+    expect(put!.some((x) => x.includes("contents/docs/specs/linear-LIN-1-add-rate-limiting.md"))).toBe(true);
+    const spec = decodePutContent(argv);
+    expect(spec).toContain("kind: linear");
+    expect(spec).toContain('ref: "LIN-1"');
+
+    expect(count(argv, isPrCreate)).toBe(1);
+    expect(commentCreates(queries)).toBe(1);
+
+    const last = updates[updates.length - 1].config as TrackerEventTriggerConfig;
+    expect(last.pollState?.intake?.["LIN-1"]?.specPrUrl).toBe("https://github.com/acme/widget/pull/7");
+  });
+
+  it("re-poll the same issue → NO 2nd PR, NO 2nd comment (watermark dedup)", async () => {
+    const { http, queries } = fakeLinear({ nodes: [SHAPED_NODE] });
+    const { run, argv } = fakeGh();
+    const { poller } = harness({ trigger: linearTrigger(), linear: http, gh: run });
+    await poller.pollAll();
+    await poller.pollAll();
+    expect(count(argv, isPrCreate)).toBe(1);
+    expect(commentCreates(queries)).toBe(1);
+  });
+
+  it("unlabelled issue → skipped (defence-in-depth)", async () => {
+    const unlabelled = { ...SHAPED_NODE, identifier: "LIN-2", labels: { nodes: [{ name: "other" }] } };
+    const { http } = fakeLinear({ nodes: [unlabelled] });
+    const { run, argv } = fakeGh();
+    const { poller } = harness({ trigger: linearTrigger(), linear: http, gh: run });
+    await poller.pollAll();
+    expect(count(argv, isPrCreate)).toBe(0);
+  });
+
+  it("free-form issue + synthesiser empty → need-criteria comment, NO PR, NO intake", async () => {
+    const freeForm = {
+      id: "uuid-3",
+      identifier: "LIN-3",
+      title: "vague",
+      description: "please make it better",
+      labels: { nodes: [{ name: "agent" }] },
+    };
+    const synthesizer: TicketSynthesizer = { synthesize: async () => ({ criteria: [] }) };
+    const { http, queries } = fakeLinear({ nodes: [freeForm] });
+    const { run, argv } = fakeGh();
+    const { poller, updates } = harness({ trigger: linearTrigger(), linear: http, gh: run, synthesizer });
+    await poller.pollAll();
+    expect(commentCreates(queries)).toBe(1);
+    expect(count(argv, isPrCreate)).toBe(0);
+    const last = updates[updates.length - 1].config as TrackerEventTriggerConfig;
+    expect(last.pollState?.intake?.["LIN-3"]).toBeUndefined();
+  });
+
+  it("no filter.label → skipped (no Linear calls)", async () => {
+    const { http, queries } = fakeLinear({ nodes: [SHAPED_NODE] });
+    const { run } = fakeGh();
+    const { poller, updates } = harness({ trigger: linearTrigger({ filter: {} }), linear: http, gh: run });
+    await poller.pollAll();
+    expect(queries.length).toBe(0);
+    expect(updates.length).toBe(0);
+  });
+
+  it("master switch off → no Linear calls at all", async () => {
+    const { http, queries } = fakeLinear({ nodes: [SHAPED_NODE] });
+    const { run } = fakeGh();
+    const { poller } = harness({ trigger: linearTrigger(), linear: http, gh: run, masterOn: false });
+    await poller.pollAll();
+    expect(queries.length).toBe(0);
+  });
+
+  it("Linear outage on poll → skip cycle, watermark untouched, no crash", async () => {
+    const { http } = fakeLinear({ pollErrors: true });
+    const { run } = fakeGh();
+    const { poller, updates } = harness({ trigger: linearTrigger(), linear: http, gh: run });
+    await expect(poller.pollAll()).resolves.toBeUndefined();
+    expect(updates.length).toBe(0);
+  });
+
+  it("targetRepoPath NOT in the allowlist → skipped fail-closed (no Linear, no gh)", async () => {
+    const { http, queries } = fakeLinear({ nodes: [SHAPED_NODE] });
+    const { run, argv } = fakeGh();
+    const { poller } = harness({
+      trigger: linearTrigger(),
+      linear: http,
+      gh: run,
+      allowedRepoPaths: () => ["/some/other/repo"],
+    });
+    await poller.pollAll();
+    expect(queries.length).toBe(0);
+    expect(argv.length).toBe(0);
+  });
+});
+
+describe("LinearIssuesPoller.start gating", () => {
+  it("tracker disabled → start() builds no interval", () => {
+    vi.useFakeTimers();
+    try {
+      const { http } = fakeLinear({ nodes: [SHAPED_NODE] });
+      const { run } = fakeGh();
+      const logs: string[] = [];
+      const { poller } = harness({ trigger: linearTrigger(), linear: http, gh: run, trackerOn: false, logs });
+      poller.start();
+      vi.advanceTimersByTime(10 * 60 * 1000);
+      expect(logs.some((l) => l.includes("disabled"))).toBe(true);
+      poller.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("tracker enabled → start() logs a started poller", () => {
+    vi.useFakeTimers();
+    try {
+      const { http } = fakeLinear({ nodes: [] });
+      const { run } = fakeGh();
+      const logs: string[] = [];
+      const { poller } = harness({ trigger: linearTrigger(), linear: http, gh: run, trackerOn: true, logs });
+      poller.start();
+      expect(logs.some((l) => l.includes("linear tracker poller started"))).toBe(true);
+      poller.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## TRACK-5 — Linear + Azure DevOps + ClickUp connectors

Implements TRACK-5 from `docs/design/task-tracker-triggers.md`: three new `TrackerConnector` implementations on the interface TRACK-3 landed. A labelled/tagged ticket → committed spec PR + pickup write-back, handing off to SPEC-1. **These connectors fire no loops** — the committed spec does (one execution route).

### The three connectors (same shape, dialect only)
Each tracker = one `*-exec.ts` (sanitized HTTP seam) + one `*-connector.ts` (dialect + naming) + one `*-issues-poller.ts` (guarded on the `tracker` discriminant).

| Tracker | Watch | Read | Write-back | Auth (env, fail-closed) |
|---|---|---|---|---|
| **Linear** | GraphQL `issues(filter:{labels,updatedAt})` | `issue(id)` | `commentCreate` + `issueUpdate` state + `attachmentCreate` link | `LINEAR_API_KEY` |
| **Azure DevOps** | WIQL poll (tag + ChangedDate + area) | `/wit/workitems/{id}` | `/comments` + `System.State` JSON-patch + Hyperlink relation | `AZURE_DEVOPS_PAT` |
| **ClickUp** | REST `/list/{id}/task?date_updated_gt=…` filtered by tag | `/task/{id}` | `/task/{id}/comment` + status PUT | `CLICKUP_API_TOKEN` |

`source: { kind: linear|azure|clickup, ref: <identifier/id>, url }`.

### Reused vs dialect-only
- **Reused unchanged (shared):** `crystallizeTicket()` (spec-intake), `renderSpecMarkdown` + `TicketSource` (issue-spec), `writeSpecPr` (spec-writer), the injectable synthesiser, per-trigger watermark dedup (one spec per ticket, even on edit), the fail-closed `targetRepoPath` allowlist, the label/tag consent gate.
- **Dialect-only (new):** how each connector watches/reads/writes-back + how it names its `spec/<kind>-<id>` branch and `docs/specs/<kind>-<id>-<slug>.md` file.

### Config / union additions (additive)
- `TrackerEventTriggerConfig.tracker` (shared/types.ts) widened to `github|jira|linear|azure|clickup`; new optional fields (`linearTeamId`, `azureOrg`, `azureAreaPath`, `clickupListId`); `baseUrl`/`transitionTo` reused.
- The trigger creation **discriminatedUnion** (`server/routes/triggers.ts`) gains linear/azure/clickup arms; github/jira arms untouched.
- `spec-writer` `SPEC_BRANCH_RE` gains `linear-…`, `azure-[0-9]+`, `clickup-…`.
- Wired into the poller-construction registry (`server/routes.ts`) sharing one synthesiser + common deps.

### Kill-switch
Gated by the existing `features.triggers.tracker.enabled` (+ master `features.triggers.enabled`), **default OFF** — no poller constructed, no behavioural change.

### GitHub + Jira byte-identical
`gh-exec`, `github-issues-poller`, `issue-spec`, `issue-writeback`, `jira-connector`, `jira-exec`, `jira-issues-poller`, `writeback-observer`, `spec-intake` — **0 diff lines** vs `origin/main`. Only additive edits to `spec-writer.ts`, `shared/types.ts`, `server/routes.ts`, `server/routes/triggers.ts`.

### Security (adversarial self-review)
- **Injection-proof by construction:** Linear via GraphQL **variables** (static query); Azure via the `@project` WIQL macro + single-quote-stripped literals (backslash kept — literal in WIQL, needed for area paths); ClickUp via `URLSearchParams`.
- Each seam: https-only, origin-checked (SSRF containment), never-throw degrade → `null`/`{ok:false}` (outage can't crash the poll loop), **secrets never logged** (headers/query scrubbed).
- Untrusted title/body: fenced before any prompt (shared synth), slug/clamped before any filename; ids reduced to shape-safe charsets (traversal/flag-injection safe).
- **Dedup:** watermark intake + deterministic branch + spec-writer pr-list dedup ⇒ never a 2nd spec PR / double comment on a ticket edit; a closed-but-intaken ticket is never re-fired.
- Write-back comment idempotency by marker; unreadable comments ⇒ no post (safety over liveness).

### Tests
72 new unit tests (connector + poller per tracker): labelled ticket → shared synth → spec PR with the right `source.kind` + one pickup comment; re-poll dedup; untagged skip; no-criteria ask-comment/no-PR; kill-switch off (no calls); tracker-off (no interval); outage skip (watermark untouched); non-allowlisted path skip; id/ref parse; GraphQL/WIQL/param injection. Full unit suite green (5320), tsc clean, tracker + trigger integration tests green. `pull_request` CI is authoritative.

> ClickUp webhook `X-Signature` HMAC (#494) is a documented follow-up; this ships the polling mode.