### PR TITLE
feat(consilium): additive class/autonomyTier fields on loops (SDLC ADR-0003 P1)

### DIFF
--- a/migrations/0054_consilium_loops_class_field.sql
+++ b/migrations/0054_consilium_loops_class_field.sql
@@ -1,0 +1,31 @@
+-- migration: 0054_consilium_loops_class_field
+-- ADR-0003 I1 (re-scoped, GH #445 P1): additive autonomy CLASS metadata on
+-- consilium_loops. Pure data addition — no behavior change, no escalation,
+-- no gating. Nothing reads these columns yet (that lands in P2/P3).
+--
+-- consilium_loops.class → new TEXT NOT NULL DEFAULT 'R0'.
+--   One of R0 | A | B | C | E (app-level union, not DB-enforced here — same
+--   convention as `state`/`review_mode` elsewhere on this table):
+--     - R0 — review/judge-only loop (no worktree write). DEFAULT for every
+--       pre-existing and newly-created review-only loop.
+--     - A  — coder-enabled loop (worktree write / Draft-PR capable, i.e.
+--       `pipeline.consiliumLoop.implement.enabled` at launch).
+--     - B/C/E — reserved for future deploy/prod targets; never assigned today.
+--   Every pre-existing loop backfills to 'R0' (the safe, review-only default),
+--   which is byte-identical to today's behavior since nothing reads this column.
+--
+-- consilium_loops.autonomy_tier → new TEXT (nullable).
+--   Reserved for a future finer-grained autonomy tier. Left unset by this PR.
+--
+-- Additive + idempotent (ADD COLUMN IF NOT EXISTS): metadata-only, no rewrite,
+-- no data loss. Re-applying against a push-managed dev DB is safe.
+--
+-- ⚠️ NOT applied by this PR. Ships for review only — the human gate applies it
+-- (no `drizzle push` / `drizzle migrate` run against any database here).
+
+ALTER TABLE consilium_loops
+  ADD COLUMN IF NOT EXISTS class TEXT NOT NULL DEFAULT 'R0',
+  ADD COLUMN IF NOT EXISTS autonomy_tier TEXT;
+
+-- Rollback:
+--   ALTER TABLE consilium_loops DROP COLUMN class, DROP COLUMN autonomy_tier;

--- a/server/routes/consilium-loops.ts
+++ b/server/routes/consilium-loops.ts
@@ -130,6 +130,10 @@ export function registerConsiliumLoopRoutes(
           maxRounds: body.maxRounds ?? cfg.maxRounds,
           lastReviewedCommit: body.lastReviewedCommit ?? null,
           createdBy: req.user.id,
+          // ADR-0003 I1 (re-scoped, GH #445 P1): additive class metadata only —
+          // no escalation, no gating reads this yet. Coder-enabled (worktree
+          // write / Draft-PR capable) ⇒ A; review-only ⇒ R0.
+          class: cfg.implement?.enabled ? "A" : "R0",
         });
         return res.status(201).json(loop);
       } catch (err) {

--- a/server/services/consilium/review-factory.ts
+++ b/server/services/consilium/review-factory.ts
@@ -1432,6 +1432,10 @@ export async function createConsiliumReview(
     // it at round time; an explicit value always wins). INERT dispatch selector.
     reviewMode: params.reviewMode ?? null,
     createdBy: params.createdBy,
+    // ADR-0003 I1 (re-scoped, GH #445 P1): additive class metadata only — no
+    // escalation, no gating reads this yet. Coder-enabled (worktree write /
+    // Draft-PR capable) ⇒ A; review-only ⇒ R0.
+    class: cfg.implement?.enabled ? "A" : "R0",
   } as InsertConsiliumLoop);
 
   // 3) Start it (PENDING → BUILDING_CONTEXT). The poller advances it from there;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1371,6 +1371,10 @@ export class MemStorage implements IStorage {
       repoPath: data.repoPath,
       lastReviewedCommit: data.lastReviewedCommit ?? null,
       reviewRef: data.reviewRef ?? null,
+      // ADR-0003 I1 (re-scoped, GH #445 P1): additive class metadata (mirrors the
+      // DB default). Nothing reads either field yet.
+      class: data.class ?? "R0",
+      autonomyTier: data.autonomyTier ?? null,
       // Single-verifier re-review: per-loop mode (nullable; null ⇒ operator default).
       reviewMode: data.reviewMode ?? null,
       // Stage 1: engineer instruction + archetype planner columns (all nullable).

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1787,6 +1787,15 @@ export const CONSILIUM_LOOP_TERMINAL_STATES = [
   "cancelled",
 ] as const satisfies readonly ConsiliumLoopState[];
 
+// ADR-0003 I1 (re-scoped, GH #445 P1): the loop's autonomy CLASS — additive
+// metadata only, set once at launch, nothing reads it yet. R0 = review/judge-only
+// loop (no worktree write, advisory). A = coder-enabled loop (worktree write /
+// Draft-PR capable, i.e. `pipeline.consiliumLoop.implement.enabled`). B/C/E are
+// reserved for future deploy/prod targets (none exist today; never assigned).
+// NO escalation and NO gating logic reads this field yet — that is P2/P3.
+export const CONSILIUM_CLASSES = ["R0", "A", "B", "C", "E"] as const;
+export type ConsiliumClass = (typeof CONSILIUM_CLASSES)[number];
+
 /**
  * Provenance of ONE operator-selected skill whose directives extended a consilium
  * loop's engineer instruction (Stage 2 — skills extend the loop's engineer
@@ -1817,6 +1826,12 @@ export const consiliumLoops = pgTable(
       .notNull()
       .references(() => taskGroups.id, { onDelete: "cascade" }),
     state: text("state").notNull().default("pending").$type<ConsiliumLoopState>(),
+    // ADR-0003 I1 (re-scoped, GH #445 P1): additive autonomy metadata, set once at
+    // launch (review-only ⇒ R0, coder-enabled ⇒ A). Nothing reads either column
+    // yet — no escalation, no gating (that is P2/P3). `autonomyTier` is reserved
+    // for a future finer-grained tier and is left unset (null) by this PR.
+    class: text("class").notNull().default("R0").$type<ConsiliumClass>(),
+    autonomyTier: text("autonomy_tier"),
     round: integer("round").notNull().default(0),
     maxRounds: integer("max_rounds").notNull().default(6),
     // Allowlisted target repo (validated at create AND re-validated each round).

--- a/tests/integration/consilium/loop-routes.test.ts
+++ b/tests/integration/consilium/loop-routes.test.ts
@@ -149,6 +149,15 @@ describe("consilium-loop routes", () => {
     expect(res.body.state).toBe("pending");
   });
 
+  // P1 (GH #445, ADR-0003 I1, additive): review-only launch (implement.enabled
+  // unset/false in this harness's fakeConfig) ⇒ class defaults to R0. No
+  // escalation, no gating — this is pure metadata.
+  it("P1: review-only loop launch → class R0", async () => {
+    const res = await post("/api/consilium-loops", { groupId: ctx.group.id, repoPath: REPO_ROOT });
+    expect(res.status).toBe(201);
+    expect(res.body.class).toBe("R0");
+  });
+
   it("H-3: a 2nd active loop on the same group → 409", async () => {
     const first = await post("/api/consilium-loops", { groupId: ctx.group.id, repoPath: REPO_ROOT });
     expect(first.status).toBe(201);
@@ -256,5 +265,57 @@ describe("consilium-loop routes", () => {
     const res = await get("/api/consilium-loops");
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(0);
+  });
+});
+
+// P1 (GH #445, ADR-0003 I1, additive): a coder-enabled operator config
+// (`implement.enabled: true`) stamps class A at launch. Separate describe block
+// so it doesn't disturb the review-only `fakeConfig` used by every test above.
+describe("consilium-loop routes — P1 class field (coder-enabled)", () => {
+  it("coder-enabled loop launch → class A", async () => {
+    const storage = new MemStorage();
+    const coderConfig = () =>
+      ({
+        pipeline: {
+          consiliumLoop: {
+            enabled: true,
+            maxRounds: 6,
+            pollIntervalMs: 5000,
+            maxDiffBytes: 200000,
+            allowedRepoPaths: [REPO_ROOT],
+            implement: { enabled: true },
+          },
+        },
+      }) as never;
+    const controller = new ConsiliumLoopController({
+      storage,
+      taskOrchestrator: {
+        startGroup: async () => ({ group: {}, iteration: { iterationNumber: 1 } }),
+        createTaskGroup: async () => ({ group: { id: "devgrp" }, tasks: [] }),
+        cancelGroup: async () => undefined,
+      } as never,
+      config: coderConfig,
+      readRepoHead: async () => "feedface",
+    });
+    const app: Express = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.user = OWNER_USER;
+      next();
+    });
+    registerConsiliumLoopRoutes(app, storage, controller, coderConfig);
+
+    const group = await storage.createTaskGroup({
+      name: "consilium",
+      description: "d",
+      input: "objective",
+      createdBy: OWNER_USER.id,
+    } as never);
+
+    const res = await request(app)
+      .post("/api/consilium-loops")
+      .send({ groupId: (group as { id: string }).id, repoPath: REPO_ROOT });
+    expect(res.status).toBe(201);
+    expect(res.body.class).toBe("A");
   });
 });


### PR DESCRIPTION
## Why
P1 of the re-scoped GH #445 plan (ADR-0003 I1, mapped onto the live consilium-loop machinery post-pipeline-retirement). Lands the additive class field first so later phases (auto-escalation, class-gated DoD, OutcomeEvent) have a stable column to build on.

## What (additive, zero behavior change)
- `shared/schema.ts`: new `ConsiliumClass = 'R0'|'A'|'B'|'C'|'E'` type + `CONSILIUM_CLASSES` const, and two new columns on `consilium_loops`: `class` (NOT NULL DEFAULT 'R0') and `autonomyTier` (nullable, unset by this PR — reserved for a future finer tier).
- Set at loop launch only, both creation paths: `server/routes/consilium-loops.ts` (POST /api/consilium-loops) and `server/services/consilium/review-factory.ts` (`createConsiliumReview`). Review-only launch ⇒ `R0`; coder-enabled launch (`pipeline.consiliumLoop.implement.enabled`, i.e. worktree-write/Draft-PR capable) ⇒ `A`.
- `server/storage.ts` (`MemStorage.createLoop`) mirrors the same default for the in-memory test backend.
- **No escalation logic, no gating, nothing reads either field yet** — that lands in P2/P3.

## Migration — NOT applied
`migrations/0054_consilium_loops_class_field.sql` ships in this PR for review only. It is **not run** here (no `drizzle push`/`migrate` against any database) — the human gate applies it separately.

## Tests
- `npx tsc --noEmit` — clean.
- New coverage: review-only loop launch → class R0; coder-enabled config (`implement.enabled: true`) → class A.
- Full suite: `npx vitest run` — 301/301 test files, 5151/5156 tests passed (5 skipped), 0 failures.