### PR TITLE
fix(ci): activate pgvector extension for e2e db:push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,10 @@ jobs:
     if: needs.guard.outputs.run == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     services:
       postgres:
-        image: postgres:16
+        # pgvector/pgvector:pg16, not plain postgres:16 — shared/schema.ts declares
+        # a `vector(...)` column (hybrid RAG memory retrieval) and db:push needs
+        # the extension's shared library available to resolve that column type.
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: multiqlti
           POSTGRES_PASSWORD: multiqlti
@@ -136,6 +139,17 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - name: Enable pgvector extension
+        run: |
+          node -e "
+            const { Client } = require('pg');
+            (async () => {
+              const client = new Client({ connectionString: process.env.DATABASE_URL });
+              await client.connect();
+              await client.query('CREATE EXTENSION IF NOT EXISTS vector');
+              await client.end();
+            })().catch((err) => { console.error(err); process.exit(1); });
+          "
       - run: npm run db:push
       - run: npx playwright install chromium --with-deps
       - run: npm run test:e2e


### PR DESCRIPTION
## Root cause

main's post-merge e2e job has been red since **PR #282** (2026-04-17, "hybrid RAG memory with pgvector retrieval"), ~82 days before this fix — not the recent #525/#526 retirement wave. `shared/schema.ts` declares a `vector("embedding", { dimensions: 1536 })` column, but the e2e job's postgres service ran a plain `postgres:16` image, which never had the `vector` extension binary installed at all.

Chain of failure:
1. `npm run db:push` (`drizzle-kit push`) hits "Pulling schema from database" and errors `type "vector" does not exist` (pg code `42704`) — confirmed identically in run `28926537416` (the run cited for this task) and the first-ever failing run back on 2026-07-03/PR #282.
2. `drizzle-kit push` exits `0` despite this internal error — confirmed via `gh run view --json jobs`: the `Run npm run db:push` step is marked `"conclusion":"success"` in the same run where it produced this error. No tables get created, but the job doesn't stop.
3. The e2e job proceeds to `npm run test:e2e`, which boots the app server against the (now-empty) schema. The app crashes on the first query hitting a nonexistent table — `relation "models" does not exist` (pg code `42P01`), surfacing as the `pg-pool`/`Error.captureStackTrace` stack trace in the webServer logs, which is what was originally reported. That's a downstream symptom of step 1, not the root cause.

## Fix

- Swap the e2e job's postgres service image from `postgres:16` to `pgvector/pgvector:pg16` — the same image `docker-compose.yml` already uses for local dev — so the extension's shared library actually exists on the server.
- Add an explicit `CREATE EXTENSION IF NOT EXISTS vector` step before `db:push`, since even the pgvector image doesn't auto-create the extension in a fresh database without an initdb script (confirmed: the pgvector image alone is necessary but not sufficient).

## Evidence

Local repro against scratch Docker postgres containers (never touched a real/dev database):

| Setup | `db:push` result |
|---|---|
| `postgres:16` + `CREATE EXTENSION vector` attempted | fails: `could not open extension control file ".../vector.control"` — confirms plain image lacks the extension entirely |
| `pgvector/pgvector:pg16`, no extension step | fails identically to CI: `type "vector" does not exist` (42704) |
| `pgvector/pgvector:pg16` + `CREATE EXTENSION IF NOT EXISTS vector` (this fix) | `[✓] Changes applied` |

With the fix applied: app server boots cleanly (`curl /api/health` → `200 {"status":"ok"}`), and `npm run test:e2e` runs its full 119-test suite against a live webServer instead of crashing at startup (previously: `Error: Process from config.webServer was not able to start. Exit code: 1`).

Not merging — for review.