### PR TITLE
feat(consilium): carry operator steering note across runner-mode rounds

### DIFF
--- a/migrations/0055_consilium_loop_rounds_human_note.sql
+++ b/migrations/0055_consilium_loop_rounds_human_note.sql
@@ -1,0 +1,20 @@
+-- migration: 0055_consilium_loop_rounds_human_note
+-- The operator's steering note for a consilium round (#18 — runner-mode carry-forward).
+--
+-- consilium_loop_rounds.human_note → new TEXT (nullable).
+--   Mirrors `task_group_iterations.human_note`: recorded by the operator AFTER a
+--   round completes, folded into the NEXT round's review context. Legacy
+--   (task-group) loops already carry the note via `task_group_iterations` +
+--   `composeIterationInput`; runner-mode rounds never mint an iteration row, so
+--   this column is where the note lives for those loops. NULL for every
+--   pre-existing round (no backfill) and for any round the operator never
+--   annotated — every consumer guards on NULL/blank before reading it.
+--
+-- Additive + idempotent (ADD COLUMN IF NOT EXISTS): metadata-only, no rewrite, no
+-- data loss. Re-applying against a push-managed dev DB is safe.
+
+ALTER TABLE consilium_loop_rounds
+  ADD COLUMN IF NOT EXISTS human_note text;
+
+-- Rollback:
+--   ALTER TABLE consilium_loop_rounds DROP COLUMN human_note;

--- a/server/routes/consilium-loops.ts
+++ b/server/routes/consilium-loops.ts
@@ -80,6 +80,15 @@ const ArchetypeOverrideSchema = z.object({
   archetype: z.enum(ARCHETYPES),
 });
 
+/**
+ * #18: body for PATCH round note. Empty string clears the note; bounded to 20k
+ * (mirrors `task-iterations.ts`'s NoteSchema — the legacy-path equivalent that
+ * cannot resolve a real iteration row for a runner-mode loop).
+ */
+const RoundNoteSchema = z.object({
+  humanNote: z.string().max(20_000),
+});
+
 /** Mask the loop row for non-admins: hide createdBy attribution. */
 function maskLoop(loop: Record<string, unknown>, isAdmin: boolean): Record<string, unknown> {
   if (isAdmin) return loop;
@@ -377,6 +386,37 @@ export function registerConsiliumLoopRoutes(
       if (!result.ok) return res.status(404).json({ error: "Consilium loop not found" });
       const isAdmin = req.user?.role === "admin";
       return res.json(maskLoop({ ...result.loop }, !!isAdmin));
+    },
+  );
+
+  // ── Round note (#18) ─────────────────────────────────────────────────────────
+  // Owner-or-admin. Human-in-the-loop steering note attached to a completed round —
+  // the runner-mode mirror of `task-iterations.ts`'s iteration-note PATCH (which
+  // cannot resolve a real iteration row for a runner-mode loop, since those never
+  // mint one). Folded into the NEXT round's review context by the review-runner
+  // (buildOperatorNote, alongside buildPriorFindings). Empty body clears the note.
+  app.patch(
+    "/api/consilium-loops/:id/rounds/:round/note",
+    validateBody(RoundNoteSchema),
+    async (req: Request, res: Response) => {
+      const auth = await authorizeConsiliumLoop(req, res, storage, String(req.params.id));
+      if (!auth) return;
+      const round = Number(req.params.round);
+      if (!Number.isInteger(round) || round < 1) {
+        return res.status(404).json({ error: "Round not found" });
+      }
+      const body = req.body as z.infer<typeof RoundNoteSchema>;
+      const humanNote = body.humanNote.trim() === "" ? null : body.humanNote;
+      try {
+        const rounds = await storage.getLoopRounds(auth.loop.id);
+        if (!rounds.some((r) => r.round === round)) {
+          return res.status(404).json({ error: "Round not found" });
+        }
+        await storage.updateLoopRoundHumanNote(auth.loop.id, round, humanNote);
+        return res.json({ round, humanNote });
+      } catch {
+        return res.status(500).json({ error: "Failed to save round note" });
+      }
     },
   );
 

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -55,6 +55,7 @@ import type { Archetype } from "@shared/types";
 import type { ActionPoint, ConvergenceVerdict, RoundVerdict, RoundParticipant, ReviewMode } from "@shared/types";
 import { P0_PRIORITY } from "@shared/types";
 import type { TaskOrchestrator } from "../task-orchestrator.js";
+import { HUMAN_NOTE_HEADING } from "../task-orchestrator.js";
 import type { AppConfig } from "../../config/schema.js";
 import { effectiveVerificationEnabled, resolveImplementForRepo } from "../../config/schema.js";
 import { readConvergence, readJudgeVerdict, extractActionPoints, normalizeActionPointMethods, applyCriteriaQa } from "../orchestrator/convergence.js";
@@ -2677,8 +2678,19 @@ export class ConsiliumLoopController {
     const cfg = this.loopConfig();
     const group = await this.storage.getTaskGroup(loop.groupId);
     const objective = group?.input ?? "";
-    const priorFindings =
+    const priorFindingsBase =
       loop.round >= 1 ? await this.buildPriorFindings(loop, cfg.maxDiffBytes) : undefined;
+    // #18: the operator's steering note (persisted on the ROUND record — runner-mode
+    // rounds mint no iteration row, so `task_group_iterations.human_note` /
+    // `composeIterationInput` — the legacy path's carry-forward — never fires here).
+    // Injected ALONGSIDE buildPriorFindings for round > 1; the legacy path is
+    // untouched (it already carries the note its own way).
+    const operatorNote =
+      loop.round >= 1 ? await this.buildOperatorNote(loop) : undefined;
+    const priorFindings =
+      [priorFindingsBase, operatorNote]
+        .filter((s): s is string => !!s && s.trim().length > 0)
+        .join("\n\n") || undefined;
     const testSummary =
       effectiveVerificationEnabled(this.deps.config()) || this.researchImplementEnabled()
         ? await this.latestRoundTestSummary(loop)
@@ -2757,6 +2769,33 @@ export class ConsiliumLoopController {
     for (let i = rounds.length - 1; i >= 0; i--) {
       const ts = rounds[i].testSummary;
       if (ts && ts.trim().length > 0) return ts;
+    }
+    return undefined;
+  }
+
+  /**
+   * #18: the operator's steering note for round > 1, carried on the ROUND record
+   * itself (`consilium_loop_rounds.human_note`) — the runner-mode mirror of the
+   * legacy path's `task_group_iterations.human_note` / `composeIterationInput`
+   * carry-forward (runner-mode rounds never mint an iteration row, so the note has
+   * nowhere else to live). Best-effort: a storage failure or empty history yields
+   * `undefined` (mirrors latestRoundTestSummary). Reads the MOST RECENT round that
+   * carries a note (mirrors latestRoundTestSummary's scan), not just the immediately
+   * prior round, so a note survives even if an intervening round has none.
+   */
+  private async buildOperatorNote(loop: ConsiliumLoopRow): Promise<string | undefined> {
+    let rounds: ConsiliumLoopRoundRow[];
+    try {
+      rounds = await this.storage.getLoopRounds(loop.id);
+    } catch (err) {
+      this.log(loop.id, `buildOperatorNote: getLoopRounds failed (no note injected): ${err instanceof Error ? err.message : String(err)}`);
+      return undefined;
+    }
+    for (let i = rounds.length - 1; i >= 0; i--) {
+      const note = rounds[i].humanNote;
+      if (note && note.trim().length > 0) {
+        return `${HUMAN_NOTE_HEADING}:\n${note.trim()}`;
+      }
     }
     return undefined;
   }

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -992,6 +992,14 @@ export class PgStorage implements IStorage {
       .where(and(eq(consiliumLoopRounds.loopId, loopId), eq(consiliumLoopRounds.round, round)));
   }
 
+  async updateLoopRoundHumanNote(loopId: string, round: number, humanNote: string | null): Promise<void> {
+    // #18: same (loop, round) scoping as testSummary/report/executionTrace.
+    await db
+      .update(consiliumLoopRounds)
+      .set({ humanNote })
+      .where(and(eq(consiliumLoopRounds.loopId, loopId), eq(consiliumLoopRounds.round, round)));
+  }
+
   // ─── Experience plane — the "Dream" distillation, WRITE side (DREAM-1) ─────
 
   async createExperienceItems(items: InsertExperienceItem[]): Promise<ExperienceItemRow[]> {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -516,6 +516,14 @@ export interface IStorage {
    */
   updateLoopRoundActionPoints(loopId: string, round: number, actionPoints: ActionPoint[]): Promise<void>;
 
+  /**
+   * #18: persist the operator's steering note on a completed round — the
+   * runner-mode mirror of `task_group_iterations.human_note`. Additive over the
+   * audit row recorded on entering `developing`; no-op when the (loop, round)
+   * row is absent. Idempotent / best-effort (mirror of updateLoopRoundTestSummary).
+   */
+  updateLoopRoundHumanNote(loopId: string, round: number, humanNote: string | null): Promise<void>;
+
   // Experience plane — the "Dream" distillation, WRITE side (DREAM-1).
   // The distiller observer reads terminal loops read-only and writes verification-grounded
   // items here. WRITE-ONLY in DREAM-1 (no planner read path — that is DREAM-2).
@@ -1536,6 +1544,7 @@ export class MemStorage implements IStorage {
       baselineCommit: data.baselineCommit ?? null,
       headCommit: data.headCommit ?? null,
       testSummary: data.testSummary ?? null,
+      humanNote: data.humanNote ?? null,
       report: data.report ?? null,
       executionTrace: data.executionTrace ?? null,
       createdAt: new Date(),
@@ -1581,6 +1590,15 @@ export class MemStorage implements IStorage {
     for (const r of this.consiliumLoopRoundsMap.values()) {
       if (r.loopId === loopId && r.round === round) {
         this.consiliumLoopRoundsMap.set(r.id, { ...r, openActionPoints: actionPoints });
+        return;
+      }
+    }
+  }
+
+  async updateLoopRoundHumanNote(loopId: string, round: number, humanNote: string | null): Promise<void> {
+    for (const r of this.consiliumLoopRoundsMap.values()) {
+      if (r.loopId === loopId && r.round === round) {
+        this.consiliumLoopRoundsMap.set(r.id, { ...r, humanNote });
         return;
       }
     }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1949,6 +1949,14 @@ export const consiliumLoopRounds = pgTable(
     baselineCommit: text("baseline_commit"),
     headCommit: text("head_commit"),
     testSummary: text("test_summary"),
+    // #18: operator steering note recorded AFTER this round completes — the
+    // runner-mode (Phase 2) mirror of `task_group_iterations.human_note`.
+    // Runner-mode rounds never mint an iteration row (see composeIterationInput
+    // in task-orchestrator.ts, legacy-path only), so this is where the note has
+    // to live for the review-runner to carry it into the NEXT round's context
+    // (alongside the existing prior-findings carry-forward). Nullable; only the
+    // latest round's note is read forward. Never wired into the legacy path.
+    humanNote: text("human_note"),
     // Stage 3 (research archetype): the structured, web-evidence-verified report the
     // research-runner produces INSTEAD of code + a Draft PR. Nullable; written
     // out-of-band by `updateLoopRoundReport` after the research run settles (mirror of

--- a/tests/integration/consilium/loop-routes.test.ts
+++ b/tests/integration/consilium/loop-routes.test.ts
@@ -142,6 +142,12 @@ describe("consilium-loop routes", () => {
   const get = (path: string): Promise<request.Response> =>
     send(() => request(ctx.app).get(path));
 
+  const patch = (path: string, body?: unknown): Promise<request.Response> =>
+    send(() => {
+      const r = request(ctx.app).patch(path);
+      return body === undefined ? r : r.send(body as object);
+    });
+
   it("POST create → 201, stamps createdBy = caller", async () => {
     const res = await post("/api/consilium-loops", { groupId: ctx.group.id, repoPath: REPO_ROOT });
     expect(res.status).toBe(201);
@@ -265,6 +271,47 @@ describe("consilium-loop routes", () => {
     const res = await get("/api/consilium-loops");
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(0);
+  });
+
+  // ─── #18: round note (runner-mode operator steering note) ──────────────────
+
+  it("PATCH round note: owner sets a note → 200, persisted on the round row", async () => {
+    const created = await post("/api/consilium-loops", { groupId: ctx.group.id, repoPath: REPO_ROOT });
+    const id = created.body.id;
+    await ctx.storage.appendLoopRound({ loopId: id, round: 1, iterationNumber: 1 } as never);
+    const res = await patch(`/api/consilium-loops/${id}/rounds/1/note`, { humanNote: "focus on the auth path" });
+    expect(res.status).toBe(200);
+    expect(res.body.humanNote).toBe("focus on the auth path");
+    const rounds = await ctx.storage.getLoopRounds(id);
+    expect(rounds.find((r) => r.round === 1)?.humanNote).toBe("focus on the auth path");
+  });
+
+  it("PATCH round note: blank body clears an existing note", async () => {
+    const created = await post("/api/consilium-loops", { groupId: ctx.group.id, repoPath: REPO_ROOT });
+    const id = created.body.id;
+    await ctx.storage.appendLoopRound({ loopId: id, round: 1, iterationNumber: 1 } as never);
+    await ctx.storage.updateLoopRoundHumanNote(id, 1, "old note");
+    const res = await patch(`/api/consilium-loops/${id}/rounds/1/note`, { humanNote: "" });
+    expect(res.status).toBe(200);
+    expect(res.body.humanNote).toBeNull();
+    const rounds = await ctx.storage.getLoopRounds(id);
+    expect(rounds.find((r) => r.round === 1)?.humanNote).toBeNull();
+  });
+
+  it("PATCH round note: unknown round → 404", async () => {
+    const created = await post("/api/consilium-loops", { groupId: ctx.group.id, repoPath: REPO_ROOT });
+    const id = created.body.id;
+    const res = await patch(`/api/consilium-loops/${id}/rounds/1/note`, { humanNote: "x" });
+    expect(res.status).toBe(404);
+  });
+
+  it("M-1: PATCH round note cross-owner → 404 (not 403)", async () => {
+    const created = await post("/api/consilium-loops", { groupId: ctx.group.id, repoPath: REPO_ROOT });
+    const id = created.body.id;
+    await ctx.storage.appendLoopRound({ loopId: id, round: 1, iterationNumber: 1 } as never);
+    ctx.setUser(OTHER_USER);
+    const res = await patch(`/api/consilium-loops/${id}/rounds/1/note`, { humanNote: "x" });
+    expect(res.status).toBe(404);
   });
 });
 

--- a/tests/unit/consilium/loop-runner-operator-note.test.ts
+++ b/tests/unit/consilium/loop-runner-operator-note.test.ts
@@ -1,0 +1,265 @@
+/**
+ * loop-runner-operator-note.test.ts — #18 coverage.
+ *
+ * Runner-mode rounds never mint a `task_group_iterations` row, so the legacy
+ * carry-forward (`humanNote` on the iteration, folded into the NEXT iteration's
+ * `input` via `composeIterationInput`) never fires for them — the operator's
+ * steering note was silently lost across runner-mode rounds.
+ *
+ * Fix: the note is now persisted on the ROUND record itself
+ * (`consilium_loop_rounds.human_note`) and `runReviewFromLoop` (the runner-mode
+ * context builder) injects the most recent round's note into round > 1 context —
+ * ALONGSIDE the existing `buildPriorFindings` carry-forward, via the SAME
+ * `priorFindings` field threaded into `buildDiffContext`.
+ *
+ * The legacy path is untouched: `startReviewRound`'s legacy branch never calls
+ * `buildOperatorNote`, and `task_group_iterations.human_note` / `TaskOrchestrator`
+ * are not exercised or changed here.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const buildDiffContextMock = vi.fn();
+vi.mock("../../../server/services/consilium/diff-context.js", () => ({
+  buildDiffContext: (...args: unknown[]) => buildDiffContextMock(...args),
+}));
+
+const runReviewTasksMock = vi.fn();
+vi.mock("../../../server/services/consilium/review-runner.js", () => ({
+  runReviewTasks: (...args: unknown[]) => runReviewTasksMock(...args),
+}));
+
+import { ConsiliumLoopController } from "../../../server/services/consilium/consilium-loop-controller.js";
+import { HUMAN_NOTE_HEADING } from "../../../server/services/task-orchestrator.js";
+import type { ConsiliumLoopRow, ConsiliumLoopRoundRow } from "@shared/schema";
+
+function makeLoop(over: Partial<ConsiliumLoopRow>): ConsiliumLoopRow {
+  return {
+    id: "loop1",
+    groupId: "grp1",
+    state: "reviewing",
+    round: 2,
+    maxRounds: 6,
+    repoPath: process.cwd(),
+    lastReviewedCommit: "abc123",
+    reviewRef: null,
+    reviewMode: null,
+    currentIterationNumber: null,
+    devGroupId: null,
+    prRef: null,
+    headCommitAtReview: null,
+    openP0: null,
+    error: null,
+    createdBy: "user1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    completedAt: null,
+    ...over,
+  } as ConsiliumLoopRow;
+}
+
+function roundRow(over: Partial<ConsiliumLoopRoundRow>): ConsiliumLoopRoundRow {
+  return {
+    id: `r${over.round}`,
+    loopId: "loop1",
+    round: 1,
+    iterationNumber: 1,
+    converged: false,
+    openP0: 0,
+    openActionPoints: [],
+    verdict: null,
+    participants: null,
+    baselineCommit: null,
+    headCommit: null,
+    testSummary: null,
+    humanNote: null,
+    report: null,
+    executionTrace: null,
+    createdAt: new Date(),
+    ...over,
+  } as ConsiliumLoopRoundRow;
+}
+
+const configFactory = () =>
+  ({
+    pipeline: {
+      taskGroups: { taskTimeoutMs: 300000, defaultModel: "claude-opus" },
+      consiliumLoop: {
+        enabled: true,
+        maxRounds: 6,
+        pollIntervalMs: 5000,
+        maxDiffBytes: 200000,
+        allowedRepoPaths: [process.cwd()],
+        directReview: { enabled: true },
+        implement: { enabled: false, verification: { enabled: false }, research: { enabled: false } },
+      },
+    },
+  }) as never;
+
+type Priv = {
+  runReviewFromLoop(loop: ConsiliumLoopRow): Promise<unknown>;
+};
+
+describe("#18 — runner-mode carries the operator's steering note into round > 1 context", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    buildDiffContextMock.mockReset();
+    buildDiffContextMock.mockResolvedValue({ ok: true, input: "assembled input", truncated: false });
+    runReviewTasksMock.mockReset();
+    runReviewTasksMock.mockResolvedValue({ converged: false, openP0: 1, openActionPoints: [], verdict: null, participants: null });
+  });
+
+  it("round with a persisted human_note: the note is folded into the round>1 priorFindings field, alongside prior findings", async () => {
+    const round1 = roundRow({ round: 1, humanNote: "Keep the retry budget at 3 — do NOT reduce it further." });
+    const storage = {
+      getLoopRounds: vi.fn(async () => [round1]),
+      getTaskGroup: vi.fn(async () => ({ id: "grp1", name: "[consilium-review:sdlc-cross-review] x", input: "objective" })),
+    };
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: { startGroup: vi.fn(), startGroupAsync: vi.fn(), createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
+      config: configFactory,
+      gateway: {} as never,
+    });
+
+    const loop = makeLoop({ round: 2 });
+    await (controller as unknown as Priv).runReviewFromLoop(loop);
+
+    expect(buildDiffContextMock).toHaveBeenCalledTimes(1);
+    const call = buildDiffContextMock.mock.calls[0][0] as { priorFindings?: string };
+    expect(call.priorFindings).toBeDefined();
+    expect(call.priorFindings).toContain(HUMAN_NOTE_HEADING);
+    expect(call.priorFindings).toContain("Keep the retry budget at 3 — do NOT reduce it further.");
+  });
+
+  it("no note on any round: priorFindings carries no operator-note section (byte-identical to before #18)", async () => {
+    const round1 = roundRow({ round: 1, humanNote: null });
+    const storage = {
+      getLoopRounds: vi.fn(async () => [round1]),
+      getTaskGroup: vi.fn(async () => ({ id: "grp1", name: "[consilium-review:sdlc-cross-review] x", input: "objective" })),
+    };
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: { startGroup: vi.fn(), startGroupAsync: vi.fn(), createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
+      config: configFactory,
+      gateway: {} as never,
+    });
+
+    const loop = makeLoop({ round: 2 });
+    await (controller as unknown as Priv).runReviewFromLoop(loop);
+
+    const call = buildDiffContextMock.mock.calls[0][0] as { priorFindings?: string };
+    expect(call.priorFindings ?? "").not.toContain(HUMAN_NOTE_HEADING);
+  });
+
+  it("note recorded on an EARLIER round survives past an intervening note-less round (latest-note scan)", async () => {
+    const round1 = roundRow({ round: 1, humanNote: "Earlier direction: prefer the simpler fix." });
+    const round2 = roundRow({ round: 2, humanNote: null });
+    const storage = {
+      getLoopRounds: vi.fn(async () => [round1, round2]),
+      getTaskGroup: vi.fn(async () => ({ id: "grp1", name: "[consilium-review:sdlc-cross-review] x", input: "objective" })),
+    };
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: { startGroup: vi.fn(), startGroupAsync: vi.fn(), createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
+      config: configFactory,
+      gateway: {} as never,
+    });
+
+    const loop = makeLoop({ round: 3 });
+    await (controller as unknown as Priv).runReviewFromLoop(loop);
+
+    const call = buildDiffContextMock.mock.calls[0][0] as { priorFindings?: string };
+    expect(call.priorFindings).toContain("Earlier direction: prefer the simpler fix.");
+  });
+
+  it("round 1 (first review, no history yet): priorFindings stays undefined — nothing to inject", async () => {
+    const storage = {
+      getLoopRounds: vi.fn(async () => []),
+      getTaskGroup: vi.fn(async () => ({ id: "grp1", name: "[consilium-review:sdlc-cross-review] x", input: "objective" })),
+    };
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: { startGroup: vi.fn(), startGroupAsync: vi.fn(), createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
+      config: configFactory,
+      gateway: {} as never,
+    });
+
+    const loop = makeLoop({ round: 1 });
+    await (controller as unknown as Priv).runReviewFromLoop(loop);
+
+    const call = buildDiffContextMock.mock.calls[0][0] as { priorFindings?: string };
+    expect(call.priorFindings).toBeUndefined();
+  });
+
+  it("getLoopRounds failure: buildOperatorNote is best-effort — round>1 review proceeds without the note", async () => {
+    const storage = {
+      getLoopRounds: vi.fn(async () => {
+        throw new Error("transient storage blip");
+      }),
+      getTaskGroup: vi.fn(async () => ({ id: "grp1", name: "[consilium-review:sdlc-cross-review] x", input: "objective" })),
+    };
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: { startGroup: vi.fn(), startGroupAsync: vi.fn(), createTaskGroup: vi.fn(), cancelGroup: vi.fn() } as never,
+      config: configFactory,
+      gateway: {} as never,
+    });
+
+    const loop = makeLoop({ round: 2 });
+    const result = await (controller as unknown as Priv).runReviewFromLoop(loop);
+
+    // NOT thrown/degraded because of the note lookup failure — the review still runs.
+    expect(runReviewTasksMock).toHaveBeenCalledTimes(1);
+    expect(result).toBeDefined();
+  });
+
+  it("legacy (directReview OFF) path: startReviewRound never consults the round's human_note", async () => {
+    // Even if a round row happens to carry a human_note (e.g. a loop that ran a
+    // runner-mode round earlier, then the flag flipped OFF), the legacy branch of
+    // startReviewRound must not inject it — it has its own carry-forward mechanism
+    // (task_group_iterations.human_note / composeIterationInput), untouched by #18.
+    const round1 = roundRow({ round: 1, humanNote: "should NEVER reach the legacy review input" });
+    const storage = {
+      getLoopRounds: vi.fn(async () => [round1]),
+      getTaskGroup: vi.fn(async () => ({ id: "grp1", name: "[consilium-review:sdlc-cross-review] x", input: "objective" })),
+      updateTaskGroup: vi.fn(async () => ({})),
+    };
+    const config = () =>
+      ({
+        pipeline: {
+          taskGroups: { taskTimeoutMs: 300000, defaultModel: "claude-opus" },
+          consiliumLoop: {
+            enabled: true,
+            maxRounds: 6,
+            pollIntervalMs: 5000,
+            maxDiffBytes: 200000,
+            allowedRepoPaths: [process.cwd()],
+            directReview: { enabled: false },
+            implement: { enabled: false, verification: { enabled: false }, research: { enabled: false } },
+          },
+        },
+      }) as never;
+    const controller = new ConsiliumLoopController({
+      storage: storage as never,
+      taskOrchestrator: {
+        startGroup: vi.fn(),
+        startGroupAsync: vi.fn(async () => ({ group: {}, iteration: { iterationNumber: 2 } })),
+        createTaskGroup: vi.fn(),
+        cancelGroup: vi.fn(),
+      } as never,
+      config,
+      gateway: {} as never,
+    });
+
+    type LegacyPriv = {
+      startReviewRound(loop: ConsiliumLoopRow, opts?: { relaunch?: boolean }): Promise<Record<string, unknown>>;
+    };
+    const loop = makeLoop({ round: 1 }); // startReviewRound reads loop.round BEFORE incrementing
+    await (controller as unknown as LegacyPriv).startReviewRound(loop);
+
+    expect(buildDiffContextMock).toHaveBeenCalledTimes(1);
+    const call = buildDiffContextMock.mock.calls[0][0] as { priorFindings?: string };
+    expect(call.priorFindings ?? "").not.toContain(HUMAN_NOTE_HEADING);
+    expect(call.priorFindings ?? "").not.toContain("should NEVER reach the legacy review input");
+  });
+});


### PR DESCRIPTION
## Summary

In runner-mode (the in-process review-runner behind the `directReview` kill-switch, PR #524), the operator's steering note was silently lost between rounds. The note has always lived on `task_group_iterations.human_note` and been folded into the next iteration's `input` via `composeIterationInput` — but runner-mode rounds never mint an iteration row, so there was nowhere for the note to persist, and nothing carried it forward into round > 1's review context.

## Fix

- New nullable column `consilium_loop_rounds.human_note` (migration `0055`), mirroring the existing `testSummary`/`verdict`/`participants` per-round fields.
- New route `PATCH /api/consilium-loops/:id/rounds/:round/note` (owner-or-admin gated, 404-not-403 on non-visible loops) to record/clear the note on a completed round.
- `ConsiliumLoopController.runReviewFromLoop` now folds the most recent round's note (via new `buildOperatorNote`, mirroring the existing `latestRoundTestSummary` scan pattern) into `priorFindings` alongside `buildPriorFindings`, for round >= 1.
- The legacy (task-group) path is untouched by construction: `startReviewRound`'s legacy branch only ever calls `buildPriorFindings`, never `buildOperatorNote` — it continues to carry notes exactly as before via `task_group_iterations` / `composeIterationInput`.
- Scope intentionally excludes client/UI wiring for setting a runner-mode round note (the persistence primitive + injection are the requested minimal scope); the existing iteration-note editor already covers legacy loops.

## Test plan

- [x] `npx tsc --noEmit` — clean, 0 errors
- [x] New unit tests: `tests/unit/consilium/loop-runner-operator-note.test.ts` (6 tests) — note injected for round > 1, no note → no injection, note survives a note-less intervening round (latest-note scan), round 1 has no history to inject, `getLoopRounds` failure degrades gracefully (best-effort), legacy path never consults the round's `human_note`
- [x] New integration tests added to `tests/integration/consilium/loop-routes.test.ts` (4 tests) — set note (200 + persisted), blank body clears note, unknown round → 404, cross-owner → 404 (not 403)
- [x] Targeted suite: `npx vitest run tests/unit/consilium tests/integration/consilium` — 93 files / 1264 tests passed
- [x] Full suite: `npx vitest run` — 295/296 files passed, 5058/5064 tests passed, 5 skipped; the 1 failure (`cross-project-http-isolation.test.ts`, unrelated HTTP middleware test, "socket hang up") is flaky/environmental — passes cleanly in isolation, unrelated to this change