### PR TITLE
refactor(triggers): rename PipelineTrigger type to Trigger

### DIFF
--- a/client/src/components/triggers/TriggerCard.tsx
+++ b/client/src/components/triggers/TriggerCard.tsx
@@ -11,7 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { useEnableTrigger, useDisableTrigger, useTriggerLoops } from "@/hooks/use-triggers";
-import type { PipelineTrigger, TriggerType, TriggerFiredLoop } from "@shared/types";
+import type { Trigger, TriggerType, TriggerFiredLoop } from "@shared/types";
 import { configSummary, loopTargetSummary } from "./trigger-form-logic";
 
 // ─── Type badge config ────────────────────────────────────────────────────────
@@ -99,9 +99,9 @@ function FiredLoopRow({ loop, onOpen }: { loop: TriggerFiredLoop; onOpen: (id: s
 // ─── Component ────────────────────────────────────────────────────────────────
 
 interface TriggerCardProps {
-  trigger: PipelineTrigger;
-  onEdit: (trigger: PipelineTrigger) => void;
-  onDelete: (trigger: PipelineTrigger) => void;
+  trigger: Trigger;
+  onEdit: (trigger: Trigger) => void;
+  onDelete: (trigger: Trigger) => void;
 }
 
 export function TriggerCard({ trigger, onEdit, onDelete }: TriggerCardProps) {

--- a/client/src/components/triggers/TriggerForm.tsx
+++ b/client/src/components/triggers/TriggerForm.tsx
@@ -33,7 +33,7 @@ import {
 } from "./trigger-form-logic";
 import {
   CONSILIUM_REVIEW_PRESETS,
-  type PipelineTrigger,
+  type Trigger,
   type TriggerType,
   type InsertTrigger,
   type ConsiliumReviewPreset,
@@ -57,7 +57,7 @@ interface TriggerFormProps {
   /** The active project's allowlisted workspaces — the loop target picklist. */
   workspaces: TriggerWorkspaceOption[];
   /** When provided, the form is in edit mode */
-  trigger?: PipelineTrigger;
+  trigger?: Trigger;
 }
 
 const PRESET_LABELS: Record<ConsiliumReviewPreset, string> = {

--- a/client/src/components/triggers/trigger-form-logic.ts
+++ b/client/src/components/triggers/trigger-form-logic.ts
@@ -7,7 +7,7 @@
  * SERVER-SIDE in the review factory — this module only shapes the request.
  */
 import type {
-  PipelineTrigger,
+  Trigger,
   TriggerType,
   ConsiliumReviewPreset,
   ConsiliumReviewTriggerAction,
@@ -158,7 +158,7 @@ export function buildLoopTemplate(state: LoopTemplateState): ConsiliumReviewTrig
  * We coalesce to `[]` and, when the array is empty/absent, fall back to a sensible
  * summary (repository / watchPath alone) rather than a trailing " · ".
  */
-export function configSummary(trigger: PipelineTrigger): string {
+export function configSummary(trigger: Trigger): string {
   switch (trigger.type) {
     case "webhook":
       return trigger.webhookUrl
@@ -190,7 +190,7 @@ export function configSummary(trigger: PipelineTrigger): string {
  * The repo basename + preset the trigger's loop targets, or null when the trigger
  * carries no loop template (webhook/github). Shown on the trigger card.
  */
-export function loopTargetSummary(trigger: PipelineTrigger): string | null {
+export function loopTargetSummary(trigger: Trigger): string | null {
   const action = (trigger.config as { action?: ConsiliumReviewTriggerAction }).action;
   if (!action || action.kind !== "consilium_review") return null;
   const repo = action.repoPath ? action.repoPath.split("/").filter(Boolean).pop() : undefined;

--- a/client/src/hooks/use-triggers.ts
+++ b/client/src/hooks/use-triggers.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import type { PipelineTrigger, InsertTrigger, UpdateTrigger, TriggerFiredLoopsResponse } from "@shared/types";
+import type { Trigger, InsertTrigger, UpdateTrigger, TriggerFiredLoopsResponse } from "@shared/types";
 import type { TriggerValidationIssue } from "@/components/triggers/trigger-form-logic";
 // Project-scoped transport: buildAuthHeaders attaches `x-project-id` (the pr-queue
 // 401 lesson — a project-scoped read that omits the header gets rejected).
@@ -54,16 +54,16 @@ export function useTriggers(pipelineId?: string) {
   const url = pipelineId
     ? `/api/triggers?pipelineId=${pipelineId}`
     : "/api/triggers";
-  return useQuery<PipelineTrigger[]>({
+  return useQuery<Trigger[]>({
     queryKey: ["/api/triggers", pipelineId ?? null],
-    queryFn: () => apiRequest("GET", url) as Promise<PipelineTrigger[]>,
+    queryFn: () => apiRequest("GET", url) as Promise<Trigger[]>,
   });
 }
 
 export function useTrigger(id: string) {
-  return useQuery<PipelineTrigger>({
+  return useQuery<Trigger>({
     queryKey: ["/api/triggers", id],
-    queryFn: () => apiRequest("GET", `/api/triggers/${id}`) as Promise<PipelineTrigger>,
+    queryFn: () => apiRequest("GET", `/api/triggers/${id}`) as Promise<Trigger>,
     enabled: !!id,
   });
 }
@@ -87,10 +87,10 @@ export function useTriggerLoops(id: string, enabled = true) {
 
 export function useCreateTrigger() {
   const qc = useQueryClient();
-  return useMutation<PipelineTrigger, Error, InsertTrigger & { _plainSecret?: string }>({
+  return useMutation<Trigger, Error, InsertTrigger & { _plainSecret?: string }>({
     mutationFn: ({ _plainSecret: secret, ...data }) => {
       const payload = secret ? { ...data, secret } : data;
-      return apiRequest("POST", "/api/triggers", payload) as Promise<PipelineTrigger>;
+      return apiRequest("POST", "/api/triggers", payload) as Promise<Trigger>;
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["/api/triggers"] });
@@ -100,9 +100,9 @@ export function useCreateTrigger() {
 
 export function useUpdateTrigger() {
   const qc = useQueryClient();
-  return useMutation<PipelineTrigger, Error, { id: string } & UpdateTrigger>({
+  return useMutation<Trigger, Error, { id: string } & UpdateTrigger>({
     mutationFn: ({ id, ...updates }) =>
-      apiRequest("PATCH", `/api/triggers/${id}`, updates) as Promise<PipelineTrigger>,
+      apiRequest("PATCH", `/api/triggers/${id}`, updates) as Promise<Trigger>,
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["/api/triggers"] });
     },
@@ -122,9 +122,9 @@ export function useDeleteTrigger() {
 
 export function useEnableTrigger() {
   const qc = useQueryClient();
-  return useMutation<PipelineTrigger, Error, string>({
+  return useMutation<Trigger, Error, string>({
     mutationFn: (id) =>
-      apiRequest("POST", `/api/triggers/${id}/enable`) as Promise<PipelineTrigger>,
+      apiRequest("POST", `/api/triggers/${id}/enable`) as Promise<Trigger>,
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["/api/triggers"] });
     },
@@ -133,9 +133,9 @@ export function useEnableTrigger() {
 
 export function useDisableTrigger() {
   const qc = useQueryClient();
-  return useMutation<PipelineTrigger, Error, string>({
+  return useMutation<Trigger, Error, string>({
     mutationFn: (id) =>
-      apiRequest("POST", `/api/triggers/${id}/disable`) as Promise<PipelineTrigger>,
+      apiRequest("POST", `/api/triggers/${id}/disable`) as Promise<Trigger>,
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["/api/triggers"] });
     },

--- a/client/src/pages/TriggersPage.tsx
+++ b/client/src/pages/TriggersPage.tsx
@@ -6,7 +6,7 @@ import { TriggerCard } from "@/components/triggers/TriggerCard";
 import { TriggerForm, type TriggerWorkspaceOption } from "@/components/triggers/TriggerForm";
 import { useTriggers, useDeleteTrigger } from "@/hooks/use-triggers";
 import { apiRequest } from "@/hooks/use-api";
-import type { PipelineTrigger } from "@shared/types";
+import type { Trigger } from "@shared/types";
 import type { WorkspaceRow } from "@shared/schema";
 
 /**
@@ -28,10 +28,10 @@ export default function TriggersPage() {
   const deleteTrigger = useDeleteTrigger();
 
   const [formOpen, setFormOpen] = useState(false);
-  const [editingTrigger, setEditingTrigger] = useState<PipelineTrigger | undefined>();
+  const [editingTrigger, setEditingTrigger] = useState<Trigger | undefined>();
 
   const subsystemDisabled = (error as (Error & { disabled?: boolean }) | null)?.disabled === true || (error as (Error & { status?: number }) | null)?.status === 503;
-  const triggerList: PipelineTrigger[] = Array.isArray(triggers) ? triggers : [];
+  const triggerList: Trigger[] = Array.isArray(triggers) ? triggers : [];
   const workspaces: TriggerWorkspaceOption[] = Array.isArray(workspaceData)
     ? workspaceData.map((w) => ({ path: w.path, name: w.name }))
     : [];
@@ -42,12 +42,12 @@ export default function TriggersPage() {
     setFormOpen(true);
   }
 
-  function handleEdit(trigger: PipelineTrigger) {
+  function handleEdit(trigger: Trigger) {
     setEditingTrigger(trigger);
     setFormOpen(true);
   }
 
-  function handleDelete(trigger: PipelineTrigger) {
+  function handleDelete(trigger: Trigger) {
     if (!confirm(`Delete this ${trigger.type} trigger? This cannot be undone.`)) return;
     deleteTrigger.mutate(trigger.id);
   }

--- a/server/services/trigger-service.ts
+++ b/server/services/trigger-service.ts
@@ -7,7 +7,7 @@
 import type { IStorage } from "../storage.js";
 import type { TriggerRow } from "@shared/schema";
 import type {
-  PipelineTrigger,
+  Trigger,
   InsertTrigger,
   UpdateTrigger,
   TriggerType,
@@ -42,9 +42,9 @@ export class TriggerService {
     return `${baseUrl}/api/webhooks/${triggerId}`;
   }
 
-  /** Map a DB row to the public-facing PipelineTrigger shape (no secrets). */
-  toPublic(row: TriggerRow): PipelineTrigger {
-    const trigger: PipelineTrigger = {
+  /** Map a DB row to the public-facing Trigger shape (no secrets). */
+  toPublic(row: TriggerRow): Trigger {
+    const trigger: Trigger = {
       id: row.id,
       type: row.type as TriggerType,
       config: row.config as TriggerConfig,
@@ -68,17 +68,17 @@ export class TriggerService {
   // ─── CRUD ─────────────────────────────────────────────────────────────────
 
   /** T1: all triggers in the current project ALS (pipeline-based AND pipeline-less). */
-  async getProjectTriggers(): Promise<PipelineTrigger[]> {
+  async getProjectTriggers(): Promise<Trigger[]> {
     const rows = await this.storage.getProjectTriggers();
     return rows.map((r) => this.toPublic(r));
   }
 
-  async getTrigger(id: string): Promise<PipelineTrigger | null> {
+  async getTrigger(id: string): Promise<Trigger | null> {
     const row = await this.storage.getTrigger(id);
     return row ? this.toPublic(row) : null;
   }
 
-  async createTrigger(data: InsertTrigger): Promise<PipelineTrigger> {
+  async createTrigger(data: InsertTrigger): Promise<Trigger> {
     const secretEncrypted = data.secret ? this.crypto.encrypt(data.secret) : undefined;
     const row = await this.storage.createTrigger({
       type: data.type,
@@ -89,7 +89,7 @@ export class TriggerService {
     return this.toPublic(row);
   }
 
-  async updateTrigger(id: string, updates: UpdateTrigger): Promise<PipelineTrigger | null> {
+  async updateTrigger(id: string, updates: UpdateTrigger): Promise<Trigger | null> {
     const existing = await this.storage.getTrigger(id);
     if (!existing) return null;
 
@@ -117,11 +117,11 @@ export class TriggerService {
     return true;
   }
 
-  async enableTrigger(id: string): Promise<PipelineTrigger | null> {
+  async enableTrigger(id: string): Promise<Trigger | null> {
     return this.updateTrigger(id, { enabled: true });
   }
 
-  async disableTrigger(id: string): Promise<PipelineTrigger | null> {
+  async disableTrigger(id: string): Promise<Trigger | null> {
     return this.updateTrigger(id, { enabled: false });
   }
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1915,7 +1915,7 @@ export type TriggerConfig =
   | TrackerEventTriggerConfig;
 
 // Public-facing Trigger shape returned from API (no secretEncrypted)
-export interface PipelineTrigger {
+export interface Trigger {
   id: string;
   type: TriggerType;
   config: TriggerConfig;

--- a/tests/unit/trigger-fired-loops.test.ts
+++ b/tests/unit/trigger-fired-loops.test.ts
@@ -5,7 +5,7 @@ import { registerTriggerRoutes } from "../../server/routes/triggers";
 import type { TriggerService } from "../../server/services/trigger-service";
 import type { IStorage } from "../../server/storage";
 import type { ConsiliumLoopRow } from "../../shared/schema";
-import type { PipelineTrigger, TriggerProvenance } from "../../shared/types";
+import type { Trigger, TriggerProvenance } from "../../shared/types";
 import { TRIGGER_FIRED_LOOPS_LIMIT } from "../../shared/types";
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -13,7 +13,7 @@ import { TRIGGER_FIRED_LOOPS_LIMIT } from "../../shared/types";
 const TRIGGER_ID = "trig-1";
 
 /** A project-scoped (pipeline-less) trigger — assertTriggerAccess passes without a pipeline owner lookup. */
-function makeTrigger(overrides: Partial<PipelineTrigger> = {}): PipelineTrigger {
+function makeTrigger(overrides: Partial<Trigger> = {}): Trigger {
   return {
     id: TRIGGER_ID,
     pipelineId: null,
@@ -61,7 +61,7 @@ function makeStorage(loops: ConsiliumLoopRow[]): IStorage {
   } as unknown as IStorage;
 }
 
-function makeService(trigger: PipelineTrigger | null): TriggerService {
+function makeService(trigger: Trigger | null): TriggerService {
   return {
     getTrigger: vi.fn(async (id: string) => (trigger && trigger.id === id ? trigger : null)),
   } as unknown as TriggerService;
@@ -93,7 +93,7 @@ function buildApp(service: TriggerService, storage: IStorage, authed = true): ex
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe("GET /api/triggers/:id/loops", () => {
-  let trigger: PipelineTrigger;
+  let trigger: Trigger;
 
   beforeEach(() => {
     trigger = makeTrigger();

--- a/tests/unit/triggers-ui.test.ts
+++ b/tests/unit/triggers-ui.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, it, expect } from "vitest";
 import type {
-  PipelineTrigger,
+  Trigger,
   TriggerType,
   ScheduleTriggerConfig,
   GitHubEventTriggerConfig,
@@ -50,7 +50,7 @@ function generateSecret(): string {
   return Array.from({ length: 64 }, () => hex[Math.floor(Math.random() * 16)]).join("");
 }
 
-function buildTrigger(overrides: Partial<PipelineTrigger> & { type: TriggerType }): PipelineTrigger {
+function buildTrigger(overrides: Partial<Trigger> & { type: TriggerType }): Trigger {
   return {
     id: "t-001",
     pipelineId: null,


### PR DESCRIPTION
## Why
PipelineTrigger is a naming vestige from the old pipelines engine, which was retired. Trigger behaviour is already loop-based (fires consilium loops, per docs/design/loop-triggers.md) — the type name no longer matches what it represents.

## What
Pure identifier rename, no behaviour change:
- shared/types.ts: `interface PipelineTrigger` -> `interface Trigger` (InsertTrigger/UpdateTrigger already used the current convention and are untouched)
- All 9 files referencing the type updated: server/services/trigger-service.ts, client/src/components/triggers/{TriggerCard,TriggerForm,trigger-form-logic}, client/src/hooks/use-triggers.ts, client/src/pages/TriggersPage.tsx, tests/unit/{trigger-fired-loops,triggers-ui}.test.ts

No DB/table/column renames, no API route changes, no logic changes.

## Tests
- `npx tsc --noEmit` — clean.
- `npx vitest run` — 5148 passed, 5 skipped, 1 pre-existing unrelated flake (tests/integration/settings-api.test.ts DELETE key test — untouched file, passes clean in isolation, confirmed unrelated to this rename).
- `npm run build` — succeeds.