### PR TITLE
feat(traces): repoint WorkspaceTraces to live task tracing

### DIFF
--- a/server/routes/workspace-traces.ts
+++ b/server/routes/workspace-traces.ts
@@ -1,9 +1,18 @@
 // server/routes/workspace-traces.ts
 // Workspace-scoped trace viewer endpoints — /workspaces/:id/traces
+//
+// Repointed (task #29) from the legacy `traces` table — whose only writer,
+// the pipeline tracer's flushTrace(), was retired along with the pipelines
+// engine (migration 0053) and fully removed in the OTel/core-tracer sweep —
+// to the live consilium task-tracing source (task-tracer.ts / task_traces).
+// The response shape (WorkspaceTraceSummary/Detail, TraceSpan) is unchanged
+// so the client page needs no changes; task_traces rows are adapted into the
+// same OpenInference-flavoured TraceSpan shape via taskSpanToTraceSpan below.
 import { z } from "zod";
 import type { Express } from "express";
 import type { IStorage } from "../storage";
-import type { WorkspaceTraceSummary, WorkspaceTraceDetail, TraceSpan } from "@shared/types";
+import type { WorkspaceTraceSummary, WorkspaceTraceDetail, TraceSpan, TaskTraceSpan } from "@shared/types";
+import type { TaskTraceRow } from "@shared/schema";
 
 // ─── Zod Schemas ──────────────────────────────────────────────────────────────
 
@@ -72,7 +81,7 @@ function aggregateSpanMetrics(spans: TraceSpan[]): {
   const model    = Object.keys(modelCounts).sort((a, b) => modelCounts[b] - modelCounts[a])[0] ?? "";
 
   return {
-    startTime:   startTime === Infinity ? 0 : startTime,
+    startTime: startTime === Infinity ? 0 : startTime,
     endTime,
     totalTokens,
     costUsd,
@@ -81,11 +90,7 @@ function aggregateSpanMetrics(spans: TraceSpan[]): {
   };
 }
 
-function toTraceSummary(
-  traceId: string,
-  runId: string,
-  spans: TraceSpan[],
-): WorkspaceTraceSummary {
+function toTraceSummary(traceId: string, runId: string, spans: TraceSpan[]): WorkspaceTraceSummary {
   const metrics = aggregateSpanMetrics(spans);
   return {
     traceId,
@@ -95,12 +100,58 @@ function toTraceSummary(
   };
 }
 
+/**
+ * Adapt a TaskTracer span (task_traces.spans, TaskTraceSpanType/metadata
+ * shape) into the OpenInference-flavoured TraceSpan the page already renders.
+ * TaskTracer never captured raw prompt/response text or tool-call args — only
+ * token/cost/model metadata — so those page sections simply stay empty
+ * (the page already handles missing attributes gracefully).
+ */
+function taskSpanToTraceSpan(span: TaskTraceSpan): TraceSpan {
+  const kind =
+    span.type === "llm_call" ? "LLM" :
+    span.type === "task"     ? "AGENT" :
+    "CHAIN"; // "stage" | "task_group"
+
+  const attributes: Record<string, string | number> = {
+    "openinference.span.kind": kind,
+  };
+  if (span.metadata.provider) attributes["llm.provider"] = span.metadata.provider;
+  if (span.metadata.modelSlug) attributes["llm.model"] = span.metadata.modelSlug;
+  if (typeof span.metadata.tokensUsed === "number") attributes["llm.token_count.total"] = span.metadata.tokensUsed;
+  if (typeof span.metadata.inputTokens === "number") attributes["llm.token_count.prompt"] = span.metadata.inputTokens;
+  if (typeof span.metadata.outputTokens === "number") attributes["llm.token_count.completion"] = span.metadata.outputTokens;
+  if (typeof span.metadata.estimatedCostUsd === "number") attributes["llm.cost_usd"] = span.metadata.estimatedCostUsd;
+  if (span.metadata.error) attributes["error.message"] = span.metadata.error;
+
+  return {
+    spanId: span.spanId,
+    parentSpanId: span.parentSpanId ?? undefined,
+    name: span.name,
+    startTime: span.startTime,
+    endTime: span.endTime ?? span.startTime,
+    attributes,
+    events: [],
+    status: span.status === "failed" ? "error" : "ok",
+  };
+}
+
+/** task_traces row → WorkspaceTraceSummary. `runId` = groupId (the closest task-groups-v2 analog to a "pipeline run"). */
+function toWorkspaceSummaryFromTaskTrace(row: TaskTraceRow): WorkspaceTraceSummary {
+  const spans = row.spans.map(taskSpanToTraceSpan);
+  return toTraceSummary(row.traceId, row.groupId, spans);
+}
+
 // ─── Route Registration ───────────────────────────────────────────────────────
 
 export function registerWorkspaceTraceRoutes(app: Express, storage: IStorage): void {
   // GET /api/workspaces/:id/traces
-  // List trace summaries for a workspace.  Workspace scoping is enforced by
-  // filtering to runs that belong to this workspace's pipelines.
+  // List trace summaries for a workspace. Scoping: the workspace must exist
+  // AND belong to the caller's project (storage.getWorkspace enforces that via
+  // ALS project context / requireProject on the /api/workspaces mount); traces
+  // are then restricted to task_traces whose group has a task recorded against
+  // THIS workspace id (server/storage.ts getWorkspaceTaskTraces) — no cross-
+  // workspace leakage even within the same project.
   app.get("/api/workspaces/:id/traces", async (req, res) => {
     const wsResult = WorkspaceIdSchema.safeParse(req.params);
     if (!wsResult.success) {
@@ -112,22 +163,20 @@ export function registerWorkspaceTraceRoutes(app: Express, storage: IStorage): v
       return res.status(400).json({ error: queryResult.error.message });
     }
 
+    const { id: workspaceId } = wsResult.data;
     const { limit, offset, runId } = queryResult.data;
 
     try {
-      // Fetch raw trace records (uses global getTraces — filtered below)
-      const allTraces = await storage.getTraces(limit + offset, 0);
+      const workspace = await storage.getWorkspace(workspaceId);
+      if (!workspace) {
+        return res.status(404).json({ error: `Workspace not found: ${workspaceId}` });
+      }
 
-      // If runId filter provided, restrict to that run
-      const filtered = runId
-        ? allTraces.filter((t) => t.runId === runId)
-        : allTraces;
+      const allTraces = await storage.getWorkspaceTaskTraces(workspaceId, limit + offset, 0);
 
+      const filtered = runId ? allTraces.filter((t) => t.groupId === runId) : allTraces;
       const page = filtered.slice(offset, offset + limit);
-
-      const summaries: WorkspaceTraceSummary[] = page.map((t) =>
-        toTraceSummary(t.traceId, t.runId, t.spans),
-      );
+      const summaries: WorkspaceTraceSummary[] = page.map(toWorkspaceSummaryFromTaskTrace);
 
       return res.json({
         traces: summaries,
@@ -142,7 +191,9 @@ export function registerWorkspaceTraceRoutes(app: Express, storage: IStorage): v
   });
 
   // GET /api/workspaces/:id/traces/:run_id
-  // Return full trace detail including span tree.
+  // Return full trace detail including span tree. `run_id` is the task
+  // group's id — the trace lookup is only permitted if that group has a task
+  // scoped to THIS workspace (getWorkspaceTaskTraceByGroupId), otherwise 404.
   app.get("/api/workspaces/:id/traces/:run_id", async (req, res) => {
     const wsResult = WorkspaceIdSchema.safeParse({ id: req.params.id });
     if (!wsResult.success) {
@@ -154,18 +205,25 @@ export function registerWorkspaceTraceRoutes(app: Express, storage: IStorage): v
       return res.status(400).json({ error: runResult.error.message });
     }
 
+    const { id: workspaceId } = wsResult.data;
     const { run_id } = runResult.data;
 
     try {
-      const trace = await storage.getTraceByRunId(run_id);
+      const workspace = await storage.getWorkspace(workspaceId);
+      if (!workspace) {
+        return res.status(404).json({ error: `Workspace not found: ${workspaceId}` });
+      }
+
+      const trace = await storage.getWorkspaceTaskTraceByGroupId(workspaceId, run_id);
       if (!trace) {
         return res.status(404).json({ error: `No trace found for run ${run_id}` });
       }
 
-      const summary = toTraceSummary(trace.traceId, trace.runId, trace.spans);
+      const spans = trace.spans.map(taskSpanToTraceSpan);
+      const summary = toTraceSummary(trace.traceId, trace.groupId, spans);
       const detail: WorkspaceTraceDetail = {
         ...summary,
-        spans: trace.spans,
+        spans,
       };
 
       return res.json(detail);

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -1355,6 +1355,48 @@ export class PgStorage implements IStorage {
     return row;
   }
 
+  // ─── Workspace-scoped task traces (task #29 — WorkspaceTraces repoint) ──────
+  // task_groups (and task_traces) have no workspace_id / project_id column —
+  // only `tasks.workspace_id` + `tasks.project_id` do. Scope through `tasks`
+  // (withProject there is safe — the column exists) and only pass the
+  // resulting, already-authorized groupIds into the taskTraces query; do NOT
+  // wrap the taskTraces query itself in withProject (that table has no
+  // projectId column and withProject() hard-throws on tables missing it).
+
+  async getWorkspaceTaskTraces(workspaceId: string, limit = 50, offset = 0): Promise<TaskTraceRow[]> {
+    const groupRows = await db
+      .selectDistinct({ groupId: tasks.groupId })
+      .from(tasks)
+      .where(withProject(tasks, eq(tasks.workspaceId, workspaceId)));
+    const groupIds = groupRows.map((r) => r.groupId);
+    if (groupIds.length === 0) return [];
+
+    return db
+      .select()
+      .from(taskTraces)
+      .where(inArray(taskTraces.groupId, groupIds))
+      .orderBy(desc(taskTraces.createdAt))
+      .limit(limit)
+      .offset(offset);
+  }
+
+  async getWorkspaceTaskTraceByGroupId(workspaceId: string, groupId: string): Promise<TaskTraceRow | null> {
+    const [task] = await db
+      .select({ id: tasks.id })
+      .from(tasks)
+      .where(withProject(tasks, and(eq(tasks.groupId, groupId), eq(tasks.workspaceId, workspaceId))))
+      .limit(1);
+    if (!task) return null;
+
+    const [row] = await db
+      .select()
+      .from(taskTraces)
+      .where(eq(taskTraces.groupId, groupId))
+      .orderBy(desc(taskTraces.createdAt))
+      .limit(1);
+    return row ?? null;
+  }
+
   // ─── Tracker Connections (Issue Tracker Integration) ────────────────────────
 
   /**

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -412,6 +412,18 @@ export interface IStorage {
   /** The trace for a specific iteration, scoped to `groupId` (MF-3). */
   getTaskTraceByIteration(groupId: string, iterationId: string): Promise<TaskTraceRow | null>;
 
+  // ─── Workspace-scoped task traces (task #29 — WorkspaceTraces repoint) ──────
+  // The legacy `traces` table (Phase 6.5, pipeline-tracer-backed) is write-less
+  // since the pipelines engine retirement (migration 0053); getTraces()/
+  // getTraceByRunId() above intentionally return empty/null. WorkspaceTraces
+  // now reads from `task_traces` instead, scoped via `tasks.workspace_id`
+  // (NOT task_groups, which has no workspace column) — a task_trace is only
+  // visible for a workspace if at least one task in its group ran against it.
+  /** Task traces whose group has a task scoped to `workspaceId`, newest first. */
+  getWorkspaceTaskTraces(workspaceId: string, limit?: number, offset?: number): Promise<TaskTraceRow[]>;
+  /** A single task trace by `groupId`, only if the group has a task scoped to `workspaceId` (else null — closes cross-workspace IDOR). */
+  getWorkspaceTaskTraceByGroupId(workspaceId: string, groupId: string): Promise<TaskTraceRow | null>;
+
   // ─── Consilium Loops (Phase B — auto-versioned FSM, design §4) ──────────────
   /** Insert a loop. The DB partial-unique index rejects a 2nd active loop per
    *  group (Security H-3) — surfaces as a unique-violation the route maps to 409. */
@@ -2011,6 +2023,28 @@ export class MemStorage implements IStorage {
     this.taskTracesMap.set(id, updated);
     this.taskTracesByGroupId.set(updated.groupId, updated);
     return updated;
+  }
+
+  // ─── Workspace-scoped task traces (task #29 — WorkspaceTraces repoint) ──────
+
+  async getWorkspaceTaskTraces(workspaceId: string, limit = 50, offset = 0): Promise<TaskTraceRow[]> {
+    const groupIds = new Set(
+      Array.from(this.tasksMap.values())
+        .filter((t) => t.workspaceId === workspaceId)
+        .map((t) => t.groupId),
+    );
+    return Array.from(this.taskTracesMap.values())
+      .filter((tr) => groupIds.has(tr.groupId))
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+      .slice(offset, offset + limit);
+  }
+
+  async getWorkspaceTaskTraceByGroupId(workspaceId: string, groupId: string): Promise<TaskTraceRow | null> {
+    const hasTask = Array.from(this.tasksMap.values()).some(
+      (t) => t.groupId === groupId && t.workspaceId === workspaceId,
+    );
+    if (!hasTask) return null;
+    return this.taskTracesByGroupId.get(groupId) ?? null;
   }
 
   // ─── Tracker Connections (Issue Tracker Integration) — MemStorage stubs ─────

--- a/tests/unit/tracing/workspace-traces-route.test.ts
+++ b/tests/unit/tracing/workspace-traces-route.test.ts
@@ -3,55 +3,78 @@ import express from "express";
 import request from "supertest";
 import type { IStorage } from "../../../server/storage.js";
 import { registerWorkspaceTraceRoutes } from "../../../server/routes/workspace-traces.js";
-import type { TraceSpan } from "../../../shared/types.js";
+import type { TaskTraceSpan } from "../../../shared/types.js";
+import type { TaskTraceRow, WorkspaceRow } from "../../../shared/schema.js";
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
-// Attribute keys below are inlined OpenInference semantic-convention literals
-// (see spec: https://github.com/Arize-ai/openinference/tree/main/spec) — this
-// test only needs the string constants, not the (now-removed) tracer module.
+// task_traces.spans are TaskTraceSpan (task-tracer native shape), NOT the
+// legacy OpenInference TraceSpan — the route adapts them via
+// taskSpanToTraceSpan(). See server/routes/workspace-traces.ts.
 
-const LLM_SPAN: TraceSpan = {
+const LLM_SPAN: TaskTraceSpan = {
   spanId: "aaaa1111aaaa1111",
+  parentSpanId: null,
   name: "llm.claude-sonnet-4-6",
+  type: "llm_call",
+  status: "completed",
   startTime: 1000,
   endTime: 2500,
-  status: "ok",
-  attributes: {
-    "openinference.span.kind": "LLM",
-    "llm.provider": "anthropic",
-    "llm.model": "claude-sonnet-4-6",
-    "llm.token_count.total": 150,
-    "llm.cost_usd": 0.0005,
+  metadata: {
+    provider: "anthropic",
+    modelSlug: "claude-sonnet-4-6",
+    tokensUsed: 150,
+    estimatedCostUsd: 0.0005,
   },
-  events: [],
 };
 
-const TOOL_SPAN: TraceSpan = {
+const TASK_SPAN: TaskTraceSpan = {
   spanId: "bbbb2222bbbb2222",
   parentSpanId: "aaaa1111aaaa1111",
-  name: "tool.bash_run",
+  name: "task.bash_run",
+  type: "task",
+  status: "completed",
   startTime: 1100,
   endTime: 1300,
-  status: "ok",
-  attributes: {
-    "openinference.span.kind": "TOOL",
-    "tool.name": "bash_run",
+  metadata: {
+    taskId: "task-1",
   },
-  events: [],
 };
 
-const SAMPLE_TRACE = {
+const WORKSPACE: WorkspaceRow = {
+  id: "ws-1",
+  projectId: "proj-1",
+  name: "ws-1",
+  type: "git",
+  path: "/tmp/ws-1",
+  branch: "main",
+  status: "active",
+  lastSyncAt: null,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  ownerId: null,
+  indexStatus: "idle",
+} as unknown as WorkspaceRow;
+
+const SAMPLE_TASK_TRACE: TaskTraceRow = {
+  id: "tt-1",
+  groupId: "run-test-ws-1",
+  iterationId: null,
   traceId: "cafebabe00000000cafebabecafebabe",
-  runId: "run-test-ws-1",
-  spans: [LLM_SPAN, TOOL_SPAN],
-};
+  rootSpan: LLM_SPAN,
+  spans: [LLM_SPAN, TASK_SPAN],
+  totalDurationMs: 1500,
+  totalTokens: 150,
+  totalCostUsd: 0.0005,
+  createdAt: new Date("2026-01-01T00:01:00Z"),
+  updatedAt: new Date("2026-01-01T00:01:00Z"),
+} as unknown as TaskTraceRow;
 
 // ─── Mock storage ─────────────────────────────────────────────────────────────
 
 function makeMockStorage(overrides: Partial<IStorage> = {}): IStorage {
   return {
-    getTraceByRunId: vi.fn().mockResolvedValue(SAMPLE_TRACE),
-    getTraces: vi.fn().mockResolvedValue([SAMPLE_TRACE]),
+    getWorkspace: vi.fn().mockResolvedValue(WORKSPACE),
+    getWorkspaceTaskTraces: vi.fn().mockResolvedValue([SAMPLE_TASK_TRACE]),
+    getWorkspaceTaskTraceByGroupId: vi.fn().mockResolvedValue(SAMPLE_TASK_TRACE),
     ...overrides,
   } as unknown as IStorage;
 }
@@ -120,7 +143,7 @@ describe("GET /api/workspaces/:id/traces", () => {
   });
 
   it("8. returns 200 with empty traces when storage returns []", async () => {
-    storage = makeMockStorage({ getTraces: vi.fn().mockResolvedValue([]) });
+    storage = makeMockStorage({ getWorkspaceTaskTraces: vi.fn().mockResolvedValue([]) });
     app = makeApp(storage);
     const res = await request(app).get("/api/workspaces/ws-1/traces");
     expect(res.status).toBe(200);
@@ -134,7 +157,7 @@ describe("GET /api/workspaces/:id/traces", () => {
   });
 
   it("10. returns 500 when storage throws", async () => {
-    storage = makeMockStorage({ getTraces: vi.fn().mockRejectedValue(new Error("DB error")) });
+    storage = makeMockStorage({ getWorkspaceTaskTraces: vi.fn().mockRejectedValue(new Error("DB error")) });
     app = makeApp(storage);
     const res = await request(app).get("/api/workspaces/ws-1/traces");
     expect(res.status).toBe(500);
@@ -142,7 +165,6 @@ describe("GET /api/workspaces/:id/traces", () => {
   });
 
   it("11. respects limit query param", async () => {
-    // Storage returns 1 item but we verify limit is parsed correctly
     const res = await request(app).get("/api/workspaces/ws-1/traces?limit=1");
     expect(res.status).toBe(200);
   });
@@ -150,6 +172,22 @@ describe("GET /api/workspaces/:id/traces", () => {
   it("12. returns 400 for invalid limit", async () => {
     const res = await request(app).get("/api/workspaces/ws-1/traces?limit=abc");
     expect(res.status).toBe(400);
+  });
+
+  it("13. returns 404 when the workspace does not exist / does not belong to caller's project", async () => {
+    storage = makeMockStorage({ getWorkspace: vi.fn().mockResolvedValue(null) });
+    app = makeApp(storage);
+    const res = await request(app).get("/api/workspaces/no-such-ws/traces");
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("14. foreign-workspace request: getWorkspaceTaskTraces is called with the requested workspace id (no cross-workspace leakage)", async () => {
+    const getWorkspaceTaskTraces = vi.fn().mockResolvedValue([]);
+    storage = makeMockStorage({ getWorkspaceTaskTraces });
+    app = makeApp(storage);
+    await request(app).get("/api/workspaces/ws-other/traces");
+    expect(getWorkspaceTaskTraces).toHaveBeenCalledWith("ws-other", expect.any(Number), expect.any(Number));
   });
 });
 
@@ -162,14 +200,14 @@ describe("GET /api/workspaces/:id/traces/:run_id", () => {
     app = makeApp(storage);
   });
 
-  it("13. returns 200 with full trace detail including spans", async () => {
+  it("15. returns 200 with full trace detail including spans", async () => {
     const res = await request(app).get("/api/workspaces/ws-1/traces/run-test-ws-1");
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body.spans)).toBe(true);
     expect(res.body.spans).toHaveLength(2);
   });
 
-  it("14. trace detail has all WorkspaceTraceSummary fields plus spans", async () => {
+  it("16. trace detail has all WorkspaceTraceSummary fields plus spans", async () => {
     const res = await request(app).get("/api/workspaces/ws-1/traces/run-test-ws-1");
     expect(res.body).toHaveProperty("traceId");
     expect(res.body).toHaveProperty("runId");
@@ -179,32 +217,51 @@ describe("GET /api/workspaces/:id/traces/:run_id", () => {
     expect(res.body).toHaveProperty("costUsd");
   });
 
-  it("15. returns 404 when trace not found", async () => {
-    storage = makeMockStorage({ getTraceByRunId: vi.fn().mockResolvedValue(null) });
+  it("17. returns 404 when trace not found", async () => {
+    storage = makeMockStorage({ getWorkspaceTaskTraceByGroupId: vi.fn().mockResolvedValue(null) });
     app = makeApp(storage);
     const res = await request(app).get("/api/workspaces/ws-1/traces/no-such-run");
     expect(res.status).toBe(404);
     expect(res.body).toHaveProperty("error");
   });
 
-  it("16. returns 500 when storage throws", async () => {
-    storage = makeMockStorage({ getTraceByRunId: vi.fn().mockRejectedValue(new Error("DB error")) });
+  it("18. returns 404 when the workspace itself does not exist / belong to caller's project", async () => {
+    storage = makeMockStorage({ getWorkspace: vi.fn().mockResolvedValue(null) });
+    app = makeApp(storage);
+    const res = await request(app).get("/api/workspaces/no-such-ws/traces/run-test-ws-1");
+    expect(res.status).toBe(404);
+  });
+
+  it("19. foreign workspace requesting a real run_id from another workspace gets nothing (IDOR closure)", async () => {
+    // Simulates storage correctly scoping: the group exists but has no task
+    // recorded against THIS workspace, so getWorkspaceTaskTraceByGroupId
+    // (which itself does the workspace-membership check) returns null.
+    const getWorkspaceTaskTraceByGroupId = vi.fn().mockResolvedValue(null);
+    storage = makeMockStorage({ getWorkspaceTaskTraceByGroupId });
+    app = makeApp(storage);
+    const res = await request(app).get("/api/workspaces/ws-foreign/traces/run-test-ws-1");
+    expect(res.status).toBe(404);
+    expect(getWorkspaceTaskTraceByGroupId).toHaveBeenCalledWith("ws-foreign", "run-test-ws-1");
+  });
+
+  it("20. returns 500 when storage throws", async () => {
+    storage = makeMockStorage({ getWorkspaceTaskTraceByGroupId: vi.fn().mockRejectedValue(new Error("DB error")) });
     app = makeApp(storage);
     const res = await request(app).get("/api/workspaces/ws-1/traces/run-test-ws-1");
     expect(res.status).toBe(500);
     expect(res.body).toHaveProperty("error");
   });
 
-  it("17. span parent-child relationship is preserved in response", async () => {
+  it("21. span parent-child relationship is preserved in response", async () => {
     const res = await request(app).get("/api/workspaces/ws-1/traces/run-test-ws-1");
-    const toolSpan = res.body.spans.find((s: TraceSpan) => s.name === "tool.bash_run");
-    expect(toolSpan).toBeDefined();
-    expect(toolSpan.parentSpanId).toBe("aaaa1111aaaa1111");
+    const taskSpan = res.body.spans.find((s: { name: string }) => s.name === "task.bash_run");
+    expect(taskSpan).toBeDefined();
+    expect(taskSpan.parentSpanId).toBe("aaaa1111aaaa1111");
   });
 
-  it("18. span attributes include OpenInference conventions", async () => {
+  it("22. span attributes include OpenInference conventions adapted from task-tracer metadata", async () => {
     const res = await request(app).get("/api/workspaces/ws-1/traces/run-test-ws-1");
-    const llmSpan = res.body.spans.find((s: TraceSpan) => s.name.startsWith("llm."));
+    const llmSpan = res.body.spans.find((s: { name: string }) => s.name.startsWith("llm."));
     expect(llmSpan).toBeDefined();
     expect(llmSpan.attributes["openinference.span.kind"]).toBe("LLM");
     expect(llmSpan.attributes["llm.provider"]).toBe("anthropic");


### PR DESCRIPTION
## Context
Follow-up to #525's pipelines-engine retirement, closing out task #29. The `traces` table's only writer (`tracing/tracer.ts` `flushTrace`, called by the removed pipeline controller) was fully deleted in the OTel/core-tracer dead-code sweep, so `storage.getTraces` had already been neutered to return empty/null as a stopgap — WorkspaceTraces ("LLM Traces" nav) showed only stale historical data with no new rows possible.

## Option chosen: (a) — route/storage reads task_traces
Repointed the feature at the live consilium/task tracing source instead of resurrecting a writer for the retired table:
- `storage.getWorkspaceTaskTraces` / `getWorkspaceTaskTraceByGroupId` (new `IStorage` methods, implemented in both `MemStorage` and `PgStorage`) read `task_traces`.
- `server/routes/workspace-traces.ts` calls these instead of the neutered `getTraces`/`getTraceByRunId`, and adapts `TaskTraceSpan` (task-tracer's native span shape) into the existing `TraceSpan` (OpenInference-attribute) shape via a `taskSpanToTraceSpan` mapper, reusing the route's existing `aggregateSpanMetrics`/`toTraceSummary` helpers unchanged.
- Response shape (`WorkspaceTraceSummary`/`WorkspaceTraceDetail`) is byte-for-byte unchanged, so `client/src/pages/WorkspaceTraces.tsx` needed zero changes — chosen over option (b) (task-tracer additionally writing `traces` rows) since it avoids reviving a retired table/writer for no functional gain.

## Authz / scoping preserved
- `task_groups` (and `task_traces`, keyed to it via `groupId`) have **no** `workspaceId` or `projectId` column — only individual `tasks` rows carry an optional `workspaceId`. Scoping is done transitively: a `task_trace` is only visible for workspace `W` if at least one task in its group has `tasks.workspaceId === W`.
- The route first resolves `storage.getWorkspace(id)` (already project-scoped via `withProject`/ALS request context under the existing `requireAuth, requireProject` mount on `/api/workspaces`) and 404s if it doesn't belong to the caller's project.
- This closes a **structural IDOR** in the prior route: the list handler called `storage.getTraces(limit+offset, 0)` globally, completely ignoring the `:id` path param, despite a comment claiming workspace scoping. The detail endpoint is similarly closed — `getWorkspaceTaskTraceByGroupId` returns `null` (→ 404) unless the group has a task scoped to the requested workspace, even for a real `run_id` belonging to a different workspace.
- `PgStorage` scopes the `tasks` lookup via `withProject(tasks, ...)` (safe — `tasks.projectId` exists) but does **not** wrap the final `task_traces` select in `withProject` — that table has no `projectId` column and `withProject()` hard-throws on tables missing it (a pre-existing characteristic of `taskTraces`, unrelated to this change). Safety instead comes transitively from only ever passing in `groupId`s already vetted by the project+workspace-scoped `tasks` query.

## Test evidence
- Targeted: `tests/unit/tracing/workspace-traces-route.test.ts` — rewritten with `TaskTraceRow`/`TaskTraceSpan` fixtures and the new storage mocks — **22/22 passed**, covering: task-trace-backed rows scoped to workspace, workspace list/detail correctly calling storage with the requested workspace id, foreign-workspace detail request returning 404 (IDOR closure), and empty-state (`[]` traces, 200 OK).
- `tsc --noEmit`: clean, zero errors.
- Full suite (`npx vitest run --reporter=dot`), 3 runs:

| Run | Test Files | Tests | Notes |
|---|---|---|---|
| 1 | 300 passed, 1 failed (301) | 5152 passed, 5 skipped | `tests/integration/task-groups-api.test.ts` failed (404 vs 200) — unrelated file, no diff touches it; passed 17/17 in isolation |
| 2 | 300 passed, 1 failed (301) | 5152 passed, 5 skipped | Different unrelated file failed (`tests/integration/activity/live-task-group.test.ts`, `socket hang up`) — pre-existing parallel-load flake class, not this PR's diff |
| 3 | 301 passed (301) | 5153 passed, 5 skipped | Clean |

Both observed failures were in different, unrelated files each run (neither in this PR's diff), consistent with pre-existing environmental flakiness under full-suite parallel load rather than a regression from this change.

Supersedes #534 (its pull_request CI events never fired — GitHub event-delivery issue; identical diff at d091802, security review reports/BkSec-PR534.md applies verbatim).