### PR TITLE
feat(inventory): render skill/model nodes, drop retired pipeline/stage from legend (54 FE)

### DIFF
--- a/client/src/lib/inventory-graph-legend.ts
+++ b/client/src/lib/inventory-graph-legend.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure, DOM-free helpers backing the Inventory graph's legend/type-filter/
+ * provenance-badge UI (#54 FE — client/src/pages/Inventory.tsx).
+ *
+ * Extracted out of the page component so the node/edge-type surface (which
+ * types the legend lists, which options the type filter offers, which
+ * provenance badge a skill/model node gets) is unit-testable without a DOM
+ * rendering harness — this repo has no RTL/jsdom setup (no
+ * @testing-library/react, no jsdom/happy-dom in package.json or
+ * node_modules), and the established pattern for FE logic coverage here is
+ * exactly this: extract pure functions/constants into client/src/lib and
+ * test them under vitest's plain "node" environment (see the sibling
+ * task-iterations.ts / task-form-logic.ts modules). See
+ * tests/unit/inventory-graph-legend.test.ts.
+ */
+import type { InventoryNode, InventoryNodeType } from "@shared/types";
+
+// ─── Node colour + short icon label ────────────────────────────────────────
+
+export const NODE_COLOUR: Record<InventoryNodeType, string> = {
+  connection: "#6366f1", // indigo
+  skill: "#8b5cf6", // violet
+  model: "#3b82f6", // blue
+};
+
+export const NODE_ICON_LABEL: Record<InventoryNodeType, string> = {
+  connection: "Conn",
+  skill: "Skill",
+  model: "Mdl",
+};
+
+// ─── Graph legend ───────────────────────────────────────────────────────────
+
+export const GRAPH_LEGEND_ITEMS: Array<{ type: InventoryNodeType; label: string }> = [
+  { type: "connection", label: "Connection" },
+  { type: "skill", label: "Skill" },
+  { type: "model", label: "Model" },
+];
+
+// ─── Type filter ────────────────────────────────────────────────────────────
+
+export type TypeFilter = InventoryNodeType | "all";
+
+export const TYPE_FILTER_OPTIONS: Array<{ value: TypeFilter; label: string }> = [
+  { value: "all", label: "All types" },
+  { value: "connection", label: "Connection" },
+  { value: "skill", label: "Skill" },
+  { value: "model", label: "Model" },
+];
+
+// ─── Provenance badges (side panel) ────────────────────────────────────────
+
+export interface ProvenanceBadge {
+  kind: "git-sourced" | "manual" | "provider" | "active" | "inactive";
+  label: string;
+}
+
+/**
+ * Derives the provenance badge descriptor(s) for a skill/model node's side
+ * panel: skill.metadata.sourceType ("git" vs "manual", + gitSourceId when
+ * present) and model.metadata.provider/isActive. Connection nodes (and any
+ * future node type) get no provenance badges.
+ */
+export function getNodeProvenanceBadges(
+  node: Pick<InventoryNode, "type" | "metadata">,
+): ProvenanceBadge[] {
+  if (node.type === "skill") {
+    const sourceType = node.metadata.sourceType as string | undefined;
+    const gitSourceId = node.metadata.gitSourceId as string | null | undefined;
+    if (sourceType === "git") {
+      return [
+        {
+          kind: "git-sourced",
+          label: gitSourceId ? `Git-sourced · ${gitSourceId}` : "Git-sourced",
+        },
+      ];
+    }
+    return [{ kind: "manual", label: "Manual" }];
+  }
+
+  if (node.type === "model") {
+    const badges: ProvenanceBadge[] = [];
+    const provider = node.metadata.provider as string | undefined;
+    if (provider) badges.push({ kind: "provider", label: provider });
+    const isActive = node.metadata.isActive as boolean | undefined;
+    badges.push(
+      isActive ? { kind: "active", label: "Active" } : { kind: "inactive", label: "Inactive" },
+    );
+    return badges;
+  }
+
+  return [];
+}

--- a/client/src/pages/Inventory.tsx
+++ b/client/src/pages/Inventory.tsx
@@ -4,7 +4,10 @@
  * Route: /workspaces/:id/inventory
  *
  * Features:
- * - Interactive SVG force-directed graph (connections/pipelines/stages/skills/models)
+ * - Interactive SVG force-directed graph (connections/skills/models — see #54,
+ *   the retired "pipeline"/"stage" node types are gone; the dependents drawer's
+ *   own "pipeline"/"stage" kind strings are a separate, unrelated concept —
+ *   ConnectionDependentsResponse — and are intentionally untouched)
  * - Filters: by type, used/unused, last activity
  * - Search box (filters nodes by label)
  * - Click node → side panel with metadata + dependents
@@ -24,6 +27,7 @@ import {
   Network,
   Plug,
   GitMerge,
+  GitBranch,
   Layers,
   Sparkles,
   Cpu,
@@ -41,6 +45,14 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
+import {
+  NODE_COLOUR,
+  NODE_ICON_LABEL,
+  GRAPH_LEGEND_ITEMS,
+  TYPE_FILTER_OPTIONS,
+  getNodeProvenanceBadges,
+  type TypeFilter,
+} from "@/lib/inventory-graph-legend";
 import type {
   InventoryGraph,
   InventoryNode,
@@ -101,35 +113,20 @@ function useDependents(workspaceId: string, connectionId: string | null) {
 
 // ─── Node colour + icon ───────────────────────────────────────────────────────
 //
-// NOTE (#54 BE): InventoryNodeType was narrowed to "connection"|"skill"|"model"
-// (server/services/inventory.ts no longer emits "pipeline"/"stage" — dead since
-// the pipelines-engine retirement, they never populated a graph). The maps below
-// keep their "pipeline"/"stage" entries under this compile-only local type so
-// this file keeps type-checking unmodified pending the FE follow-up PR, which
-// owns removing them for real (design brief "FE PR" section).
-type LegacyInventoryNodeType = InventoryNodeType | "pipeline" | "stage";
-
-const NODE_COLOUR: Record<LegacyInventoryNodeType, string> = {
-  connection: "#6366f1", // indigo
-  pipeline: "#10b981",  // emerald
-  stage: "#f59e0b",     // amber
-  skill: "#8b5cf6",     // violet
-  model: "#3b82f6",     // blue
-};
-
-const NODE_ICON_LABEL: Record<LegacyInventoryNodeType, string> = {
-  connection: "Conn",
-  pipeline: "Pipe",
-  stage: "Stg",
-  skill: "Skill",
-  model: "Mdl",
-};
+// #54 FE: "pipeline"/"stage" node types are retired for real here (were dead —
+// no source data ever populated them since the pipelines-engine retirement;
+// see server/services/inventory.ts's DERIVATION note). GitMerge/Layers stay
+// imported — they're still used by the (untouched) dependents drawer below,
+// which renders an unrelated "pipeline"/"stage" kind from
+// ConnectionDependentsResponse.
+//
+// NODE_COLOUR/NODE_ICON_LABEL/GRAPH_LEGEND_ITEMS/TYPE_FILTER_OPTIONS live in
+// lib/inventory-graph-legend.ts (pure, DOM-free) so this type surface is
+// unit-testable without a rendering harness — see that module's header.
 
 function NodeTypeIcon({ type, className }: { type: InventoryNodeType; className?: string }) {
-  const icons: Record<LegacyInventoryNodeType, React.ReactNode> = {
+  const icons: Record<InventoryNodeType, React.ReactNode> = {
     connection: <Plug className={cn("h-4 w-4", className)} />,
-    pipeline: <GitMerge className={cn("h-4 w-4", className)} />,
-    stage: <Layers className={cn("h-4 w-4", className)} />,
     skill: <Sparkles className={cn("h-4 w-4", className)} />,
     model: <Cpu className={cn("h-4 w-4", className)} />,
   };
@@ -267,9 +264,9 @@ function InventoryGraphSvg({ nodes, edges, selectedId, onSelectNode }: GraphProp
         const src = posMap.get(edge.source);
         const tgt = posMap.get(edge.target);
         if (!src || !tgt) return null;
-        // NOTE (#54 BE): "contains" (pipeline→stage) is dead — swapped for
-        // "compatible" (model↔skill) to keep the same visual weighting; real
-        // FE styling pass is the follow-up FE PR.
+        // #54: "compatible" (model<->skill, curated) renders as a solid,
+        // slightly thicker/darker line; "uses" (task->model, observed) renders
+        // dashed — see GraphLegend for the matching labels.
         return (
           <line
             key={i}
@@ -365,6 +362,55 @@ function MetadataRow({ label, value }: { label: string; value: unknown }) {
   );
 }
 
+/**
+ * #54: skill/model provenance badges shown alongside the type badge in the
+ * side panel — skill.sourceType ("git" vs "manual") and model provider/
+ * isActive. Badge selection is the pure getNodeProvenanceBadges() (lib/
+ * inventory-graph-legend.ts); this component only maps its descriptors to
+ * JSX/styling.
+ */
+function NodeProvenanceBadges({ node }: { node: InventoryNode }) {
+  const badges = getNodeProvenanceBadges(node);
+  return (
+    <>
+      {badges.map((badge) => {
+        if (badge.kind === "git-sourced") {
+          return (
+            <Badge
+              key={badge.kind}
+              variant="outline"
+              className="gap-1 text-emerald-500 border-emerald-500/50"
+            >
+              <GitBranch className="h-3 w-3" />
+              {badge.label}
+            </Badge>
+          );
+        }
+        if (badge.kind === "active") {
+          return (
+            <Badge key={badge.kind} variant="outline" className="text-emerald-500 border-emerald-500/50">
+              {badge.label}
+            </Badge>
+          );
+        }
+        if (badge.kind === "provider") {
+          return (
+            <Badge key={badge.kind} variant="outline" className="capitalize">
+              {badge.label}
+            </Badge>
+          );
+        }
+        // "manual" | "inactive"
+        return (
+          <Badge key={badge.kind} variant="outline" className="text-muted-foreground">
+            {badge.label}
+          </Badge>
+        );
+      })}
+    </>
+  );
+}
+
 interface SidePanelProps {
   node: InventoryNode;
   workspaceId: string;
@@ -400,6 +446,7 @@ function NodeSidePanel({ node, workspaceId, onClose }: SidePanelProps) {
             <NodeTypeIcon type={node.type} className="mr-1" />
             {node.type}
           </Badge>
+          <NodeProvenanceBadges node={node} />
           {node.isOrphan && (
             <Badge variant="outline" className="text-amber-500 border-amber-500/50">
               <AlertTriangle className="h-3 w-3 mr-1" />
@@ -415,9 +462,17 @@ function NodeSidePanel({ node, workspaceId, onClose }: SidePanelProps) {
           </p>
           <div className="bg-muted/40 rounded-md px-3 py-2 space-y-0.5">
             <MetadataRow label="ID" value={node.id} />
-            {Object.entries(node.metadata).map(([k, v]) => (
-              <MetadataRow key={k} label={k} value={v} />
-            ))}
+            {Object.entries(node.metadata)
+              // sourceType/gitSourceId (skill) and provider/isActive (model)
+              // are already surfaced as badges above — skip the raw duplicate.
+              .filter(([k]) => {
+                if (node.type === "skill") return k !== "sourceType" && k !== "gitSourceId";
+                if (node.type === "model") return k !== "provider" && k !== "isActive";
+                return true;
+              })
+              .map(([k, v]) => (
+                <MetadataRow key={k} label={k} value={v} />
+              ))}
           </div>
         </section>
 
@@ -502,8 +557,9 @@ function OrphanList({ nodes }: { nodes: InventoryNode[] }) {
 }
 
 // ─── Filters ─────────────────────────────────────────────────────────────────
+//
+// TypeFilter lives in lib/inventory-graph-legend.ts (pure, DOM-free).
 
-type TypeFilter = InventoryNodeType | "all";
 type UsageFilter = "all" | "used" | "unused";
 
 function applyFilters(
@@ -552,16 +608,9 @@ function applyFilters(
 // ─── Legend ───────────────────────────────────────────────────────────────────
 
 function GraphLegend() {
-  const items: Array<{ type: LegacyInventoryNodeType; label: string }> = [
-    { type: "connection", label: "Connection" },
-    { type: "pipeline", label: "Pipeline" },
-    { type: "stage", label: "Stage" },
-    { type: "skill", label: "Skill" },
-    { type: "model", label: "Model" },
-  ];
   return (
     <div className="flex flex-wrap gap-3 px-4 py-2 border-t border-border bg-card/50">
-      {items.map((item) => (
+      {GRAPH_LEGEND_ITEMS.map((item) => (
         <div key={item.type} className="flex items-center gap-1.5 text-xs">
           <span
             className="inline-block w-3 h-3 rounded-full"
@@ -578,7 +627,7 @@ function GraphLegend() {
         <svg width="24" height="8">
           <line x1="0" y1="4" x2="20" y2="4" stroke="#4b5563" strokeWidth={1.5} />
         </svg>
-        <span className="text-muted-foreground">Contains</span>
+        <span className="text-muted-foreground">Compatible</span>
       </div>
       <div className="flex items-center gap-1.5 text-xs">
         <svg width="24" height="8">
@@ -670,12 +719,11 @@ export default function Inventory() {
             <SelectValue placeholder="All types" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">All types</SelectItem>
-            <SelectItem value="connection">Connection</SelectItem>
-            <SelectItem value="pipeline">Pipeline</SelectItem>
-            <SelectItem value="stage">Stage</SelectItem>
-            <SelectItem value="skill">Skill</SelectItem>
-            <SelectItem value="model">Model</SelectItem>
+            {TYPE_FILTER_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
 

--- a/tests/unit/inventory-graph-legend.test.ts
+++ b/tests/unit/inventory-graph-legend.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for the Inventory graph's legend/type-filter/provenance-badge
+ * PURE helpers (#54 FE — client/src/pages/Inventory.tsx). Like
+ * task-iterations-logic.test.ts / task-form.test.ts, these exercise the pure
+ * helpers behind the page without a DOM renderer (the repo has no jsdom /
+ * @testing-library/react) — they import from @/lib/inventory-graph-legend
+ * (no React):
+ *   - NODE_COLOUR / NODE_ICON_LABEL / GRAPH_LEGEND_ITEMS — the legend lists
+ *     exactly connection/skill/model (the retired pipeline/stage node types
+ *     are gone for real, see #54 BE's DERIVATION note).
+ *   - TYPE_FILTER_OPTIONS — the type filter's options match the legend types
+ *     (+ "all").
+ *   - getNodeProvenanceBadges — skill (git-sourced incl. gitSourceId, vs
+ *     manual) and model (provider + active/inactive) badge selection, run
+ *     against a mixed-graph-shaped fixture (connection + skill + model
+ *     nodes), plus the "no badges for a connection node" case.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  NODE_COLOUR,
+  NODE_ICON_LABEL,
+  GRAPH_LEGEND_ITEMS,
+  TYPE_FILTER_OPTIONS,
+  getNodeProvenanceBadges,
+} from "../../client/src/lib/inventory-graph-legend";
+import type { InventoryNode } from "../../shared/types";
+
+const ALL_NODE_TYPES = ["connection", "skill", "model"] as const;
+
+// ─── A mixed-graph-shaped fixture (connection + skill + model nodes) ────────
+
+function mixedGraphFixture(): InventoryNode[] {
+  return [
+    {
+      id: "conn-1",
+      type: "connection",
+      label: "GitHub Conn",
+      metadata: { connectionType: "github", status: "active" },
+    },
+    {
+      id: "skill-git",
+      type: "skill",
+      label: "Code Review",
+      metadata: { sourceType: "git", gitSourceId: "git-src-1" },
+    },
+    {
+      id: "skill-manual",
+      type: "skill",
+      label: "Summarizer",
+      metadata: { sourceType: "manual", gitSourceId: null },
+    },
+    {
+      id: "model-active",
+      type: "model",
+      label: "Sonnet",
+      metadata: { provider: "anthropic", isActive: true },
+    },
+    {
+      id: "model-inactive",
+      type: "model",
+      label: "Legacy Model",
+      metadata: { provider: "openai", isActive: false },
+    },
+  ];
+}
+
+// ─── Legend ──────────────────────────────────────────────────────────────────
+
+describe("GRAPH_LEGEND_ITEMS", () => {
+  it("lists exactly connection, skill, model — no pipeline/stage remnants", () => {
+    expect(GRAPH_LEGEND_ITEMS.map((i) => i.type)).toEqual(ALL_NODE_TYPES.slice());
+    for (const item of GRAPH_LEGEND_ITEMS) {
+      expect(item.type).not.toBe("pipeline");
+      expect(item.type).not.toBe("stage");
+    }
+  });
+});
+
+describe("NODE_COLOUR / NODE_ICON_LABEL", () => {
+  it("has exactly one entry per node type, no pipeline/stage keys", () => {
+    expect(Object.keys(NODE_COLOUR).sort()).toEqual(ALL_NODE_TYPES.slice().sort());
+    expect(Object.keys(NODE_ICON_LABEL).sort()).toEqual(ALL_NODE_TYPES.slice().sort());
+    expect(NODE_COLOUR).not.toHaveProperty("pipeline");
+    expect(NODE_COLOUR).not.toHaveProperty("stage");
+    expect(NODE_ICON_LABEL).not.toHaveProperty("pipeline");
+    expect(NODE_ICON_LABEL).not.toHaveProperty("stage");
+  });
+});
+
+// ─── Type filter ─────────────────────────────────────────────────────────────
+
+describe("TYPE_FILTER_OPTIONS", () => {
+  it("matches the legend types plus 'all', no pipeline/stage remnants", () => {
+    expect(TYPE_FILTER_OPTIONS.map((o) => o.value)).toEqual(["all", ...ALL_NODE_TYPES]);
+    for (const opt of TYPE_FILTER_OPTIONS) {
+      expect(opt.value).not.toBe("pipeline");
+      expect(opt.value).not.toBe("stage");
+    }
+  });
+});
+
+// ─── Provenance badges (mixed-graph fixture) ─────────────────────────────────
+
+describe("getNodeProvenanceBadges", () => {
+  const fixture = mixedGraphFixture();
+
+  it("returns a git-sourced badge (with gitSourceId) for a git skill", () => {
+    const skill = fixture.find((n) => n.id === "skill-git")!;
+    const badges = getNodeProvenanceBadges(skill);
+    expect(badges).toEqual([{ kind: "git-sourced", label: "Git-sourced · git-src-1" }]);
+  });
+
+  it("returns a manual badge for a manual skill", () => {
+    const skill = fixture.find((n) => n.id === "skill-manual")!;
+    const badges = getNodeProvenanceBadges(skill);
+    expect(badges).toEqual([{ kind: "manual", label: "Manual" }]);
+  });
+
+  it("omits the gitSourceId suffix when git-sourced with no gitSourceId", () => {
+    const skill: InventoryNode = {
+      id: "skill-git-no-src",
+      type: "skill",
+      label: "X",
+      metadata: { sourceType: "git", gitSourceId: null },
+    };
+    expect(getNodeProvenanceBadges(skill)).toEqual([
+      { kind: "git-sourced", label: "Git-sourced" },
+    ]);
+  });
+
+  it("returns provider + active badges for an active model", () => {
+    const model = fixture.find((n) => n.id === "model-active")!;
+    const badges = getNodeProvenanceBadges(model);
+    expect(badges).toEqual([
+      { kind: "provider", label: "anthropic" },
+      { kind: "active", label: "Active" },
+    ]);
+  });
+
+  it("returns provider + inactive badges for an inactive model", () => {
+    const model = fixture.find((n) => n.id === "model-inactive")!;
+    const badges = getNodeProvenanceBadges(model);
+    expect(badges).toEqual([
+      { kind: "provider", label: "openai" },
+      { kind: "inactive", label: "Inactive" },
+    ]);
+  });
+
+  it("returns no badges for a connection node", () => {
+    const conn = fixture.find((n) => n.id === "conn-1")!;
+    expect(getNodeProvenanceBadges(conn)).toEqual([]);
+  });
+
+  it("renders skill+model badges for every registry node in the mixed-graph fixture", () => {
+    const registryNodes = fixture.filter((n) => n.type === "skill" || n.type === "model");
+    for (const node of registryNodes) {
+      expect(getNodeProvenanceBadges(node).length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Drops the retired `pipeline`/`stage` node-type entries from `NODE_COLOUR`, `NODE_ICON_LABEL`, `NodeTypeIcon`, the type `<Select>` filter, and `GraphLegend` in `client/src/pages/Inventory.tsx` — replaced with real `skill`/`model` rendering (distinct colours/icons/legend rows), matching the `InventoryNodeType`/`InventoryEdge.relation` narrowing shipped in #537 (54 BE, merged).
- Edge line styles now distinguish `"compatible"` (solid, thicker) vs `"uses"` (dashed) relations, with matching legend rows.
- Adds skill/model provenance badges to the node side panel: skill `sourceType` ("git" vs "manual", + `gitSourceId` when present) and model `provider`/`isActive`.
- `ConnectionDependentsResponse`'s dependents drawer (its own, unrelated `pipeline`/`stage` *kind* strings) is untouched — out of scope per design (confirmed via grep: only comments + that drawer retain those strings).
- New `client/src/lib/inventory-graph-legend.ts` — pure, DOM-free legend/filter/provenance-badge logic extracted out of the page component (see deviation note below).

## Deviation from "RTL" test instruction (flagged)
This repo has **no RTL/jsdom test infrastructure** — zero `.test.tsx` files exist anywhere, no `@testing-library/react`/`jsdom`/`happy-dom` in `package.json` or `node_modules`, and `vitest.config.ts`'s projects are all `environment: "node"` with `include: ["tests/unit/**/*.test.ts"]` (`.ts` only). Standing up a new jsdom+RTL harness is an infra decision out of scope for this feature PR. Instead, following this repo's own established FE-testing convention (see `client/src/lib/task-iterations.ts` / `tests/unit/task-iterations-logic.test.ts`, listed in `vitest.config.ts`'s coverage allowlist as "FE (node-testable, DOM)"), I extracted the legend/filter/provenance-badge logic into a pure module and wrote `tests/unit/inventory-graph-legend.test.ts` against it under plain node-environment vitest — covering exactly the assertions requested: legend lists exactly connection/skill/model, filter options match, a mixed-graph fixture (connection+skill+model) yields correct provenance badges, and no `pipeline`/`stage` remnants in any exported constant.

## PR-chain note
Branched off `feat/inventory-graph-registries` (the #537/54-BE branch) as instructed, since FE needs BE's shared types. **#537 is now merged** (confirmed via `gh pr view 537` — `state: MERGED`), so this branch was rebased onto current `main` for a clean, FE-only diff (pushed under `feat/inventory-graph-fe-v2` since a force-push to the original `feat/inventory-graph-fe` branch was blocked by sandbox permissions — that earlier branch/PR was never opened and can be deleted).

## Test plan
- [x] `npx tsc --noEmit --pretty false` — clean, 0 errors
- [x] `npx vitest run tests/unit/inventory-graph-legend.test.ts` — 10/10 passed
- [x] `npx vitest run tests/unit/inventory.test.ts` — passed (54 BE coverage, unaffected)
- [x] `npx vitest run --reporter=dot` (full suite) — 301 files / 5168 tests passed, 15 skipped, 1 unrelated pre-existing flaky failure (`tests/integration/knowledge/ingest.test.ts`, network `ETIMEDOUT`) — confirmed flaky/unrelated by re-running in isolation (passed clean)
- [x] `npm run build` — exit 0 (pre-existing, unrelated `import.meta`/cjs warnings only)
- [x] `grep -n '"pipeline"\|"stage"' client/src/pages/Inventory.tsx` — only explanatory comments + the intentionally-untouched dependents drawer remain