### PR TITLE
feat(consilium): in-process review runner behind a kill-switch (retire the task-group execution engine from the loop review path)

### DIFF
--- a/client/src/hooks/use-consilium-loops.ts
+++ b/client/src/hooks/use-consilium-loops.ts
@@ -166,6 +166,20 @@ export interface RoundVerdict {
   actionPoints: ActionPoint[];
 }
 
+/**
+ * One debater's turn in a round's dispute — the NEW round-sourced `participants`
+ * jsonb column (Phase 2). Replaces the iteration-sourced transcript for rounds that
+ * carry it; old pre-Phase-2 rounds have no `participants` and fall back to the
+ * task-group iteration view. `role` distinguishes a `primary` argument from a
+ * `rebuttal`. All fields are model-authored → rendered as INERT React text.
+ */
+export interface RoundParticipant {
+  name: string;
+  model: string;
+  role: "primary" | "rebuttal";
+  text: string;
+}
+
 export type ConsiliumLoopRoundDetail = ConsiliumLoopRoundRow & {
   /** The research artifact, on the latest round of a `research` loop only. */
   report?: ResearchReport | null;
@@ -173,6 +187,9 @@ export type ConsiliumLoopRoundDetail = ConsiliumLoopRoundRow & {
   executionTrace?: ExecutionTrace | null;
   /** The FULL judge verdict — see {@link RoundVerdict}. Null on old/backfilled rounds. */
   verdict?: RoundVerdict | null;
+  /** The round-sourced dispute transcript — see {@link RoundParticipant}. Null on
+   *  old pre-Phase-2 rounds (they fall back to the iteration-sourced view). */
+  participants?: RoundParticipant[] | null;
 };
 
 // ─── Composition (Observability GAP 2 — the "who does what" of a round) ───────

--- a/client/src/hooks/use-consilium-loops.ts
+++ b/client/src/hooks/use-consilium-loops.ts
@@ -24,6 +24,7 @@ import type {
   ActionPoint,
   Archetype,
   OpenRemainder,
+  RoundParticipant,
   ResearchReport,
   ResearchClaim,
   ResearchCitation,
@@ -164,20 +165,6 @@ export interface RoundVerdict {
   pros: string[];
   cons: string[];
   actionPoints: ActionPoint[];
-}
-
-/**
- * One debater's turn in a round's dispute — the NEW round-sourced `participants`
- * jsonb column (Phase 2). Replaces the iteration-sourced transcript for rounds that
- * carry it; old pre-Phase-2 rounds have no `participants` and fall back to the
- * task-group iteration view. `role` distinguishes a `primary` argument from a
- * `rebuttal`. All fields are model-authored → rendered as INERT React text.
- */
-export interface RoundParticipant {
-  name: string;
-  model: string;
-  role: "primary" | "rebuttal";
-  text: string;
 }
 
 export type ConsiliumLoopRoundDetail = ConsiliumLoopRoundRow & {

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -66,7 +66,6 @@ import {
   type ConsiliumLoopRoundRow,
   type ConsiliumLoopRoundDetail,
   type RoundVerdict,
-  type RoundParticipant,
   type ConsiliumLoopDetail as ConsiliumLoopDetailRow,
   type DevProgress,
   type ResearchReport,
@@ -120,7 +119,7 @@ import {
 } from "@/components/ui/select";
 import type { ConsiliumLoopState } from "@/hooks/use-consilium-loops";
 import { IterationDetailView } from "@/components/task-groups/iterations-panel";
-import type { ActionPoint, Archetype, OpenRemainder } from "@shared/types";
+import type { ActionPoint, Archetype, OpenRemainder, RoundParticipant } from "@shared/types";
 import { ARCHETYPES } from "@shared/types";
 import { summarizeNonP0Remainder } from "@shared/consilium-remainder";
 import {

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -757,9 +757,10 @@ function RoundParticipantsView({
               {p.role}
             </Badge>
           </div>
-          {/* INERT model-authored transcript text */}
+          {/* INERT model-authored transcript text. Capped with a max-height +
+              scroll so a long review stays a bounded card instead of a wall. */}
           {p.text && p.text.trim() !== "" && (
-            <p className="whitespace-pre-wrap break-words text-xs text-foreground/80">
+            <p className="max-h-64 overflow-y-auto whitespace-pre-wrap break-words text-xs text-foreground/80">
               {p.text}
             </p>
           )}

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -66,6 +66,7 @@ import {
   type ConsiliumLoopRoundRow,
   type ConsiliumLoopRoundDetail,
   type RoundVerdict,
+  type RoundParticipant,
   type ConsiliumLoopDetail as ConsiliumLoopDetailRow,
   type DevProgress,
   type ResearchReport,
@@ -718,6 +719,56 @@ function RoundVerdictPanel({
   );
 }
 
+// ─── Round-sourced dispute transcript (Phase 2, F1) ─────────────────────────────
+//
+// The NEW round-sourced dispute view: one card per debater turn from the round's
+// `participants` column (name / model / role + text). It REPLACES the
+// iteration-sourced IterationDetailView for rounds that carry `participants`; old
+// pre-Phase-2 rounds have none and fall back to that view. This path is READ-ONLY
+// (the human-note editor stays on the iteration fallback).
+//
+// SECURITY: `name`, `model`, and `text` are model-authored → rendered as INERT
+// React text (never HTML, never a link/attribute sink). `role` is a fixed union.
+function RoundParticipantsView({
+  participants,
+}: {
+  participants: RoundParticipant[];
+}) {
+  return (
+    <div className="space-y-2" data-testid="loop-dispute-participants">
+      {participants.map((p, i) => (
+        <div
+          key={i}
+          className="space-y-1 rounded-md border border-border/60 p-2"
+          data-testid="loop-participant"
+          data-role={p.role}
+        >
+          <div className="flex flex-wrap items-center gap-1.5 text-xs">
+            <Users className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+            {/* INERT model-authored debater name */}
+            <span className="font-medium">{p.name || "—"}</span>
+            {p.model && (
+              <span className="font-mono text-[11px] text-muted-foreground">{p.model}</span>
+            )}
+            <Badge
+              variant={p.role === "rebuttal" ? "outline" : "secondary"}
+              className="text-[10px] py-0"
+            >
+              {p.role}
+            </Badge>
+          </div>
+          {/* INERT model-authored transcript text */}
+          {p.text && p.text.trim() !== "" && (
+            <p className="whitespace-pre-wrap break-words text-xs text-foreground/80">
+              {p.text}
+            </p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 // ─── Rounds table ─────────────────────────────────────────────────────────────
 
 function RoundRow({
@@ -742,7 +793,13 @@ function RoundRow({
   // group). Its DISPUTE — the debaters' + judge's executions plus the human-note
   // editor — lives ON the round now (the standalone Task Groups page is retired)
   // and is fetched LAZILY only when the operator opens this section.
-  const canShowDispute = !!groupId;
+  // Dispute transcript — Phase 2 prefers the round-sourced `participants`; old
+  // pre-Phase-2 rounds have none and fall back to the iteration-sourced view.
+  const participants: RoundParticipant[] = Array.isArray(round.participants)
+    ? round.participants
+    : [];
+  const hasParticipants = participants.length > 0;
+  const canShowDispute = hasParticipants || !!groupId;
   // The FULL judge verdict (new `verdict` col) — null on old/backfilled rounds.
   // Its presence makes the row expandable even when there are no open APs / trace.
   const hasVerdict = round.verdict != null;
@@ -865,10 +922,12 @@ function RoundRow({
               <p className="text-[11px] text-muted-foreground/70">{PRIORITY_LEGEND}</p>
                 </div>
               )}
-              {/* Dispute — the consilium debate behind this round: each
-                  participant's execution + the judge, plus the human-note editor
-                  whose text flows into the NEXT round's dispute context. Mounted
-                  (and fetched) only when opened, so the loop page stays light. */}
+              {/* Dispute — the consilium debate behind this round. Phase 2 (F1):
+                  a round-sourced `participants` transcript is preferred; old
+                  pre-Phase-2 rounds fall back to the iteration-sourced
+                  IterationDetailView (which also hosts the human-note editor whose
+                  text flows into the NEXT round). Mounted (and fetched, in the
+                  fallback) only when opened, so the loop page stays light. */}
               {canShowDispute && (
                 <div className="space-y-1.5">
                   <button
@@ -883,14 +942,19 @@ function RoundRow({
                       <ChevronRight className="h-3.5 w-3.5" />
                     )}
                     <Gavel className="h-3.5 w-3.5" />
-                    Dispute (iteration #{round.iterationNumber})
+                    {hasParticipants
+                      ? "Dispute"
+                      : `Dispute (iteration #${round.iterationNumber})`}
                   </button>
-                  {disputeOpen && (
-                    <IterationDetailView
-                      groupId={groupId}
-                      iterationNumber={round.iterationNumber}
-                    />
-                  )}
+                  {disputeOpen &&
+                    (hasParticipants ? (
+                      <RoundParticipantsView participants={participants} />
+                    ) : groupId ? (
+                      <IterationDetailView
+                        groupId={groupId}
+                        iterationNumber={round.iterationNumber}
+                      />
+                    ) : null)}
                 </div>
               )}
             </div>

--- a/migrations/0052_consilium_loop_rounds_participants.sql
+++ b/migrations/0052_consilium_loop_rounds_participants.sql
@@ -1,0 +1,21 @@
+-- migration: 0052_consilium_loop_rounds_participants
+-- The review participants for a consilium round (Phase 2 — direct review-runner).
+--
+-- consilium_loop_rounds.participants → new JSONB (nullable).
+--   The round's review contributions, shape:
+--     [{ name: string, model: string, role: 'primary' | 'rebuttal', text: string }]
+--   The primary reviewers and their rebuttals, each with the seat name, the model
+--   that filled it, the role, and the human-readable review prose. Bounded before
+--   write (count + per-text clamp, Security L-2, same as verdict) and rendered as
+--   INERT text on the client (RoundParticipant). NEVER the raw diff / prompt input
+--   (H-4). NULL for every pre-existing round (no backfill) and for any round run via
+--   the legacy task-group path — every consumer guards on NULL before reading it.
+--
+-- Additive + idempotent (ADD COLUMN IF NOT EXISTS): metadata-only, no rewrite, no
+-- data loss. Re-applying against a push-managed dev DB is safe.
+
+ALTER TABLE consilium_loop_rounds
+  ADD COLUMN IF NOT EXISTS participants jsonb;
+
+-- Rollback:
+--   ALTER TABLE consilium_loop_rounds DROP COLUMN participants;

--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -427,6 +427,20 @@ export const ConfigSchema = z.object({
         maxRepoMapBytes: z.coerce.number().int().min(512).max(200_000).default(6_000),
       }).default({}),
       /**
+       * Phase 2 (defect-B): run the per-round review via the DIRECT in-process
+       * review-runner (`review-runner.ts`) instead of the task-group
+       * `startGroupAsync` engine. Default OFF ⇒ BYTE-IDENTICAL to today: the review
+       * dispatches through startGroupAsync and mints a task_group iteration exactly as
+       * before. When ON, entering `reviewing` dispatches a background direct review
+       * (reviewRuns registry, no iteration); the read path keys off the ROUND's actual
+       * mode, so a round started under one mode is always read back under it (a
+       * mid-flight flip never mis-reads an in-flight round). Ships dark.
+       */
+      directReview: z.object({
+        /** Kill-switch: false (default) → the legacy task-group review path (byte-identical). */
+        enabled: z.boolean().default(false),
+      }).default({}),
+      /**
        * Hard wall-clock timeout PER action-point SDLC coder run (ms). The SDLC
        * executor runs the agentic coder once per action point sequentially in one
        * worktree, so this bounds a SINGLE action point, not the whole round.

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -1309,11 +1309,19 @@ export class ConsiliumLoopController {
 
   /**
    * SERVER-READ the FULL action-point list (ALL priorities) from the loop's
-   * current iteration's judge verdict, via `pickJudgeOutput`→`extractActionPoints`
-   * (the SAME server-read path the removed execute-sdlc button used). Returns `[]`
-   * for a missing iteration / unparseable verdict (→ NO_ACTION_POINTS).
+   * current round's judge verdict. STRADDLE (Phase 2 B6) keyed off the round's ACTUAL
+   * mode (NOT the live flag): a RUNNER round's full ranked list is the persisted
+   * `RoundVerdict.actionPoints` (written via the SHARED `readJudgeVerdict`) — runner
+   * rounds have NO executions. Else the UNCHANGED old path: `pickJudgeOutput`→
+   * `extractActionPoints` off the iteration executions (the SAME server-read path the
+   * removed execute-sdlc button used). Returns `[]` for a missing round/iteration /
+   * unparseable verdict (→ NO_ACTION_POINTS).
    */
   private async resolveDevActionPoints(loop: ConsiliumLoopRow): Promise<ActionPoint[]> {
+    if (loop.currentIterationNumber == null) {
+      const round = await this.currentRoundRow(loop);
+      if (this.isRunnerRound(round)) return round.verdict?.actionPoints ?? [];
+    }
     const n = loop.currentIterationNumber;
     if (n == null) return [];
     const iteration = await this.storage.getIteration(loop.groupId, n);
@@ -1792,8 +1800,16 @@ export class ConsiliumLoopController {
     const verdict = await this.resolveVerdict(loop);
     if (!verdict) return null;
     const rounds = await this.storage.getLoopRounds(loop.id);
-    const priorOpenP0 = rounds.map((r) => r.openP0 ?? 0);
-    priorOpenP0.push(verdict.openP0); // include the round just decided
+    // B6 guard (Phase 2): build the prior series from rounds STRICTLY BEFORE the current
+    // round, then push the FRESH verdict. A RUNNER round records its row EARLY (at
+    // reviewing→deciding), so `rounds` already contains round N here — the `< loop.round`
+    // filter excludes that early row; without it round N is counted twice, corrupting BOTH
+    // isAntiStall's 3-window (a duplicate tail ⇒ spurious `escalated`) AND `decide()`'s
+    // `round = priorOpenP0.length`. Byte-identical for legacy: the current round is NOT
+    // recorded during its own deciding (recorded later at deciding→X), so the filter drops
+    // nothing and this equals the prior `rounds.map(...).push(verdict.openP0)`.
+    const priorOpenP0 = rounds.filter((r) => r.round < loop.round).map((r) => r.openP0 ?? 0);
+    priorOpenP0.push(verdict.openP0); // include the round just decided (fresh)
     return { kind: "decided", verdict, priorOpenP0 };
   }
 
@@ -2800,8 +2816,58 @@ export class ConsiliumLoopController {
     }
   }
 
-  /** Resolve the judge convergence verdict for the loop's current iteration. */
+  /**
+   * The recorded round row for the loop's CURRENT round, or undefined — the STRADDLE
+   * anchor for {@link resolveVerdict} / {@link resolveDevActionPoints} (Phase 2 B6).
+   */
+  private async currentRoundRow(loop: ConsiliumLoopRow): Promise<ConsiliumLoopRoundRow | undefined> {
+    try {
+      const rounds = await this.storage.getLoopRounds(loop.id);
+      return rounds.find((r) => r.round === loop.round);
+    } catch {
+      // Best-effort straddle anchor (same discipline as buildPriorFindings /
+      // latestRoundTestSummary): a getLoopRounds failure degrades to the OLD path rather
+      // than crashing a tick/plan/develop — the round-row read is never load-bearing enough
+      // to abort on.
+      return undefined;
+    }
+  }
+
+  /**
+   * True when the loop's current round was produced by the DIRECT RUNNER — the STRADDLE
+   * discriminator, keyed off the round's ACTUAL mode, NEVER the live directReview flag.
+   *
+   * Keyed on `participants` (non-null): the runner ALWAYS writes the array — even EMPTY
+   * for a single-verifier round — whereas the legacy task-group path ALWAYS leaves it null.
+   * `verdict` is NOT a discriminator: the legacy path writes it too (via `readJudgeVerdict`
+   * off the iteration executions), so a legacy round with a readable judge output carries a
+   * non-null `verdict`. `!= null` (loose) also treats an absent field (undefined, e.g. a
+   * legacy fake round row) as legacy.
+   */
+  private isRunnerRound(round: ConsiliumLoopRoundRow | undefined): round is ConsiliumLoopRoundRow {
+    return round != null && round.participants != null;
+  }
+
+  /**
+   * Resolve the judge convergence verdict for the loop's current round. STRADDLE
+   * (Phase 2 B6): a RUNNER round has NO task executions — its convergence was persisted on
+   * the round row by `recordRound` via the SHARED `readConvergence`, so read it straight
+   * back (no private re-parse). The round-row probe fires ONLY under the runner marker
+   * (`currentIterationNumber == null`), so a legacy loop (iteration set) skips it entirely
+   * and its path is byte-identical (never a getLoopRounds read). Else the UNCHANGED old
+   * path: the injected `readIterationVerdict` seam first, then the iteration executions.
+   */
   private async resolveVerdict(loop: ConsiliumLoopRow): Promise<ConvergenceVerdict | null> {
+    if (loop.currentIterationNumber == null) {
+      const round = await this.currentRoundRow(loop);
+      if (this.isRunnerRound(round)) {
+        return {
+          converged: round.converged ?? false,
+          openP0: round.openP0 ?? 0,
+          openActionPoints: round.openActionPoints ?? [],
+        };
+      }
+    }
     if (this.deps.readIterationVerdict) return this.deps.readIterationVerdict(loop);
     const judgeOutput = await this.resolveJudgeOutput(loop);
     if (judgeOutput === undefined) return null;

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -2785,14 +2785,18 @@ export class ConsiliumLoopController {
       // detail page shows it — but NEVER rethrow: the FSM state transition already
       // committed and must not be undone by a best-effort audit write. The nested
       // catch keeps recordRound total even if the error-persist itself fails.
-      this.log(loop.id, `recordRound: appendLoopRound failed for round ${loop.round}: ${message}`);
+      // Security L1: the raw exception `message` goes to the LOGS ONLY, scrubbed (fs
+      // paths stripped) — a model/exception-derived string must never reach the
+      // PERSISTED, UI-rendered `loop.error`.
+      this.log(loop.id, `recordRound: appendLoopRound failed for round ${loop.round}: ${scrubErr(message)}`);
       // Write ONLY when the (committed) row's error is still empty — `loop` is the
       // post-commit `won` row at every call site, so this is the freshest value.
       // Never clobber a terminal explanation the transition itself just set (e.g. a
-      // cancel note); the log line above records the audit failure regardless.
+      // cancel note). Security L1: a FIXED GENERIC — the scrubbed detail is in the log
+      // above, never on the row (which the loop detail page renders verbatim).
       if (!loop.error) {
         await this.storage
-          .updateLoop(loop.id, { error: `round ${loop.round} audit write failed: ${message}` })
+          .updateLoop(loop.id, { error: `round ${loop.round} audit write failed` })
           .catch(() => undefined);
       }
     }

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -2155,7 +2155,13 @@ export class ConsiliumLoopController {
         `startReviewRound${opts?.relaunch ? " (relaunch)" : ""} -> dispatchReview (runner) round ${nextRound}`,
       );
       this.dispatchReview({ ...loop, round: nextRound });
-      return { round: nextRound, openP0: null };
+      // EXPLICIT null (not omit): a round run earlier on the OLD path persisted a real
+      // currentIterationNumber; after the flag flips ON, the runner-mode extra must CLEAR
+      // it so the row's sole in-flight marker is the reviewRuns entry. Omitting the field
+      // would leave the stale non-null value — and on a crash (registry lost) the null-ref
+      // stranded check would read FALSE (round stuck, never redriven) and the straddle's
+      // getIteration(stale) would misclassify the runner round as old-path.
+      return { round: nextRound, openP0: null, currentIterationNumber: null };
     }
     const group = await this.storage.getTaskGroup(loop.groupId);
     const objective = group?.input ?? "";

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -484,6 +484,15 @@ function degradedReviewResult(error: string): ReviewRunResult {
 }
 
 /**
+ * Security L1: the FIXED GENERIC explanation surfaced to `consilium_loops.error`
+ * when a runner-mode review DEGRADES (gateway/model/parse failure). The raw scrubbed
+ * detail (`ReviewRunResult.error`) is logged only — a model/exception-derived string
+ * must never reach the persisted, UI-rendered `loop.error`. Per-site fixed string
+ * (the peer of the other curated terminal explanations), NOT the raw reason.
+ */
+const REVIEW_RUN_FAILED = "review run failed";
+
+/**
  * Decide whether the open-P0 count failed to decrease across two consecutive
  * rounds (design §3 anti-stall). `series` is the per-round openP0 history,
  * oldest→newest, INCLUDING the round just decided.
@@ -1725,8 +1734,44 @@ export class ConsiliumLoopController {
     }
   }
 
-  /** REVIEWING: poll the consilium iteration; settle → completed/failed. */
+  /**
+   * REVIEWING → the next FSM event. Runner-mode (Phase 2 B5) and the legacy task-group
+   * iteration STRADDLE here, keyed off the ROUND's ACTUAL mode — a `reviewRuns` entry
+   * FOR THIS round (set by `dispatchReview` when the round entered reviewing under the
+   * runner) — NOT the live `directReview` flag (inv #5): a round dispatched under one
+   * mode is always read back under it, even across a mid-flight flip.
+   *
+   * Runner-mode: read the settled background review (mirrors `deriveDevEvent`). In-flight
+   * ⇒ null (wait). Settled+error ⇒ `review_failed` carrying the FIXED-GENERIC reason —
+   * the raw scrubbed detail goes to the LOGS only (Security L1; a model/exception-derived
+   * string must never land on the UI-rendered `loop.error`). Settled+clean ⇒
+   * `review_completed` with the runner's convergence (already computed via the SHARED
+   * readConvergence/readJudgeVerdict INSIDE the runner — no private re-parse, inv #2). The
+   * round audit (verdict + participants) is persisted on the CAS winner in `runSideEffect`,
+   * and the consumed entry dropped there (keeping this derive a pure read like deriveDevEvent).
+   *
+   * Legacy mode (no runner entry for this round): the UNCHANGED consilium-iteration poll.
+   */
   private async deriveReviewEvent(loop: ConsiliumLoopRow): Promise<LoopEvent | null> {
+    const run = this.reviewRuns.get(loop.id);
+    if (run && run.round === loop.round) {
+      if (!run.done || !run.result) return null; // in-flight ⇒ wait (no transition yet)
+      const result = run.result;
+      if (result.error) {
+        // L1: raw scrubbed detail → LOGS only; `loop.error` gets the fixed generic.
+        this.log(loop.id, `review run degraded (round ${loop.round}): ${result.error}`);
+        return { kind: "review_failed", error: REVIEW_RUN_FAILED };
+      }
+      return {
+        kind: "review_completed",
+        verdict: {
+          converged: result.converged,
+          openP0: result.openP0,
+          openActionPoints: result.openActionPoints,
+        },
+      };
+    }
+    // Legacy iteration path (byte-identical — no runner entry keyed to this round).
     const n = loop.currentIterationNumber;
     if (n == null) return null;
     const iteration = await this.storage.getIteration(loop.groupId, n);
@@ -1793,6 +1838,28 @@ export class ConsiliumLoopController {
         return {};
       }
       return extra;
+    }
+    // Phase 2 (B5) runner-mode: a reviewing→(deciding|failed) transition driven by a
+    // settled `reviewRuns` entry records the round audit HERE — on the CAS WINNER,
+    // single-flight — threading the runner's ALREADY-parsed judge verdict + participants
+    // (runner-mode has NO task executions the DECIDING recordRound could re-read; that
+    // later 2-arg recordRound(round) re-append hits the idempotent UNIQUE no-op, so THIS
+    // rich row wins). The consumed entry is then dropped. A DEGRADED settle
+    // (review_failed) records NO round — mirroring a failed legacy iteration — but still
+    // drops the entry. INERT in legacy mode: `reviewRuns` is empty (dispatchReview never
+    // ran), so this returns `{}` exactly like the prior fall-through ⇒ byte-identical.
+    if (transition.from === "reviewing") {
+      const run = this.reviewRuns.get(loop.id);
+      if (run && run.round === loop.round && run.done && run.result) {
+        if (event.kind === "review_completed" && !run.result.error) {
+          await this.recordRound(loop, event.verdict, {
+            verdict: run.result.verdict,
+            participants: run.result.participants,
+          });
+        }
+        this.reviewRuns.delete(loop.id);
+      }
+      return {};
     }
     if (transition.to === "developing" && event.kind === "decided") {
       return this.startDevHandoff(loop, event.verdict);
@@ -2650,13 +2717,24 @@ export class ConsiliumLoopController {
    * FSM transition. Fail-OPEN on state (never rethrow — the transition already
    * committed), fail-LOUD on the audit write.
    */
-  private async recordRound(loop: ConsiliumLoopRow, verdict: ConvergenceVerdict): Promise<void> {
+  private async recordRound(
+    loop: ConsiliumLoopRow,
+    verdict: ConvergenceVerdict,
+    runnerAudit?: { verdict: RoundVerdict | null; participants: RoundParticipant[] | null },
+  ): Promise<void> {
     const head = await this.readRepoHead(loop);
     // Rich judge verdict for the Rounds panel (best-effort, bounded, never blocks the
     // audit write — null when the raw judge output is unreadable). Read from the RAW
     // judge output, NOT reconstructed from the ConvergenceVerdict, so the prose /
     // pros / cons / full ranked action points survive.
-    const judgeVerdict = await this.readRoundVerdict(loop);
+    //
+    // Phase 2 (B5) runner-mode threads the ALREADY-parsed verdict + participants: a
+    // runner round has NO task executions for `readRoundVerdict` to re-read, and the
+    // legacy task-group path never captured participants. Legacy (no `runnerAudit`):
+    // read the verdict from the iteration executions as before and leave participants
+    // NULL (the column defaults null) ⇒ the persisted row is byte-identical to today.
+    const judgeVerdict = runnerAudit ? runnerAudit.verdict : await this.readRoundVerdict(loop);
+    const participants = runnerAudit?.participants ?? null;
     try {
       await this.storage.appendLoopRound({
         loopId: loop.id,
@@ -2666,6 +2744,7 @@ export class ConsiliumLoopController {
         openP0: verdict.openP0,
         openActionPoints: verdict.openActionPoints,
         verdict: judgeVerdict,
+        participants,
         baselineCommit: loop.lastReviewedCommit,
         headCommit: head,
       });

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -72,7 +72,9 @@ import {
 } from "./experience/experience-reader.js";
 import { assertAllowedRepoPath } from "./repo-allowlist.js";
 import { buildBranchName } from "./pr-wrapper.js";
-import { assertRepoIsProjectWorkspace, backtickFence, stripControlMultiline, buildSingleVerifierTask, VERIFIER_TASK_NAME } from "./review-factory.js";
+import { assertRepoIsProjectWorkspace, backtickFence, stripControlMultiline, buildSingleVerifierTask, VERIFIER_TASK_NAME, buildCrossReviewTasks, PRESET_PANELS, JUDGE_TASK_NAME } from "./review-factory.js";
+import { parseConsiliumPreset } from "./composition.js";
+import { runReviewTasks } from "./review-runner.js";
 
 // ─── FSM events (design §3 "Event / guard" column) ──────────────────────────
 
@@ -1490,6 +1492,22 @@ export class ConsiliumLoopController {
       }
     }
 
+    // Phase 2 (B4) — the reviewing peer of the developing gate above. A runner review
+    // ALWAYS keeps currentIterationNumber NULL, so the null-ref check treats it as
+    // stranded; the `reviewRuns` registry is AUTHORITATIVE — an entry for this
+    // loop+round means NOT stranded (in-flight ⇒ wait; settled ⇒ deriveReviewEvent
+    // advances it). Re-dispatch ONLY when the registry has NO entry (a genuine
+    // crash/restart that lost it), gated by the grace + claimRedrive below — exactly
+    // the developing discipline. INERT in legacy mode: reviewRuns is empty (dispatchReview
+    // never ran), so this never fires and the legacy stranded-review redrive runs unchanged.
+    if (loop.state === "reviewing") {
+      const run = this.reviewRuns.get(loop.id);
+      if (run && run.round === loop.round) {
+        this.log(loop.id, `reviewing has a registered review run (round ${run.round}, done=${run.done}) — not stranded, no re-drive`);
+        return null;
+      }
+    }
+
     const ageMs = Date.now() - new Date(loop.updatedAt).getTime();
     if (ageMs < this.redriveGraceMs(loop.state)) {
       this.log(loop.id, `null child ref in ${loop.state} but within grace (${ageMs}ms) — assume in-flight, no re-drive`);
@@ -2124,6 +2142,21 @@ export class ConsiliumLoopController {
     opts?: { relaunch?: boolean },
   ): Promise<Record<string, unknown>> {
     const cfg = this.loopConfig();
+    // Phase 2 (B4) runner-mode: dispatch a background DIRECT review (no task_group
+    // iteration) and return immediately. `dispatchReview` keys the reviewRuns entry off
+    // the round the review is FOR (nextRound); the runner (`runReviewFromLoop`) rebuilds
+    // the review context + DAG from the loop. currentIterationNumber stays NULL (the
+    // marker) — the reviewRuns entry is the sole in-flight signal. Flag OFF ⇒ the legacy
+    // startGroupAsync path below runs UNCHANGED (byte-identical parity).
+    if (cfg.directReview?.enabled) {
+      const nextRound = opts?.relaunch ? loop.round : loop.round + 1;
+      this.log(
+        loop.id,
+        `startReviewRound${opts?.relaunch ? " (relaunch)" : ""} -> dispatchReview (runner) round ${nextRound}`,
+      );
+      this.dispatchReview({ ...loop, round: nextRound });
+      return { round: nextRound, openP0: null };
+    }
     const group = await this.storage.getTaskGroup(loop.groupId);
     const objective = group?.input ?? "";
     // Enh1: for every review AFTER the first (loop.round >= 1), inject the prior
@@ -2454,13 +2487,10 @@ export class ConsiliumLoopController {
   private dispatchReview(loop: ConsiliumLoopRow): void {
     const run: ReviewRun = { round: loop.round, done: false };
     this.reviewRuns.set(loop.id, run);
-    const runner = this.deps.runReview;
-    if (!runner) {
-      // Round-1 isolation: the real review-runner.ts is not wired yet (B2). Settle a
-      // degraded result rather than leave the entry in-flight forever.
-      this.settleReviewRun(loop.id, run, degradedReviewResult("no review runner configured"));
-      return;
-    }
+    // Default runner (production) rebuilds the review context + DAG from the loop and
+    // runs it directly via `runReviewFromLoop` (mirrors how `closeout` rebuilds the SDLC
+    // context); tests inject `deps.runReview` (a fake) to bypass the gateway/model.
+    const runner = this.deps.runReview ?? ((l: ConsiliumLoopRow) => this.runReviewFromLoop(l));
     void runner(loop)
       .then((result) => this.settleReviewRun(loop.id, run, result))
       .catch((err: unknown) =>
@@ -2498,6 +2528,64 @@ export class ConsiliumLoopController {
     }
     run.result = result;
     run.done = true;
+  }
+
+  /**
+   * Default runner-mode review executor (Phase 2 B4): rebuilds the review context +
+   * DAG from the loop — objective, prior findings, test summary, repo map, diff
+   * context (the SAME inputs `startReviewRound`'s legacy path assembles), then the
+   * cross-review DAG (or the lone single-verifier for round > 1) — and runs it via
+   * `runReviewTasks`. Mirrors `closeout` rebuilding the SDLC context from the loop
+   * (not a caller hand-off). NEVER throws: a missing gateway or an unbuildable diff
+   * context (incl. an unresolved ref) settles a degraded {error} — the loop then
+   * fails closed via `review_failed` (fail-closed, exception-derived per L1; the
+   * curated failUnresolvedReview reason is a legacy-path nicety, tracked as a
+   * follow-up). `deps.runReview` bypasses this entirely in tests.
+   */
+  private async runReviewFromLoop(loop: ConsiliumLoopRow): Promise<ReviewRunResult> {
+    const gateway = this.deps.gateway;
+    if (!gateway) return degradedReviewResult("no review gateway configured");
+    const cfg = this.loopConfig();
+    const group = await this.storage.getTaskGroup(loop.groupId);
+    const objective = group?.input ?? "";
+    const priorFindings =
+      loop.round >= 1 ? await this.buildPriorFindings(loop, cfg.maxDiffBytes) : undefined;
+    const testSummary =
+      effectiveVerificationEnabled(this.deps.config()) || this.researchImplementEnabled()
+        ? await this.latestRoundTestSummary(loop)
+        : undefined;
+    const repoMap = await this.buildReviewRepoMap(loop, cfg);
+    const ctx = await buildDiffContext({
+      repoPath: loop.repoPath,
+      baselineCommit: loop.lastReviewedCommit,
+      ref: loop.reviewRef,
+      objective,
+      allowedRepoPaths: cfg.allowedRepoPaths,
+      maxDiffBytes: cfg.maxDiffBytes,
+      priorFindings,
+      testSummary,
+      repoMap,
+    });
+    if (!ctx.ok) return degradedReviewResult(ctx.message);
+    // Panel from the group's preset (recovered from the group NAME — the SAME source
+    // the task-group setup used), falling back to the sdlc-cross-review default panel.
+    const preset = parseConsiliumPreset(group?.name);
+    const panel = (preset && PRESET_PANELS[preset]) || PRESET_PANELS["sdlc-cross-review"];
+    // Single-verifier re-review (round > 1 ONLY) mirrors startReviewRound's swap.
+    const reviewMode = resolveReviewMode(loop.reviewMode, cfg.verifyReview?.enabled ?? false);
+    const singleVerifier = loop.round > 1 && reviewMode === "single-verifier";
+    const tasks = singleVerifier
+      ? [buildSingleVerifierTask({ model: cfg.verifyReview?.model ?? "claude-opus", priorFindings })]
+      : buildCrossReviewTasks(panel);
+    const judgeTaskName = singleVerifier ? VERIFIER_TASK_NAME : JUDGE_TASK_NAME;
+    return runReviewTasks({
+      tasks,
+      judgeTaskName,
+      groupName: group?.name ?? "",
+      groupInput: ctx.input,
+      gateway,
+      timeoutMs: this.deps.config().pipeline.taskGroups.taskTimeoutMs,
+    });
   }
 
   /**

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -409,6 +409,21 @@ const SDLC_DEV_MAX_ACTION_POINTS = 24;
 export const SDLC_DEV_REDRIVE_GRACE_MS = SDLC_DEV_GRACE_MS * SDLC_DEV_MAX_ACTION_POINTS;
 
 /**
+ * M-1 (Security MEDIUM): the number of SEQUENTIAL waves a runner review executes — the
+ * cross-review DAG runs primaries∥ → rebuttals∥ → judge, each wave bounded by the per-call
+ * `taskTimeoutMs`. The reviewing redrive grace is sized to a WHOLE runner review
+ * (`taskTimeoutMs × REVIEW_RUNNER_WAVES`) — the reviewing peer of {@link SDLC_DEV_REDRIVE_GRACE_MS}.
+ * A runner review keeps `currentIterationNumber` NULL, so the null-ref stranded check treats it
+ * as stranded; cross-instance, another instance holds NO local `reviewRuns` entry and would
+ * otherwise redrive a LIVE multi-wave review at the bare ~30s base (duplicate model spend +
+ * round-counter inflation + a redrive storm). Governs ONLY the registry-empty (cross-instance /
+ * cross-restart) case — the in-process `reviewRuns` registry is the authoritative same-instance
+ * guard — so erring toward a full-review span is safe. A single-verifier round is ONE wave, well
+ * under this bound.
+ */
+export const REVIEW_RUNNER_WAVES = 3;
+
+/**
  * R1 — process GLOBAL ceiling on simultaneously in-flight HUMAN-triggered dev
  * handoffs (`controller.develop`). Each spawns a real agentic coder + worktree,
  * so the human surface must be bounded just as the removed execute-sdlc path was
@@ -895,7 +910,32 @@ export class ConsiliumLoopController {
     // governs the registry-empty (cross-restart) case; the authoritative
     // in-process guard is the `sdlcRuns` registry consulted in redriveStranded.
     if (state === "developing") return Math.max(base, SDLC_DEV_REDRIVE_GRACE_MS);
+    // M-1: a RUNNER review keeps currentIterationNumber NULL (⇒ nullRef true), so — like
+    // developing — its TIME fallback must cover a WHOLE multi-wave review, not the bare base,
+    // or a cross-instance poller (no local reviewRuns entry) redrives a LIVE review (duplicate
+    // model spend + round-counter inflation + a redrive storm). Sized to the 3-wave cross-review
+    // DAG at the configured per-call timeout.
+    //
+    // GATED on the runner kill-switch to KEEP FLAG-OFF PARITY: under the legacy path a review
+    // mints an iteration (currentIterationNumber SET ⇒ nullRef false ⇒ never reaches here) EXCEPT
+    // in the sub-second crash window before the child-ref write, which the legacy crash-redrive
+    // must recover at the SHORT base grace (unchanged). So only when the runner is enabled do we
+    // extend the reviewing grace. Trade-off: a mid-flight flip to OFF reverts a live runner review
+    // to the base grace, so a cross-instance poller could redrive it ONCE as legacy — one round of
+    // duplicate spend, but the round row stays single (UNIQUE(loop,round)) and the FSM advances
+    // once (CAS), so no loop is stranded or misread (the settle READS still key off the round's
+    // actual mode, never the flag — inv #5).
+    if (state === "reviewing" && this.directReviewEnabled()) {
+      const taskTimeoutMs = this.deps.config().pipeline.taskGroups?.taskTimeoutMs ?? 600_000;
+      return Math.max(base, taskTimeoutMs * REVIEW_RUNNER_WAVES);
+    }
     return base;
+  }
+
+  /** M-1: the runner kill-switch, read live — gates ONLY the reviewing redrive grace sizing
+   *  (the settle/verdict READS never consult it — they key off the round's actual mode). */
+  private directReviewEnabled(): boolean {
+    return this.loopConfig().directReview?.enabled ?? false;
   }
 
   /** Begin round 1. 409s (returns null) unless the loop is PENDING. */

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -52,7 +52,7 @@ import { runAsSystem, runAsProject } from "../../context.js";
 import type { ConsiliumLoopRow, ConsiliumLoopRoundRow, ConsiliumLoopState, TaskGroupIterationRow, InsertTask } from "@shared/schema";
 import { ARCHETYPES } from "@shared/types";
 import type { Archetype } from "@shared/types";
-import type { ActionPoint, ConvergenceVerdict, RoundVerdict, ReviewMode } from "@shared/types";
+import type { ActionPoint, ConvergenceVerdict, RoundVerdict, RoundParticipant, ReviewMode } from "@shared/types";
 import { P0_PRIORITY } from "@shared/types";
 import type { TaskOrchestrator } from "../task-orchestrator.js";
 import type { AppConfig } from "../../config/schema.js";
@@ -436,9 +436,49 @@ interface SdlcRun {
   viaCommand?: boolean;
 }
 
+/**
+ * The settled result of a direct review run (Phase 2, mirrors DevCloseoutResult).
+ * Carries BOTH the FSM-facing convergence (converged/openP0/openActionPoints — what
+ * `deriveReviewEvent` reduces on) AND the rich round-audit payload (verdict +
+ * participants — what recordRound persists). A DEGRADED run (gateway/model failure)
+ * settles with `error` set + `verdict`/`participants` NULL + a conservative
+ * NOT-CONVERGED convergence, exactly like a no-PR degraded SDLC close-out.
+ */
+export interface ReviewRunResult {
+  converged: boolean;
+  openP0: number;
+  openActionPoints: ActionPoint[];
+  verdict: RoundVerdict | null;
+  participants: RoundParticipant[] | null;
+  error?: string;
+}
+
+/**
+ * H-2 (Phase 2): process-local registry entry for an in-flight/settled BACKGROUND
+ * review run, keyed by loopId — the direct-review peer of {@link SdlcRun}. The
+ * review-runner runs OFF the tick path (N LLM calls, ~minutes), so a tick never
+ * blocks the poller; `deriveReviewEvent` reads the settled result here (Round-2 B5)
+ * and `reviewRuns` is the AUTHORITATIVE in-flight gate for the reviewing redrive
+ * (Round-2 B4) — exactly as `sdlcRuns` is for developing.
+ */
+interface ReviewRun {
+  round: number;
+  done: boolean;
+  result?: ReviewRunResult;
+}
+
 /** Minimal error scrub (strip fs paths) for the background-run catch. */
 function scrubErr(raw: string): string {
   return raw.replace(/\/[^\s'"]+/g, "<path>").replace(/\s+/g, " ").trim().slice(0, 200);
+}
+
+/**
+ * A DEGRADED (errored) review settle (Phase 2): a conservative NOT-CONVERGED
+ * convergence + NO verdict/participants to render, carrying the scrubbed error —
+ * the review peer of a no-PR degraded DevCloseoutResult on an SDLC close-out throw.
+ */
+function degradedReviewResult(error: string): ReviewRunResult {
+  return { converged: false, openP0: 0, openActionPoints: [], verdict: null, participants: null, error };
 }
 
 /**
@@ -656,6 +696,14 @@ export interface ConsiliumLoopControllerDeps {
    */
   readJudgeOutput?: (loop: ConsiliumLoopRow) => Promise<unknown | undefined>;
   /**
+   * Phase 2 (direct review-runner): the review executor `dispatchReview` fires as a
+   * BACKGROUND job. Injectable so unit tests drive the `reviewRuns` registry with a
+   * fake runner (mirrors `runSdlc?`/`runResearch?`), never touching a real gateway/
+   * model. Defaults to the real `review-runner.ts` executor (Round-2 B2). Absent in
+   * Round 1 ⇒ `dispatchReview` settles a degraded "no runner configured" result.
+   */
+  runReview?: (loop: ConsiliumLoopRow) => Promise<ReviewRunResult>;
+  /**
    * Resolve the repo HEAD sha for audit / the merge-gate baseline. Injectable so
    * tests never touch real `process.cwd()` git (the default routes through A2's
    * buildDiffContext). Returns "" when unreadable (caller treats it as best-effort).
@@ -724,6 +772,16 @@ export class ConsiliumLoopController {
    * settled result here and the developing->awaiting_merge CAS consumes it.
    */
   private readonly sdlcRuns = new Map<string, SdlcRun>();
+
+  /**
+   * H-2 (Phase 2): process-local registry of in-flight/settled BACKGROUND review
+   * runs, keyed by loopId — the direct-review peer of `sdlcRuns`. `dispatchReview`
+   * sets the entry SYNCHRONOUSLY before the async runner so a concurrent tick sees
+   * it in-flight; `deriveReviewEvent` (Round-2 B5) consumes the settle. In Round 1
+   * this registry + its methods are ISOLATED — nothing in the live FSM path calls
+   * `dispatchReview` yet (that's Round-2 B4), so the reviewing path is byte-identical.
+   */
+  private readonly reviewRuns = new Map<string, ReviewRun>();
   /** MED-2: emit the "verification ignored" gate warning at most once per instance. */
   private warnedVerificationGate = false;
 
@@ -2376,6 +2434,66 @@ export class ConsiliumLoopController {
       run.result = existing.result;
       run.done = true;
       this.sdlcRuns.set(loopId, existing); // keep the good-PR entry authoritative
+      return;
+    }
+    run.result = result;
+    run.done = true;
+  }
+
+  /**
+   * Phase 2 (H-2, direct review-runner): dispatch a background review run — the
+   * review peer of `dispatchSdlc`. Registers the `reviewRuns` entry SYNCHRONOUSLY
+   * (before the await) so a concurrent tick sees it in-flight, then fires the runner
+   * FIRE-AND-FORGET: non-blocking, and it NEVER throws out (a runner rejection is
+   * caught and settled as a degraded, error-carrying result). Does NOT mutate the
+   * loop — the ONLY marker of an in-flight runner review is the `reviewRuns` entry;
+   * `currentIterationNumber` stays NULL (mirrors dispatchSdlc leaving devGroupId null
+   * for developing), so the null-ref stranded check (Round-2 B4) still recognises an
+   * in-flight runner review and the client never mounts a broken iteration view.
+   */
+  private dispatchReview(loop: ConsiliumLoopRow): void {
+    const run: ReviewRun = { round: loop.round, done: false };
+    this.reviewRuns.set(loop.id, run);
+    const runner = this.deps.runReview;
+    if (!runner) {
+      // Round-1 isolation: the real review-runner.ts is not wired yet (B2). Settle a
+      // degraded result rather than leave the entry in-flight forever.
+      this.settleReviewRun(loop.id, run, degradedReviewResult("no review runner configured"));
+      return;
+    }
+    void runner(loop)
+      .then((result) => this.settleReviewRun(loop.id, run, result))
+      .catch((err: unknown) =>
+        this.settleReviewRun(
+          loop.id,
+          run,
+          degradedReviewResult(scrubErr(err instanceof Error ? err.message : String(err))),
+        ),
+      );
+  }
+
+  /**
+   * Idempotent settle of a BACKGROUND review run into `reviewRuns` — the review peer
+   * of `settleSdlcRun`. A late/duplicate DEGRADED settle (a redrive that lost the
+   * race but still resolved with an error) must NEVER clobber an already-recorded
+   * GOOD (error-free) result for the SAME round: the good entry stays authoritative
+   * and the late run mirrors it, so `deriveReviewEvent` (B5) only ever observes the
+   * good verdict (mirrors settleSdlcRun's null-prRef-can't-clobber-a-good-PR guard).
+   */
+  private settleReviewRun(loopId: string, run: ReviewRun, result: ReviewRunResult): void {
+    const existing = this.reviewRuns.get(loopId);
+    if (
+      existing &&
+      existing.done &&
+      existing.round === run.round &&
+      existing.result &&
+      !existing.result.error &&
+      result.error
+    ) {
+      this.log(loopId, `idempotent settle: degraded review result IGNORED — keeping the recorded verdict (round ${run.round})`);
+      run.result = existing.result;
+      run.done = true;
+      this.reviewRuns.set(loopId, existing); // keep the good entry authoritative
       return;
     }
     run.result = result;

--- a/server/services/consilium/review-factory.ts
+++ b/server/services/consilium/review-factory.ts
@@ -188,7 +188,7 @@ function judgeDescription(): string {
 }
 
 /** Judge task name — stable so the DAG/tests reference it by name. */
-const JUDGE_TASK_NAME = "Judge verdict";
+export const JUDGE_TASK_NAME = "Judge verdict";
 
 /** Primary task name for a seat: "Opus primary" / "Gemini primary". */
 function primaryName(r: ReviewerModel): string {

--- a/server/services/consilium/review-runner.ts
+++ b/server/services/consilium/review-runner.ts
@@ -1,0 +1,160 @@
+/**
+ * review-runner.ts — the direct (task-group-free) consilium review executor.
+ *
+ * Phase 2 (defect-B): replaces the task-group `startGroupAsync` path with an
+ * in-process runner that executes the SAME cross-review DAG (buildCrossReviewTasks:
+ * primaries∥ → rebuttals → judge, or the lone buildSingleVerifierTask for a
+ * round>1 confirmation) DIRECTLY over the gateway. It reproduces the orchestrator's
+ * `executeDirectLlm` prompt + parse EXACTLY — the SAME `buildSystemPrompt` system
+ * prompt, temperature 0.7 / maxTokens 4096 / `overallTimeoutMs`, and
+ * `parseDirectLlmResponse` — so the judge output it yields is byte-identical to what
+ * a task `execution.output` held and `pickJudgeOutput` / `readConvergence` /
+ * `readJudgeVerdict` consume it UNCHANGED.
+ *
+ * PURE: no storage, no FSM, no task_group rows — trivially unit-testable with a fake
+ * gateway. NEVER throws: a gateway/parse failure on ANY stage degrades the WHOLE run
+ * to a conservative NOT-CONVERGED result carrying the scrubbed error (the review peer
+ * of a no-PR degraded SDLC close-out), so the controller's `dispatchReview` settle
+ * path is total.
+ */
+import type { CreateTaskParam } from "../task-orchestrator.js";
+import type { TaskRow, TaskGroupIterationRow } from "@shared/schema";
+import type { RoundParticipant } from "@shared/types";
+import type { ReviewRunResult } from "./consilium-loop-controller.js";
+import { buildSystemPrompt, parseDirectLlmResponse } from "../orchestrator/direct-llm-prompt.js";
+import { readConvergence, readJudgeVerdict } from "../orchestrator/convergence.js";
+
+/** The gateway slice the runner needs — the completeStreaming shape of PlannerGateway. */
+export interface ReviewGateway {
+  completeStreaming(
+    request: {
+      modelSlug: string;
+      messages: Array<{ role: string; content: string }>;
+      temperature?: number;
+      maxTokens?: number;
+    },
+    privacyOptions?: unknown,
+    loggingOptions?: unknown,
+    streamOptions?: { overallTimeoutMs?: number },
+  ): Promise<{ content: string }>;
+}
+
+// Participant bounds (Security L-2, parity with the verdict / action-point caps): the
+// review prose is UNTRUSTED model text — cap the participant COUNT and each `text` so a
+// malicious/verbose debate cannot bloat the persisted round row.
+const MAX_PARTICIPANTS = 24;
+const MAX_PARTICIPANT_TEXT = 8_000;
+
+/** executeDirectLlm's per-call knobs (reproduced exactly for prompt/behaviour parity). */
+const REVIEW_TEMPERATURE = 0.7;
+const REVIEW_MAX_TOKENS = 4096;
+
+function clampText(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max) : s;
+}
+
+/** Cap the participant list length and clamp each `text` (never throws). */
+function boundParticipants(participants: RoundParticipant[]): RoundParticipant[] {
+  return participants
+    .slice(0, MAX_PARTICIPANTS)
+    .map((p) => ({ ...p, text: clampText(p.text, MAX_PARTICIPANT_TEXT) }));
+}
+
+/** Minimal error scrub (strip fs paths + cap length) — mirrors the controller's scrubErr. */
+function scrub(raw: string): string {
+  return raw.replace(/\/[^\s'"]+/g, "<path>").replace(/\s+/g, " ").trim().slice(0, 200);
+}
+
+/** A degraded (errored) run: conservative NOT-CONVERGED, no verdict/participants. */
+function degraded(error: string): ReviewRunResult {
+  return { converged: false, openP0: 0, openActionPoints: [], verdict: null, participants: null, error };
+}
+
+export interface RunReviewTasksParams {
+  /** The review DAG — `buildCrossReviewTasks(panel)`, or `[buildSingleVerifierTask(...)]`. */
+  tasks: CreateTaskParam[];
+  /** The task whose parsed `.output` IS the verdict (JUDGE_TASK_NAME / VERIFIER_TASK_NAME). */
+  judgeTaskName: string;
+  /** The consilium group name (rides the system prompt, like the old `group.name`). */
+  groupName: string;
+  /** The review input — objective + diff-context, exactly what `iteration.input` held. */
+  groupInput: string;
+  gateway: ReviewGateway;
+  /** Per-call wall-clock cap (pipeline.taskGroups.taskTimeoutMs), like executeDirectLlm. */
+  timeoutMs: number;
+}
+
+/**
+ * Execute the review DAG and assemble a {@link ReviewRunResult}. Runs tasks in
+ * DEPENDENCY ORDER — primaries (no deps) first, then each task once all its deps have
+ * settled — with the tasks in a wave running in PARALLEL (so primaries∥ → rebuttals∥ →
+ * judge). Every NON-judge task becomes a participant (role from its dependency shape:
+ * no deps ⇒ `primary`, else ⇒ `rebuttal`); the judge task's parsed `.output` is the
+ * verdict feeding `readConvergence` / `readJudgeVerdict`. NEVER throws.
+ */
+export async function runReviewTasks(params: RunReviewTasksParams): Promise<ReviewRunResult> {
+  const { tasks, judgeTaskName, groupName, groupInput, gateway, timeoutMs } = params;
+  const outputs = new Map<string, unknown>(); // task name → its parsed `.output`
+  const participants: RoundParticipant[] = [];
+  try {
+    const pending = [...tasks];
+    while (pending.length > 0) {
+      const ready = pending.filter((t) => (t.dependsOn ?? []).every((d) => outputs.has(d)));
+      if (ready.length === 0) throw new Error("review DAG has an unsatisfiable dependency");
+      await Promise.all(
+        ready.map(async (t) => {
+          const deps = t.dependsOn ?? [];
+          const depOutputs: Record<string, unknown> = {};
+          for (const d of deps) depOutputs[d] = outputs.get(d);
+          // Reuse buildSystemPrompt VERBATIM (fidelity with executeDirectLlm) — it reads
+          // only `.name`/`.description` off the task and `.input` off the iteration, so a
+          // minimal cast is safe. objective+diff-context ride the SYSTEM prompt (as the
+          // old path did via iteration.input); the user turn carries the per-task input.
+          const system = buildSystemPrompt(
+            { name: t.name, description: t.description } as unknown as TaskRow,
+            { name: groupName },
+            { input: groupInput } as unknown as TaskGroupIterationRow,
+            depOutputs,
+          );
+          const userInput = t.input ? JSON.stringify(t.input) : "{}";
+          const res = await gateway.completeStreaming(
+            {
+              modelSlug: t.modelSlug ?? "",
+              messages: [
+                { role: "system", content: system },
+                { role: "user", content: userInput },
+              ],
+              temperature: REVIEW_TEMPERATURE,
+              maxTokens: REVIEW_MAX_TOKENS,
+            },
+            undefined,
+            undefined,
+            { overallTimeoutMs: timeoutMs },
+          );
+          const parsed = parseDirectLlmResponse(res.content);
+          outputs.set(t.name, parsed.output);
+          if (t.name !== judgeTaskName) {
+            participants.push({
+              name: t.name,
+              model: t.modelSlug ?? "",
+              role: deps.length > 0 ? "rebuttal" : "primary",
+              text: parsed.summary,
+            });
+          }
+        }),
+      );
+      for (const t of ready) pending.splice(pending.indexOf(t), 1);
+    }
+    const judgeOutput = outputs.get(judgeTaskName);
+    const convergence = readConvergence(judgeOutput);
+    return {
+      converged: convergence.converged,
+      openP0: convergence.openP0,
+      openActionPoints: convergence.openActionPoints,
+      verdict: readJudgeVerdict(judgeOutput),
+      participants: boundParticipants(participants),
+    };
+  } catch (err) {
+    return degraded(scrub(err instanceof Error ? err.message : String(err)));
+  }
+}

--- a/server/services/orchestrator/convergence.ts
+++ b/server/services/orchestrator/convergence.ts
@@ -219,14 +219,17 @@ export function extractActionPoints(judgeOutput: unknown): ActionPoint[] {
  * length (`MAX_PROS_CONS`) and each entry's length (`MAX_FIELD_LEN`). Never throws.
  */
 function boundStringList(value: unknown): string[] {
-  const arr = typeof value === "string" ? [value] : Array.isArray(value) ? value : [];
-  const out: string[] = [];
-  for (const item of arr) {
-    if (typeof item !== "string") continue;
-    out.push(clampStr(item, MAX_FIELD_LEN) ?? "");
-    if (out.length >= MAX_PROS_CONS) break;
-  }
-  return out;
+  // A lone string coerces to a one-element list; anything non-array is empty (guard).
+  if (typeof value === "string") return [clampStr(value, MAX_FIELD_LEN) ?? ""];
+  if (!Array.isArray(value)) return [];
+  // Security L-2: SLICE to the cap BEFORE filter/clamp so the work is bounded by
+  // MAX_PROS_CONS regardless of input size — a malicious multi-million-element array
+  // (especially one padded with non-strings) can never drive an O(N) scan. Legit judge
+  // output carries <= MAX_PROS_CONS entries, so slicing is a no-op for it.
+  return value
+    .slice(0, MAX_PROS_CONS)
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => clampStr(item, MAX_FIELD_LEN) ?? "");
 }
 
 /**

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1973,6 +1973,7 @@ export class MemStorage implements IStorage {
       openP0: data.openP0 ?? null,
       openActionPoints: data.openActionPoints ?? null,
       verdict: data.verdict ?? null,
+      participants: data.participants ?? null,
       baselineCommit: data.baselineCommit ?? null,
       headCommit: data.headCommit ?? null,
       testSummary: data.testSummary ?? null,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -17,7 +17,7 @@ import {
 import { vector } from "drizzle-orm/pg-core/columns/vector_extension/vector";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
-import type { TriggerConfig, TriggerType, TriggerProvenance, ManagerConfig, ManagerDecision, TraceSpan, SwarmCloneResult, SwarmMerger, SwarmSplitter, SkillVersionConfig, TaskTraceSpan, TrackerProvider, ActionPoint, Archetype, ArchetypeSource, ResearchReport, RoundVerdict, ExecutionTrace, ReviewMode, ExperienceScope, ExperienceEvidence, ExperienceVerification, ExperienceProvenance, ExperienceFreshness, ExperienceConfidence, ExperienceConsolidation, SkillProposalStatus, SkillProposalProvenance, SkillProposalEvidence } from "./types.js";
+import type { TriggerConfig, TriggerType, TriggerProvenance, ManagerConfig, ManagerDecision, TraceSpan, SwarmCloneResult, SwarmMerger, SwarmSplitter, SkillVersionConfig, TaskTraceSpan, TrackerProvider, ActionPoint, Archetype, ArchetypeSource, ResearchReport, RoundVerdict, RoundParticipant, ExecutionTrace, ReviewMode, ExperienceScope, ExperienceEvidence, ExperienceVerification, ExperienceProvenance, ExperienceFreshness, ExperienceConfidence, ExperienceConsolidation, SkillProposalStatus, SkillProposalProvenance, SkillProposalEvidence } from "./types.js";
 
 // ─── RBAC ────────────────────────────────────────────
 
@@ -2131,6 +2131,12 @@ export const consiliumLoopRounds = pgTable(
     // openActionPoints (H-4: NEVER the raw diff/prompt input). NULL on pre-column /
     // backfilled rounds and whenever the raw judge output is unreadable at record time.
     verdict: jsonb("verdict").$type<RoundVerdict>(),
+    // Phase 2 (direct review-runner): the round's review participants — primary
+    // reviewers + rebuttals, each carrying the seat name, the model that filled it,
+    // the role, and the review prose (design: RoundParticipant). Bounded before write
+    // (Security L-2, same as verdict; H-4: NEVER the raw diff/prompt input). NULL on
+    // pre-column / backfilled rounds and on rounds run via the legacy task-group path.
+    participants: jsonb("participants").$type<RoundParticipant[]>(),
     baselineCommit: text("baseline_commit"),
     headCommit: text("head_commit"),
     testSummary: text("test_summary"),

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -2408,6 +2408,26 @@ export interface RoundVerdict {
 }
 
 /**
+ * One review participant's contribution to a round, persisted in
+ * `consilium_loop_rounds.participants` (jsonb). Populated by the direct
+ * review-runner (Phase 2): the primary reviewers and their rebuttals, each with
+ * the seat NAME, the MODEL that filled it, the role, and the human-readable
+ * review PROSE. Nullable on the column — absent on old/backfilled rounds and on
+ * rounds run under the legacy task-group path.
+ *
+ * SECURITY (L-2): `text` (and `name`/`model`) are UNTRUSTED model output —
+ * bounded on persist (count + per-`text` length caps, same discipline as
+ * {@link RoundVerdict}) and rendered as INERT text on the client. Client-safe
+ * (like {@link ActionPoint}): the FE imports THIS type — single source of truth.
+ */
+export interface RoundParticipant {
+  name: string;
+  model: string;
+  role: "primary" | "rebuttal";
+  text: string;
+}
+
+/**
  * Finding #5 — the READ-TIME (never-persisted) summary of the STILL-OPEN action
  * points carried by a TERMINAL loop's LAST recorded round. Convergence is keyed
  * on `P0` BY DESIGN (a loop converges the moment no P0 remains), but the judge

--- a/tests/unit/consilium/loop-directreview-straddle.test.ts
+++ b/tests/unit/consilium/loop-directreview-straddle.test.ts
@@ -1,0 +1,298 @@
+/**
+ * loop-directreview-straddle.test.ts — B7 (Phase 2) capstone: the directReview kill-switch
+ * straddle proven END-TO-END through `controller.tick()`.
+ *
+ * The straddle READS already landed in B4/B5/B6 and NONE consult the live flag on read
+ * (dispatch keys off the flag; deriveReviewEvent keys off the reviewRuns ENTRY; resolveVerdict
+ * keys off currentIterationNumber+participants). This file is the pure test proof:
+ *   1. kill-switch parity SNAPSHOT — flag OFF ⇒ startGroupAsync + marker set, reviewRuns
+ *      EMPTY, runReview NEVER called, full lifecycle byte-identical.
+ *   2. mid-flip STRADDLE, BOTH directions — a round STARTED under one mode READS BACK under
+ *      that mode even when the operator flips the flag mid-flight (inv #5: the read keys off
+ *      the round's ACTUAL mode, never the live flag).
+ *   3. single-verifier round>1 via `buildSingleVerifierTask` DIRECT (runner path) — ONE
+ *      gateway call carrying the verifier prompt; round 1 is the full preset DAG (N calls).
+ *
+ * `config` is a live getter over a mutable flag closure, flipped BETWEEN ticks to simulate a
+ * mid-flight toggle. Legacy dispatch runs the real `startReviewRound`→`buildDiffContext`, which
+ * with `lastReviewedCommit=null` only resolves the committed HEAD ref (`revparse HEAD^{commit}`
+ * — no collectDiff, no working-tree read → deterministic), the same pattern the B4 flag-OFF
+ * test already relies on. `readRepoHead` is injected so recordRound never touches git.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { ConsiliumLoopController } from "../../../server/services/consilium/consilium-loop-controller.js";
+import type { ConsiliumLoopRow, ConsiliumLoopState, ConsiliumLoopRoundRow, InsertConsiliumLoopRound } from "@shared/schema";
+import type { RoundVerdict, RoundParticipant, ActionPoint, ConvergenceVerdict } from "@shared/types";
+
+function makeLoop(over: Partial<ConsiliumLoopRow>): ConsiliumLoopRow {
+  return {
+    id: "loop1",
+    groupId: "grp1",
+    state: "building_context",
+    round: 0,
+    maxRounds: 6,
+    repoPath: process.cwd(),
+    lastReviewedCommit: null,
+    currentIterationNumber: null,
+    devGroupId: null,
+    prRef: null,
+    headCommitAtReview: null,
+    reviewMode: null,
+    reviewRef: null,
+    openP0: null,
+    error: null,
+    createdBy: "user1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    completedAt: null,
+    ...over,
+  } as ConsiliumLoopRow;
+}
+
+const AP0: ActionPoint = { title: "fix the null deref", priority: "P0" } as ActionPoint;
+const VERDICT: RoundVerdict = { verdict: "one P0 open", pros: [], cons: ["gap"], actionPoints: [AP0] };
+const PARTS: RoundParticipant[] = [{ name: "rev-a", model: "claude-opus", role: "primary", text: "found it" }];
+const CONVERGED: ConvergenceVerdict = { converged: true, openP0: 0, openActionPoints: [] };
+
+/** Storage honouring the CAS + storing rounds with a real UNIQUE(loop,round) guard. */
+function makeFakeStorage(loop: ConsiliumLoopRow, iter: { status: string }) {
+  let current = loop;
+  const roundRows: ConsiliumLoopRoundRow[] = [];
+  const cas = vi.fn(
+    async (id: string, expected: ConsiliumLoopState, next: ConsiliumLoopState, extra?: Record<string, unknown>) => {
+      if (id !== current.id || current.state !== expected) return undefined;
+      current = { ...current, ...(extra ?? {}), state: next };
+      return current;
+    },
+  );
+  const appendLoopRound = vi.fn(async (data: InsertConsiliumLoopRound) => {
+    if (roundRows.some((r) => r.loopId === data.loopId && r.round === data.round)) {
+      const err = new Error("consilium_loop_rounds_uq");
+      (err as NodeJS.ErrnoException).code = "23505";
+      throw err;
+    }
+    const row = { id: `r${roundRows.length}`, createdAt: new Date(), ...data } as ConsiliumLoopRoundRow;
+    roundRows.push(row);
+    return row;
+  });
+  const storage = {
+    getLoop: vi.fn(async () => current),
+    getLoops: vi.fn(async () => [current]),
+    getLoopRounds: vi.fn(async () => [...roundRows].sort((a, b) => a.round - b.round)),
+    casLoopState: cas,
+    claimRedrive: vi.fn(async () => undefined),
+    appendLoopRound,
+    updateLoop: vi.fn(async (_id: string, extra?: Record<string, unknown>) => {
+      current = { ...current, ...(extra ?? {}) };
+      return current;
+    }),
+    getTaskGroup: vi.fn(async () => ({ id: current.groupId, name: "[consilium-review:sdlc-cross-review] x", input: "the objective" })),
+    updateTaskGroup: vi.fn(async () => ({})),
+    getIteration: vi.fn(async () => (iter.status ? { id: "it", status: iter.status } : undefined)),
+    getExecutionsByIteration: vi.fn(async () => []),
+  };
+  return { storage, get: () => current, rounds: () => roundRows };
+}
+
+const makeConfig = (flag: { on: boolean }) =>
+  (() => ({
+    pipeline: {
+      taskGroups: { taskTimeoutMs: 300000, defaultModel: "claude-opus" },
+      consiliumLoop: {
+        enabled: true,
+        maxRounds: 6,
+        pollIntervalMs: 5000,
+        maxDiffBytes: 200000,
+        allowedRepoPaths: [process.cwd()],
+        directReview: { enabled: flag.on }, // LIVE — re-read on every config() call
+        implement: { enabled: false, verification: { enabled: false }, research: { enabled: false } },
+      },
+    },
+    providers: {},
+  })) as never;
+
+const orchestrator = (startGroupAsync: unknown) =>
+  ({ startGroup: startGroupAsync, startGroupAsync, createTaskGroup: vi.fn(), cancelGroup: vi.fn() }) as never;
+
+const reviewRunsOf = (c: ConsiliumLoopController): Map<string, unknown> =>
+  (c as unknown as { reviewRuns: Map<string, unknown> }).reviewRuns;
+
+const flush = () => new Promise((r) => setImmediate(r));
+
+describe("B7 — directReview kill-switch straddle proven end-to-end", () => {
+  it("parity SNAPSHOT: flag OFF ⇒ startGroupAsync + marker set, reviewRuns EMPTY, runReview NEVER called (byte-identical legacy)", async () => {
+    const flag = { on: false };
+    const iter = { status: "" };
+    const loop = makeLoop({ state: "building_context", round: 0 });
+    const { storage, get, rounds } = makeFakeStorage(loop, iter);
+    const startGroupAsync = vi.fn(async () => ({ group: {}, iteration: { iterationNumber: 1 } }));
+    const runReview = vi.fn();
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: orchestrator(startGroupAsync),
+      config: makeConfig(flag),
+      runReview: runReview as never,
+      readRepoHead: async () => "HEADSHA",
+      readIterationVerdict: async () => CONVERGED, // round-1 immediate convergence ⇒ terminal
+    });
+
+    await controller.tick(loop.id); // building_context → reviewing (LEGACY dispatch)
+    expect(get().state).toBe("reviewing");
+    expect(get().currentIterationNumber).toBe(1); // legacy marker set
+    expect(startGroupAsync).toHaveBeenCalledTimes(1);
+    expect(reviewRunsOf(controller).size).toBe(0); // NO runner entry
+
+    iter.status = "completed";
+    await controller.tick(loop.id); // reviewing → deciding (via the ITERATION)
+    expect(get().state).toBe("deciding");
+    await controller.tick(loop.id); // deciding → converged (terminal)
+    expect(get().state).toBe("converged");
+
+    expect(runReview).not.toHaveBeenCalled(); // the runner is NEVER touched under flag OFF
+    expect(reviewRunsOf(controller).size).toBe(0); // reviewRuns stays empty the whole lifecycle
+    expect(rounds()).toHaveLength(1);
+    expect(rounds()[0].participants ?? null).toBeNull(); // legacy round ⇒ no participants
+  });
+
+  it("mid-flip ON→OFF: a RUNNER-dispatched round reads back via the ENTRY after the flag flips OFF", async () => {
+    const flag = { on: true };
+    const iter = { status: "" };
+    const loop = makeLoop({ state: "building_context", round: 0 });
+    const { storage, get, rounds } = makeFakeStorage(loop, iter);
+    const startGroupAsync = vi.fn(async () => ({ group: {}, iteration: { iterationNumber: 1 } }));
+    const runReview = vi.fn(async () => ({
+      converged: false, openP0: 1, openActionPoints: [AP0], verdict: VERDICT, participants: PARTS,
+    }));
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: orchestrator(startGroupAsync),
+      config: makeConfig(flag),
+      runReview: runReview as never,
+      readRepoHead: async () => "HEADSHA",
+    });
+
+    await controller.tick(loop.id); // building_context → reviewing (RUNNER dispatch, flag ON)
+    expect(get().state).toBe("reviewing");
+    expect(get().currentIterationNumber ?? null).toBeNull(); // runner marker: NO iteration
+    expect(startGroupAsync).not.toHaveBeenCalled(); // ZERO task-group iterations
+    expect(runReview).toHaveBeenCalledTimes(1);
+    await flush(); // let the fire-and-forget runner settle into reviewRuns
+    expect(reviewRunsOf(controller).get(loop.id)).toMatchObject({ round: 1, done: true });
+
+    flag.on = false; // ── OPERATOR FLIPS THE FLAG OFF MID-FLIGHT ──
+
+    const res = await controller.tick(loop.id); // reviewing → deciding VIA THE ENTRY (runner)
+    expect(res?.state).toBe("deciding");
+    // Read back under the RUNNER despite flag OFF: the round carries participants, and the
+    // legacy startGroupAsync was NEVER called.
+    expect(rounds()).toHaveLength(1);
+    expect(rounds()[0].participants).toEqual(PARTS);
+    expect(startGroupAsync).not.toHaveBeenCalled();
+    expect(reviewRunsOf(controller).get(loop.id)).toBeUndefined(); // consumed + dropped
+  });
+
+  it("mid-flip OFF→ON: a LEGACY-dispatched round reads back via the ITERATION after the flag flips ON", async () => {
+    const flag = { on: false };
+    const iter = { status: "" };
+    const loop = makeLoop({ state: "building_context", round: 0 });
+    const { storage, get, rounds } = makeFakeStorage(loop, iter);
+    const startGroupAsync = vi.fn(async () => ({ group: {}, iteration: { iterationNumber: 1 } }));
+    const runReview = vi.fn(); // MUST never be called
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: orchestrator(startGroupAsync),
+      config: makeConfig(flag),
+      runReview: runReview as never,
+      readRepoHead: async () => "HEADSHA",
+      readIterationVerdict: async () => CONVERGED,
+    });
+
+    await controller.tick(loop.id); // building_context → reviewing (LEGACY dispatch, flag OFF)
+    expect(get().state).toBe("reviewing");
+    expect(get().currentIterationNumber).toBe(1); // legacy marker set
+    expect(startGroupAsync).toHaveBeenCalledTimes(1);
+    expect(reviewRunsOf(controller).size).toBe(0); // NO runner entry
+
+    flag.on = true; // ── OPERATOR FLIPS THE FLAG ON MID-FLIGHT ──
+    iter.status = "completed";
+
+    await controller.tick(loop.id); // reviewing → deciding VIA THE ITERATION (legacy)
+    expect(get().state).toBe("deciding");
+    await controller.tick(loop.id); // deciding → converged (terminal)
+    expect(get().state).toBe("converged");
+
+    // Read back under LEGACY despite flag ON: the runner was NEVER dispatched, no entry ever
+    // existed, and the round carries NO participants.
+    expect(runReview).not.toHaveBeenCalled();
+    expect(reviewRunsOf(controller).size).toBe(0);
+    expect(rounds()).toHaveLength(1);
+    expect(rounds()[0].participants ?? null).toBeNull();
+  });
+});
+
+// ─── single-verifier round>1 via the RUNNER path (buildSingleVerifierTask DIRECT) ───────
+
+/** A verifier/judge reply in the canonical execution.output shape (mirrors review-runner.test). */
+const judgeReply = (converged: boolean, openP0: number): string =>
+  JSON.stringify({
+    summary: "verifier summary",
+    output: {
+      verdict: "the verdict", pros: [], cons: [],
+      action_points: openP0 > 0 ? [{ title: "fix it", priority: "P0" }] : [],
+      convergence: { converged, open_p0: openP0, open_action_points: openP0 > 0 ? [{ title: "fix it", priority: "P0" }] : [] },
+    },
+  });
+
+/** Controller wired for a DIRECT runReviewFromLoop call — fake gateway captures the prompts.
+ *  Deterministic: lastReviewedCommit=null ⇒ buildDiffContext resolves only the committed HEAD
+ *  ref (revparse HEAD^{commit}); no collectDiff, no working-tree read. */
+function makeRunnerController(systems: string[]) {
+  const storage = {
+    getLoopRounds: vi.fn(async () => []),
+    getTaskGroup: vi.fn(async () => ({ id: "grp1", name: "[consilium-review:sdlc-cross-review] x", input: "the objective" })),
+  };
+  const gateway = {
+    completeStreaming: vi.fn(async (req: { messages: Array<{ role: string; content: string }> }) => {
+      systems.push(req.messages.find((m) => m.role === "system")?.content ?? "");
+      return { content: judgeReply(false, 1) };
+    }),
+  };
+  const controller = new ConsiliumLoopController({
+    storage: storage as never,
+    taskOrchestrator: orchestrator(vi.fn()),
+    config: makeConfig({ on: true }),
+    gateway: gateway as never,
+  });
+  return { controller, gateway };
+}
+type RunnerPriv = { runReviewFromLoop(loop: ConsiliumLoopRow): Promise<{ converged: boolean; openP0: number; error?: string }> };
+
+describe("B7 — single-verifier round>1 runs buildSingleVerifierTask DIRECT (runner path)", () => {
+  it("round > 1 + single-verifier ⇒ EXACTLY ONE gateway call carrying the Verifier prompt", async () => {
+    const systems: string[] = [];
+    const { controller, gateway } = makeRunnerController(systems);
+    const loop = makeLoop({ round: 2, reviewMode: "single-verifier", lastReviewedCommit: null, reviewRef: null });
+
+    const r = await (controller as unknown as RunnerPriv).runReviewFromLoop(loop);
+
+    expect(r.error).toBeUndefined();
+    expect(gateway.completeStreaming).toHaveBeenCalledTimes(1); // ONE task, not the DAG
+    expect(systems).toHaveLength(1);
+    expect(systems[0]).toContain("Your specific task: Verifier"); // buildSingleVerifierTask, direct
+    // The verifier output feeds convergence via VERIFIER_TASK_NAME as the judge.
+    expect(r.converged).toBe(false);
+    expect(r.openP0).toBe(1);
+  });
+
+  it("round 1 is ALWAYS the full preset DAG (N gateway calls) — NEVER the single verifier", async () => {
+    const systems: string[] = [];
+    const { controller, gateway } = makeRunnerController(systems);
+    // Same single-verifier mode, but round 1 ⇒ the `round > 1` guard forces the full DAG.
+    const loop = makeLoop({ round: 1, reviewMode: "single-verifier", lastReviewedCommit: null, reviewRef: null });
+
+    await (controller as unknown as RunnerPriv).runReviewFromLoop(loop);
+
+    expect((gateway.completeStreaming as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(1);
+    expect(systems.some((s) => s.includes("Your specific task: Verifier"))).toBe(false); // no lone verifier
+  });
+});

--- a/tests/unit/consilium/loop-error-redaction.test.ts
+++ b/tests/unit/consilium/loop-error-redaction.test.ts
@@ -1,0 +1,112 @@
+/**
+ * loop-error-redaction.test.ts — B-sec L1: an EXCEPTION-derived `loop.error` must be a
+ * FIXED GENERIC; the raw (scrubbed) detail goes to the LOGS ONLY.
+ *
+ * The one raw-leak site is `recordRound`'s non-unique audit-write failure: it used to
+ * persist `round N audit write failed: ${err.message}` — an UNSCRUBBED exception string on
+ * the persisted, UI-rendered `loop.error`. Now the row carries the FIXED generic
+ * `round N audit write failed`, and the scrubbed detail rides the server log only.
+ *
+ * (Curated explanations — composeCancelExplanation, failUnresolvedReview, merge-HEAD-delta —
+ * and the already-scrubbed operator reasons are UNCHANGED and covered by their own suites;
+ * this file pins the one redaction.)
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { ConsiliumLoopController } from "../../../server/services/consilium/consilium-loop-controller.js";
+import type { ConsiliumLoopRow, ConsiliumLoopState } from "@shared/schema";
+import type { ConvergenceVerdict } from "@shared/types";
+
+const CONVERGED: ConvergenceVerdict = { converged: true, openP0: 0, openActionPoints: [] };
+
+function makeLoop(over: Partial<ConsiliumLoopRow>): ConsiliumLoopRow {
+  return {
+    id: "loop1",
+    groupId: "grp1",
+    state: "deciding",
+    round: 2,
+    maxRounds: 6,
+    repoPath: process.cwd(),
+    lastReviewedCommit: null,
+    currentIterationNumber: 2, // legacy round ⇒ resolveVerdict uses the injected seam
+    devGroupId: null,
+    prRef: null,
+    headCommitAtReview: null,
+    openP0: null,
+    error: null,
+    createdBy: "user1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    completedAt: null,
+    ...over,
+  } as ConsiliumLoopRow;
+}
+
+/** Storage whose appendLoopRound throws a RAW, path-bearing NON-unique error. */
+function makeFakeStorage(loop: ConsiliumLoopRow, rawAppendError: string) {
+  let current = loop;
+  const cas = vi.fn(
+    async (id: string, expected: ConsiliumLoopState, next: ConsiliumLoopState, extra?: Record<string, unknown>) => {
+      if (id !== current.id || current.state !== expected) return undefined;
+      current = { ...current, ...(extra ?? {}), state: next };
+      return current;
+    },
+  );
+  const storage = {
+    getLoop: vi.fn(async () => current),
+    getLoops: vi.fn(async () => [current]),
+    getLoopRounds: vi.fn(async () => []),
+    casLoopState: cas,
+    claimRedrive: vi.fn(async () => undefined),
+    appendLoopRound: vi.fn(async () => {
+      throw new Error(rawAppendError);
+    }),
+    updateLoop: vi.fn(async (_id: string, extra?: Record<string, unknown>) => {
+      current = { ...current, ...(extra ?? {}) };
+      return current;
+    }),
+    getTaskGroup: vi.fn(async () => ({ id: current.groupId, input: "objective" })),
+    updateTaskGroup: vi.fn(async () => ({})),
+    getIteration: vi.fn(async () => ({ id: "it1", iterationNumber: current.currentIterationNumber ?? 1, status: "completed" })),
+    getExecutionsByIteration: vi.fn(async () => []),
+  };
+  return { storage, get: () => current };
+}
+
+const fakeConfig = () =>
+  ({
+    pipeline: {
+      taskGroups: { taskTimeoutMs: 300000 },
+      consiliumLoop: { enabled: true, maxRounds: 6, pollIntervalMs: 5000, maxDiffBytes: 200000, allowedRepoPaths: [process.cwd()], implement: { enabled: false, verification: { enabled: false }, research: { enabled: false } } },
+    },
+  }) as never;
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("B-sec L1 — recordRound audit-write failure redacts the exception off loop.error", () => {
+  it("persists a FIXED GENERIC on loop.error; the raw scrubbed detail goes to the LOGS only", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const RAW = "disk full writing /Users/secret/db.sock"; // a path + a secret-y token
+    const loop = makeLoop({ state: "deciding", round: 2, currentIterationNumber: 2 });
+    const { storage, get } = makeFakeStorage(loop, RAW);
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: { startGroup: vi.fn(), startGroupAsync: vi.fn(), createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
+      config: fakeConfig,
+      readIterationVerdict: async () => CONVERGED, // deciding → converged (terminal) ⇒ recordRound
+      readRepoHead: async () => "HEADSHA",
+    });
+
+    const res = await controller.tick(loop.id);
+
+    // The FSM transition still committed (audit write is best-effort, never blocks it).
+    expect(res?.state).toBe("converged");
+    // loop.error is the FIXED GENERIC — NO raw message, NO path, NO secret token.
+    expect(get().error).toBe("round 2 audit write failed");
+    expect(get().error).not.toContain("disk full");
+    expect(get().error).not.toContain("/Users/secret");
+    // The scrubbed detail reached the LOGS: fs path stripped to <path>, raw path absent.
+    const logged = logSpy.mock.calls.map((c) => String(c[0]));
+    expect(logged.some((l) => l.includes("disk full writing <path>"))).toBe(true);
+    expect(logged.some((l) => l.includes("/Users/secret"))).toBe(false);
+  });
+});

--- a/tests/unit/consilium/loop-review-dispatch.test.ts
+++ b/tests/unit/consilium/loop-review-dispatch.test.ts
@@ -112,6 +112,34 @@ describe("B4 — reviewing dispatch keys off the live directReview flag", () => 
     release({ converged: false, openP0: 1, openActionPoints: [], verdict: null, participants: null });
   });
 
+  it("flag ON: a STALE currentIterationNumber (from a prior OLD-path round) is CLEARED to explicit null", async () => {
+    // A round ran earlier on the legacy path (currentIterationNumber persisted), then the
+    // flag flips ON. The runner extra MUST set currentIterationNumber: null explicitly —
+    // otherwise the stale non-null value survives and, on a crash, redriveStranded's
+    // null-ref check reads false (round stuck) + the straddle misreads it as old-path.
+    const loop = makeLoop({ state: "building_context", round: 1, currentIterationNumber: 5 });
+    const { storage, get } = makeFakeStorage(loop);
+    const startGroupAsync = vi.fn(async () => ({ group: {}, iteration: { iterationNumber: 9 } }));
+    let release: (r: unknown) => void = () => {};
+    const runReview = vi.fn(() => new Promise((res) => { release = res; }));
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: { startGroup: startGroupAsync, startGroupAsync, createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
+      config: configWith(true),
+      runReview: runReview as never,
+    });
+
+    const res = await controller.tick(loop.id);
+
+    expect(res?.state).toBe("reviewing");
+    expect(res?.round).toBe(2); // nextRound
+    // toBeNull fails on undefined — so an OMITTED field (stale 5 surviving) is caught.
+    expect(res?.currentIterationNumber).toBeNull(); // stale 5 EXPLICITLY cleared
+    expect(get().currentIterationNumber).toBeNull(); // persisted null
+    expect(startGroupAsync).not.toHaveBeenCalled();
+    release({ converged: true, openP0: 0, openActionPoints: [], verdict: null, participants: null });
+  });
+
   it("flag OFF: entering reviewing runs the legacy startGroupAsync path (byte-identical), NO reviewRuns entry", async () => {
     const loop = makeLoop({ state: "building_context", round: 0, lastReviewedCommit: null });
     const { storage } = makeFakeStorage(loop);

--- a/tests/unit/consilium/loop-review-dispatch.test.ts
+++ b/tests/unit/consilium/loop-review-dispatch.test.ts
@@ -1,0 +1,136 @@
+/**
+ * loop-review-dispatch.test.ts — B4 (Phase 2) coverage for the runner-mode DISPATCH
+ * side of the reviewing transition, driven end-to-end through `controller.tick()`.
+ *
+ * With `pipeline.consiliumLoop.directReview.enabled = true`, entering `reviewing`
+ * must dispatch a BACKGROUND direct review (a `reviewRuns` entry keyed off the round
+ * the review is FOR) and mint ZERO task_group iterations — currentIterationNumber
+ * stays NULL (the marker). The flag-OFF parity is proven by the entire existing
+ * consilium/loop-fsm suite passing UNMODIFIED, so this file only pins the flag-ON
+ * dispatch contract + the kill-switch parity at the single-transition level.
+ *
+ * Round-2 note: the settle→advance (deriveReviewEvent reads the settled reviewRuns
+ * result) is B5; this file asserts the dispatch happened, not the consume.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { ConsiliumLoopController } from "../../../server/services/consilium/consilium-loop-controller.js";
+import type { ConsiliumLoopRow, ConsiliumLoopState } from "@shared/schema";
+
+function makeLoop(over: Partial<ConsiliumLoopRow>): ConsiliumLoopRow {
+  return {
+    id: "loop1",
+    groupId: "grp1",
+    state: "building_context",
+    round: 0,
+    maxRounds: 6,
+    repoPath: process.cwd(),
+    lastReviewedCommit: null,
+    currentIterationNumber: null,
+    devGroupId: null,
+    prRef: null,
+    headCommitAtReview: null,
+    openP0: null,
+    error: null,
+    createdBy: "user1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    completedAt: null,
+    ...over,
+  } as ConsiliumLoopRow;
+}
+
+/** Minimal fake storage honouring the CAS (mirrors loop-fsm.test.ts's harness). */
+function makeFakeStorage(loop: ConsiliumLoopRow) {
+  let current = loop;
+  const cas = vi.fn(
+    async (id: string, expected: ConsiliumLoopState, next: ConsiliumLoopState, extra?: Record<string, unknown>) => {
+      if (id !== current.id || current.state !== expected) return undefined;
+      current = { ...current, ...(extra ?? {}), state: next };
+      return current;
+    },
+  );
+  const storage = {
+    getLoop: vi.fn(async () => current),
+    getLoops: vi.fn(async () => [current]),
+    getLoopRounds: vi.fn(async () => []),
+    casLoopState: cas,
+    claimRedrive: vi.fn(async () => undefined),
+    appendLoopRound: vi.fn(async () => ({})),
+    updateLoop: vi.fn(async (_id: string, extra?: Record<string, unknown>) => {
+      current = { ...current, ...(extra ?? {}) };
+      return current;
+    }),
+    getTaskGroup: vi.fn(async () => ({ id: current.groupId, name: "[consilium-review:sdlc-cross-review] x", input: "objective" })),
+    updateTaskGroup: vi.fn(async () => ({})),
+    createTaskGroup: vi.fn(async () => ({ group: { id: "g" } })),
+    getIteration: vi.fn(async () => undefined),
+    getExecutionsByIteration: vi.fn(async () => []),
+  };
+  return { storage, get: () => current };
+}
+
+const configWith = (directReviewEnabled: boolean) =>
+  (() => ({
+    pipeline: {
+      taskGroups: { taskTimeoutMs: 300000, defaultModel: "claude-opus" },
+      consiliumLoop: {
+        enabled: true,
+        maxRounds: 6,
+        pollIntervalMs: 5000,
+        maxDiffBytes: 200000,
+        allowedRepoPaths: [process.cwd()],
+        directReview: { enabled: directReviewEnabled },
+        implement: { enabled: false, verification: { enabled: false }, research: { enabled: false } },
+      },
+    },
+  })) as never;
+
+describe("B4 — reviewing dispatch keys off the live directReview flag", () => {
+  it("flag ON: entering reviewing dispatches the runner, mints ZERO iterations, marker stays NULL", async () => {
+    const loop = makeLoop({ state: "building_context", round: 0 });
+    const { storage } = makeFakeStorage(loop);
+    const startGroupAsync = vi.fn(async () => ({ group: {}, iteration: { iterationNumber: 1 } }));
+    let release: (r: unknown) => void = () => {};
+    const runReview = vi.fn(() => new Promise((res) => { release = res; })); // stays in-flight
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: { startGroup: startGroupAsync, startGroupAsync, createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
+      config: configWith(true),
+      runReview: runReview as never,
+    });
+
+    const res = await controller.tick(loop.id);
+
+    expect(res?.state).toBe("reviewing");
+    expect(res?.round).toBe(1); // nextRound
+    expect(res?.currentIterationNumber ?? null).toBeNull(); // marker NULL — no iteration
+    expect(startGroupAsync).not.toHaveBeenCalled(); // ZERO task_group iterations minted
+    expect(runReview).toHaveBeenCalledTimes(1); // the direct runner was dispatched
+    // reviewRuns entry keyed off the round the review is FOR (nextRound).
+    const c = controller as unknown as { reviewRuns: Map<string, { round: number; done: boolean }> };
+    expect(c.reviewRuns.get(loop.id)).toMatchObject({ round: 1, done: false });
+    release({ converged: false, openP0: 1, openActionPoints: [], verdict: null, participants: null });
+  });
+
+  it("flag OFF: entering reviewing runs the legacy startGroupAsync path (byte-identical), NO reviewRuns entry", async () => {
+    const loop = makeLoop({ state: "building_context", round: 0, lastReviewedCommit: null });
+    const { storage } = makeFakeStorage(loop);
+    const startGroupAsync = vi.fn(async () => ({ group: {}, iteration: { iterationNumber: 1 } }));
+    const runReview = vi.fn();
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: { startGroup: startGroupAsync, startGroupAsync, createTaskGroup: storage.createTaskGroup, cancelGroup: vi.fn() } as never,
+      config: configWith(false),
+      runReview: runReview as never,
+    });
+
+    const res = await controller.tick(loop.id);
+
+    expect(res?.state).toBe("reviewing");
+    expect(res?.currentIterationNumber).toBe(1); // legacy: a real iteration
+    expect(startGroupAsync).toHaveBeenCalledTimes(1); // legacy dispatch
+    expect(runReview).not.toHaveBeenCalled(); // runner never touched
+    const c = controller as unknown as { reviewRuns: Map<string, unknown> };
+    expect(c.reviewRuns.get(loop.id)).toBeUndefined(); // no runner-mode entry
+  });
+});

--- a/tests/unit/consilium/loop-review-redrive-grace.test.ts
+++ b/tests/unit/consilium/loop-review-redrive-grace.test.ts
@@ -1,0 +1,140 @@
+/**
+ * loop-review-redrive-grace.test.ts — M-1 (Security MEDIUM): the reviewing-runner redrive
+ * grace must cover a WHOLE multi-wave runner review, not the bare ~30s null-ref base.
+ *
+ * A runner review keeps `currentIterationNumber` NULL (⇒ `nullRef` true in redriveStranded).
+ * The in-process `reviewRuns` registry gates the SAME instance, but a DIFFERENT instance holds
+ * no local entry — so without a round-sized grace it would redrive a LIVE multi-wave review at
+ * ~30s (duplicate model spend + round-counter inflation + a redrive storm). This sizes the
+ * reviewing grace to `taskTimeoutMs × REVIEW_RUNNER_WAVES` — the reviewing peer of the developing
+ * round-sized grace — while still redriving a GENUINELY stranded review past that window.
+ *
+ * The extension is GATED on the runner kill-switch to keep FLAG-OFF byte-identical: under flag
+ * OFF the reviewing grace stays the bare base, so the legacy crash-window redrive (null-ref
+ * before the iteration child-ref write) recovers at the SHORT grace exactly as before.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { ConsiliumLoopController, REVIEW_RUNNER_WAVES } from "../../../server/services/consilium/consilium-loop-controller.js";
+import type { ConsiliumLoopRow, ConsiliumLoopState } from "@shared/schema";
+
+const MIN = 60_000;
+const TASK_TIMEOUT_MS = 600_000; // 10 min per wave
+const BASE_GRACE = 30_000; // max(2×poll=10s, 30s)
+const ROUND_GRACE = TASK_TIMEOUT_MS * REVIEW_RUNNER_WAVES; // 30 min
+
+function makeLoop(over: Partial<ConsiliumLoopRow>): ConsiliumLoopRow {
+  return {
+    id: "loop1",
+    groupId: "grp1",
+    state: "reviewing",
+    round: 1,
+    maxRounds: 6,
+    repoPath: process.cwd(),
+    lastReviewedCommit: null,
+    currentIterationNumber: null,
+    devGroupId: null,
+    prRef: null,
+    headCommitAtReview: null,
+    reviewMode: null,
+    reviewRef: null,
+    openP0: null,
+    error: null,
+    createdBy: "user1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    completedAt: null,
+    ...over,
+  } as ConsiliumLoopRow;
+}
+
+function makeFakeStorage(loop: ConsiliumLoopRow) {
+  let current = loop;
+  const claimRedrive = vi.fn(async () => undefined); // always "claim lost" ⇒ no side effect runs
+  const storage = {
+    getLoop: vi.fn(async () => current),
+    getLoops: vi.fn(async () => [current]),
+    getLoopRounds: vi.fn(async () => []),
+    casLoopState: vi.fn(async () => undefined),
+    claimRedrive,
+    appendLoopRound: vi.fn(async () => ({})),
+    updateLoop: vi.fn(async (_id: string, extra?: Record<string, unknown>) => {
+      current = { ...current, ...(extra ?? {}) };
+      return current;
+    }),
+    getTaskGroup: vi.fn(async () => ({ id: current.groupId, input: "obj" })),
+    updateTaskGroup: vi.fn(async () => ({})),
+    getIteration: vi.fn(async () => undefined),
+    getExecutionsByIteration: vi.fn(async () => []),
+  };
+  return { storage, claimRedrive };
+}
+
+const configWith = (directReviewEnabled: boolean) =>
+  (() => ({
+    pipeline: {
+      taskGroups: { taskTimeoutMs: TASK_TIMEOUT_MS },
+      consiliumLoop: { enabled: true, maxRounds: 6, pollIntervalMs: 5000, maxDiffBytes: 200000, allowedRepoPaths: [process.cwd()], directReview: { enabled: directReviewEnabled }, implement: { enabled: false, verification: { enabled: false }, research: { enabled: false } } },
+    },
+  })) as never;
+
+function makeController(loop: ConsiliumLoopRow, directReviewEnabled: boolean) {
+  const { storage, claimRedrive } = makeFakeStorage(loop);
+  const controller = new ConsiliumLoopController({
+    storage: storage as never,
+    taskOrchestrator: { startGroup: vi.fn(), startGroupAsync: vi.fn(), createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
+    config: configWith(directReviewEnabled),
+    readRepoHead: async () => "HEADSHA",
+  });
+  return { controller, claimRedrive };
+}
+type Priv = { redriveGraceMs(state?: ConsiliumLoopState): number };
+
+describe("M-1 — reviewing-runner redrive grace (flag ON)", () => {
+  it("redriveGraceMs(reviewing) is sized to taskTimeoutMs × REVIEW_RUNNER_WAVES, far above the base", () => {
+    const { controller } = makeController(makeLoop({}), true);
+    const p = controller as unknown as Priv;
+    expect(p.redriveGraceMs("reviewing")).toBe(ROUND_GRACE); // 30 min
+    expect(p.redriveGraceMs("reviewing")).toBeGreaterThan(p.redriveGraceMs("building_context"));
+    expect(p.redriveGraceMs("building_context")).toBe(BASE_GRACE);
+  });
+
+  it("a runner reviewing loop (no local reviewRuns entry) WITHIN the grace is NOT cross-instance redrive-eligible", async () => {
+    // Age 5 min ≪ 30 min grace: a legitimately-in-flight multi-wave review on another instance.
+    const loop = makeLoop({ state: "reviewing", round: 1, currentIterationNumber: null, updatedAt: new Date(Date.now() - 5 * MIN) });
+    const { controller, claimRedrive } = makeController(loop, true);
+
+    await controller.tick(loop.id);
+
+    expect(claimRedrive).not.toHaveBeenCalled(); // within grace ⇒ no cross-instance redrive
+  });
+
+  it("a runner reviewing loop PAST the grace still redrives (never stranded-forever)", async () => {
+    // Age 40 min > 30 min grace: a genuinely crashed/registry-lost review.
+    const loop = makeLoop({ state: "reviewing", round: 1, currentIterationNumber: null, updatedAt: new Date(Date.now() - 40 * MIN) });
+    const { controller, claimRedrive } = makeController(loop, true);
+
+    await controller.tick(loop.id);
+
+    expect(claimRedrive).toHaveBeenCalledTimes(1); // past grace ⇒ cross-instance claim attempted
+    expect(claimRedrive).toHaveBeenCalledWith(loop.id, "reviewing", ROUND_GRACE);
+  });
+});
+
+describe("M-1 — FLAG-OFF parity: reviewing grace stays the bare base", () => {
+  it("redriveGraceMs(reviewing) === the base grace under flag OFF (round-sized NOT applied)", () => {
+    const { controller } = makeController(makeLoop({}), false);
+    expect((controller as unknown as Priv).redriveGraceMs("reviewing")).toBe(BASE_GRACE);
+  });
+
+  it("a null-ref reviewing loop under flag OFF PAST the base grace redrives at the SHORT window (legacy crash-window recovery unchanged)", async () => {
+    // Age 2 min: past the 30s base, WITHIN the 30-min round grace. Under flag OFF the base grace
+    // applies, so this legacy crash-window still redrives promptly (the pre-M-1 behaviour).
+    const loop = makeLoop({ state: "reviewing", round: 1, currentIterationNumber: null, updatedAt: new Date(Date.now() - 2 * MIN) });
+    const { controller, claimRedrive } = makeController(loop, false);
+
+    await controller.tick(loop.id);
+
+    expect(claimRedrive).toHaveBeenCalledTimes(1); // base grace ⇒ redrives (NOT held by the round grace)
+    expect(claimRedrive).toHaveBeenCalledWith(loop.id, "reviewing", BASE_GRACE);
+  });
+});

--- a/tests/unit/consilium/loop-review-settle.test.ts
+++ b/tests/unit/consilium/loop-review-settle.test.ts
@@ -1,0 +1,285 @@
+/**
+ * loop-review-settle.test.ts — B5 (Phase 2) coverage for the runner-mode SETTLE→CONSUME
+ * side of the reviewing transition, the peer of loop-review-dispatch.test.ts (B4 = dispatch).
+ *
+ * Once a background direct review settles in `reviewRuns`, `deriveReviewEvent` reads it
+ * (keyed off the ROUND's actual mode — the entry — NOT the live flag) and drives the FSM:
+ *   - clean settle  ⇒ reviewing→deciding, and `recordRound` persists the round audit with
+ *     the runner's ALREADY-parsed judge verdict + participants (on the CAS winner, in
+ *     runSideEffect), then the consumed entry is dropped.
+ *   - degraded settle ⇒ reviewing→failed carrying the FIXED-GENERIC `loop.error`
+ *     ("review run failed"); the raw scrubbed detail goes to the LOGS only (Security L1);
+ *     NO round recorded (mirrors a failed legacy iteration); entry dropped.
+ *   - in-flight ⇒ no transition (loop stays reviewing, entry intact).
+ *
+ * Double-record: the runner records round N (rich) at reviewing→deciding; the later
+ * deciding→terminal recordRound(N) re-append MUST hit the idempotent UNIQUE(loop,round)
+ * swallow (Postgres/Mem `code = "23505"`), leaving the rich row intact and `loop.error`
+ * clean. deciding is unstuck here via the existing `readIterationVerdict` seam (runner-mode
+ * verdict-read is B6); this file only proves the double-record is non-destructive.
+ *
+ * Flag-OFF / legacy parity is proven by the whole consilium/loop-fsm suite passing
+ * UNMODIFIED; the last case here additionally pins the straddle fall-through (no entry ⇒
+ * the UNCHANGED iteration path).
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { ConsiliumLoopController } from "../../../server/services/consilium/consilium-loop-controller.js";
+import type { ConsiliumLoopRow, ConsiliumLoopState, ConsiliumLoopRoundRow, InsertConsiliumLoopRound } from "@shared/schema";
+import type { RoundVerdict, RoundParticipant, ActionPoint } from "@shared/types";
+
+function makeLoop(over: Partial<ConsiliumLoopRow>): ConsiliumLoopRow {
+  return {
+    id: "loop1",
+    groupId: "grp1",
+    state: "reviewing",
+    round: 1,
+    maxRounds: 6,
+    repoPath: process.cwd(),
+    lastReviewedCommit: null,
+    currentIterationNumber: null,
+    devGroupId: null,
+    prRef: null,
+    headCommitAtReview: null,
+    openP0: null,
+    error: null,
+    createdBy: "user1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    completedAt: null,
+    ...over,
+  } as ConsiliumLoopRow;
+}
+
+/**
+ * Fake storage honouring the CAS + STORING rounds with a real UNIQUE(loop,round) guard
+ * (throws the Postgres-parity `code = "23505"` on a duplicate append), so the double-record
+ * idempotency is exercised for real — not stubbed away.
+ */
+function makeFakeStorage(loop: ConsiliumLoopRow) {
+  let current = loop;
+  const roundRows: ConsiliumLoopRoundRow[] = [];
+  const cas = vi.fn(
+    async (id: string, expected: ConsiliumLoopState, next: ConsiliumLoopState, extra?: Record<string, unknown>) => {
+      if (id !== current.id || current.state !== expected) return undefined;
+      current = { ...current, ...(extra ?? {}), state: next };
+      return current;
+    },
+  );
+  const appendLoopRound = vi.fn(async (data: InsertConsiliumLoopRound) => {
+    if (roundRows.some((r) => r.loopId === data.loopId && r.round === data.round)) {
+      const err = new Error("consilium_loop_rounds_uq");
+      (err as NodeJS.ErrnoException).code = "23505";
+      throw err;
+    }
+    const row = { id: `r${roundRows.length}`, createdAt: new Date(), ...data } as ConsiliumLoopRoundRow;
+    roundRows.push(row);
+    return row;
+  });
+  const storage = {
+    getLoop: vi.fn(async () => current),
+    getLoops: vi.fn(async () => [current]),
+    getLoopRounds: vi.fn(async () => [...roundRows].sort((a, b) => a.round - b.round)),
+    casLoopState: cas,
+    claimRedrive: vi.fn(async () => undefined),
+    appendLoopRound,
+    updateLoop: vi.fn(async (_id: string, extra?: Record<string, unknown>) => {
+      current = { ...current, ...(extra ?? {}) };
+      return current;
+    }),
+    getTaskGroup: vi.fn(async () => ({ id: current.groupId, name: "[consilium-review:sdlc-cross-review] x", input: "objective" })),
+    getIteration: vi.fn(async () => undefined),
+    getExecutionsByIteration: vi.fn(async () => []),
+  };
+  return { storage, get: () => current, rounds: () => roundRows };
+}
+
+const configWith = (directReviewEnabled: boolean) =>
+  (() => ({
+    pipeline: {
+      taskGroups: { taskTimeoutMs: 300000, defaultModel: "claude-opus" },
+      consiliumLoop: {
+        enabled: true,
+        maxRounds: 6,
+        pollIntervalMs: 5000,
+        maxDiffBytes: 200000,
+        allowedRepoPaths: [process.cwd()],
+        directReview: { enabled: directReviewEnabled },
+        implement: { enabled: false, verification: { enabled: false }, research: { enabled: false } },
+      },
+    },
+    providers: {},
+  })) as never;
+
+const orchestratorStub = {
+  startGroup: vi.fn(),
+  startGroupAsync: vi.fn(),
+  createTaskGroup: vi.fn(),
+  cancelGroup: vi.fn(),
+} as never;
+
+/** Seed a settled/in-flight review run directly (isolates the consume from the dispatch). */
+function seedReviewRun(controller: ConsiliumLoopController, loopId: string, run: unknown): void {
+  (controller as unknown as { reviewRuns: Map<string, unknown> }).reviewRuns.set(loopId, run);
+}
+function reviewRunsOf(controller: ConsiliumLoopController): Map<string, unknown> {
+  return (controller as unknown as { reviewRuns: Map<string, unknown> }).reviewRuns;
+}
+
+const AP: ActionPoint = { title: "fix the null deref", priority: "P0" } as ActionPoint;
+const VERDICT: RoundVerdict = {
+  verdict: "not yet — one P0 open",
+  pros: ["clear structure"],
+  cons: ["missing guard"],
+  actionPoints: [AP],
+};
+const PARTICIPANTS: RoundParticipant[] = [
+  { name: "reviewer-a", model: "claude-opus", role: "primary", text: "found a null deref" },
+  { name: "reviewer-b", model: "claude-sonnet", role: "rebuttal", text: "agree, P0" },
+];
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("B5 — reviewing settle→consume drives the FSM off the reviewRuns registry", () => {
+  it("clean settle ⇒ reviewing→deciding, round persisted with verdict+participants, entry dropped", async () => {
+    const loop = makeLoop({ state: "reviewing", round: 1, currentIterationNumber: null });
+    const { storage, get, rounds } = makeFakeStorage(loop);
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: orchestratorStub,
+      config: configWith(true),
+      readRepoHead: async () => "HEADSHA",
+    });
+    seedReviewRun(controller, loop.id, {
+      round: 1,
+      done: true,
+      result: { converged: false, openP0: 1, openActionPoints: [AP], verdict: VERDICT, participants: PARTICIPANTS },
+    });
+
+    const res = await controller.tick(loop.id);
+
+    expect(res?.state).toBe("deciding");
+    expect(get().state).toBe("deciding");
+    // The round audit was persisted with the runner's parsed verdict + participants.
+    expect(rounds()).toHaveLength(1);
+    expect(rounds()[0]).toMatchObject({
+      round: 1,
+      converged: false,
+      openP0: 1,
+      verdict: VERDICT,
+      participants: PARTICIPANTS,
+      headCommit: "HEADSHA",
+    });
+    // The consumed entry was dropped.
+    expect(reviewRunsOf(controller).get(loop.id)).toBeUndefined();
+  });
+
+  it("degraded settle ⇒ reviewing→failed with the FIXED-GENERIC error, raw→logs only, NO round, entry dropped", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const loop = makeLoop({ state: "reviewing", round: 2, currentIterationNumber: null });
+    const { storage, get, rounds } = makeFakeStorage(loop);
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: orchestratorStub,
+      config: configWith(true),
+      readRepoHead: async () => "HEADSHA",
+    });
+    seedReviewRun(controller, loop.id, {
+      round: 2,
+      done: true,
+      result: { converged: false, openP0: 0, openActionPoints: [], verdict: null, participants: null, error: "kaboom in <path>" },
+    });
+
+    const res = await controller.tick(loop.id);
+
+    expect(res?.state).toBe("failed");
+    // L1: loop.error is the FIXED GENERIC — the raw detail never reaches it.
+    expect(res?.error).toBe("review run failed");
+    expect(res?.error).not.toContain("kaboom");
+    // A degraded run records NO round (mirrors a failed legacy iteration).
+    expect(rounds()).toHaveLength(0);
+    // Entry dropped.
+    expect(reviewRunsOf(controller).get(loop.id)).toBeUndefined();
+    // Raw scrubbed detail went to the LOGS only.
+    const loggedRaw = logSpy.mock.calls.some(
+      (c) => String(c[0]).includes("review run degraded") && String(c[0]).includes("kaboom"),
+    );
+    expect(loggedRaw).toBe(true);
+    expect(get().state).toBe("failed");
+  });
+
+  it("in-flight settle ⇒ no transition (loop stays reviewing, entry intact, no round)", async () => {
+    const loop = makeLoop({ state: "reviewing", round: 1, currentIterationNumber: null });
+    const { storage, get, rounds } = makeFakeStorage(loop);
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: orchestratorStub,
+      config: configWith(true),
+      readRepoHead: async () => "HEADSHA",
+    });
+    seedReviewRun(controller, loop.id, { round: 1, done: false });
+
+    const res = await controller.tick(loop.id);
+
+    expect(res).toBeNull(); // no event ⇒ no-op
+    expect(get().state).toBe("reviewing");
+    expect(reviewRunsOf(controller).get(loop.id)).toMatchObject({ round: 1, done: false });
+    expect(rounds()).toHaveLength(0);
+  });
+
+  it("double-record: the later deciding→terminal recordRound(N) hits the UNIQUE swallow — rich row survives, loop.error clean", async () => {
+    const loop = makeLoop({ state: "reviewing", round: 1, currentIterationNumber: null });
+    const { storage, get, rounds } = makeFakeStorage(loop);
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: orchestratorStub,
+      config: configWith(true),
+      readRepoHead: async () => "HEADSHA",
+      // Unstick deciding for THIS test (runner-mode verdict-read is B6): a converged
+      // verdict routes deciding→converged, exercising the terminal recordRound(1) re-append.
+      readIterationVerdict: async () => ({ converged: true, openP0: 0, openActionPoints: [] }),
+    });
+    seedReviewRun(controller, loop.id, {
+      round: 1,
+      done: true,
+      result: { converged: true, openP0: 0, openActionPoints: [], verdict: VERDICT, participants: PARTICIPANTS },
+    });
+
+    await controller.tick(loop.id); // reviewing→deciding, records round 1 (rich)
+    expect(get().state).toBe("deciding");
+    expect(rounds()).toHaveLength(1);
+
+    await controller.tick(loop.id); // deciding→converged, recordRound(1)#2 → UNIQUE swallow
+    expect(get().state).toBe("converged");
+
+    // Exactly ONE round row, still carrying the runner's rich verdict + participants
+    // (the #2 re-append — verdict:null/participants:null — was swallowed, never overwrote).
+    expect(rounds()).toHaveLength(1);
+    expect(rounds()[0]).toMatchObject({ round: 1, verdict: VERDICT, participants: PARTICIPANTS });
+    // UNIQUE-swallow is a true no-op: loop.error stays clean (never the audit-write path).
+    expect(get().error ?? null).toBeNull();
+  });
+
+  it("legacy straddle: NO reviewRuns entry ⇒ the UNCHANGED iteration path drives review_completed", async () => {
+    const loop = makeLoop({ state: "reviewing", round: 1, currentIterationNumber: 7 });
+    const { storage, get, rounds } = makeFakeStorage(loop);
+    // Legacy: a settled task-group iteration + an injected iteration verdict (the old seam).
+    storage.getIteration = vi.fn(async () => ({ status: "completed" })) as never;
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: orchestratorStub,
+      config: configWith(true), // flag ON, but NO entry for this round ⇒ still legacy path
+      readRepoHead: async () => "HEADSHA",
+      readIterationVerdict: async () => ({ converged: false, openP0: 1, openActionPoints: [AP] }),
+    });
+    // NO seedReviewRun — the straddle must fall through to the iteration poll.
+
+    const res = await controller.tick(loop.id);
+
+    expect(res?.state).toBe("deciding"); // review_completed via the legacy iteration path
+    expect(reviewRunsOf(controller).get(loop.id)).toBeUndefined(); // never a runner entry
+    // Legacy reviewing→deciding records NO round here (recorded later at deciding→X), and
+    // carries no participants — proving the runner branch stayed inert.
+    expect(rounds()).toHaveLength(0);
+    expect(get().state).toBe("deciding");
+  });
+});

--- a/tests/unit/consilium/loop-runner-verdict-straddle.test.ts
+++ b/tests/unit/consilium/loop-runner-verdict-straddle.test.ts
@@ -1,0 +1,166 @@
+/**
+ * loop-runner-verdict-straddle.test.ts — B6 (Phase 2) coverage for the verdict/action-point
+ * STRADDLE read + the anti-stall guard.
+ *
+ * `resolveVerdict` / `resolveDevActionPoints` read the loop's CURRENT round via the round's
+ * ACTUAL mode (NOT the live directReview flag): a RUNNER round (identified by a recorded
+ * round row carrying `participants`, under the `currentIterationNumber == null` marker)
+ * yields its convergence + full action-point list straight off the persisted row (written
+ * by recordRound via the SHARED readConvergence/readJudgeVerdict — no re-parse); a LEGACY
+ * round falls through to the UNCHANGED old path (the `readIterationVerdict` seam / executions).
+ *
+ * Anti-stall guard (`deriveDecideEvent`): a runner round records its row EARLY (at
+ * reviewing→deciding), so the current round is already in `getLoopRounds` during its own
+ * deciding. The guard builds the prior series from rounds STRICTLY BEFORE the current round
+ * then pushes the fresh verdict — excluding the early row so it is not double-counted
+ * (which would corrupt isAntiStall's 3-window AND decide()'s round number). Byte-identical
+ * for legacy (the current round is not recorded during its own deciding, so nothing is
+ * excluded). The exact bug Architect reproduced (runner r1=2/r2=2 flat ⇒ spurious escalate)
+ * is pinned here as the parity gate.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { ConsiliumLoopController, reduce } from "../../../server/services/consilium/consilium-loop-controller.js";
+import type { ConsiliumLoopRow, ConsiliumLoopRoundRow, ConvergenceVerdict } from "@shared/schema";
+import type { RoundVerdict, RoundParticipant, ActionPoint } from "@shared/types";
+
+function makeLoop(over: Partial<ConsiliumLoopRow>): ConsiliumLoopRow {
+  return {
+    id: "loop1",
+    groupId: "grp1",
+    state: "deciding",
+    round: 1,
+    maxRounds: 6,
+    repoPath: process.cwd(),
+    lastReviewedCommit: null,
+    currentIterationNumber: null,
+    devGroupId: null,
+    prRef: null,
+    headCommitAtReview: null,
+    openP0: null,
+    error: null,
+    createdBy: "user1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    completedAt: null,
+    ...over,
+  } as ConsiliumLoopRow;
+}
+
+const AP0: ActionPoint = { title: "fix the null deref", priority: "P0" } as ActionPoint;
+const AP1: ActionPoint = { title: "tidy the log line", priority: "P1" } as ActionPoint;
+const VERDICT: RoundVerdict = { verdict: "one P0 open", pros: ["ok"], cons: ["gap"], actionPoints: [AP0, AP1] };
+const PARTS: RoundParticipant[] = [{ name: "rev-a", model: "claude-opus", role: "primary", text: "found it" }];
+
+function roundRow(over: Partial<ConsiliumLoopRoundRow>): ConsiliumLoopRoundRow {
+  return {
+    id: `r${over.round}`,
+    loopId: "loop1",
+    round: 1,
+    iterationNumber: 1,
+    converged: false,
+    openP0: 0,
+    openActionPoints: [],
+    verdict: null,
+    participants: null,
+    baselineCommit: null,
+    headCommit: null,
+    testSummary: null,
+    report: null,
+    executionTrace: null,
+    createdAt: new Date(),
+    ...over,
+  } as ConsiliumLoopRoundRow;
+}
+
+/** Minimal storage exposing the reads the straddle + old path touch. */
+function makeController(opts: {
+  rounds: ConsiliumLoopRoundRow[];
+  readIterationVerdict?: (loop: ConsiliumLoopRow) => Promise<ConvergenceVerdict | null>;
+}) {
+  const storage = {
+    getLoopRounds: vi.fn(async () => opts.rounds),
+    getIteration: vi.fn(async () => ({ id: "it", status: "completed" })),
+    getExecutionsByIteration: vi.fn(async () => []),
+    getTaskGroup: vi.fn(async () => ({ id: "grp1", name: "x", input: "obj" })),
+  };
+  const controller = new ConsiliumLoopController({
+    storage: storage as never,
+    taskOrchestrator: { startGroup: vi.fn(), startGroupAsync: vi.fn(), createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
+    config: (() => ({ pipeline: { taskGroups: { taskTimeoutMs: 300000 }, consiliumLoop: { enabled: true, maxRounds: 6, pollIntervalMs: 5000, allowedRepoPaths: [process.cwd()], directReview: { enabled: true } } } })) as never,
+    ...(opts.readIterationVerdict ? { readIterationVerdict: opts.readIterationVerdict } : {}),
+  });
+  return { controller, storage };
+}
+type Priv = {
+  resolveVerdict(loop: ConsiliumLoopRow): Promise<ConvergenceVerdict | null>;
+  resolveDevActionPoints(loop: ConsiliumLoopRow): Promise<ActionPoint[]>;
+  deriveDecideEvent(loop: ConsiliumLoopRow): Promise<{ kind: string; verdict: ConvergenceVerdict; priorOpenP0: number[] } | null>;
+};
+
+describe("B6 — verdict/action-point straddle keys off the round's actual mode", () => {
+  it("runner round: resolveVerdict reads convergence off the round row, NOT the iteration seam", async () => {
+    const loop = makeLoop({ round: 1, currentIterationNumber: null });
+    const round = roundRow({ round: 1, converged: false, openP0: 3, openActionPoints: [AP0], verdict: VERDICT, participants: PARTS });
+    // The iteration seam would return a DIFFERENT verdict — the runner round must win.
+    const { controller } = makeController({ rounds: [round], readIterationVerdict: async () => ({ converged: true, openP0: 0, openActionPoints: [] }) });
+
+    const v = await (controller as unknown as Priv).resolveVerdict(loop);
+
+    expect(v).toEqual({ converged: false, openP0: 3, openActionPoints: [AP0] });
+  });
+
+  it("runner round: resolveDevActionPoints returns the FULL ranked list from the persisted RoundVerdict", async () => {
+    const loop = makeLoop({ round: 1, currentIterationNumber: null });
+    const round = roundRow({ round: 1, openP0: 1, openActionPoints: [AP0], verdict: VERDICT, participants: PARTS });
+    const { controller } = makeController({ rounds: [round] });
+
+    const aps = await (controller as unknown as Priv).resolveDevActionPoints(loop);
+
+    expect(aps).toEqual([AP0, AP1]); // FULL list (all priorities), not just the open subset
+  });
+
+  it("legacy round (iteration set, participants null): resolveVerdict falls through to the OLD-path seam", async () => {
+    const loop = makeLoop({ round: 1, currentIterationNumber: 5 });
+    // A recorded round with participants NULL is a legacy round — the straddle must NOT claim it.
+    const round = roundRow({ round: 1, converged: false, openP0: 9, verdict: VERDICT, participants: null });
+    const seam = async () => ({ converged: true, openP0: 0, openActionPoints: [] });
+    const { controller } = makeController({ rounds: [round], readIterationVerdict: seam });
+
+    const v = await (controller as unknown as Priv).resolveVerdict(loop);
+
+    // The OLD-path seam wins (converged:true) — NOT the legacy round row's openP0:9.
+    expect(v).toEqual({ converged: true, openP0: 0, openActionPoints: [] });
+  });
+
+  it("anti-stall PARITY (the gate): a runner 2-round FLAT-openP0 loop (r1=2, r2=2) does NOT spuriously escalate", async () => {
+    const loop = makeLoop({ state: "deciding", round: 2, currentIterationNumber: null });
+    const r1 = roundRow({ round: 1, openP0: 2, participants: PARTS });
+    // r2 is the CURRENT round, recorded EARLY at reviewing→deciding (runner-mode).
+    const r2 = roundRow({ round: 2, converged: false, openP0: 2, openActionPoints: [AP0], verdict: VERDICT, participants: PARTS });
+    const { controller } = makeController({ rounds: [r1, r2] });
+
+    const event = await (controller as unknown as Priv).deriveDecideEvent(loop);
+
+    expect(event?.kind).toBe("decided");
+    // The guard excluded the early r2 row: [2,2], NOT the double-counted [2,2,2].
+    expect(event?.priorOpenP0).toEqual([2, 2]);
+    expect(reduce("deciding", { kind: "decided", verdict: event!.verdict, priorOpenP0: event!.priorOpenP0 })?.to).toBe("developing");
+    // Contrast: the double-counted series is exactly what would have spuriously escalated.
+    expect(reduce("deciding", { kind: "decided", verdict: event!.verdict, priorOpenP0: [2, 2, 2] })?.to).toBe("escalated");
+  });
+
+  it("legacy guard parity: a legacy 3-round loop still pushes the fresh verdict (round not pre-recorded) and anti-stall is UNCHANGED", async () => {
+    const loop = makeLoop({ state: "deciding", round: 3, currentIterationNumber: 9 });
+    // Legacy: only PRIOR rounds are recorded during this round's deciding (round 3 not yet).
+    const r1 = roundRow({ round: 1, openP0: 2, participants: null });
+    const r2 = roundRow({ round: 2, openP0: 2, participants: null });
+    const { controller } = makeController({ rounds: [r1, r2], readIterationVerdict: async () => ({ converged: false, openP0: 2, openActionPoints: [AP0] }) });
+
+    const event = await (controller as unknown as Priv).deriveDecideEvent(loop);
+
+    // Push FIRED: filter(r<3)=[r1,r2]=[2,2], then push the fresh 2 → [2,2,2] (length rounds.length+1).
+    expect(event?.priorOpenP0).toEqual([2, 2, 2]);
+    // Legacy anti-stall behaviour is preserved — a genuine 3-round flat stall STILL escalates.
+    expect(reduce("deciding", { kind: "decided", verdict: event!.verdict, priorOpenP0: event!.priorOpenP0 })?.to).toBe("escalated");
+  });
+});

--- a/tests/unit/consilium/loop-runner-verdict-straddle.test.ts
+++ b/tests/unit/consilium/loop-runner-verdict-straddle.test.ts
@@ -132,21 +132,27 @@ describe("B6 — verdict/action-point straddle keys off the round's actual mode"
     expect(v).toEqual({ converged: true, openP0: 0, openActionPoints: [] });
   });
 
-  it("anti-stall PARITY (the gate): a runner 2-round FLAT-openP0 loop (r1=2, r2=2) does NOT spuriously escalate", async () => {
-    const loop = makeLoop({ state: "deciding", round: 2, currentIterationNumber: null });
-    const r1 = roundRow({ round: 1, openP0: 2, participants: PARTS });
-    // r2 is the CURRENT round, recorded EARLY at reviewing→deciding (runner-mode).
-    const r2 = roundRow({ round: 2, converged: false, openP0: 2, openActionPoints: [AP0], verdict: VERDICT, participants: PARTS });
-    const { controller } = makeController({ rounds: [r1, r2] });
+  it("anti-stall PARITY (the gate): a runner 3-round loop (openP0 3→2→2) does NOT spuriously escalate", async () => {
+    // 3 REAL rounds — a 2-round series would pass with OR without the guard (isAntiStall
+    // needs round≥3), so it cannot catch the bug. Here the early-recorded current round is
+    // the difference between a correct [3,2,2] and the corrupt [3,2,2,2].
+    const loop = makeLoop({ state: "deciding", round: 3, currentIterationNumber: null });
+    const r1 = roundRow({ round: 1, openP0: 3, participants: PARTS });
+    const r2 = roundRow({ round: 2, openP0: 2, participants: PARTS });
+    // r3 is the CURRENT round, recorded EARLY at reviewing→deciding (runner-mode).
+    const r3 = roundRow({ round: 3, converged: false, openP0: 2, openActionPoints: [AP0], verdict: VERDICT, participants: PARTS });
+    const { controller } = makeController({ rounds: [r1, r2, r3] });
 
     const event = await (controller as unknown as Priv).deriveDecideEvent(loop);
 
     expect(event?.kind).toBe("decided");
-    // The guard excluded the early r2 row: [2,2], NOT the double-counted [2,2,2].
-    expect(event?.priorOpenP0).toEqual([2, 2]);
+    // Guard excluded the early r3 row: prior [3,2] + fresh verdict 2 = [3,2,2], NOT [3,2,2,2].
+    expect(event?.priorOpenP0).toEqual([3, 2, 2]);
+    // [3,2,2]: slice(-3)=[3,2,2] — 2>=2 but 2>=3 FALSE ⇒ NOT a stall ⇒ developing.
     expect(reduce("deciding", { kind: "decided", verdict: event!.verdict, priorOpenP0: event!.priorOpenP0 })?.to).toBe("developing");
-    // Contrast: the double-counted series is exactly what would have spuriously escalated.
-    expect(reduce("deciding", { kind: "decided", verdict: event!.verdict, priorOpenP0: [2, 2, 2] })?.to).toBe("escalated");
+    // Contrast (the exact bug): WITHOUT the guard the early r3 is double-counted ⇒ [3,2,2,2]
+    // ⇒ round 4, slice(-3)=[2,2,2] ⇒ non-decreasing ⇒ SPURIOUS escalate.
+    expect(reduce("deciding", { kind: "decided", verdict: event!.verdict, priorOpenP0: [3, 2, 2, 2] })?.to).toBe("escalated");
   });
 
   it("legacy guard parity: a legacy 3-round loop still pushes the fresh verdict (round not pre-recorded) and anti-stall is UNCHANGED", async () => {

--- a/tests/unit/consilium/review-runner.test.ts
+++ b/tests/unit/consilium/review-runner.test.ts
@@ -1,0 +1,203 @@
+/**
+ * review-runner.test.ts — B2 unit coverage for the PURE direct review executor
+ * (`runReviewTasks`). Drives the DAG with a FAKE gateway (no model), asserting:
+ *   - the full cross-review DAG (primaries∥ → rebuttals → judge) assembles a
+ *     ReviewRunResult whose convergence/verdict come from the JUDGE task's parsed
+ *     `.output` (byte-identical to what pickJudgeOutput/readConvergence consumed
+ *     off a task execution.output) and whose participants carry the right roles;
+ *   - a single-verifier round (lone task IS the judge) → no participants;
+ *   - a gateway throw on ANY stage → a degraded {error} result (NEVER throws);
+ *   - participant `text` is bounded (Security L-2);
+ *   - prompt fidelity with executeDirectLlm — objective/diff in the SYSTEM prompt,
+ *     user turn = the per-task input, temperature 0.7 / maxTokens 4096 / timeout.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { runReviewTasks, type ReviewGateway } from "../../../server/services/consilium/review-runner.js";
+import type { CreateTaskParam } from "../../../server/services/task-orchestrator.js";
+
+/** A judge reply in the canonical shape a task execution.output held. */
+const judgeReply = (converged: boolean, openP0: number): string =>
+  JSON.stringify({
+    summary: "judge summary",
+    output: {
+      verdict: "the verdict prose",
+      pros: ["clean tests"],
+      cons: ["a gap"],
+      action_points: openP0 > 0 ? [{ title: "fix it", priority: "P0" }] : [],
+      convergence: {
+        converged,
+        open_p0: openP0,
+        open_action_points: openP0 > 0 ? [{ title: "fix it", priority: "P0" }] : [],
+      },
+    },
+  });
+
+const debaterReply = (name: string): string =>
+  JSON.stringify({ summary: `${name} review prose`, output: { note: name }, decisions: [] });
+
+/** Fake gateway that routes a canned reply by the task name embedded in the system prompt. */
+function fakeGateway(byTask: Record<string, string>): ReviewGateway {
+  return {
+    completeStreaming: vi.fn(async (req: { messages: Array<{ role: string; content: string }> }) => {
+      const system = req.messages.find((m) => m.role === "system")?.content ?? "";
+      const name = Object.keys(byTask).find((n) => system.includes(`Your specific task: ${n}`));
+      return { content: byTask[name ?? ""] ?? "{}" };
+    }),
+  };
+}
+
+const crossReviewTasks = (): CreateTaskParam[] => [
+  { name: "P-A", description: "primary A", executionMode: "direct_llm", modelSlug: "opus", dependsOn: [] },
+  { name: "P-B", description: "primary B", executionMode: "direct_llm", modelSlug: "gemini", dependsOn: [] },
+  { name: "R-A", description: "A rebuts B", executionMode: "direct_llm", modelSlug: "opus", dependsOn: ["P-B"] },
+  { name: "R-B", description: "B rebuts A", executionMode: "direct_llm", modelSlug: "gemini", dependsOn: ["P-A"] },
+  { name: "Judge", description: "judge", executionMode: "direct_llm", modelSlug: "opus", dependsOn: ["P-A", "P-B", "R-A", "R-B"] },
+];
+
+const base = {
+  judgeTaskName: "Judge",
+  groupName: "grp",
+  groupInput: "THE OBJECTIVE AND DIFF",
+  timeoutMs: 1000,
+};
+
+describe("runReviewTasks — full cross-review DAG", () => {
+  it("assembles convergence + verdict from the judge output and participants with correct roles", async () => {
+    const gateway = fakeGateway({
+      "P-A": debaterReply("P-A"),
+      "P-B": debaterReply("P-B"),
+      "R-A": debaterReply("R-A"),
+      "R-B": debaterReply("R-B"),
+      Judge: judgeReply(false, 1),
+    });
+    const r = await runReviewTasks({ ...base, tasks: crossReviewTasks(), gateway });
+
+    expect(r.error).toBeUndefined();
+    // Convergence/verdict come from the JUDGE task's parsed .output, byte-identically.
+    expect(r.converged).toBe(false);
+    expect(r.openP0).toBe(1);
+    expect(r.openActionPoints).toEqual([{ title: "fix it", priority: "P0" }]);
+    expect(r.verdict).toEqual({
+      verdict: "the verdict prose",
+      pros: ["clean tests"],
+      cons: ["a gap"],
+      actionPoints: [{ title: "fix it", priority: "P0" }],
+    });
+    // Participants = the 4 non-judge tasks; roles from the dependency shape (order-independent).
+    const byName = Object.fromEntries((r.participants ?? []).map((p) => [p.name, p]));
+    expect(Object.keys(byName).sort()).toEqual(["P-A", "P-B", "R-A", "R-B"]);
+    expect(byName["P-A"]).toEqual({ name: "P-A", model: "opus", role: "primary", text: "P-A review prose" });
+    expect(byName["R-A"]).toEqual({ name: "R-A", model: "opus", role: "rebuttal", text: "R-A review prose" });
+    expect(byName["R-B"].role).toBe("rebuttal");
+    // The judge is NOT a participant.
+    expect(byName["Judge"]).toBeUndefined();
+  });
+
+  it("runs primaries before their dependent rebuttals (dependency order)", async () => {
+    const order: string[] = [];
+    const gateway: ReviewGateway = {
+      completeStreaming: vi.fn(async (req: { messages: Array<{ role: string; content: string }> }) => {
+        const system = req.messages.find((m) => m.role === "system")?.content ?? "";
+        const name = ["P-A", "P-B", "R-A", "R-B", "Judge"].find((n) => system.includes(`Your specific task: ${n}`))!;
+        order.push(name);
+        return { content: name === "Judge" ? judgeReply(true, 0) : debaterReply(name) };
+      }),
+    };
+    await runReviewTasks({ ...base, tasks: crossReviewTasks(), gateway });
+    // Each rebuttal must run after the primary it depends on; the judge runs last.
+    expect(order.indexOf("R-A")).toBeGreaterThan(order.indexOf("P-B")); // R-A depends on P-B
+    expect(order.indexOf("R-B")).toBeGreaterThan(order.indexOf("P-A")); // R-B depends on P-A
+    expect(order[order.length - 1]).toBe("Judge");
+  });
+});
+
+describe("runReviewTasks — single-verifier round (lone task IS the judge)", () => {
+  it("yields the verdict from the lone task and NO participants", async () => {
+    const gateway = fakeGateway({ Verifier: judgeReply(true, 0) });
+    const r = await runReviewTasks({
+      ...base,
+      judgeTaskName: "Verifier",
+      tasks: [{ name: "Verifier", description: "verify", executionMode: "direct_llm", modelSlug: "opus", dependsOn: [] }],
+      gateway,
+    });
+    expect(r.error).toBeUndefined();
+    expect(r.converged).toBe(true);
+    expect(r.openP0).toBe(0);
+    expect(r.participants).toEqual([]); // the lone verifier is the judge, not a participant
+  });
+});
+
+describe("runReviewTasks — never throws; degrades on failure", () => {
+  it("a gateway throw on any stage → a degraded {error} result (scrubbed), NOT-CONVERGED, no verdict/participants", async () => {
+    const gateway: ReviewGateway = {
+      completeStreaming: vi.fn(async () => {
+        throw new Error("gateway timed out reading /Users/secret/key.pem");
+      }),
+    };
+    const r = await runReviewTasks({ ...base, tasks: crossReviewTasks(), gateway });
+    expect(r.error).toBeTruthy();
+    expect(r.error).not.toContain("/Users"); // fs path scrubbed
+    expect(r.converged).toBe(false);
+    expect(r.openP0).toBe(0);
+    expect(r.verdict).toBeNull();
+    expect(r.participants).toBeNull();
+  });
+});
+
+describe("runReviewTasks — participant text is bounded (Security L-2)", () => {
+  it("clamps a huge participant text to the cap", async () => {
+    const gateway = fakeGateway({
+      "P-A": JSON.stringify({ summary: "x".repeat(20_000), output: {} }),
+      "P-B": debaterReply("P-B"),
+      "R-A": debaterReply("R-A"),
+      "R-B": debaterReply("R-B"),
+      Judge: judgeReply(false, 1),
+    });
+    const r = await runReviewTasks({ ...base, tasks: crossReviewTasks(), gateway });
+    const pa = (r.participants ?? []).find((p) => p.name === "P-A");
+    expect(pa?.text.length).toBe(8_000); // MAX_PARTICIPANT_TEXT
+  });
+});
+
+describe("runReviewTasks — prompt fidelity with executeDirectLlm", () => {
+  it("objective/diff ride the SYSTEM prompt, user turn is the per-task input, temp 0.7 / maxTokens 4096 / timeout", async () => {
+    let captured: { system: string; user: string; temperature?: number; maxTokens?: number; timeout?: number } | null = null;
+    const gateway: ReviewGateway = {
+      completeStreaming: vi.fn(
+        async (
+          req: { messages: Array<{ role: string; content: string }>; temperature?: number; maxTokens?: number },
+          _p?: unknown,
+          _l?: unknown,
+          streamOptions?: { overallTimeoutMs?: number },
+        ) => {
+          captured = {
+            system: req.messages.find((m) => m.role === "system")?.content ?? "",
+            user: req.messages.find((m) => m.role === "user")?.content ?? "",
+            temperature: req.temperature,
+            maxTokens: req.maxTokens,
+            timeout: streamOptions?.overallTimeoutMs,
+          };
+          return { content: judgeReply(true, 0) };
+        },
+      ),
+    };
+    await runReviewTasks({
+      ...base,
+      judgeTaskName: "Solo",
+      groupName: "my-group",
+      groupInput: "THE OBJECTIVE AND DIFF",
+      timeoutMs: 555,
+      tasks: [{ name: "Solo", description: "primary A desc", executionMode: "direct_llm", modelSlug: "opus", dependsOn: [] }],
+      gateway,
+    });
+    expect(captured).not.toBeNull();
+    expect(captured!.system).toContain("THE OBJECTIVE AND DIFF"); // objective+diff in SYSTEM
+    expect(captured!.system).toContain("Task group: my-group");
+    expect(captured!.system).toContain("Your specific task: Solo");
+    expect(captured!.system).toContain("Description: primary A desc");
+    expect(captured!.user).toBe("{}"); // per-task input (empty) in the user turn
+    expect(captured!.temperature).toBe(0.7);
+    expect(captured!.maxTokens).toBe(4096);
+    expect(captured!.timeout).toBe(555);
+  });
+});

--- a/tests/unit/consilium/review-runs-registry.test.ts
+++ b/tests/unit/consilium/review-runs-registry.test.ts
@@ -1,0 +1,250 @@
+/**
+ * review-runs-registry.test.ts — Phase 2 (direct review runner), Round 1 unit
+ * coverage for the `reviewRuns` registry ONLY. Same risk class as Phase 1's
+ * `sdlcRuns` (BUG-1 — a background job outliving a naive time-only grace check
+ * re-dispatches a duplicate). Mirrors the `sdlcRuns` suite in
+ * `tests/unit/consilium/loop-fsm.test.ts`, adapted per team-lead + Architect
+ * sign-off (2026-07-07):
+ *
+ *   - Round 1 (B3) is FULLY ISOLATED — no `tick()`/FSM wiring yet (that's B4,
+ *     Round 2). These tests call the registry methods (`dispatchReview`,
+ *     `settleReviewRun`) DIRECTLY, exactly like `loop-fsm.test.ts`'s
+ *     "IDEMPOTENT SETTLE (c)" test calls `settleSdlcRun` directly instead of
+ *     going through `tick()`.
+ *   - `deps.runReview?` (mirrors `runSdlc?`/`runResearch?`) — CONFIRMED.
+ *   - `round.participants` shape is `RoundParticipant { name: string; model:
+ *     string; role: "primary" | "rebuttal"; text: string }[] | null` —
+ *     CONFIRMED (Backend B1 = Frontend F1-A, one shared type in
+ *     shared/types.ts once it lands — task #19). NOT `CompositionRole`.
+ *   - MARKER: a runner-path round keeps `currentIterationNumber` NULL always
+ *     (mirrors `devGroupId` staying null for `developing`) — dispatch must
+ *     NEVER set it to `loop.round` or anything else. This file asserts that.
+ *   - Redrive (`claimRedrive` winner-only) and the cross-instance single-flight
+ *     case are INTEGRATION-level (real atomic-DB CAS, same as Phase 1's
+ *     sdlcRuns cross-instance tests) — NOT in this file. Tick-wiring end-to-end
+ *     (kill-switch parity, straddle) is Round 2 (B4) — also not in this file.
+ *
+ * `dispatchReview`/`settleReviewRun` are still UNCONFIRMED exact names (team-
+ * lead used them descriptively; Backend's actual code may differ slightly) —
+ * every access goes through an `as unknown as {...}` cast, so a rename is a
+ * one-place edit. Expect this file to be RED (or need a mechanical rename)
+ * until Backend's B3 lands; that's the point — it's the target contract,
+ * written before the implementation (TDD).
+ */
+import { describe, it, expect, vi } from "vitest";
+import { ConsiliumLoopController } from "../../../server/services/consilium/consilium-loop-controller.js";
+import type { ConsiliumLoopRow } from "@shared/schema";
+import type { ActionPoint } from "@shared/types";
+
+/** Confirmed shape (Architect, 2026-07-07) — Backend B1 col / Frontend F1-A render type. */
+interface RoundParticipant {
+  name: string;
+  model: string;
+  role: "primary" | "rebuttal";
+  text: string;
+}
+
+/** Best-guess RoundVerdict-shaped result the runner produces per round. */
+interface ReviewRunResult {
+  converged: boolean;
+  openP0: number;
+  openActionPoints: ActionPoint[];
+  verdict: { verdict: string; pros: string[]; cons: string[]; actionPoints: ActionPoint[] } | null;
+  participants: RoundParticipant[] | null;
+  error?: string;
+}
+
+/** Best-guess registry entry shape, mirroring `SdlcRun`. */
+interface ReviewRun {
+  round: number;
+  done: boolean;
+  result?: ReviewRunResult;
+}
+
+function makeLoop(over: Partial<ConsiliumLoopRow>): ConsiliumLoopRow {
+  return {
+    id: "loop1",
+    groupId: "grp1",
+    state: "reviewing",
+    round: 1,
+    maxRounds: 6,
+    repoPath: process.cwd(),
+    lastReviewedCommit: null,
+    // MARKER (Architect, confirmed): the runner path keeps this NULL always —
+    // mirrors devGroupId staying null for `developing`. Never set to loop.round.
+    currentIterationNumber: null,
+    devGroupId: null,
+    prRef: null,
+    headCommitAtReview: null,
+    openP0: null,
+    error: null,
+    createdBy: "user1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    completedAt: null,
+    ...over,
+  } as ConsiliumLoopRow;
+}
+
+const goodResult = (over: Partial<ReviewRunResult> = {}): ReviewRunResult => ({
+  converged: false,
+  openP0: 1,
+  openActionPoints: [{ title: "fix null check", priority: "P0" }],
+  verdict: {
+    verdict: "one blocking issue",
+    pros: ["clean tests"],
+    cons: ["missing check"],
+    actionPoints: [{ title: "fix null check", priority: "P0" }],
+  },
+  participants: [
+    { name: "Opus", model: "claude-opus", role: "primary", text: "primary1 findings" },
+    { name: "Gemini", model: "gemini-3.1-pro", role: "primary", text: "primary2 findings" },
+  ],
+  ...over,
+});
+
+/** Minimal controller — Round-1 registry methods don't need storage/orchestrator
+ *  (mirrors the exact minimalism of loop-fsm.test.ts's "IDEMPOTENT SETTLE" test). */
+function makeController(runReview?: (loop: ConsiliumLoopRow) => Promise<ReviewRunResult>) {
+  return new ConsiliumLoopController({
+    storage: {} as never,
+    taskOrchestrator: {} as never,
+    config: (() => ({ pipeline: { consiliumLoop: { enabled: true, directReview: { enabled: true } } } })) as never,
+    runReview,
+  } as never);
+}
+
+/** Reach into the not-yet-existing registry/dispatch/settle internals. */
+function internalsOf(controller: ConsiliumLoopController) {
+  return controller as unknown as {
+    reviewRuns: Map<string, ReviewRun>;
+    dispatchReview(loop: ConsiliumLoopRow): void;
+    settleReviewRun(loopId: string, run: ReviewRun, result: ReviewRunResult): void;
+  };
+}
+
+describe("dispatchReview — registers the run SYNCHRONOUSLY, before runReview resolves", () => {
+  it("reviewRuns carries {round, done:false} immediately after the (sync, fire-and-forget) call", () => {
+    const loop = makeLoop({ round: 1 });
+    let releaseRunReview: (r: ReviewRunResult) => void = () => {};
+    const runReview = vi.fn(
+      () => new Promise<ReviewRunResult>((resolve) => { releaseRunReview = resolve; }),
+    );
+    const controller = makeController(runReview);
+    const c = internalsOf(controller);
+
+    c.dispatchReview(loop); // NOT awaited — mirrors dispatchSdlc's fire-and-forget shape
+
+    expect(c.reviewRuns.get(loop.id)).toEqual({ round: 1, done: false });
+    expect(runReview).toHaveBeenCalledTimes(1);
+    releaseRunReview(goodResult()); // let the dangling promise settle so the test exits cleanly
+  });
+
+  it("never sets currentIterationNumber — the runner-path marker stays null (mirrors devGroupId for developing)", () => {
+    const loop = makeLoop({ round: 1, currentIterationNumber: null });
+    const runReview = vi.fn(async () => goodResult());
+    const controller = makeController(runReview);
+    const c = internalsOf(controller);
+
+    c.dispatchReview(loop);
+
+    // dispatchReview must not mutate the loop object it was handed, and the
+    // registry entry itself carries no iteration-number field at all — the
+    // ONLY marker of an in-flight runner-path round is the reviewRuns entry.
+    expect(loop.currentIterationNumber).toBeNull();
+    expect(c.reviewRuns.get(loop.id)).not.toHaveProperty("iterationNumber");
+  });
+});
+
+describe("dispatchReview -> settle lifecycle — in-flight, then settled with the runReview result", () => {
+  it("the registry entry is done:false while runReview is pending, then done:true with .result once it resolves", async () => {
+    const loop = makeLoop({ round: 1 });
+    let releaseRunReview: (r: ReviewRunResult) => void = () => {};
+    const runReview = vi.fn(
+      () => new Promise<ReviewRunResult>((resolve) => { releaseRunReview = resolve; }),
+    );
+    const controller = makeController(runReview);
+    const c = internalsOf(controller);
+
+    c.dispatchReview(loop);
+    expect(c.reviewRuns.get(loop.id)?.done).toBe(false); // in-flight
+
+    const result = goodResult();
+    releaseRunReview(result);
+    await Promise.resolve().then(() => Promise.resolve()); // flush the .then() settle handler
+
+    const settled = c.reviewRuns.get(loop.id);
+    expect(settled?.done).toBe(true);
+    expect(settled?.result).toEqual(result);
+  });
+});
+
+describe("degraded settle on a runner throw — dispatch never throws; the registry still settles", () => {
+  it("a rejecting runReview settles the registry done:true with an error-carrying result, not an unhandled rejection", async () => {
+    const loop = makeLoop({ round: 1 });
+    const runReview = vi.fn(async () => {
+      throw new Error("model gateway timed out");
+    });
+    const controller = makeController(runReview);
+    const c = internalsOf(controller);
+
+    expect(() => c.dispatchReview(loop)).not.toThrow();
+    await Promise.resolve().then(() => Promise.resolve()).then(() => Promise.resolve());
+
+    const settled = c.reviewRuns.get(loop.id);
+    expect(settled?.done).toBe(true);
+    expect(settled?.result?.error).toBeTruthy();
+    // Degraded settle carries no verdict/participants to render (mirrors the
+    // no-PR degraded DevCloseoutResult shape on an SDLC close-out throw).
+    expect(settled?.result?.verdict ?? null).toBeNull();
+    expect(settled?.result?.participants ?? null).toBeNull();
+  });
+});
+
+describe("settleReviewRun — idempotent settle never clobbers a completed result", () => {
+  it("a late/duplicate settle for the SAME round must not downgrade an already-done good result", () => {
+    // Mirrors loop-fsm.test.ts's "IDEMPOTENT SETTLE (c)" test for sdlcRuns
+    // (settleSdlcRun) verbatim, calling the settle method directly (no dispatch).
+    const controller = makeController();
+    const c = internalsOf(controller);
+
+    const good: ReviewRun = { round: 1, done: false };
+    c.reviewRuns.set("loop1", good);
+    c.settleReviewRun("loop1", good, goodResult());
+    expect(c.reviewRuns.get("loop1")?.result?.participants).toEqual(goodResult().participants);
+
+    // A late/duplicate settle for the SAME round arrives with a DEGRADED result
+    // (e.g. a redrive that lost the race but still resolved with an error).
+    const late: ReviewRun = { round: 1, done: false };
+    c.settleReviewRun("loop1", late, { ...goodResult(), participants: null, verdict: null, error: "redrive lost the race" });
+
+    // The good, already-settled result is preserved — the late settle must not
+    // clobber it (mirrors settleSdlcRun's null-prRef-can't-clobber-a-good-PR guard).
+    expect(c.reviewRuns.get("loop1")?.result?.participants).toEqual(goodResult().participants);
+  });
+});
+
+/**
+ * DEFERRED (per team-lead/Architect sign-off, 2026-07-07) — not in this file:
+ *
+ *   - Redrive single-dispatch + cross-instance single-flight: INTEGRATION-level.
+ *     Architect clarified (2026-07-07): `claimRedrive` is ALREADY state-
+ *     parameterized and the OLD reviewing redrive already calls it
+ *     (consilium-loop-controller.ts:1414, `claimRedrive(loop.id, "reviewing",
+ *     grace)`) — there is NO new reviewing-mode carve-out on the claim itself.
+ *     What B4 adds is a REGISTRY GATE in front of it, mirroring the
+ *     `developing`/`sdlcRuns` branch in `redriveStranded`: a `reviewRuns` entry
+ *     for `loop.round` ⇒ in-flight, skip (no claim attempt); registry EMPTY
+ *     past grace ⇒ fall through to `claimRedrive` as today. So the deferred
+ *     cross-instance test is: two controllers, empty registry, past grace →
+ *     exactly one `claimRedrive` wins → exactly one re-dispatch — same shape
+ *     as Phase 1's developing cross-instance test, just gated by the reviewing
+ *     registry check first. Belongs in a future
+ *     tests/integration/consilium/review-runs-redrive.test.ts once
+ *     review-runner.ts + the B4 tick-wiring exist to exercise end-to-end.
+ *   - Kill-switch parity (directReview.enabled=false) and STRADDLE: Round 2
+ *     (B4 wires the runner into tick()/deriveReviewEvent/resolveVerdict) — the
+ *     existing loop-fsm.test.ts assertions already cover parity unmodified
+ *     (readIterationVerdict injection is untouched by this change) and will be
+ *     re-asserted once B4 lands.
+ */

--- a/tests/unit/orchestrator/convergence.test.ts
+++ b/tests/unit/orchestrator/convergence.test.ts
@@ -373,6 +373,16 @@ describe("readJudgeVerdict — bounded, fail-soft rich judge verdict", () => {
     expect(r!.pros[0].length).toBe(MAX_FIELD_LEN); // each entry clamped
   });
 
+  it("SLICES pros/cons to the cap BEFORE filtering (Security L-2) — bounds work on a padded array", () => {
+    // A hostile array padded with MAX_PROS_CONS non-strings then a trailing string. Slicing
+    // to the cap BEFORE the type-filter bounds the work to MAX_PROS_CONS entries, so the
+    // trailing string (beyond the cap) is dropped ⇒ []. The pre-fix scan-past-non-strings
+    // impl walked the WHOLE array and collected ["late-string"] — so this is a real guard.
+    const padded = [...Array.from({ length: MAX_PROS_CONS }, () => 0), "late-string"];
+    const r = readJudgeVerdict({ verdict: "v", pros: padded });
+    expect(r!.pros).toEqual([]);
+  });
+
   it("bounds a huge action-point list (parity with extractActionPoints)", () => {
     const many = Array.from({ length: 500 }, (_, i) => ({ title: `ap${i}`, priority: "P1" }));
     const r = readJudgeVerdict({ output: { verdict: "v", action_points: many } });


### PR DESCRIPTION
## Summary

Phase 1 (#522) made the loop the single source of truth for its **result** — it fixed the blank Rounds panel and surfaced the judge's full verdict on the loop page. This PR (Phase 2) removes the **task-group execution engine** from the consilium-loop review path: the loop no longer delegates a review to a `task_group` / `task_group_iteration` via `startGroupAsync`. Instead it runs the review **in-process** via a new `review-runner.ts` and writes the round result (convergence + verdict + participants) directly to `consilium_loop_rounds`.

The entire new path ships **behind a kill-switch** — `pipeline.consiliumLoop.directReview.enabled` (default **false**). With the flag OFF the diff is **byte-identical to legacy**: the pre-existing `startGroupAsync` path, the FSM, and the full `loop-fsm` test suite are untouched. This lets the swap merge dark and be verified in production before enablement.

Stacks on #522.

## Design

- **Kill-switch, ship dark.** `directReview.enabled = z.boolean().default(false)`. The flag is read at **one** place only — the reviewing dispatch (`startReviewRound`). Everything else (settle, verdict/action-point reads, redrive) keys off the **round's actual mode**, never the live flag — so a mid-flight flip cannot mis-read or corrupt an in-flight review (proven both directions).
- **`review-runner.ts` — a pure, in-process executor.** Runs the same multi-model debate the task-group did (primaries ∥ → rebuttals ∥ → judge) via `gateway.completeStreaming`, reusing `buildSystemPrompt` verbatim and extracting convergence/verdict through the **shared** `readConvergence` / `readJudgeVerdict` (no private re-parse). It never throws (degrades to `{error}`), and bounds `participants` (24 × 8000 chars).
- **`reviewRuns` registry — concurrency core.** Process-local map, sync-register-before-await dispatch, idempotent settle, `claimRedrive` single-flight (mirrors the existing `sdlcRuns` pattern). Crash-safe: a runner round keeps `currentIterationNumber` explicit **null** so it can't be mis-classified.
- **Straddle read.** `deriveReviewEvent` reads the settled run off the `reviewRuns` entry; `resolveVerdict` / `resolveDevActionPoints` read the persisted **round** (discriminated by `participants != null` + the null marker — never `verdict`, which the legacy path also writes). Legacy rounds fall through to the retained `readIterationVerdict` seam.

## Changes (behind the flag unless noted)

**Backend** (`consilium-loop-controller.ts`, `review-runner.ts`, `convergence.ts`, `shared/schema.ts` + `shared/types.ts`)
- New `review-runner.ts` in-process executor; `reviewRuns` registry + non-blocking dispatch/settle.
- `startReviewRound` dispatches to the runner when the flag is ON, else the legacy `startGroupAsync` (unchanged).
- `deriveReviewEvent` consumes the settled run; `recordRound` persists convergence + verdict + **participants** (additive `runnerAudit` param; the 2-arg legacy call is byte-identical).
- `resolveVerdict` / `resolveDevActionPoints` straddle-read the round; anti-stall `priorOpenP0` guard (filter rounds strictly before the current one, so the early-recorded runner round isn't double-counted).
- **New `participants jsonb` column** (migration `0052`, additive `ADD COLUMN IF NOT EXISTS`; reuses Phase-1's `verdict jsonb`).
- **Security hardening (applies always, not flag-gated):** L1 — the `recordRound` audit-write failure genericizes its operator-facing `loop.error` (raw exception → server logs only); L2 — `boundStringList` slices its input to the cap **before** map/clamp (bounds work on a hostile array).
- **M-1 (redrive grace):** the reviewing redrive grace is sized to the runner DAG span (`taskTimeoutMs × 3 waves`) when the flag is ON, so a cross-instance poller can't prematurely redrive a legitimately-running review (duplicate model spend). Flag OFF keeps the base grace → legacy crash-window recovery (120s) unchanged.

**Frontend** (`ConsiliumLoopDetail.tsx`)
- Dual-path round dispute: renders `round.participants` (runner) with the `IterationDetailView` retained as the legacy fallback. Participants render as **inert** React text.

## Test plan

- **Unit** (new): `loop-review-settle`, `loop-runner-verdict-straddle`, `loop-directreview-straddle` (kill-switch parity snapshot + mid-flip both directions + single-verifier round>1), `loop-error-redaction`, `loop-review-redrive-grace`, `review-runs-registry`, `loop-review-dispatch`; `convergence` +bounded-work case.
- **Mutation-verified discriminators:** the B6 anti-stall test was proven to FAIL when the guard is reverted; the redrive-grace + straddle tests key off the round's actual mode.
- **Parity proof:** `loop-fsm.test.ts` (and `loop-planner.test.ts`) pass **UNMODIFIED** across every milestone — the flag-OFF path is byte-identical.
- **Green:** `npm run check` clean; consilium + orchestrator + integration **1334 / 0** (my run) — 98 files; full unit suite green on the branch. Migration `0052` applied + verified on the dev DB (`verdict` + `participants` columns present).

## Security

Reviewed — **APPROVE the merge** (no CRITICAL / HIGH). The runner path ships dark (default OFF), so the diff as-merged is byte-identical to legacy and carries zero production risk. All focus areas pass: untrusted model output bounded (participants 24×8000, verdict via shared readers, `maxTokens` pinned, L2 slice-before-map); no raw exception / diff / prompt / secret reaches `loop.error` (L1 generic + scrub-to-logs; curated reasons run through `scrubMessage`); straddle keys off the round's mode never the flag; the branch ref still passes the Phase-1 four-layer server-side allowlist inside `buildDiffContext`; participants render inert (no `dangerouslySetInnerHTML`).

**One MEDIUM (M-1) — addressed in this PR** (see the redrive-grace change): before the fix, a multi-instance deployment with the flag ON could prematurely redrive a legitimately-running runner review (~30s) → duplicate model spend + round-counter inflation. Now the reviewing grace is round-sized (`taskTimeoutMs × 3 waves` ≈ 30 min at defaults) when the flag is ON. Residual (perf-only, bounded): flipping the flag **OFF mid-review** reverts a live runner review to the base grace → at most **one** cross-instance duplicate round — self-limiting, not a storm (the legacy dispatch then sets `currentIterationNumber`, so the null-ref base-grace redrive can't re-fire), verdict/state stay single via UNIQUE + CAS, no strand, no misread. Re-reviewed after the fix: **pre-enable gate CLOSED, APPROVE unconditional** — `directReview.enabled = true` is safe in multi-instance at steady state.

## Rollout

- Ship with `directReview.enabled = false` (this is the default). The feature is dark on merge.
- Bake, then flip the flag ON to enable the in-process runner. Prefer flipping when no reviews are in flight — this fully avoids even the one-round mid-flip residual.
- A crashed / restart-orphaned runner review recovers within one grace window (~30 min at default `taskTimeoutMs`), matching the developing path's round-sized discipline — expected, not a regression.
- **Maintenance:** `REVIEW_RUNNER_WAVES = 3` is coupled to the cross-review DAG shape (primaries → rebuttals → judge). If the DAG ever gains sequential waves, bump this constant in lockstep or the premature-redrive window reopens.
- **Known follow-ups (flag-OFF-safe, tracked; land before/with wider enablement):** human note→next-round steer in runner-mode (#18); the runner-mode unresolved-ref surfaces a generic reason vs the curated `failUnresolvedReview` (#21); a client-side "review running…" placeholder for live runner reviews; transcript-richness bake-watch (participant `text` is the recap summary; surface full `## FINDINGS` prose if thin).

## Architecture sign-off

Full-PR review APPROVED (line-verified every milestone + the cumulative diff against the blueprint): additive shape (~2365 ins / 37 del incl. M-1), ~2:1 tests:prod, reviewRuns concurrency core + straddle + kill-switch parity all conformant, legacy path fully intact (`startGroupAsync`, `IterationDetailView` fallback, `groupId`, factory DAG kept inert). Two correctness bugs were caught + fixed in review (the crash-safe explicit-null marker; the anti-stall double-count guard).

## Not in this PR / how to enable

The task-group execution engine is retained but **inert** on the review path when the flag is OFF. Enabling is a config flip (`directReview.enabled = true`) after bake; no further code change is required for single-instance. For multi-instance, M-1 (in this PR) is the prerequisite and is already satisfied.
