### PR TITLE
feat: role library + graduation signal (ROLE-4)

### DIFF
--- a/client/src/hooks/use-roles.ts
+++ b/client/src/hooks/use-roles.ts
@@ -11,6 +11,8 @@ import type {
   StandingRoleLoopTemplate,
   StandingRolePolicy,
   StandingRoleConcernTrigger,
+  StandingRoleDefinition,
+  GraduationReadiness,
 } from "@shared/types";
 
 const ROLES_KEY = ["/api/roles"] as const;
@@ -126,5 +128,39 @@ export function useWokenLoops(roleId: string, enabled = true) {
         Array<{ id: string; state?: string; repoPath?: string }>
       >,
     enabled,
+  });
+}
+
+// ─── ROLE-4: track record / graduation signal + export / import ────────────────
+
+/**
+ * The role's MEASURED track record + graduation-readiness verdict (ADR-0002 success-
+ * delta). Read-only — computed server-side from woken loops + role-scoped experience.
+ */
+export function useTrackRecord(roleId: string, enabled = true) {
+  return useQuery<GraduationReadiness>({
+    queryKey: ["/api/roles", roleId, "track-record"],
+    queryFn: () => apiRequest("GET", `/api/roles/${roleId}/track-record`) as Promise<GraduationReadiness>,
+    enabled,
+  });
+}
+
+/**
+ * Fetch a role's PORTABLE definition (skills by name, no runtime/secret state). Returns
+ * the JSON object — the caller serialises + downloads it. Not a hook (imperative, on click).
+ */
+export function exportRoleDefinition(roleId: string): Promise<StandingRoleDefinition> {
+  return apiRequest("GET", `/api/roles/${roleId}/export`) as Promise<StandingRoleDefinition>;
+}
+
+/**
+ * Import a role FROM a portable definition. Creates a DISABLED role (skills re-validated
+ * against THIS project fail-closed) — a human enables it. Invalidates the roles list.
+ */
+export function useImportRole() {
+  const qc = useQueryClient();
+  return useMutation<StandingRoleRow, Error, StandingRoleDefinition>({
+    mutationFn: (definition) => apiRequest("POST", "/api/roles/import", definition) as Promise<StandingRoleRow>,
+    onSuccess: () => qc.invalidateQueries({ queryKey: ROLES_KEY }),
   });
 }

--- a/client/src/pages/Roles.tsx
+++ b/client/src/pages/Roles.tsx
@@ -9,9 +9,15 @@
  */
 import { useState } from "react";
 import { useLocation } from "wouter";
-import { UserCog, Plus, Trash2, Zap, Eye, Radio } from "lucide-react";
+import { UserCog, Plus, Trash2, Zap, Eye, Radio, Download, Upload, Award } from "lucide-react";
 import { CONSILIUM_REVIEW_PRESETS, REVIEW_MODES } from "@shared/types";
-import type { ConsiliumReviewPreset, ReviewMode, StandingRoleConcern } from "@shared/types";
+import type {
+  ConsiliumReviewPreset,
+  ReviewMode,
+  StandingRoleConcern,
+  StandingRoleDefinition,
+  GraduationStatus,
+} from "@shared/types";
 import type { StandingRoleRow } from "@shared/schema";
 import { useSkills } from "@/hooks/use-skills";
 import {
@@ -22,6 +28,9 @@ import {
   useAddConcern,
   useDeleteConcern,
   useWokenLoops,
+  useTrackRecord,
+  useImportRole,
+  exportRoleDefinition,
 } from "@/hooks/use-roles";
 import { useToast } from "@/hooks/use-toast";
 import { Button } from "@/components/ui/button";
@@ -568,6 +577,127 @@ function WokenLoops({ roleId }: { roleId: string }) {
   );
 }
 
+// ─── ROLE-4: graduation-readiness badge (measured, read-only) ─────────────────
+
+const GRADUATION_LABEL: Record<GraduationStatus, string> = {
+  proven: "proven",
+  "needs-more-evidence": "needs more evidence",
+  "insufficient-evidence": "insufficient evidence",
+};
+
+/**
+ * The role's "proven → graduate" signal. EARNED from measured outcomes (woken-loop
+ * terminal states + role-scoped verified/refuted experience) — never self-reported.
+ * Read-only; a human decides the actual cross-repo graduation (§6).
+ */
+function GraduationBadge({ roleId }: { roleId: string }) {
+  const { data, isLoading } = useTrackRecord(roleId);
+  if (isLoading || !data) return null;
+  const proven = data.status === "proven";
+  return (
+    <Badge
+      variant={proven ? "default" : "outline"}
+      className="text-xs gap-1"
+      title={`${data.summary}\n${data.rationale.join("\n")}`}
+      data-testid={`graduation-badge-${roleId}`}
+    >
+      {proven && <Award className="h-3 w-3" />}
+      {GRADUATION_LABEL[data.status]}
+    </Badge>
+  );
+}
+
+/** Export the role's portable definition as a downloaded JSON file. */
+function ExportRoleButton({ role }: { role: StandingRoleRow }) {
+  const { toast } = useToast();
+  const [busy, setBusy] = useState(false);
+  const onExport = async () => {
+    setBusy(true);
+    try {
+      const def: StandingRoleDefinition = await exportRoleDefinition(role.id);
+      const blob = new Blob([JSON.stringify(def, null, 2)], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `role-${role.name.replace(/[^A-Za-z0-9._-]/g, "_")}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+      toast({ title: `Exported "${role.name}" definition` });
+    } catch (e) {
+      toast({ title: "Failed to export role", description: e instanceof Error ? e.message : undefined, variant: "destructive" });
+    } finally {
+      setBusy(false);
+    }
+  };
+  return (
+    <Button size="sm" variant="ghost" onClick={onExport} disabled={busy} data-testid={`export-role-${role.id}`}>
+      <Download className="h-4 w-4" />
+    </Button>
+  );
+}
+
+// ─── ROLE-4: import a portable definition ─────────────────────────────────────
+
+function ImportRoleDialog() {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState("");
+  const { toast } = useToast();
+  const importRole = useImportRole();
+
+  const submit = async () => {
+    let parsed: StandingRoleDefinition;
+    try {
+      parsed = JSON.parse(text) as StandingRoleDefinition;
+    } catch {
+      toast({ title: "Not valid JSON", variant: "destructive" });
+      return;
+    }
+    try {
+      const role = await importRole.mutateAsync(parsed);
+      toast({ title: `Imported "${role.name}" — created disabled; enable it to use.` });
+      setText("");
+      setOpen(false);
+    } catch (e) {
+      // The server threads the fail-closed skill / schema-version rejection verbatim.
+      toast({ title: "Failed to import role", description: e instanceof Error ? e.message : undefined, variant: "destructive" });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="outline" data-testid="import-role-button">
+          <Upload className="h-4 w-4 mr-2" />
+          Import
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Import a role definition</DialogTitle>
+          <DialogDescription>
+            Paste a portable role definition (exported JSON). Its skills are re-validated
+            against this project — an unknown skill is rejected. The role is created
+            DISABLED; enable it when you are ready.
+          </DialogDescription>
+        </DialogHeader>
+        <Textarea
+          data-testid="import-role-textarea"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          rows={12}
+          placeholder='{ "kind": "standing-role-definition", "schemaVersion": 1, ... }'
+          className="font-mono text-xs"
+        />
+        <DialogFooter>
+          <Button onClick={submit} disabled={importRole.isPending || !text.trim()} data-testid="import-role-submit">
+            {importRole.isPending ? "Importing…" : "Import"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 // ─── Role card ──────────────────────────────────────────────────────────────
 
 function RoleCard({ role }: { role: StandingRoleRow }) {
@@ -596,6 +726,7 @@ function RoleCard({ role }: { role: StandingRoleRow }) {
           <CardTitle className="flex items-center gap-2">
             {role.name}
             {!role.enabled && <Badge variant="outline">disabled</Badge>}
+            <GraduationBadge roleId={role.id} />
           </CardTitle>
           <Badge variant="secondary">{tpl.preset}</Badge>
         </div>
@@ -639,6 +770,7 @@ function RoleCard({ role }: { role: StandingRoleRow }) {
       </CardContent>
       <CardFooter className="gap-2">
         <WakeRoleDialog role={role} />
+        <ExportRoleButton role={role} />
         <Button
           size="sm"
           variant="ghost"
@@ -665,7 +797,10 @@ export default function Roles() {
           <UserCog className="h-5 w-5" />
           <h1 className="text-xl font-semibold">Standing Roles</h1>
         </div>
-        <CreateRoleDialog />
+        <div className="flex items-center gap-2">
+          <ImportRoleDialog />
+          <CreateRoleDialog />
+        </div>
       </div>
 
       {isLoading && <p className="text-muted-foreground">Loading roles…</p>}

--- a/server/routes/standing-roles.ts
+++ b/server/routes/standing-roles.ts
@@ -39,10 +39,16 @@
 import { randomUUID } from "node:crypto";
 import type { Express, Request, Response } from "express";
 import { z } from "zod";
-import { CONSILIUM_REVIEW_PRESETS, REVIEW_MODES } from "@shared/types";
-import type { StandingRoleConcern, TriggerConfig, TriggerType } from "@shared/types";
+import { CONSILIUM_REVIEW_PRESETS, REVIEW_MODES, STANDING_ROLE_DEFINITION_VERSION } from "@shared/types";
+import type {
+  StandingRoleConcern,
+  StandingRoleDefinition,
+  TriggerConfig,
+  TriggerType,
+} from "@shared/types";
 import type { IStorage } from "../storage.js";
-import type { InsertStandingRole } from "@shared/schema";
+import type { InsertStandingRole, StandingRoleRow } from "@shared/schema";
+import { computeRoleGraduation } from "../services/consilium/role-track-record.js";
 import { validateBody } from "../middleware/validate.js";
 import {
   createConsiliumReview,
@@ -126,15 +132,49 @@ const TrackerConcernFilterSchema = z.object({
  * discriminated union. TRACK-6 adds `tracker_event` (github only) — a role whose INBOX
  * is a tracker project; the labelled ticket crystallises a spec STAMPED with the role.
  */
+/** The concern's trigger union — shared by add-concern AND import (identical bounds). */
+const ConcernTriggerSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("file_change"), filter: FileChangeConcernFilterSchema }),
+  z.object({ type: z.literal("github_event"), filter: GitHubConcernFilterSchema }),
+  z.object({ type: z.literal("tracker_event"), filter: TrackerConcernFilterSchema }),
+]);
+
 const AddConcernSchema = z.object({
   repoPath: z.string().min(1).max(4096),
   focus: z.string().min(1).max(8000),
   enabled: z.boolean().optional(),
-  trigger: z.discriminatedUnion("type", [
-    z.object({ type: z.literal("file_change"), filter: FileChangeConcernFilterSchema }),
-    z.object({ type: z.literal("github_event"), filter: GitHubConcernFilterSchema }),
-    z.object({ type: z.literal("tracker_event"), filter: TrackerConcernFilterSchema }),
-  ]),
+  trigger: ConcernTriggerSchema,
+});
+
+/**
+ * ROLE-4 (standing-role.md §8): the portable-definition body `POST /api/roles/import`
+ * accepts. Mirrors `StandingRoleDefinition`. Skills travel by NAME (re-resolved against
+ * the TARGET registry, fail-closed). `id`/`projectId`/`createdBy`/`triggerId` are NOT
+ * accepted — identity/runtime is minted fresh by the import (an incoming `enabled` is
+ * IGNORED: import always creates DISABLED, §6). Same bounds as create/add-concern so an
+ * oversized/foreign definition is a clean 400, never a downstream truncation.
+ */
+const ImportRoleSchema = z.object({
+  kind: z.literal("standing-role-definition"),
+  schemaVersion: z.number().int(),
+  // exportedAt is informational — accepted but not trusted (bounded to a sane length).
+  exportedAt: z.string().max(64).optional(),
+  name: z.string().min(1).max(200),
+  persona: z.string().min(1).max(8000),
+  skills: z.array(z.object({ name: z.string().min(1).max(200) })).max(MAX_ROLE_SKILLS).default([]),
+  loopTemplate: LoopTemplateSchema,
+  policy: PolicySchema.nullish(),
+  concerns: z
+    .array(
+      z.object({
+        repoPath: z.string().min(1).max(4096),
+        focus: z.string().min(1).max(8000),
+        enabled: z.boolean().optional(),
+        trigger: ConcernTriggerSchema,
+      }),
+    )
+    .max(50)
+    .default([]),
 });
 
 /** PATCH is a partial of create (every field optional). */
@@ -162,6 +202,118 @@ async function firstUnknownSkillId(storage: IStorage, skillIds: readonly string[
     if (!skill) return id;
   }
   return null;
+}
+
+/**
+ * ROLE-4 export: map a role's stored skill IDS → portable NAMES (the SKILL.md slug —
+ * the only cross-project-stable key; a UUID is meaningless elsewhere). A skill id that
+ * no longer resolves (a since-deleted skill) is DROPPED from the portable definition —
+ * it is already a dangling reference, and export must never leak an opaque local id as a
+ * "name" (that would fail-closed on import in a confusing way). Returns { names, dropped }.
+ */
+async function skillIdsToPortableNames(
+  storage: IStorage,
+  skillIds: readonly string[],
+): Promise<{ names: string[]; dropped: number }> {
+  const names: string[] = [];
+  let dropped = 0;
+  for (const id of skillIds) {
+    const skill = await storage.getSkill(id);
+    if (skill?.name) names.push(skill.name);
+    else dropped += 1;
+  }
+  return { names, dropped };
+}
+
+/**
+ * ROLE-4 import: re-resolve portable skill NAMES against the TARGET project's registry,
+ * FAIL-CLOSED. Returns the resolved local ids OR the FIRST offending name (safe to echo
+ * — it is the caller's own input). This is the import trust gate: an imported role can
+ * NEVER reference a capability the target project lacks (adversarial: "import trusting
+ * unvalidated skills"). Name is the join key; the first registry match by name wins.
+ */
+async function resolveSkillNames(
+  storage: IStorage,
+  names: readonly string[],
+): Promise<{ ids: string[] } | { unknownName: string }> {
+  if (names.length === 0) return { ids: [] };
+  const registry = await storage.getSkills();
+  const byName = new Map<string, string>();
+  for (const s of registry) {
+    if (!byName.has(s.name)) byName.set(s.name, s.id);
+  }
+  const ids: string[] = [];
+  for (const name of names) {
+    const id = byName.get(name);
+    if (!id) return { unknownName: name };
+    ids.push(id);
+  }
+  return { ids };
+}
+
+/**
+ * ROLE-4 export: render a StandingRole row → its PORTABLE definition (standing-role.md
+ * §8). Emits DEFINITION only — persona/skills(by name)/loopTemplate/policy/concerns —
+ * and DELIBERATELY OMITS all runtime/identity/secret state: `id`, `projectId`,
+ * `createdBy`, timestamps, the role's live `enabled`, and every concern's `id` +
+ * backing `triggerId`. (A concern's `id`/`triggerId` are per-project runtime rows; a
+ * fresh import mints its own.) Nothing here can wake work or leak a secret — it is a
+ * spec, not a session.
+ */
+async function roleToDefinition(
+  storage: IStorage,
+  role: StandingRoleRow,
+): Promise<{ definition: StandingRoleDefinition; skillsDropped: number }> {
+  const { names, dropped } = await skillIdsToPortableNames(storage, role.skills ?? []);
+  const concerns = ((role.concerns ?? []) as StandingRoleConcern[]).map((c) => ({
+    repoPath: c.repoPath,
+    focus: c.focus,
+    trigger: c.trigger,
+    ...(c.enabled !== undefined ? { enabled: c.enabled } : {}),
+  }));
+  const definition: StandingRoleDefinition = {
+    kind: "standing-role-definition",
+    schemaVersion: STANDING_ROLE_DEFINITION_VERSION,
+    exportedAt: new Date().toISOString(),
+    name: role.name,
+    persona: role.persona,
+    skills: names.map((name) => ({ name })),
+    loopTemplate: role.loopTemplate,
+    policy: role.policy ?? null,
+    concerns,
+  };
+  return { definition, skillsDropped: dropped };
+}
+
+/**
+ * ROLE-2/ROLE-4: build a concern (fresh id) + MATERIALISE its backing trigger, returning
+ * the concern with its `triggerId` set. Shared by the add-concern endpoint AND import so
+ * the trigger-wiring can never drift between the two paths. The backing trigger's
+ * `enabled` mirrors the concern; the ROLE's own `enabled` is the master gate the dispatch
+ * checks first (a disabled role never wakes — verified in trigger-dispatch), so an
+ * imported concern is doubly inert until a human enables the (disabled-on-import) role.
+ */
+async function materializeConcern(
+  storage: IStorage,
+  roleId: string,
+  input: { repoPath: string; focus: string; trigger: StandingRoleConcern["trigger"]; enabled?: boolean },
+): Promise<StandingRoleConcern> {
+  const concern: StandingRoleConcern = {
+    id: randomUUID(),
+    repoPath: input.repoPath,
+    focus: input.focus,
+    trigger: input.trigger,
+    ...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
+  };
+  const { type, config } = buildConcernTriggerConfig(concern, roleId);
+  const trigger = await storage.createTrigger({
+    pipelineId: null,
+    type,
+    config,
+    enabled: concern.enabled !== false,
+  } as Parameters<IStorage["createTrigger"]>[0]);
+  concern.triggerId = trigger.id;
+  return concern;
 }
 
 /**
@@ -380,25 +532,14 @@ export function registerStandingRoleRoutes(app: Express, deps: CreateConsiliumRe
     const role = await storage.getStandingRole(String(req.params.id));
     if (!role) return res.status(404).json({ error: "Role not found" });
 
-    const concern: StandingRoleConcern = {
-      id: randomUUID(),
+    // Materialise the concern + its backing trigger via the shared helper (same wiring
+    // import uses). createTrigger sets projectId from the request ALS (project-scoped).
+    const concern = await materializeConcern(storage, role.id, {
       repoPath: body.repoPath,
       focus: body.focus,
       trigger: body.trigger as StandingRoleConcern["trigger"],
-      ...(body.enabled !== undefined ? { enabled: body.enabled } : {}),
-    };
-
-    // Materialise the backing trigger FIRST so its id can be stored on the concern for
-    // lifecycle (delete concern → delete trigger). createTrigger sets projectId from the
-    // request ALS (project-scoped). enabled mirrors the concern (default on).
-    const { type, config } = buildConcernTriggerConfig(concern, role.id);
-    const trigger = await storage.createTrigger({
-      pipelineId: null,
-      type,
-      config,
-      enabled: concern.enabled !== false,
-    } as Parameters<IStorage["createTrigger"]>[0]);
-    concern.triggerId = trigger.id;
+      enabled: body.enabled,
+    });
 
     const concerns = [...((role.concerns ?? []) as StandingRoleConcern[]), concern];
     const updated = await storage.updateStandingRole(String(req.params.id), {
@@ -444,5 +585,113 @@ export function registerStandingRoleRoutes(app: Express, deps: CreateConsiliumRe
     const loops = await storage.getLoops();
     const woken = loops.filter((l) => l.triggerProvenance?.role?.roleId === role.id);
     return res.json(woken);
+  });
+
+  // ─── ROLE-4: TRACK RECORD → the "proven → graduate" signal ─────────────────
+  // READ-ONLY (standing-role.md §8, ADR-0002 success-delta): compute the role's measured
+  // track record from its woken loops' terminal states + its ROLE-SCOPED (fail-closed)
+  // Experience items, and derive the graduation-readiness verdict. Mutates NOTHING — a
+  // read of this endpoint can never alter a loop or an item. `proven` is EARNED from
+  // ground truth here; there is no user-settable "proven" field anywhere.
+  app.get("/api/roles/:id/track-record", async (req: Request, res: Response) => {
+    if (!req.user?.id) return res.status(401).json({ error: "Authentication required" });
+    if (!req.projectId) return res.status(400).json({ error: "x-project-id header is required" });
+    const role = await storage.getStandingRole(String(req.params.id));
+    if (!role) return res.status(404).json({ error: "Role not found" });
+
+    // Both reads are project-scoped by the request ALS. Experience items are filtered to
+    // THIS role fail-closed inside the pure computation (scope.role === role.id); a
+    // generous limit so an active role's full record is seen (role-id filter is exact).
+    const [loops, items] = await Promise.all([
+      storage.getLoops(),
+      storage.listExperienceItems(2000),
+    ]);
+    const readiness = computeRoleGraduation(role.id, loops, items);
+    return res.json(readiness);
+  });
+
+  // ─── ROLE-4: EXPORT a role as a portable, shareable definition ─────────────
+  // Emits the DEFINITION only (persona/skills-by-name/loopTemplate/policy/concerns) with
+  // NO runtime/identity/secret state — see `roleToDefinition`. The JSON a human hands to
+  // another project (or attaches to a genai-enablement ADR for cross-repo graduation).
+  app.get("/api/roles/:id/export", async (req: Request, res: Response) => {
+    if (!req.user?.id) return res.status(401).json({ error: "Authentication required" });
+    if (!req.projectId) return res.status(400).json({ error: "x-project-id header is required" });
+    const role = await storage.getStandingRole(String(req.params.id));
+    if (!role) return res.status(404).json({ error: "Role not found" });
+
+    const { definition, skillsDropped } = await roleToDefinition(storage, role);
+    // Suggest a filename; the client can save the body verbatim.
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="role-${role.name.replace(/[^A-Za-z0-9._-]/g, "_")}.json"`,
+    );
+    if (skillsDropped > 0) res.setHeader("X-Skills-Dropped", String(skillsDropped));
+    return res.json(definition);
+  });
+
+  // ─── ROLE-4: IMPORT a role FROM a portable definition ──────────────────────
+  // Create-from-definition (standing-role.md §8). SAFETY:
+  //   - schemaVersion mismatch → 400 (fail-closed, never a silent mis-map).
+  //   - skills re-resolved by NAME against THIS project's registry, FAIL-CLOSED (an
+  //     unknown skill → 400, NOTHING created) — the import trust gate.
+  //   - the role is ALWAYS created DISABLED (§6: enabling a role is a human act) — an
+  //     imported definition can never wake work on arrival.
+  //   - persona/focus stay UNTRUSTED end-to-end (fenced by the factory at any later wake).
+  //   - no cross-repo auto-push / auto-graduation — import is a LOCAL create only.
+  app.post("/api/roles/import", validateBody(ImportRoleSchema), async (req: Request, res: Response) => {
+    if (!req.user?.id) return res.status(401).json({ error: "Authentication required" });
+    if (!req.projectId) return res.status(400).json({ error: "x-project-id header is required" });
+    const def = req.body as z.infer<typeof ImportRoleSchema>;
+
+    if (def.schemaVersion !== STANDING_ROLE_DEFINITION_VERSION) {
+      return res.status(400).json({
+        error: `unsupported definition schemaVersion ${def.schemaVersion} (this server imports version ${STANDING_ROLE_DEFINITION_VERSION})`,
+      });
+    }
+
+    // Fail-closed skill re-validation against the TARGET registry (by name).
+    const resolved = await resolveSkillNames(storage, def.skills.map((s) => s.name));
+    if ("unknownName" in resolved) {
+      return res.status(400).json({
+        error: `skill "${resolved.unknownName}" from the imported definition was not found in this project — create it first, then re-import.`,
+      });
+    }
+
+    // Create the role DISABLED with the LOCAL skill ids. Concerns are materialised
+    // AFTER (each needs the role id for its backing-trigger binding).
+    const created = await storage.createStandingRole({
+      name: def.name,
+      persona: def.persona,
+      skills: resolved.ids,
+      loopTemplate: def.loopTemplate,
+      concerns: [],
+      policy: def.policy ?? null,
+      // §6: import NEVER enables — a shared definition arrives inert; a human enables it.
+      enabled: false,
+      createdBy: req.user.id,
+    } as InsertStandingRole);
+
+    // Re-materialise each concern's backing trigger (shared wiring). The role is disabled,
+    // so none can fire until a human enables it (double-gated: role + concern `enabled`).
+    if (def.concerns.length > 0) {
+      const concerns: StandingRoleConcern[] = [];
+      for (const c of def.concerns) {
+        concerns.push(
+          await materializeConcern(storage, created.id, {
+            repoPath: c.repoPath,
+            focus: c.focus,
+            trigger: c.trigger as StandingRoleConcern["trigger"],
+            enabled: c.enabled,
+          }),
+        );
+      }
+      const updated = await storage.updateStandingRole(created.id, {
+        concerns,
+      } as Partial<InsertStandingRole>);
+      return res.status(201).json(updated);
+    }
+
+    return res.status(201).json(created);
   });
 }

--- a/server/services/consilium/role-track-record.ts
+++ b/server/services/consilium/role-track-record.ts
@@ -1,0 +1,209 @@
+/**
+ * role-track-record.ts — ROLE-4 (standing-role.md §8): a Standing Role's MEASURED
+ * track record + the "proven → graduate" signal. Spec: standing-role.md §8 (role
+ * library / graduation), [[platform-canon]] ADR-0002 (the skills trust envelope:
+ * unverified → verified → deprecated; graduation is a MEASURED success-delta, never a
+ * self-report).
+ *
+ * THIS MODULE IS PURE + READ-ONLY (like distiller.ts / experience-reader.ts): it takes
+ * already-read rows (a role's woken loops + its role-scoped Experience items) and
+ * returns a computed record + verdict. It performs NO I/O and MUTATES NOTHING — a
+ * track-record read can never alter a loop or an Experience item (the anti-Goodhart
+ * point: the signal observes ground truth, it does not manufacture it).
+ *
+ * WHY OUTCOME-MEASURED (the whole ROLE-4 safety story): every input is GROUND TRUTH the
+ * factory set independently of any agent's self-report —
+ *   - a loop's terminal `state` (`converged` = the panel/verifier/merge gate closed it;
+ *     `stopped_cap`/`failed`/`escalated`/`cancelled` = it did not), and
+ *   - an Experience item's `confidence` (`verified` ⇐ an INDEPENDENT criterion passed;
+ *     `refuted` ⇐ one failed — see experience-plane-dream.md §6).
+ * There is NO field a user can set to "proven". `proven` is EARNED here or not at all.
+ */
+import type { ConsiliumLoopState } from "@shared/schema";
+import { CONSILIUM_LOOP_TERMINAL_STATES } from "@shared/schema";
+import type {
+  ExperienceConfidence,
+  ExperienceScope,
+  GraduationReadiness,
+  GraduationStatus,
+  RoleTrackRecord,
+} from "@shared/types";
+
+/** The minimal loop shape the computation needs — a terminal state + role provenance. */
+export interface TrackRecordLoop {
+  state: ConsiliumLoopState;
+  triggerProvenance?: { role?: { roleId: string } | null } | null;
+}
+
+/** The minimal Experience-item shape — a scope (for the role bind) + a confidence. */
+export interface TrackRecordItem {
+  scope: ExperienceScope;
+  confidence: ExperienceConfidence;
+}
+
+// ── Graduation thresholds (ADR-0002 success-delta; tuned conservative on purpose) ──
+// A role must have EARNED enough settled outcomes before ANY verdict beyond
+// "insufficient-evidence" is meaningful — a single lucky loop is not a track record.
+/** Below this many SETTLED (terminal) loops, there is not enough signal to judge. */
+export const MIN_TERMINAL_LOOPS_FOR_SIGNAL = 3;
+/** `proven` needs at least this many settled loops (a sustained beat, not a fluke). */
+export const PROVEN_MIN_TERMINAL_LOOPS = 5;
+/** `proven` needs a convergence rate at/above this (measured, not self-reported). */
+export const PROVEN_MIN_CONVERGENCE_RATE = 0.7;
+/** `proven` needs at least this many INDEPENDENTLY-verified role-scoped patterns. */
+export const PROVEN_MIN_VERIFIED_PATTERNS = 1;
+
+/** `converged` is the ONLY converged terminal; the rest are non-converged terminals. */
+const TERMINAL: ReadonlySet<ConsiliumLoopState> = new Set(CONSILIUM_LOOP_TERMINAL_STATES);
+
+/**
+ * Compute a role's track record from its woken loops + role-scoped Experience items.
+ * PURE: the caller pre-filters to this role's rows OR passes the roleId and lets this
+ * fn filter (it filters defensively either way — an item/loop that does not bind to the
+ * role is never counted). No I/O, no mutation.
+ */
+export function computeRoleTrackRecord(
+  roleId: string,
+  loops: readonly TrackRecordLoop[],
+  items: readonly TrackRecordItem[],
+): RoleTrackRecord {
+  let convergedLoops = 0;
+  let failedLoops = 0;
+  let activeLoops = 0;
+
+  for (const loop of loops) {
+    // Defensive re-bind: only loops THIS role woke count (the caller may pass a superset).
+    if (loop.triggerProvenance?.role?.roleId !== roleId) continue;
+    if (loop.state === "converged") convergedLoops += 1;
+    else if (TERMINAL.has(loop.state)) failedLoops += 1;
+    else activeLoops += 1;
+  }
+
+  let verifiedPatterns = 0;
+  let refutedPatterns = 0;
+  let observedPatterns = 0;
+  for (const item of items) {
+    // FAIL-CLOSED role bind (ROLE-3 §6): ONLY items learned AS this role count toward
+    // its record. A role-agnostic item (no `scope.role`) or another role's item never
+    // inflates this role's readiness — the same boundary the reader enforces.
+    if (item.scope?.role !== roleId) continue;
+    if (item.confidence === "verified") verifiedPatterns += 1;
+    else if (item.confidence === "refuted") refutedPatterns += 1;
+    else observedPatterns += 1;
+  }
+
+  const wokenLoops = convergedLoops + failedLoops + activeLoops;
+  const terminalLoops = convergedLoops + failedLoops;
+  const convergenceRate = terminalLoops === 0 ? null : convergedLoops / terminalLoops;
+
+  return {
+    wokenLoops,
+    convergedLoops,
+    failedLoops,
+    activeLoops,
+    terminalLoops,
+    convergenceRate,
+    verifiedPatterns,
+    refutedPatterns,
+    observedPatterns,
+  };
+}
+
+/** Render the convergence rate as a whole-percent string ("83%"), or "n/a" when unsettled. */
+function pct(rate: number | null): string {
+  return rate === null ? "n/a" : `${Math.round(rate * 100)}%`;
+}
+
+/**
+ * Derive the graduation signal from a measured record. PURE. The verdict is a pure
+ * function of the counts — the SAME record always yields the SAME status, and no input
+ * is self-reported. `proven` requires ALL of: a settled-loop floor, a convergence-rate
+ * floor, a verified-pattern floor, AND net-positive learning (verified > refuted) — a
+ * role that mostly refutes its own patterns has NOT proven its beat.
+ */
+export function computeGraduationReadiness(trackRecord: RoleTrackRecord): GraduationReadiness {
+  const {
+    wokenLoops,
+    convergedLoops,
+    terminalLoops,
+    convergenceRate,
+    verifiedPatterns,
+    refutedPatterns,
+  } = trackRecord;
+
+  const rationale: string[] = [];
+  let status: GraduationStatus;
+
+  if (terminalLoops < MIN_TERMINAL_LOOPS_FOR_SIGNAL) {
+    status = "insufficient-evidence";
+    rationale.push(
+      `only ${terminalLoops} settled loop(s) — need ≥ ${MIN_TERMINAL_LOOPS_FOR_SIGNAL} before a graduation verdict is meaningful`,
+    );
+    return {
+      status,
+      summary: summarise(wokenLoops, convergenceRate, verifiedPatterns, status),
+      rationale,
+      trackRecord,
+    };
+  }
+
+  const meetsLoopFloor = terminalLoops >= PROVEN_MIN_TERMINAL_LOOPS;
+  const meetsRate = convergenceRate !== null && convergenceRate >= PROVEN_MIN_CONVERGENCE_RATE;
+  const meetsVerified = verifiedPatterns >= PROVEN_MIN_VERIFIED_PATTERNS;
+  const netPositive = verifiedPatterns > refutedPatterns;
+
+  if (meetsLoopFloor && meetsRate && meetsVerified && netPositive) {
+    status = "proven";
+    rationale.push(
+      `${convergedLoops}/${terminalLoops} settled loops converged (${pct(convergenceRate)} ≥ ${Math.round(PROVEN_MIN_CONVERGENCE_RATE * 100)}%)`,
+      `${verifiedPatterns} independently-verified pattern(s) vs ${refutedPatterns} refuted (net-positive)`,
+      `${terminalLoops} settled loops ≥ ${PROVEN_MIN_TERMINAL_LOOPS} — a sustained beat, not a fluke`,
+    );
+  } else {
+    status = "needs-more-evidence";
+    if (!meetsLoopFloor) {
+      rationale.push(`${terminalLoops} settled loops — need ≥ ${PROVEN_MIN_TERMINAL_LOOPS} for proven`);
+    }
+    if (!meetsRate) {
+      rationale.push(
+        `convergence rate ${pct(convergenceRate)} — need ≥ ${Math.round(PROVEN_MIN_CONVERGENCE_RATE * 100)}%`,
+      );
+    }
+    if (!meetsVerified) {
+      rationale.push(
+        `${verifiedPatterns} verified pattern(s) — need ≥ ${PROVEN_MIN_VERIFIED_PATTERNS} independently-verified`,
+      );
+    }
+    if (meetsVerified && !netPositive) {
+      rationale.push(`${verifiedPatterns} verified vs ${refutedPatterns} refuted — not net-positive`);
+    }
+  }
+
+  return {
+    status,
+    summary: summarise(wokenLoops, convergenceRate, verifiedPatterns, status),
+    rationale,
+    trackRecord,
+  };
+}
+
+/** "N loops, X% converged, Y verified patterns — status". */
+function summarise(
+  wokenLoops: number,
+  convergenceRate: number | null,
+  verifiedPatterns: number,
+  status: GraduationStatus,
+): string {
+  const loopWord = wokenLoops === 1 ? "loop" : "loops";
+  const patWord = verifiedPatterns === 1 ? "pattern" : "patterns";
+  return `${wokenLoops} ${loopWord}, ${pct(convergenceRate)} converged, ${verifiedPatterns} verified ${patWord} — ${status}`;
+}
+
+/** One-call convenience: compute the record AND the readiness verdict from raw rows. */
+export function computeRoleGraduation(
+  roleId: string,
+  loops: readonly TrackRecordLoop[],
+  items: readonly TrackRecordItem[],
+): GraduationReadiness {
+  return computeGraduationReadiness(computeRoleTrackRecord(roleId, loops, items));
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1563,6 +1563,111 @@ export interface RoleConcernBinding {
 }
 
 /**
+ * ROLE-4 (standing-role.md §8): the CURRENT export/import schema version. A portable
+ * definition carries this so an import from a newer/older exporter fails-closed with a
+ * clear error rather than silently mis-mapping fields.
+ */
+export const STANDING_ROLE_DEFINITION_VERSION = 1 as const;
+
+/**
+ * ROLE-4 (standing-role.md §8): a PORTABLE StandingRole definition — the shareable
+ * artifact `GET /api/roles/:id/export` emits and `POST /api/roles/import` consumes.
+ *
+ * It is the role's DEFINITION only — deliberately WITHOUT runtime/identity/secret state:
+ *   - NO `id` / `projectId` / `createdBy` / timestamps (identity is per-project; import
+ *     mints a fresh row owned by the importer).
+ *   - NO backing `triggerId` on any concern (that is a per-project runtime row; import
+ *     re-materialises its own backing triggers).
+ *   - NO `enabled: true` bypass — import ALWAYS creates the role DISABLED (§6: enabling a
+ *     role is a human act), so a shared definition can never wake work on arrival.
+ *
+ * Skills travel by NAME (the ADR-0002 SKILL.md slug), NOT by the source project's opaque
+ * skill UUID — a UUID is meaningless in another project. Import re-resolves each name
+ * against the TARGET project's registry FAIL-CLOSED (an unknown skill → 400, nothing
+ * created), so an imported role can never reference a capability the target lacks.
+ */
+export interface StandingRoleDefinition {
+  /** Discriminator so a stray JSON blob is rejected before field access. */
+  kind: "standing-role-definition";
+  /** Schema version — `STANDING_ROLE_DEFINITION_VERSION`; a mismatch fails-closed. */
+  schemaVersion: number;
+  /** ISO-8601 when the export was taken (informational; not trusted on import). */
+  exportedAt: string;
+  name: string;
+  persona: string;
+  /** Skills by portable NAME (SKILL.md slug), re-validated against the target registry. */
+  skills: StandingRoleDefinitionSkill[];
+  loopTemplate: StandingRoleLoopTemplate;
+  /** The per-role rails (budget/cascade), carried as-is (config, not runtime). */
+  policy?: StandingRolePolicy | null;
+  /** The concerns the role watches — declarations only (no `id`, no `triggerId`). */
+  concerns: StandingRoleDefinitionConcern[];
+}
+
+/** A skill reference in a portable definition — the NAME is the join key on import. */
+export interface StandingRoleDefinitionSkill {
+  /** The skill's NAME (SKILL.md slug) — re-resolved to a local id on import. */
+  name: string;
+}
+
+/** A concern in a portable definition — the ROLE-2 concern MINUS its runtime bookkeeping. */
+export interface StandingRoleDefinitionConcern {
+  repoPath: string;
+  focus: string;
+  trigger: StandingRoleConcernTrigger;
+  enabled?: boolean;
+}
+
+/**
+ * ROLE-4 (standing-role.md §8, [[platform-canon]] ADR-0002 success-delta): a role's
+ * MEASURED track record — computed READ-ONLY from its woken loops' terminal states +
+ * its role-scoped Experience items (ROLE-3). NOTHING here is self-reported; every count
+ * is ground-truth (a loop's terminal `state` / an item's independently-set `confidence`).
+ */
+export interface RoleTrackRecord {
+  /** All loops this role has woken (manual + trigger), terminal or not. */
+  wokenLoops: number;
+  /** Woken loops that reached the `converged` terminal. */
+  convergedLoops: number;
+  /** Woken loops that reached a NON-converged terminal (stopped_cap/failed/escalated/cancelled). */
+  failedLoops: number;
+  /** Woken loops still running (non-terminal) — excluded from the convergence rate. */
+  activeLoops: number;
+  /** convergedLoops + failedLoops — the loops with a settled outcome. */
+  terminalLoops: number;
+  /** convergedLoops / terminalLoops, or null when no loop has settled yet. */
+  convergenceRate: number | null;
+  /** Role-scoped Experience items independently CONFIRMED (`confidence: verified`). */
+  verifiedPatterns: number;
+  /** Role-scoped Experience items independently REFUTED (`confidence: refuted`). */
+  refutedPatterns: number;
+  /** Role-scoped Experience items merely observed (unverified). */
+  observedPatterns: number;
+}
+
+/** The graduation signal's verdict — EARNED from `RoleTrackRecord`, never self-reported. */
+export type GraduationStatus = "proven" | "needs-more-evidence" | "insufficient-evidence";
+
+/**
+ * ROLE-4: the "proven → graduate" signal (standing-role.md §8, ADR-0002). A role EARNS
+ * `proven` from measured outcomes (a floor of settled loops, a convergence-rate floor,
+ * net-positive verified patterns) — it can NEVER be set by a user. This surfaces
+ * READINESS + the export; a human (per §6 / CODEOWNERS) decides the actual cross-repo
+ * graduation. ROLE-4 ships the exportable definition + this signal; the cross-repo
+ * publish to omnius/genai-enablement is a documented boundary (a separate ADR), not an
+ * auto-push.
+ */
+export interface GraduationReadiness {
+  status: GraduationStatus;
+  /** One-line human summary, e.g. "6 loops, 83% converged, 3 verified patterns — proven". */
+  summary: string;
+  /** Why the status is what it is — each gate's contribution (audit, never opinion). */
+  rationale: string[];
+  /** The measured record the verdict was computed from. */
+  trackRecord: RoleTrackRecord;
+}
+
+/**
  * A file-change trigger ACTION that launches a consilium review. Embedded in the
  * trigger's `config` JSONB. `repoPath`, when present, MUST resolve inside the
  * consilium-loop allowlist (re-validated INSIDE the factory — never trusted from

--- a/tests/unit/consilium/role-track-record.test.ts
+++ b/tests/unit/consilium/role-track-record.test.ts
@@ -1,0 +1,154 @@
+/**
+ * role-track-record.test.ts — ROLE-4 (standing-role.md §8, ADR-0002 success-delta).
+ *
+ * The PURE track-record computation + the "proven → graduate" signal. Asserts that:
+ *   - the record is computed from GROUND TRUTH (loop terminal states + role-scoped
+ *     experience confidence) and counts converged / failed / active + verified / refuted;
+ *   - `graduationReadiness` reflects MEASURED outcomes — `proven` ONLY above the floors,
+ *     and NEVER from a self-report (there is no user-settable proven);
+ *   - the role bind is FAIL-CLOSED: another role's loops/items never inflate this role;
+ *   - the computation MUTATES NOTHING (a read never alters the input rows).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  computeRoleTrackRecord,
+  computeGraduationReadiness,
+  computeRoleGraduation,
+  PROVEN_MIN_TERMINAL_LOOPS,
+  MIN_TERMINAL_LOOPS_FOR_SIGNAL,
+  type TrackRecordLoop,
+  type TrackRecordItem,
+} from "../../../server/services/consilium/role-track-record.js";
+import type { ConsiliumLoopState, ExperienceConfidence } from "@shared/schema";
+
+const ROLE = "role-A";
+
+function loop(state: ConsiliumLoopState, roleId: string | null = ROLE): TrackRecordLoop {
+  return { state, triggerProvenance: roleId ? { role: { roleId } } : null };
+}
+
+function item(confidence: ExperienceConfidence, roleId: string | null = ROLE): TrackRecordItem {
+  return {
+    confidence,
+    scope: { repo: "r", archetype: null, criterionClass: "test-run", ...(roleId ? { role: roleId } : {}) },
+  };
+}
+
+/** Build N converged loops + M verified items so a role clears every `proven` floor. */
+function provenInputs() {
+  const loops = [
+    ...Array.from({ length: 5 }, () => loop("converged")),
+    loop("stopped_cap"), // one non-converged terminal → rate 5/6 ≈ 83% (≥ 70%)
+  ];
+  const items = [item("verified"), item("verified"), item("verified")];
+  return { loops, items };
+}
+
+describe("computeRoleTrackRecord", () => {
+  it("counts converged / non-converged terminal / active loops from ground-truth state", () => {
+    const loops = [
+      loop("converged"),
+      loop("converged"),
+      loop("stopped_cap"),
+      loop("failed"),
+      loop("escalated"),
+      loop("cancelled"),
+      loop("reviewing"), // non-terminal → active
+      loop("pending"), // non-terminal → active
+    ];
+    const tr = computeRoleTrackRecord(ROLE, loops, []);
+    expect(tr.convergedLoops).toBe(2);
+    expect(tr.failedLoops).toBe(4); // stopped_cap + failed + escalated + cancelled
+    expect(tr.activeLoops).toBe(2);
+    expect(tr.terminalLoops).toBe(6);
+    expect(tr.wokenLoops).toBe(8);
+    expect(tr.convergenceRate).toBeCloseTo(2 / 6, 5);
+  });
+
+  it("counts verified / refuted / observed from role-scoped experience items", () => {
+    const items = [item("verified"), item("verified"), item("refuted"), item("observed")];
+    const tr = computeRoleTrackRecord(ROLE, [], items);
+    expect(tr.verifiedPatterns).toBe(2);
+    expect(tr.refutedPatterns).toBe(1);
+    expect(tr.observedPatterns).toBe(1);
+  });
+
+  it("FAIL-CLOSED role bind: another role's loops + items are NOT counted", () => {
+    const loops = [loop("converged"), loop("converged", "role-B"), loop("failed", null)];
+    const items = [item("verified"), item("verified", "role-B"), item("verified", null)]; // role-B + role-agnostic
+    const tr = computeRoleTrackRecord(ROLE, loops, items);
+    expect(tr.convergedLoops).toBe(1); // only role-A's
+    expect(tr.wokenLoops).toBe(1);
+    expect(tr.verifiedPatterns).toBe(1); // only the scope.role === role-A item
+  });
+
+  it("convergenceRate is null when no loop has settled (all active)", () => {
+    const tr = computeRoleTrackRecord(ROLE, [loop("reviewing"), loop("pending")], []);
+    expect(tr.terminalLoops).toBe(0);
+    expect(tr.convergenceRate).toBeNull();
+  });
+
+  it("does NOT mutate the input rows (a read is read-only)", () => {
+    const loops = [loop("converged")];
+    const items = [item("verified")];
+    const snapLoop = JSON.stringify(loops);
+    const snapItem = JSON.stringify(items);
+    computeRoleTrackRecord(ROLE, loops, items);
+    expect(JSON.stringify(loops)).toBe(snapLoop);
+    expect(JSON.stringify(items)).toBe(snapItem);
+  });
+});
+
+describe("computeGraduationReadiness", () => {
+  it("proven ONLY when every measured floor is cleared", () => {
+    const { loops, items } = provenInputs();
+    const g = computeRoleGraduation(ROLE, loops, items);
+    expect(g.status).toBe("proven");
+    expect(g.summary).toMatch(/proven$/);
+    expect(g.summary).toMatch(/83% converged/);
+    expect(g.trackRecord.verifiedPatterns).toBe(3);
+  });
+
+  it("insufficient-evidence below the settled-loop floor (a fluke is not a record)", () => {
+    const loops = Array.from({ length: MIN_TERMINAL_LOOPS_FOR_SIGNAL - 1 }, () => loop("converged"));
+    const g = computeRoleGraduation(ROLE, loops, [item("verified")]);
+    expect(g.status).toBe("insufficient-evidence");
+    expect(g.rationale.join(" ")).toMatch(/settled loop/);
+  });
+
+  it("needs-more-evidence when convergence rate is below the floor", () => {
+    // 6 settled loops but only 2 converged → 33% < 70%.
+    const loops = [
+      loop("converged"),
+      loop("converged"),
+      loop("failed"),
+      loop("failed"),
+      loop("stopped_cap"),
+      loop("failed"),
+    ];
+    const g = computeRoleGraduation(ROLE, loops, [item("verified"), item("verified")]);
+    expect(g.status).toBe("needs-more-evidence");
+    expect(g.rationale.join(" ")).toMatch(/convergence rate/);
+  });
+
+  it("needs-more-evidence when there is no independently-verified pattern", () => {
+    const loops = Array.from({ length: PROVEN_MIN_TERMINAL_LOOPS }, () => loop("converged"));
+    const g = computeRoleGraduation(ROLE, loops, [item("observed"), item("observed")]);
+    expect(g.status).toBe("needs-more-evidence");
+    expect(g.rationale.join(" ")).toMatch(/verified pattern/);
+  });
+
+  it("NOT proven when refuted patterns outnumber verified (not net-positive learning)", () => {
+    const loops = Array.from({ length: PROVEN_MIN_TERMINAL_LOOPS }, () => loop("converged"));
+    const items = [item("verified"), item("refuted"), item("refuted")];
+    const g = computeRoleGraduation(ROLE, loops, items);
+    expect(g.status).toBe("needs-more-evidence");
+    expect(g.rationale.join(" ")).toMatch(/not net-positive/);
+  });
+
+  it("is a PURE function of the record — same record ⇒ same verdict (no self-report seam)", () => {
+    const { loops, items } = provenInputs();
+    const tr = computeRoleTrackRecord(ROLE, loops, items);
+    expect(computeGraduationReadiness(tr)).toEqual(computeGraduationReadiness(tr));
+  });
+});

--- a/tests/unit/consilium/standing-roles-route.test.ts
+++ b/tests/unit/consilium/standing-roles-route.test.ts
@@ -89,6 +89,10 @@ function makeStorage(seed: FakeRole[] = [], knownSkills: string[] = []) {
       roles.delete(id);
     }),
     getSkill: vi.fn(async (id: string) => (skillSet.has(id) ? { id, name: id } : undefined)),
+    // ROLE-4 import re-validates skills by NAME against the registry (here name === id).
+    getSkills: vi.fn(async () => Array.from(skillSet).map((id) => ({ id, name: id }))),
+    // ROLE-4 track record reads role-scoped experience items (seeded per-test).
+    listExperienceItems: vi.fn(async () => [] as unknown[]),
     // ROLE-2: the concern endpoints materialise / tear down a backing trigger + read loops.
     createTrigger: vi.fn(async (data: { type: string; config: unknown; enabled?: boolean }) => {
       trigSeq += 1;
@@ -407,5 +411,193 @@ describe("ROLE-2 concern endpoints", () => {
     const res = await request(makeApp(storage)).get("/api/roles/role-1/woken-loops");
     expect(res.status).toBe(200);
     expect(res.body.map((l: { id: string }) => l.id)).toEqual(["loop-a"]);
+  });
+});
+
+// ─── ROLE-4: export / import / track-record ───────────────────────────────────
+
+describe("ROLE-4 export (portable definition)", () => {
+  it("GET /api/roles/:id/export emits the DEFINITION with skills BY NAME + no runtime/secret state", async () => {
+    const storage = makeStorage([seedRole({ skills: ["sk-1"] })], ["sk-1"]);
+    const res = await request(makeApp(storage)).get("/api/roles/role-1/export");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      kind: "standing-role-definition",
+      schemaVersion: 1,
+      name: "devops-reviewer",
+      persona: "You are a senior DevOps reviewer.",
+      skills: [{ name: "sk-1" }], // by NAME, not the opaque local id
+      loopTemplate: { preset: "sdlc-cross-review" },
+    });
+    // NO runtime/identity/secret state leaks into the portable definition.
+    expect(res.body).not.toHaveProperty("id");
+    expect(res.body).not.toHaveProperty("projectId");
+    expect(res.body).not.toHaveProperty("createdBy");
+    expect(res.body).not.toHaveProperty("enabled");
+  });
+
+  it("export strips a concern's runtime bookkeeping (no id / triggerId)", async () => {
+    const role = seedRole({
+      concerns: [
+        {
+          id: "c-1",
+          triggerId: "trig-99",
+          repoPath: "/repos/iac",
+          focus: "watch modules",
+          trigger: { type: "file_change", filter: { watchPath: "/repos/iac", patterns: ["**/*.tf"] } },
+        },
+      ] as unknown[],
+    });
+    const storage = makeStorage([role], ["sk-1"]);
+    const res = await request(makeApp(storage)).get("/api/roles/role-1/export");
+    expect(res.status).toBe(200);
+    expect(res.body.concerns).toHaveLength(1);
+    expect(res.body.concerns[0]).toMatchObject({ repoPath: "/repos/iac", focus: "watch modules" });
+    expect(res.body.concerns[0]).not.toHaveProperty("id");
+    expect(res.body.concerns[0]).not.toHaveProperty("triggerId");
+  });
+
+  it("export of an unknown role → 404", async () => {
+    const res = await request(makeApp(makeStorage())).get("/api/roles/ghost/export");
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("ROLE-4 import (create-from-definition)", () => {
+  const DEF = {
+    kind: "standing-role-definition",
+    schemaVersion: 1,
+    name: "imported-role",
+    persona: "You are a reviewer.",
+    skills: [{ name: "sk-1" }],
+    loopTemplate: { preset: "sdlc-cross-review", maxRounds: 2 },
+    concerns: [],
+  };
+
+  it("POST /api/roles/import creates a DISABLED role with skills re-resolved to LOCAL ids", async () => {
+    const storage = makeStorage([], ["sk-1"]);
+    const res = await request(makeApp(storage)).post("/api/roles/import").send(DEF);
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe("imported-role");
+    // §6: import NEVER enables — a shared definition arrives inert.
+    expect(res.body.enabled).toBe(false);
+    const created = storage.createStandingRole.mock.calls[0][0] as { enabled: boolean; skills: string[]; createdBy: string };
+    expect(created.enabled).toBe(false);
+    expect(created.skills).toEqual(["sk-1"]); // name → local id
+    expect(created.createdBy).toBe("user-1");
+  });
+
+  it("FAIL-CLOSED: an imported skill NAME absent from THIS project's registry → 400, NOTHING created", async () => {
+    const storage = makeStorage([], []); // registry empty ⇒ sk-1 unknown here
+    const res = await request(makeApp(storage)).post("/api/roles/import").send(DEF);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/sk-1/);
+    expect(res.body.error).toMatch(/was not found in this project/);
+    expect(storage.createStandingRole).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unsupported schemaVersion (fail-closed, nothing created)", async () => {
+    const storage = makeStorage([], ["sk-1"]);
+    const res = await request(makeApp(storage)).post("/api/roles/import").send({ ...DEF, schemaVersion: 99 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/schemaVersion/);
+    expect(storage.createStandingRole).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-definition blob (wrong kind) via schema validation", async () => {
+    const storage = makeStorage([], ["sk-1"]);
+    const res = await request(makeApp(storage)).post("/api/roles/import").send({ name: "x", persona: "y" });
+    expect(res.status).toBe(400);
+    expect(storage.createStandingRole).not.toHaveBeenCalled();
+  });
+
+  it("re-materialises imported concerns' backing triggers (role still DISABLED → doubly inert)", async () => {
+    const storage = makeStorage([], ["sk-1"]);
+    const res = await request(makeApp(storage))
+      .post("/api/roles/import")
+      .send({
+        ...DEF,
+        concerns: [
+          {
+            repoPath: "/repos/iac",
+            focus: "watch modules",
+            trigger: { type: "file_change", filter: { watchPath: "/repos/iac", patterns: ["**/*.tf"] } },
+          },
+        ],
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.enabled).toBe(false); // master gate: disabled role never wakes
+    expect(storage.createTrigger).toHaveBeenCalledTimes(1);
+    const concerns = res.body.concerns as Array<Record<string, unknown>>;
+    expect(concerns).toHaveLength(1);
+    expect(typeof concerns[0].id).toBe("string"); // fresh id minted
+    expect(concerns[0].triggerId).toBeTruthy();
+  });
+
+  it("round-trips: export a role → import it → an equivalent (disabled) role", async () => {
+    const storage = makeStorage([seedRole({ skills: ["sk-1"] })], ["sk-1"]);
+    const exported = await request(makeApp(storage)).get("/api/roles/role-1/export");
+    const imported = await request(makeApp(storage)).post("/api/roles/import").send(exported.body);
+    expect(imported.status).toBe(201);
+    expect(imported.body.name).toBe("devops-reviewer");
+    expect(imported.body.skills).toEqual(["sk-1"]);
+    expect(imported.body.enabled).toBe(false);
+  });
+});
+
+describe("ROLE-4 track record → graduation signal", () => {
+  it("GET /api/roles/:id/track-record computes converged/failed + verified patterns from ground truth", async () => {
+    const storage = makeStorage([seedRole()], ["sk-1"]);
+    storage.getLoops.mockResolvedValue([
+      { id: "l1", state: "converged", triggerProvenance: { role: { roleId: "role-1" } } },
+      { id: "l2", state: "converged", triggerProvenance: { role: { roleId: "role-1" } } },
+      { id: "l3", state: "failed", triggerProvenance: { role: { roleId: "role-1" } } },
+      { id: "l4", state: "converged", triggerProvenance: { role: { roleId: "other" } } }, // not this role
+    ]);
+    storage.listExperienceItems.mockResolvedValue([
+      { confidence: "verified", scope: { repo: "r", archetype: null, criterionClass: "test-run", role: "role-1" } },
+      { confidence: "refuted", scope: { repo: "r", archetype: null, criterionClass: "test-run", role: "role-1" } },
+      { confidence: "verified", scope: { repo: "r", archetype: null, criterionClass: "test-run", role: "other" } }, // not this role
+    ]);
+    const res = await request(makeApp(storage)).get("/api/roles/role-1/track-record");
+    expect(res.status).toBe(200);
+    expect(res.body.trackRecord).toMatchObject({
+      wokenLoops: 3, // role-1 only
+      convergedLoops: 2,
+      failedLoops: 1,
+      verifiedPatterns: 1,
+      refutedPatterns: 1,
+    });
+    // 3 settled loops (< 5) ⇒ not proven, but past the insufficient floor.
+    expect(res.body.status).toBe("needs-more-evidence");
+  });
+
+  it("surfaces PROVEN only above the measured floors (never self-reported)", async () => {
+    const storage = makeStorage([seedRole()], ["sk-1"]);
+    storage.getLoops.mockResolvedValue([
+      ...Array.from({ length: 5 }, (_, i) => ({ id: `c${i}`, state: "converged", triggerProvenance: { role: { roleId: "role-1" } } })),
+      { id: "f1", state: "stopped_cap", triggerProvenance: { role: { roleId: "role-1" } } },
+    ]);
+    storage.listExperienceItems.mockResolvedValue([
+      { confidence: "verified", scope: { repo: "r", archetype: null, criterionClass: "test-run", role: "role-1" } },
+      { confidence: "verified", scope: { repo: "r", archetype: null, criterionClass: "test-run", role: "role-1" } },
+    ]);
+    const res = await request(makeApp(storage)).get("/api/roles/role-1/track-record");
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("proven");
+    expect(res.body.summary).toMatch(/proven$/);
+  });
+
+  it("does NOT mutate loops or experience items (read-only)", async () => {
+    const storage = makeStorage([seedRole()], ["sk-1"]);
+    await request(makeApp(storage)).get("/api/roles/role-1/track-record");
+    // No write path is touched by a track-record read.
+    expect(storage.updateStandingRole).not.toHaveBeenCalled();
+    expect(storage.createTrigger).not.toHaveBeenCalled();
+  });
+
+  it("track-record of an unknown role → 404", async () => {
+    const res = await request(makeApp(makeStorage())).get("/api/roles/ghost/track-record");
+    expect(res.status).toBe(404);
   });
 });


### PR DESCRIPTION
Implements **ROLE-4** from `docs/design/standing-role.md` §8 — the role library + graduation — building on ROLE-1 (record + wake), ROLE-2 (concerns/triggers), and ROLE-3 (role-scoped experience). Aligned to `[[platform-canon]]` **ADR-0002** (the skills trust envelope `unverified → verified → deprecated`; graduation as a measured **success-delta**, never a self-report) and §6/§7 (four-plane, human-owned decisions).

### 1. Role library — shareable definitions
- **`GET /api/roles/:id/export`** → a **portable definition** (`kind`/`schemaVersion`/`name`/`persona`/`skills`/`loopTemplate`/`policy`/`concerns`) with **no runtime/identity/secret state**: omits `id`/`projectId`/`createdBy`/timestamps/`enabled` and every concern's `id` + backing `triggerId`. **Skills travel by NAME** (the ADR-0002 SKILL.md slug) — a per-project UUID is meaningless elsewhere.
- **`POST /api/roles/import`** → create-from-definition. Skills are **re-resolved by name against the target project's registry, fail-closed** (unknown skill → 400, nothing created); an unsupported `schemaVersion` → 400. The role is **always created DISABLED** (§6: enabling a role is a human act), and its concerns' backing triggers are re-materialised **inert** (doubly gated by the disabled role + per-concern `enabled` — verified against the dispatch's `if (!role.enabled) skipped` gate).
- The **roles library list view** surfaces every role + status (existing grid + new badge).

### 2. Track record → the outcome-measured proven signal
- **`GET /api/roles/:id/track-record`** computes, **READ-ONLY**, from a role's **woken loops' terminal states** + its **role-scoped verified/refuted Experience items** (ROLE-3), a `graduationReadiness` verdict: `proven` / `needs-more-evidence` / `insufficient-evidence` + a one-line summary + per-gate rationale.
- **ADR-0002 success-delta applied to a role**: `proven` is **EARNED** above measured floors — a settled-loop count, a convergence-rate floor, ≥1 independently-verified pattern, **and** net-positive (verified > refuted). There is **no user-settable "proven"** anywhere; every input is ground truth (a loop's terminal `state`, an item's independently-set `confidence`). Computation lives in a **pure module** (`role-track-record.ts`) and mutates nothing.

### 3. Graduation path (the human-gated boundary)
ROLE-4 ships the **exportable definition + the proven signal** (the mechanics). The actual cross-repo publish to omnius / genai-enablement stays a **documented boundary** (a separate DREAM-5-style ADR), **never an auto-push** — a human/CODEOWNERS decides (§6). The UI surfaces readiness + the export; graduation is a human act.

### UI
Graduation-readiness badge on each role card (tooltip = summary + rationale), an **Export** (download JSON) button, and an **Import** dialog (paste a definition). Existing role CRUD/wake unchanged.

### Adversarial self-review
- **export leaking secrets/runtime** → omits identity/runtime + concern `triggerId`; skills by name; test asserts absence.
- **import trusting unvalidated skills** → fail-closed name re-resolution; unknown → 400, nothing created; incoming `enabled` ignored (always disabled).
- **self-reported "proven"** → computed purely from ground truth; no settable field; track-record is GET-only.
- **auto-graduation without a human** → import arrives disabled; no cross-repo push; export is a manual download.
- **mutating loops/experience on a read** → pure computation over reads; test asserts no write path is touched.

### Tests
- **`role-track-record.test.ts`** (pure): converged/failed/active + verified/refuted counts, fail-closed role bind (another role's loops/items never inflate), `proven` only above every floor, no-mutation, pure-function determinism.
- **`standing-roles-route.test.ts`** (extended): export omits secrets/runtime + concern bookkeeping; import re-validates skills fail-closed, arrives disabled, rejects bad schemaVersion/blob, re-materialises inert concerns, **round-trips**; track-record from ground truth, proven only above floors, read-only.

`tsc` clean. Full unit suite green except one **pre-existing parallelism flake** (`trust-telemetry-route` "BOUNDS the scan" — passes in isolation, outside this ZONE, untouched). pull_request CI is authoritative.
