### PR TITLE
feat(inventory): derive skill/model nodes from registries with compatible/uses edges (54 BE)

### DIFF
--- a/client/src/pages/Inventory.tsx
+++ b/client/src/pages/Inventory.tsx
@@ -100,8 +100,16 @@ function useDependents(workspaceId: string, connectionId: string | null) {
 }
 
 // ─── Node colour + icon ───────────────────────────────────────────────────────
+//
+// NOTE (#54 BE): InventoryNodeType was narrowed to "connection"|"skill"|"model"
+// (server/services/inventory.ts no longer emits "pipeline"/"stage" — dead since
+// the pipelines-engine retirement, they never populated a graph). The maps below
+// keep their "pipeline"/"stage" entries under this compile-only local type so
+// this file keeps type-checking unmodified pending the FE follow-up PR, which
+// owns removing them for real (design brief "FE PR" section).
+type LegacyInventoryNodeType = InventoryNodeType | "pipeline" | "stage";
 
-const NODE_COLOUR: Record<InventoryNodeType, string> = {
+const NODE_COLOUR: Record<LegacyInventoryNodeType, string> = {
   connection: "#6366f1", // indigo
   pipeline: "#10b981",  // emerald
   stage: "#f59e0b",     // amber
@@ -109,7 +117,7 @@ const NODE_COLOUR: Record<InventoryNodeType, string> = {
   model: "#3b82f6",     // blue
 };
 
-const NODE_ICON_LABEL: Record<InventoryNodeType, string> = {
+const NODE_ICON_LABEL: Record<LegacyInventoryNodeType, string> = {
   connection: "Conn",
   pipeline: "Pipe",
   stage: "Stg",
@@ -118,7 +126,7 @@ const NODE_ICON_LABEL: Record<InventoryNodeType, string> = {
 };
 
 function NodeTypeIcon({ type, className }: { type: InventoryNodeType; className?: string }) {
-  const icons: Record<InventoryNodeType, React.ReactNode> = {
+  const icons: Record<LegacyInventoryNodeType, React.ReactNode> = {
     connection: <Plug className={cn("h-4 w-4", className)} />,
     pipeline: <GitMerge className={cn("h-4 w-4", className)} />,
     stage: <Layers className={cn("h-4 w-4", className)} />,
@@ -259,6 +267,9 @@ function InventoryGraphSvg({ nodes, edges, selectedId, onSelectNode }: GraphProp
         const src = posMap.get(edge.source);
         const tgt = posMap.get(edge.target);
         if (!src || !tgt) return null;
+        // NOTE (#54 BE): "contains" (pipeline→stage) is dead — swapped for
+        // "compatible" (model↔skill) to keep the same visual weighting; real
+        // FE styling pass is the follow-up FE PR.
         return (
           <line
             key={i}
@@ -266,8 +277,8 @@ function InventoryGraphSvg({ nodes, edges, selectedId, onSelectNode }: GraphProp
             y1={src.y}
             x2={tgt.x}
             y2={tgt.y}
-            stroke={edge.relation === "contains" ? "#4b5563" : "#9ca3af"}
-            strokeWidth={edge.relation === "contains" ? 1.5 : 1}
+            stroke={edge.relation === "compatible" ? "#4b5563" : "#9ca3af"}
+            strokeWidth={edge.relation === "compatible" ? 1.5 : 1}
             strokeDasharray={edge.relation === "uses" ? "4 2" : undefined}
             markerEnd="url(#arrowhead)"
             opacity={0.6}
@@ -541,7 +552,7 @@ function applyFilters(
 // ─── Legend ───────────────────────────────────────────────────────────────────
 
 function GraphLegend() {
-  const items: Array<{ type: InventoryNodeType; label: string }> = [
+  const items: Array<{ type: LegacyInventoryNodeType; label: string }> = [
     { type: "connection", label: "Connection" },
     { type: "pipeline", label: "Pipeline" },
     { type: "stage", label: "Stage" },

--- a/server/services/inventory.ts
+++ b/server/services/inventory.ts
@@ -3,21 +3,41 @@
  *
  * Builds a workspace-scoped dependency graph from storage data.
  *
- * INTERIM STATE (pipelines engine retirement, migration 0053): the graph is
- * connection-nodes only. It previously also derived pipeline/stage nodes
- * (from the now-removed `pipelines` table) plus skill/model nodes and
- * stage→{connection,skill,model} edges — all of which were sourced SOLELY
- * via a pipeline stage's config, with no other data source in this function.
- * `InventoryNodeType`/the FE legend (client/src/pages/Inventory.tsx) still
- * list "pipeline"/"stage"/"skill"/"model" — deliberately left broad so the
- * FE compiles untouched; those types simply never appear in a graph today.
- * Follow-up #54 repoints skill/model nodes to the skill/model registry and
- * connection-usage edges to a KEPT dependents source (consilium loops /
- * workspaces), then narrows the type and cleans the FE legend — mirroring
- * the WorkspaceTraces write-less-then-repoint pattern (task #29).
+ * DERIVATION (#54 — registry-backed redesign, follow-up to the pipelines
+ * engine retirement, migration 0053):
+ *   - `connection` nodes — `storage.getWorkspaceConnections(workspaceId)`, workspace-scoped.
+ *   - `skill` nodes — `storage.getSkills()`, project-scoped (tenant context), ALL
+ *     skills in the project (not filtered to this workspace — skills have no
+ *     workspace FK). Metadata surfaces `sourceType` ("manual"|"git") and
+ *     `gitSourceId` for provenance (git-sync rows are a parallel, separate PR).
+ *   - `model` nodes — `storage.getModels()`, project-or-global catalog. Metadata
+ *     surfaces `provider` and `isActive`.
+ *   - `"compatible"` edges (model ↔ skill) — `storage.getAllModelSkillBindings()`
+ *     (bulk read, avoids an N+1 per-model lookup), a curated capability match,
+ *     NOT an observed-usage signal.
+ *   - `"uses"` edges (task → model) — `storage.getWorkspaceTaskModelUsage(workspaceId)`,
+ *     genuine observed usage but SPARSE/best-effort: only tasks with both a
+ *     non-null `modelSlug` and a `workspaceId` matching this workspace are
+ *     included (`tasks.workspaceId` is populated only via the consilium loop
+ *     DEV handoff path — most tasks have none, so this edge set is partial by
+ *     design, not a bug).
+ *   - NO skill-usage edge (workspace/task → skill): no kept table supports this
+ *     link (no `skillId` FK exists on `tasks`/`taskExecutions`/consilium-loop
+ *     tables — the only skill-adjacent FK is `skill_proposals.skillId`, a
+ *     nullable DREAM-4 feedback reference, "NEVER an FK write target" per its
+ *     own schema comment). Deliberately not fabricated via a `teamId` string
+ *     match — too imprecise, would risk false dependency edges.
+ *
+ * `InventoryNodeType` is narrowed to "connection"|"skill"|"model" (dropped
+ * "pipeline"|"stage", dead since the pipelines-engine retirement — no source
+ * data ever populated them). `InventoryEdge.relation` drops "contains"
+ * (pipeline→stage, now dead) for "compatible"|"uses" (see @shared/types.ts).
+ * FE (client/src/pages/Inventory.tsx) legend/filter cleanup is a separate,
+ * follow-up PR.
  *
  * Orphan detection: a connection node is flagged as an orphan when it has had
- * zero MCP tool-call activity in the last ORPHAN_DAYS days.
+ * zero MCP tool-call activity in the last ORPHAN_DAYS days. Skill/model nodes
+ * are never flagged as orphans (no comparable per-node usage series exists).
  */
 
 import type { IStorage } from "../storage";
@@ -34,9 +54,9 @@ export const ORPHAN_DAYS = 30;
 // ─── Build dependency graph ───────────────────────────────────────────────────
 
 /**
- * Builds a connection-only dependency graph for the given workspace.
- * See the file-level INTERIM STATE note for why pipeline/stage/skill/model
- * nodes are absent for now.
+ * Builds the workspace dependency graph: connection nodes (workspace-scoped)
+ * plus skill/model registry nodes (project-scoped) and their compatible/uses
+ * edges. See the file-level DERIVATION note for exact sourcing per node/edge.
  */
 export async function buildInventoryGraph(
   storage: IStorage,
@@ -44,6 +64,10 @@ export async function buildInventoryGraph(
   nowMs = Date.now(),
 ): Promise<InventoryGraph> {
   const connections = await storage.getWorkspaceConnections(workspaceId);
+  const skills = await storage.getSkills();
+  const models = await storage.getModels();
+  const bindings = await storage.getAllModelSkillBindings();
+  const taskModelUsage = await storage.getWorkspaceTaskModelUsage(workspaceId);
 
   const nodes: InventoryNode[] = [];
   const edges: InventoryEdge[] = [];
@@ -75,6 +99,58 @@ export async function buildInventoryGraph(
       },
       isOrphan: connectionOrphanMap.get(conn.id) ?? true,
     });
+  }
+
+  // ── Skill nodes ────────────────────────────────────────────────────────────
+
+  for (const skill of skills) {
+    nodes.push({
+      id: skill.id,
+      type: "skill",
+      label: skill.name,
+      metadata: {
+        sourceType: skill.sourceType,
+        gitSourceId: skill.gitSourceId,
+      },
+    });
+  }
+
+  // ── Model nodes ────────────────────────────────────────────────────────────
+  // model_skill_bindings.modelId and tasks.modelSlug both reference a model by
+  // its stable slug-ish identifier (route validation at
+  // server/routes/model-skill-bindings.ts accepts either models.slug or the
+  // provider-side models.modelId) — index both so edge resolution below is a
+  // single map lookup, no N+1 per-edge query.
+
+  const modelNodeIdByIdentifier = new Map<string, string>();
+  for (const model of models) {
+    modelNodeIdByIdentifier.set(model.slug, model.id);
+    if (model.modelId) modelNodeIdByIdentifier.set(model.modelId, model.id);
+    nodes.push({
+      id: model.id,
+      type: "model",
+      label: model.name,
+      metadata: {
+        provider: model.provider,
+        isActive: model.isActive,
+      },
+    });
+  }
+
+  // ── "compatible" edges: model ↔ skill (curated bindings) ───────────────────
+
+  for (const binding of bindings) {
+    const modelNodeId = modelNodeIdByIdentifier.get(binding.modelId);
+    if (!modelNodeId) continue; // binding references a model outside this catalog
+    edges.push({ source: modelNodeId, target: binding.skillId, relation: "compatible" });
+  }
+
+  // ── "uses" edges: task → model (sparse, observed — see file header) ────────
+
+  for (const usage of taskModelUsage) {
+    const modelNodeId = modelNodeIdByIdentifier.get(usage.modelSlug);
+    if (!modelNodeId) continue; // modelSlug doesn't resolve to a known model row
+    edges.push({ source: usage.taskId, target: modelNodeId, relation: "uses" });
   }
 
   return { nodes, edges };

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -1,8 +1,8 @@
-import { eq, desc, and, or, ilike, lt, ne, gte, lte, asc, isNull, inArray, sql as drizzleSql } from "drizzle-orm";
+import { eq, desc, and, or, ilike, lt, ne, gte, lte, asc, isNull, isNotNull, inArray, sql as drizzleSql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { db, withProject, withProjectList, withProjectInsert, withProjectOrGlobal } from "./db";
 import { unscopedSystemQuery, getProjectId } from "./context";
-import type { IStorage, PracticeCardFilters, LlmRequestFilters, LlmRequestStats, LlmStatsByModel, LlmStatsByProvider, LlmStatsByTeam, LlmStatsByWorkspace, LlmTimelinePoint, RunHistoryQuery, TaskGroupHistoryRow } from "./storage";
+import type { IStorage, PracticeCardFilters, LlmRequestFilters, LlmRequestStats, LlmStatsByModel, LlmStatsByProvider, LlmStatsByTeam, LlmStatsByWorkspace, LlmTimelinePoint, RunHistoryQuery, TaskGroupHistoryRow, WorkspaceTaskModelUsage } from "./storage";
 import {
   TASK_GROUP_V2_MAX_LIMIT,
   IterationConflictError,
@@ -1269,6 +1269,19 @@ export class PgStorage implements IStorage {
       .orderBy(asc(tasks.sortOrder), asc(tasks.createdAt));
   }
 
+  async getWorkspaceTaskModelUsage(workspaceId: string): Promise<WorkspaceTaskModelUsage[]> {
+    const rows = await db
+      .select({ taskId: tasks.id, modelSlug: tasks.modelSlug })
+      .from(tasks)
+      .where(withProject(
+        tasks,
+        and(eq(tasks.workspaceId, workspaceId), isNotNull(tasks.modelSlug)),
+      ));
+    return rows
+      .filter((r): r is { taskId: string; modelSlug: string } => r.modelSlug !== null)
+      .map((r) => ({ taskId: r.taskId, modelSlug: r.modelSlug }));
+  }
+
   async getTask(id: string): Promise<TaskRow | undefined> {
     const [row] = await db.select().from(tasks).where(withProject(tasks, eq(tasks.id, id)));
     return row;
@@ -1411,6 +1424,12 @@ export class PgStorage implements IStorage {
   async getModelSkillBindings(modelId: string): Promise<ModelSkillBinding[]> {
     return db.select().from(modelSkillBindings)
       .where(withProject(modelSkillBindings, eq(modelSkillBindings.modelId, modelId)))
+      .orderBy(asc(modelSkillBindings.createdAt));
+  }
+
+  async getAllModelSkillBindings(): Promise<ModelSkillBinding[]> {
+    return db.select().from(modelSkillBindings)
+      .where(withProjectList(modelSkillBindings))
       .orderBy(asc(modelSkillBindings.createdAt));
   }
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -142,6 +142,17 @@ export interface LlmTimelinePoint {
   costUsd: number;
 }
 
+/**
+ * A task→model "uses" observation for the inventory graph (#54). Sparse and
+ * best-effort: only tasks with a non-null modelSlug AND a workspaceId that
+ * matches the queried workspace are included — tasks.workspaceId is populated
+ * only via the consilium loop DEV handoff path, so most tasks have none.
+ */
+export interface WorkspaceTaskModelUsage {
+  taskId: string;
+  modelSlug: string;
+}
+
 /** Recency sort key for a lesson (createdAt may be null in degenerate rows). */
 function lessonTime(lesson: Lesson): number {
   return lesson.createdAt?.getTime() ?? 0;
@@ -356,6 +367,8 @@ export interface IStorage {
 
   // Tasks (Task Orchestrator)
   getTasksByGroup(groupId: string): Promise<TaskRow[]>;
+  /** Bulk task→modelSlug usage for the inventory graph (#54) — see WorkspaceTaskModelUsage doc. */
+  getWorkspaceTaskModelUsage(workspaceId: string): Promise<WorkspaceTaskModelUsage[]>;
   getTask(id: string): Promise<TaskRow | undefined>;
   createTask(data: InsertTask): Promise<TaskRow>;
   updateTask(id: string, updates: Partial<TaskRow>): Promise<TaskRow>;
@@ -582,6 +595,8 @@ export interface IStorage {
 
   // Model Skill Bindings (Phase 6.17)
   getModelSkillBindings(modelId: string): Promise<ModelSkillBinding[]>;
+  /** Bulk read of every model↔skill binding across all models — for the inventory graph (#54), avoids per-model N+1. */
+  getAllModelSkillBindings(): Promise<ModelSkillBinding[]>;
   getModelsWithSkillBindings(): Promise<string[]>;
   createModelSkillBinding(data: InsertModelSkillBinding): Promise<ModelSkillBinding>;
   deleteModelSkillBinding(modelId: string, skillId: string): Promise<void>;
@@ -1888,6 +1903,14 @@ export class MemStorage implements IStorage {
       .sort((a, b) => a.sortOrder - b.sortOrder);
   }
 
+  async getWorkspaceTaskModelUsage(workspaceId: string): Promise<WorkspaceTaskModelUsage[]> {
+    return Array.from(this.tasksMap.values())
+      .filter((t): t is TaskRow & { modelSlug: string } =>
+        t.workspaceId === workspaceId && t.modelSlug !== null,
+      )
+      .map((t) => ({ taskId: t.id, modelSlug: t.modelSlug }));
+  }
+
   async getTask(id: string): Promise<TaskRow | undefined> {
     return this.tasksMap.get(id);
   }
@@ -2057,6 +2080,10 @@ export class MemStorage implements IStorage {
     return Array.from(this.modelSkillBindingsMap.values()).filter(
       (b) => b.modelId === modelId,
     );
+  }
+
+  async getAllModelSkillBindings(): Promise<ModelSkillBinding[]> {
+    return Array.from(this.modelSkillBindingsMap.values());
   }
 
   async getModelsWithSkillBindings(): Promise<string[]> {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -3345,7 +3345,7 @@ export type McpConnectionUsage = ConnectionUsageMetrics;
 // ── Inventory & Dependency Graph (issue #275) ─────────────────────────────────
 
 /** Node types present in the workspace dependency graph. */
-export type InventoryNodeType = "connection" | "pipeline" | "stage" | "skill" | "model";
+export type InventoryNodeType = "connection" | "skill" | "model";
 
 /** A node in the workspace dependency graph. */
 export interface InventoryNode {
@@ -3365,11 +3365,13 @@ export interface InventoryEdge {
   /** ID of the target node. */
   target: string;
   /**
-   * Relationship label:
-   * - "contains"  — pipeline → stage
-   * - "uses"      — stage → connection | skill | model
+   * Relationship label (#54 — registry-backed derivation):
+   * - "compatible" — model ↔ skill, curated via model_skill_bindings
+   * - "uses"       — task → model, observed via tasks.modelSlug (sparse/best-effort,
+   *                  scoped to tasks with a matching tasks.workspaceId — see
+   *                  server/services/inventory.ts file header)
    */
-  relation: "contains" | "uses";
+  relation: "compatible" | "uses";
 }
 
 /** Full inventory graph returned by GET /api/workspaces/:id/inventory. */

--- a/tests/unit/inventory.test.ts
+++ b/tests/unit/inventory.test.ts
@@ -1,18 +1,20 @@
 /**
  * Tests for inventory service and API routes (issue #275)
  *
- * INTERIM STATE (pipelines engine retirement, migration 0053): the graph is
- * connection-nodes only — see server/services/inventory.ts's file-level note
- * and follow-up #54 for the planned skill/model-registry-backed redesign.
- *
  * Coverage:
  * - Graph construction (connection nodes + orphan flag)
  * - Orphan detection (unused 30d+ connections)
  * - Inventory API routes (2 endpoints)
+ * - #54: skill/model registry nodes + compatible/uses edges (see
+ *   server/services/inventory.ts's DERIVATION note for exact sourcing).
+ *   Registry-sourced cases below run against both MemStorage (always) and
+ *   PgStorage (gated behind DATABASE_URL), mirroring the parity-harness
+ *   pattern in tests/integration/storage/mem-pg-parity.test.ts.
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { MemStorage } from "../../server/storage";
+import type { IStorage } from "../../server/storage";
 import {
   buildInventoryGraph,
   getOrphanNodes,
@@ -22,6 +24,9 @@ import type {
   CreateWorkspaceConnectionInput,
   RecordMcpToolCallInput,
 } from "../../shared/types";
+import type { InsertModel, InsertSkill, InsertModelSkillBinding } from "../../shared/schema";
+
+const HAS_DATABASE = Boolean(process.env.DATABASE_URL);
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -39,6 +44,40 @@ function makeConnInput(
     config: {},
     ...overrides,
   };
+}
+
+/** A short unique suffix so PG runs (shared DB) don't collide across cases. */
+function uniq(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function makeModelInput(overrides: Partial<InsertModel> = {}): InsertModel {
+  const suffix = uniq();
+  return {
+    name: `Model ${suffix}`,
+    slug: `model-${suffix}`,
+    provider: "anthropic",
+    isActive: true,
+    ...overrides,
+  } as InsertModel;
+}
+
+function makeSkillInput(overrides: Partial<InsertSkill> = {}): InsertSkill {
+  const suffix = uniq();
+  return {
+    name: `Skill ${suffix}`,
+    teamId: "team-1",
+    sourceType: "manual",
+    ...overrides,
+  } as InsertSkill;
+}
+
+function makeBindingInput(
+  modelId: string,
+  skillId: string,
+  overrides: Partial<InsertModelSkillBinding> = {},
+): InsertModelSkillBinding {
+  return { modelId, skillId, ...overrides } as InsertModelSkillBinding;
 }
 
 /** Returns a nowMs that is 31 days in the future relative to the tool call date. */
@@ -202,4 +241,229 @@ describe("ORPHAN_DAYS constant", () => {
   it("is 30", () => {
     expect(ORPHAN_DAYS).toBe(30);
   });
+});
+
+// ─── #54: registry-backed nodes/edges — dual-impl cases ───────────────────────
+//
+// One shared case table run against MemStorage (always) and PgStorage (gated
+// behind DATABASE_URL), mirroring tests/integration/storage/mem-pg-parity.test.ts.
+
+function runRegistryCases(label: string, makeGraphStorage: () => IStorage): void {
+  describe(`buildInventoryGraph registries — ${label}`, () => {
+    describe("skill nodes", () => {
+      it("creates a skill node for every skill regardless of workspace", async () => {
+        const storage = makeGraphStorage();
+        const skill = await storage.createSkill(
+          makeSkillInput({ name: "Code Review", sourceType: "git", gitSourceId: "git-src-1" }),
+        );
+
+        const graph = await buildInventoryGraph(storage, "ws-skills-1");
+
+        const node = graph.nodes.find((n) => n.id === skill.id);
+        expect(node).toBeDefined();
+        expect(node?.type).toBe("skill");
+        expect(node?.label).toBe("Code Review");
+        expect(node?.metadata.sourceType).toBe("git");
+        expect(node?.metadata.gitSourceId).toBe("git-src-1");
+      });
+    });
+
+    describe("model nodes", () => {
+      it("creates a model node surfacing provider and isActive", async () => {
+        const storage = makeGraphStorage();
+        const model = await storage.createModel(
+          makeModelInput({ name: "Sonnet", provider: "anthropic", isActive: false }),
+        );
+
+        const graph = await buildInventoryGraph(storage, "ws-models-1");
+
+        const node = graph.nodes.find((n) => n.id === model.id);
+        expect(node).toBeDefined();
+        expect(node?.type).toBe("model");
+        expect(node?.label).toBe("Sonnet");
+        expect(node?.metadata.provider).toBe("anthropic");
+        expect(node?.metadata.isActive).toBe(false);
+      });
+    });
+
+    describe("compatible edges (model <-> skill bindings)", () => {
+      it("creates a compatible edge between a model and a bound skill via slug", async () => {
+        const storage = makeGraphStorage();
+        const model = await storage.createModel(makeModelInput());
+        const skill = await storage.createSkill(makeSkillInput());
+        await storage.createModelSkillBinding(makeBindingInput(model.slug, skill.id));
+
+        const graph = await buildInventoryGraph(storage, "ws-bind-1");
+
+        expect(graph.edges).toContainEqual({
+          source: model.id,
+          target: skill.id,
+          relation: "compatible",
+        });
+      });
+
+      it("resolves a binding keyed by the provider modelId (not slug)", async () => {
+        const storage = makeGraphStorage();
+        const model = await storage.createModel(
+          makeModelInput({ modelId: `provider-${uniq()}` }),
+        );
+        const skill = await storage.createSkill(makeSkillInput());
+        await storage.createModelSkillBinding(
+          makeBindingInput(model.modelId as string, skill.id),
+        );
+
+        const graph = await buildInventoryGraph(storage, "ws-bind-2");
+
+        expect(graph.edges).toContainEqual({
+          source: model.id,
+          target: skill.id,
+          relation: "compatible",
+        });
+      });
+
+      it("skips a binding whose modelId resolves to no known model", async () => {
+        const storage = makeGraphStorage();
+        const skill = await storage.createSkill(makeSkillInput());
+        await storage.createModelSkillBinding(makeBindingInput("unknown-model-slug", skill.id));
+
+        const graph = await buildInventoryGraph(storage, "ws-bind-3");
+
+        expect(graph.edges.some((e) => e.relation === "compatible")).toBe(false);
+      });
+    });
+
+    describe("uses edges (task -> model, sparse/best-effort)", () => {
+      it("creates a uses edge for a task with matching workspaceId and a modelSlug", async () => {
+        const storage = makeGraphStorage();
+        const model = await storage.createModel(makeModelInput());
+        const group = await storage.createTaskGroup({
+          name: `group-${uniq()}`,
+          description: "d",
+          input: "the prompt",
+        });
+        const task = await storage.createTask({
+          groupId: group.id,
+          name: "t",
+          description: "d",
+          sortOrder: 0,
+          workspaceId: "ws-uses-1",
+          modelSlug: model.slug,
+        });
+
+        const graph = await buildInventoryGraph(storage, "ws-uses-1");
+
+        expect(graph.edges).toContainEqual({
+          source: task.id,
+          target: model.id,
+          relation: "uses",
+        });
+      });
+
+      it("excludes a task whose workspaceId does not match the queried workspace", async () => {
+        const storage = makeGraphStorage();
+        const model = await storage.createModel(makeModelInput());
+        const group = await storage.createTaskGroup({
+          name: `group-${uniq()}`,
+          description: "d",
+          input: "the prompt",
+        });
+        await storage.createTask({
+          groupId: group.id,
+          name: "t",
+          description: "d",
+          sortOrder: 0,
+          workspaceId: "ws-other",
+          modelSlug: model.slug,
+        });
+
+        const graph = await buildInventoryGraph(storage, "ws-uses-2");
+
+        expect(graph.edges.some((e) => e.relation === "uses")).toBe(false);
+      });
+
+      it("excludes a task with a null modelSlug even when workspaceId matches", async () => {
+        const storage = makeGraphStorage();
+        const group = await storage.createTaskGroup({
+          name: `group-${uniq()}`,
+          description: "d",
+          input: "the prompt",
+        });
+        await storage.createTask({
+          groupId: group.id,
+          name: "t",
+          description: "d",
+          sortOrder: 0,
+          workspaceId: "ws-uses-3",
+        });
+
+        const graph = await buildInventoryGraph(storage, "ws-uses-3");
+
+        expect(graph.edges.some((e) => e.relation === "uses")).toBe(false);
+      });
+    });
+
+    describe("mixed graph", () => {
+      it("combines connection, skill, and model nodes with compatible + uses edges", async () => {
+        const storage = makeGraphStorage();
+        const wsId = `ws-mixed-${uniq()}`;
+        const conn = await storage.createWorkspaceConnection(makeConnInput({ workspaceId: wsId }));
+        const model = await storage.createModel(makeModelInput());
+        const skill = await storage.createSkill(makeSkillInput());
+        await storage.createModelSkillBinding(makeBindingInput(model.slug, skill.id));
+        const group = await storage.createTaskGroup({
+          name: `group-${uniq()}`,
+          description: "d",
+          input: "the prompt",
+        });
+        const task = await storage.createTask({
+          groupId: group.id,
+          name: "t",
+          description: "d",
+          sortOrder: 0,
+          workspaceId: wsId,
+          modelSlug: model.slug,
+        });
+
+        const graph = await buildInventoryGraph(storage, wsId);
+
+        const nodeIds = graph.nodes.map((n) => n.id);
+        expect(nodeIds).toContain(conn.id);
+        expect(nodeIds).toContain(model.id);
+        expect(nodeIds).toContain(skill.id);
+        expect(graph.nodes.find((n) => n.id === conn.id)?.type).toBe("connection");
+        expect(graph.edges).toContainEqual({ source: model.id, target: skill.id, relation: "compatible" });
+        expect(graph.edges).toContainEqual({ source: task.id, target: model.id, relation: "uses" });
+      });
+    });
+
+    describe("orphan connections alongside registry nodes", () => {
+      it("still flags an unused connection as orphan when skill/model nodes are present", async () => {
+        const storage = makeGraphStorage();
+        const wsId = `ws-orphan-${uniq()}`;
+        const conn = await storage.createWorkspaceConnection(makeConnInput({ workspaceId: wsId }));
+        await storage.createModel(makeModelInput());
+        await storage.createSkill(makeSkillInput());
+
+        const graph = await buildInventoryGraph(storage, wsId, Date.now());
+
+        const connNode = graph.nodes.find((n) => n.id === conn.id);
+        expect(connNode?.isOrphan).toBe(true);
+        // Skill/model nodes never carry an orphan flag (no comparable usage series).
+        for (const node of graph.nodes.filter((n) => n.type !== "connection")) {
+          expect(node.isOrphan).toBeUndefined();
+        }
+      });
+    });
+  });
+}
+
+// MemStorage: always runs (DB-free).
+runRegistryCases("MemStorage", () => new MemStorage());
+
+// PgStorage: registered only when DATABASE_URL is set (kept `./db`'s eager pg
+// Pool construction out of the DB-free import path — same guard as the parity
+// harness).
+describe.skipIf(!HAS_DATABASE)("buildInventoryGraph registries — PgStorage gate", async () => {
+  const { PgStorage } = await import("../../server/storage-pg");
+  runRegistryCases("PgStorage", () => new PgStorage());
 });


### PR DESCRIPTION
## Summary

Implements the BE PR from the approved #54 design (`BkArch-54-design.md`): `buildInventoryGraph` now derives skill/model registry nodes and compatible/uses edges, replacing the connection-nodes-only interim state left after the pipelines-engine retirement.

- **Skill nodes** — `storage.getSkills()`, project-scoped. Metadata surfaces `sourceType`/`gitSourceId` (provenance for the parallel git-backed rows).
- **Model nodes** — `storage.getModels()`, project-or-global catalog. Metadata surfaces `provider`/`isActive`.
- **`"compatible"` edges** (model ↔ skill) — curated via a new bulk `storage.getAllModelSkillBindings()` (avoids the per-model N+1 that `getModelSkillBindings` would require). A dual slug/modelId index resolves `model_skill_bindings.modelId`'s ambiguous identifier format (it can hold either a model's `slug` or its provider-side `modelId`) in a single pass, no extra queries.
- **`"uses"` edges** (task → model) — a new `storage.getWorkspaceTaskModelUsage(workspaceId)` helper, sparse/best-effort: only tasks with a non-null `modelSlug` AND a `workspaceId` matching the queried workspace are included. `tasks.workspaceId` is populated only via the consilium-loop DEV handoff path — documented as intentionally partial, not a bug.
- **No skill-usage edge.** No kept table supports a workspace/task → skill link. The only skill-adjacent FK is `skill_proposals.skillId`, whose own schema comment marks it "NEVER an FK write target." A `teamId`-string heuristic was considered and rejected — too imprecise, risks fabricating false dependency edges. Left out entirely per the design.

### Wire shape

Additive at the data level (new node types, new edge relation, new metadata keys), but **type-level breaking** in `shared/types.ts`:
- `InventoryNodeType` narrows from `"connection"|"pipeline"|"stage"|"skill"|"model"` to `"connection"|"skill"|"model"` — `"pipeline"`/`"stage"` were dead (no source data ever populated them, unused since the pipelines-engine retirement).
- `InventoryEdge.relation` swaps `"contains"` for `"compatible"` (keeps `"uses"`).

No external TS consumer of `@shared/types` exists outside this monorepo, so this is safe, but it does affect the one internal FE consumer's compile — see below.

### client/ touch (flagging as a deviation — explained)

`client/src/pages/Inventory.tsx` is otherwise out of scope for this PR (FE follow-up is separate), but the type narrowing above broke its `tsc --noEmit`: the node-colour/icon `Record<InventoryNodeType, ...>` maps and the legend's `items` array still had `"pipeline"`/`"stage"` entries, and one edge-style check compared `edge.relation === "contains"` (now a strict-mode literal-comparison error, since `"contains"` no longer overlaps the narrowed type). Fixed with the smallest possible compile-preserving shim:
- A local `LegacyInventoryNodeType = InventoryNodeType | "pipeline" | "stage"` widens the 3 `Record`/array type annotations so the existing (dead) `"pipeline"`/`"stage"` legend entries keep compiling unchanged.
- `edge.relation === "contains"` → `"compatible"`, keeping the same visual weighting (thicker/darker line) it had before.

Zero JSX, filtering, or rendering behavior changed. Removing the dead legend entries and giving `"compatible"`/`"uses"` real distinct styling is FE follow-up work.

### Tests

Extended `tests/unit/inventory.test.ts` — all prior connection-only tests (lines 56–201) unchanged and still green. New coverage, one `describe` per new source plus a mixed-graph case and an orphan-connections-alongside-registries case:
- skill nodes
- model nodes
- compatible edges (including the modelId-vs-slug resolution case, and the "binding references an unknown model" skip case)
- uses edges (matching workspace+modelSlug, workspaceId-mismatch exclusion, null-modelSlug exclusion)
- mixed graph (all sources combined)
- orphan connections still flagged correctly alongside registry nodes (which never carry an orphan flag)

All new cases run against both `MemStorage` (always) and `PgStorage` (gated behind `DATABASE_URL`), mirroring the existing `tests/integration/storage/mem-pg-parity.test.ts` dual-impl pattern.

## Test plan

- [x] `npx tsc --noEmit --pretty false` — clean, 0 errors
- [x] `npx vitest run tests/unit/inventory.test.ts` — 21 passed, 10 skipped (PgStorage gate, no `DATABASE_URL` in this environment)
- [x] `npx vitest run` (full suite) — 301 test files passed, 5159 tests passed, 15 skipped, 0 failed
- [ ] PgStorage-gated cases exercised against a real Postgres (CI/reviewer with `DATABASE_URL` set)