### PR TITLE
fix(consilium): surface the review result on the loop page (stopped_cap round persistence + rich verdict)

### DIFF
--- a/client/src/components/consilium/new-review-dialog.tsx
+++ b/client/src/components/consilium/new-review-dialog.tsx
@@ -70,6 +70,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { apiRequest } from "@/hooks/use-pipeline";
 import { useSkills } from "@/hooks/use-skills";
 import { useToast } from "@/hooks/use-toast";
+import { parseBranchFromUrl } from "@/components/consilium/parse-branch-url";
 
 /**
  * The presets the backend accepts, with human labels + a one-line description of
@@ -198,6 +199,12 @@ export function NewConsiliumReviewDialog({
   // workspaces exist (for an allowlisted repo not registered as a workspace).
   const [customMode, setCustomMode] = useState(false);
   const [branch, setBranch] = useState("");
+  // "Paste a branch URL / ref" — an additional affordance alongside the dropdown
+  // (mirrors the repo `customMode` pattern). When on, the branch control becomes a
+  // free-text input that accepts a GitHub/GitLab branch URL OR a bare ref;
+  // `parseBranchFromUrl` derives the ref that is actually submitted.
+  const [branchCustomMode, setBranchCustomMode] = useState(false);
+  const [branchUrlDraft, setBranchUrlDraft] = useState("");
   const [maxRounds, setMaxRounds] = useState("1");
   // Single-verifier re-review: OPTIONAL per-loop review mode. "" = use the instance
   // default (verifyReview.enabled); otherwise pin the mode for this loop. Sent as
@@ -316,6 +323,26 @@ export function NewConsiliumReviewDialog({
       ? [branch, ...liveBranches]
       : liveBranches;
 
+  // The ref parsed from the pasted URL / bare ref (custom mode only). Shown as a
+  // live hint and used as the submitted ref, so the operator always sees what a
+  // pasted URL resolved to before starting the review.
+  const parsedCustomBranch = parseBranchFromUrl(branchUrlDraft);
+  // The single source of truth for the submitted branch: the pasted-URL derivation
+  // in custom mode, otherwise the dropdown/free-text `branch`.
+  const effectiveBranch = branchCustomMode ? parsedCustomBranch : branch;
+
+  // Enter the paste-URL affordance, seeding the draft from the current selection
+  // so a picked branch carries over as an editable starting point.
+  const enterBranchCustom = () => {
+    setBranchUrlDraft(branch);
+    setBranchCustomMode(true);
+  };
+  // Return to the dropdown, carrying the derived ref back so the choice survives.
+  const useBranchPicker = () => {
+    setBranch(parseBranchFromUrl(branchUrlDraft));
+    setBranchCustomMode(false);
+  };
+
   const enterCustomPath = () => {
     // Carry the current selection into the input as a starting point.
     setCustomMode(true);
@@ -395,7 +422,9 @@ export function NewConsiliumReviewDialog({
     // Branch → `ref`. Omit when empty, or (in workspace mode) when it equals the
     // workspace default — the server treats an absent ref as the working-tree
     // HEAD, so this preserves the prior behavior for the unchanged-default case.
-    const chosenBranch = branch.trim();
+    // `effectiveBranch` is the pasted-URL derivation in custom mode, else the
+    // dropdown/free-text branch — the SAME `ref` field either way.
+    const chosenBranch = effectiveBranch.trim();
     if (
       chosenBranch &&
       !(selectedWorkspace && chosenBranch === workspaceDefaultBranch)
@@ -528,10 +557,52 @@ export function NewConsiliumReviewDialog({
           </div>
 
           {/* Branch — a Select over the workspace's live branches, with graceful
-              loading / failure / free-text fallbacks so it's never a dead end. */}
+              loading / failure / free-text fallbacks so it's never a dead end,
+              PLUS a "paste a branch URL / ref" affordance (mirrors the repo
+              customMode toggle) that derives the submitted ref from a pasted
+              GitHub/GitLab URL or a bare ref. */}
           <div className="space-y-2">
-            <Label>Branch</Label>
-            {branchesLoading ? (
+            <div className="flex items-baseline justify-between gap-2">
+              <Label htmlFor={branchCustomMode ? "new-review-branch-url" : undefined}>
+                Branch
+              </Label>
+              <button
+                type="button"
+                className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+                onClick={branchCustomMode ? useBranchPicker : enterBranchCustom}
+                data-testid="new-review-toggle-branch-url"
+              >
+                {branchCustomMode ? "Pick from the list instead" : "Paste a branch URL / ref"}
+              </button>
+            </div>
+            {branchCustomMode ? (
+              <>
+                <Input
+                  id="new-review-branch-url"
+                  value={branchUrlDraft}
+                  onChange={(e) => setBranchUrlDraft(e.target.value)}
+                  placeholder="https://github.com/owner/repo/tree/release/1.2 — or a bare ref"
+                  data-testid="new-review-branch-url"
+                />
+                <p className="text-xs text-muted-foreground">
+                  {parsedCustomBranch ? (
+                    <>
+                      Will review ref{" "}
+                      <span
+                        className="font-mono text-foreground"
+                        data-testid="new-review-branch-url-parsed"
+                      >
+                        {parsedCustomBranch}
+                      </span>
+                      . Paste a GitHub/GitLab branch URL (…/tree/&lt;branch&gt;) or a
+                      bare ref.
+                    </>
+                  ) : (
+                    "Paste a GitHub/GitLab branch URL (…/tree/<branch>) or a bare ref — leave empty for the repo's current branch (HEAD)."
+                  )}
+                </p>
+              </>
+            ) : branchesLoading ? (
               <Select disabled value="">
                 <SelectTrigger data-testid="new-review-branch-loading">
                   <span className="inline-flex items-center gap-2 text-muted-foreground">
@@ -546,7 +617,12 @@ export function NewConsiliumReviewDialog({
                 <SelectTrigger data-testid="new-review-branch-select">
                   <SelectValue placeholder="Select a branch" />
                 </SelectTrigger>
-                <SelectContent>
+                {/* Bounded, scrollable list: the shared SelectContent's base
+                    max-height resolves tiny when the trigger sits low in the
+                    viewport-capped dialog, clipping a long branch list. A fixed
+                    max-h (twMerge wins over the base var) + overflow-y keeps the
+                    portal popover itself scrolling, independent of the dialog. */}
+                <SelectContent className="max-h-60 overflow-y-auto">
                   {branchOptions.map((b) => (
                     <SelectItem key={b} value={b}>
                       {b}

--- a/client/src/components/consilium/parse-branch-url.ts
+++ b/client/src/components/consilium/parse-branch-url.ts
@@ -1,0 +1,56 @@
+/**
+ * parse-branch-url.ts — a single pure helper for the "paste a branch URL / custom
+ * ref" affordance on the New consilium review dialog (diff/PR review flow).
+ *
+ * The operator may either pick a branch from the live dropdown OR paste a branch
+ * URL (or type a bare ref). This derives the ref the review submits from whatever
+ * they pasted:
+ *   • GitHub tree URL   — https://github.com/owner/repo/tree/<ref>
+ *   • GitLab tree URL   — https://gitlab.com/group/project/-/tree/<ref>
+ *   • a bare ref        — main, release/1.2 (passed through unchanged)
+ *
+ * It is deliberately dependency-free (no React, no DOM) so it is unit-testable in
+ * a plain node environment, and it NEVER throws — the value it returns is only
+ * ever placed into the JSON review body as `ref` (allowlist-validated server-side),
+ * never interpolated into a URL path or shell.
+ */
+
+/** The path marker both GitHub (`…/tree/<ref>`) and GitLab (`…/-/tree/<ref>`) share. */
+const TREE_MARKER = "/tree/";
+
+/**
+ * Derive a git ref from a pasted branch URL, or pass a bare ref through unchanged.
+ *
+ * Extraction rule: everything after the FIRST `/tree/` is the ref. This covers
+ * GitHub (`…/tree/<ref>`) and GitLab (`…/-/tree/<ref>`) alike — the GitLab `-/`
+ * stays to the LEFT of the marker, so no provider-specific branching is needed.
+ * We then strip a trailing `?query` / `#hash` / slash and URL-decode the result.
+ *
+ * A ref may legitimately contain slashes (`release/1.2`), so internal slashes are
+ * preserved. That makes a subdirectory-browse URL (`…/tree/main/src/app`)
+ * genuinely ambiguous with a slash-containing branch — we keep the full remainder
+ * rather than guess, matching the documented behaviour.
+ *
+ * When the input contains no `/tree/`, it is treated as a bare ref and returned
+ * trimmed (only a trailing slash is stripped; internal slashes are untouched).
+ */
+export function parseBranchFromUrl(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) return "";
+
+  const at = trimmed.indexOf(TREE_MARKER);
+  if (at === -1) {
+    // Not a tree URL → a bare ref. Keep internal slashes; drop a trailing slash.
+    return trimmed.replace(/\/+$/, "");
+  }
+
+  let ref = trimmed.slice(at + TREE_MARKER.length);
+  ref = ref.split(/[?#]/, 1)[0]; // drop any ?query / #hash
+  ref = ref.replace(/\/+$/, ""); // drop trailing slash(es)
+  try {
+    ref = decodeURIComponent(ref); // e.g. an encoded %2F within the ref
+  } catch {
+    // Malformed percent-encoding — keep the raw ref rather than throw.
+  }
+  return ref;
+}

--- a/client/src/hooks/use-consilium-loops.ts
+++ b/client/src/hooks/use-consilium-loops.ts
@@ -21,6 +21,7 @@ import type {
   AppliedSkillRef,
 } from "@shared/schema";
 import type {
+  ActionPoint,
   Archetype,
   OpenRemainder,
   ResearchReport,
@@ -147,11 +148,31 @@ export type ExecutionCriterionMethod = ExecutionCriterion["method"];
  * `ConsiliumLoopRoundDetail` is structurally a `ConsiliumLoopRoundRow`, so every
  * existing round consumer keeps working unchanged.
  */
+/**
+ * The FULL judge verdict for a round — the NEW nullable `verdict` jsonb column.
+ * Distinct from the round's SUMMARY fields (`converged` / `openP0` /
+ * `openActionPoints`): it carries the judge's prose summary, the pros/cons, and the
+ * FULL RANKED action-point list (ALL priorities, not just the still-open subset).
+ * Absent/null on old rounds (incl. the backfilled one), so every consumer guards
+ * on `verdict == null` before reading it.
+ *
+ * SECURITY: `verdict`, every `pros`/`cons` entry, and each `actionPoints` field are
+ * model-authored (judge) text — rendered as INERT React text, never a sink.
+ */
+export interface RoundVerdict {
+  verdict: string;
+  pros: string[];
+  cons: string[];
+  actionPoints: ActionPoint[];
+}
+
 export type ConsiliumLoopRoundDetail = ConsiliumLoopRoundRow & {
   /** The research artifact, on the latest round of a `research` loop only. */
   report?: ResearchReport | null;
   /** The Stage-4 observability tree — present once the backend persists it. */
   executionTrace?: ExecutionTrace | null;
+  /** The FULL judge verdict — see {@link RoundVerdict}. Null on old/backfilled rounds. */
+  verdict?: RoundVerdict | null;
 };
 
 // ─── Composition (Observability GAP 2 — the "who does what" of a round) ───────

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -161,16 +161,24 @@ function p0ClassName(openP0: number | null | undefined, terminal: boolean): stri
 function ConvergenceMark({
   converged,
   terminal,
+  "data-testid": testId,
 }: {
   converged: boolean | null | undefined;
   terminal: boolean;
+  /** Optional test hook applied to whichever element renders (span / icon). */
+  "data-testid"?: string;
 }) {
-  if (converged == null) return <span className="text-muted-foreground">—</span>;
-  if (converged) return <Check className="h-4 w-4 text-green-600" />;
+  if (converged == null)
+    return (
+      <span data-testid={testId} className="text-muted-foreground">
+        —
+      </span>
+    );
+  if (converged) return <Check data-testid={testId} className="h-4 w-4 text-green-600" />;
   return terminal ? (
-    <X className="h-4 w-4 text-red-500" />
+    <X data-testid={testId} className="h-4 w-4 text-red-500" />
   ) : (
-    <Clock className="h-4 w-4 text-amber-500" aria-label="in progress" />
+    <Clock data-testid={testId} className="h-4 w-4 text-amber-500" aria-label="in progress" />
   );
 }
 
@@ -543,6 +551,7 @@ function RoundRow({
   return (
     <>
       <TableRow
+        data-testid="loop-round-row"
         className={expandable ? "cursor-pointer" : ""}
         onClick={expandable ? () => setOpen((v) => !v) : undefined}
       >
@@ -558,7 +567,11 @@ function RoundRow({
           </span>
         </TableCell>
         <TableCell>
-          <ConvergenceMark converged={round.converged} terminal={terminal} />
+          <ConvergenceMark
+            converged={round.converged}
+            terminal={terminal}
+            data-testid="loop-convergence-mark"
+          />
         </TableCell>
         <TableCell className={`tabular-nums font-medium ${p0ClassName(round.openP0, terminal)}`}>
           {round.openP0 ?? "—"}
@@ -595,7 +608,12 @@ function RoundRow({
               </p>
               <ul className="space-y-1.5">
                 {aps.map((ap, i) => (
-                  <li key={i} className="flex items-start gap-2 text-sm">
+                  <li
+                    key={i}
+                    className="flex items-start gap-2 text-sm"
+                    data-testid="loop-ap-item"
+                    data-priority={ap.priority ?? ""}
+                  >
                     {ap.priority && (
                       <Badge className={`${PRIORITY_COLOR[ap.priority] ?? "bg-muted"} shrink-0`}>
                         {ap.priority}
@@ -839,7 +857,12 @@ function ResultPanel({
             {latestAps.length > 0 ? (
               <ul className="space-y-1.5">
                 {latestAps.map((ap, i) => (
-                  <li key={i} className="flex items-start gap-2 text-sm">
+                  <li
+                    key={i}
+                    className="flex items-start gap-2 text-sm"
+                    data-testid="loop-ap-item"
+                    data-priority={ap.priority ?? ""}
+                  >
                     {ap.priority && (
                       <Badge className={`${PRIORITY_COLOR[ap.priority] ?? "bg-muted"} shrink-0`}>
                         {ap.priority}

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -65,6 +65,7 @@ import {
   isVerdictTerminalLoopState,
   type ConsiliumLoopRoundRow,
   type ConsiliumLoopRoundDetail,
+  type RoundVerdict,
   type ConsiliumLoopDetail as ConsiliumLoopDetailRow,
   type DevProgress,
   type ResearchReport,
@@ -521,6 +522,202 @@ function SettledExecutionTree({ trace }: { trace: ExecutionTrace }) {
   );
 }
 
+// ─── Round verdict panel (the FULL judge verdict for a round) ───────────────────
+//
+// Surfaces the NEW `verdict` jsonb column: the judge's prose summary, the pros/cons,
+// a convergence badge (reusing the round SUMMARY fields), and the FULL RANKED action
+// point list — ALL priorities, distinct from the still-open `openActionPoints` subset
+// — GROUPED BY PRIORITY (P0→P3). Rendered only when `round.verdict` is present, so
+// old / backfilled rounds (verdict null) omit it entirely and never crash.
+//
+// The grouping-by-priority is EXCLUSIVE to this full list; the separate still-open
+// list below the panel stays a flat, badge-per-item list (QA asserts badge counts
+// there, scoped via the `loop-open-ap-list` container).
+//
+// SECURITY: the verdict prose, every pro/con, and each action-point field are
+// model-authored (judge) text rendered as INERT React text.
+
+const PRIORITY_ORDER = ["P0", "P1", "P2", "P3"] as const;
+
+/**
+ * Group action points into ordered priority buckets (P0→P3), with any
+ * unknown/absent-priority items after the known tiers (sorted for stability). The
+ * judge's ranked order is preserved WITHIN each bucket.
+ */
+function groupActionPointsByPriority(
+  aps: ActionPoint[],
+): { priority: string; items: ActionPoint[] }[] {
+  const buckets = new Map<string, ActionPoint[]>();
+  for (const ap of aps) {
+    const key = (ap.priority ?? "").trim().toUpperCase() || "—";
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(ap);
+    else buckets.set(key, [ap]);
+  }
+  const ordered: { priority: string; items: ActionPoint[] }[] = [];
+  for (const p of PRIORITY_ORDER) {
+    const items = buckets.get(p);
+    if (items) {
+      ordered.push({ priority: p, items });
+      buckets.delete(p);
+    }
+  }
+  for (const key of [...buckets.keys()].sort()) {
+    ordered.push({ priority: key, items: buckets.get(key)! });
+  }
+  return ordered;
+}
+
+function RoundVerdictPanel({
+  verdict,
+  converged,
+  openP0,
+  terminal,
+}: {
+  verdict: RoundVerdict;
+  converged: boolean | null | undefined;
+  openP0: number | null | undefined;
+  terminal: boolean;
+}) {
+  const pros = Array.isArray(verdict.pros) ? verdict.pros : [];
+  const cons = Array.isArray(verdict.cons) ? verdict.cons : [];
+  const aps = Array.isArray(verdict.actionPoints) ? verdict.actionPoints : [];
+  const groups = groupActionPointsByPriority(aps);
+
+  return (
+    <div
+      className="space-y-3 rounded-md border border-primary/30 bg-primary/5 p-3"
+      data-testid="loop-verdict-panel"
+    >
+      {/* Header — judge verdict + convergence badge (reuses the round summary fields).
+          The ConvergenceMark here is intentionally UNTAGGED: `loop-convergence-mark`
+          stays unique per round on the table-cell mark. */}
+      <div className="flex flex-wrap items-center gap-2">
+        <p className="inline-flex items-center gap-1.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+          <Gavel className="h-3.5 w-3.5" />
+          Judge verdict
+        </p>
+        <ConvergenceMark converged={converged} terminal={terminal} />
+        <span className={`tabular-nums text-xs font-medium ${p0ClassName(openP0, terminal)}`}>
+          {openP0 ?? "—"} open P0
+        </span>
+      </div>
+
+      {/* Verdict prose (INERT) — the judge's summary. */}
+      {verdict.verdict && verdict.verdict.trim() !== "" && (
+        <p className="text-sm leading-relaxed">{verdict.verdict}</p>
+      )}
+
+      {/* Pros / cons — two columns (INERT). */}
+      {(pros.length > 0 || cons.length > 0) && (
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1">
+            <p className="inline-flex items-center gap-1 text-[11px] uppercase tracking-wide text-green-700 dark:text-green-400">
+              <Check className="h-3.5 w-3.5" /> Pros
+            </p>
+            {pros.length > 0 ? (
+              <ul className="space-y-1">
+                {pros.map((p, i) => (
+                  <li key={i} className="flex items-start gap-1.5 text-xs">
+                    <Check className="mt-0.5 h-3 w-3 shrink-0 text-green-600" />
+                    <span className="min-w-0 break-words">{p}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-xs text-muted-foreground">—</p>
+            )}
+          </div>
+          <div className="space-y-1">
+            <p className="inline-flex items-center gap-1 text-[11px] uppercase tracking-wide text-red-700 dark:text-red-400">
+              <X className="h-3.5 w-3.5" /> Cons
+            </p>
+            {cons.length > 0 ? (
+              <ul className="space-y-1">
+                {cons.map((c, i) => (
+                  <li key={i} className="flex items-start gap-1.5 text-xs">
+                    <X className="mt-0.5 h-3 w-3 shrink-0 text-red-500" />
+                    <span className="min-w-0 break-words">{c}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-xs text-muted-foreground">—</p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* FULL ranked action points, GROUPED BY PRIORITY (P0→P3). */}
+      {aps.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
+            Action points ({aps.length})
+          </p>
+          <div className="space-y-2" data-testid="loop-verdict-ap-list">
+            {groups.map((group) => (
+              <div key={group.priority} className="space-y-1.5">
+                <div className="flex items-center gap-1.5">
+                  <Badge className={`${PRIORITY_COLOR[group.priority] ?? "bg-muted"} shrink-0`}>
+                    {group.priority}
+                  </Badge>
+                  <span className="text-[11px] tabular-nums text-muted-foreground">
+                    {group.items.length}
+                  </span>
+                </div>
+                <ul className="space-y-1.5 pl-1">
+                  {group.items.map((ap, i) => (
+                    <li
+                      key={i}
+                      className="space-y-0.5 border-l-2 border-border/60 pl-2 text-sm"
+                      data-testid="loop-ap-item"
+                      data-priority={ap.priority ?? ""}
+                    >
+                      {/* INERT model-authored text */}
+                      <span className="font-medium">{ap.title}</span>
+                      {ap.rationale && (
+                        <p className="text-xs text-muted-foreground break-words">
+                          {ap.rationale}
+                        </p>
+                      )}
+                      {ap.tradeoff && (
+                        <p className="text-xs text-muted-foreground break-words">
+                          <span className="font-medium uppercase tracking-wide text-muted-foreground/70">
+                            Tradeoff:
+                          </span>{" "}
+                          {ap.tradeoff}
+                        </p>
+                      )}
+                      {ap.acceptanceCriterion && (
+                        <p className="text-xs text-muted-foreground break-words">
+                          <span className="font-medium uppercase tracking-wide text-muted-foreground/70">
+                            Acceptance criterion (DoD):
+                          </span>{" "}
+                          {ap.acceptanceCriterion}
+                        </p>
+                      )}
+                      {ap.weakCriterion && (
+                        <span
+                          className="inline-flex items-center gap-1 text-[10px] font-medium text-amber-600 dark:text-amber-400"
+                          title="Weak/absent acceptance criterion — demoted to judge verification (never counts as tests-green)."
+                        >
+                          <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+                          weak DoD — demoted to judge
+                        </span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+          <p className="text-[11px] text-muted-foreground/70">{PRIORITY_LEGEND}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ─── Rounds table ─────────────────────────────────────────────────────────────
 
 function RoundRow({
@@ -546,7 +743,10 @@ function RoundRow({
   // editor — lives ON the round now (the standalone Task Groups page is retired)
   // and is fetched LAZILY only when the operator opens this section.
   const canShowDispute = !!groupId;
-  const expandable = aps.length > 0 || hasTrace || canShowDispute;
+  // The FULL judge verdict (new `verdict` col) — null on old/backfilled rounds.
+  // Its presence makes the row expandable even when there are no open APs / trace.
+  const hasVerdict = round.verdict != null;
+  const expandable = aps.length > 0 || hasTrace || canShowDispute || hasVerdict;
 
   return (
     <>
@@ -592,6 +792,17 @@ function RoundRow({
         <TableRow>
           <TableCell colSpan={5} className="bg-muted/30">
             <div className="space-y-3 py-1">
+              {/* FULL judge verdict (new `verdict` col) — prose + pros/cons +
+                  convergence + the full ranked AP list grouped by priority. Guarded
+                  on presence; old/backfilled rounds (verdict null) omit it. */}
+              {round.verdict && (
+                <RoundVerdictPanel
+                  verdict={round.verdict}
+                  converged={round.converged}
+                  openP0={round.openP0}
+                  terminal={terminal}
+                />
+              )}
               {/* Per-round mini-tree — how THIS round ran (Stage 4 history). */}
               {traceHasContent(trace) && (
                 <div className="space-y-1.5">
@@ -606,7 +817,10 @@ function RoundRow({
               <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
                 Still-open action points
               </p>
-              <ul className="space-y-1.5">
+              {/* The still-open SUBSET — a FLAT list with a per-item badge (distinct
+                  from the verdict panel's full grouped list). Scoped for QA via this
+                  container id so counts don't collide with the verdict list above. */}
+              <ul className="space-y-1.5" data-testid="loop-open-ap-list">
                 {aps.map((ap, i) => (
                   <li
                     key={i}
@@ -841,6 +1055,13 @@ function ResultPanel({
                 {latest.openP0 ?? "—"} open P0
               </span>
             </div>
+            {/* The judge's prose verdict from the new `verdict` col, when present —
+                INERT model-authored text. Absent on old/backfilled rounds. */}
+            {latest.verdict?.verdict && latest.verdict.verdict.trim() !== "" && (
+              <p className="text-sm leading-relaxed" data-testid="loop-result-verdict">
+                {latest.verdict.verdict}
+              </p>
+            )}
             {/* Finding #5 — trivial priority breakdown of the still-open remainder.
                 A CONVERGED loop gets the dedicated actionable callout above; here
                 we only enrich the OTHER terminal verdicts (stopped_cap/escalated,

--- a/migrations/0051_consilium_loop_rounds_verdict.sql
+++ b/migrations/0051_consilium_loop_rounds_verdict.sql
@@ -1,0 +1,22 @@
+-- migration: 0051_consilium_loop_rounds_verdict
+-- The FULL judge verdict for a consilium round.
+--
+-- consilium_loop_rounds.verdict → new JSONB (nullable).
+--   The judge's rich verdict for the round, shape:
+--     { verdict: string, pros: string[], cons: string[], actionPoints: ActionPoint[] }
+--   Distinct from the round's SUMMARY columns (converged / open_p0 /
+--   open_action_points): `verdict` carries the judge's prose summary, the pros/cons,
+--   and the FULL RANKED action-point list (ALL priorities, not just the still-open
+--   P0 subset). Bounded before write (readJudgeVerdict, Security L-2) and rendered as
+--   INERT text on the client (RoundVerdict). NEVER the raw diff / prompt input (H-4).
+--   NULL for every pre-existing round (no backfill) and whenever the raw judge output
+--   is unreadable at record time — every consumer guards on NULL before reading it.
+--
+-- Additive + idempotent (ADD COLUMN IF NOT EXISTS): metadata-only, no rewrite, no
+-- data loss. Re-applying against a push-managed dev DB is safe.
+
+ALTER TABLE consilium_loop_rounds
+  ADD COLUMN IF NOT EXISTS verdict jsonb;
+
+-- Rollback:
+--   ALTER TABLE consilium_loop_rounds DROP COLUMN verdict;

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -364,6 +364,17 @@ export function parseJudgeVerifierOutput(content: string): { passed: boolean; su
 const ANTI_STALL_MIN_ROUND = 3;
 
 /**
+ * The UNIQUE(loop_id, round) constraint on `consilium_loop_rounds`
+ * (shared/schema.ts: `unique("consilium_loop_rounds_uq")`). A duplicate round
+ * append is a LEGITIMATE idempotent no-op (re-tick / crash redrive re-recording
+ * the same round) — `recordRound` swallows ONLY this, and surfaces every other
+ * insert failure. NOTE: the MemStorage shape throws a BARE `Error` whose message
+ * is exactly this name — it contains `_uq`, NOT `unique` — so a `/unique/i` test
+ * alone misses it; the constraint-name check is the reliable discriminator.
+ */
+const LOOP_ROUND_UNIQUE_CONSTRAINT = "consilium_loop_rounds_uq";
+
+/**
  * Per-coder reference grace (one coder run + buffer). The SDLC coder's hard
  * timeout is configurable (coder default 1_200_000ms / 20min); this is only a
  * reference floor. The AUTHORITATIVE developing re-drive guard is the process-
@@ -2398,11 +2409,22 @@ export class ConsiliumLoopController {
     return undefined;
   }
 
-  /** Persist this round's audit row (NEVER the raw diff/input — H-4). */
+  /**
+   * Persist this round's audit row (NEVER the raw diff/input — H-4).
+   *
+   * Defect C: this used to `.catch(() => undefined)` EVERY append error, so a
+   * transient storage failure (dropped connection, serialization failure, disk
+   * full, …) left `consilium_loop_rounds` silently empty — the detail page
+   * rendered blank with `loop.error` null and NO signal. Now we swallow ONLY the
+   * legitimate `UNIQUE(loop_id, round)` re-tick/redrive conflict; every OTHER
+   * failure is surfaced (logged + written to `loop.error`) WITHOUT blocking the
+   * FSM transition. Fail-OPEN on state (never rethrow — the transition already
+   * committed), fail-LOUD on the audit write.
+   */
   private async recordRound(loop: ConsiliumLoopRow, verdict: ConvergenceVerdict): Promise<void> {
     const head = await this.readRepoHead(loop);
-    await this.storage
-      .appendLoopRound({
+    try {
+      await this.storage.appendLoopRound({
         loopId: loop.id,
         round: loop.round,
         iterationNumber: loop.currentIterationNumber ?? loop.round,
@@ -2411,8 +2433,33 @@ export class ConsiliumLoopController {
         openActionPoints: verdict.openActionPoints,
         baselineCommit: loop.lastReviewedCommit,
         headCommit: head,
-      })
-      .catch(() => undefined); // UNIQUE(loop,round) → idempotent re-tick
+      });
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      const message = err instanceof Error ? err.message : String(err);
+      // UNIQUE(loop,round) → idempotent re-tick / crash redrive re-recording the
+      // same round. Detection follows the repo convention (model-skill-bindings.ts:115)
+      // — `code === "23505"` (Postgres) OR `/unique/i` (its message text) — EXTENDED
+      // with the constraint name, because the MemStorage bare `Error` message is
+      // `consilium_loop_rounds_uq` (contains `_uq`, not `unique`) and carries no code.
+      // A true no-op: leave `loop.error` untouched, emit NO log.
+      if (
+        code === "23505" ||
+        /unique/i.test(message) ||
+        message.includes(LOOP_ROUND_UNIQUE_CONSTRAINT)
+      ) {
+        return;
+      }
+      // Any OTHER failure is a real audit-write loss. Surface it — log (this.log's
+      // console.log convention, ~L792) AND persist to `loop.error` so the loop
+      // detail page shows it — but NEVER rethrow: the FSM state transition already
+      // committed and must not be undone by a best-effort audit write. The nested
+      // catch keeps recordRound total even if the error-persist itself fails.
+      this.log(loop.id, `recordRound: appendLoopRound failed for round ${loop.round}: ${message}`);
+      await this.storage
+        .updateLoop(loop.id, { error: `round ${loop.round} audit write failed: ${message}` })
+        .catch(() => undefined);
+    }
   }
 
   /** Resolve the judge convergence verdict for the loop's current iteration. */

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -52,12 +52,12 @@ import { runAsSystem, runAsProject } from "../../context.js";
 import type { ConsiliumLoopRow, ConsiliumLoopRoundRow, ConsiliumLoopState, TaskGroupIterationRow, InsertTask } from "@shared/schema";
 import { ARCHETYPES } from "@shared/types";
 import type { Archetype } from "@shared/types";
-import type { ActionPoint, ConvergenceVerdict, ReviewMode } from "@shared/types";
+import type { ActionPoint, ConvergenceVerdict, RoundVerdict, ReviewMode } from "@shared/types";
 import { P0_PRIORITY } from "@shared/types";
 import type { TaskOrchestrator } from "../task-orchestrator.js";
 import type { AppConfig } from "../../config/schema.js";
 import { effectiveVerificationEnabled, resolveImplementForRepo } from "../../config/schema.js";
-import { readConvergence, extractActionPoints, normalizeActionPointMethods, applyCriteriaQa } from "../orchestrator/convergence.js";
+import { readConvergence, readJudgeVerdict, extractActionPoints, normalizeActionPointMethods, applyCriteriaQa } from "../orchestrator/convergence.js";
 import { buildDiffContext } from "./diff-context.js";
 import { buildRepoMap, createDbRepoMapSource, listTouchedFiles, repoMapGit } from "./repo-map.js";
 import { findLoopWorkspace } from "./workspace-bind.js";
@@ -2432,6 +2432,11 @@ export class ConsiliumLoopController {
    */
   private async recordRound(loop: ConsiliumLoopRow, verdict: ConvergenceVerdict): Promise<void> {
     const head = await this.readRepoHead(loop);
+    // Rich judge verdict for the Rounds panel (best-effort, bounded, never blocks the
+    // audit write — null when the raw judge output is unreadable). Read from the RAW
+    // judge output, NOT reconstructed from the ConvergenceVerdict, so the prose /
+    // pros / cons / full ranked action points survive.
+    const judgeVerdict = await this.readRoundVerdict(loop);
     try {
       await this.storage.appendLoopRound({
         loopId: loop.id,
@@ -2440,6 +2445,7 @@ export class ConsiliumLoopController {
         converged: verdict.converged,
         openP0: verdict.openP0,
         openActionPoints: verdict.openActionPoints,
+        verdict: judgeVerdict,
         baselineCommit: loop.lastReviewedCommit,
         headCommit: head,
       });
@@ -2465,23 +2471,59 @@ export class ConsiliumLoopController {
       // committed and must not be undone by a best-effort audit write. The nested
       // catch keeps recordRound total even if the error-persist itself fails.
       this.log(loop.id, `recordRound: appendLoopRound failed for round ${loop.round}: ${message}`);
-      await this.storage
-        .updateLoop(loop.id, { error: `round ${loop.round} audit write failed: ${message}` })
-        .catch(() => undefined);
+      // Write ONLY when the (committed) row's error is still empty — `loop` is the
+      // post-commit `won` row at every call site, so this is the freshest value.
+      // Never clobber a terminal explanation the transition itself just set (e.g. a
+      // cancel note); the log line above records the audit failure regardless.
+      if (!loop.error) {
+        await this.storage
+          .updateLoop(loop.id, { error: `round ${loop.round} audit write failed: ${message}` })
+          .catch(() => undefined);
+      }
+    }
+  }
+
+  /**
+   * Best-effort rich judge verdict for the round audit ({@link RoundVerdict}),
+   * bounded by {@link readJudgeVerdict}. Reads the RAW judge output for the loop's
+   * current iteration; returns null when unreadable. NEVER throws — a verdict-read
+   * failure must not block the round-audit write (fail-soft, like the summary read).
+   */
+  private async readRoundVerdict(loop: ConsiliumLoopRow): Promise<RoundVerdict | null> {
+    try {
+      return readJudgeVerdict(await this.resolveJudgeOutput(loop));
+    } catch (err) {
+      this.log(
+        loop.id,
+        `recordRound: judge verdict read failed for round ${loop.round}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
     }
   }
 
   /** Resolve the judge convergence verdict for the loop's current iteration. */
   private async resolveVerdict(loop: ConsiliumLoopRow): Promise<ConvergenceVerdict | null> {
     if (this.deps.readIterationVerdict) return this.deps.readIterationVerdict(loop);
-    const n = loop.currentIterationNumber;
-    if (n == null) return null;
-    const iteration = await this.storage.getIteration(loop.groupId, n);
-    if (!iteration) return null;
-    const executions = await this.storage.getExecutionsByIteration(loop.groupId, iteration.id);
-    const judgeOutput = pickJudgeOutput(executions.map((e) => e.output));
+    const judgeOutput = await this.resolveJudgeOutput(loop);
     if (judgeOutput === undefined) return null;
     return readConvergence(judgeOutput);
+  }
+
+  /**
+   * Sibling to {@link resolveVerdict}: resolve the RAW judge output for the loop's
+   * current iteration (the pre-`readConvergence` object), so the round audit can
+   * persist the FULL {@link RoundVerdict} (prose + pros/cons + ranked action points)
+   * alongside the summary. `resolveVerdict` reuses this — same read, so a loop with a
+   * settled iteration yields the SAME judge output to both. `undefined` when there is
+   * no current iteration / no parseable judge execution.
+   */
+  private async resolveJudgeOutput(loop: ConsiliumLoopRow): Promise<unknown | undefined> {
+    const n = loop.currentIterationNumber;
+    if (n == null) return undefined;
+    const iteration = await this.storage.getIteration(loop.groupId, n);
+    if (!iteration) return undefined;
+    const executions = await this.storage.getExecutionsByIteration(loop.groupId, iteration.id);
+    return pickJudgeOutput(executions.map((e) => e.output));
   }
 
   /** Best-effort HEAD read for audit; bounded, never throws (H-4 scrubbed). */

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -648,6 +648,14 @@ export interface ConsiliumLoopControllerDeps {
   /** Resolve the judge convergence verdict for a settled iteration. */
   readIterationVerdict?: (loop: ConsiliumLoopRow) => Promise<ConvergenceVerdict | null>;
   /**
+   * Resolve the RAW judge output for a settled iteration (the pre-`readConvergence`
+   * object recordRound reads to persist the FULL {@link RoundVerdict}). Injectable
+   * companion to `readIterationVerdict` so a test can populate a round's `verdict`
+   * without fabricating raw execution/output rows; absent ⇒ the default reads the
+   * iteration's executions via storage (see `resolveJudgeOutput`).
+   */
+  readJudgeOutput?: (loop: ConsiliumLoopRow) => Promise<unknown | undefined>;
+  /**
    * Resolve the repo HEAD sha for audit / the merge-gate baseline. Injectable so
    * tests never touch real `process.cwd()` git (the default routes through A2's
    * buildDiffContext). Returns "" when unreadable (caller treats it as best-effort).
@@ -2518,6 +2526,7 @@ export class ConsiliumLoopController {
    * no current iteration / no parseable judge execution.
    */
   private async resolveJudgeOutput(loop: ConsiliumLoopRow): Promise<unknown | undefined> {
+    if (this.deps.readJudgeOutput) return this.deps.readJudgeOutput(loop);
     const n = loop.currentIterationNumber;
     if (n == null) return undefined;
     const iteration = await this.storage.getIteration(loop.groupId, n);

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -1321,11 +1321,20 @@ export class ConsiliumLoopController {
     // Cap precedence (M-2): a `decided` event at the cap round with open P0s is
     // STOPPED_CAP — but a CONVERGED verdict still wins (handled in `decide`).
     if (event.kind === "decided" && !event.verdict.converged && loop.round >= loop.maxRounds) {
-      return this.commit(loop, {
+      const won = await this.commit(loop, {
         from: "deciding",
         to: "stopped_cap",
         extra: { completedAt: new Date() },
       });
+      // Defect A (loop 456c3b8e): `stopped_cap` is constructed ONLY here — `decide`
+      // never yields it, so this early exit returns directly from `commit` and never
+      // reaches `runSideEffect`/`recordRound`. A capped loop (e.g. maxRounds=1, still
+      // open) therefore recorded ZERO rounds and its detail page rendered blank. Record
+      // the round on the CAS winner (single-flight), exactly as the converged/escalated
+      // terminal exits do. `recordRound` is idempotent and never throws, so it can
+      // neither undo nor block the already-committed transition.
+      if (won) await this.recordRound(won, event.verdict);
+      return won;
     }
 
     const transition = reduce(loop.state, event, {

--- a/server/services/orchestrator/convergence.ts
+++ b/server/services/orchestrator/convergence.ts
@@ -19,7 +19,7 @@
  */
 import { z } from "zod";
 import { P0_PRIORITY, JUDGE_PROPOSABLE_METHODS } from "@shared/types";
-import type { ActionPoint, ConvergenceVerdict, Archetype, VerificationMethod } from "@shared/types";
+import type { ActionPoint, ConvergenceVerdict, RoundVerdict, Archetype, VerificationMethod } from "@shared/types";
 
 const actionPointSchema = z.object({
   title: z.string(),
@@ -81,6 +81,12 @@ const MAX_CRITERION_LEN = 1000;
 // wave planner drops nonexistent refs anyway, so over-bounding is safe.
 const MAX_DEPENDS_ON = 50;
 const MAX_DEPENDS_REF_LEN = 500;
+// RoundVerdict bounds (Security L-2, parity with the action-point caps above): the
+// judge's prose verdict + its pros/cons are UNTRUSTED model text. Cap the prose length
+// and both the count and per-item length of the pros/cons lists so a malicious or
+// malfunctioning judge cannot bloat the persisted round row.
+const MAX_VERDICT_LEN = 4000;
+const MAX_PROS_CONS = 50;
 
 /** Truncate a string to `max` chars; pass through `undefined`. */
 function clampStr(v: string | undefined, max: number): string | undefined {
@@ -204,6 +210,50 @@ export function extractActionPoints(judgeOutput: unknown): ActionPoint[] {
   const parsed = z.array(actionPointSchema).safeParse(body.action_points);
   if (!parsed.success) return [];
   return boundActionPoints(parsed.data);
+}
+
+/**
+ * Coerce a judge-authored `pros`/`cons` value into a bounded `string[]`. The field
+ * is UNTRUSTED and may arrive as a single string, an array, or garbage — coerce a
+ * lone string to a one-element list, drop non-string entries, then cap BOTH the list
+ * length (`MAX_PROS_CONS`) and each entry's length (`MAX_FIELD_LEN`). Never throws.
+ */
+function boundStringList(value: unknown): string[] {
+  const arr = typeof value === "string" ? [value] : Array.isArray(value) ? value : [];
+  const out: string[] = [];
+  for (const item of arr) {
+    if (typeof item !== "string") continue;
+    out.push(clampStr(item, MAX_FIELD_LEN) ?? "");
+    if (out.length >= MAX_PROS_CONS) break;
+  }
+  return out;
+}
+
+/**
+ * Read the FULL {@link RoundVerdict} from arbitrary judge output — the judge's prose
+ * `verdict`, its `pros`/`cons`, and the FULL RANKED `action_points` list (ALL
+ * priorities via {@link extractActionPoints}, NOT the open-P0 subset the FSM's
+ * `readConvergence` narrows to). Persisted per round for the loop detail page.
+ *
+ * Fail-soft, NEVER throws (mirrors {@link readConvergence}): routes through the same
+ * {@link pickJudgeBody} (so it finds the fields whether top-level or under `.output`)
+ * and bounds EVERYTHING (Security L-2) — `clampStr` the prose, `boundStringList` the
+ * pros/cons (count + per-item length, string-or-array coerced), `boundActionPoints`
+ * the list. Returns `null` when nothing parseable is present (no body, or every field
+ * empty) so the column stays NULL and consumers guard on it.
+ */
+export function readJudgeVerdict(judgeOutput: unknown): RoundVerdict | null {
+  const body = pickJudgeBody(judgeOutput);
+  if (!body) return null;
+  const verdict = clampStr(typeof body.verdict === "string" ? body.verdict : undefined, MAX_VERDICT_LEN);
+  const pros = boundStringList(body.pros);
+  const cons = boundStringList(body.cons);
+  const actionPoints = extractActionPoints(judgeOutput);
+  // Nothing recognizable → null (leave the column empty), rather than a hollow row.
+  if (verdict === undefined && pros.length === 0 && cons.length === 0 && actionPoints.length === 0) {
+    return null;
+  }
+  return { verdict: verdict ?? "", pros, cons, actionPoints };
 }
 
 /**

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1954,10 +1954,14 @@ export class MemStorage implements IStorage {
   }
 
   async appendLoopRound(data: InsertConsiliumLoopRound): Promise<ConsiliumLoopRoundRow> {
-    // UNIQUE(loop, round): reject a duplicate round append.
+    // UNIQUE(loop, round): reject a duplicate round append. Carry a Postgres-parity
+    // `code = "23505"` so callers can discriminate the conflict uniformly across the
+    // Mem and Pg backends (the constraint NAME in the message is the fallback signal).
     for (const r of this.consiliumLoopRoundsMap.values()) {
       if (r.loopId === data.loopId && r.round === data.round) {
-        throw new Error("consilium_loop_rounds_uq");
+        const err = new Error("consilium_loop_rounds_uq");
+        (err as NodeJS.ErrnoException).code = "23505";
+        throw err;
       }
     }
     const row: ConsiliumLoopRoundRow = {
@@ -1968,6 +1972,7 @@ export class MemStorage implements IStorage {
       converged: data.converged ?? null,
       openP0: data.openP0 ?? null,
       openActionPoints: data.openActionPoints ?? null,
+      verdict: data.verdict ?? null,
       baselineCommit: data.baselineCommit ?? null,
       headCommit: data.headCommit ?? null,
       testSummary: data.testSummary ?? null,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -17,7 +17,7 @@ import {
 import { vector } from "drizzle-orm/pg-core/columns/vector_extension/vector";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
-import type { TriggerConfig, TriggerType, TriggerProvenance, ManagerConfig, ManagerDecision, TraceSpan, SwarmCloneResult, SwarmMerger, SwarmSplitter, SkillVersionConfig, TaskTraceSpan, TrackerProvider, ActionPoint, Archetype, ArchetypeSource, ResearchReport, ExecutionTrace, ReviewMode, ExperienceScope, ExperienceEvidence, ExperienceVerification, ExperienceProvenance, ExperienceFreshness, ExperienceConfidence, ExperienceConsolidation, SkillProposalStatus, SkillProposalProvenance, SkillProposalEvidence } from "./types.js";
+import type { TriggerConfig, TriggerType, TriggerProvenance, ManagerConfig, ManagerDecision, TraceSpan, SwarmCloneResult, SwarmMerger, SwarmSplitter, SkillVersionConfig, TaskTraceSpan, TrackerProvider, ActionPoint, Archetype, ArchetypeSource, ResearchReport, RoundVerdict, ExecutionTrace, ReviewMode, ExperienceScope, ExperienceEvidence, ExperienceVerification, ExperienceProvenance, ExperienceFreshness, ExperienceConfidence, ExperienceConsolidation, SkillProposalStatus, SkillProposalProvenance, SkillProposalEvidence } from "./types.js";
 
 // ─── RBAC ────────────────────────────────────────────
 
@@ -2124,6 +2124,13 @@ export const consiliumLoopRounds = pgTable(
     // We persist the structured AP metadata for audit + the DEV handoff, but
     // NEVER the raw diff / assembled prompt input (Security H-4).
     openActionPoints: jsonb("open_action_points").$type<ActionPoint[]>(),
+    // The FULL judge verdict for this round (design: RoundVerdict) — the judge's
+    // prose summary, pros/cons, and the FULL RANKED action-point list (ALL
+    // priorities, not just the still-open P0 subset the SUMMARY fields carry).
+    // Bounded (readJudgeVerdict) before write — same Security L-2 discipline as
+    // openActionPoints (H-4: NEVER the raw diff/prompt input). NULL on pre-column /
+    // backfilled rounds and whenever the raw judge output is unreadable at record time.
+    verdict: jsonb("verdict").$type<RoundVerdict>(),
     baselineCommit: text("baseline_commit"),
     headCommit: text("head_commit"),
     testSummary: text("test_summary"),

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -2387,6 +2387,27 @@ export interface ConvergenceVerdict {
 }
 
 /**
+ * The FULL judge verdict persisted per round (`consilium_loop_rounds.verdict`
+ * jsonb). Distinct from the round's SUMMARY fields (`converged` / `openP0` /
+ * `openActionPoints`): it carries the judge's prose summary, the pros/cons, and
+ * the FULL RANKED action-point list (ALL priorities, not just the still-open P0
+ * subset). Nullable on the column — absent on pre-column / backfilled rows, and
+ * whenever the raw judge output is unreadable at record time — so every consumer
+ * guards on `verdict == null` before reading it.
+ *
+ * SECURITY (L-2): `verdict`, every `pros`/`cons` entry, and each `actionPoints`
+ * field are UNTRUSTED model (judge) text — bounded on write by `readJudgeVerdict`
+ * (count + per-field length caps) and rendered as INERT text on the client. The
+ * client mirrors this shape (client/src/hooks/use-consilium-loops.ts `RoundVerdict`).
+ */
+export interface RoundVerdict {
+  verdict: string;
+  pros: string[];
+  cons: string[];
+  actionPoints: ActionPoint[];
+}
+
+/**
  * Finding #5 — the READ-TIME (never-persisted) summary of the STILL-OPEN action
  * points carried by a TERMINAL loop's LAST recorded round. Convergence is keyed
  * on `P0` BY DESIGN (a loop converges the moment no P0 remains), but the judge

--- a/tests/e2e/consilium-loop-detail.spec.ts
+++ b/tests/e2e/consilium-loop-detail.spec.ts
@@ -1,0 +1,236 @@
+/**
+ * consilium-loop-detail.spec.ts — E2E coverage that a consilium loop's recorded
+ * rounds render on the loop detail page (design §7): the convergence badge,
+ * the still-open action points with their priority badges, and the "no open
+ * action points" empty state.
+ *
+ * DB dependency: consilium loops/rounds use PgStorage in the full server (same
+ * reasoning as knowledge.spec.ts) — SKIPPED when DATABASE_URL is absent.
+ *
+ * Seeding: a real Judge run needs a live model gateway, which is non-deterministic
+ * and slow for E2E. Task group + consilium-loop CREATION goes through the real
+ * HTTP API (`page.request`, matching the convention in run-execution.spec.ts /
+ * pipeline-crud.spec.ts); fast-forwarding the loop's FSM state and inserting the
+ * two round rows goes through a direct `pg` connection, mirroring the seeding
+ * precedent in tests/e2e/global-setup.ts (idempotent, scoped to rows this test
+ * itself creates — never a broad UPDATE/DELETE).
+ *
+ * Project scoping: `/api/task-groups` and `/api/consilium-loops` require
+ * `x-project-id` (server/middleware/project.ts) — `page.request` bypasses the
+ * client's fetch interceptor (client/src/lib/projectHeaders.ts) that normally
+ * attaches it, so this file creates its own project via `POST /api/projects`
+ * (project-agnostic, requireAuth only) and (a) passes `x-project-id` explicitly
+ * on every `page.request` call, and (b) writes `localStorage.project_id` so the
+ * loop detail page's OWN fetches (triggered by `page.goto`) resolve it too.
+ *
+ * Frontend note: `RoundVerdictPanel` (the grouped-by-priority full verdict list,
+ * `loop-verdict-ap-list`) is gated on `consilium_loop_rounds.verdict` (migration
+ * 0051, Phase 1 items 1-3). Round 1 below seeds that column directly (bypassing
+ * `readJudgeVerdict` — the raw-judge-output → `RoundVerdict` transform is unit-
+ * tested in tests/unit/orchestrator/convergence.test.ts) to exercise the panel's
+ * positive path; round 2 deliberately omits it to prove the panel is omitted
+ * (never a crash / hollow shell) when a round has no rich verdict — e.g. a
+ * pre-Phase-1 backfilled row. The still-open flat list (`loop-open-ap-list` →
+ * `loop-ap-item`) is the OTHER, always-populated surface (what defect A fixed)
+ * and is asserted independently of whether `verdict` is present.
+ *
+ * Playwright discovers this file via testDir: "./tests/e2e" in
+ * playwright.config.ts. No other file imports this module.
+ */
+import { test, expect } from "@playwright/test";
+import { Pool } from "pg";
+import { loginPage } from "./helpers/auth";
+
+const HAS_DATABASE = !!process.env.DATABASE_URL;
+
+test.describe("Consilium loop detail — recorded rounds surface", () => {
+  test.skip(!HAS_DATABASE, "Requires DATABASE_URL (consilium loops use PgStorage in the full server)");
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    await loginPage(page, testInfo.project.use.baseURL ?? "http://localhost:3099");
+  });
+
+  test("two recorded rounds render: convergence badges, priority-badged action points, and the empty-round message", async ({ page }) => {
+    // ── Project (required for x-project-id on the task-group/loop routes) ────
+    const projectRes = await page.request.post("/api/projects", {
+      data: { name: `E2E Consilium Loop ${Date.now()}`, description: "e2e seed project" },
+    });
+    expect(projectRes.status()).toBe(201);
+    const project = (await projectRes.json()) as { id: string };
+    await page.evaluate((pid) => localStorage.setItem("project_id", pid), project.id);
+
+    const projectHeaders = { "x-project-id": project.id };
+
+    // ── Task group (the loop's groupId FK; never started — the round data is
+    //    seeded directly, so no real debate/model call runs). ──────────────────
+    const groupRes = await page.request.post("/api/task-groups", {
+      headers: projectHeaders,
+      data: {
+        name: "[consilium-review:sdlc-cross-review] e2e-seed",
+        description: "e2e seed group",
+        input: "objective",
+        tasks: [{ name: "Reviewer", description: "seed task", executionMode: "direct_llm", modelSlug: "mock" }],
+      },
+    });
+    expect(groupRes.status()).toBe(201);
+    const group = (await groupRes.json()) as { id: string };
+
+    // ── Consilium loop (created via the real route; repoPath must be inside
+    //    consiliumLoop.allowedRepoPaths — config.yaml allowlists the whole
+    //    `.../project` parent, which covers process.cwd() here). ────────────────
+    const loopRes = await page.request.post("/api/consilium-loops", {
+      headers: projectHeaders,
+      data: { groupId: group.id, repoPath: process.cwd() },
+    });
+    expect(loopRes.status()).toBe(201);
+    const loop = (await loopRes.json()) as { id: string };
+
+    // ── Fast-forward the FSM state + seed two rounds directly (no HTTP surface
+    //    exists to insert a round or jump FSM state — see file header). ───────
+    const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+    try {
+      await pool.query(
+        `UPDATE consilium_loops SET state = 'converged', round = 2, current_iteration_number = 2, completed_at = now() WHERE id = $1`,
+        [loop.id],
+      );
+      // Round 1 — not yet converged, 2 P0 + 1 P1 still open, PLUS a full rich
+      // verdict (prose + pros/cons + the FULL ranked action-point list, all
+      // priorities) to exercise RoundVerdictPanel's positive path.
+      await pool.query(
+        `INSERT INTO consilium_loop_rounds (loop_id, round, iteration_number, converged, open_p0, open_action_points, verdict, baseline_commit, head_commit)
+         VALUES ($1, 1, 1, false, 2, $2::jsonb, $3::jsonb, 'aaaaaaa', 'bbbbbbb')`,
+        [
+          loop.id,
+          JSON.stringify([
+            { title: "Fix null check", priority: "P0" },
+            { title: "Add missing test", priority: "P0" },
+            { title: "Rename confusing var", priority: "P1" },
+          ]),
+          JSON.stringify({
+            verdict: "Solid overall, one blocking issue.",
+            pros: ["Good test coverage", "Clear naming"],
+            cons: ["Missing null check"],
+            actionPoints: [
+              { title: "Fix null check", priority: "P0" },
+              { title: "Add missing test", priority: "P0" },
+              { title: "Rename confusing var", priority: "P1" },
+              { title: "Add a doc note", priority: "P2" },
+            ],
+          }),
+        ],
+      );
+      // Round 2 — converged clean, nothing left open.
+      await pool.query(
+        `INSERT INTO consilium_loop_rounds (loop_id, round, iteration_number, converged, open_p0, open_action_points, baseline_commit, head_commit)
+         VALUES ($1, 2, 2, true, 0, '[]'::jsonb, 'bbbbbbb', 'ccccccc')`,
+        [loop.id],
+      );
+    } finally {
+      await pool.end();
+    }
+
+    // ── Navigate + assert ──────────────────────────────────────────────────────
+    await page.goto(`/consilium-loops/${loop.id}`);
+    await page.waitForLoadState("networkidle");
+
+    const body = await page.locator("body").textContent();
+    expect(body).not.toContain("Something went wrong");
+
+    const rows = page.getByTestId("loop-round-row");
+    await expect(rows).toHaveCount(2);
+
+    // Round 2 (latest, rendered last — rounds are sorted ascending) converged
+    // clean → green check; the loop is terminal (converged) so round 1's mark
+    // (not converged) renders red, not amber.
+    await expect(rows.nth(1).getByTestId("loop-convergence-mark")).toHaveClass(/text-green-600/);
+    await expect(rows.nth(0).getByTestId("loop-convergence-mark")).toHaveClass(/text-red-500/);
+
+    // The Result panel shows the LATEST round (2) — 0 open action points.
+    await expect(page.getByText("No open action points recorded for this round.")).toBeVisible();
+
+    // Round 1's still-open action points are behind its expandable row.
+    await rows.nth(0).click();
+    const openApList = page.getByTestId("loop-open-ap-list");
+    // data-priority lives on the loop-ap-item element itself — filter on the attribute directly.
+    await expect(openApList.getByTestId("loop-ap-item")).toHaveCount(3);
+    await expect(openApList.locator('[data-testid="loop-ap-item"][data-priority="P0"]')).toHaveCount(2);
+    await expect(openApList.locator('[data-testid="loop-ap-item"][data-priority="P1"]')).toHaveCount(1);
+    await expect(openApList.getByText("Fix null check")).toBeVisible();
+    await expect(openApList.getByText("Rename confusing var")).toBeVisible();
+
+    // RoundVerdictPanel — round 1 carries a rich verdict, so it renders: prose,
+    // pros/cons, and the FULL ranked action-point list GROUPED by priority
+    // (distinct from loop-open-ap-list above, which is the flat still-open subset).
+    const verdictPanel = page.getByTestId("loop-verdict-panel");
+    await expect(verdictPanel).toHaveCount(1);
+    await expect(verdictPanel.getByText("Solid overall, one blocking issue.")).toBeVisible();
+    await expect(verdictPanel.getByText("Good test coverage")).toBeVisible();
+    await expect(verdictPanel.getByText("Missing null check")).toBeVisible();
+    const verdictApList = verdictPanel.getByTestId("loop-verdict-ap-list");
+    // 4 action points across P0(2)/P1(1)/P2(1) — the FULL list, not just the 3
+    // still-open ones in loop-open-ap-list above.
+    await expect(verdictApList.getByTestId("loop-ap-item")).toHaveCount(4);
+    await expect(verdictApList.locator('[data-testid="loop-ap-item"][data-priority="P0"]')).toHaveCount(2);
+    await expect(verdictApList.locator('[data-testid="loop-ap-item"][data-priority="P1"]')).toHaveCount(1);
+    await expect(verdictApList.locator('[data-testid="loop-ap-item"][data-priority="P2"]')).toHaveCount(1);
+    await expect(verdictApList.getByText("Add a doc note")).toBeVisible();
+
+    // Round 2 has NO verdict (omitted from its seed) — expanding it must NOT add a
+    // second panel: the omission is silent (no crash, no hollow shell), not merely
+    // "we didn't check". Still only the ONE panel from round 1 above.
+    await rows.nth(1).click();
+    await expect(page.getByTestId("loop-verdict-panel")).toHaveCount(1);
+  });
+
+  test("a loop whose round failed to persist surfaces loop.error instead of rendering blank", async ({ page }) => {
+    // Regression-adjacent: seeds the FRONTEND side of defect C directly (no
+    // rounds recorded, `error` set) to prove the existing plumbing
+    // (ResultPanel / LoopStatusCallout) renders it — the backend fix (recordRound
+    // no longer swallowing non-unique failures) is covered at the unit/integration
+    // level in tests/unit/consilium/loop-round-persist-failure.test.ts.
+    const projectRes = await page.request.post("/api/projects", {
+      data: { name: `E2E Consilium Loop Error ${Date.now()}`, description: "e2e seed project" },
+    });
+    const project = (await projectRes.json()) as { id: string };
+    await page.evaluate((pid) => localStorage.setItem("project_id", pid), project.id);
+    const projectHeaders = { "x-project-id": project.id };
+
+    const groupRes = await page.request.post("/api/task-groups", {
+      headers: projectHeaders,
+      data: {
+        name: "[consilium-review:sdlc-cross-review] e2e-seed-error",
+        description: "e2e seed group",
+        input: "objective",
+        tasks: [{ name: "Reviewer", description: "seed task", executionMode: "direct_llm", modelSlug: "mock" }],
+      },
+    });
+    const group = (await groupRes.json()) as { id: string };
+    const loopRes = await page.request.post("/api/consilium-loops", {
+      headers: projectHeaders,
+      data: { groupId: group.id, repoPath: process.cwd() },
+    });
+    const loop = (await loopRes.json()) as { id: string };
+
+    const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+    try {
+      await pool.query(
+        `UPDATE consilium_loops SET state = 'converged', round = 1, current_iteration_number = 1, completed_at = now(),
+                error = 'round 1 audit write failed: connection terminated unexpectedly'
+         WHERE id = $1`,
+        [loop.id],
+      );
+      // Deliberately NO consilium_loop_rounds row — this is exactly the pre-fix
+      // symptom (round persist failed, nothing recorded).
+    } finally {
+      await pool.end();
+    }
+
+    await page.goto(`/consilium-loops/${loop.id}`);
+    await page.waitForLoadState("networkidle");
+
+    const body = await page.locator("body").textContent();
+    expect(body).not.toContain("Something went wrong");
+    await expect(page.getByText("No rounds recorded yet.")).toBeVisible();
+    await expect(page.getByText(/round 1 audit write failed/i)).toBeVisible();
+  });
+});

--- a/tests/integration/consilium/loop-review-result-surface.test.ts
+++ b/tests/integration/consilium/loop-review-result-surface.test.ts
@@ -167,6 +167,11 @@ describe.each(PRESETS)("preset coverage: %s", (preset) => {
     expect(round.converged).toBe(false);
     expect(round.openP0).toBe(2);
     expect(round.openActionPoints).toEqual(verdict.openActionPoints);
+    // No task_executions were seeded for this iteration, so the rich judge verdict
+    // (Phase 1, items 1-3) has nothing to read and stays null — the RoundVerdictPanel
+    // correctly omits itself rather than rendering a hollow shell (see the E2E spec's
+    // null-verdict assertion).
+    expect(round.verdict ?? null).toBeNull();
     // Self-sufficient payload — no follow-up call to any task-group endpoint needed.
     expect(round).not.toHaveProperty("devGroupId");
     expect(round).not.toHaveProperty("taskGroupId");
@@ -223,5 +228,73 @@ describe("research archetype — the develop-phase report surfaces on the SAME r
     expect(res.body.rounds).toHaveLength(1);
     expect(res.body.rounds[0].report).toEqual(report);
     expect(res.body.rounds[0].openActionPoints).toEqual(verdict.openActionPoints);
+  });
+});
+
+describe("verdict column (Phase 1, items 1-3) — the FULL judge verdict surfaces on the round", () => {
+  it("a real judge execution's verdict/pros/cons/full action-point list persists to the round and surfaces via GET", async () => {
+    const ctx = await setup();
+    const group = await ctx.storage.createTaskGroup({
+      name: "[consilium-review:sdlc-cross-review] myrepo",
+      description: "d",
+      input: "objective",
+      createdBy: OWNER_USER.id,
+    } as never);
+    const created = await ctx.post("/api/consilium-loops", { groupId: group.id, repoPath: REPO_ROOT });
+    const id = created.body.id as string;
+
+    // Seed a REAL iteration + judge execution (unlike the other tests in this file,
+    // no `readIterationVerdict` is injected here — recordRound's `readRoundVerdict`
+    // reads the raw judge output via `getExecutionsByIteration` UNCONDITIONALLY,
+    // regardless of whether the ConvergenceVerdict summary is injected or resolved
+    // the default way, so this exercises both resolution paths against real storage.
+    const iteration = await ctx.storage.createIteration({
+      groupId: group.id,
+      iterationNumber: 1,
+      status: "completed",
+      input: "objective",
+    });
+    await ctx.storage.createExecution({
+      iterationId: iteration.id,
+      groupId: group.id,
+      status: "completed",
+      output: {
+        verdict: "Solid overall, one blocking issue.",
+        pros: ["Good test coverage", "Clear naming"],
+        cons: ["Missing null check"],
+        action_points: [
+          { title: "Fix null check", priority: "P0" },
+          { title: "Add a doc note", priority: "P2" },
+        ],
+        convergence: { converged: false, open_p0: 1 },
+      },
+    });
+
+    await ctx.storage.updateLoop(id, { state: "deciding", round: 1, currentIterationNumber: 1 });
+
+    const controller = ctx.makeController({ runCloseout: async () => ({ prRef: null, headCommit: "" }) });
+    const tickRes = await controller.tick(id);
+    expect(tickRes?.state).toBe("developing"); // 1 open P0, room left
+
+    const res = await ctx.get(`/api/consilium-loops/${id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.rounds).toHaveLength(1);
+    const round = res.body.rounds[0];
+
+    // Summary fields resolved the DEFAULT way (no readIterationVerdict injected).
+    expect(round.converged).toBe(false);
+    expect(round.openP0).toBe(1);
+
+    // The rich verdict — prose + pros/cons + the FULL ranked action-point list
+    // (both P0 AND P2, not just the still-open subset in openActionPoints).
+    expect(round.verdict).toEqual({
+      verdict: "Solid overall, one blocking issue.",
+      pros: ["Good test coverage", "Clear naming"],
+      cons: ["Missing null check"],
+      actionPoints: [
+        { title: "Fix null check", priority: "P0" },
+        { title: "Add a doc note", priority: "P2" },
+      ],
+    });
   });
 });

--- a/tests/integration/consilium/loop-review-result-surface.test.ts
+++ b/tests/integration/consilium/loop-review-result-surface.test.ts
@@ -1,0 +1,227 @@
+/**
+ * loop-review-result-surface.test.ts — integration coverage that a completed
+ * consilium review surfaces on `GET /api/consilium-loops/:id` (design §7) via
+ * the REAL `MemStorage` + `ConsiliumLoopController` + HTTP router, mirroring
+ * the harness in `tests/integration/consilium/loop-routes.test.ts`.
+ *
+ * Scope note (per team-lead direction): this file asserts the OBSERVABLE
+ * contract — the round persists and GET returns it self-sufficiently, with no
+ * task-group-shaped field on the round row — rather than pinning to how the
+ * review round is dispatched internally. Full removal of the task-group
+ * EXECUTION mechanism (`taskOrchestrator.startGroupAsync`) is a separate,
+ * larger refactor pending the Architect's blueprint; the "no task_group
+ * created for this round" spy assertion is deliberately deferred until that
+ * lands, per the team-lead's explicit scope split (defects C+A ship first).
+ *
+ * These tests drive the FSM past `building_context`/`reviewing` by seeding
+ * state directly via `storage.updateLoop` (same convention as the existing
+ * merge-approved tests in loop-routes.test.ts, which seed `awaiting_merge`
+ * directly) and injecting `readIterationVerdict` — so no real git/task-group
+ * dispatch is exercised, only the deciding→{developing} round-recording path
+ * and the GET surface.
+ */
+process.env.NO_PROXY = ["127.0.0.1", "localhost", process.env.NO_PROXY].filter(Boolean).join(",");
+process.env.no_proxy = process.env.NO_PROXY;
+delete process.env.HTTP_PROXY;
+delete process.env.http_proxy;
+delete process.env.HTTPS_PROXY;
+delete process.env.https_proxy;
+
+import { describe, it, expect, afterAll } from "vitest";
+import request from "supertest";
+import express, { type Express } from "express";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { User, ConvergenceVerdict } from "../../../shared/types.js";
+import { MemStorage } from "../../../server/storage.js";
+import { ConsiliumLoopController } from "../../../server/services/consilium/consilium-loop-controller.js";
+import { registerConsiliumLoopRoutes } from "../../../server/routes/consilium-loops.js";
+
+const REPO_ROOT = realpathSync(mkdtempSync(join(tmpdir(), "loop-review-result-surface-")));
+afterAll(() => {
+  rmSync(REPO_ROOT, { recursive: true, force: true });
+});
+
+const OWNER_USER: User = { id: "owner-1", email: "o@x.io", name: "Owner", isActive: true, role: "user", lastLoginAt: null, createdAt: new Date(0) };
+
+const fakeConfig = () =>
+  ({
+    pipeline: {
+      consiliumLoop: {
+        enabled: true,
+        maxRounds: 6,
+        pollIntervalMs: 5000,
+        maxDiffBytes: 200000,
+        allowedRepoPaths: [REPO_ROOT],
+        implement: {
+          enabled: true,
+          verification: { enabled: false },
+          maxFixIterations: 3,
+          testCommand: null,
+          testRunTimeoutMs: 300000,
+          research: { enabled: true, maxResearchIterations: 3, model: "claude-sonnet" },
+        },
+      },
+      taskGroups: { taskTimeoutMs: 60000 },
+    },
+    providers: { tavily: { apiKey: "test-tavily-key" } },
+  }) as never;
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+interface ControllerDeps {
+  readIterationVerdict?: (loop: never) => Promise<ConvergenceVerdict | null>;
+  runCloseout?: () => Promise<{ prRef: string | null; headCommit: string; report?: unknown }>;
+  runResearch?: (...args: unknown[]) => Promise<{ prRef: string | null; headCommit: string; report?: unknown }>;
+  gateway?: unknown;
+}
+
+async function setup() {
+  const storage = new MemStorage();
+  const app: Express = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.user = OWNER_USER;
+    next();
+  });
+
+  const makeController = (deps: ControllerDeps = {}) =>
+    new ConsiliumLoopController({
+      storage,
+      taskOrchestrator: {
+        startGroup: async () => ({ group: {}, iteration: { iterationNumber: 1 } }),
+        startGroupAsync: async () => ({ group: {}, iteration: { iterationNumber: 1 } }),
+        createTaskGroup: async () => ({ group: { id: "devgrp" }, tasks: [] }),
+        cancelGroup: async () => undefined,
+      } as never,
+      config: fakeConfig,
+      readRepoHead: async () => "cafefeed",
+      ...deps,
+    } as never);
+
+  const controller = makeController();
+  registerConsiliumLoopRoutes(app, storage, controller, fakeConfig);
+  app.use((err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(400).json({ error: "bad request", detail: (err as Error)?.message });
+  });
+
+  const isProxyArtifact = (res: request.Response): boolean =>
+    res.status === 400 && typeof res.text === "string" && res.text.includes("explicit proxy server");
+  async function send(make: () => request.Test): Promise<request.Response> {
+    let res = await make();
+    for (let i = 0; i < 5 && isProxyArtifact(res); i++) res = await make();
+    return res;
+  }
+  const post = (path: string, body?: unknown): Promise<request.Response> =>
+    send(() => {
+      const r = request(app).post(path);
+      return body === undefined ? r : r.send(body as object);
+    });
+  const get = (path: string): Promise<request.Response> => send(() => request(app).get(path));
+
+  return { app, storage, post, get, makeController };
+}
+
+const PRESETS = ["sdlc-cross-review", "diff-pr-review", "full-viability"] as const;
+
+describe.each(PRESETS)("preset coverage: %s", (preset) => {
+  it("a decided round surfaces via GET self-sufficiently (converged/openP0/action points), no task-group field on the round", async () => {
+    const ctx = await setup();
+    const group = await ctx.storage.createTaskGroup({
+      name: `[consilium-review:${preset}] myrepo`,
+      description: "d",
+      input: "objective",
+      createdBy: OWNER_USER.id,
+    } as never);
+
+    const created = await ctx.post("/api/consilium-loops", { groupId: group.id, repoPath: REPO_ROOT });
+    expect(created.status).toBe(201);
+    const id = created.body.id as string;
+
+    // Fast-forward past building_context/reviewing (same seeding convention the
+    // existing merge-approved tests in loop-routes.test.ts use for awaiting_merge).
+    await ctx.storage.updateLoop(id, { state: "deciding", round: 1, currentIterationNumber: 1 });
+
+    const verdict: ConvergenceVerdict = {
+      converged: false,
+      openP0: 2,
+      openActionPoints: [
+        { title: "fix null check", priority: "P0" },
+        { title: "add missing test", priority: "P0" },
+        { title: "rename confusing var", priority: "P1" },
+      ],
+    };
+    const controller = ctx.makeController({
+      readIterationVerdict: async () => verdict,
+      runCloseout: async () => ({ prRef: null, headCommit: "" }),
+    });
+    const tickRes = await controller.tick(id);
+    expect(tickRes?.state).toBe("developing"); // open P0s, room left (round 1 < maxRounds 6)
+
+    const res = await ctx.get(`/api/consilium-loops/${id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.rounds).toHaveLength(1);
+
+    const round = res.body.rounds[0];
+    expect(round.converged).toBe(false);
+    expect(round.openP0).toBe(2);
+    expect(round.openActionPoints).toEqual(verdict.openActionPoints);
+    // Self-sufficient payload — no follow-up call to any task-group endpoint needed.
+    expect(round).not.toHaveProperty("devGroupId");
+    expect(round).not.toHaveProperty("taskGroupId");
+  });
+});
+
+describe("research archetype — the develop-phase report surfaces on the SAME round", () => {
+  it("a research close-out's report attaches to the recorded round and is visible via GET", async () => {
+    const ctx = await setup();
+    const group = await ctx.storage.createTaskGroup({
+      name: "[consilium-review:sdlc-cross-review] myrepo",
+      description: "d",
+      input: "objective",
+      createdBy: OWNER_USER.id,
+    } as never);
+    const created = await ctx.post("/api/consilium-loops", { groupId: group.id, repoPath: REPO_ROOT });
+    const id = created.body.id as string;
+
+    // archetype set directly (this test targets the round/report surfacing
+    // contract, not the PATCH .../archetype override route, which has its own
+    // coverage elsewhere).
+    await ctx.storage.updateLoop(id, {
+      state: "deciding",
+      round: 1,
+      currentIterationNumber: 1,
+      archetype: "research",
+    });
+
+    const verdict: ConvergenceVerdict = {
+      converged: false,
+      openP0: 0,
+      openActionPoints: [{ title: "investigate migration risk", priority: "P1" }],
+    };
+    const report = {
+      question: "Is the migration safe?",
+      recommendation: "Proceed with a canary rollout.",
+      claims: [],
+      sources: [],
+      verdict: "green" as const,
+      generatedAt: new Date(0).toISOString(),
+    };
+    const controller = ctx.makeController({
+      readIterationVerdict: async () => verdict,
+      gateway: {} as never, // only checked for truthiness before the research branch
+      runResearch: async () => ({ prRef: null, headCommit: "", report }),
+    });
+
+    const tickRes = await controller.tick(id);
+    expect(tickRes?.state).toBe("developing");
+    await flush(); // let the fire-and-forget closeout settle + persist the report
+
+    const res = await ctx.get(`/api/consilium-loops/${id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.rounds).toHaveLength(1);
+    expect(res.body.rounds[0].report).toEqual(report);
+    expect(res.body.rounds[0].openActionPoints).toEqual(verdict.openActionPoints);
+  });
+});

--- a/tests/unit/consilium/loop-round-persist-failure.test.ts
+++ b/tests/unit/consilium/loop-round-persist-failure.test.ts
@@ -1,0 +1,399 @@
+/**
+ * loop-round-persist-failure.test.ts — regression coverage for the silent
+ * round-audit failure: `recordRound()` (consilium-loop-controller.ts) used to
+ * do `.appendLoopRound({...}).catch(() => undefined)`, swallowing EVERY insert
+ * error — not just the expected `UNIQUE(loop,round)` re-tick conflict. That
+ * left `consilium_loop_rounds` silently empty on any transient storage error
+ * (a dropped connection, a serialization failure, disk full, …), so the loop
+ * detail page rendered blank with `loop.error` empty even though a Judge had
+ * produced a real verdict.
+ *
+ * The fix must:
+ *   - swallow ONLY the `consilium_loop_rounds_uq` unique-conflict (idempotent
+ *     re-tick / redrive) — in BOTH the Postgres shape (`err.code === "23505"`
+ *     + the constraint name in the message) and the `MemStorage` shape (a
+ *     bare `Error("consilium_loop_rounds_uq")`, no `.code` — see
+ *     server/storage.ts:1956-1962), matching the detection convention already
+ *     used in server/routes/model-skill-bindings.ts:115.
+ *   - surface every OTHER insert failure: log it and set `loop.error`, without
+ *     blocking the FSM transition itself (fail-open on state, fail-loud on the
+ *     audit row).
+ *
+ * These tests drive the controller through the PUBLIC `tick()` entry point
+ * (never the private `recordRound`), so they also prove the fix survives
+ * `tick()`'s own follow-up `updateLoop(won.id, extra)` merge
+ * (consilium-loop-controller.ts:1340-1342) — i.e. whichever call actually
+ * persists `loop.error`, the final row must carry it.
+ *
+ * STOPPED_CAP note: this used to be a SEPARATE gap (flagged to the team while
+ * writing this file) — `STOPPED_CAP` is committed via an early-exit in
+ * `tickInner()` (~L1310-1318) that returns directly from `commit()`, so it
+ * never reached `runSideEffect()`/`recordRound()` at all, independent of the
+ * swallow bug. Fixed in 929aa8c ("record the round on the stopped_cap cap
+ * early-exit"), so it's covered as a normal case below alongside the other
+ * three decided outcomes.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ConsiliumLoopController } from "../../../server/services/consilium/consilium-loop-controller.js";
+import type { ConsiliumLoopRow, ConsiliumLoopState } from "@shared/schema";
+import type { ConvergenceVerdict } from "@shared/types";
+
+const verdict = (converged: boolean, openP0: number): ConvergenceVerdict => ({
+  converged,
+  openP0,
+  openActionPoints: Array.from({ length: openP0 }, (_, i) => ({
+    title: `ap${i}`,
+    priority: "P0",
+  })),
+});
+
+function makeLoop(over: Partial<ConsiliumLoopRow>): ConsiliumLoopRow {
+  return {
+    id: "loop1",
+    groupId: "grp1",
+    state: "deciding",
+    round: 2,
+    maxRounds: 6,
+    repoPath: process.cwd(),
+    lastReviewedCommit: null,
+    currentIterationNumber: 2,
+    devGroupId: null,
+    prRef: null,
+    headCommitAtReview: null,
+    openP0: null,
+    error: null,
+    createdBy: "user1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    completedAt: null,
+    ...over,
+  } as ConsiliumLoopRow;
+}
+
+/**
+ * Same shape as `makeFakeStorage` in loop-fsm.test.ts, with an OVERRIDABLE
+ * `appendLoopRound` so each test can inject a specific failure. `getLoop()`
+ * (via `get()`) always reflects the LATEST merge from either `casLoopState`
+ * or `updateLoop` — so asserting against `get()` is robust to whichever of
+ * the two the fix uses to persist `loop.error` (a direct `updateLoop` inside
+ * `recordRound`'s catch, or folding it into the transition's returned
+ * `extra`); we deliberately do NOT assert on `tick()`'s return value alone.
+ */
+function makeFakeStorage(
+  loop: ConsiliumLoopRow,
+  rounds: { round: number; openP0: number }[] = [],
+) {
+  let current = loop;
+  const cas = vi.fn(
+    async (
+      id: string,
+      expected: ConsiliumLoopState,
+      next: ConsiliumLoopState,
+      extra?: Record<string, unknown>,
+    ) => {
+      if (id !== current.id || current.state !== expected) return undefined;
+      current = { ...current, ...(extra ?? {}), state: next };
+      return current;
+    },
+  );
+  const storage = {
+    getLoop: vi.fn(async () => current),
+    getLoops: vi.fn(async () => [current]),
+    getLoopRounds: vi.fn(async () => rounds.map((r) => ({ ...r }))),
+    casLoopState: cas,
+    claimRedrive: vi.fn(async () => undefined),
+    appendLoopRound: vi.fn(async () => ({})),
+    updateLoop: vi.fn(async (_id: string, extra?: Record<string, unknown>) => {
+      current = { ...current, ...(extra ?? {}) };
+      return current;
+    }),
+    getTaskGroup: vi.fn(async () => ({ id: current.groupId, input: "objective" })),
+    updateTaskGroup: vi.fn(async () => ({})),
+    createTaskGroup: vi.fn(async () => ({ group: { id: "devgrp" } })),
+    getIteration: vi.fn(async () => ({
+      id: "it1",
+      iterationNumber: current.currentIterationNumber ?? 1,
+      status: "completed",
+    })),
+    getExecutionsByIteration: vi.fn(async () => []),
+  };
+  return { storage, cas, get: () => current };
+}
+
+const fakeConfig = () =>
+  ({
+    pipeline: {
+      consiliumLoop: {
+        enabled: true,
+        maxRounds: 6,
+        pollIntervalMs: 5000,
+        maxDiffBytes: 200000,
+        allowedRepoPaths: [process.cwd()],
+        implement: {
+          enabled: true,
+          verification: { enabled: false },
+          maxFixIterations: 3,
+          testCommand: null,
+          testRunTimeoutMs: 300000,
+          research: { enabled: false, maxResearchIterations: 3, model: "claude-sonnet" },
+        },
+      },
+    },
+  }) as never;
+
+/** Postgres-realistic unique-violation shape (server/routes/model-skill-bindings.ts:115). */
+const pgUniqueErr = () =>
+  Object.assign(
+    new Error('duplicate key value violates unique constraint "consilium_loop_rounds_uq"'),
+    { code: "23505" },
+  );
+/** The EXACT shape MemStorage.appendLoopRound throws today (storage.ts:1956-1962) — no `.code`. */
+const memUniqueErr = () => new Error("consilium_loop_rounds_uq");
+/** A genuinely transient, non-conflict failure (dropped connection, disk full, …). */
+const transientErr = () => new Error("connection terminated unexpectedly");
+
+describe("recordRound — a non-unique appendLoopRound failure MUST surface (not be swallowed)", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it("CONVERGED: transition still completes, but loop.error is set + the failure is logged", async () => {
+    const loop = makeLoop({ round: 2, maxRounds: 6, currentIterationNumber: 2, error: null });
+    const { storage, get } = makeFakeStorage(loop, [{ round: 1, openP0: 1 }]);
+    storage.appendLoopRound.mockRejectedValue(transientErr());
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: {
+        startGroup: vi.fn(),
+        startGroupAsync: vi.fn(),
+        createTaskGroup: vi.fn(),
+        cancelGroup: vi.fn(),
+      } as never,
+      config: fakeConfig,
+      readIterationVerdict: async () => verdict(true, 0),
+    });
+
+    const res = await controller.tick(loop.id);
+
+    // The FSM transition itself must NOT be blocked by the audit-write failure.
+    expect(res?.state).toBe("converged");
+    expect(storage.appendLoopRound).toHaveBeenCalledTimes(1);
+
+    // The failure must surface on the loop, never vanish silently.
+    const persisted = get();
+    expect(persisted.error).toBeTruthy();
+    expect(persisted.error).toMatch(/round|persist|append/i);
+
+    // ...and be logged (this.log()'s `console.log` convention, consilium-loop-controller.ts:792-795).
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining(loop.id));
+  });
+
+  it("ESCALATED (anti-stall): transition still completes, loop.error is set + logged", async () => {
+    const loop = makeLoop({ round: 3, maxRounds: 6, currentIterationNumber: 3, error: null });
+    const { storage, get } = makeFakeStorage(loop, [
+      { round: 1, openP0: 3 },
+      { round: 2, openP0: 3 },
+    ]);
+    storage.appendLoopRound.mockRejectedValue(transientErr());
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: {
+        startGroup: vi.fn(),
+        startGroupAsync: vi.fn(),
+        createTaskGroup: vi.fn(),
+        cancelGroup: vi.fn(),
+      } as never,
+      config: fakeConfig,
+      readIterationVerdict: async () => verdict(false, 3), // flat at 3 → anti-stall
+    });
+
+    const res = await controller.tick(loop.id);
+
+    expect(res?.state).toBe("escalated");
+    expect(storage.appendLoopRound).toHaveBeenCalledTimes(1);
+    const persisted = get();
+    expect(persisted.error).toBeTruthy();
+    expect(persisted.error).toMatch(/round|persist|append/i);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining(loop.id));
+  });
+
+  it("DEVELOPING: transition still completes (coder still dispatches), loop.error is set + logged", async () => {
+    const loop = makeLoop({ round: 2, maxRounds: 6, currentIterationNumber: 2, error: null });
+    const { storage, get } = makeFakeStorage(loop, [{ round: 1, openP0: 3 }]);
+    storage.appendLoopRound.mockRejectedValue(transientErr());
+    const runCloseout = vi.fn(async () => ({ prRef: null, headCommit: "" }));
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: {
+        startGroup: vi.fn(),
+        startGroupAsync: vi.fn(),
+        createTaskGroup: vi.fn(),
+        cancelGroup: vi.fn(),
+      } as never,
+      config: fakeConfig,
+      readIterationVerdict: async () => verdict(false, 2), // open P0s, room left → DEVELOPING
+      runCloseout,
+    });
+
+    const res = await controller.tick(loop.id);
+
+    expect(res?.state).toBe("developing");
+    expect(storage.appendLoopRound).toHaveBeenCalledTimes(1);
+    const persisted = get();
+    expect(persisted.error).toBeTruthy();
+    expect(persisted.error).toMatch(/round|persist|append/i);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining(loop.id));
+  });
+
+  // Fixed in 929aa8c ("record the round on the stopped_cap cap early-exit") —
+  // see the file header note. The cap-precedence early-exit in `tickInner()`
+  // now calls `recordRound` on the CAS winner before returning, mirroring the
+  // converged/escalated terminal exits.
+  it("STOPPED_CAP (cap round, open P0s): a round IS recorded and a persist failure surfaces the same way", async () => {
+    const loop = makeLoop({ round: 6, maxRounds: 6, currentIterationNumber: 6, error: null });
+    const { storage, get } = makeFakeStorage(loop, [
+      { round: 1, openP0: 3 },
+      { round: 2, openP0: 2 },
+    ]);
+    storage.appendLoopRound.mockRejectedValue(transientErr());
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: {
+        startGroup: vi.fn(),
+        startGroupAsync: vi.fn(),
+        createTaskGroup: vi.fn(),
+        cancelGroup: vi.fn(),
+      } as never,
+      config: fakeConfig,
+      readIterationVerdict: async () => verdict(false, 2), // still open → cap binds
+    });
+
+    const res = await controller.tick(loop.id);
+
+    expect(res?.state).toBe("stopped_cap");
+    expect(storage.appendLoopRound).toHaveBeenCalledTimes(1);
+    const persisted = get();
+    expect(persisted.error).toBeTruthy();
+    expect(persisted.error).toMatch(/round|persist|append/i);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining(loop.id));
+  });
+});
+
+describe("recordRound — UNIQUE(loop,round) conflict stays a silent, idempotent no-op", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it("Postgres-shaped conflict (code 23505 + constraint name): transition completes, loop.error UNCHANGED", async () => {
+    const loop = makeLoop({ round: 2, maxRounds: 6, currentIterationNumber: 2, error: null });
+    const { storage, get } = makeFakeStorage(loop, [{ round: 1, openP0: 1 }]);
+    storage.appendLoopRound.mockRejectedValue(pgUniqueErr());
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: {
+        startGroup: vi.fn(),
+        startGroupAsync: vi.fn(),
+        createTaskGroup: vi.fn(),
+        cancelGroup: vi.fn(),
+      } as never,
+      config: fakeConfig,
+      readIterationVerdict: async () => verdict(true, 0),
+    });
+
+    const res = await controller.tick(loop.id);
+
+    expect(res?.state).toBe("converged");
+    expect(get().error).toBeNull(); // NOT clobbered — a duplicate re-tick is a true no-op
+  });
+
+  it("MemStorage-shaped conflict (bare Error, no `.code`): transition completes, loop.error UNCHANGED", async () => {
+    // The exact shape MemStorage.appendLoopRound throws today (storage.ts:1956-1962).
+    // A fix that only checks `err.code === "23505"` would MISS this and misclassify
+    // every dev/in-memory-mode re-tick as a surfaced failure.
+    const loop = makeLoop({ round: 2, maxRounds: 6, currentIterationNumber: 2, error: null });
+    const { storage, get } = makeFakeStorage(loop, [{ round: 1, openP0: 1 }]);
+    storage.appendLoopRound.mockRejectedValue(memUniqueErr());
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: {
+        startGroup: vi.fn(),
+        startGroupAsync: vi.fn(),
+        createTaskGroup: vi.fn(),
+        cancelGroup: vi.fn(),
+      } as never,
+      config: fakeConfig,
+      readIterationVerdict: async () => verdict(true, 0),
+    });
+
+    const res = await controller.tick(loop.id);
+
+    expect(res?.state).toBe("converged");
+    expect(get().error).toBeNull();
+  });
+
+  it("a genuine re-tick of an ALREADY-recorded round (redrive/CAS-race replay) is a true no-op", async () => {
+    // Round 1 already succeeded once (simulated: appendLoopRound resolves on the
+    // FIRST call, then throws the unique conflict on every subsequent call for the
+    // same round) — a second tick for the SAME decided round must not surface an
+    // error or duplicate anything.
+    const loop = makeLoop({ round: 2, maxRounds: 6, currentIterationNumber: 2, error: null, state: "deciding" });
+    const { storage } = makeFakeStorage(loop, [{ round: 1, openP0: 1 }]);
+    storage.appendLoopRound.mockResolvedValueOnce({} as never).mockRejectedValue(memUniqueErr());
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: {
+        startGroup: vi.fn(),
+        startGroupAsync: vi.fn(),
+        createTaskGroup: vi.fn(),
+        cancelGroup: vi.fn(),
+      } as never,
+      config: fakeConfig,
+      readIterationVerdict: async () => verdict(true, 0),
+    });
+
+    const first = await controller.tick(loop.id);
+    expect(first?.state).toBe("converged");
+    expect(first?.error ?? null).toBeNull();
+    // A second tick on an already-terminal (converged) loop is a straight no-op
+    // (isTerminal short-circuits in tickInner) — appendLoopRound must not be
+    // called again, and error stays untouched either way.
+    const second = await controller.tick(loop.id);
+    expect(second).toBeNull();
+    expect(storage.appendLoopRound).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("deciding — an unresolvable/malformed judge verdict no-ops cleanly (no round recorded)", () => {
+  it("tick() returns null; appendLoopRound and casLoopState are never called", async () => {
+    const loop = makeLoop({ round: 2, maxRounds: 6, currentIterationNumber: 2, state: "deciding" });
+    const { storage } = makeFakeStorage(loop, [{ round: 1, openP0: 1 }]);
+    // No `readIterationVerdict` injected → falls back to the default
+    // getIteration/getExecutionsByIteration/pickJudgeOutput path; the fake's
+    // getExecutionsByIteration resolves `[]`, so pickJudgeOutput returns
+    // undefined and resolveVerdict/deriveDecideEvent resolve null.
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: {
+        startGroup: vi.fn(),
+        startGroupAsync: vi.fn(),
+        createTaskGroup: vi.fn(),
+        cancelGroup: vi.fn(),
+      } as never,
+      config: fakeConfig,
+    });
+
+    const res = await controller.tick(loop.id);
+
+    expect(res).toBeNull();
+    expect(storage.appendLoopRound).not.toHaveBeenCalled();
+    expect(storage.casLoopState).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/orchestrator/convergence.test.ts
+++ b/tests/unit/orchestrator/convergence.test.ts
@@ -309,3 +309,88 @@ describe("Stage C — applyCriteriaQa demotion", () => {
     expect(out).not.toBe(aps);
   });
 });
+
+// ─── readJudgeVerdict — the FULL RoundVerdict (Phase 1, item 2) ───────────────
+import { readJudgeVerdict } from "../../../server/services/orchestrator/convergence.js";
+
+// Module-private caps mirrored here (convergence.ts): keep in sync with the reader.
+const MAX_VERDICT_LEN = 4000;
+const MAX_PROS_CONS = 50;
+const MAX_FIELD_LEN = 1000;
+
+describe("readJudgeVerdict — bounded, fail-soft rich judge verdict", () => {
+  it("extracts verdict + pros/cons + the FULL ranked action-point list (nested under .output)", () => {
+    const judge = {
+      output: {
+        verdict: "Looks solid overall.",
+        pros: ["clean tests", "good naming"],
+        cons: ["missing an edge case"],
+        // FULL ranked list — P0 AND lower priorities (NOT just the open-P0 subset).
+        action_points: [
+          { title: "handle null input", priority: "P0" },
+          { title: "add a doc note", priority: "P2" },
+        ],
+        convergence: { converged: false, open_p0: 1 },
+      },
+    };
+    const r = readJudgeVerdict(judge);
+    expect(r).not.toBeNull();
+    expect(r!.verdict).toBe("Looks solid overall.");
+    expect(r!.pros).toEqual(["clean tests", "good naming"]);
+    expect(r!.cons).toEqual(["missing an edge case"]);
+    expect(r!.actionPoints.map((a) => a.title)).toEqual(["handle null input", "add a doc note"]);
+  });
+
+  it("accepts a bare top-level object (no `output` wrapper)", () => {
+    const r = readJudgeVerdict({
+      verdict: "ok",
+      pros: ["a"],
+      cons: ["b"],
+      action_points: [{ title: "t", priority: "P0" }],
+    });
+    expect(r).toEqual({ verdict: "ok", pros: ["a"], cons: ["b"], actionPoints: [{ title: "t", priority: "P0" }] });
+  });
+
+  it("coerces a single-string pros/cons into a one-element list", () => {
+    const r = readJudgeVerdict({ verdict: "v", pros: "just one pro", cons: "just one con" });
+    expect(r!.pros).toEqual(["just one pro"]);
+    expect(r!.cons).toEqual(["just one con"]);
+  });
+
+  it("drops non-string pros/cons entries defensively (never throws)", () => {
+    const r = readJudgeVerdict({ verdict: "v", pros: ["ok", 42, null, { x: 1 }, "two"], cons: [{}, "real"] });
+    expect(r!.pros).toEqual(["ok", "two"]);
+    expect(r!.cons).toEqual(["real"]);
+  });
+
+  it("bounds the verdict prose length and the pros/cons count + per-item length (Security L-2)", () => {
+    const r = readJudgeVerdict({
+      verdict: "x".repeat(MAX_VERDICT_LEN + 5000),
+      pros: Array.from({ length: MAX_PROS_CONS + 25 }, () => "p".repeat(MAX_FIELD_LEN + 500)),
+    });
+    expect(r!.verdict.length).toBe(MAX_VERDICT_LEN);
+    expect(r!.pros.length).toBe(MAX_PROS_CONS); // list capped
+    expect(r!.pros[0].length).toBe(MAX_FIELD_LEN); // each entry clamped
+  });
+
+  it("bounds a huge action-point list (parity with extractActionPoints)", () => {
+    const many = Array.from({ length: 500 }, (_, i) => ({ title: `ap${i}`, priority: "P1" }));
+    const r = readJudgeVerdict({ output: { verdict: "v", action_points: many } });
+    expect(r!.actionPoints.length).toBe(50); // MAX_ACTION_POINTS
+  });
+
+  it("returns null when nothing is parseable (fail-soft) and NEVER throws on garbage", () => {
+    for (const bad of [undefined, null, 42, "a string", [], {}, { output: { convergence: null } }]) {
+      expect(() => readJudgeVerdict(bad)).not.toThrow();
+      expect(readJudgeVerdict(bad)).toBeNull();
+    }
+  });
+
+  it("returns a verdict with empty prose when only action_points are present", () => {
+    const r = readJudgeVerdict({ output: { action_points: [{ title: "t", priority: "P0" }] } });
+    expect(r).not.toBeNull();
+    expect(r!.verdict).toBe("");
+    expect(r!.pros).toEqual([]);
+    expect(r!.actionPoints).toEqual([{ title: "t", priority: "P0" }]);
+  });
+});

--- a/tests/unit/parse-branch-url.test.ts
+++ b/tests/unit/parse-branch-url.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for parseBranchFromUrl — the pure helper backing the "paste a branch
+ * URL / custom ref" affordance on the New consilium review dialog.
+ *
+ * Cases (per the task): a GitHub tree URL, a GitLab `-/tree` URL, a branch with
+ * slashes (release/1.2) via BOTH a URL and a bare ref, a bare-ref passthrough, and
+ * trailing junk (query / hash / trailing slash). Plus empty / whitespace guards.
+ */
+import { describe, it, expect } from "vitest";
+import { parseBranchFromUrl } from "@/components/consilium/parse-branch-url";
+
+describe("parseBranchFromUrl", () => {
+  it("extracts the ref from a GitHub tree URL", () => {
+    expect(parseBranchFromUrl("https://github.com/owner/repo/tree/main")).toBe(
+      "main",
+    );
+  });
+
+  it("extracts the ref from a GitLab `-/tree` URL", () => {
+    expect(
+      parseBranchFromUrl("https://gitlab.com/group/project/-/tree/main"),
+    ).toBe("main");
+  });
+
+  it("preserves a slash-containing ref from a GitHub tree URL", () => {
+    expect(
+      parseBranchFromUrl("https://github.com/owner/repo/tree/release/1.2"),
+    ).toBe("release/1.2");
+  });
+
+  it("preserves a slash-containing ref from a GitLab `-/tree` URL", () => {
+    expect(
+      parseBranchFromUrl("https://gitlab.com/group/project/-/tree/release/1.2"),
+    ).toBe("release/1.2");
+  });
+
+  it("passes a bare slash-containing ref through unchanged", () => {
+    expect(parseBranchFromUrl("release/1.2")).toBe("release/1.2");
+  });
+
+  it("passes a bare simple ref through unchanged", () => {
+    expect(parseBranchFromUrl("main")).toBe("main");
+  });
+
+  it("strips a trailing query string from a tree URL", () => {
+    expect(
+      parseBranchFromUrl("https://github.com/owner/repo/tree/main?tab=readme"),
+    ).toBe("main");
+  });
+
+  it("strips a trailing hash fragment from a tree URL", () => {
+    expect(
+      parseBranchFromUrl("https://github.com/owner/repo/tree/main#section"),
+    ).toBe("main");
+  });
+
+  it("strips a trailing slash from a tree URL", () => {
+    expect(parseBranchFromUrl("https://github.com/owner/repo/tree/main/")).toBe(
+      "main",
+    );
+  });
+
+  it("strips trailing junk while keeping a slash-containing ref", () => {
+    expect(
+      parseBranchFromUrl(
+        "https://gitlab.com/group/project/-/tree/release/1.2?ref_type=heads",
+      ),
+    ).toBe("release/1.2");
+  });
+
+  it("decodes a percent-encoded ref segment", () => {
+    expect(
+      parseBranchFromUrl("https://github.com/owner/repo/tree/feature%2Fauth"),
+    ).toBe("feature/auth");
+  });
+
+  it("trims surrounding whitespace from a bare ref", () => {
+    expect(parseBranchFromUrl("  develop  ")).toBe("develop");
+  });
+
+  it("returns an empty string for empty / whitespace-only input", () => {
+    expect(parseBranchFromUrl("")).toBe("");
+    expect(parseBranchFromUrl("   ")).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Consilium review loops ran a full multi-model debate (primaries + rebuttals + judge) but the loop detail page showed **nothing** — a blank Rounds panel with no error surfaced. This makes the loop the single source of truth for its own result: it fixes the blank page, persists and surfaces the judge's full verdict on the loop itself, and adds two review-dialog UX fixes.

## Root cause — three distinct defects, all producing the same blank page

1. **`stopped_cap` never recorded a round.** The only site constructing the `stopped_cap` transition is the cap-precedence early-exit in `tickInner`, which returns straight from `commit()` and never reaches `runSideEffect` — the only place `recordRound` runs for terminal exits. `decide()` never returns `stopped_cap`, so that `runSideEffect` branch was dead code. Any round-capped, non-converged review recorded **zero** rounds. This is the literal reported repro (a `maxRounds=1` review that ends non-converged).
2. **`recordRound` swallowed every insert error.** `appendLoopRound(...).catch(() => undefined)` silently dropped all failures, so even a real insert error left the page blank with `loop.error` empty — no signal at all.
3. **The judge's rich verdict was never persisted.** The round stored only the convergence summary (`converged` / `openP0` / `openActionPoints`); the judge's prose verdict, pros/cons, and full ranked action-point list had no column, so they could not be shown even when a round existed.

## Changes

**Backend**
- Record the round on the `stopped_cap` CAS winner — the core blank-page fix. CAS-gated so a lost tick records nothing (no multi-instance double-record).
- Narrow `recordRound`'s catch to only the `UNIQUE(loop, round)` conflict (both the Postgres `23505` shape and the in-memory bare-`Error` shape). Every other failure is logged and surfaced to `loop.error` — written only when `loop.error` is empty, so it never clobbers a terminal explanation.
- New nullable `verdict jsonb` column (+ migration `0051`, additive/idempotent `ADD COLUMN IF NOT EXISTS`) carrying the full `RoundVerdict { verdict, pros, cons, actionPoints }`. `readJudgeVerdict()` bounds every field (prose clamp, pros/cons count + per-item caps, full ranked action points) and is fail-soft (returns null, never throws). `recordRound` captures the raw judge output alongside the summary.

**Frontend**
- New `RoundVerdictPanel` on the loop detail page: verdict prose + pros/cons + convergence badge + the full ranked action points grouped by priority. Guarded on null — pre-existing rounds omit the panel without crashing.
- Diff/PR review dialog: the branch dropdown now scrolls (it was clipped by the viewport-height cap), and a "paste a branch URL / ref" affordance was added (`parseBranchFromUrl` extracts the ref from a GitHub/GitLab tree URL or a bare ref).

## Test plan

- **Unit**: `loop-round-persist-failure.test.ts` (silent-failure regression, both error shapes, the four terminal-outcome matrix including the `stopped_cap` repro), `convergence.test.ts` (`readJudgeVerdict` bounds — huge/garbage/nested input), `parse-branch-url.test.ts` (13 cases).
- **Integration**: `loop-review-result-surface.test.ts` (`GET /api/consilium-loops/:id` returns rounds with convergence + verdict, across all three presets).
- **E2E**: `consilium-loop-detail.spec.ts` — **executed against a live Postgres** (2 passed): recorded rounds render with convergence badges + priority-badged action points, and a persist-failure round surfaces `loop.error` instead of a blank page.
- Full unit project **5564 / 0**; consilium + orchestrator + integration **1237 / 1237**. `check` and `build` green. Migration `0051` applied and verified on the dev DB; the judge verdict flows end-to-end through `GET /api/consilium-loops/:id`.

## Security

Reviewed — **APPROVE, no CRITICAL / HIGH**. All new untrusted judge output is bounded (~55 KB max per row); no raw diff, prompt input, or secret can reach `verdict` or `loop.error`; the pasted branch ref passes a four-layer server-side allowlist before git (validated `ref` regex → factory validation → diff-context re-validation → simple-git arg-array with `--end-of-options`, no shell). All verdict fields render as inert React text (no `dangerouslySetInnerHTML`). The narrowed catch cannot silently swallow a permission/FK/check error.

### Known follow-ups (LOW, non-blocking)
- Redact the operator-facing `loop.error` text — a DB connection error could disclose host:port in the authenticated UI (the full message is already server-logged).
- `boundStringList` iterates the full input array before the count cap short-circuits — bounded and non-amplifying.

## Not in this PR

Removing the task-group **execution engine** from the review path (replacing `startGroupAsync` with a direct in-process review runner) is designed and staged as a **separate follow-up PR**, behind a kill-switch. This PR deliberately does not touch the execution mechanism — it makes the loop the single source of truth for its *result* only.
