### PR TITLE
feat: TRACK-6 — Standing Role on a tracker + comment commands

### DIFF
--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -152,6 +152,23 @@ export const ConfigSchema = z.object({
         writeback: z.object({
           enabled: z.boolean().default(false),
         }).default({}),
+        /**
+         * TRACK-6 (task-tracker-triggers.md §8). A command poller scans a repo's
+         * recent ISSUE COMMENTS for `/spec` (force intake), `/approve` (mark the spec
+         * PR ready), and `/stop` (cancel the ticket's active loop). Only the ticket
+         * ASSIGNEE or a repo MAINTAINER (write/admin) may command — the poller verifies
+         * the commenter's role via the `gh` API before acting; an unauthorized command
+         * is ignored + logged. Commands are idempotent (comment-id deduped) and
+         * best-effort.
+         *
+         * Default FALSE ⇒ the command poller is never constructed and NO comment is
+         * ever acted on (byte-identical to TRACK-1..5). ALSO requires the tracker
+         * `enabled` switch above and the master `features.triggers.enabled`. Rides the
+         * tracker `pollIntervalSec` so it cannot hammer `gh`.
+         */
+        commands: z.object({
+          enabled: z.boolean().default(false),
+        }).default({}),
       }).default({}),
     }).default({}),
   }).default({}),

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -48,6 +48,7 @@ import { LinearIssuesPoller } from "./services/consilium/trackers/linear-issues-
 import { AzureIssuesPoller } from "./services/consilium/trackers/azure-issues-poller";
 import { ClickUpIssuesPoller } from "./services/consilium/trackers/clickup-issues-poller";
 import { TrackerWritebackObserver } from "./services/consilium/trackers/writeback-observer";
+import { GithubCommandPoller } from "./services/consilium/trackers/github-command-poller";
 import { ExperienceDistillerObserver } from "./services/consilium/experience/experience-distiller-observer";
 import { buildSynthPrompt, parseSynthOutput } from "./services/consilium/trackers/issue-spec";
 import { DEFAULT_TASK_MODEL } from "./config/schema";
@@ -432,6 +433,7 @@ export async function registerRoutes(
   let azureIssuesPoller: AzureIssuesPoller | null = null;
   let clickupIssuesPoller: ClickUpIssuesPoller | null = null;
   let trackerWritebackObserver: TrackerWritebackObserver | null = null;
+  let githubCommandPoller: GithubCommandPoller | null = null;
 
   try {
     triggerService = new TriggerService(storage);
@@ -618,6 +620,10 @@ export async function registerRoutes(
         updateTrigger: (id, updates) => storage.updateTrigger(id, updates),
         config: () => appConfigLoader.get(),
         allowedRepoPaths: () => appConfigLoader.get().pipeline.consiliumLoop.allowedRepoPaths,
+        // TRACK-6 (standing-role.md §5): project-scoped role load so a tracker trigger
+        // bound to a Standing Role's concern STAMPS the role's name + skills into the
+        // crystallised spec (undefined roleConcern ⇒ no stamp — byte-identical TRACK-1).
+        getStandingRole: (id) => storage.getStandingRole(id),
         // Gateway-backed synthesiser for FREE-FORM issues (no spec-shaped body). Any
         // error degrades to no-criteria (never throws into the poll loop) -> the poller
         // posts an ask-for-criteria comment instead of opening a spec PR.
@@ -868,6 +874,66 @@ export async function registerRoutes(
       trackerWritebackObserver.start();
     }
 
+    // TRACK-6 (task-tracker-triggers.md §8). When the commands sub-switch is on (and the
+    // tracker switch), a command poller scans a repo's recent ISSUE COMMENTS for /spec
+    // (force intake), /approve (mark the spec PR ready), and /stop (cancel the ticket's
+    // active loop) — acting ONLY on comments authored by the ticket assignee or a repo
+    // maintainer (verified via the `gh` API, fail-closed). Default OFF -> not constructed
+    // (TRACK-1..5 byte-identical — no comment is ever acted on). The /stop path reaches
+    // the loop controller's `cancel`; /spec reuses the SHARED github crystallise dialect.
+    if (
+      appConfigLoader.get().features.triggers.tracker.enabled &&
+      appConfigLoader.get().features.triggers.tracker.commands.enabled &&
+      consiliumLoopController
+    ) {
+      // Capture a non-null const so the /stop closure keeps the narrowing (a `let` is
+      // not narrowed inside a closure).
+      const loopControllerForCommands = consiliumLoopController;
+      githubCommandPoller = new GithubCommandPoller({
+        // The ONLY cross-project read — under runAsSystem (unscopedSystemQuery).
+        getEnabledTriggersByType: (type) =>
+          runAsSystem("tracker-command-bootstrap", () => storage.getAllEnabledTriggersByType(type)),
+        // Per-trigger storage + loop reads run INSIDE runAsProject(trigger.projectId).
+        runInProject: runAsProject,
+        getTrigger: (id) => storage.getTrigger(id),
+        updateTrigger: (id, updates) => storage.updateTrigger(id, updates),
+        config: () => appConfigLoader.get(),
+        allowedRepoPaths: () => appConfigLoader.get().pipeline.consiliumLoop.allowedRepoPaths,
+        // TRACK-6: project-scoped role load for the /spec role stamp (same as intake).
+        getStandingRole: (id) => storage.getStandingRole(id),
+        // Reuse the intake poller's gateway-backed synthesiser for free-form issues on /spec.
+        synthesizer: {
+          synthesize: async (issue) => {
+            try {
+              const { system, user } = buildSynthPrompt(issue);
+              const res = await gateway.completeStreaming(
+                {
+                  modelSlug: DEFAULT_TASK_MODEL,
+                  messages: [
+                    { role: "system", content: system },
+                    { role: "user", content: user },
+                  ],
+                  temperature: 0.2,
+                  maxTokens: 2048,
+                },
+                undefined,
+                undefined,
+                { overallTimeoutMs: 60_000 },
+              );
+              return parseSynthOutput(res.content);
+            } catch {
+              return { criteria: [] };
+            }
+          },
+        },
+        getLoops: () => storage.getLoops(),
+        // /stop cancels via the loop controller (the SAME cancel the UI/API uses).
+        cancelLoop: (loopId, opts) => loopControllerForCommands.cancel(loopId, opts),
+        log: (m: string) => log(m, "tracker-commands"),
+      });
+      githubCommandPoller.start();
+    }
+
     log("[triggers] Trigger subsystem started", "triggers");
   } catch (e) {
     // TriggerCrypto throws if TRIGGER_SECRET_KEY is absent — subsystem is disabled.
@@ -950,6 +1016,7 @@ export async function registerRoutes(
     azureIssuesPoller?.stop();
     clickupIssuesPoller?.stop();
     trackerWritebackObserver?.stop();
+    githubCommandPoller?.stop();
     getRefreshScheduler()?.stop();
     stopRateLimitCleanup();
     await remoteAgentManager?.shutdown();

--- a/server/routes/standing-roles.ts
+++ b/server/routes/standing-roles.ts
@@ -103,12 +103,28 @@ const GitHubConcernFilterSchema = z.object({
   refFilter: z.string().min(1).max(300).optional(),
 });
 
+/** `owner/repo` — the conservative GitHub name charset the pollers accept (no flag). */
+const OWNER_REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
+/**
+ * TRACK-6 (task-tracker-triggers.md §5): tracker_event concern filter — the role's
+ * INBOX is a tracker project. Only `tracker: "github"` is accepted today (the stamped
+ * reference path); the concern's own `repoPath` is the `targetRepoPath` (allowlisted
+ * local repo the spec PR lands in — re-validated by the poller). The `label` is the
+ * consent-to-intake gate the poller requires at fire time.
+ */
+const TrackerConcernFilterSchema = z.object({
+  tracker: z.literal("github"),
+  repo: z.string().regex(OWNER_REPO_RE, "repo must be owner/repo").max(200),
+  label: z.string().min(1).max(100),
+});
+
 /**
  * ROLE-2 (standing-role.md §3/§8): a concern to ADD to a role. `repoPath` is
  * re-validated fail-closed by the factory at wake (not here). `focus` is UNTRUSTED —
- * fenced by the factory. The `trigger` is a file_change | github_event discriminated
- * union; tracker_event is a documented follow-up (TRACK-6) so it is intentionally NOT
- * accepted here.
+ * fenced by the factory. The `trigger` is a file_change | github_event | tracker_event
+ * discriminated union. TRACK-6 adds `tracker_event` (github only) — a role whose INBOX
+ * is a tracker project; the labelled ticket crystallises a spec STAMPED with the role.
  */
 const AddConcernSchema = z.object({
   repoPath: z.string().min(1).max(4096),
@@ -117,6 +133,7 @@ const AddConcernSchema = z.object({
   trigger: z.discriminatedUnion("type", [
     z.object({ type: z.literal("file_change"), filter: FileChangeConcernFilterSchema }),
     z.object({ type: z.literal("github_event"), filter: GitHubConcernFilterSchema }),
+    z.object({ type: z.literal("tracker_event"), filter: TrackerConcernFilterSchema }),
   ]),
 });
 
@@ -191,6 +208,26 @@ function buildConcernTriggerConfig(
       config: {
         watchPath: f.watchPath,
         patterns: f.patterns ?? [],
+        roleConcern: binding,
+      } as TriggerConfig,
+    };
+  }
+  if (concern.trigger.type === "tracker_event") {
+    // TRACK-6: the role's INBOX is a tracker project. The backing trigger is a normal
+    // tracker_event trigger (the SAME github-issues poller picks it up) whose config
+    // ALSO carries `roleConcern` — on crystallise the poller stamps the role's name +
+    // skills into the spec. The concern's own `repoPath` is the allowlisted local
+    // targetRepoPath (the poller re-validates it fail-closed). No `action` — a
+    // tracker trigger never fires a loop directly (it produces a spec PR).
+    const f = concern.trigger.filter as { tracker: "github"; repo: string; label: string };
+    return {
+      type: "tracker_event",
+      config: {
+        tracker: f.tracker,
+        repo: f.repo,
+        targetRepoPath: concern.repoPath,
+        filter: { label: f.label },
+        specStatus: "ready",
         roleConcern: binding,
       } as TriggerConfig,
     };

--- a/server/services/consilium/trackers/command-auth.ts
+++ b/server/services/consilium/trackers/command-auth.ts
@@ -1,0 +1,87 @@
+/**
+ * command-auth.ts — TRACK-6 (task-tracker-triggers.md §8): verify a COMMENTER is
+ * authorised to run a `/spec`,`/approve`,`/stop` command on a GitHub issue. The
+ * connector verifies the commenter's ROLE via the tracker API BEFORE acting — the
+ * comment body is NEVER trusted to self-assert authority (an attacker can write any
+ * comment; only the tracker knows who may command).
+ *
+ * WHO MAY COMMAND (§8): the ticket ASSIGNEE or a repo MAINTAINER.
+ *   - ASSIGNEE — the login appears in the issue's `assignees`.
+ *   - MAINTAINER — the login has repo push access: the collaborator permission is
+ *     `admin` | `maintain` | `write` (GitHub's `repos/{repo}/collaborators/{login}/
+ *     permission` endpoint). `read`/`none`/404 (not a collaborator) ⇒ NOT authorised.
+ *
+ * FAIL-CLOSED (adversarial: an unauthorized commenter executing a command)
+ *   - A `gh` outage / auth error / unparseable response on EITHER check ⇒ NOT
+ *     authorised (a degraded API can never grant authority). We only ever return
+ *     `true` on a POSITIVE signal from GitHub.
+ *   - The commenter `login` is shape-validated to GitHub's charset (`[A-Za-z0-9-]`, no
+ *     leading dash) BEFORE it is placed in an `gh api` path segment — nothing
+ *     attacker-shaped is read as a flag or can traverse the path. An invalid login ⇒
+ *     NOT authorised.
+ *   - `repo` is shape-validated `owner/repo`. `issueNumber` is a positive integer.
+ *
+ * READ-ONLY: this module only READS (issue assignees, collaborator permission). It
+ * never writes and never throws.
+ */
+import { runGhJson, type ExecFileFn } from "../../github-status.js";
+
+/** `owner/repo` — the conservative GitHub charset (no leading dash / no flag). */
+const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+/** A GitHub login: 1–39 chars of `[A-Za-z0-9-]`, no leading/trailing/double dash. */
+const LOGIN_RE = /^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/;
+/** Collaborator permission levels that count as MAINTAINER (push access). */
+const MAINTAINER_PERMISSIONS: ReadonlySet<string> = new Set(["admin", "maintain", "write"]);
+
+/** True iff `login` is an assignee of the issue. Fail-closed on any degrade. */
+async function isAssignee(
+  repo: string,
+  issueNumber: number,
+  login: string,
+  runGh?: ExecFileFn,
+): Promise<boolean> {
+  const view = await runGhJson<{ assignees?: Array<{ login?: string }> }>(
+    ["issue", "view", String(issueNumber), "--repo", repo, "--json", "assignees"],
+    runGh,
+  );
+  const assignees = view?.assignees;
+  if (!Array.isArray(assignees)) return false;
+  return assignees.some((a) => typeof a?.login === "string" && a.login === login);
+}
+
+/** True iff `login` has repo push access (admin/maintain/write). Fail-closed. */
+async function isMaintainer(
+  repo: string,
+  login: string,
+  runGh?: ExecFileFn,
+): Promise<boolean> {
+  // `gh api repos/<owner>/<repo>/collaborators/<login>/permission` → { permission }.
+  // A non-collaborator returns 404 → runGhJson degrades to null → not a maintainer.
+  const res = await runGhJson<{ permission?: string }>(
+    ["api", `repos/${repo}/collaborators/${login}/permission`],
+    runGh,
+  );
+  const permission = res?.permission;
+  return typeof permission === "string" && MAINTAINER_PERMISSIONS.has(permission);
+}
+
+/**
+ * Authorise a commenter to run a command on an issue. Returns `true` ONLY on a
+ * positive GitHub signal (assignee OR maintainer); everything else — invalid shapes,
+ * `gh` degrade, `read`/`none` permission, not found — is `false` (fail-closed). Never
+ * throws.
+ */
+export async function isAuthorizedCommenter(
+  params: { repo: string; issueNumber: number; login: string },
+  runGh?: ExecFileFn,
+): Promise<boolean> {
+  const { repo, issueNumber, login } = params;
+  if (!REPO_RE.test(repo)) return false;
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) return false;
+  if (typeof login !== "string" || !LOGIN_RE.test(login)) return false;
+
+  // Assignee is the cheaper, ticket-scoped check — try it first.
+  if (await isAssignee(repo, issueNumber, login, runGh)) return true;
+  if (await isMaintainer(repo, login, runGh)) return true;
+  return false;
+}

--- a/server/services/consilium/trackers/command-parser.ts
+++ b/server/services/consilium/trackers/command-parser.ts
@@ -1,0 +1,58 @@
+/**
+ * command-parser.ts — TRACK-6 (task-tracker-triggers.md §8): the PURE, strict parser
+ * for the three tracker COMMENT COMMANDS. No I/O; unit-tested in isolation like
+ * `command-parser.test.ts` (mirrors github-event-map.ts / role-compose.ts).
+ *
+ * THE THREE COMMANDS
+ *   /spec    — force intake of this ticket (crystallise a spec) even if UNLABELLED.
+ *   /approve — approve the spec: mark the ticket's spec PR ready-for-review.
+ *   /stop    — cancel the ticket's active loop.
+ *
+ * STRICT TOKEN MATCH (adversarial: command injection via substring / casing)
+ *   A command is recognised ONLY when it is the FIRST whitespace-delimited token of
+ *   SOME line of the comment, matched EXACTLY (case-sensitive) against `/spec` |
+ *   `/approve` | `/stop`. Consequences:
+ *     - `/specification`, `/approved`, `/stopped` → the first token is NOT one of the
+ *       exact tokens ⇒ NO match (never a substring/prefix match).
+ *     - `please /stop` / `do not /approve` → the leading token is `please` / `do` ⇒ NO
+ *       match (a command must LEAD its line, so it cannot be smuggled mid-sentence).
+ *     - `/APPROVE`, `/Spec` → case-mismatch ⇒ NO match (no casing-bypass surface).
+ *     - `/approve looks good` → leading token exactly `/approve` ⇒ approve (trailing
+ *       prose after the token is allowed; only the token itself is load-bearing).
+ *   The comment BODY is NEVER interpreted beyond this token check — it never reaches a
+ *   shell or a prompt (the /spec crystallise path re-reads + fences the ISSUE text, not
+ *   the comment).
+ *
+ * FIRST-WINS: a comment with multiple command lines resolves to the FIRST matching
+ * line (top-to-bottom) so the outcome is deterministic and a trailing decoy cannot
+ * override the operator's leading intent.
+ */
+
+/** The recognised command tokens (exact, case-sensitive). */
+export type TrackerCommand = "spec" | "approve" | "stop";
+
+/** token → command (exact match table; the ONLY accepted spellings). */
+const COMMAND_TOKENS: Readonly<Record<string, TrackerCommand>> = {
+  "/spec": "spec",
+  "/approve": "approve",
+  "/stop": "stop",
+};
+
+/**
+ * Parse the FIRST command a comment body carries, or `null` when it carries none.
+ * Strict per the contract above: the command must be the exact leading token of a line.
+ */
+export function parseTrackerCommand(body: string | undefined): TrackerCommand | null {
+  if (typeof body !== "string" || body.length === 0) return null;
+  // Bound the scan — a pathological comment cannot cost unbounded work.
+  const lines = body.slice(0, 20_000).split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    // The first whitespace-delimited token of the line, matched EXACTLY.
+    const token = trimmed.split(/\s+/, 1)[0];
+    const cmd = COMMAND_TOKENS[token];
+    if (cmd) return cmd;
+  }
+  return null;
+}

--- a/server/services/consilium/trackers/github-command-poller.ts
+++ b/server/services/consilium/trackers/github-command-poller.ts
@@ -1,0 +1,481 @@
+/**
+ * github-command-poller.ts — TRACK-6 (task-tracker-triggers.md §8): scan a GitHub
+ * repo's recent ISSUE COMMENTS for the three commands and act on the AUTHORISED ones.
+ *
+ *   /spec    — force intake of THIS ticket even if UNLABELLED → crystallise a spec PR
+ *              (reuses the SHARED github crystallise dialect; role-stamped if the
+ *              trigger carries a `roleConcern`).
+ *   /approve — approve the spec: mark the ticket's spec PR (`spec/gh-issue-<n>`)
+ *              ready-for-review (`gh pr ready`). A human still MERGES it (L4).
+ *   /stop    — cancel the ticket's active consilium loop (controller.cancel).
+ *
+ * WHY A SEPARATE POLLER (not folded into the issues poller)
+ *   The issues poller PRODUCES specs from LABELLED issues; commands are a DISTINCT
+ *   surface — they read COMMENTS (not issues), need commenter-role AUTH, and reach the
+ *   loop CONTROLLER (for /stop). Keeping it separate keeps the intake poller
+ *   byte-identical and gives commands their own kill-switch (`tracker.commands.enabled`,
+ *   default OFF) + their own watermark (`config.commandState`, a TOP-LEVEL key so the
+ *   two pollers never clobber each other's watermark).
+ *
+ * RAILS / SECURITY (adversarial)
+ *   (a) AUTH FIRST — every command is gated by `isAuthorizedCommenter` (assignee OR repo
+ *       maintainer, verified via the `gh` API, fail-closed). An unauthorised command is
+ *       IGNORED + logged + marked processed (never acted on, never re-evaluated). The
+ *       comment body is NEVER trusted to self-assert authority.
+ *   (b) IDEMPOTENT — a per-trigger `commandState` (newest-comment cursor +
+ *       comment-id processed set) dedups so a re-poll never re-acts a command. Each
+ *       action is ALSO idempotent on its own (crystallise dedups on the deterministic
+ *       branch; `gh pr ready` is a no-op when already ready; cancel is a no-op on a
+ *       terminal loop).
+ *   (c) STRICT PARSE — `parseTrackerCommand` matches the EXACT leading token of a line
+ *       (never a substring / prefix / casing bypass). A non-command comment is skipped.
+ *   (d) UNTRUSTED TEXT FENCED — the comment body never reaches a shell or a prompt. The
+ *       /spec path re-reads the ISSUE and runs the SAME fenced synth/crystallise as the
+ *       label poll; nothing from the comment enters a prompt.
+ *   (e) ALLOWLIST FAIL-CLOSED — `targetRepoPath` must be in the consilium-loop allowlist
+ *       (realpath-normalised) or the trigger is skipped; the crystallise + SPEC-1 fire
+ *       re-validate it too. A role stamp can only name the role's own allowlisted repo.
+ *   (f) gh OUTAGE / BEST-EFFORT — every `gh` read degrades to null / skip; a throw in one
+ *       comment / trigger / cycle never stops the others. Kill-switches (master +
+ *       tracker + commands) gate the whole surface; all default OFF.
+ */
+import { realpathSync } from "fs";
+import { resolve } from "path";
+import type { TriggerRow, StandingRoleRow, ConsiliumLoopRow } from "@shared/schema";
+import { CONSILIUM_LOOP_TERMINAL_STATES } from "@shared/schema";
+import type { TrackerEventTriggerConfig, TrackerCommandState } from "@shared/types";
+import type { AppConfig } from "../../../config/schema.js";
+import { runGhJson, type ExecFileFn } from "../../github-status.js";
+import { runGhCapture } from "./gh-exec.js";
+import { extractSpecFromIssue, specBranchName, type GhIssue } from "./issue-spec.js";
+import { crystallizeGithubIssue } from "./github-crystallize.js";
+import { resolveRoleStamp } from "./role-stamp.js";
+import { parseTrackerCommand, type TrackerCommand } from "./command-parser.js";
+import { isAuthorizedCommenter } from "./command-auth.js";
+import type { SpecSynthesizer } from "./github-issues-poller.js";
+
+/** `owner/repo` — conservative GitHub name charset (no leading dash / no flag). */
+const OWNER_REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+/** Max commands acted per trigger per cycle (bounds blast radius). */
+const MAX_COMMANDS_PER_CYCLE = 20;
+/** Cap on tracked processed-comment ids per trigger (bounds the watermark jsonb). */
+const MAX_TRACKED_PROCESSED = 500;
+/** Default look-back when a trigger has no command watermark yet. */
+const DEFAULT_LOOKBACK_MS = 24 * 60 * 60 * 1000;
+
+const TERMINAL_LOOP_STATES: ReadonlySet<string> = new Set(CONSILIUM_LOOP_TERMINAL_STATES);
+
+/** A repo issue-comment as returned by `GET /repos/{repo}/issues/comments`. */
+interface RepoIssueComment {
+  id?: number | string;
+  body?: string;
+  created_at?: string;
+  user?: { login?: string };
+  issue_url?: string;
+}
+
+export interface GithubCommandPollerDeps {
+  /** Cross-project, SYSTEM-context load of enabled tracker_event triggers (runAsSystem). */
+  getEnabledTriggersByType: (type: "tracker_event") => Promise<TriggerRow[]>;
+  /** Establish a project-scoped ALS context for one trigger's poll (= runAsProject). */
+  runInProject: <T>(projectId: string, fn: () => Promise<T>) => Promise<T>;
+  /** Re-read a trigger fresh so the watermark write does not clobber a concurrent edit. */
+  getTrigger: (id: string) => Promise<TriggerRow | undefined>;
+  /** Persist the advanced watermark (writes back `config.commandState`). */
+  updateTrigger: (id: string, updates: Partial<TriggerRow>) => Promise<unknown>;
+  /** Live config accessor (kill-switches + interval). */
+  config: () => AppConfig;
+  /** Fail-closed allowlist of local repo paths (consilium-loop allowlist). */
+  allowedRepoPaths: () => string[];
+  /** Project-scoped role load for the /spec role stamp (absent ⇒ unstamped forced spec). */
+  getStandingRole?: (id: string) => Promise<StandingRoleRow | undefined>;
+  /** Model-backed synthesiser for free-form issues on /spec (absent ⇒ normalise-only). */
+  synthesizer?: SpecSynthesizer;
+  /** Project-scoped read of consilium loops (for /stop — the SAME path the observer uses). */
+  getLoops: () => Promise<ConsiliumLoopRow[]>;
+  /** Cancel a loop (the loop controller's `cancel`) — for /stop. Best-effort, never throws here. */
+  cancelLoop: (loopId: string, opts?: { reason?: string; actor?: string }) => Promise<ConsiliumLoopRow | null>;
+  /** Injectable `gh` runner (tests pass a fake — no real `gh`/network). */
+  runGh?: ExecFileFn;
+  /** Injectable git-remote reader (default: real `git`) for the /spec crystallise. */
+  gitRemoteUrl?: (repoPath: string) => Promise<string | null>;
+  /** Structured logger. */
+  log: (message: string) => void;
+  /** Injectable clock (tests). */
+  now?: () => number;
+}
+
+/** Best-effort realpath (collapses symlinks/`..` for an EXISTING path), else lexical. */
+function canonicalPath(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return resolve(p);
+  }
+}
+
+/** Fail-closed allowlist check — target must equal or sit beneath an allowed root. */
+function isAllowedRepoPath(targetRepoPath: string, allowed: readonly string[]): boolean {
+  const target = canonicalPath(targetRepoPath);
+  for (const a of allowed) {
+    const root = canonicalPath(a);
+    if (target === root || target.startsWith(root + "/")) return true;
+  }
+  return false;
+}
+
+/** The origin issue number embedded in an `issue_url` (`.../issues/<n>`), else null. */
+function issueNumberFromUrl(issueUrl: string | undefined, repo: string): number | null {
+  if (typeof issueUrl !== "string" || issueUrl.length === 0) return null;
+  // Defence: the comment must belong to THIS repo (we listed from this repo's endpoint,
+  // but re-check so a spoofed issue_url can never retarget another repo).
+  if (!issueUrl.toLowerCase().includes(`/repos/${repo.toLowerCase()}/issues/`)) return null;
+  const m = /\/issues\/(\d+)(?:$|[/?#])/.exec(issueUrl);
+  if (!m) return null;
+  const n = Number.parseInt(m[1], 10);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+/** Keep at most MAX_TRACKED_PROCESSED processed ids (most recent by `at` win). */
+function boundProcessed(processed: Record<string, { at: string }>): Record<string, { at: string }> {
+  const keys = Object.keys(processed);
+  if (keys.length <= MAX_TRACKED_PROCESSED) return processed;
+  const kept = keys
+    .sort((a, b) => Date.parse(processed[b]?.at ?? "") - Date.parse(processed[a]?.at ?? ""))
+    .slice(0, MAX_TRACKED_PROCESSED);
+  const out: Record<string, { at: string }> = {};
+  for (const k of kept) out[k] = processed[k];
+  return out;
+}
+
+export class GithubCommandPoller {
+  private readonly deps: GithubCommandPollerDeps;
+  private readonly gitRemoteUrl: (repoPath: string) => Promise<string | null>;
+  private readonly now: () => number;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private polling = false;
+
+  constructor(deps: GithubCommandPollerDeps) {
+    this.deps = deps;
+    this.gitRemoteUrl =
+      deps.gitRemoteUrl ??
+      (async (repoPath: string) => {
+        try {
+          const { stdout } = await (deps.runGh
+            ? deps.runGh("git", ["-C", repoPath, "remote", "get-url", "origin"], { timeout: 10_000 })
+            : Promise.reject(new Error("no runner")));
+          const url = (stdout ?? "").trim();
+          return url.length > 0 ? url : null;
+        } catch {
+          return null;
+        }
+      });
+    this.now = deps.now ?? Date.now;
+  }
+
+  /**
+   * Start the interval poller IFF `tracker.enabled && tracker.commands.enabled`. The
+   * caller only constructs + starts this when both are on. Idempotent.
+   */
+  start(): void {
+    if (this.timer) return;
+    const cfg = this.deps.config().features.triggers.tracker;
+    if (!cfg.enabled || !cfg.commands.enabled) {
+      this.deps.log("tracker commands disabled — command poller not started");
+      return;
+    }
+    const intervalMs = cfg.pollIntervalSec * 1000;
+    this.timer = setInterval(() => void this.pollAllSafe(), intervalMs);
+    this.timer.unref?.();
+    this.deps.log(`tracker command poller started (every ${cfg.pollIntervalSec}s)`);
+  }
+
+  /** Stop the interval poller. */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** One cycle, fully guarded — a throw here must never kill the interval. */
+  async pollAllSafe(): Promise<void> {
+    if (this.polling) return;
+    this.polling = true;
+    try {
+      await this.pollAll();
+    } catch (e) {
+      this.deps.log(`tracker command poll cycle error: ${(e as Error).message}`);
+    } finally {
+      this.polling = false;
+    }
+  }
+
+  /**
+   * Poll every enabled tracker_event trigger for commands. Gated on the MASTER switch
+   * AND the commands sub-switch: either off ⇒ skip the whole cycle (byte-identical to
+   * TRACK-1..5 — no comment is ever acted on).
+   */
+  async pollAll(): Promise<void> {
+    const triggers = this.deps.config().features.triggers;
+    if (!triggers.enabled) {
+      this.deps.log("tracker command poll skipped — features.triggers.enabled (master switch) off");
+      return;
+    }
+    if (!triggers.tracker.commands.enabled) {
+      this.deps.log("tracker command poll skipped — commands sub-switch off");
+      return;
+    }
+    const rows = await this.deps.getEnabledTriggersByType("tracker_event");
+    for (const trigger of rows) {
+      try {
+        await this.pollTrigger(trigger);
+      } catch (e) {
+        this.deps.log(`tracker command poll error for trigger ${trigger.id}: ${(e as Error).message}`);
+      }
+    }
+  }
+
+  /** Poll one trigger: validate config + allowlist, then process new command comments. */
+  async pollTrigger(trigger: TriggerRow): Promise<void> {
+    if (!trigger.projectId) return;
+    const config = trigger.config as TrackerEventTriggerConfig;
+    if (config.tracker !== "github") return;
+    const repo = (config.repo ?? "").trim();
+    if (!OWNER_REPO_RE.test(repo)) {
+      this.deps.log(`tracker command poll skipped for trigger ${trigger.id} — repo not owner/repo`);
+      return;
+    }
+    const targetRepoPath = config.targetRepoPath;
+    if (!targetRepoPath || targetRepoPath.length === 0) {
+      this.deps.log(`tracker command poll skipped for trigger ${trigger.id} — no targetRepoPath`);
+      return;
+    }
+    if (!isAllowedRepoPath(targetRepoPath, this.deps.allowedRepoPaths())) {
+      this.deps.log(`tracker command poll skipped for trigger ${trigger.id} — targetRepoPath not in allowlist`);
+      return;
+    }
+
+    const projectId = trigger.projectId;
+    await this.deps.runInProject(projectId, async () => {
+      const state: TrackerCommandState = { ...(config.commandState ?? {}) };
+      const processed = { ...(state.processed ?? {}) };
+      const sinceMs = state.lastCommentAt
+        ? Date.parse(state.lastCommentAt)
+        : this.now() - DEFAULT_LOOKBACK_MS;
+      const sinceIso = new Date(Number.isFinite(sinceMs) ? sinceMs : this.now() - DEFAULT_LOOKBACK_MS).toISOString();
+
+      const comments = await runGhJson<RepoIssueComment[]>(
+        [
+          "api", "-X", "GET", `repos/${repo}/issues/comments`,
+          "-f", `since=${sinceIso}`, "-f", "sort=created", "-f", "direction=asc", "-f", "per_page=100",
+        ],
+        this.deps.runGh,
+      );
+      if (comments === null || !Array.isArray(comments)) {
+        this.deps.log(`tracker command poll: comments unavailable for ${repo} (gh degraded) — skipping cycle`);
+        return; // do NOT advance the watermark.
+      }
+
+      let newestMs = Number.isFinite(sinceMs) ? sinceMs : this.now() - DEFAULT_LOOKBACK_MS;
+      let acted = 0;
+      for (const comment of comments) {
+        const createdMs = comment.created_at ? Date.parse(comment.created_at) : NaN;
+        if (Number.isFinite(createdMs) && createdMs > newestMs) newestMs = createdMs;
+
+        const id = comment.id;
+        const key = id !== undefined && id !== null ? String(id) : "";
+        if (key.length === 0) continue;
+        if (processed[key]) continue; // idempotency — already decided.
+
+        const cmd = parseTrackerCommand(comment.body);
+        if (!cmd) continue; // not a command — skip (watermark advances past it).
+
+        if (acted >= MAX_COMMANDS_PER_CYCLE) break;
+
+        const issueNumber = issueNumberFromUrl(comment.issue_url, repo);
+        if (issueNumber === null) {
+          this.deps.log(`tracker command poll: comment ${key} on ${repo} has no resolvable issue — skipping`);
+          continue;
+        }
+        const login = comment.user?.login;
+        if (typeof login !== "string" || login.length === 0) {
+          processed[key] = { at: new Date(this.now()).toISOString() };
+          continue;
+        }
+
+        // AUTH FIRST — verify the commenter's role via the tracker API (fail-closed).
+        const authorized = await isAuthorizedCommenter(
+          { repo, issueNumber, login },
+          this.deps.runGh,
+        );
+        if (!authorized) {
+          this.deps.log(
+            `tracker command poll: IGNORED unauthorized /${cmd} by "${login}" on ${repo}#${issueNumber}`,
+          );
+          processed[key] = { at: new Date(this.now()).toISOString() }; // never re-evaluate.
+          continue;
+        }
+
+        await this.runCommand(cmd, { repo, targetRepoPath, issueNumber, config });
+        processed[key] = { at: new Date(this.now()).toISOString() };
+        acted++;
+      }
+
+      // Advance the cursor to the newest comment seen; bound the processed set.
+      state.lastCommentAt = new Date(newestMs).toISOString();
+      state.processed = boundProcessed(processed);
+      await this.persistWatermark(trigger.id, state);
+    });
+  }
+
+  /** Dispatch one authorised command. Best-effort — a failure logs, never throws. */
+  private async runCommand(
+    cmd: TrackerCommand,
+    ctx: { repo: string; targetRepoPath: string; issueNumber: number; config: TrackerEventTriggerConfig },
+  ): Promise<void> {
+    try {
+      if (cmd === "spec") return await this.forceIntake(ctx);
+      if (cmd === "approve") return await this.approveSpecPr(ctx);
+      if (cmd === "stop") return await this.stopLoop(ctx);
+    } catch (e) {
+      this.deps.log(
+        `tracker command poll: /${cmd} on ${ctx.repo}#${ctx.issueNumber} errored: ${(e as Error).message}`,
+      );
+    }
+  }
+
+  /** /spec — force intake of the issue (crystallise a spec PR), role-stamped if bound. */
+  private async forceIntake(ctx: {
+    repo: string;
+    targetRepoPath: string;
+    issueNumber: number;
+    config: TrackerEventTriggerConfig;
+  }): Promise<void> {
+    const { repo, targetRepoPath, issueNumber, config } = ctx;
+    const issue = await runGhJson<GhIssue>(
+      ["issue", "view", String(issueNumber), "--repo", repo, "--json", "number,title,body,labels,url"],
+      this.deps.runGh,
+    );
+    if (!issue || typeof issue.number !== "number") {
+      this.deps.log(`tracker command poll: /spec could not read ${repo}#${issueNumber} — skipping`);
+      return;
+    }
+
+    const extract = extractSpecFromIssue(issue);
+    let { problem, scope, outOfScope, criteria } = extract;
+    if (criteria.length === 0 && this.deps.synthesizer) {
+      try {
+        const syn = await this.deps.synthesizer.synthesize(issue);
+        if (syn && Array.isArray(syn.criteria) && syn.criteria.length > 0) {
+          criteria = syn.criteria;
+          problem = problem ?? syn.problem;
+          scope = scope ?? syn.scope;
+          outOfScope = outOfScope ?? syn.outOfScope;
+        }
+      } catch (e) {
+        this.deps.log(`tracker command poll: /spec synth error for ${repo}#${issueNumber}: ${(e as Error).message}`);
+      }
+    }
+
+    const roleStamp = await this.resolveRoleStamp(config);
+    const title = typeof issue.title === "string" ? issue.title : "";
+    const result = await crystallizeGithubIssue(
+      { runGh: this.deps.runGh, gitRemoteUrl: this.gitRemoteUrl, log: this.deps.log },
+      {
+        repo,
+        targetRepoPath,
+        number: issueNumber,
+        title,
+        url: issue.url,
+        status: config.specStatus ?? "ready",
+        problem: problem ?? title,
+        scope,
+        outOfScope,
+        criteria,
+        roleStamp,
+      },
+    );
+    this.deps.log(`tracker command poll: /spec on ${repo}#${issueNumber} → ${result.outcome}`);
+  }
+
+  /** /approve — mark the ticket's spec PR ready-for-review (a human still merges). */
+  private async approveSpecPr(ctx: { repo: string; issueNumber: number }): Promise<void> {
+    const { repo, issueNumber } = ctx;
+    // The spec PR head is the deterministic `spec/gh-issue-<n>` branch (issue-spec.ts).
+    const branch = specBranchName(issueNumber);
+    const res = await runGhCapture(
+      ["pr", "ready", branch, "--repo", repo],
+      this.deps.runGh,
+    );
+    if (!res.ok) {
+      this.deps.log(`tracker command poll: /approve on ${repo}#${issueNumber} (${branch}) failed: ${res.stderr}`);
+      return;
+    }
+    this.deps.log(`tracker command poll: /approve on ${repo}#${issueNumber} → spec PR ${branch} marked ready`);
+  }
+
+  /** /stop — cancel the ticket's active (non-terminal) consilium loop. */
+  private async stopLoop(ctx: { repo: string; issueNumber: number }): Promise<void> {
+    const { repo, issueNumber } = ctx;
+    const loops = await this.deps.getLoops();
+    const target = loops.find((l) => this.loopMatchesIssue(l, repo, issueNumber));
+    if (!target) {
+      this.deps.log(`tracker command poll: /stop on ${repo}#${issueNumber} — no active loop to cancel`);
+      return;
+    }
+    const cancelled = await this.deps.cancelLoop(target.id, {
+      actor: "tracker:/stop",
+      reason: `cancelled by /stop comment on ${repo}#${issueNumber}`,
+    });
+    this.deps.log(
+      cancelled
+        ? `tracker command poll: /stop on ${repo}#${issueNumber} → cancelled loop ${target.id}`
+        : `tracker command poll: /stop on ${repo}#${issueNumber} → loop ${target.id} already terminal (no-op)`,
+    );
+  }
+
+  /**
+   * True iff a NON-TERMINAL loop traces to `repo#issueNumber` — the SAME provenance
+   * join the write-back observer uses (`spec.source.kind==="github"` + ref===n + the
+   * issue URL under this repo). A terminal loop is skipped (cancel would no-op).
+   */
+  private loopMatchesIssue(loop: ConsiliumLoopRow, repo: string, issueNumber: number): boolean {
+    if (TERMINAL_LOOP_STATES.has(loop.state)) return false;
+    const src = loop.triggerProvenance?.spec?.source;
+    if (!src || src.kind !== "github") return false;
+    if (src.ref !== String(issueNumber)) return false;
+    const url = src.url;
+    if (typeof url === "string" && url.length > 0) {
+      return url.toLowerCase().includes(`/${repo.toLowerCase()}/issues/`);
+    }
+    return true; // no url (legacy edge) — attribute by ref alone within this repo trigger.
+  }
+
+  /** Resolve the /spec role stamp from the trigger's roleConcern (project-scoped). */
+  private async resolveRoleStamp(config: TrackerEventTriggerConfig) {
+    const binding = config.roleConcern;
+    if (!binding || !this.deps.getStandingRole) return null;
+    try {
+      const role = await this.deps.getStandingRole(binding.roleId);
+      const res = resolveRoleStamp(role, binding.concernId);
+      if (!res.ok) {
+        this.deps.log(`tracker command poll: /spec role stamp skipped — ${res.reason} (role ${binding.roleId})`);
+        return null;
+      }
+      return res.stamp;
+    } catch (e) {
+      this.deps.log(`tracker command poll: /spec role stamp error: ${(e as Error).message}`);
+      return null;
+    }
+  }
+
+  /** Re-read fresh + write `config.commandState` (no migration; own top-level key). */
+  private async persistWatermark(triggerId: string, state: TrackerCommandState): Promise<void> {
+    const fresh = await this.deps.getTrigger(triggerId);
+    if (!fresh) return;
+    const freshConfig = (fresh.config ?? {}) as TrackerEventTriggerConfig;
+    const nextConfig: TrackerEventTriggerConfig = { ...freshConfig, commandState: state };
+    await this.deps.updateTrigger(triggerId, { config: nextConfig });
+  }
+}

--- a/server/services/consilium/trackers/github-crystallize.ts
+++ b/server/services/consilium/trackers/github-crystallize.ts
@@ -1,0 +1,117 @@
+/**
+ * github-crystallize.ts — TRACK-6: the ONE GitHub "issue → committed spec PR" dialect,
+ * shared by the label-poll intake (`github-issues-poller.ts`) and the `/spec`
+ * force-intake command (`github-command-poller.ts`) so the two CANNOT drift. It fixes
+ * the GitHub copy (commit message, PR title/body, `closes #n`), the deterministic
+ * branch/file names, the `{ kind:"github", ref }` provenance, and the pickup /
+ * need-criteria write-backs, then delegates to the connector-agnostic
+ * `crystallizeTicket` (spec-intake.ts) — the SAME shared renderer + spec-writer + order
+ * every tracker uses.
+ *
+ * BYTE-IDENTICAL: extracted verbatim from TRACK-1's inline tail — the same argv, the
+ * same order, the same copy — so `github-issues-poller.test.ts`'s round-trip assertions
+ * are unchanged. The `/spec` command path reuses it so a forced spec is identical to a
+ * labelled-intake spec (only the trigger differs).
+ */
+import type { ExecFileFn } from "../../github-status.js";
+import { specBranchName, specFilePath } from "./issue-spec.js";
+import { crystallizeTicket, type CrystallizeOutcome } from "./spec-intake.js";
+import { postPickupComment, postNeedCriteriaComment } from "./issue-writeback.js";
+import type { RoleStamp } from "./role-stamp.js";
+
+/** Single-line control-strip + collapse + clamp for the (untrusted) issue title. */
+export function sanitizeTitleLine(value: string, max = 160): string {
+  return value
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001f\u007f]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, max);
+}
+
+export interface GithubCrystallizeDeps {
+  runGh?: ExecFileFn;
+  gitRemoteUrl: (repoPath: string) => Promise<string | null>;
+  log: (message: string) => void;
+}
+
+export interface GithubCrystallizeInput {
+  /** `owner/repo` (already shape-validated by the caller). */
+  repo: string;
+  /** Allowlisted local repo path (already allowlist-validated by the caller). */
+  targetRepoPath: string;
+  /** The issue number (positive integer, validated by the caller). */
+  number: number;
+  /** The raw (untrusted) issue title — rendered as a quoted YAML scalar downstream. */
+  title: string;
+  url?: string;
+  status: "ready" | "draft";
+  /** Resolved spec fields (criteria EMPTY ⇒ the ask-for-criteria path). */
+  problem: string;
+  scope?: string;
+  outOfScope?: string;
+  criteria: string[];
+  /** TRACK-6: the role STAMP (name + skills) → spec frontmatter; undefined ⇒ unstamped. */
+  roleStamp?: RoleStamp | null;
+}
+
+/**
+ * Crystallise one GitHub issue into a committed spec PR + pickup comment (or an
+ * ask-for-criteria comment when there are no testable criteria). Byte-identical to
+ * TRACK-1's inline tail. Never throws (every failure is a typed `CrystallizeOutcome`).
+ */
+export async function crystallizeGithubIssue(
+  deps: GithubCrystallizeDeps,
+  input: GithubCrystallizeInput,
+): Promise<CrystallizeOutcome> {
+  const { repo, number } = input;
+  const sanitizedTitle = sanitizeTitleLine(input.title);
+  const commitMessage = `feat: add spec for issue #${number} (closes #${number})`;
+  const prTitle = `spec: ${sanitizedTitle || `issue #${number}`} (closes #${number})`;
+  const prBody = [
+    `Track-1 auto-produced spec for issue #${number}.`,
+    "",
+    "This spec was generated from the linked GitHub issue by the factory's Track-1 intake.",
+    "Merging it fires the SPEC-1 spec-watch, which launches the review loop off the committed spec.",
+    "",
+    `Closes #${number}`,
+  ].join("\n");
+
+  return crystallizeTicket(
+    {
+      runGh: deps.runGh,
+      gitRemoteUrl: deps.gitRemoteUrl,
+      log: deps.log,
+      writeback: {
+        pickup: (specPrUrl) =>
+          postPickupComment(
+            { runGh: deps.runGh, log: deps.log },
+            { repo, issueNumber: number, specPrUrl },
+          ),
+        needCriteria: () =>
+          postNeedCriteriaComment(
+            { runGh: deps.runGh, log: deps.log },
+            { repo, issueNumber: number },
+          ),
+      },
+    },
+    {
+      source: { kind: "github", ref: String(number), url: input.url },
+      targetRepoPath: input.targetRepoPath,
+      branch: specBranchName(number),
+      filePath: specFilePath(number, input.title),
+      title: input.title.trim().length > 0 ? input.title : `Issue #${number}`,
+      status: input.status,
+      problem: input.problem,
+      scope: input.scope,
+      outOfScope: input.outOfScope,
+      criteria: input.criteria,
+      // TRACK-6: stamp the role's name + skills so the merged spec fires the ROLE's loop.
+      role: input.roleStamp?.role,
+      skills: input.roleStamp?.skills,
+      commitMessage,
+      prTitle,
+      prBody,
+    },
+  );
+}

--- a/server/services/consilium/trackers/github-issues-poller.ts
+++ b/server/services/consilium/trackers/github-issues-poller.ts
@@ -44,18 +44,13 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import { realpathSync } from "fs";
 import { resolve } from "path";
-import type { TriggerRow } from "@shared/schema";
+import type { TriggerRow, StandingRoleRow } from "@shared/schema";
 import type { TrackerEventTriggerConfig, TrackerPollState } from "@shared/types";
 import type { AppConfig } from "../../../config/schema.js";
 import { runGhJson, type ExecFileFn } from "../../github-status.js";
-import {
-  extractSpecFromIssue,
-  specBranchName,
-  specFilePath,
-  type GhIssue,
-} from "./issue-spec.js";
-import { crystallizeTicket } from "./spec-intake.js";
-import { postPickupComment, postNeedCriteriaComment } from "./issue-writeback.js";
+import { extractSpecFromIssue, type GhIssue } from "./issue-spec.js";
+import { crystallizeGithubIssue } from "./github-crystallize.js";
+import { resolveRoleStamp, type RoleStamp } from "./role-stamp.js";
 
 const execFileAsync: ExecFileFn = promisify(execFile);
 
@@ -94,6 +89,13 @@ export interface GithubIssuesPollerDeps {
   config: () => AppConfig;
   /** Fail-closed allowlist of local repo paths (consilium-loop allowlist). */
   allowedRepoPaths: () => string[];
+  /**
+   * TRACK-6 (standing-role.md §5): project-scoped load of a Standing Role — used ONLY
+   * when a tracker_event trigger carries `roleConcern`, to STAMP the role's name +
+   * skills into the crystallised spec. Called INSIDE `runInProject` (project-scoped).
+   * Absent ⇒ role stamping is disabled (an unstamped spec — byte-identical to TRACK-1).
+   */
+  getStandingRole?: (id: string) => Promise<StandingRoleRow | undefined>;
   /** Optional model-backed synthesiser for free-form issues (absent ⇒ normalise-only). */
   synthesizer?: SpecSynthesizer;
   /** Injectable `gh` runner (tests pass a fake — no real `gh`/network). */
@@ -148,16 +150,6 @@ function isAllowedRepoPath(targetRepoPath: string, allowed: readonly string[]): 
     if (target === root || target.startsWith(root + "/")) return true;
   }
   return false;
-}
-
-/** Single-line control-strip + collapse + clamp for the (untrusted) issue title. */
-function sanitizeTitleLine(value: string, max = 160): string {
-  return value
-    // eslint-disable-next-line no-control-regex
-    .replace(/[\u0000-\u001f\u007f]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, max);
 }
 
 /** Keep at most MAX_TRACKED_INTAKE intakes (highest issue numbers win — most recent). */
@@ -285,6 +277,13 @@ export class GithubIssuesPoller {
 
     const projectId = trigger.projectId;
     await this.deps.runInProject(projectId, async () => {
+      // TRACK-6 (standing-role.md §5): if this tracker trigger is the BACKING trigger of
+      // a Standing Role's tracker concern, resolve the role STAMP ONCE for the cycle
+      // (role name + skills → the spec frontmatter). A missing / DISABLED role, or a
+      // disabled / missing concern, yields NO stamp — the poller then produces an
+      // UNSTAMPED spec (byte-identical to TRACK-1), never a disabled role's work.
+      const roleStamp = await this.resolveTriggerRoleStamp(trigger, config);
+
       const state: TrackerPollState = { ...(config.pollState ?? {}) };
       if (!state.intake) state.intake = {};
 
@@ -334,57 +333,28 @@ export class GithubIssuesPoller {
           }
         }
 
-        // Crystallise via the SHARED spec-intake (same renderer + spec-writer + order
-        // as Jira/TRACK-4/5). GitHub supplies only its dialect: the `github` source,
-        // the `spec/gh-issue-<n>` branch/path, the `closes #n` copy, and the pickup /
-        // need-criteria GitHub-comment write-backs. Byte-identical to the original
-        // inline tail (same gh calls, same order) — github-issues-poller.test asserts it.
+        // Crystallise via the SHARED github dialect (`crystallizeGithubIssue` →
+        // spec-intake): the `github` source, the `spec/gh-issue-<n>` branch/path, the
+        // `closes #n` copy, and the pickup / need-criteria write-backs. Byte-identical to
+        // the original inline tail (github-issues-poller.test asserts it) and shared with
+        // the `/spec` command force-intake so the two paths cannot drift. TRACK-6 threads
+        // the role STAMP (undefined ⇒ unstamped, TRACK-1 bytes).
         const specStatus = config.specStatus ?? "ready";
         const title = typeof issue.title === "string" ? issue.title : "";
-        const sanitizedTitle = sanitizeTitleLine(title);
-        const commitMessage = `feat: add spec for issue #${number} (closes #${number})`;
-        const prTitle = `spec: ${sanitizedTitle || `issue #${number}`} (closes #${number})`;
-        const prBody = [
-          `Track-1 auto-produced spec for issue #${number}.`,
-          "",
-          "This spec was generated from the linked GitHub issue by the factory's Track-1 intake.",
-          "Merging it fires the SPEC-1 spec-watch, which launches the review loop off the committed spec.",
-          "",
-          `Closes #${number}`,
-        ].join("\n");
-
-        const result = await crystallizeTicket(
+        const result = await crystallizeGithubIssue(
+          { runGh: this.deps.runGh, gitRemoteUrl: this.gitRemoteUrl, log: this.deps.log },
           {
-            runGh: this.deps.runGh,
-            gitRemoteUrl: this.gitRemoteUrl,
-            log: this.deps.log,
-            writeback: {
-              pickup: (specPrUrl) =>
-                postPickupComment(
-                  { runGh: this.deps.runGh, log: this.deps.log },
-                  { repo, issueNumber: number, specPrUrl },
-                ),
-              needCriteria: () =>
-                postNeedCriteriaComment(
-                  { runGh: this.deps.runGh, log: this.deps.log },
-                  { repo, issueNumber: number },
-                ),
-            },
-          },
-          {
-            source: { kind: "github", ref: String(number), url: issue.url },
+            repo,
             targetRepoPath, // the allowlisted local path → SPEC-1's resolveSpecRepo maps it.
-            branch: specBranchName(number),
-            filePath: specFilePath(number, title),
-            title: title.trim().length > 0 ? title : `Issue #${number}`,
+            number,
+            title,
+            url: issue.url,
             status: specStatus,
             problem: problem ?? title,
             scope,
             outOfScope,
             criteria,
-            commitMessage,
-            prTitle,
-            prBody,
+            roleStamp,
           },
         );
 
@@ -404,6 +374,35 @@ export class GithubIssuesPoller {
       state.lastPolledAt = new Date(this.now()).toISOString();
       await this.persistWatermark(trigger.id, state);
     });
+  }
+
+  /**
+   * TRACK-6: resolve the role STAMP for a tracker trigger, or `null` when the trigger
+   * carries no `roleConcern` (byte-identical TRACK-1) / role stamping is not wired /
+   * the role or concern is missing or DISABLED. MUST be called inside `runInProject`
+   * (the role load is project-scoped). Never throws — a lookup failure logs + degrades
+   * to no stamp (an unstamped spec), never a crash of the poll cycle.
+   */
+  private async resolveTriggerRoleStamp(
+    trigger: TriggerRow,
+    config: TrackerEventTriggerConfig,
+  ): Promise<RoleStamp | null> {
+    const binding = config.roleConcern;
+    if (!binding || !this.deps.getStandingRole) return null;
+    try {
+      const role = await this.deps.getStandingRole(binding.roleId);
+      const res = resolveRoleStamp(role, binding.concernId);
+      if (!res.ok) {
+        this.deps.log(
+          `tracker poll: role stamp skipped for trigger ${trigger.id} — ${res.reason} (role ${binding.roleId})`,
+        );
+        return null;
+      }
+      return res.stamp;
+    } catch (e) {
+      this.deps.log(`tracker poll: role stamp error for trigger ${trigger.id}: ${(e as Error).message}`);
+      return null;
+    }
   }
 
   /** Re-read fresh + write the watermark into `config.pollState` (no migration). */

--- a/server/services/consilium/trackers/role-stamp.ts
+++ b/server/services/consilium/trackers/role-stamp.ts
@@ -1,0 +1,65 @@
+/**
+ * role-stamp.ts — TRACK-6 (task-tracker-triggers.md §5, standing-role.md §5): the PURE
+ * decision that turns a loaded Standing Role + a firing tracker concern into the
+ * `{ role, skills }` STAMP a crystallised spec carries in its frontmatter. Kept pure +
+ * unit-testable (no gh / storage / ALS) exactly like `role-compose.ts` and
+ * `github-event-map.ts`.
+ *
+ * WHAT THE STAMP IS (and why it is enough)
+ *   The role's INBOX is the tracker; the crystallised SPEC is the task. Stamping the
+ *   spec frontmatter `role: <name>` + `skills: [...]` is ALL that is needed for the
+ *   merged spec to fire the ROLE's loop: SPEC-1's `buildSpecInstruction` folds `role`
+ *   into the objective header and passes `skills` as the loop's skillIds. So the
+ *   loop composed on merge carries the role's capability + identity — reusing the
+ *   already-shipped spec-watch, NOT a reimplemented wake. The role's persona is not a
+ *   spec field (it is the standing instruction on the role); the `role:` name header is
+ *   the SPEC-1 contract for role provenance on a spec-fired loop.
+ *
+ * FAIL-CLOSED GATES (adversarial: a tracker concern must never wake a disabled role or
+ * bypass the role's kill-switch)
+ *   - A missing role, a role whose `enabled` is false, a concern not on the role, or a
+ *     concern whose `enabled` is false ⇒ NO stamp (`{ ok: false, reason }`). The poller
+ *     then produces an UNSTAMPED spec (byte-identical to TRACK-1) rather than silently
+ *     firing a disabled role's loop. The role's `enabled` column is the authoritative
+ *     gate — checked HERE, before any spec is stamped.
+ *   - The stamped `skills` are re-resolved PROJECT-SCOPED by the review factory when the
+ *     merged spec fires (a foreign id fails closed there), same posture as ROLE-2's wake.
+ */
+import type { StandingRoleRow } from "@shared/schema";
+import type { StandingRoleConcern } from "@shared/types";
+
+/** The stamp applied to a crystallised spec's frontmatter (role name + skills). */
+export interface RoleStamp {
+  /** The role's stored (human-authored) name → the spec's `role:` header. */
+  role: string;
+  /** The role's skill ids → the spec's `skills:` (re-resolved fail-closed on fire). */
+  skills?: string[];
+}
+
+export type RoleStampResult =
+  | { ok: true; stamp: RoleStamp }
+  | { ok: false; reason: string };
+
+/**
+ * Resolve the stamp for a firing tracker concern. PURE. `role` is the already-loaded
+ * (project-scoped) role, or undefined when the lookup missed. `concernId` names the
+ * concern whose backing trigger fired. Returns the stamp only when the role AND the
+ * concern are both enabled; otherwise a typed skip reason (the poller logs it and
+ * crystallises an UNSTAMPED spec — never a disabled role's work).
+ */
+export function resolveRoleStamp(
+  role: StandingRoleRow | undefined,
+  concernId: string,
+): RoleStampResult {
+  if (!role) return { ok: false, reason: "role-not-found" };
+  if (!role.enabled) return { ok: false, reason: "role-disabled" };
+
+  const concerns = (role.concerns ?? []) as StandingRoleConcern[];
+  const concern = concerns.find((c) => c && c.id === concernId);
+  if (!concern) return { ok: false, reason: "concern-not-found" };
+  // Per-concern kill (default on): a disabled concern never stamps.
+  if (concern.enabled === false) return { ok: false, reason: "concern-disabled" };
+
+  const skills = Array.isArray(role.skills) && role.skills.length > 0 ? [...role.skills] : undefined;
+  return { ok: true, stamp: { role: role.name, ...(skills ? { skills } : {}) } };
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1487,10 +1487,15 @@ export interface StandingRoleConcern {
   triggerId?: string;
 }
 
-/** A concern's trigger: the class (file_change | github_event) + its filter shape. */
+/**
+ * A concern's trigger: the class (file_change | github_event | tracker_event) + its
+ * filter shape. TRACK-6 adds `tracker_event` — a role whose INBOX is a tracker project
+ * (standing-role.md §5, task-tracker-triggers.md §5): a labelled ticket crystallises a
+ * spec STAMPED with the role's skills/persona, so the merged spec fires the ROLE's loop.
+ */
 export interface StandingRoleConcernTrigger {
-  type: "file_change" | "github_event";
-  filter: FileChangeConcernFilter | GitHubConcernFilter;
+  type: "file_change" | "github_event" | "tracker_event";
+  filter: FileChangeConcernFilter | GitHubConcernFilter | TrackerConcernFilter;
 }
 
 /** file_change concern filter — the path watched + optional glob patterns. */
@@ -1504,6 +1509,27 @@ export interface GitHubConcernFilter {
   repository: string;
   events?: string[];
   refFilter?: string;
+}
+
+/**
+ * TRACK-6 (task-tracker-triggers.md §5): a `tracker_event` concern filter — the role's
+ * INBOX is a tracker project. `tracker`/`repo`/`label` are the source coordinates the
+ * backing `tracker_event` trigger polls; the concern's own `repoPath` becomes the
+ * `targetRepoPath` (the allowlisted local repo the spec PR lands in + the spec's
+ * `repo:`). When a labelled ticket crystallises a spec, the poller STAMPS the role's
+ * name + skills into the spec frontmatter, so on merge SPEC-1 fires the ROLE's loop.
+ *
+ * GitHub-first (TRACK-6 boundary): only `tracker: "github"` stamps the role today (the
+ * `gh` reference path); other trackers already have their pollers + the shared
+ * crystallise pipeline, so extending the stamp to them is a documented follow-up.
+ */
+export interface TrackerConcernFilter {
+  /** TRACK-6 stamps only "github" today; the other kinds are a documented follow-up. */
+  tracker: "github";
+  /** `owner/repo` whose ISSUES are polled (also the git repo the spec PR lands in). */
+  repo: string;
+  /** The label gate — the operator's consent-to-intake (required, like the poller's). */
+  label: string;
 }
 
 /**
@@ -1664,6 +1690,18 @@ export interface TrackerPollState {
 }
 
 /**
+ * TRACK-6 (task-tracker-triggers.md §8) command-poller watermark. `lastCommentAt` is
+ * the newest issue-comment instant already scanned (the `since` cursor); `processed`
+ * maps a comment id → when it was acted on / decided (idempotency across the cursor
+ * boundary, bounded). Persisted INSIDE the trigger's `config.commandState`; OWNED by
+ * the command poller (never authored in the UI).
+ */
+export interface TrackerCommandState {
+  lastCommentAt?: string;
+  processed?: Record<string, { at: string }>;
+}
+
+/**
  * TRACK-1 (github-issues -> committed spec PR). A tracker_event trigger polls a
  * GitHub repo's ISSUES; each labelled, spec-ready issue becomes a committed spec
  * PR (which SPEC-1's spec-watch fires the loop off on merge) + a pickup comment.
@@ -1680,6 +1718,22 @@ export interface TrackerEventTriggerConfig {
   filter?: { label?: string };  // label/tag gate (consent to intake) — required at fire time (Jira label, Linear label, Azure tag, ClickUp tag)
   specStatus?: "ready" | "draft";
   pollState?: TrackerPollState;  // owned by the poller (watermark)
+  /**
+   * TRACK-6 (standing-role.md §5): when present, this tracker_event trigger is the
+   * BACKING trigger of a Standing Role's tracker concern. The github-issues poller
+   * loads the named role and STAMPS its name + skills into each crystallised spec, so
+   * the merged spec fires the ROLE's loop. Absent ⇒ the poller is byte-identical to
+   * TRACK-1 (an unstamped spec). Inert on every non-github tracker (follow-up).
+   */
+  roleConcern?: RoleConcernBinding;
+  /**
+   * TRACK-6 (task-tracker-triggers.md §8): the command poller's watermark for
+   * `/spec`,`/approve`,`/stop` comment commands — the newest comment instant seen and
+   * a bounded set of processed comment ids (idempotency). OWNED by the command poller
+   * (never authored in the UI); a TOP-LEVEL key (not under `pollState`) so the issues
+   * poller and the command poller each rewrite only their own watermark key.
+   */
+  commandState?: TrackerCommandState;
   // ─── Jira-only (TRACK-3; ignored by the github poller) ──────────────────────
   /** Jira site base URL, e.g. `https://acme.atlassian.net` (validated https). Also the
    *  optional API base override for the TRACK-5 connectors (Linear/Azure/ClickUp each

--- a/tests/unit/consilium/standing-roles-route.test.ts
+++ b/tests/unit/consilium/standing-roles-route.test.ts
@@ -348,15 +348,35 @@ describe("ROLE-2 concern endpoints", () => {
     expect(trig.config.roleConcern).toBeTruthy();
   });
 
-  it("POST a concern with an invalid trigger type (tracker_event → TRACK-6) → 400", async () => {
+  it("POST a tracker_event concern with an INCOMPLETE filter → 400 (no trigger created)", async () => {
     const storage = makeStorage([seedRole()], ["sk-1"]);
     const res = await request(makeApp(storage)).post("/api/roles/role-1/concerns").send({
       repoPath: "/repos/iac",
       focus: "f",
-      trigger: { type: "tracker_event", filter: {} },
+      trigger: { type: "tracker_event", filter: {} }, // missing tracker/repo/label
     });
     expect(res.status).toBe(400);
     expect(storage.createTrigger).not.toHaveBeenCalled();
+  });
+
+  it("POST a tracker_event concern (TRACK-6) builds a github tracker_event backing trigger with the roleConcern", async () => {
+    const storage = makeStorage([seedRole()], ["sk-1"]);
+    const res = await request(makeApp(storage)).post("/api/roles/role-1/concerns").send({
+      repoPath: "/repos/iac",
+      focus: "implement the ticket",
+      trigger: { type: "tracker_event", filter: { tracker: "github", repo: "acme/widget", label: "agent" } },
+    });
+    expect(res.status).toBe(201);
+    const trig = storage.createTrigger.mock.calls[0][0] as { type: string; config: Record<string, unknown> };
+    expect(trig.type).toBe("tracker_event");
+    expect(trig.config.tracker).toBe("github");
+    expect(trig.config.repo).toBe("acme/widget");
+    // The concern's own repoPath becomes the allowlisted targetRepoPath.
+    expect(trig.config.targetRepoPath).toBe("/repos/iac");
+    expect(trig.config.filter).toMatchObject({ label: "agent" });
+    // The binding names the SAME concern id that was stored on the role.
+    const concerns = res.body.concerns as Array<Record<string, unknown>>;
+    expect((trig.config.roleConcern as { roleId: string; concernId: string })).toMatchObject({ roleId: "role-1", concernId: concerns[0].id });
   });
 
   it("POST a concern to an unknown role → 404 (no trigger created)", async () => {

--- a/tests/unit/consilium/trackers/command-auth.test.ts
+++ b/tests/unit/consilium/trackers/command-auth.test.ts
@@ -1,0 +1,72 @@
+/**
+ * command-auth.test.ts — TRACK-6 (task-tracker-triggers.md §8): commenter authorisation
+ * is verified via the tracker API, fail-closed. Adversarial: an unauthorized commenter
+ * must never be granted authority; a degraded API must never grant authority; a hostile
+ * login shape must never reach a `gh` path as a flag.
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { ExecFileFn } from "../../../../server/services/github-status.js";
+import { isAuthorizedCommenter } from "../../../../server/services/consilium/trackers/command-auth.js";
+
+interface GhOpts {
+  assignees?: Array<{ login?: string }>;
+  permission?: string;
+  /** args→throw to simulate a gh outage. */
+  throwOn?: (args: string[]) => boolean;
+}
+
+function fakeGh(opts: GhOpts): { run: ExecFileFn; argv: string[][] } {
+  const argv: string[][] = [];
+  const run: ExecFileFn = vi.fn(async (_file: string, args: string[]) => {
+    argv.push(args);
+    if (opts.throwOn?.(args)) throw new Error("gh boom");
+    const json = (o: unknown) => ({ stdout: JSON.stringify(o), stderr: "" });
+    if (args[0] === "issue" && args[1] === "view") return json({ assignees: opts.assignees ?? [] });
+    if (args[0] === "api" && String(args[1]).includes("/collaborators/")) {
+      if (opts.permission === undefined) throw new Error("404 Not Found"); // not a collaborator
+      return json({ permission: opts.permission });
+    }
+    return { stdout: "", stderr: "" };
+  });
+  return { run, argv };
+}
+
+const base = { repo: "acme/widget", issueNumber: 42, login: "alice" };
+
+describe("isAuthorizedCommenter", () => {
+  it("authorises the ticket ASSIGNEE", async () => {
+    const { run } = fakeGh({ assignees: [{ login: "alice" }] });
+    expect(await isAuthorizedCommenter(base, run)).toBe(true);
+  });
+
+  it("authorises a MAINTAINER (write/admin/maintain permission)", async () => {
+    for (const permission of ["admin", "maintain", "write"]) {
+      const { run } = fakeGh({ assignees: [], permission });
+      expect(await isAuthorizedCommenter(base, run)).toBe(true);
+    }
+  });
+
+  it("REJECTS a non-assignee, non-maintainer (read/none/not-a-collaborator)", async () => {
+    expect(await isAuthorizedCommenter(base, fakeGh({ assignees: [], permission: "read" }).run)).toBe(false);
+    expect(await isAuthorizedCommenter(base, fakeGh({ assignees: [] }).run)).toBe(false); // 404
+  });
+
+  it("fails closed on a gh outage (degraded API never grants authority)", async () => {
+    const { run } = fakeGh({ throwOn: () => true });
+    expect(await isAuthorizedCommenter(base, run)).toBe(false);
+  });
+
+  it("rejects a hostile login shape without ever calling the permission endpoint", async () => {
+    const { run, argv } = fakeGh({ assignees: [], permission: "admin" });
+    expect(await isAuthorizedCommenter({ ...base, login: "--flag" }, run)).toBe(false);
+    expect(await isAuthorizedCommenter({ ...base, login: "a/../b" }, run)).toBe(false);
+    // Never reached the collaborators endpoint with an invalid login.
+    expect(argv.some((a) => a[0] === "api" && String(a[1]).includes("/collaborators/"))).toBe(false);
+  });
+
+  it("rejects a bad repo shape / non-positive issue number", async () => {
+    const { run } = fakeGh({ assignees: [{ login: "alice" }], permission: "admin" });
+    expect(await isAuthorizedCommenter({ ...base, repo: "not-a-repo" }, run)).toBe(false);
+    expect(await isAuthorizedCommenter({ ...base, issueNumber: 0 }, run)).toBe(false);
+  });
+});

--- a/tests/unit/consilium/trackers/command-parser.test.ts
+++ b/tests/unit/consilium/trackers/command-parser.test.ts
@@ -1,0 +1,50 @@
+/**
+ * command-parser.test.ts — TRACK-6 (task-tracker-triggers.md §8): STRICT command
+ * parsing. A command is recognised ONLY as the exact leading token of a line — never a
+ * substring, prefix, or casing bypass (the adversarial "command injection via
+ * substring/casing").
+ */
+import { describe, it, expect } from "vitest";
+import { parseTrackerCommand } from "../../../../server/services/consilium/trackers/command-parser.js";
+
+describe("parseTrackerCommand", () => {
+  it("recognises each exact command as a leading token", () => {
+    expect(parseTrackerCommand("/spec")).toBe("spec");
+    expect(parseTrackerCommand("/approve")).toBe("approve");
+    expect(parseTrackerCommand("/stop")).toBe("stop");
+  });
+
+  it("allows trailing prose after the leading token", () => {
+    expect(parseTrackerCommand("/approve looks good to me")).toBe("approve");
+    expect(parseTrackerCommand("/stop please, wrong ticket")).toBe("stop");
+  });
+
+  it("finds a command on any line (first match wins)", () => {
+    expect(parseTrackerCommand("some context\n\n/spec\nthanks")).toBe("spec");
+    expect(parseTrackerCommand("/stop\n/approve")).toBe("stop"); // first-wins, deterministic
+  });
+
+  it("does NOT substring/prefix match", () => {
+    expect(parseTrackerCommand("/specification of the api")).toBeNull();
+    expect(parseTrackerCommand("/approved by lead")).toBeNull();
+    expect(parseTrackerCommand("/stopwatch")).toBeNull();
+  });
+
+  it("does NOT match a command that is not the leading token of its line", () => {
+    expect(parseTrackerCommand("please /stop this")).toBeNull();
+    expect(parseTrackerCommand("do not /approve")).toBeNull();
+    expect(parseTrackerCommand("the `/spec` command")).toBeNull();
+  });
+
+  it("is case-sensitive (no casing bypass)", () => {
+    expect(parseTrackerCommand("/APPROVE")).toBeNull();
+    expect(parseTrackerCommand("/Spec")).toBeNull();
+    expect(parseTrackerCommand("/Stop")).toBeNull();
+  });
+
+  it("returns null for empty / non-command / non-string bodies", () => {
+    expect(parseTrackerCommand("")).toBeNull();
+    expect(parseTrackerCommand("just a normal comment")).toBeNull();
+    expect(parseTrackerCommand(undefined)).toBeNull();
+  });
+});

--- a/tests/unit/consilium/trackers/github-command-poller.test.ts
+++ b/tests/unit/consilium/trackers/github-command-poller.test.ts
@@ -1,0 +1,204 @@
+/**
+ * github-command-poller.test.ts — TRACK-6 (task-tracker-triggers.md §8): the /spec,
+ * /approve, /stop comment commands with commenter-role auth, idempotency, and the
+ * kill-switches. Fakes the `gh` seam + the loop controller.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  GithubCommandPoller,
+  type GithubCommandPollerDeps,
+} from "../../../../server/services/consilium/trackers/github-command-poller.js";
+import type { ExecFileFn } from "../../../../server/services/github-status.js";
+import type { TriggerRow, ConsiliumLoopRow } from "../../../../shared/schema.js";
+import type { AppConfig, TrackerEventTriggerConfig } from "../../../../shared/types.js";
+
+interface GhOpts {
+  comments?: Array<{ id: number; body: string; created_at?: string; user?: { login?: string }; issue_url?: string }>;
+  assignees?: Array<{ login?: string }>;
+  permission?: string;
+}
+
+/** A fake `gh` dispatching on argv, recording every call. */
+function fakeGh(opts: GhOpts): { run: ExecFileFn; argv: string[][] } {
+  const argv: string[][] = [];
+  const run: ExecFileFn = vi.fn(async (_file: string, args: string[]) => {
+    argv.push(args);
+    const json = (o: unknown) => ({ stdout: JSON.stringify(o), stderr: "" });
+    // Repo issue-comments list.
+    if (args[0] === "api" && args.includes("repos/acme/widget/issues/comments")) {
+      return json(opts.comments ?? []);
+    }
+    // Collaborator permission (auth maintainer check).
+    if (args[0] === "api" && String(args[1]).includes("/collaborators/")) {
+      if (opts.permission === undefined) throw new Error("404");
+      return json({ permission: opts.permission });
+    }
+    // issue view — assignees (auth) | crystallise read | pickup comments.
+    if (args[0] === "issue" && args[1] === "view") {
+      if (args.includes("assignees")) return json({ assignees: opts.assignees ?? [] });
+      if (args.some((a) => a.includes("number,title,body"))) {
+        return json({ number: 42, title: "Add caching", url: "https://github.com/acme/widget/issues/42", labels: [], body: "## Acceptance Criteria\n- [ ] cache hit ratio > 0.9" });
+      }
+      return json({ comments: [] });
+    }
+    if (args[0] === "issue" && args[1] === "comment") return { stdout: "", stderr: "" };
+    if (args[0] === "pr" && args[1] === "list") return json([]);
+    if (args[0] === "pr" && args[1] === "ready") return { stdout: "", stderr: "" };
+    if (args[0] === "pr" && args[1] === "create") return { stdout: "https://github.com/acme/widget/pull/9\n", stderr: "" };
+    if (args[0] === "repo" && args[1] === "view") return json({ defaultBranchRef: { name: "main" } });
+    if (args[0] === "api") return json({ object: { sha: "basesha" } });
+    return { stdout: "", stderr: "" };
+  });
+  return { run, argv };
+}
+
+function trigger(): TriggerRow {
+  const config: TrackerEventTriggerConfig = {
+    tracker: "github", repo: "acme/widget", targetRepoPath: "/repo/widget",
+    filter: { label: "agent" }, specStatus: "ready",
+  };
+  return {
+    id: "trk-1", projectId: "proj-1", pipelineId: null, type: "tracker_event",
+    config: JSON.parse(JSON.stringify(config)) as TrackerEventTriggerConfig,
+    secretEncrypted: null, enabled: true, lastTriggeredAt: null, suppressedCount: 0,
+    createdAt: new Date(0), updatedAt: new Date(0),
+  } as unknown as TriggerRow;
+}
+
+function activeLoop(): ConsiliumLoopRow {
+  return {
+    id: "loop-1", state: "reviewing", repoPath: "/repo/widget",
+    triggerProvenance: { firedAt: "2020", spec: { specPath: "docs/specs/x.md", status: "ready", source: { kind: "github", ref: "42", url: "https://github.com/acme/widget/issues/42" } } },
+  } as unknown as ConsiliumLoopRow;
+}
+
+function cfg(masterOn = true, commandsOn = true, trackerOn = true): () => AppConfig {
+  return () => ({
+    features: { triggers: { enabled: masterOn, tracker: { enabled: trackerOn, pollIntervalSec: 300, commands: { enabled: commandsOn } } } },
+  }) as unknown as AppConfig;
+}
+
+interface HarnessOpts {
+  gh: ExecFileFn;
+  masterOn?: boolean;
+  commandsOn?: boolean;
+  loops?: ConsiliumLoopRow[];
+  cancelLoop?: GithubCommandPollerDeps["cancelLoop"];
+}
+
+function harness(opts: HarnessOpts) {
+  let stored = trigger();
+  const updates: Array<Partial<TriggerRow>> = [];
+  const cancelLoop = opts.cancelLoop ?? vi.fn(async () => activeLoop());
+  const deps: GithubCommandPollerDeps = {
+    getEnabledTriggersByType: async () => [stored],
+    runInProject: async (_pid, fn) => fn(),
+    getTrigger: async () => stored,
+    updateTrigger: async (_id, u) => {
+      updates.push(u);
+      if (u.config) stored = { ...stored, config: u.config } as TriggerRow;
+      return stored;
+    },
+    config: cfg(opts.masterOn ?? true, opts.commandsOn ?? true),
+    allowedRepoPaths: () => ["/repo/widget"],
+    getLoops: async () => opts.loops ?? [],
+    cancelLoop,
+    runGh: opts.gh,
+    gitRemoteUrl: async () => "https://github.com/acme/widget.git",
+    log: () => {},
+    now: () => 1_000_000,
+  };
+  return { poller: new GithubCommandPoller(deps), updates, cancelLoop };
+}
+
+const comment = (body: string, over: Partial<{ id: number; user: { login?: string } }> = {}) => ({
+  id: over.id ?? 100,
+  body,
+  created_at: "2021-01-01T00:00:00Z",
+  user: over.user ?? { login: "alice" },
+  issue_url: "https://api.github.com/repos/acme/widget/issues/42",
+});
+
+const isPrCreate = (a: string[]) => a[0] === "pr" && a[1] === "create";
+const isPrReady = (a: string[]) => a[0] === "pr" && a[1] === "ready";
+const count = (argv: string[][], p: (a: string[]) => boolean) => argv.filter(p).length;
+
+describe("GithubCommandPoller", () => {
+  it("/spec from an AUTHORIZED commenter (assignee) forces intake (opens a spec PR)", async () => {
+    const { run, argv } = fakeGh({ comments: [comment("/spec")], assignees: [{ login: "alice" }] });
+    const { poller } = harness({ gh: run });
+    await poller.pollAll();
+    expect(count(argv, isPrCreate)).toBe(1);
+  });
+
+  it("/spec from an UNAUTHORIZED commenter is IGNORED (no intake)", async () => {
+    const { run, argv } = fakeGh({ comments: [comment("/spec", { user: { login: "mallory" } })], assignees: [{ login: "alice" }] });
+    const { poller } = harness({ gh: run });
+    await poller.pollAll();
+    expect(count(argv, isPrCreate)).toBe(0);
+  });
+
+  it("/approve (authorized) marks the spec PR ready-for-review", async () => {
+    const { run, argv } = fakeGh({ comments: [comment("/approve")], assignees: [{ login: "alice" }] });
+    const { poller } = harness({ gh: run });
+    await poller.pollAll();
+    const ready = argv.find(isPrReady);
+    expect(ready).toBeTruthy();
+    expect(ready).toEqual(["pr", "ready", "spec/gh-issue-42", "--repo", "acme/widget"]);
+  });
+
+  it("/stop (authorized) cancels the ticket's active loop", async () => {
+    const { run } = fakeGh({ comments: [comment("/stop")], assignees: [{ login: "alice" }] });
+    const cancelLoop = vi.fn(async () => activeLoop());
+    const { poller } = harness({ gh: run, loops: [activeLoop()], cancelLoop });
+    await poller.pollAll();
+    expect(cancelLoop).toHaveBeenCalledWith("loop-1", expect.objectContaining({ actor: "tracker:/stop" }));
+  });
+
+  it("/stop (authorized) is a no-op when no active loop traces to the ticket", async () => {
+    const { run } = fakeGh({ comments: [comment("/stop")], assignees: [{ login: "alice" }] });
+    const cancelLoop = vi.fn(async () => null);
+    const { poller } = harness({ gh: run, loops: [], cancelLoop });
+    await poller.pollAll();
+    expect(cancelLoop).not.toHaveBeenCalled();
+  });
+
+  it("is IDEMPOTENT — a re-poll does not re-act the same command", async () => {
+    const { run, argv } = fakeGh({ comments: [comment("/spec")], assignees: [{ login: "alice" }] });
+    const { poller } = harness({ gh: run });
+    await poller.pollAll();
+    await poller.pollAll(); // watermark now carries the processed comment id.
+    expect(count(argv, isPrCreate)).toBe(1);
+  });
+
+  it("records the command watermark (processed id + lastCommentAt)", async () => {
+    const { run } = fakeGh({ comments: [comment("/approve")], assignees: [{ login: "alice" }] });
+    const { poller, updates } = harness({ gh: run });
+    await poller.pollAll();
+    const last = updates[updates.length - 1].config as TrackerEventTriggerConfig;
+    expect(last.commandState?.processed?.["100"]).toBeTruthy();
+    expect(last.commandState?.lastCommentAt).toBe("2021-01-01T00:00:00.000Z");
+  });
+
+  it("commands sub-switch OFF → no gh at all (kill-switch holds)", async () => {
+    const { run, argv } = fakeGh({ comments: [comment("/spec")], assignees: [{ login: "alice" }] });
+    const { poller } = harness({ gh: run, commandsOn: false });
+    await poller.pollAll();
+    expect(argv.length).toBe(0);
+  });
+
+  it("master switch OFF → no gh at all", async () => {
+    const { run, argv } = fakeGh({ comments: [comment("/spec")], assignees: [{ login: "alice" }] });
+    const { poller } = harness({ gh: run, masterOn: false });
+    await poller.pollAll();
+    expect(argv.length).toBe(0);
+  });
+
+  it("a non-command comment is skipped (no auth check, no action)", async () => {
+    const { run, argv } = fakeGh({ comments: [comment("just a normal note")], assignees: [{ login: "alice" }] });
+    const { poller } = harness({ gh: run });
+    await poller.pollAll();
+    // Only the comments-list read happened; no issue view (auth) / pr / etc.
+    expect(argv.every((a) => a[0] === "api" && a.includes("repos/acme/widget/issues/comments"))).toBe(true);
+  });
+});

--- a/tests/unit/consilium/trackers/github-issues-poller-role-stamp.test.ts
+++ b/tests/unit/consilium/trackers/github-issues-poller-role-stamp.test.ts
@@ -1,0 +1,137 @@
+/**
+ * github-issues-poller-role-stamp.test.ts — TRACK-6 (standing-role.md §5): a tracker
+ * trigger BOUND to a Standing Role's concern STAMPS the role's name + skills into the
+ * crystallised spec, so on merge SPEC-1 fires the ROLE's loop. A disabled role (or the
+ * absence of a role binding) yields an UNSTAMPED spec — byte-identical to TRACK-1.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  GithubIssuesPoller,
+  type GithubIssuesPollerDeps,
+} from "../../../../server/services/consilium/trackers/github-issues-poller.js";
+import type { ExecFileFn } from "../../../../server/services/github-status.js";
+import type { TriggerRow, StandingRoleRow } from "../../../../shared/schema.js";
+import type { AppConfig, TrackerEventTriggerConfig } from "../../../../shared/types.js";
+
+function fakeGh(issues: unknown[], prUrl = "https://github.com/acme/widget/pull/7"): { run: ExecFileFn; argv: string[][] } {
+  const argv: string[][] = [];
+  const run: ExecFileFn = vi.fn(async (_file: string, args: string[]) => {
+    argv.push(args);
+    const json = (o: unknown) => ({ stdout: JSON.stringify(o), stderr: "" });
+    if (args[0] === "issue" && args[1] === "list") return json(issues);
+    if (args[0] === "issue" && args[1] === "view") return json({ comments: [] });
+    if (args[0] === "issue" && args[1] === "comment") return { stdout: "", stderr: "" };
+    if (args[0] === "pr" && args[1] === "list") return json([]);
+    if (args[0] === "repo" && args[1] === "view") return json({ defaultBranchRef: { name: "main" } });
+    if (args[0] === "api") {
+      if (args.indexOf("--method") === -1 && args.indexOf("PUT") === -1) return json({ object: { sha: "basesha" } });
+      return { stdout: "", stderr: "" };
+    }
+    if (args[0] === "pr" && args[1] === "create") return { stdout: `${prUrl}\n`, stderr: "" };
+    return { stdout: "", stderr: "" };
+  });
+  return { run, argv };
+}
+
+const ISSUE = {
+  number: 5,
+  title: "Add pagination",
+  url: "https://github.com/acme/widget/issues/5",
+  labels: [{ name: "agent" }],
+  body: "## Problem\nNo paging.\n\n## Acceptance Criteria\n- [ ] returns next-page cursor",
+};
+
+function trackerTrigger(roleConcern?: { roleId: string; concernId: string }): TriggerRow {
+  const config: TrackerEventTriggerConfig = {
+    tracker: "github",
+    repo: "acme/widget",
+    targetRepoPath: "/repo/widget",
+    filter: { label: "agent" },
+    specStatus: "ready",
+    ...(roleConcern ? { roleConcern } : {}),
+  };
+  return {
+    id: "trk-1", projectId: "proj-1", pipelineId: null, type: "tracker_event",
+    config: JSON.parse(JSON.stringify(config)) as TrackerEventTriggerConfig,
+    secretEncrypted: null, enabled: true, lastTriggeredAt: null, suppressedCount: 0,
+    createdAt: new Date(0), updatedAt: new Date(0),
+  } as unknown as TriggerRow;
+}
+
+function roleRow(over: Partial<StandingRoleRow> = {}): StandingRoleRow {
+  return {
+    id: "role-1", name: "backend-dev", persona: "senior backend engineer",
+    skills: ["python-dev", "test-authoring"], loopTemplate: { preset: "sdlc-cross-review" },
+    concerns: [{
+      id: "c-1", repoPath: "/repo/widget", focus: "implement the ticket",
+      trigger: { type: "tracker_event", filter: { tracker: "github", repo: "acme/widget", label: "agent" } },
+    }],
+    policy: null, enabled: true, createdBy: "u-1", createdAt: new Date(0), updatedAt: new Date(0),
+    ...over,
+  } as unknown as StandingRoleRow;
+}
+
+function cfg(): () => AppConfig {
+  return () => ({ features: { triggers: { enabled: true, tracker: { enabled: true, pollIntervalSec: 300 } } } }) as unknown as AppConfig;
+}
+
+function harness(trigger: TriggerRow, role: StandingRoleRow | undefined, gh: ExecFileFn) {
+  const deps: GithubIssuesPollerDeps = {
+    getEnabledTriggersByType: async () => [trigger],
+    runInProject: async (_pid, fn) => fn(),
+    getTrigger: async () => trigger,
+    updateTrigger: async () => trigger,
+    config: cfg(),
+    allowedRepoPaths: () => ["/repo/widget"],
+    getStandingRole: async (id) => (role && role.id === id ? role : undefined),
+    runGh: gh,
+    gitRemoteUrl: async () => "https://github.com/acme/widget.git",
+    log: () => {},
+    now: () => 0,
+  };
+  return new GithubIssuesPoller(deps);
+}
+
+function decodePutContent(argv: string[][]): string {
+  const put = argv.find((a) => a[0] === "api" && a.includes("PUT") && a.some((x) => x.startsWith("repos/acme/widget/contents/")));
+  const arg = put?.find((x) => x.startsWith("content="));
+  return arg ? Buffer.from(arg.slice("content=".length), "base64").toString("utf8") : "";
+}
+
+describe("GithubIssuesPoller role stamping (TRACK-6)", () => {
+  it("a role-bound tracker trigger stamps the role's name + skills into the spec", async () => {
+    const { run, argv } = fakeGh([ISSUE]);
+    const poller = harness(trackerTrigger({ roleId: "role-1", concernId: "c-1" }), roleRow(), run);
+    await poller.pollAll();
+    const spec = decodePutContent(argv);
+    expect(spec).toContain('role: "backend-dev"');
+    expect(spec).toContain("skills:");
+    expect(spec).toContain('- "python-dev"');
+    expect(spec).toContain('- "test-authoring"');
+    // Still a valid TRACK-1 spec (github provenance intact).
+    expect(spec).toContain("kind: github");
+    expect(spec).toContain('ref: "5"');
+  });
+
+  it("a DISABLED role → UNSTAMPED spec (never a disabled role's work)", async () => {
+    const { run, argv } = fakeGh([ISSUE]);
+    const poller = harness(
+      trackerTrigger({ roleId: "role-1", concernId: "c-1" }),
+      roleRow({ enabled: false } as Partial<StandingRoleRow>),
+      run,
+    );
+    await poller.pollAll();
+    const spec = decodePutContent(argv);
+    expect(spec).not.toContain("role:");
+    expect(spec).not.toContain("skills:");
+  });
+
+  it("no role binding → UNSTAMPED spec (byte-identical TRACK-1)", async () => {
+    const { run, argv } = fakeGh([ISSUE]);
+    const poller = harness(trackerTrigger(), undefined, run);
+    await poller.pollAll();
+    const spec = decodePutContent(argv);
+    expect(spec).not.toContain("role:");
+    expect(spec).not.toContain("skills:");
+  });
+});

--- a/tests/unit/consilium/trackers/role-stamp.test.ts
+++ b/tests/unit/consilium/trackers/role-stamp.test.ts
@@ -1,0 +1,69 @@
+/**
+ * role-stamp.test.ts — TRACK-6 (standing-role.md §5): the PURE stamp resolution that
+ * turns a loaded Standing Role + a firing tracker concern into the `{ role, skills }`
+ * a crystallised spec carries. Covers the fail-closed gates (adversarial: a tracker
+ * concern waking a DISABLED role / a disabled or missing concern).
+ */
+import { describe, it, expect } from "vitest";
+import type { StandingRoleRow } from "@shared/schema";
+import type { StandingRoleConcern } from "@shared/types";
+import { resolveRoleStamp } from "../../../../server/services/consilium/trackers/role-stamp.js";
+
+function concern(over: Partial<StandingRoleConcern> = {}): StandingRoleConcern {
+  return {
+    id: "c-1",
+    repoPath: "/allowed/widget",
+    focus: "implement the ticket",
+    trigger: { type: "tracker_event", filter: { tracker: "github", repo: "acme/widget", label: "agent" } },
+    ...over,
+  };
+}
+
+function role(over: Partial<StandingRoleRow> = {}): StandingRoleRow {
+  return {
+    id: "role-1",
+    name: "backend-dev",
+    persona: "You are a senior backend engineer.",
+    skills: ["python-dev", "test-authoring"],
+    loopTemplate: { preset: "sdlc-cross-review" },
+    concerns: [concern()],
+    policy: null,
+    enabled: true,
+    createdBy: "u-1",
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...over,
+  } as unknown as StandingRoleRow;
+}
+
+describe("resolveRoleStamp", () => {
+  it("stamps role name + skills for an enabled role + concern", () => {
+    const res = resolveRoleStamp(role(), "c-1");
+    expect(res).toEqual({ ok: true, stamp: { role: "backend-dev", skills: ["python-dev", "test-authoring"] } });
+  });
+
+  it("omits skills when the role has none", () => {
+    const res = resolveRoleStamp(role({ skills: [] } as Partial<StandingRoleRow>), "c-1");
+    expect(res).toEqual({ ok: true, stamp: { role: "backend-dev" } });
+  });
+
+  it("fails closed for a missing role", () => {
+    expect(resolveRoleStamp(undefined, "c-1")).toEqual({ ok: false, reason: "role-not-found" });
+  });
+
+  it("fails closed for a DISABLED role (never wakes a disabled role)", () => {
+    expect(resolveRoleStamp(role({ enabled: false } as Partial<StandingRoleRow>), "c-1")).toEqual({
+      ok: false,
+      reason: "role-disabled",
+    });
+  });
+
+  it("fails closed for a concern not on the role", () => {
+    expect(resolveRoleStamp(role(), "nope")).toEqual({ ok: false, reason: "concern-not-found" });
+  });
+
+  it("fails closed for a DISABLED concern", () => {
+    const r = role({ concerns: [concern({ enabled: false })] } as Partial<StandingRoleRow>);
+    expect(resolveRoleStamp(r, "c-1")).toEqual({ ok: false, reason: "concern-disabled" });
+  });
+});


### PR DESCRIPTION
Implements **TRACK-6** (`docs/design/task-tracker-triggers.md` §5/§8 + `docs/design/standing-role.md` §5). Builds on ROLE-2 (concerns/wake, which deferred tracker concerns here) and the 7 shipped tracker connectors. **GitHub-first reference path**; other connectors are a documented follow-up.

## 1. Standing Role on a tracker → a role-stamped spec
A role's INBOX becomes a tracker project. `StandingRoleConcernTrigger.type` gains `tracker_event` (+ a `TrackerConcernFilter` of `tracker`/`repo`/`label`); the concern's own `repoPath` is the allowlisted `targetRepoPath`. The concern endpoint materialises a normal `tracker_event` backing trigger whose `config.roleConcern` names `{ roleId, concernId }` — the **same github-issues poller** picks it up.

On crystallise, the poller loads the bound role (project-scoped) and **stamps the role's name + skills into the spec frontmatter** (pure `resolveRoleStamp`). So when a human merges the spec PR, SPEC-1's spec-watch fires the loop with the role's `role:` header + `skills` (role provenance + skills + template) — **reusing the shared crystallise pipeline + SPEC-1, not a reimplemented wake**. The GitHub crystallise dialect is extracted to a shared **byte-identical** helper (`github-crystallize.ts`) reused by both the label poll and `/spec`.

Fail-closed: a missing / **disabled** role, or a disabled / missing concern ⇒ an **unstamped** spec (byte-identical TRACK-1) — never a disabled role's work.

## 2. Comment commands (`/spec`, `/approve`, `/stop`) with commenter-role auth
A new `github-command-poller` scans a repo's recent **issue comments**:
- **`/spec`** — force intake of the ticket even if unlabelled → crystallise a spec PR (role-stamped if bound).
- **`/approve`** — mark the ticket's spec PR (`spec/gh-issue-<n>`) **ready-for-review** (`gh pr ready`). A human still merges (L4).
- **`/stop`** — cancel the ticket's active consilium loop via the loop controller's `cancel`.

**Auth (§8):** only the ticket **assignee** or a repo **maintainer** (write/admin/maintain) may command — verified via the `gh` API (`isAuthorizedCommenter`), **fail-closed**. An unauthorized command is ignored + logged + marked processed (never acted, never re-evaluated). The comment body is **never** trusted to self-assert authority.

**Strict parse:** `parseTrackerCommand` matches the exact leading token of a line — no substring (`/specification`), prefix, or casing (`/APPROVE`) bypass. **Idempotent:** a per-trigger `commandState` watermark (newest-comment cursor + processed comment-ids) plus each action idempotent on its own. **Untrusted text fenced:** the comment body never reaches a shell/prompt; `/spec` re-reads the ISSUE and runs the same fenced synth/crystallise; the commenter login is shape-validated before any `gh` path.

## 3. Rails & kill-switches
- Role stamp gated by `role.enabled` + `concern.enabled` + the tracker kill-switch; the poller's `MAX_PER_CYCLE` + watermark bound intake.
- Commands behind a **new default-off** `features.triggers.tracker.commands.enabled` sub-switch (AND master + tracker). Byte-identical when off.
- `targetRepoPath` allowlist-checked in both pollers; a role stamp only adds name+skills and can never retarget the repo (SPEC-1 `resolveSpecRepo` re-validates on fire).

**Boundary (honest):** the per-role **budget/cascade** rails (`evaluateRoleRails`) bind at the SPEC-1 loop-launch, which is not yet role-aware for spec-fired loops; a tracker-woken role is bounded at intake (role/concern enabled + kill-switch + per-cycle budget + watermark dedup) and its eventual loop by SPEC-1's own dedup. Extending `evaluateRoleRails` to spec-fired loops and stamping for non-github trackers are the documented follow-ups.

## Tests (tsc + vitest only; full unit suite green — 5448 passing)
- `role-stamp` (stamp + disabled/missing gates), strict `command-parser`, `command-auth` (assignee/maintainer, fail-closed on degrade, hostile login rejected).
- `github-command-poller`: `/spec` authorized→intake / unauthorized→ignored, `/approve`→PR ready, `/stop`→cancel (auth-gated), idempotency, watermark, master/commands kill-switches, non-command skip.
- `github-issues-poller-role-stamp`: labelled ticket → spec stamped with role name+skills; disabled role / no binding → unstamped (TRACK-1 bytes). Existing TRACK-1..5 + ROLE-2 tests unchanged.

**Adversarial self-review:** unauthorized command (auth verifies commenter's role via the tracker API, never trusts the comment); substring/casing injection (strict token parse); disabled-role wake / rail bypass (fail-closed stamp + kill-switch); untrusted comment text to shell/prompt (only strict token check; issue re-read + fenced); arbitrary-repo pick (allowlist fail-closed both sides).

Do not merge — draft for review.