### PR TITLE
fix(consilium): pre-validate diff ref before runner dispatch (curated terminal reason)

### DIFF
--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -2273,6 +2273,29 @@ export class ConsiliumLoopController {
     // startGroupAsync path below runs UNCHANGED (byte-identical parity).
     if (cfg.directReview?.enabled) {
       const nextRound = opts?.relaunch ? loop.round : loop.round + 1;
+      // #21 follow-up (B4 review): pre-validate the diff ref BEFORE dispatching the
+      // runner. Left unchecked, a DETERMINISTIC unresolved ref (the legacy path's
+      // `errorKind === "unresolved-ref"` below) would instead only be discovered
+      // INSIDE `runReviewFromLoop`'s own `buildDiffContext` call, which settles ANY
+      // build failure as the runner's generic scrubbed `{error}` → `review_failed` —
+      // losing the curated "diff ref unresolvable" terminal reason `failUnresolvedReview`
+      // surfaces on the legacy path. This call is ref-resolution-only (the throwaway
+      // objective never rides a prompt): the runner independently rebuilds the REAL
+      // diff context (real objective/priorFindings/testSummary/repoMap) on dispatch, so
+      // a non-"unresolved-ref" failure here is NOT terminal — it falls through to
+      // dispatch, where the runner's own attempt keeps the existing generic path for
+      // genuinely-transient failures.
+      const preflight = await buildDiffContext({
+        repoPath: loop.repoPath,
+        baselineCommit: loop.lastReviewedCommit,
+        ref: loop.reviewRef,
+        objective: "preflight-ref-check",
+        allowedRepoPaths: cfg.allowedRepoPaths,
+        maxDiffBytes: cfg.maxDiffBytes,
+      });
+      if (!preflight.ok && preflight.errorKind === "unresolved-ref") {
+        return { error: preflight.message, terminal: true };
+      }
       this.log(
         loop.id,
         `startReviewRound${opts?.relaunch ? " (relaunch)" : ""} -> dispatchReview (runner) round ${nextRound}`,
@@ -2666,10 +2689,13 @@ export class ConsiliumLoopController {
    * cross-review DAG (or the lone single-verifier for round > 1) — and runs it via
    * `runReviewTasks`. Mirrors `closeout` rebuilding the SDLC context from the loop
    * (not a caller hand-off). NEVER throws: a missing gateway or an unbuildable diff
-   * context (incl. an unresolved ref) settles a degraded {error} — the loop then
-   * fails closed via `review_failed` (fail-closed, exception-derived per L1; the
-   * curated failUnresolvedReview reason is a legacy-path nicety, tracked as a
-   * follow-up). `deps.runReview` bypasses this entirely in tests.
+   * context settles a degraded {error} — the loop then fails closed via
+   * `review_failed` (fail-closed, exception-derived per L1). #21: an unresolved ref
+   * specifically should never reach HERE — `startReviewRound` pre-validates it and
+   * fails closed with the curated `failUnresolvedReview` reason BEFORE dispatch; this
+   * generic degraded path now only carries genuinely-transient failures (a flaky
+   * fetch, a missing gateway, a parse error, …). `deps.runReview` bypasses this
+   * entirely in tests.
    */
   private async runReviewFromLoop(loop: ConsiliumLoopRow): Promise<ReviewRunResult> {
     const gateway = this.deps.gateway;

--- a/tests/unit/consilium/loop-runner-prevalidate-diff-ref.test.ts
+++ b/tests/unit/consilium/loop-runner-prevalidate-diff-ref.test.ts
@@ -1,0 +1,195 @@
+/**
+ * loop-runner-prevalidate-diff-ref.test.ts — #21 (B4-review follow-up) coverage.
+ *
+ * In runner-mode (`directReview.enabled`), `startReviewRound` now pre-validates the
+ * diff ref BEFORE dispatching the background runner (`dispatchReview`). A
+ * DETERMINISTIC `unresolved-ref` `buildDiffContext` failure must fail the loop
+ * CLOSED with the curated `failUnresolvedReview` terminal reason — the SAME
+ * operator-readable explanation the legacy (task-group) path has surfaced since
+ * loop-unresolved-ref.test.ts (BUG 2) — instead of ever reaching the runner, whose
+ * own `buildDiffContext` call (inside `runReviewFromLoop`) would otherwise settle it
+ * as a generic scrubbed `{error}` via `review_failed`.
+ *
+ * Any OTHER (non-"unresolved-ref") `buildDiffContext` failure is a genuinely
+ * transient condition — it must NOT be treated as terminal here; the runner is
+ * still dispatched and keeps the existing generic degraded-result path.
+ *
+ * The legacy (directReview OFF) path is untouched by this change — pinned here
+ * against the SAME mock to prove it.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const UNRESOLVED_REASON =
+  "diff head 0000000 not present in local checkout omniscience; fetch PR ref or point review to a local branch";
+
+const buildDiffContextMock = vi.fn();
+vi.mock("../../../server/services/consilium/diff-context.js", () => ({
+  buildDiffContext: (...args: unknown[]) => buildDiffContextMock(...args),
+}));
+
+import { ConsiliumLoopController } from "../../../server/services/consilium/consilium-loop-controller.js";
+import type { ConsiliumLoopRow, ConsiliumLoopState } from "@shared/schema";
+
+function makeLoop(over: Partial<ConsiliumLoopRow>): ConsiliumLoopRow {
+  return {
+    id: "loop1",
+    groupId: "grp1",
+    state: "building_context",
+    round: 0,
+    maxRounds: 6,
+    repoPath: process.cwd(),
+    lastReviewedCommit: null,
+    reviewRef: null,
+    reviewMode: null,
+    currentIterationNumber: null,
+    devGroupId: null,
+    prRef: null,
+    headCommitAtReview: null,
+    openP0: null,
+    error: null,
+    createdBy: "user1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    completedAt: null,
+    ...over,
+  } as ConsiliumLoopRow;
+}
+
+function makeFakeStorage(loop: ConsiliumLoopRow) {
+  let current = loop;
+  const cas = vi.fn(
+    async (id: string, expected: ConsiliumLoopState, next: ConsiliumLoopState, extra?: Record<string, unknown>) => {
+      if (id !== current.id || current.state !== expected) return undefined;
+      current = { ...current, ...(extra ?? {}), state: next };
+      return current;
+    },
+  );
+  const storage = {
+    getLoop: vi.fn(async () => current),
+    getLoops: vi.fn(async () => [current]),
+    getLoopRounds: vi.fn(async () => []),
+    casLoopState: cas,
+    claimRedrive: vi.fn(async () => undefined),
+    appendLoopRound: vi.fn(async () => ({})),
+    updateLoop: vi.fn(async (_id: string, extra?: Record<string, unknown>) => {
+      current = { ...current, ...(extra ?? {}) };
+      return current;
+    }),
+    getTaskGroup: vi.fn(async () => ({ id: current.groupId, name: "[consilium-review:sdlc-cross-review] x", input: "objective" })),
+    updateTaskGroup: vi.fn(async () => ({})),
+    createTaskGroup: vi.fn(async () => ({ group: { id: "g" } })),
+    getIteration: vi.fn(async () => undefined),
+    getExecutionsByIteration: vi.fn(async () => []),
+  };
+  return { storage, get: () => current };
+}
+
+const configWith = (directReviewEnabled: boolean) =>
+  (() => ({
+    pipeline: {
+      taskGroups: { taskTimeoutMs: 300000, defaultModel: "claude-opus" },
+      consiliumLoop: {
+        enabled: true,
+        maxRounds: 6,
+        pollIntervalMs: 5000,
+        maxDiffBytes: 200000,
+        allowedRepoPaths: [process.cwd()],
+        directReview: { enabled: directReviewEnabled },
+        implement: { enabled: false, verification: { enabled: false }, research: { enabled: false } },
+      },
+    },
+  })) as never;
+
+const unresolvedFail = () => ({
+  ok: false,
+  errorKind: "unresolved-ref",
+  message: UNRESOLVED_REASON,
+});
+
+const transientFail = () => ({
+  ok: false,
+  errorKind: "unknown",
+  message: "transient git failure (flaky fetch)",
+});
+
+describe("#21 — runner-mode pre-validates the diff ref before dispatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    buildDiffContextMock.mockReset();
+  });
+
+  it("unresolvable ref: fails CLOSED with the curated terminal reason, runner NEVER dispatched", async () => {
+    buildDiffContextMock.mockResolvedValue(unresolvedFail());
+    const loop = makeLoop({ state: "building_context", round: 0 });
+    const { storage, get } = makeFakeStorage(loop);
+    const runReview = vi.fn();
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: { startGroup: vi.fn(), startGroupAsync: vi.fn(), createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
+      config: configWith(true),
+      runReview: runReview as never,
+    });
+
+    // The building_context -> reviewing CAS wins first (runSideEffect then runs
+    // the terminal fail-closed AS A FOLLOW-UP commit), so — mirroring
+    // loop-unresolved-ref.test.ts — assert the FINAL persisted row, not tick()'s
+    // return value (which reflects the intermediate `reviewing` CAS winner).
+    await controller.tick(loop.id);
+
+    // The runner was NEVER dispatched — the ref could not be resolved.
+    expect(runReview).not.toHaveBeenCalled();
+    // The loop was driven straight to the terminal `failed` state, carrying the
+    // SAME curated reason the legacy path's `failUnresolvedReview` uses (not the
+    // runner's generic scrubbed error).
+    const final = get();
+    expect(final.state).toBe("failed");
+    expect(final.error).toBe(UNRESOLVED_REASON);
+    expect(final.completedAt).toBeInstanceOf(Date);
+    const c = controller as unknown as { reviewRuns: Map<string, unknown> };
+    expect(c.reviewRuns.get(loop.id)).toBeUndefined(); // no runner-mode entry registered
+  });
+
+  it("transient buildDiffContext failure: NOT terminal — runner still dispatched, generic path unchanged", async () => {
+    buildDiffContextMock.mockResolvedValue(transientFail());
+    const loop = makeLoop({ state: "building_context", round: 0 });
+    const { storage } = makeFakeStorage(loop);
+    let release: (r: unknown) => void = () => {};
+    const runReview = vi.fn(() => new Promise((res) => { release = res; }));
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: { startGroup: vi.fn(), startGroupAsync: vi.fn(), createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
+      config: configWith(true),
+      runReview: runReview as never,
+    });
+
+    const res = await controller.tick(loop.id);
+
+    expect(res?.state).toBe("reviewing"); // NOT failed — dispatch proceeded
+    expect(runReview).toHaveBeenCalledTimes(1); // the runner WAS dispatched
+    const c = controller as unknown as { reviewRuns: Map<string, { round: number; done: boolean }> };
+    expect(c.reviewRuns.get(loop.id)).toMatchObject({ round: 1, done: false });
+    release({ converged: false, openP0: 1, openActionPoints: [], verdict: null, participants: null });
+  });
+
+  it("legacy (directReview OFF) path is untouched by the SAME unresolved-ref failure", async () => {
+    buildDiffContextMock.mockResolvedValue(unresolvedFail());
+    const loop = makeLoop({ state: "building_context", round: 0 });
+    const { storage, get } = makeFakeStorage(loop);
+    const startGroupAsync = vi.fn(async () => ({ group: {}, iteration: { iterationNumber: 1 } }));
+    const runReview = vi.fn();
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: { startGroup: startGroupAsync, startGroupAsync, createTaskGroup: storage.createTaskGroup, cancelGroup: vi.fn() } as never,
+      config: configWith(false),
+      runReview: runReview as never,
+    });
+
+    await controller.tick(loop.id);
+
+    expect(startGroupAsync).not.toHaveBeenCalled(); // never dispatched (as before)
+    expect(runReview).not.toHaveBeenCalled(); // runner never touched (legacy mode)
+    const final = get();
+    expect(final.state).toBe("failed");
+    expect(final.error).toBe(UNRESOLVED_REASON);
+  });
+});


### PR DESCRIPTION
## Summary
- In runner-mode (`directReview.enabled`), an unresolved diff ref (a missing baseline/head sha) was previously discovered only *inside* `runReviewFromLoop`'s own `buildDiffContext` call, which settles ANY build failure as a generic scrubbed `{error}` -> `review_failed`. This lost the curated "diff ref unresolvable" terminal reason the legacy (task-group) path surfaces via `failUnresolvedReview` (#486-style operator-readable explanation).
- `startReviewRound`'s runner-mode branch now runs a `buildDiffContext` preflight (ref-resolution only, throwaway objective) BEFORE `dispatchReview`. When it comes back `errorKind === "unresolved-ref"`, the round returns `{ error, terminal: true }` — the SAME shape the legacy path already returns — so all three existing `terminal` call sites (`runSideEffect`, the stranded-review redrive, the stalled-review relaunch) drive the loop to `failed` via `failUnresolvedReview`, unchanged.
- Any OTHER build failure (a flaky fetch, a transient git error, …) is NOT treated as terminal here — it falls through to `dispatchReview` and keeps the existing generic degraded-result path, since the runner independently rebuilds the real diff context (real objective/priorFindings/testSummary/repoMap) on dispatch anyway.
- Legacy (directReview OFF) path is untouched — it never enters the new branch.

## Test plan
- [x] New `tests/unit/consilium/loop-runner-prevalidate-diff-ref.test.ts`:
  - runner-mode + unresolvable ref -> loop fails CLOSED carrying the curated reason string, runner is NEVER dispatched, no `reviewRuns` entry registered.
  - runner-mode + a transient (non-`unresolved-ref`) `buildDiffContext` failure -> NOT terminal, runner still dispatched, `reviewRuns` entry registered as before.
  - legacy (directReview OFF) path against the SAME unresolved-ref mock -> unchanged (fails closed via the pre-existing legacy path).
- [x] `tsc --noEmit --pretty false` clean.
- [x] Full suite: 302 files / 5155 tests passed, 5 skipped, 0 failed (incl. `loop-unresolved-ref.test.ts`, `loop-review-dispatch.test.ts`, `loop-directreview-straddle.test.ts`, `loop-runner-verdict-straddle.test.ts`, `loop-review-redrive-grace.test.ts`, `loop-fsm.test.ts`).