### PR TITLE
feat: role-scoped experience — a Role starts warm (ROLE-3)

### DIFF
--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -1132,10 +1132,17 @@ export class ConsiliumLoopController {
             .filter((m): m is NonNullable<typeof m> => typeof m === "string"),
         ),
       );
+      // ROLE-3 (standing-role.md §3/§6/§8): if THIS loop was role-fired, key the read by its
+      // (role, concern) too so the Role reads its OWN prior lessons first (warm start) and —
+      // fail-closed — never another role's. Absent for human/spec/non-role loops (role null),
+      // which then read only role-agnostic (repo-scoped) items, byte-identical to DREAM-2.
+      const roleProv = loop.triggerProvenance?.role;
       const query: ExperienceReadQuery = {
         repo: normalizeExperienceRepo(loop.repoPath),
         archetype: loop.archetype ?? null,
         criterionClasses,
+        role: roleProv?.roleId ?? null,
+        concern: roleProv?.concernId ?? null,
       };
       const opts = {
         topK: readCfg.topK,

--- a/server/services/consilium/experience/distiller.ts
+++ b/server/services/consilium/experience/distiller.ts
@@ -180,6 +180,17 @@ export function distillLoop(
   const loopConverged = loop.state === "converged";
   const archetype = loop.archetype ?? null;
 
+  // ── ROLE-3 (standing-role.md §3/§6/§8) — SCOPE experience by role ────────────
+  // When THIS loop was ROLE-FIRED (ROLE-1 wake / ROLE-2 trigger records
+  // `triggerProvenance.role`), stamp the role (+ its concern) onto every item's scope so
+  // the item records "as THIS role on THIS concern, pattern X was verified". A non-role
+  // loop leaves both ABSENT — its items are byte-identical to pre-ROLE-3 (repo-scoped).
+  // We stamp only the server-generated IDs (never the role's human `name`), clamped inert
+  // for defence-in-depth; a concern is stamped ONLY alongside a role (meaningless alone).
+  const roleProv = loop.triggerProvenance?.role;
+  const roleId = clampText(roleProv?.roleId) || null;
+  const concernId = roleId ? clampText(roleProv?.concernId) || null : null;
+
   // Collapse duplicate (criterionClass + claim) leaves across rounds into ONE item,
   // keeping the STRONGEST confidence and accumulating (bounded) evidence links.
   const byKey = new Map<string, Candidate>();
@@ -246,7 +257,14 @@ export function distillLoop(
     };
     items.push({
       projectId: loop.projectId ?? null,
-      scope: { repo, archetype, criterionClass: cand.method },
+      scope: {
+        repo,
+        archetype,
+        criterionClass: cand.method,
+        // ROLE-3: additive — present ONLY for a role-fired loop (fail-closed on read).
+        ...(roleId ? { role: roleId } : {}),
+        ...(concernId ? { concern: concernId } : {}),
+      },
       claim: cand.claim,
       evidence: cand.evidence,
       verification,

--- a/server/services/consilium/experience/experience-reader.ts
+++ b/server/services/consilium/experience/experience-reader.ts
@@ -39,6 +39,20 @@ export interface ExperienceReadQuery {
   archetype: Archetype | null;
   /** The criterion classes named in the verdict (the APs' methods). Empty ⇒ any class. */
   criterionClasses: readonly string[];
+  /**
+   * ROLE-3 (standing-role.md §3/§6/§8): the Standing Role that FIRED this loop
+   * (`triggerProvenance.role.roleId`), or null/undefined for a human/spec/non-role loop.
+   * This is the KEY to the fail-closed boundary (§6): a role reads its OWN role-scoped
+   * items PLUS every role-agnostic (repo-scoped) item, and NEVER another role's items. A
+   * non-role loop (role null) reads ONLY role-agnostic items. Absent ⇒ treated as null.
+   */
+  role?: string | null;
+  /**
+   * ROLE-3: the CONCERN that woke the role (`triggerProvenance.role.concernId`), or null.
+   * NOT part of the fail-closed boundary (that is `role` alone) — it only RANKS a role's
+   * own `(role, concern)` lessons above its other-concern / generic ones.
+   */
+  concern?: string | null;
 }
 
 /** Bounds for the read (all sourced from config so an operator can tune/clamp them). */
@@ -69,6 +83,14 @@ const CONFIDENCE_TIE_RANK: Record<ExperienceConfidence, number> = {
   refuted: 1,
 };
 
+// ── ROLE-3 rank affinity (a Role starts warm, standing-role.md §3/§8) ───────────
+/** A role's OWN `(role, concern)` lesson — its beat; leads its plan. */
+const ROLE_CONCERN_AFFINITY = 2.0;
+/** Same role, other/absent concern — boosted above generic, below same-concern. */
+const ROLE_AFFINITY = 1.5;
+/** Role-agnostic (repo-scoped) — the shared cross-role baseline (byte-identical pre-ROLE-3). */
+const GENERIC_AFFINITY = 1.0;
+
 const MS_PER_DAY = 86_400_000;
 /** Never render a claim longer than this in the block (distiller already clamps to 400). */
 const MAX_CLAIM_RENDER = 400;
@@ -93,8 +115,9 @@ export function normalizeExperienceRepo(repoPath: string | null | undefined): st
 }
 
 /**
- * SCOPE BIND (§8): does this item apply to this query? `repo` is a HARD exact match (the
- * anti-cross-repo guard); `archetype` and `criterionClass` are soft (null/empty ⇒ wildcard).
+ * SCOPE BIND (§8 + ROLE-3 §6): does this item apply to this query? `repo` is a HARD exact
+ * match (the anti-cross-repo guard); `archetype` and `criterionClass` are soft (null/empty
+ * ⇒ wildcard); and a ROLE-scoped item is FAIL-CLOSED — readable only by the same role.
  */
 export function itemMatchesScope(item: ExperienceItemRow, query: ExperienceReadQuery): boolean {
   const scope = item.scope;
@@ -110,7 +133,41 @@ export function itemMatchesScope(item: ExperienceItemRow, query: ExperienceReadQ
   if (query.criterionClasses.length > 0 && !query.criterionClasses.includes(scope.criterionClass)) {
     return false;
   }
+  // ROLE-3 FAIL-CLOSED role bind (standing-role.md §6): a ROLE-SCOPED item
+  // (`scope.role` set) is a private lesson — it is readable ONLY by the SAME role. A
+  // different role, OR a non-role loop (`query.role` null/undefined), NEVER sees it — a
+  // DevOps role must not silently inherit a Security role's lesson. A role-AGNOSTIC item
+  // (no `scope.role`) has NO such gate: it is repo-scoped and read by every role and by
+  // non-role loops alike (that is the shared, cross-role repo experience).
+  if (scope.role != null) {
+    if (query.role == null || query.role !== scope.role) return false;
+  }
   return true;
+}
+
+/**
+ * ROLE-3 RANK affinity (standing-role.md §3/§8 — "a Role starts warm"): a role's OWN
+ * experience should LEAD its plan. This is a multiplier folded into the base
+ * `confidence × freshness` score in `selectExperienceItems`, so a role-scoped verified
+ * item out-ranks a generic one of comparable freshness, while §6 decay still applies (a
+ * badly-stale role item can still be overtaken — the plane stays anti-Goodhart honest).
+ *
+ * Only role-scoped items reach the boosted branches (the fail-closed `itemMatchesScope`
+ * already guarantees any surviving role-scoped item shares the query's role), so:
+ *   - same role AND same concern → strongest (the role's own beat, `(role, concern)`);
+ *   - same role, other/no concern → boosted, but below same-concern;
+ *   - role-agnostic (no `scope.role`) → neutral (the shared repo baseline).
+ */
+export function roleAffinity(item: ExperienceItemRow, query: ExperienceReadQuery): number {
+  const itemRole = item.scope?.role;
+  if (itemRole == null) return GENERIC_AFFINITY; // role-agnostic — shared repo baseline.
+  // Defensive: fail-closed scope should already exclude a role mismatch; re-check anyway.
+  if (query.role == null || query.role !== itemRole) return GENERIC_AFFINITY;
+  const itemConcern = item.scope?.concern;
+  if (query.concern != null && itemConcern != null && itemConcern === query.concern) {
+    return ROLE_CONCERN_AFFINITY; // the role's own (role, concern) beat — leads.
+  }
+  return ROLE_AFFINITY; // same role, different/absent concern — boosted, below same-concern.
 }
 
 /** Age in whole+fractional days since `lastConfirmedAt` (>= 0; unparseable ⇒ very stale). */
@@ -152,11 +209,14 @@ interface Ranked {
   score: number;
   effConfidence: ExperienceConfidence;
   age: number;
+  affinity: number;
 }
 
 /**
- * Filter to scope, rank by `confidence × freshness` (verified-first, fresher-first, refuted
- * shown but sunk), and take the top-K. PURE — the input array is never mutated.
+ * Filter to scope, rank by `confidence × freshness × role-affinity` (ROLE-3: a role's own
+ * `(role, concern)` lessons lead — verified-first, fresher-first, refuted shown but sunk),
+ * and take the top-K. PURE — the input array is never mutated. For a non-role query every
+ * surviving item is role-agnostic (affinity 1.0), so the ranking is byte-identical to DREAM-2.
  */
 export function selectExperienceItems(
   items: readonly ExperienceItemRow[],
@@ -167,15 +227,20 @@ export function selectExperienceItems(
   const ranked: Ranked[] = [];
   for (const item of items) {
     if (!itemMatchesScope(item, query)) continue;
+    const affinity = roleAffinity(item, query);
     ranked.push({
       item,
-      score: scoreExperienceItem(item, opts, now),
+      // ROLE-3: the affinity multiplier biases toward the role's own experience while §6
+      // time-decay still applies (affinity 1.0 for role-agnostic ⇒ unchanged base score).
+      score: scoreExperienceItem(item, opts, now) * affinity,
       effConfidence: effectiveConfidence(item, opts, now),
       age: ageDays(item, now),
+      affinity,
     });
   }
   ranked.sort((a, b) => {
-    if (b.score !== a.score) return b.score - a.score; // higher confidence×freshness first
+    if (b.score !== a.score) return b.score - a.score; // higher confidence×freshness×affinity
+    if (b.affinity !== a.affinity) return b.affinity - a.affinity; // then the role's own leads
     const tie = CONFIDENCE_TIE_RANK[b.effConfidence] - CONFIDENCE_TIE_RANK[a.effConfidence];
     if (tie !== 0) return tie; // verified > observed > refuted at equal score
     return a.age - b.age; // then fresher first

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -2335,7 +2335,9 @@ export const experienceItems = pgTable(
     id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
     // Nullable, mirrors consilium_loops.project_id — the source loop's project.
     projectId: text("project_id").references(() => projects.id, { onDelete: "cascade" }),
-    // WHERE the pattern applies (§3): { repo, archetype, criterionClass }.
+    // WHERE the pattern applies (§3): { repo, archetype, criterionClass } — plus an
+    // OPTIONAL ROLE-3 (role, concern) when the source loop was role-fired (additive, no
+    // migration: jsonb). A role-scoped item is fail-closed on read (same role only).
     scope: jsonb("scope").$type<ExperienceScope>().notNull(),
     // ONE distilled fact/pattern (clamped, inert).
     claim: text("claim").notNull(),

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -3696,6 +3696,24 @@ export interface ExperienceScope {
    * planner match "coverage-gate/test-run patterns on this repo".
    */
   criterionClass: string;
+  /**
+   * ROLE-3 (standing-role.md §3/§6/§8, additive to the DREAM-1/2 tuple): the Standing
+   * Role this item was learned AS, when the source loop was ROLE-FIRED
+   * (`triggerProvenance.role.roleId`). ABSENT on a non-role loop's items — those stay
+   * role-agnostic (repo-scoped) and byte-identical to pre-ROLE-3. Its presence makes an
+   * item FAIL-CLOSED: only the SAME role reads it (a DevOps role never inherits a Security
+   * role's lesson); a role-agnostic item (no `role`) is read by any role. See the reader's
+   * `itemMatchesScope` for the enforcement.
+   */
+  role?: string;
+  /**
+   * ROLE-3: the CONCERN the role was watching when it learned this (`role.concernId`).
+   * Only ever set alongside `role` (a concern is meaningless without its role). Used to
+   * RANK a role's own `(role, concern)` lessons above its other-concern / generic ones —
+   * it is NOT part of the fail-closed boundary (that is `role` alone). Absent on a
+   * ROLE-1 manual wake (which has a role but no concern) and on non-role loops.
+   */
+  concern?: string;
 }
 
 /** One auditable link back to the raw session the claim was distilled from (§2/§3). */

--- a/tests/unit/consilium/experience/distiller.test.ts
+++ b/tests/unit/consilium/experience/distiller.test.ts
@@ -213,3 +213,70 @@ describe("distillLoop — grounding", () => {
     expect(items).toEqual([]);
   });
 });
+
+// ── ROLE-3: role-scoped experience on the WRITE side ────────────────────────────
+// (standing-role.md §3/§6/§8) — a ROLE-FIRED terminal loop stamps (role, concern) onto
+// every item's scope so it records "as THIS role on THIS concern, pattern X was verified".
+// A non-role loop's items are UNCHANGED (repo-scoped, byte-identical to pre-ROLE-3).
+
+describe("distillLoop — ROLE-3 role scope", () => {
+  const roleProv = (roleId: string, concernId?: string) => ({
+    firedAt: "2026-07-01T00:30:00.000Z",
+    role: { roleId, name: "devops-reviewer", ...(concernId ? { concernId } : {}) },
+  });
+
+  it("a ROLE-FIRED terminal loop ⇒ items carry scope.role + scope.concern", () => {
+    const loop = makeLoop({
+      id: "loop-role-1",
+      state: "converged",
+      triggerProvenance: roleProv("role-devops", "concern-iac"),
+    });
+    const items = distillLoop(loop, [round(1, traceWith([crit({ method: "test-run", ran: true, passed: true })]))], OPTS);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].scope).toEqual({
+      repo: "widget",
+      archetype: "repo-assessment",
+      criterionClass: "test-run",
+      role: "role-devops",
+      concern: "concern-iac",
+    });
+  });
+
+  it("a NON-role loop ⇒ NO role/concern scope (unchanged, byte-identical to pre-ROLE-3)", () => {
+    const loop = makeLoop({ id: "loop-role-2", state: "converged" }); // no triggerProvenance.role
+    const items = distillLoop(loop, [round(1, traceWith([crit({ method: "test-run", ran: true, passed: true })]))], OPTS);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].scope).toEqual({ repo: "widget", archetype: "repo-assessment", criterionClass: "test-run" });
+    expect(items[0].scope).not.toHaveProperty("role");
+    expect(items[0].scope).not.toHaveProperty("concern");
+  });
+
+  it("a ROLE-1 MANUAL wake (role, no concern) ⇒ scope.role only, concern absent", () => {
+    const loop = makeLoop({
+      id: "loop-role-3",
+      state: "converged",
+      triggerProvenance: roleProv("role-security"), // wake has a role but no concern
+    });
+    const items = distillLoop(loop, [round(1, traceWith([crit({ method: "test-run", ran: true, passed: true })]))], OPTS);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].scope.role).toBe("role-security");
+    expect(items[0].scope).not.toHaveProperty("concern"); // no concern without a concernId
+  });
+
+  it("a concern WITHOUT a role is never stamped alone (a concern is meaningless without its role)", () => {
+    // Defensive: a malformed provenance with a concernId but no roleId must not leak a concern.
+    const loop = makeLoop({
+      id: "loop-role-4",
+      state: "converged",
+      triggerProvenance: { firedAt: "2026-07-01T00:30:00.000Z", role: { roleId: "", name: "x", concernId: "c" } },
+    });
+    const items = distillLoop(loop, [round(1, traceWith([crit({ method: "test-run", ran: true, passed: true })]))], OPTS);
+
+    expect(items).toHaveLength(1);
+    expect(items[0].scope).not.toHaveProperty("role");
+    expect(items[0].scope).not.toHaveProperty("concern");
+  });
+});

--- a/tests/unit/consilium/experience/experience-reader.test.ts
+++ b/tests/unit/consilium/experience/experience-reader.test.ts
@@ -40,6 +40,8 @@ function makeItem(p: {
   claim?: string;
   lastConfirmedDaysAgo?: number;
   evidence?: ExperienceItemRow["evidence"];
+  role?: string; // ROLE-3: role-scoped when set (omitted ⇒ role-agnostic / repo-scoped)
+  concern?: string; // ROLE-3: only meaningful alongside role
 }): ExperienceItemRow {
   return {
     id: p.id,
@@ -48,6 +50,8 @@ function makeItem(p: {
       repo: p.repo ?? "widget",
       archetype: p.archetype ?? "repo-assessment",
       criterionClass: p.criterionClass ?? "test-run",
+      ...(p.role ? { role: p.role } : {}),
+      ...(p.concern ? { concern: p.concern } : {}),
     },
     claim: p.claim ?? `On widget, criterion ${p.id} was checked.`,
     evidence: p.evidence ?? [{ loopId: `loop-${p.id}`, round: 1, apTitle: "AP", diffRef: "abc123" }],
@@ -213,5 +217,83 @@ describe("buildPriorExperienceBlock — fenced, byte-bounded, refuted-as-negativ
     // The block opens/closes with a fence strictly longer than any backtick run inside.
     const firstFence = block.split("\n").find((l) => /^`{4,}$/.test(l));
     expect(firstFence).toBeTruthy();
+  });
+});
+
+// ── ROLE-3: role-scoped READ (a Role starts warm; fail-closed) ──────────────────
+// (standing-role.md §3/§6/§8) — a role-fired loop reads its OWN (role, concern) items
+// FIRST (higher rank), PLUS every role-agnostic repo item, and NEVER another role's items.
+
+const DEVOPS_QUERY: ExperienceReadQuery = {
+  repo: "widget",
+  archetype: "repo-assessment",
+  criterionClasses: ["test-run"],
+  role: "role-devops",
+  concern: "concern-iac",
+};
+
+describe("itemMatchesScope — ROLE-3 fail-closed role boundary (§6)", () => {
+  it("a role reads its OWN role-scoped item", () => {
+    const own = makeItem({ id: "own", role: "role-devops", concern: "concern-iac" });
+    expect(itemMatchesScope(own, DEVOPS_QUERY)).toBe(true);
+  });
+
+  it("a role reads role-AGNOSTIC (repo-scoped) items — the shared cross-role baseline", () => {
+    const generic = makeItem({ id: "generic" }); // no scope.role
+    expect(itemMatchesScope(generic, DEVOPS_QUERY)).toBe(true);
+  });
+
+  it("a role does NOT read ANOTHER role's role-scoped item (a DevOps role never inherits Security's lesson)", () => {
+    const otherRole = makeItem({ id: "sec", role: "role-security", concern: "concern-authz" });
+    expect(itemMatchesScope(otherRole, DEVOPS_QUERY)).toBe(false);
+  });
+
+  it("a NON-role loop (query.role null) reads ONLY role-agnostic items, NEVER any role-scoped item", () => {
+    const nonRoleQuery: ExperienceReadQuery = { repo: "widget", archetype: "repo-assessment", criterionClasses: ["test-run"] };
+    expect(itemMatchesScope(makeItem({ id: "roleScoped", role: "role-devops" }), nonRoleQuery)).toBe(false);
+    expect(itemMatchesScope(makeItem({ id: "generic" }), nonRoleQuery)).toBe(true);
+  });
+
+  it("same role, DIFFERENT concern is still readable (the fail-closed boundary is ROLE, not concern)", () => {
+    const sameRoleOtherConcern = makeItem({ id: "otherConcern", role: "role-devops", concern: "concern-k8s" });
+    expect(itemMatchesScope(sameRoleOtherConcern, DEVOPS_QUERY)).toBe(true);
+  });
+});
+
+describe("selectExperienceItems — ROLE-3 a Role starts warm (rank its own first)", () => {
+  it("ranks the role's own (role, concern) VERIFIED item ABOVE a generic verified one of equal freshness", () => {
+    const own = makeItem({ id: "own", role: "role-devops", concern: "concern-iac", confidence: "verified", lastConfirmedDaysAgo: 1 });
+    const generic = makeItem({ id: "generic", confidence: "verified", lastConfirmedDaysAgo: 1 });
+    const out = selectExperienceItems([generic, own], DEVOPS_QUERY, OPTS);
+    expect(out.map((i) => i.id)).toEqual(["own", "generic"]); // the role's own leads
+  });
+
+  it("ranks same-role SAME-concern above same-role OTHER-concern above generic", () => {
+    const sameConcern = makeItem({ id: "sameC", role: "role-devops", concern: "concern-iac", lastConfirmedDaysAgo: 1 });
+    const otherConcern = makeItem({ id: "otherC", role: "role-devops", concern: "concern-k8s", lastConfirmedDaysAgo: 1 });
+    const generic = makeItem({ id: "generic", lastConfirmedDaysAgo: 1 });
+    const out = selectExperienceItems([generic, otherConcern, sameConcern], DEVOPS_QUERY, OPTS);
+    expect(out.map((i) => i.id)).toEqual(["sameC", "otherC", "generic"]);
+  });
+
+  it("a DIFFERENT role's items are DROPPED (fail-closed) but role-agnostic items are KEPT", () => {
+    const own = makeItem({ id: "own", role: "role-devops", concern: "concern-iac" });
+    const foreign = makeItem({ id: "foreign", role: "role-security" });
+    const generic = makeItem({ id: "generic" });
+    const out = selectExperienceItems([foreign, own, generic], DEVOPS_QUERY, OPTS);
+    expect(out.map((i) => i.id).sort()).toEqual(["generic", "own"]);
+    expect(out.map((i) => i.id)).not.toContain("foreign");
+  });
+
+  it("BYTE-IDENTICAL to DREAM-2: a non-role query over role-agnostic items ranks unchanged", () => {
+    // No role on the query, no role on the items ⇒ affinity is 1.0 throughout ⇒ pure
+    // confidence×freshness order, exactly as DREAM-2 (verified > observed > refuted).
+    const items = [
+      makeItem({ id: "refuted", confidence: "refuted", lastConfirmedDaysAgo: 1 }),
+      makeItem({ id: "verified", confidence: "verified", lastConfirmedDaysAgo: 1 }),
+      makeItem({ id: "observed", confidence: "observed", lastConfirmedDaysAgo: 1 }),
+    ];
+    const out = selectExperienceItems(items, QUERY, OPTS); // QUERY has no role
+    expect(out.map((i) => i.id)).toEqual(["verified", "observed", "refuted"]);
   });
 });


### PR DESCRIPTION
## ROLE-3 — role-scoped experience (a Standing Role starts warm)

Implements **ROLE-3** from `docs/design/standing-role.md` §7–§8 + `docs/design/experience-plane-dream.md` §3/§8. The Dream now keys Experience items by `(role, concern)` too, and a role-fired loop's planner reads **its own** prior experience so a Standing Role starts warm instead of cold. Composes ROLE-2 (concerns/triggers) with DREAM-1 (distiller write) + DREAM-2 (planner read) — all additive, nothing rewritten.

### Write side — scope experience by role
When the distiller (`experience/distiller.ts`) processes a **terminal, role-fired** loop (one carrying `triggerProvenance.role` from a ROLE-1 wake / ROLE-2 trigger), it stamps `scope.role` (the `roleId`) and — when present — `scope.concern` (the `concernId`) onto every emitted item. So an item records *"as THIS role on THIS concern, pattern X was verified"*. A **non-role loop's items are unchanged** (`{repo, archetype, criterionClass}` only) — byte-identical to pre-ROLE-3. `scope.role` / `scope.concern` are added to `ExperienceScope` as **optional** fields; the column is `jsonb`, so **no migration**. Only server-generated IDs are stamped (never the role's human `name`), clamped inert; a `concern` is never stamped without its `role`.

### Read side — a Role reads its own experience first
The planner's experience query (`consilium-loop-controller.readPriorExperience`) now carries the loop's `(role, concern)` from `triggerProvenance.role`. The reader (`experience/experience-reader.ts`):
- **matches** a role's own `(role, concern)` items **in addition to** the repo/archetype match;
- **ranks** them above generic ones via a role-affinity multiplier (`role+concern` 2.0 > `role` 1.5 > generic 1.0) folded into `confidence × freshness` — so §6 decay still applies (a badly-stale role item can still be overtaken; anti-Goodhart intact).

### Fail-closed cross-role boundary (§6)
`itemMatchesScope` enforces: a **role-scoped item** (`scope.role` set) is readable **only by the same role**. A different role — or a **non-role loop** (`query.role` null) — never sees it. A **role-agnostic** item (no `scope.role`) is repo-scoped and read by **every** role and non-role loop alike (the shared cross-role baseline). So a DevOps role does **not** silently inherit a Security role's lesson, but both still read the shared repo experience.

### Kill-switch
Rides the existing `experiencePlane.enabled` (write) + `experiencePlane.read.enabled` (read) switches — **no new default-on behavior**. Role-scoping is inert when the plane is off; the read path returns early (byte-identical prompt), and for a non-role loop the ranking is byte-identical to DREAM-2 (affinity 1.0 throughout).

### Tests
- **Write:** a role-fired terminal loop ⇒ items carry `scope.role` + `scope.concern`; a ROLE-1 manual wake ⇒ `role` only; a non-role loop ⇒ no role scope (unchanged); a concern without a role is never stamped alone.
- **Read:** a role reads its own + role-agnostic items, never another role's (fail-closed); a non-role loop reads only role-agnostic items; same-role/different-concern still readable (boundary is role, not concern); the role's own `(role, concern)` verified item ranks above generic; same-concern > other-concern > generic; non-role ranking byte-identical to DREAM-2.
- `tsc --noEmit` clean; full unit project green (**292 files / 5428 tests**, no flakes triggered).

### Adversarial self-review
- **cross-role read** — fail-closed in `itemMatchesScope` (role gate) + tested;
- **role scope leaking into non-role items** — write only stamps when `triggerProvenance.role.roleId` present + tested;
- **plane-off not byte-identical** — read returns early when off; distiller runs only when the observer is constructed; non-role ranking unchanged (affinity 1.0) + tested;
- **unbounded reads** — no bounds changed; `roleAffinity` is O(1) per item; scan-limit + byte-cap + top-K intact.

Draft — do not merge.