### PR TITLE
fix(remote-agents): guard background heartbeat timers against transient DB errors

### DIFF
--- a/server/remote-agents/remote-agent-manager.ts
+++ b/server/remote-agents/remote-agent-manager.ts
@@ -276,11 +276,43 @@ export class RemoteAgentManager {
   // ── Heartbeat ──────────────────────────────────────────────────────
 
   private startHeartbeat(intervalMs: number): void {
-    this.heartbeatInterval = setInterval(async () => {
+    // The timer callback is intentionally NOT async. An async callback returns a
+    // promise that setInterval discards; a rejection from the sweep (e.g. a
+    // Postgres ECONNRESET during listAgents) would then surface as an
+    // unhandledRejection and crash the whole server process. runHeartbeatSweep
+    // already swallows its own errors, and the defensive .catch() below is a
+    // belt-and-braces guard so the heartbeat can never take the process down.
+    this.heartbeatInterval = setInterval(() => {
+      void this.runHeartbeatSweep().catch((err) => {
+        console.warn(
+          "[remote-agent-manager] heartbeat sweep crashed unexpectedly (recovering, not fatal):",
+          err instanceof Error ? err.message : err,
+        );
+      });
+    }, intervalMs);
+  }
+
+  /**
+   * One heartbeat pass over all agents. Never rejects: a DB fault (ECONNRESET)
+   * while listing agents, or a single agent's health-check/update failure, is
+   * logged and the loop continues. A transient fault must not crash the server.
+   */
+  private async runHeartbeatSweep(): Promise<void> {
+    let agents: RemoteAgentConfig[];
+    try {
       // listAgents() reads across all projects; runAsSystem provides context + audit.
-      const agents = await runAsSystem("remote-agent-heartbeat", () => this.listAgents());
-      for (const agent of agents) {
-        if (!agent.enabled) continue;
+      agents = await runAsSystem("remote-agent-heartbeat", () => this.listAgents());
+    } catch (err) {
+      console.warn(
+        "[remote-agent-manager] heartbeat: failed to list agents (skipping this cycle):",
+        err instanceof Error ? err.message : err,
+      );
+      return;
+    }
+
+    for (const agent of agents) {
+      if (!agent.enabled) continue;
+      try {
         const health = await this.discovery.healthCheck(agent);
         await db
           .update(remoteAgents)
@@ -291,8 +323,14 @@ export class RemoteAgentManager {
             updatedAt: new Date(),
           })
           .where(eq(remoteAgents.id, agent.id));
+      } catch (err) {
+        // One agent's failure must not abort the sweep for the others.
+        console.warn(
+          `[remote-agent-manager] heartbeat: agent ${agent.id} update failed (continuing):`,
+          err instanceof Error ? err.message : err,
+        );
       }
-    }, intervalMs);
+    }
   }
 
   // ── Helpers ────────────────────────────────────────────────────────

--- a/tests/unit/remote-agent-manager.test.ts
+++ b/tests/unit/remote-agent-manager.test.ts
@@ -513,6 +513,88 @@ describe("RemoteAgentManager", () => {
     });
   });
 
+  // ── heartbeat resilience (regression: #26) ─────────────────────
+
+  describe("heartbeat resilience", () => {
+    // Regression for #26: a Postgres ECONNRESET during the heartbeat's
+    // listAgents() read used to reject the discarded setInterval promise,
+    // surfacing as an unhandledRejection and crashing the whole server.
+    it("does not throw when listAgents rejects with a Postgres ECONNRESET", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockDb.select.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnThis(),
+          orderBy: vi.fn().mockRejectedValue(new Error("read ECONNRESET")),
+        }),
+      });
+
+      const mgr = await getManager();
+
+      // runHeartbeatSweep is exactly what the interval callback invokes each tick.
+      await expect((mgr as any).runHeartbeatSweep()).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("failed to list agents"),
+        expect.anything(),
+      );
+      // A failed listing short-circuits: no agent is probed this cycle.
+      expect(mockHealthCheck).not.toHaveBeenCalled();
+    });
+
+    it("continues the sweep when one agent's health check fails", async () => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      const bad = makeAgentRow({ id: "bad", enabled: true });
+      const good = makeAgentRow({ id: "good", enabled: true });
+      mockDb.select.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnThis(),
+          orderBy: vi.fn().mockReturnValue([bad, good]),
+        }),
+      });
+      mockHealthCheck
+        .mockRejectedValueOnce(new Error("health probe timeout"))
+        .mockResolvedValueOnce({ status: "online", latencyMs: 5 });
+      const updateChain = createQueryChain({ onExecute: () => [] });
+      mockDb.update.mockReturnValue(updateChain);
+
+      const mgr = await getManager();
+      await expect((mgr as any).runHeartbeatSweep()).resolves.toBeUndefined();
+
+      // Both agents were probed despite the first one throwing, and the healthy
+      // agent still received its DB update.
+      expect(mockHealthCheck).toHaveBeenCalledTimes(2);
+      expect(mockDb.update).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the heartbeat timer alive after a rejected sweep (no process crash)", async () => {
+      const mgr = await getManager();
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockDb.select.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnThis(),
+          orderBy: vi.fn().mockRejectedValue(new Error("read ECONNRESET")),
+        }),
+      });
+      // Spy that calls through to the real (self-guarding) sweep, so we can count
+      // invocations deterministically without depending on async warn ordering.
+      const sweepSpy = vi.spyOn(mgr as any, "runHeartbeatSweep");
+
+      vi.useFakeTimers();
+      try {
+        (mgr as any).startHeartbeat(1000);
+        // Two ticks: prove the interval survives a rejected sweep and fires again.
+        await vi.advanceTimersByTimeAsync(1000);
+        await vi.advanceTimersByTimeAsync(1000);
+
+        // The interval fired twice and was not torn down by the rejected sweeps.
+        expect(sweepSpy).toHaveBeenCalledTimes(2);
+        expect((mgr as any).heartbeatInterval).not.toBeNull();
+      } finally {
+        await mgr.shutdown();
+        vi.useRealTimers();
+      }
+    });
+  });
+
   // ── listAgents ─────────────────────────────────────────────────
 
   describe("listAgents", () => {


### PR DESCRIPTION
## Problem
The dev server crashed with an unhandled rejection: `RemoteAgentManager`'s heartbeat used an `async` `setInterval` callback. Postgres transient errors (e.g. `read ECONNRESET`) thrown from `listAgents()` rejected the promise that `setInterval` silently discards, surfacing as an `unhandledRejection` that killed the whole process.

## Fix
- `startHeartbeat` now uses a non-async timer callback that invokes `runHeartbeatSweep()` and explicitly `.catch()`s it, logging a warning instead of crashing.
- `runHeartbeatSweep` never rejects: a failure listing agents (DB fault) is caught and logged, skipping that cycle; a failure on one agent's health-check/update is caught per-agent so the loop continues for the rest.

## Audit
Reviewed every other `setInterval` background timer under `server/` for the same unguarded-async-callback pattern:
- `routes.ts` lease sweeper — async callback, but body is already wrapped in try/catch (self-guarded).
- `federation/config-sync.ts`, `federation/session-sharing.ts`, `federation/transport.ts`, `federation/crdt/sync.ts` — sync callbacks or promises already `.catch()`-guarded.
- `services/webhook-handler.ts` — sync callback, no async work.
- `services/github-poller.ts` — async `pollAllSafe()` fully wrapped in try/catch/finally, so it never rejects.

No other unguarded async timer bodies found; no further changes required.

## Tests
- `npx tsc --noEmit` — clean.
- `npx vitest run tests/unit/remote-agent-manager.test.ts` — 21/21 passed, including new regression coverage for ECONNRESET during heartbeat, per-agent failure isolation, and timer survival across a rejected sweep.