### PR TITLE
feat: Experience consolidation — dedup/decay/successDelta (DREAM-3)

### DIFF
--- a/migrations/0049_experience_items_consolidation.sql
+++ b/migrations/0049_experience_items_consolidation.sql
@@ -1,0 +1,27 @@
+-- migration: 0049_experience_items_consolidation
+-- Experience plane — the "Dream" distillation, CONSOLIDATE side (DREAM-3).
+-- Spec: docs/design/experience-plane-dream.md §4 (scheduled/consolidating) / §6
+-- (freshness/decay/self-correction) / §9 (DREAM-3).
+--
+-- A SINGLE additive, nullable column on the existing experience_items table. A
+-- background, scheduled consolidator re-reads recent items, MERGES duplicates,
+-- DECAYS stale ones (verified → observed), flags verified↔refuted CONTRADICTIONS
+-- (keeping both), and recomputes success_delta from any reuse signal. This column is
+-- the consolidator's durable AUDIT TRAIL for what it did to a surviving item
+-- (merge count, contradiction cross-link, decay origin, last pass id).
+--
+-- BOUNDARIES (§5): the consolidator writes ONLY to experience_items — never the
+-- Omniscience state graph, never SKILL.md (DREAM-4). This column keeps the audit
+-- trail inside the same plane.
+--
+-- Additive + idempotent (ADD COLUMN IF NOT EXISTS): no existing column is touched and
+-- the new column defaults to NULL, so every current row is byte-identical. Off by
+-- default at runtime (pipeline.consiliumLoop.experiencePlane.consolidate.enabled=false
+-- ⇒ no consolidator ⇒ the column is never populated ⇒ the store just accumulates,
+-- exactly the DREAM-1/DREAM-2 behaviour).
+
+ALTER TABLE experience_items
+  ADD COLUMN IF NOT EXISTS consolidation JSONB;
+
+-- Rollback:
+--   ALTER TABLE experience_items DROP COLUMN IF EXISTS consolidation;

--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -960,6 +960,36 @@ export const ConfigSchema = z.object({
           /** A `verified` item unconfirmed longer than this (days) is down-weighted to `observed`. 1..365; default 60. */
           staleVerifiedDays: z.coerce.number().min(1).max(365).default(60),
         }).default({}),
+        /**
+         * DREAM-3 — the CONSOLIDATION pass (§4 consolidating / §6 self-correction). When
+         * ON, a background, scheduled consolidator re-reads recent Experience items and:
+         *   - MERGES duplicates (same scope + claim) into one — union evidence, keep the
+         *     STRONGEST verification (verified > observed > refuted), union relatedComponents;
+         *   - DECAYS a stale `verified` item (unconfirmed too long, per `read.staleVerifiedDays`)
+         *     to `observed`, WRITTEN BACK so the store self-corrects (not just the read, §6);
+         *   - flags a verified↔refuted CONTRADICTION on the same scope — keeps BOTH, fresher-
+         *     verified leads, never silently overwrites (§6);
+         *   - recomputes `successDelta` from any available reuse signal (the pattern recurred
+         *     across independent loops and was re-verified/refuted).
+         *
+         * It runs OFF the hot path (its own interval, like the DREAM-1 distiller / the
+         * tracker poller), is idempotent + bounded (batched — a large store never OOMs the
+         * pass), and writes ONLY to `experience_items`. It NEVER blocks or races a loop.
+         *
+         * Kill-switch DEFAULT FALSE ⇒ BYTE-IDENTICAL: the consolidator observer is NEVER
+         * constructed (routes.ts), so no item is ever merged/decayed/updated — the store
+         * just ACCUMULATES exactly as in DREAM-1/DREAM-2.
+         */
+        consolidate: z.object({
+          /** Kill-switch: false (default) → no consolidator constructed (inert; store only accumulates). */
+          enabled: z.boolean().default(false),
+          /**
+           * Scheduled sweep interval (SECONDS) — how often the consolidator re-reads recent
+           * items to merge/decay/recompute. Deliberately coarse (off the hot path). 30s..24h;
+           * default 1h. NaN/out-of-range fails load.
+           */
+          intervalSec: z.coerce.number().int().min(30).max(86_400).default(3_600),
+        }).default({}),
       }).default({}),
     }).default({}),
   }).default({}),

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -50,6 +50,7 @@ import { ClickUpIssuesPoller } from "./services/consilium/trackers/clickup-issue
 import { TrackerWritebackObserver } from "./services/consilium/trackers/writeback-observer";
 import { GithubCommandPoller } from "./services/consilium/trackers/github-command-poller";
 import { ExperienceDistillerObserver } from "./services/consilium/experience/experience-distiller-observer";
+import { ExperienceConsolidatorObserver } from "./services/consilium/experience/experience-consolidator-observer";
 import { buildSynthPrompt, parseSynthOutput } from "./services/consilium/trackers/issue-spec";
 import { DEFAULT_TASK_MODEL } from "./config/schema";
 import { stopRateLimitCleanup } from "./services/webhook-handler";
@@ -272,6 +273,10 @@ export async function registerRoutes(
   // DREAM-1: the Experience-plane distiller observer (read-only, post-loop). KILL-SWITCH
   // default FALSE ⇒ never constructed (byte-identical). Stopped in the cleanup below.
   let experienceDistillerObserver: ExperienceDistillerObserver | null = null;
+  // DREAM-3: the Experience-plane consolidator (scheduled dedup/decay/successDelta). Its
+  // OWN kill-switch (consolidate.enabled), default FALSE ⇒ never constructed (byte-identical:
+  // the store just accumulates + is read). Stopped in the cleanup below.
+  let experienceConsolidatorObserver: ExperienceConsolidatorObserver | null = null;
   // Hoisted to the registerRoutes scope (was a block-local const) so the
   // file-change `fireTrigger` closure below can launch consilium reviews via the
   // SAME controller. Stays null when the kill-switch is off — fireTrigger then
@@ -387,6 +392,31 @@ export async function registerRoutes(
     });
     experienceDistillerObserver.start();
     log("[experience-distiller] enabled — post-loop distiller observer started", "experience-distiller");
+  }
+
+  // DREAM-3 — Experience-plane CONSOLIDATION (the "global profile", §4/§6). When its
+  // OWN kill-switch is on, a background, SCHEDULED consolidator re-reads a bounded window
+  // of recent items and MERGES duplicates, DECAYS stale `verified` items to `observed`
+  // (written back — the store self-corrects, §6), flags verified↔refuted CONTRADICTIONS
+  // (keeps both, fresher-verified leads), and recomputes `successDelta` from any reuse
+  // signal. It NEVER touches the loop controller (off the hot path, like DREAM-1) and
+  // writes ONLY to `experience_items` (never state, never SKILL.md — DREAM-4 owns that).
+  // Default OFF ⇒ NOT constructed ⇒ byte-identical (no merge/decay; the store accumulates).
+  if (appConfigLoader.get().pipeline.consiliumLoop.experiencePlane.consolidate.enabled) {
+    experienceConsolidatorObserver = new ExperienceConsolidatorObserver({
+      // Cross-project reads/writes run under ONE system context per pass (runAsSystem
+      // audits the access; listExperienceItems then returns all projects' rows and the
+      // update/delete resolve cross-project — merges never cross projects: the pure
+      // consolidator keys groups by projectId).
+      runInSystem: (fn) => runAsSystem("experience-consolidator", fn),
+      listExperienceItems: (limit) => storage.listExperienceItems(limit),
+      updateExperienceItem: (id, patch) => storage.updateExperienceItem(id, patch),
+      deleteExperienceItems: (ids) => storage.deleteExperienceItems(ids),
+      config: () => appConfigLoader.get(),
+      log: (m: string) => log(m, "experience-consolidator"),
+    });
+    experienceConsolidatorObserver.start();
+    log("[experience-consolidator] enabled — scheduled consolidation observer started", "experience-consolidator");
   }
 
   // Live Activity observability lens (read-only, owner/admin-scoped, metadata-only).
@@ -1006,6 +1036,7 @@ export async function registerRoutes(
     cronScheduler?.stopAll();
     consiliumLoopPoller?.stop();
     experienceDistillerObserver?.stop();
+    experienceConsolidatorObserver?.stop();
     fileWatcherService?.stopAll();
     githubPoller?.stop();
     githubIssuesPoller?.stop();

--- a/server/services/consilium/experience/consolidator.ts
+++ b/server/services/consilium/experience/consolidator.ts
@@ -1,0 +1,498 @@
+/**
+ * consolidator.ts — DREAM-3: the PURE consolidation of accumulated Experience items.
+ * Spec: docs/design/experience-plane-dream.md §4 (scheduled/consolidating),
+ * §6 (freshness/decay/self-correction/contradiction), §9 (DREAM-3).
+ *
+ * This module is PURE and DB-agnostic (like the DREAM-1 distiller and the DREAM-2
+ * reader): it takes an already-read, bounded batch of `ExperienceItemRow`s and returns a
+ * `ConsolidationPlan` (updates + deletes) for the observer to apply. It performs NO I/O,
+ * touches NO loop controller, NO state graph, NO SKILL.md — so it can NEVER block, race,
+ * or mutate a running loop or DREAM-1's writes (§4/§5 safe-degrade). The observer owns
+ * persistence; keeping the merge/decay/contradiction logic pure makes it unit-testable
+ * and guarantees the pass is deterministic and idempotent.
+ *
+ * WHAT IT DOES, per (projectId, scope, normalized-claim) GROUP (§4/§6):
+ *
+ *   1. DEDUP / MERGE — items in the SAME group collapse into ONE survivor: evidence is
+ *      UNIONED (never lost), the STRONGEST verification is kept (verified > refuted >
+ *      observed by grounding rank — a grounded verdict always beats a bare `observed`),
+ *      relatedComponents + provenance.sourceLoops are UNIONED, freshness.lastConfirmedAt
+ *      takes the MAX. The non-survivor members are DELETED. A merge can NEVER lose
+ *      evidence and NEVER flips a grounded verdict to a weaker one.
+ *
+ *   2. DECAY (§6 self-correction) — a `verified` survivor unconfirmed for longer than
+ *      `staleVerifiedDays` is demoted to `observed` and WRITTEN BACK (the durable version
+ *      of DREAM-2's read-time down-weight — the store self-corrects, not just the read).
+ *      Recorded in `consolidation.decayedFrom` for audit. A demoted item is NEVER
+ *      silently re-upgraded; only a FRESH grounded duplicate (a real re-verification)
+ *      lifts it back on a later pass (that duplicate merges in as `verified`, fresh).
+ *
+ *   3. CONTRADICTION (§6) — when a group holds BOTH a `verified` and a `refuted` grounded
+ *      outcome on the same scope+claim, the two are NOT collapsed: a positive survivor
+ *      (verified/observed) and a negative survivor (refuted) are BOTH KEPT and cross-
+ *      flagged as a conflict, so the planner sees "worked here / failed there" and the
+ *      fresher-verified one leads. Never a silent overwrite.
+ *
+ *   4. successDelta (§3 R2 / §6) — recomputed from the AVAILABLE reuse signal: when the
+ *      same (scope, claim) recurred across >= 2 INDEPENDENT loops with grounded outcomes,
+ *      `successDelta` = (nVerified − nRefuted) / (nVerified + nRefuted) ∈ [−1, 1] — the
+ *      measured net effect of the pattern being reused. A single occurrence has no reuse,
+ *      so `successDelta` stays null. (The FULL reuse-attribution — linking DREAM-2's
+ *      plan-time injection of item X to the LATER loop's independent outcome — needs a
+ *      persisted injection→outcome edge that DREAM-2 only LOGS today; that stronger signal
+ *      is a documented boundary, see the observer header.)
+ *
+ * IDEMPOTENCY (the anti-thrash guarantee, §4): re-running the pass on an already-
+ * consolidated batch produces NO updates and NO deletes — every group is already a single
+ * survivor (or the two stable contradiction survivors), and an update is emitted ONLY when
+ * a field would actually change. The pass converges and then holds steady.
+ */
+import type { ExperienceItemRow } from "@shared/schema";
+import type {
+  ExperienceConfidence,
+  ExperienceConsolidation,
+  ExperienceEvidence,
+  ExperienceProvenance,
+  ExperienceVerification,
+} from "@shared/types";
+
+// ── Adversarial bounds (a large store must NEVER OOM the pass) ──────────────────
+/** Hard cap on items processed in one pass (the observer also caps the read). */
+const MAX_ITEMS = 5_000;
+/** Max evidence links kept on a merged survivor (union is bounded — never unbounded growth). */
+const MAX_EVIDENCE = 16;
+/** Max source loops kept on a merged survivor's provenance. */
+const MAX_SOURCE_LOOPS = 32;
+/** Max relatedComponents kept on a merged survivor. */
+const MAX_RELATED = 32;
+/** Clamp for the inert conflict note. */
+const MAX_NOTE = 200;
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * Grounding rank for MERGE (which verification a single survivor keeps). A grounded
+ * verdict (verified/refuted) always beats a bare `observed`; between the two grounded
+ * verdicts `verified` leads — but a group holding BOTH is a CONTRADICTION (handled
+ * separately, never collapsed by this rank).
+ */
+const MERGE_RANK: Record<ExperienceConfidence, number> = {
+  verified: 3,
+  refuted: 2,
+  observed: 1,
+};
+
+export interface ConsolidateOptions {
+  /** The consolidation pass id (one per sweep) — stamped into `consolidation`. */
+  dreamRunId: string;
+  /**
+   * A `verified` item unconfirmed for longer than this (days) is demoted to `observed`
+   * (§6). MUST match DREAM-2's `read.staleVerifiedDays` so the durable decay agrees with
+   * the read-time down-weight.
+   */
+  staleVerifiedDays: number;
+  /** Injectable clock for deterministic tests. */
+  now?: () => Date;
+  /** Optional override of the per-pass item cap (defaults to MAX_ITEMS). */
+  maxItems?: number;
+}
+
+/** A single field-level update to apply to a SURVIVING item (never a full overwrite). */
+export interface ExperienceItemPatch {
+  claim?: string;
+  evidence?: ExperienceEvidence[];
+  verification?: ExperienceVerification;
+  confidence?: ExperienceConfidence;
+  successDelta?: number | null;
+  provenance?: ExperienceProvenance;
+  freshness?: ExperienceItemRow["freshness"];
+  relatedComponents?: string[];
+  consolidation?: ExperienceConsolidation;
+}
+
+export interface ExperienceItemUpdate {
+  id: string;
+  patch: ExperienceItemPatch;
+}
+
+export interface ConsolidationPlan {
+  /** Field-level updates for surviving items (merge results / decay / successDelta / flags). */
+  updates: ExperienceItemUpdate[];
+  /** Ids of merged-away DUPLICATES to delete (their evidence already folded into a survivor). */
+  deletes: string[];
+  /** Observability counters (logged by the observer). */
+  stats: {
+    scanned: number;
+    groups: number;
+    merged: number; // survivors that absorbed >= 1 duplicate
+    deleted: number;
+    decayed: number; // survivors demoted verified → observed
+    conflicts: number; // contradiction groups (both survivors kept)
+    successDeltaSet: number;
+  };
+}
+
+/**
+ * Normalize a claim to its OUTCOME-INDEPENDENT criterion identity — the load-bearing
+ * grouping key (§4 dedup / §6 contradiction). The DREAM-1 distiller embeds the outcome
+ * verb IN the claim text (`... the criterion "X" was VERIFIED/REFUTED/OBSERVED ...`), so a
+ * verified and a refuted item about the SAME criterion have DIFFERENT claim strings. If we
+ * grouped on the raw claim, those two would never meet and a CONTRADICTION could never be
+ * detected. So we cut the claim at the outcome clause (` was `) and keep the prefix — the
+ * stable "on <repo>, the criterion <title>" identity that is the SAME across all three
+ * outcomes. Same criterion, opposite outcome ⇒ same key ⇒ contradiction fires; two
+ * DIFFERENT criteria keep different titles ⇒ different keys ⇒ never wrongly merged.
+ *
+ * Falls back to the full normalized claim when there is no ` was ` clause — still a safe,
+ * exact-match dedup, just without outcome-blind contradiction on that (non-distiller) shape.
+ */
+function normalizeClaim(claim: string): string {
+  const lowered = (typeof claim === "string" ? claim : "").toLowerCase();
+  const cut = lowered.indexOf(" was ");
+  const identity = cut >= 0 ? lowered.slice(0, cut) : lowered;
+  return identity
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/[.,;:!?"'`()[\]{}\-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Group key: project + scope + outcome-independent claim identity. projectId is INCLUDED
+ *  so two projects with a same-basename repo NEVER cross-merge (isolation, §5). Joined
+ *  with a space delimiter that cannot survive inside a normalized identity (no collisions). */
+function groupKey(item: ExperienceItemRow): string {
+  const s = item.scope;
+  const repo = s?.repo ?? "";
+  const arch = s?.archetype ?? "";
+  const klass = s?.criterionClass ?? "";
+  return [item.projectId ?? "", repo, arch, klass, normalizeClaim(item.claim)].join(" ");
+}
+
+/** ms-safe parse of an ISO stamp; unparseable ⇒ 0 (maximally stale) for a MAX comparison. */
+function parseIso(s: string | null | undefined): number {
+  const t = s ? Date.parse(s) : NaN;
+  return Number.isFinite(t) ? t : 0;
+}
+
+/** Age in days since an item's `lastConfirmedAt`; unparseable ⇒ +Infinity (maximally stale). */
+function ageDays(item: ExperienceItemRow, now: number): number {
+  const t = parseIso(item.freshness?.lastConfirmedAt);
+  if (t === 0) return Number.POSITIVE_INFINITY;
+  return Math.max(0, (now - t) / MS_PER_DAY);
+}
+
+/** Dedup an evidence list by (loopId, round, diffRef), preserving order, bounded. */
+function unionEvidence(items: readonly ExperienceItemRow[]): ExperienceEvidence[] {
+  const seen = new Set<string>();
+  const out: ExperienceEvidence[] = [];
+  for (const it of items) {
+    const list = Array.isArray(it.evidence) ? it.evidence : [];
+    for (const ev of list) {
+      if (!ev) continue;
+      const k = `${ev.loopId}${ev.round}${ev.diffRef ?? ""}`;
+      if (seen.has(k)) continue;
+      seen.add(k);
+      out.push(ev);
+      if (out.length >= MAX_EVIDENCE) return out;
+    }
+  }
+  return out;
+}
+
+/** Union + sort + bound a string list (relatedComponents / sourceLoops) for a stable survivor. */
+function unionStrings(lists: Array<readonly string[] | undefined | null>, cap: number): string[] {
+  const set = new Set<string>();
+  for (const list of lists) {
+    if (!Array.isArray(list)) continue;
+    for (const s of list) if (typeof s === "string" && s.length > 0) set.add(s);
+  }
+  return Array.from(set).sort().slice(0, cap);
+}
+
+/** Deterministic survivor pick within a partition: strongest confidence, then freshest, then lowest id. */
+function pickSurvivor(members: readonly ExperienceItemRow[], now: number): ExperienceItemRow {
+  return [...members].sort((a, b) => {
+    const r = MERGE_RANK[b.confidence] - MERGE_RANK[a.confidence];
+    if (r !== 0) return r;
+    const fa = ageDays(a, now);
+    const fb = ageDays(b, now);
+    if (fa !== fb) return fa - fb; // fresher (smaller age) first
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  })[0];
+}
+
+/** The strongest confidence present in a set of members (never returns a contradiction). */
+function strongestConfidence(members: readonly ExperienceItemRow[]): ExperienceConfidence {
+  let best: ExperienceConfidence = "observed";
+  for (const m of members) {
+    if (MERGE_RANK[m.confidence] > MERGE_RANK[best]) best = m.confidence;
+  }
+  return best;
+}
+
+/**
+ * The reuse signal (§3 R2 / §6): net measured effect of a pattern that RECURRED across
+ * INDEPENDENT loops. Returns a value in [−1, 1], or null when there is no reuse (fewer
+ * than 2 grounded occurrences across distinct loops). Verified occurrences count +1,
+ * refuted −1; observed is not a ground-truth outcome and does not count.
+ */
+function reuseSuccessDelta(members: readonly ExperienceItemRow[]): number | null {
+  const verifiedLoops = new Set<string>();
+  const refutedLoops = new Set<string>();
+  for (const m of members) {
+    const loops =
+      Array.isArray(m.provenance?.sourceLoops) && m.provenance.sourceLoops.length > 0
+        ? m.provenance.sourceLoops
+        : [m.sourceLoopId];
+    for (const lid of loops) {
+      if (typeof lid !== "string" || lid.length === 0) continue;
+      if (m.confidence === "verified") verifiedLoops.add(lid);
+      else if (m.confidence === "refuted") refutedLoops.add(lid);
+    }
+  }
+  // A loop that both verified AND refuted the pattern (across items) is itself a
+  // contradiction at the source; count it on neither side to avoid double-weighting.
+  for (const lid of Array.from(verifiedLoops)) {
+    if (refutedLoops.has(lid)) {
+      verifiedLoops.delete(lid);
+      refutedLoops.delete(lid);
+    }
+  }
+  const nV = verifiedLoops.size;
+  const nR = refutedLoops.size;
+  const total = nV + nR;
+  if (total < 2) return null; // no reuse across independent loops ⇒ no measured effect.
+  return (nV - nR) / total;
+}
+
+/** Round a delta to a stable precision so equal signals compare equal (idempotency). */
+function roundDelta(x: number): number {
+  return Math.round(x * 1e6) / 1e6;
+}
+
+interface BuiltSurvivor {
+  patch: ExperienceItemPatch;
+  /** True if this survivor absorbed >= 1 duplicate (for stats.merged). */
+  mergedFrom: number;
+  /** True if decay demoted it this pass (for stats.decayed). */
+  decayed: boolean;
+}
+
+/**
+ * Build the merged/decayed patch for ONE survivor from its partition `members`. `conflict`
+ * cross-links the opposing contradiction survivor (or null). Applies decay to a stale
+ * `verified` survivor. Sets `successDelta` from the whole GROUP's reuse signal.
+ */
+function buildSurvivor(
+  survivor: ExperienceItemRow,
+  members: readonly ExperienceItemRow[],
+  groupMembers: readonly ExperienceItemRow[],
+  opts: ConsolidateOptions,
+  now: number,
+  nowIso: string,
+  conflict: ExperienceConsolidation["conflict"],
+): BuiltSurvivor {
+  const evidence = unionEvidence(members);
+  const relatedComponents = unionStrings(members.map((m) => m.relatedComponents), MAX_RELATED);
+  const sourceLoops = unionStrings(
+    members.map((m) => (m.provenance?.sourceLoops?.length ? m.provenance.sourceLoops : [m.sourceLoopId])),
+    MAX_SOURCE_LOOPS,
+  );
+  const lastConfirmedAt = members
+    .map((m) => m.freshness?.lastConfirmedAt)
+    .filter((s): s is string => typeof s === "string" && parseIso(s) > 0)
+    .sort((a, b) => parseIso(b) - parseIso(a))[0] ?? survivor.freshness.lastConfirmedAt;
+
+  // Kept verification = the strongest grounded member's verification (never a weaker one).
+  let confidence = strongestConfidence(members);
+  const kept = pickSurvivor(members.filter((m) => m.confidence === confidence), now);
+  const verification: ExperienceVerification = kept.verification;
+
+  // DECAY (§6): a stale `verified` survivor is demoted to `observed`, written back.
+  let decayedFrom: ExperienceConfidence | null = null;
+  const mergedAge = Math.max(0, (now - parseIso(lastConfirmedAt)) / MS_PER_DAY);
+  if (confidence === "verified" && mergedAge > opts.staleVerifiedDays) {
+    decayedFrom = "verified";
+    confidence = "observed";
+  }
+
+  // successDelta is (re)computed ONLY when this pass actually MERGES >= 2 distinct items
+  // (i.e. the pattern recurred across independent loops THIS pass — the reuse signal is
+  // measured from the members' own grounded verdicts, each a distinct loop in the common
+  // DREAM-1 case). For a lone survivor we DO NOT recompute — a merged survivor collapses
+  // several loops under one confidence, so re-deriving from its unioned sourceLoops would
+  // mis-attribute (and thrash idempotency); its successDelta was measured correctly at its
+  // merge and is preserved. `undefined` ⇒ the field is omitted from the patch (kept as-is).
+  // (This narrower recurrence proxy is the documented reuse-attribution boundary — the
+  // stronger DREAM-2 injection→outcome edge is not persisted yet; see the observer header.)
+  const successDelta: number | null | undefined =
+    groupMembers.length > 1 ? reuseSuccessDelta(groupMembers) : undefined;
+
+  const provenance: ExperienceProvenance = {
+    createdAt: survivor.provenance?.createdAt ?? nowIso,
+    dreamRunId: survivor.provenance?.dreamRunId ?? opts.dreamRunId,
+    sourceLoops,
+  };
+
+  const consolidation: ExperienceConsolidation = {
+    lastConsolidatedAt: nowIso,
+    dreamRunId: opts.dreamRunId,
+    mergedLoopCount: sourceLoops.length,
+    conflict: conflict ?? null,
+    decayedFrom,
+  };
+
+  const patch: ExperienceItemPatch = {
+    evidence,
+    relatedComponents,
+    verification,
+    confidence,
+    provenance,
+    freshness: { ...survivor.freshness, lastConfirmedAt },
+    consolidation,
+  };
+  if (successDelta !== undefined) patch.successDelta = successDelta;
+
+  return {
+    patch,
+    mergedFrom: members.length - 1,
+    decayed: decayedFrom != null,
+  };
+}
+
+/** Would applying `patch` actually CHANGE `item`? If not, we emit no update (anti-thrash). */
+function patchChangesItem(item: ExperienceItemRow, patch: ExperienceItemPatch): boolean {
+  if (patch.confidence !== undefined && patch.confidence !== item.confidence) return true;
+  if (patch.successDelta !== undefined && roundDeltaEq(patch.successDelta, item.successDelta) === false) return true;
+  if (patch.evidence !== undefined && patch.evidence.length !== (item.evidence?.length ?? 0)) return true;
+  if (
+    patch.relatedComponents !== undefined &&
+    patch.relatedComponents.length !== (item.relatedComponents?.length ?? 0)
+  ) {
+    return true;
+  }
+  if (
+    patch.freshness !== undefined &&
+    patch.freshness.lastConfirmedAt !== item.freshness?.lastConfirmedAt
+  ) {
+    return true;
+  }
+  if (patch.provenance !== undefined) {
+    const before = item.provenance?.sourceLoops?.length ?? 0;
+    if (patch.provenance.sourceLoops.length !== before) return true;
+  }
+  // Conflict flag newly set / changed (a first-time contradiction stamp is a real change).
+  const beforeConflict = item.consolidation?.conflict ?? null;
+  const afterConflict = patch.consolidation?.conflict ?? null;
+  if ((beforeConflict?.withItemId ?? null) !== (afterConflict?.withItemId ?? null)) return true;
+  // NOTE: a first-ever consolidation stamp is deliberately NOT a change by itself — a
+  // singleton with no merge/decay/conflict/successDelta work is left untouched (no mass
+  // rewrite on first enable; the pass only writes items it actually consolidated).
+  return false;
+}
+
+/** Delta equality at the stored precision (both null ⇒ equal). */
+function roundDeltaEq(a: number | null | undefined, b: number | null | undefined): boolean {
+  if (a == null && b == null) return true;
+  if (a == null || b == null) return false;
+  return roundDelta(a) === roundDelta(b);
+}
+
+/**
+ * Consolidate a bounded batch of Experience items into a plan of updates + deletes.
+ * PURE — the input array is never mutated. Deterministic + idempotent.
+ */
+export function consolidate(
+  items: readonly ExperienceItemRow[],
+  opts: ConsolidateOptions,
+): ConsolidationPlan {
+  const now = (opts.now ?? (() => new Date()))();
+  const nowMs = now.getTime();
+  const nowIso = now.toISOString();
+  const cap = Math.max(0, Math.floor(opts.maxItems ?? MAX_ITEMS));
+  const scanned = Math.min(items.length, cap);
+  const batch = items.slice(0, cap);
+
+  const groups = new Map<string, ExperienceItemRow[]>();
+  for (const it of batch) {
+    if (!it || !it.scope || typeof it.scope.repo !== "string") continue;
+    const key = groupKey(it);
+    const g = groups.get(key);
+    if (g) g.push(it);
+    else groups.set(key, [it]);
+  }
+
+  const plan: ConsolidationPlan = {
+    updates: [],
+    deletes: [],
+    stats: { scanned, groups: groups.size, merged: 0, deleted: 0, decayed: 0, conflicts: 0, successDeltaSet: 0 },
+  };
+
+  const pushUpdate = (item: ExperienceItemRow, built: BuiltSurvivor): void => {
+    if (!patchChangesItem(item, built.patch)) {
+      // Idempotent no-op: only a first-time conflict stamp forces an update below.
+      return;
+    }
+    plan.updates.push({ id: item.id, patch: built.patch });
+    if (built.mergedFrom > 0) plan.stats.merged += 1;
+    if (built.decayed) plan.stats.decayed += 1;
+    if (built.patch.successDelta != null) plan.stats.successDeltaSet += 1;
+  };
+
+  for (const members of groups.values()) {
+    const hasVerified = members.some((m) => m.confidence === "verified");
+    const hasRefuted = members.some((m) => m.confidence === "refuted");
+
+    if (hasVerified && hasRefuted) {
+      // ── CONTRADICTION (§6): keep BOTH sides, cross-flag, fresher-verified leads. ──
+      // Positive partition = verified ∪ observed (observed is weak-positive, not a
+      // contradiction); negative partition = refuted. Each collapses to one survivor.
+      const positive = members.filter((m) => m.confidence !== "refuted");
+      const negative = members.filter((m) => m.confidence === "refuted");
+      const posSurvivor = pickSurvivor(positive, nowMs);
+      const negSurvivor = pickSurvivor(negative, nowMs);
+      plan.stats.conflicts += 1;
+
+      const posConflict: ExperienceConsolidation["conflict"] = {
+        withItemId: negSurvivor.id,
+        opposingConfidence: "refuted",
+        note: clampNote("Contradiction: this pattern was REFUTED elsewhere on the same scope — verify before trusting."),
+      };
+      const negConflict: ExperienceConsolidation["conflict"] = {
+        withItemId: posSurvivor.id,
+        opposingConfidence: "verified",
+        note: clampNote("Contradiction: this pattern was VERIFIED elsewhere on the same scope — the fresher-verified one leads."),
+      };
+
+      const posBuilt = buildSurvivor(posSurvivor, positive, members, opts, nowMs, nowIso, posConflict);
+      const negBuilt = buildSurvivor(negSurvivor, negative, members, opts, nowMs, nowIso, negConflict);
+
+      // BOTH survivors kept + cross-flagged. pushUpdate emits on the FIRST pass (the
+      // conflict cross-link is new) and then holds steady (stable contradiction ⇒ no
+      // re-write), so the conflict flag is durable + the pass stays idempotent.
+      pushUpdate(posSurvivor, posBuilt);
+      pushUpdate(negSurvivor, negBuilt);
+
+      // Delete only the NON-survivor duplicates within each partition (both survivors kept).
+      for (const m of positive) if (m.id !== posSurvivor.id) plan.deletes.push(m.id);
+      for (const m of negative) if (m.id !== negSurvivor.id) plan.deletes.push(m.id);
+      continue;
+    }
+
+    // ── NO CONTRADICTION: collapse the whole group into ONE survivor. ──
+    const survivor = pickSurvivor(members, nowMs);
+    const built = buildSurvivor(survivor, members, members, opts, nowMs, nowIso, null);
+    pushUpdate(survivor, built);
+    for (const m of members) if (m.id !== survivor.id) plan.deletes.push(m.id);
+  }
+
+  plan.stats.deleted = plan.deletes.length;
+  return plan;
+}
+
+/** Clamp + neutralise the inert conflict note. */
+function clampNote(s: string): string {
+  const cleaned = s.replace(/\s+/g, " ").trim();
+  return cleaned.length > MAX_NOTE ? cleaned.slice(0, MAX_NOTE) : cleaned;
+}

--- a/server/services/consilium/experience/experience-consolidator-observer.ts
+++ b/server/services/consilium/experience/experience-consolidator-observer.ts
@@ -1,0 +1,168 @@
+/**
+ * experience-consolidator-observer.ts — DREAM-3: the background, SCHEDULED consolidator
+ * that keeps the accumulated Experience store honest.
+ * Spec: docs/design/experience-plane-dream.md §4 (scheduled/consolidating), §6
+ * (freshness/decay/self-correction), §9 (DREAM-3).
+ *
+ * WHY OFF THE HOT PATH (the loop controller is off-limits — §4/§5)
+ *   Modelled on the DREAM-1 distiller observer (itself modelled on TRACK-2's writeback
+ *   observer): this NEVER imports or mutates the consilium-loop-controller, and it never
+ *   runs on a loop's critical path. It rides its OWN coarse interval, READS a bounded
+ *   window of already-persisted items (`storage.listExperienceItems`), computes a PURE
+ *   `ConsolidationPlan` (see consolidator.ts), and applies it by WRITING ONLY to the
+ *   `experience_items` table (`updateExperienceItem` / `deleteExperienceItems`). If this
+ *   observer is down, the Experience plane behaves EXACTLY as DREAM-1/DREAM-2 (the store
+ *   just accumulates) — safe degrade (§4). It can never block, race, or fail a loop, and
+ *   it never touches the state graph or SKILL.md (DREAM-4 owns skill feedback, §5).
+ *
+ * IDEMPOTENT + BOUNDED (adversarial — never OOM, never thrash)
+ *   Only a bounded window (CONSOLIDATE_SCAN_LIMIT, most-recent-first) is read per pass, so
+ *   a huge store can never blow memory. The pure consolidator is deterministic and emits
+ *   an update ONLY when a field would actually change — so a re-run over an already-
+ *   consolidated batch produces no writes (the pass converges and holds). Passes never
+ *   overlap (single-flight), and a throw in one item's write is caught so it can never
+ *   kill the interval.
+ *
+ * WHAT "REUSE" MEANS HERE (the successDelta boundary — see consolidator.ts §4)
+ *   `successDelta` is recomputed from the AVAILABLE reuse signal: the same (scope, claim)
+ *   RECURRING across >= 2 independent loops with grounded outcomes. The STRONGER signal —
+ *   linking DREAM-2's plan-time injection of item X to the LATER loop's independent
+ *   outcome — needs a persisted injection→outcome edge that DREAM-2 only LOGS today; wiring
+ *   that edge is deferred (DREAM-2 emits `plan: experience injected — N item(s)` but does
+ *   not persist WHICH items fed WHICH loop). That full reuse-attribution is a documented
+ *   boundary; the recurrence proxy is honest (measured from outcomes, not opinion).
+ *
+ * KILL-SWITCH (§9)
+ *   `pipeline.consiliumLoop.experiencePlane.consolidate.enabled` — default false. Off ⇒
+ *   this observer is NEVER constructed (routes.ts), so no item is ever merged/decayed/
+ *   updated: byte-identical to DREAM-1/DREAM-2 (the store only accumulates + is read).
+ */
+import { randomUUID } from "crypto";
+import type { ExperienceItemRow } from "@shared/schema";
+import type { AppConfig } from "../../../config/schema.js";
+import { consolidate, type ExperienceItemPatch } from "./consolidator.js";
+
+/** Max items read + consolidated per pass (bounds memory; recent-first window, §4). */
+const CONSOLIDATE_SCAN_LIMIT = 2_000;
+/** Default sweep interval (seconds) when config omits one — deliberately coarse. */
+const DEFAULT_INTERVAL_SEC = 3_600;
+
+export interface ExperienceConsolidatorObserverDeps {
+  /** Read a bounded, most-recent-first window of Experience items (cross-project under system). */
+  listExperienceItems: (limit: number) => Promise<ExperienceItemRow[]>;
+  /** Apply ONE surviving item's field-level patch (merge result / decay / successDelta / flag). */
+  updateExperienceItem: (id: string, patch: ExperienceItemPatch) => Promise<unknown>;
+  /** Delete merged-away duplicate items (their evidence already folded into a survivor). */
+  deleteExperienceItems: (ids: string[]) => Promise<void>;
+  /**
+   * Establish a SYSTEM ALS context around a pass (runAsSystem) so the cross-project
+   * storage reads/writes resolve. Mirrors the DREAM-1 distiller observer.
+   */
+  runInSystem: <T>(fn: () => Promise<T>) => Promise<T>;
+  /** Live config accessor (the kill-switch + interval + shared staleVerifiedDays). */
+  config: () => AppConfig;
+  /** Structured logger. */
+  log: (message: string) => void;
+  /** Injectable clock (tests). */
+  now?: () => Date;
+}
+
+export class ExperienceConsolidatorObserver {
+  private readonly deps: ExperienceConsolidatorObserverDeps;
+  private readonly now: () => Date;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private consolidating = false;
+
+  constructor(deps: ExperienceConsolidatorObserverDeps) {
+    this.deps = deps;
+    this.now = deps.now ?? (() => new Date());
+  }
+
+  /** Start the interval consolidator IFF the kill-switch is on. Idempotent. */
+  start(): void {
+    if (this.timer) return;
+    const cfg = this.deps.config().pipeline.consiliumLoop.experiencePlane.consolidate;
+    if (!cfg?.enabled) {
+      this.deps.log("experience plane consolidation disabled — consolidator not started");
+      return;
+    }
+    const intervalMs = (cfg.intervalSec ?? DEFAULT_INTERVAL_SEC) * 1000;
+    this.timer = setInterval(() => void this.consolidateSafe(), intervalMs);
+    this.timer.unref?.();
+    this.deps.log(`experience consolidator started (every ${Math.round(intervalMs / 1000)}s)`);
+  }
+
+  /** Stop the interval consolidator. */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** One pass, fully guarded — a throw here must never kill the interval. */
+  async consolidateSafe(): Promise<void> {
+    if (this.consolidating) return; // never overlap passes.
+    this.consolidating = true;
+    try {
+      await this.runPass();
+    } catch (e) {
+      this.deps.log(`experience consolidation pass error: ${(e as Error).message}`);
+    } finally {
+      this.consolidating = false;
+    }
+  }
+
+  /**
+   * One consolidation pass: re-check the kill-switch, read a bounded window under a SYSTEM
+   * context, compute the pure plan, and apply updates then deletes. Each write is guarded
+   * individually so one bad row can never abort the whole pass or crash the interval.
+   */
+  async runPass(): Promise<void> {
+    const cfg = this.deps.config().pipeline.consiliumLoop.experiencePlane;
+    if (!cfg.consolidate?.enabled) {
+      this.deps.log("experience consolidation skipped — consolidate.enabled off");
+      return;
+    }
+    const dreamRunId = randomUUID();
+    // staleVerifiedDays is SHARED with the DREAM-2 reader so the durable decay agrees with
+    // the read-time down-weight (§6). Falls back to a safe default if the read block is absent.
+    const staleVerifiedDays = cfg.read?.staleVerifiedDays ?? 60;
+
+    await this.deps.runInSystem(async () => {
+      const items = await this.deps.listExperienceItems(CONSOLIDATE_SCAN_LIMIT);
+      if (items.length === 0) return;
+
+      const plan = consolidate(items, { dreamRunId, staleVerifiedDays, now: this.now });
+
+      let applied = 0;
+      for (const upd of plan.updates) {
+        try {
+          await this.deps.updateExperienceItem(upd.id, upd.patch);
+          applied += 1;
+        } catch (e) {
+          this.deps.log(`experience consolidation: update ${upd.id} failed — ${(e as Error).message}`);
+        }
+      }
+
+      // Deletes are applied AFTER updates so a survivor is never left dangling if a delete
+      // fails; a failed delete just means a duplicate lingers to next pass (idempotent).
+      if (plan.deletes.length > 0) {
+        try {
+          await this.deps.deleteExperienceItems(plan.deletes);
+        } catch (e) {
+          this.deps.log(`experience consolidation: delete batch failed — ${(e as Error).message}`);
+        }
+      }
+
+      const s = plan.stats;
+      if (applied > 0 || s.deleted > 0) {
+        this.deps.log(
+          `experience consolidation: scanned=${s.scanned} groups=${s.groups} ` +
+            `merged=${s.merged} decayed=${s.decayed} conflicts=${s.conflicts} ` +
+            `successDelta=${s.successDeltaSet} updated=${applied} deleted=${s.deleted}`,
+        );
+      }
+    });
+  }
+}

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -1353,6 +1353,33 @@ export class PgStorage implements IStorage {
       .limit(limit);
   }
 
+  // ─── Experience plane — the "Dream" distillation, CONSOLIDATE side (DREAM-3) ──
+  // The scheduled consolidator merges/decays/recomputes items IN PLACE. withProjectList
+  // lets the system-context pass (runAsSystem) update/delete across all projects; a
+  // project-scoped caller would be confined to its own rows. Writes ONLY this table.
+
+  async updateExperienceItem(
+    id: string,
+    patch: Partial<ExperienceItemRow>,
+  ): Promise<ExperienceItemRow | undefined> {
+    // Never let a patch change identity/lineage columns.
+    const { id: _i, createdAt: _c, sourceLoopId: _s, projectId: _p, ...safe } = patch;
+    if (Object.keys(safe).length === 0) return undefined;
+    const [row] = await db
+      .update(experienceItems)
+      .set(safe)
+      .where(withProjectList(experienceItems, eq(experienceItems.id, id)))
+      .returning();
+    return row;
+  }
+
+  async deleteExperienceItems(ids: string[]): Promise<void> {
+    if (ids.length === 0) return;
+    await db
+      .delete(experienceItems)
+      .where(withProjectList(experienceItems, inArray(experienceItems.id, ids)));
+  }
+
   // ─── Triggers (Phase 6.3) ─────────────────────────────────────────────────
 
   async getTriggers(pipelineId: string): Promise<TriggerRow[]> {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -593,6 +593,20 @@ export interface IStorage {
   getExperienceItemsBySourceLoop(loopId: string): Promise<ExperienceItemRow[]>;
   /** Inspection: list Experience items, most-recent first (DREAM-1 quality check). */
   listExperienceItems(limit?: number): Promise<ExperienceItemRow[]>;
+  // DREAM-3 (consolidation) write seams — the SCHEDULED consolidator merges/decays/
+  // recomputes items in place. It writes ONLY to experience_items (never state, never
+  // SKILL.md) and only these two mutators exist so the surface is auditable.
+  /**
+   * Apply a field-level patch to ONE surviving Experience item (merge result / decay /
+   * successDelta / conflict flag). Partial: only the provided fields change. Returns the
+   * updated row, or undefined if the id is gone (a concurrent delete — safe no-op).
+   */
+  updateExperienceItem(id: string, patch: Partial<ExperienceItemRow>): Promise<ExperienceItemRow | undefined>;
+  /**
+   * Delete merged-away DUPLICATE items by id (their evidence is already folded into a
+   * survivor). Idempotent: unknown ids are ignored. Bounded batch (the consolidator caps it).
+   */
+  deleteExperienceItems(ids: string[]): Promise<void>;
 
 
   // Tracker Connections (Issue Tracker Integration)
@@ -1986,6 +2000,7 @@ export class MemStorage implements IStorage {
         successDelta: data.successDelta ?? null,
         provenance: data.provenance,
         freshness: data.freshness,
+        consolidation: data.consolidation ?? null,
         relatedComponents: data.relatedComponents ?? [],
         sourceLoopId: data.sourceLoopId,
         createdAt: new Date(),
@@ -2004,6 +2019,24 @@ export class MemStorage implements IStorage {
     return Array.from(this.experienceItemsMap.values())
       .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
       .slice(0, limit);
+  }
+
+  // DREAM-3 — consolidation write seams (merge/decay/successDelta in place).
+  async updateExperienceItem(
+    id: string,
+    patch: Partial<ExperienceItemRow>,
+  ): Promise<ExperienceItemRow | undefined> {
+    const existing = this.experienceItemsMap.get(id);
+    if (!existing) return undefined; // concurrent delete — safe no-op.
+    // Never let a patch change identity/lineage columns.
+    const { id: _i, createdAt: _c, sourceLoopId: _s, projectId: _p, ...safe } = patch;
+    const updated: ExperienceItemRow = { ...existing, ...safe };
+    this.experienceItemsMap.set(id, updated);
+    return updated;
+  }
+
+  async deleteExperienceItems(ids: string[]): Promise<void> {
+    for (const id of ids) this.experienceItemsMap.delete(id);
   }
 
   // ─── Triggers (Phase 6.3) ─────────────────────────────────────────────────

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -17,7 +17,7 @@ import {
 import { vector } from "drizzle-orm/pg-core/columns/vector_extension/vector";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
-import type { TriggerConfig, TriggerType, TriggerProvenance, ManagerConfig, ManagerDecision, TraceSpan, SwarmCloneResult, SwarmMerger, SwarmSplitter, SkillVersionConfig, TaskTraceSpan, TrackerProvider, ActionPoint, Archetype, ArchetypeSource, ResearchReport, ExecutionTrace, ReviewMode, ExperienceScope, ExperienceEvidence, ExperienceVerification, ExperienceProvenance, ExperienceFreshness, ExperienceConfidence } from "./types.js";
+import type { TriggerConfig, TriggerType, TriggerProvenance, ManagerConfig, ManagerDecision, TraceSpan, SwarmCloneResult, SwarmMerger, SwarmSplitter, SkillVersionConfig, TaskTraceSpan, TrackerProvider, ActionPoint, Archetype, ArchetypeSource, ResearchReport, ExecutionTrace, ReviewMode, ExperienceScope, ExperienceEvidence, ExperienceVerification, ExperienceProvenance, ExperienceFreshness, ExperienceConfidence, ExperienceConsolidation } from "./types.js";
 
 // ─── RBAC ────────────────────────────────────────────
 
@@ -2353,6 +2353,12 @@ export const experienceItems = pgTable(
     provenance: jsonb("provenance").$type<ExperienceProvenance>().notNull(),
     // Freshness/decay descriptor stamped at write (§6); decay machinery is DREAM-3.
     freshness: jsonb("freshness").$type<ExperienceFreshness>().notNull(),
+    // DREAM-3 (§4/§6): the SCHEDULED consolidation pass's durable audit trail (merge
+    // count, contradiction cross-link, decay origin). NULL on a DREAM-1 item; set the
+    // first time the consolidator touches a surviving item. The consolidator writes ONLY
+    // to this table — never state, never SKILL.md. Nullable ⇒ byte-identical for existing
+    // rows and for a consolidate.enabled=false runtime (no pass ⇒ never populated).
+    consolidation: jsonb("consolidation").$type<ExperienceConsolidation>(),
     // Links into Omniscience state (state ≠ experience, §5) — NEVER mutated here.
     relatedComponents: jsonb("related_components").$type<string[]>().notNull().default(sql`'[]'::jsonb`),
     // The single loop this item was distilled from — the idempotency dedup key.

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -3823,3 +3823,41 @@ export interface ExperienceFreshness {
   /** e.g. "reuse:5" (drop verified→observed after 5 unconfirmed reuses) — descriptor. */
   decayPolicy: string;
 }
+
+/**
+ * DREAM-3 (§4 consolidating / §6 self-correction) — the durable audit trail the
+ * SCHEDULED consolidation pass stamps onto a SURVIVING Experience item. Null on a
+ * freshly-distilled DREAM-1 item; set the first time the consolidator touches it.
+ *
+ * This is the ONLY new persisted state DREAM-3 adds, and it lives on `experience_items`
+ * (a nullable jsonb column) — the pass writes NOWHERE else (never state, never SKILL.md).
+ * It records WHAT the consolidator did so a merge/decay/contradiction is auditable and
+ * so a re-run can recognise an already-consolidated item (idempotency, no thrash).
+ */
+export interface ExperienceConsolidation {
+  /** ISO-8601 — when the consolidator last processed this surviving item. */
+  lastConsolidatedAt: string;
+  /** The consolidation pass id (one per sweep) that last touched it. */
+  dreamRunId: string;
+  /** How many DISTINCT source loops merged into this survivor (>= 1). */
+  mergedLoopCount: number;
+  /**
+   * A verified↔refuted CONTRADICTION on the SAME (scope, claim): both survivors are
+   * KEPT (never silently overwritten, §6). This flags the conflict and cross-links the
+   * opposing survivor; the fresher-verified side leads at read time. Null when no conflict.
+   */
+  conflict?: {
+    /** The opposing survivor's id (the other side of the contradiction). */
+    withItemId: string;
+    /** The opposing survivor's confidence ('verified' | 'refuted'). */
+    opposingConfidence: ExperienceConfidence;
+    /** Human-readable, inert note ("worked here / failed there"). */
+    note: string;
+  } | null;
+  /**
+   * When DECAY demoted this item (a stale `verified` unconfirmed too long → `observed`,
+   * §6), the confidence it was demoted FROM — an audit trail so the demotion is visible
+   * and never silently reverses a grounded verdict. Null when no decay was applied.
+   */
+  decayedFrom?: ExperienceConfidence | null;
+}

--- a/tests/unit/consilium/experience/consolidator.test.ts
+++ b/tests/unit/consilium/experience/consolidator.test.ts
@@ -1,0 +1,289 @@
+/**
+ * consolidator.test.ts — DREAM-3: the PURE consolidation logic (dedup/merge, decay,
+ * contradiction, successDelta). Spec: experience-plane-dream.md §4/§6/§9.
+ *
+ * Covers (the adversarial checklist from the ticket):
+ *   - two duplicate items in a scope → MERGED: evidence unioned, strongest verification
+ *     kept, relatedComponents unioned, the duplicate DELETED (never loses evidence);
+ *   - a stale `verified` item → DECAYED to `observed`, written back (decayedFrom audit);
+ *   - contradictory items (verified + refuted, same scope+claim) → BOTH kept + conflict
+ *     flagged (fresher-verified leads), never a silent overwrite / verified→refuted flip;
+ *   - `successDelta` recomputed from a reuse signal (same pattern re-verified across loops);
+ *   - the pass is IDEMPOTENT: a second run over the applied result yields no updates/deletes;
+ *   - a HUGE store is BOUNDED (maxItems cap; evidence/sourceLoops bounded — no OOM);
+ *   - different projects with a same-basename repo NEVER cross-merge (isolation).
+ */
+import { describe, it, expect } from "vitest";
+import { consolidate, type ConsolidateOptions } from "../../../../server/services/consilium/experience/consolidator.js";
+import type { ExperienceItemRow } from "@shared/schema";
+import type { ExperienceConfidence, ExperienceEvidence } from "@shared/types";
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const T0 = new Date("2026-07-06T00:00:00.000Z");
+/** A fixed "now" far enough after the fixtures that a 60-day stale item is stale. */
+const NOW = new Date("2026-07-06T00:00:00.000Z");
+
+function ev(loopId: string, round: number, diffRef: string | null = "sha"): ExperienceEvidence {
+  return { loopId, round, apTitle: `AP ${loopId}`, diffRef };
+}
+
+function item(p: Partial<ExperienceItemRow> & { id: string }): ExperienceItemRow {
+  const confidence: ExperienceConfidence = p.confidence ?? "verified";
+  const base: ExperienceItemRow = {
+    id: p.id,
+    projectId: "proj-1",
+    scope: { repo: "widget", archetype: "repo-assessment", criterionClass: "test-run" },
+    claim: "On widget, the criterion \"coverage gate\" was VERIFIED (test-run).",
+    evidence: [ev(`loop-${p.id}`, 1)],
+    verification: { method: "test-run", outcome: "independent-pass", groundingRatioAtTime: 1 },
+    confidence,
+    successDelta: null,
+    provenance: { createdAt: T0.toISOString(), dreamRunId: "dr-0", sourceLoops: [`loop-${p.id}`] },
+    freshness: { lastConfirmedAt: T0.toISOString(), decayPolicy: "reuse:5" },
+    consolidation: null,
+    relatedComponents: [],
+    sourceLoopId: `loop-${p.id}`,
+    createdAt: T0,
+  } as ExperienceItemRow;
+  return { ...base, ...p } as ExperienceItemRow;
+}
+
+function opts(over: Partial<ConsolidateOptions> = {}): ConsolidateOptions {
+  return { dreamRunId: "dr-1", staleVerifiedDays: 60, now: () => NOW, ...over };
+}
+
+/** Apply a plan to a working set (mimics the observer) so idempotency can be re-checked. */
+function apply(items: ExperienceItemRow[], plan: ReturnType<typeof consolidate>): ExperienceItemRow[] {
+  const map = new Map(items.map((i) => [i.id, { ...i }]));
+  for (const u of plan.updates) {
+    const cur = map.get(u.id);
+    if (cur) map.set(u.id, { ...cur, ...u.patch } as ExperienceItemRow);
+  }
+  for (const id of plan.deletes) map.delete(id);
+  return Array.from(map.values());
+}
+
+// ── Dedup / merge ─────────────────────────────────────────────────────────────
+
+describe("consolidate — dedup / merge", () => {
+  it("merges two duplicate items: evidence unioned, strongest verification kept, duplicate deleted", () => {
+    const a = item({ id: "a", confidence: "observed", evidence: [ev("loop-a", 1)], relatedComponents: ["svc:auth"] });
+    const b = item({
+      id: "b",
+      confidence: "verified",
+      evidence: [ev("loop-b", 2)],
+      relatedComponents: ["svc:db"],
+      sourceLoopId: "loop-b",
+      provenance: { createdAt: T0.toISOString(), dreamRunId: "dr-0", sourceLoops: ["loop-b"] },
+    });
+    const plan = consolidate([a, b], opts());
+
+    // Exactly one survivor updated, exactly one duplicate deleted.
+    expect(plan.deletes).toHaveLength(1);
+    expect(plan.updates).toHaveLength(1);
+    const survivorId = plan.updates[0].id;
+    const deletedId = plan.deletes[0];
+    expect(new Set([survivorId, deletedId])).toEqual(new Set(["a", "b"]));
+
+    const patch = plan.updates[0].patch;
+    // Strongest verification kept (verified beats observed) — NEVER downgraded.
+    expect(patch.confidence).toBe("verified");
+    expect(patch.verification?.outcome).toBe("independent-pass");
+    // Evidence UNIONED (both links present) — never lost.
+    expect(patch.evidence?.map((e) => e.loopId).sort()).toEqual(["loop-a", "loop-b"]);
+    // relatedComponents unioned.
+    expect(patch.relatedComponents?.sort()).toEqual(["svc:auth", "svc:db"]);
+    // sourceLoops unioned.
+    expect(patch.provenance?.sourceLoops.sort()).toEqual(["loop-a", "loop-b"]);
+    expect(plan.stats.merged).toBe(1);
+  });
+
+  it("never flips a verified survivor to refuted when merging with an observed duplicate", () => {
+    const a = item({ id: "a", confidence: "verified" });
+    const b = item({ id: "b", confidence: "observed", sourceLoopId: "loop-b" });
+    const plan = consolidate([a, b], opts());
+    expect(plan.updates[0].patch.confidence).toBe("verified");
+  });
+});
+
+// ── Decay ─────────────────────────────────────────────────────────────────────
+
+describe("consolidate — decay (§6 self-correction)", () => {
+  it("demotes a stale verified item to observed and writes it back with a decay audit", () => {
+    const stale = item({
+      id: "stale",
+      confidence: "verified",
+      freshness: { lastConfirmedAt: "2026-01-01T00:00:00.000Z", decayPolicy: "reuse:5" }, // ~186 days old
+    });
+    const plan = consolidate([stale], opts({ staleVerifiedDays: 60 }));
+    expect(plan.updates).toHaveLength(1);
+    expect(plan.deletes).toHaveLength(0);
+    const patch = plan.updates[0].patch;
+    expect(patch.confidence).toBe("observed");
+    expect(patch.consolidation?.decayedFrom).toBe("verified");
+    expect(plan.stats.decayed).toBe(1);
+  });
+
+  it("does NOT decay a fresh verified item (no update, no thrash)", () => {
+    const fresh = item({
+      id: "fresh",
+      confidence: "verified",
+      freshness: { lastConfirmedAt: "2026-07-01T00:00:00.000Z", decayPolicy: "reuse:5" }, // 5 days old
+    });
+    const plan = consolidate([fresh], opts({ staleVerifiedDays: 60 }));
+    expect(plan.updates).toHaveLength(0);
+    expect(plan.deletes).toHaveLength(0);
+  });
+
+  it("does NOT re-demote an already-observed item (idempotent decay)", () => {
+    const obs = item({
+      id: "obs",
+      confidence: "observed",
+      freshness: { lastConfirmedAt: "2026-01-01T00:00:00.000Z", decayPolicy: "reuse:5" },
+    });
+    const plan = consolidate([obs], opts());
+    expect(plan.updates).toHaveLength(0);
+  });
+});
+
+// ── Contradiction ───────────────────────────────────────────────────────────
+
+describe("consolidate — contradiction (§6)", () => {
+  // REALISTIC distiller-shaped claims: the SAME criterion, but the outcome verb differs
+  // (VERIFIED vs REFUTED). The outcome-independent grouping MUST still unite them so the
+  // contradiction is detected (a raw-claim-match would miss it — the guard this asserts).
+  const goodClaim = 'On widget, the criterion "coverage gate" was VERIFIED (test-run).';
+  const badClaim = 'On widget, the criterion "coverage gate" was REFUTED (test-run) — the change did not close it.';
+
+  it("keeps BOTH a verified and a refuted item on the same scope+criterion, flags the conflict", () => {
+    const good = item({
+      id: "good",
+      confidence: "verified",
+      claim: goodClaim,
+      freshness: { lastConfirmedAt: "2026-07-05T00:00:00.000Z", decayPolicy: "reuse:5" }, // fresher
+    });
+    const bad = item({
+      id: "bad",
+      confidence: "refuted",
+      claim: badClaim,
+      verification: { method: "test-run", outcome: "independent-fail", groundingRatioAtTime: 1 },
+      sourceLoopId: "loop-bad",
+      provenance: { createdAt: T0.toISOString(), dreamRunId: "dr-0", sourceLoops: ["loop-bad"] },
+      freshness: { lastConfirmedAt: "2026-06-01T00:00:00.000Z", decayPolicy: "reuse:5" },
+    });
+    const plan = consolidate([good, bad], opts());
+
+    // BOTH kept — neither deleted (no silent overwrite).
+    expect(plan.deletes).toHaveLength(0);
+    expect(plan.updates).toHaveLength(2);
+    expect(plan.stats.conflicts).toBe(1);
+
+    const byId = new Map(plan.updates.map((u) => [u.id, u.patch]));
+    // Neither side's grounded confidence is flipped.
+    expect(byId.get("good")?.confidence).toBe("verified");
+    expect(byId.get("bad")?.confidence).toBe("refuted");
+    // Cross-linked conflict flags (fresher-verified leads).
+    expect(byId.get("good")?.consolidation?.conflict?.withItemId).toBe("bad");
+    expect(byId.get("good")?.consolidation?.conflict?.opposingConfidence).toBe("refuted");
+    expect(byId.get("bad")?.consolidation?.conflict?.withItemId).toBe("good");
+    expect(byId.get("bad")?.consolidation?.conflict?.opposingConfidence).toBe("verified");
+  });
+
+  it("collapses same-polarity duplicates within each side of a contradiction", () => {
+    const v1 = item({ id: "v1", confidence: "verified", claim: goodClaim, evidence: [ev("loop-v1", 1)] });
+    const v2 = item({ id: "v2", confidence: "verified", claim: goodClaim, evidence: [ev("loop-v2", 1)], sourceLoopId: "loop-v2",
+      provenance: { createdAt: T0.toISOString(), dreamRunId: "dr-0", sourceLoops: ["loop-v2"] } });
+    const r1 = item({ id: "r1", confidence: "refuted", claim: badClaim, sourceLoopId: "loop-r1",
+      provenance: { createdAt: T0.toISOString(), dreamRunId: "dr-0", sourceLoops: ["loop-r1"] } });
+    const plan = consolidate([v1, v2, r1], opts());
+    // One verified survivor (v1|v2 merged, the other deleted) + one refuted survivor kept.
+    expect(plan.deletes).toHaveLength(1);
+    expect(plan.updates).toHaveLength(2);
+    expect(plan.stats.conflicts).toBe(1);
+  });
+});
+
+// ── successDelta from reuse ───────────────────────────────────────────────────
+
+describe("consolidate — successDelta from reuse (§3 R2 / §6)", () => {
+  it("sets successDelta=1 when the same pattern was verified across two independent loops", () => {
+    const a = item({ id: "a", confidence: "verified", sourceLoopId: "loop-1",
+      provenance: { createdAt: T0.toISOString(), dreamRunId: "dr-0", sourceLoops: ["loop-1"] } });
+    const b = item({ id: "b", confidence: "verified", sourceLoopId: "loop-2",
+      provenance: { createdAt: T0.toISOString(), dreamRunId: "dr-0", sourceLoops: ["loop-2"] } });
+    const plan = consolidate([a, b], opts());
+    expect(plan.updates[0].patch.successDelta).toBe(1);
+    expect(plan.stats.successDeltaSet).toBe(1);
+  });
+
+  it("leaves successDelta null for a single occurrence (no reuse to measure)", () => {
+    const a = item({ id: "a", confidence: "verified" });
+    const plan = consolidate([a], opts());
+    // Nothing to consolidate ⇒ no update at all.
+    expect(plan.updates).toHaveLength(0);
+  });
+});
+
+// ── Idempotency ───────────────────────────────────────────────────────────────
+
+describe("consolidate — idempotency (anti-thrash, §4)", () => {
+  it("a re-run over the applied result yields NO updates and NO deletes", () => {
+    const a = item({ id: "a", confidence: "observed", evidence: [ev("loop-a", 1)] });
+    const b = item({ id: "b", confidence: "verified", evidence: [ev("loop-b", 2)], sourceLoopId: "loop-b",
+      provenance: { createdAt: T0.toISOString(), dreamRunId: "dr-0", sourceLoops: ["loop-b"] } });
+    const first = consolidate([a, b], opts());
+    const afterFirst = apply([a, b], first);
+
+    const second = consolidate(afterFirst, opts({ dreamRunId: "dr-2" }));
+    expect(second.updates).toHaveLength(0);
+    expect(second.deletes).toHaveLength(0);
+  });
+
+  it("a stable contradiction re-run yields NO further writes", () => {
+    const good = item({ id: "good", confidence: "verified", claim: 'On widget, the criterion "x" was VERIFIED (test-run).' });
+    const bad = item({ id: "bad", confidence: "refuted", claim: 'On widget, the criterion "x" was REFUTED (test-run).', sourceLoopId: "loop-bad",
+      verification: { method: "test-run", outcome: "independent-fail", groundingRatioAtTime: 1 },
+      provenance: { createdAt: T0.toISOString(), dreamRunId: "dr-0", sourceLoops: ["loop-bad"] } });
+    const first = consolidate([good, bad], opts());
+    const afterFirst = apply([good, bad], first);
+    const second = consolidate(afterFirst, opts({ dreamRunId: "dr-2" }));
+    expect(second.updates).toHaveLength(0);
+    expect(second.deletes).toHaveLength(0);
+  });
+});
+
+// ── Bounds / isolation ────────────────────────────────────────────────────────
+
+describe("consolidate — bounds + isolation", () => {
+  it("respects the maxItems cap on a huge store (never OOMs)", () => {
+    const many = Array.from({ length: 10_000 }, (_, i) =>
+      item({ id: `i${i}`, claim: `distinct claim ${i}`, sourceLoopId: `loop-${i}` }),
+    );
+    const plan = consolidate(many, opts({ maxItems: 100 }));
+    expect(plan.stats.scanned).toBe(100);
+    expect(plan.stats.groups).toBeLessThanOrEqual(100);
+  });
+
+  it("never cross-merges two projects that share a repo basename", () => {
+    const p1 = item({ id: "p1", projectId: "proj-1", sourceLoopId: "loop-p1" });
+    const p2 = item({ id: "p2", projectId: "proj-2", sourceLoopId: "loop-p2",
+      provenance: { createdAt: T0.toISOString(), dreamRunId: "dr-0", sourceLoops: ["loop-p2"] } });
+    const plan = consolidate([p1, p2], opts());
+    // Same repo/claim but DIFFERENT projects ⇒ two groups ⇒ no merge, no delete.
+    expect(plan.deletes).toHaveLength(0);
+    expect(plan.stats.groups).toBe(2);
+  });
+
+  it("bounds unioned evidence on a survivor (no unbounded growth)", () => {
+    const claim = "On widget, one shared claim.";
+    const dupes = Array.from({ length: 40 }, (_, i) =>
+      item({ id: `d${i}`, claim, evidence: [ev(`loop-${i}`, i)], sourceLoopId: `loop-${i}`,
+        provenance: { createdAt: T0.toISOString(), dreamRunId: "dr-0", sourceLoops: [`loop-${i}`] } }),
+    );
+    const plan = consolidate(dupes, opts());
+    expect(plan.updates).toHaveLength(1);
+    expect(plan.deletes).toHaveLength(39);
+    expect(plan.updates[0].patch.evidence!.length).toBeLessThanOrEqual(16);
+  });
+});

--- a/tests/unit/consilium/experience/experience-consolidator-observer.test.ts
+++ b/tests/unit/consilium/experience/experience-consolidator-observer.test.ts
@@ -1,0 +1,163 @@
+/**
+ * experience-consolidator-observer.test.ts — DREAM-3: the background, SCHEDULED
+ * consolidator observer. FAKE storage (stateful, so a re-run "sees" the applied result)
+ * exercises the read → pure-consolidate → apply(updates + deletes) loop. Covers:
+ *   - kill-switch OFF ⇒ start() does not start AND a manual pass writes nothing;
+ *   - kill-switch ON ⇒ a duplicate pair is MERGED (one update, one delete);
+ *   - a re-run is IDEMPOTENT (no further writes — the store has converged);
+ *   - a write that throws is CAUGHT (the pass never crashes the interval);
+ *   - it touches ONLY the experience_items seams (list/update/delete) — never a loop.
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  ExperienceConsolidatorObserver,
+  type ExperienceConsolidatorObserverDeps,
+} from "../../../../server/services/consilium/experience/experience-consolidator-observer.js";
+import type { ExperienceItemRow } from "@shared/schema";
+import type { ExperienceConfidence, ExperienceEvidence } from "@shared/types";
+import type { AppConfig } from "../../../../server/config/schema.js";
+
+// ── Fakes ────────────────────────────────────────────────────────────────────
+
+function cfg(consolidateEnabled: boolean): AppConfig {
+  return {
+    pipeline: {
+      consiliumLoop: {
+        experiencePlane: {
+          enabled: true,
+          read: { staleVerifiedDays: 60 },
+          consolidate: { enabled: consolidateEnabled, intervalSec: 3_600 },
+        },
+      },
+    },
+  } as unknown as AppConfig;
+}
+
+const T0 = "2026-07-06T00:00:00.000Z";
+
+function ev(loopId: string, round: number): ExperienceEvidence {
+  return { loopId, round, apTitle: `AP ${loopId}`, diffRef: "sha" };
+}
+
+function item(p: Partial<ExperienceItemRow> & { id: string }): ExperienceItemRow {
+  const confidence: ExperienceConfidence = p.confidence ?? "verified";
+  const base: ExperienceItemRow = {
+    id: p.id,
+    projectId: "proj-1",
+    scope: { repo: "widget", archetype: "repo-assessment", criterionClass: "test-run" },
+    claim: "On widget, the coverage gate was VERIFIED (test-run).",
+    evidence: [ev(`loop-${p.id}`, 1)],
+    verification: { method: "test-run", outcome: "independent-pass", groundingRatioAtTime: 1 },
+    confidence,
+    successDelta: null,
+    provenance: { createdAt: T0, dreamRunId: "dr-0", sourceLoops: [`loop-${p.id}`] },
+    freshness: { lastConfirmedAt: T0, decayPolicy: "reuse:5" },
+    consolidation: null,
+    relatedComponents: [],
+    sourceLoopId: `loop-${p.id}`,
+    createdAt: new Date(T0),
+  } as ExperienceItemRow;
+  return { ...base, ...p } as ExperienceItemRow;
+}
+
+/** A stateful fake store — updates/deletes persist so idempotency is exercised. */
+function fakeStore(seed: ExperienceItemRow[]) {
+  const map = new Map(seed.map((i) => [i.id, { ...i }]));
+  const updateSpy = vi.fn(async (id: string, patch: Partial<ExperienceItemRow>) => {
+    const cur = map.get(id);
+    if (!cur) return undefined;
+    const next = { ...cur, ...patch } as ExperienceItemRow;
+    map.set(id, next);
+    return next;
+  });
+  const deleteSpy = vi.fn(async (ids: string[]) => {
+    for (const id of ids) map.delete(id);
+  });
+  const listSpy = vi.fn(async (_limit: number) => Array.from(map.values()));
+  return { map, updateSpy, deleteSpy, listSpy };
+}
+
+function makeObserver(store: ReturnType<typeof fakeStore>, config: AppConfig): ExperienceConsolidatorObserver {
+  const deps: ExperienceConsolidatorObserverDeps = {
+    runInSystem: (fn) => fn(),
+    listExperienceItems: store.listSpy,
+    updateExperienceItem: store.updateSpy,
+    deleteExperienceItems: store.deleteSpy,
+    config: () => config,
+    log: () => {},
+    now: () => new Date("2026-07-06T00:00:00.000Z"),
+  };
+  return new ExperienceConsolidatorObserver(deps);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("ExperienceConsolidatorObserver", () => {
+  it("kill-switch OFF ⇒ start() does not start and a pass writes nothing", () => {
+    const store = fakeStore([item({ id: "a", confidence: "observed" }), item({ id: "b" })]);
+    const obs = makeObserver(store, cfg(false));
+    obs.start();
+    expect(store.listSpy).not.toHaveBeenCalled();
+  });
+
+  it("kill-switch OFF ⇒ runPass no-ops (never reads or writes)", async () => {
+    const store = fakeStore([item({ id: "a" })]);
+    const obs = makeObserver(store, cfg(false));
+    await obs.runPass();
+    expect(store.listSpy).not.toHaveBeenCalled();
+    expect(store.updateSpy).not.toHaveBeenCalled();
+    expect(store.deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it("kill-switch ON ⇒ merges a duplicate pair (one update, one delete)", async () => {
+    const a = item({ id: "a", confidence: "observed", evidence: [ev("loop-a", 1)] });
+    const b = item({ id: "b", confidence: "verified", evidence: [ev("loop-b", 2)] });
+    const store = fakeStore([a, b]);
+    const obs = makeObserver(store, cfg(true));
+
+    await obs.runPass();
+
+    expect(store.updateSpy).toHaveBeenCalledTimes(1);
+    expect(store.deleteSpy).toHaveBeenCalledTimes(1);
+    // The store now holds exactly one survivor, verified, with unioned evidence.
+    expect(store.map.size).toBe(1);
+    const survivor = Array.from(store.map.values())[0];
+    expect(survivor.confidence).toBe("verified");
+    expect(survivor.evidence.map((e) => e.loopId).sort()).toEqual(["loop-a", "loop-b"]);
+  });
+
+  it("is idempotent: a second pass writes nothing more", async () => {
+    const a = item({ id: "a", confidence: "observed", evidence: [ev("loop-a", 1)] });
+    const b = item({ id: "b", confidence: "verified", evidence: [ev("loop-b", 2)] });
+    const store = fakeStore([a, b]);
+    const obs = makeObserver(store, cfg(true));
+
+    await obs.runPass();
+    store.updateSpy.mockClear();
+    store.deleteSpy.mockClear();
+
+    await obs.runPass();
+    expect(store.updateSpy).not.toHaveBeenCalled();
+    expect(store.deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it("a throwing update is caught — the pass never rejects", async () => {
+    const a = item({ id: "a", confidence: "observed", evidence: [ev("loop-a", 1)] });
+    const b = item({ id: "b", confidence: "verified", evidence: [ev("loop-b", 2)] });
+    const store = fakeStore([a, b]);
+    store.updateSpy.mockRejectedValueOnce(new Error("db down"));
+    const obs = makeObserver(store, cfg(true));
+
+    // consolidateSafe swallows; runPass surfaces the update error only via the guarded loop
+    // (it does not throw — a bad write must never kill the interval).
+    await expect(obs.runPass()).resolves.toBeUndefined();
+  });
+
+  it("empty store ⇒ no writes", async () => {
+    const store = fakeStore([]);
+    const obs = makeObserver(store, cfg(true));
+    await obs.runPass();
+    expect(store.updateSpy).not.toHaveBeenCalled();
+    expect(store.deleteSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## DREAM-3 — Experience consolidation (the "global profile")

Implements **DREAM-3** from `docs/design/experience-plane-dream.md` (§4 consolidating, §6 self-correction, §9). Builds on **DREAM-1** (write) and **DREAM-2** (read), both in main. The store previously only *accumulated* items and read them at plan time; nothing consolidated them. This adds the scheduled pass that keeps the plane honest.

### The scheduled pass
A background, off-the-hot-path interval consolidator (`experience-consolidator-observer.ts`), modelled on the DREAM-1 distiller observer / the tracker poller. Each pass: reads a **bounded window** of recent items under a system context → computes a **pure** `ConsolidationPlan` → applies updates then deletes. Single-flight (passes never overlap), every write individually guarded (a bad row can't kill the interval). It **never touches the loop controller** and **never blocks or races a loop** — if it's down, the plane behaves exactly as DREAM-1/DREAM-2 (safe degrade).

### Dedup / merge rules + verification precedence
Items are grouped by `(projectId, scope.repo, scope.archetype, scope.criterionClass, outcome-independent claim identity)`. Within a group, duplicates collapse into **one survivor**:
- **evidence** unioned (deduped, bounded to 16 — never lost, never unbounded)
- **strongest verification kept**: `verified > refuted > observed` (a grounded verdict always beats a bare `observed`; a merge can never downgrade or flip `verified → refuted`)
- **relatedComponents** and **provenance.sourceLoops** unioned; `freshness.lastConfirmedAt` takes the max
- merged-away duplicates are **deleted** (their evidence already folded into the survivor)

> **Key subtlety:** the DREAM-1 distiller embeds the outcome verb in the claim text (`... was VERIFIED/REFUTED/OBSERVED ...`), so the grouping identity is computed **outcome-independently** (the claim prefix before the ` was ` clause). Otherwise a verified and a refuted item about the same criterion would never meet and a contradiction could never be detected.

### Decay writeback (§6 self-correction)
A `verified` survivor unconfirmed for longer than `staleVerifiedDays` (shared with DREAM-2's read config, so the durable decay agrees with the read-time down-weight) is demoted to `observed` and **written back** — the store self-corrects, not just the read. `consolidation.decayedFrom` records the origin. Never touches `refuted`/`observed`; never flips `verified → refuted`; a demoted item is only re-lifted by a genuine fresh grounded duplicate on a later pass.

### Contradiction handling (§6)
Two items with **opposite grounded outcomes** (verified vs refuted) on the same scope+criterion → **both survivors are kept** and cross-flagged (`consolidation.conflict`), fresher-verified leads. Never a silent overwrite. Same-polarity duplicates within each side still collapse.

### successDelta recompute (+ reuse-attribution boundary)
`successDelta` is recomputed from the **available reuse signal**: when the same (scope, criterion) recurred across **≥ 2 independent loops** with grounded outcomes, `successDelta = (nVerified − nRefuted) / (nVerified + nRefuted) ∈ [−1, 1]` — the measured net effect of reuse. A single occurrence has no reuse ⇒ stays `null`. It is (re)computed **only on an actual multi-item merge**, never re-derived for a lone survivor (which would mis-attribute a merged survivor's collapsed loops and thrash idempotency).

**Documented boundary:** the *stronger* reuse signal — linking DREAM-2's plan-time injection of item X to the later loop's independent outcome — needs a persisted injection→outcome edge. DREAM-2 only **logs** injection today (`plan: experience injected — N item(s)`), it does not persist which items fed which loop. Wiring that edge is deferred; the recurrence proxy here is honest (measured from outcomes, not opinion).

### Kill-switch
`pipeline.consiliumLoop.experiencePlane.consolidate.{enabled (default false), intervalSec}`. Off ⇒ the observer is **never constructed** (routes.ts) ⇒ byte-identical: no merge, no decay, no writes — the store just accumulates + is read (DREAM-1/DREAM-2 behavior).

### Boundaries
Writes **only** to `experience_items` (merge/decay/successDelta/flag via `updateExperienceItem` / `deleteExperienceItems`) — never the state graph, never SKILL.md (that's DREAM-4). Idempotent (re-run over a consolidated batch yields no writes), bounded (per-pass item cap + bounded evidence/sourceLoops — a huge store can't OOM the pass), project-isolated (two projects sharing a repo basename never cross-merge).

### Schema
One additive, nullable `experience_items.consolidation` jsonb column (migration `0049`, `ADD COLUMN IF NOT EXISTS`) + `ExperienceConsolidation` type — the consolidator's durable audit trail (merge count, contradiction cross-link, decay origin, last pass id). NULL for existing rows and for a kill-switch-off runtime.

### Tests
- **consolidator (pure):** merge (evidence unioned, strongest verification kept, duplicate deleted), never-downgrade, decay writeback + no-decay-when-fresh + no-re-demote, contradiction (both kept + cross-flagged, same-polarity collapse), successDelta from reuse, idempotency (merge + stable contradiction), bounds/maxItems, evidence bound, project isolation
- **observer:** kill-switch off (no start / no writes), merge apply loop (one update + one delete), idempotent second pass, a throwing write is caught, empty store

`tsc` clean; experience suite (54) + consilium/storage suites (1174) + full unit suite (5435) green locally.

### Adversarial self-review
Checked against: a merge losing evidence or upgrading confidence wrongly (union is bounded + lossless; upgrade only to a real grounded member's verdict); decay flipping too aggressively (only `verified→observed`, threshold-gated, never `→refuted`); the pass blocking/racing a loop or DREAM-1's writes (pure core + read-only-then-apply, own interval, single-flight, off the controller); unbounded memory (per-pass cap + bounded unions); writing outside `experience_items` (only two mutators, both on that table); a non-idempotent pass thrashing the store (updates emitted only on real change; successDelta not re-derived for lone survivors — verified by re-run tests).

Do not merge — Draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
