### PR TITLE
refactor(settings): fold Privacy page into a Settings section

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,7 +13,6 @@ import { useAuth } from "@/hooks/use-auth";
 import MainLayout from "@/components/layout/MainLayout";
 import TriggersPage from "@/pages/TriggersPage";
 import Settings from "@/pages/Settings";
-import Privacy from "@/pages/Privacy";
 import Statistics from "@/pages/Statistics";
 import KnowledgeBase from "@/pages/KnowledgeBase";
 import WorkspaceList from "@/pages/WorkspaceList";
@@ -113,9 +112,8 @@ function ProtectedRouter() {
         <Route path="/settings/users" component={() => (
           <ErrorBoundary><UserManagement /></ErrorBoundary>
         )} />
-        <Route path="/privacy" component={() => (
-          <ErrorBoundary><Privacy /></ErrorBoundary>
-        )} />
+        {/* Privacy moved into Settings ("Privacy & Compliance" section) — redirect legacy bookmarks. */}
+        <Route path="/privacy" component={() => <Redirect to="/settings" />} />
         <Route path="/contour" component={() => (
           <ErrorBoundary><ContourObservability /></ErrorBoundary>
         )} />

--- a/client/src/components/settings/PrivacySection.tsx
+++ b/client/src/components/settings/PrivacySection.tsx
@@ -1,3 +1,17 @@
+/**
+ * PrivacySection — the Privacy & Compliance controls, rendered as the body of a
+ * Settings "Privacy & Compliance" SettingsSection.
+ *
+ * Extracted verbatim from the former standalone `pages/Privacy.tsx` (route
+ * `/privacy`, which had no nav entry and no inbound links). The page chrome
+ * (header + ScrollArea) is dropped here because the SettingsSection wrapper
+ * provides the collapsible card; only the functional panels move.
+ *
+ * NOTE (copy): the opt-in wording below is a pre-retirement vestige ("per
+ * pipeline stage" / "Agent Node's Advanced settings"). It is carried over
+ * unchanged in this move — the correct post-retirement scope is a separate
+ * copy pass, pending a caller-trace of the anonymizer.
+ */
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -7,7 +21,7 @@ import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { ShieldCheck, Trash2, Plus, Play, AlertTriangle, Lock } from "lucide-react";
+import { Trash2, Plus, Play, AlertTriangle, Lock } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { apiRequest } from "@/lib/queryClient";
 
@@ -365,41 +379,26 @@ function PatternsTable() {
   );
 }
 
-export default function Privacy() {
+export function PrivacySection() {
   return (
-    <div className="flex flex-col h-full overflow-hidden">
-      <div className="px-6 py-4 border-b border-border">
-        <div className="flex items-center gap-2">
-          <ShieldCheck className="h-5 w-5 text-primary" />
-          <h1 className="text-lg font-semibold">Privacy &amp; Compliance</h1>
-        </div>
-        <p className="text-sm text-muted-foreground mt-0.5">
-          Configure the Privacy Proxy Layer to pseudonymize sensitive identifiers before they reach public LLM APIs.
-          Disabled by default — opt-in per pipeline stage.
-        </p>
-      </div>
+    <div className="p-4 space-y-4">
+      <Card className="border-amber-500/30 bg-amber-500/5">
+        <CardContent className="pt-4 pb-4">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="h-4 w-4 text-amber-500 mt-0.5 shrink-0" />
+            <div className="text-xs text-amber-700 dark:text-amber-400 space-y-1">
+              <p className="font-medium">Privacy proxy is opt-in per pipeline stage</p>
+              <p className="text-muted-foreground">
+                Enable it in each Agent Node's Advanced settings. Real values are never stored in the audit log.
+                In-memory vault is cleared after the session TTL (default 1 hour).
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
 
-      <ScrollArea className="flex-1">
-        <div className="p-6 space-y-6 max-w-3xl">
-          <Card className="border-amber-500/30 bg-amber-500/5">
-            <CardContent className="pt-4 pb-4">
-              <div className="flex items-start gap-3">
-                <AlertTriangle className="h-4 w-4 text-amber-500 mt-0.5 shrink-0" />
-                <div className="text-xs text-amber-700 dark:text-amber-400 space-y-1">
-                  <p className="font-medium">Privacy proxy is opt-in per pipeline stage</p>
-                  <p className="text-muted-foreground">
-                    Enable it in each Agent Node's Advanced settings. Real values are never stored in the audit log.
-                    In-memory vault is cleared after the session TTL (default 1 hour).
-                  </p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          <TestPanel />
-          <PatternsTable />
-        </div>
-      </ScrollArea>
+      <TestPanel />
+      <PatternsTable />
     </div>
   );
 }

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -26,6 +26,7 @@ import {
   Terminal,
   Link2,
   Info,
+  ShieldCheck,
 } from "lucide-react";
 import {
   useModels,
@@ -42,6 +43,7 @@ import { cn } from "@/lib/utils";
 import { useQueryClient, useMutation, useQuery } from "@tanstack/react-query";
 import { ArgocdSettings } from "@/components/settings/ArgocdSettings";
 import { SettingsSection } from "@/components/settings/SettingsSection";
+import { PrivacySection } from "@/components/settings/PrivacySection";
 import { VersionInfoPanel } from "@/components/settings/VersionInfoPanel";
 import { LocalModelsSection } from "@/components/settings/LocalModelsSection";
 
@@ -1080,6 +1082,17 @@ export default function Settings() {
                 </div>
               </div>
             </div>
+          </SettingsSection>
+
+          {/* ── Privacy & Compliance ───────────────────────── */}
+          <SettingsSection
+            title="Privacy & Compliance"
+            icon={<ShieldCheck className="h-4 w-4" />}
+            shortDescription="Pseudonymize sensitive identifiers before they reach public LLM APIs."
+            longDescription="Configure the privacy proxy: test the anonymizer against sample text at off/standard/strict levels, and manage custom detection patterns. Real values are never stored in the audit log; the in-memory vault is cleared after the session TTL."
+            defaultOpen={false}
+          >
+            <PrivacySection />
           </SettingsSection>
 
           {/* ── 8. ArgoCD ──────────────────────────────────── */}


### PR DESCRIPTION
## What
- Extract the Privacy panels into `client/src/components/settings/PrivacySection.tsx` (rename of `pages/Privacy.tsx`; page chrome stripped — the `SettingsSection` card provides it)
- Add an always-visible "Privacy & Compliance" section in `Settings.tsx`
- Redirect legacy `/privacy` → `/settings`; delete the standalone page

## Why
Privacy is PII-anonymization configuration (off/standard/strict + custom patterns), not a standalone surface — it belongs under Settings. Part of the post-retirement route cleanup wave.

## Notes
- FE-only; `/api/privacy/*` untouched (still behind `requireAuth, requireProject`)
- Both old and new routes live inside `ProtectedRouter`; no auth surface change
- Carried-over "per pipeline stage" opt-in copy is flagged in-code for a separate copy pass

## Testing
- Security review: CLEAN (auth/authz, PII patterns, audit-log, route wiring, import hygiene)
- `/privacy` redirect verified wired via wouter `Redirect`