### PR TITLE
test(integration): stabilize gateway-mock socket flake in zod-validation

### DIFF
--- a/tests/integration/zod-validation.test.ts
+++ b/tests/integration/zod-validation.test.ts
@@ -78,6 +78,27 @@ function expectValidationFailure(body: unknown) {
   expect(b.error).toBeTruthy();
 }
 
+// supertest spins up an ephemeral listener per call; under full-suite parallel
+// load these can intermittently die mid-request ("socket hang up" / ECONNRESET).
+// Retry immediately (no delay) on that specific transient error only.
+async function requestWithRetry(
+  fn: () => Promise<import("supertest").Response>,
+  retries = 3,
+): Promise<import("supertest").Response> {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      const isTransientSocketError =
+        err instanceof Error &&
+        (err.message.includes("socket hang up") || code === "ECONNRESET" || code === "ECONNREFUSED");
+      if (!isTransientSocketError || attempt === retries) throw err;
+    }
+  }
+  throw new Error("unreachable");
+}
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe("Zod validation — POST /api/models", () => {
@@ -226,9 +247,11 @@ describe("Zod validation — POST /api/gateway/complete", () => {
 
   it("passes through with valid body", async () => {
     const app = createGatewayApp();
-    const res = await request(app)
-      .post("/api/gateway/complete")
-      .send({ modelSlug: "llama3", messages: [{ role: "user", content: "Hello" }] });
+    const res = await requestWithRetry(() =>
+      request(app)
+        .post("/api/gateway/complete")
+        .send({ modelSlug: "llama3", messages: [{ role: "user", content: "Hello" }] }),
+    );
     expect(res.status).toBe(200);
   });
 });


### PR DESCRIPTION
## Flake

`tests/integration/zod-validation.test.ts > Zod validation — POST /api/gateway/complete > "passes through valid body"` intermittently failed with `Error: socket hang up` when run under full-suite parallel load (301 test files concurrently). Green 20/20 in isolation, so the test logic itself was never the problem.

## Root cause

`supertest` opens an ephemeral listener per request against the in-process gateway mock app. Under heavy parallel test-worker load, that listener/socket can be torn down mid-request before the response completes, surfacing as `socket hang up` / `ECONNRESET` on the client side — a transient infra timing issue, not a functional bug in the endpoint or the test assertion.

## Fix (test-harness only, no production code touched)

Added a small `requestWithRetry` helper local to the spec file that immediately retries (no sleep/delay) only when the caught error is a transient socket error (`socket hang up`, `ECONNRESET`, `ECONNREFUSED`), up to 3 attempts, and rethrows any other error or the last attempt's error untouched. Applied it only to the one flaky request in the "passes through valid body" case — no change to any other test or to application code.

## Evidence — 3x full-suite parallel runs

| Run | Test Files | Tests | zod-validation failures |
|---|---|---|---|
| 1 | 301 passed (301) | 5149 passed, 5 skipped | 0 |
| 2 | 301 passed (301) | 5149 passed, 5 skipped | 0 |
| 3 | 301 passed (301) | 5149 passed, 5 skipped | 0 |

Plus isolated run: 20/20 passed. No other flakes observed across the 3 full-suite runs.