### PR TITLE
test(e2e): fix stale specs to send x-project-id (root cause, not route retirement)

### DIFF
--- a/tests/e2e/argocd-settings.spec.ts
+++ b/tests/e2e/argocd-settings.spec.ts
@@ -25,7 +25,7 @@
  * has DATABASE_URL set in CI. They are skipped when DATABASE_URL is absent.
  */
 import { test, expect, request as playwrightRequest } from "@playwright/test";
-import { loginPage, getAuthToken } from "./helpers/auth";
+import { loginPage, getAuthToken, ensureProjectHeaders } from "./helpers/auth";
 
 const BASE_URL_FALLBACK = "http://localhost:3099";
 const HAS_DATABASE = !!process.env.DATABASE_URL;
@@ -48,18 +48,28 @@ async function openArgoCdSection(page: import("@playwright/test").Page) {
   await page.waitForTimeout(300);
 }
 
-/** Create an authenticated API context against the Playwright webServer. */
-async function authenticatedApiContext(baseURL: string) {
+/**
+ * Create an authenticated API context against the Playwright webServer.
+ * /api/settings (which covers /api/settings/argocd) is mounted behind
+ * requireAuth + requireProject (server/routes.ts) — extraHeaders lets
+ * callers merge in x-project-id since this context bypasses the client's
+ * fetch interceptor entirely.
+ */
+async function authenticatedApiContext(baseURL: string, extraHeaders: Record<string, string> = {}) {
   const token = await getAuthToken(baseURL);
   return playwrightRequest.newContext({
     baseURL,
-    extraHTTPHeaders: { Authorization: `Bearer ${token}` },
+    extraHTTPHeaders: { Authorization: `Bearer ${token}`, ...extraHeaders },
   });
 }
 
 test.describe("ArgoCD Settings", () => {
+  let projectHeaders: { "x-project-id": string };
+
   test.beforeEach(async ({ page }, testInfo) => {
-    await loginPage(page, testInfo.project.use.baseURL ?? BASE_URL_FALLBACK);
+    const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
+    await loginPage(page, baseURL);
+    projectHeaders = await ensureProjectHeaders(page, baseURL);
   });
 
   // ─── Settings page renders ArgoCD section ─────────────────────────────────
@@ -184,6 +194,7 @@ test.describe("ArgoCD Settings", () => {
   test("PUT /api/settings/argocd with SSRF URL (localhost) → 400", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
     const res = await page.request.put(`${baseURL}/api/settings/argocd`, {
+      headers: projectHeaders,
       data: {
         serverUrl: "http://localhost:8080",
         token: "some-token",
@@ -199,6 +210,7 @@ test.describe("ArgoCD Settings", () => {
   test("PUT /api/settings/argocd with private IP 10.x.x.x → 400", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
     const res = await page.request.put(`${baseURL}/api/settings/argocd`, {
+      headers: projectHeaders,
       data: {
         serverUrl: "https://10.0.0.1:8080",
         token: "some-token",
@@ -214,6 +226,7 @@ test.describe("ArgoCD Settings", () => {
   }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
     const res = await page.request.put(`${baseURL}/api/settings/argocd`, {
+      headers: projectHeaders,
       data: {
         serverUrl: "https://192.168.1.50",
         token: "some-token",
@@ -227,6 +240,7 @@ test.describe("ArgoCD Settings", () => {
   test("PUT /api/settings/argocd with invalid URL → 400", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
     const res = await page.request.put(`${baseURL}/api/settings/argocd`, {
+      headers: projectHeaders,
       data: {
         serverUrl: "not-a-url",
         token: "some-token",
@@ -240,6 +254,7 @@ test.describe("ArgoCD Settings", () => {
   test("PUT /api/settings/argocd missing serverUrl → 400", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
     const res = await page.request.put(`${baseURL}/api/settings/argocd`, {
+      headers: projectHeaders,
       data: {
         token: "some-token",
         verifySsl: true,
@@ -256,7 +271,7 @@ test.describe("ArgoCD Settings", () => {
   test("GET /api/settings/argocd returns configured field (DB)", async ({}, testInfo) => {
     test.skip(!HAS_DATABASE, "Requires DATABASE_URL");
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const ctx = await authenticatedApiContext(baseURL);
+    const ctx = await authenticatedApiContext(baseURL, projectHeaders);
     try {
       const res = await ctx.get("/api/settings/argocd");
       expect(res.status()).toBe(200);
@@ -271,7 +286,7 @@ test.describe("ArgoCD Settings", () => {
   test("GET /api/settings/argocd response is valid JSON not HTML (DB)", async ({}, testInfo) => {
     test.skip(!HAS_DATABASE, "Requires DATABASE_URL");
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const ctx = await authenticatedApiContext(baseURL);
+    const ctx = await authenticatedApiContext(baseURL, projectHeaders);
     try {
       const res = await ctx.get("/api/settings/argocd");
       expect(res.status()).toBe(200);
@@ -289,7 +304,7 @@ test.describe("ArgoCD Settings", () => {
   test("PUT /api/settings/argocd missing token on first config → 400 (DB)", async ({}, testInfo) => {
     test.skip(!HAS_DATABASE, "Requires DATABASE_URL");
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const ctx = await authenticatedApiContext(baseURL);
+    const ctx = await authenticatedApiContext(baseURL, projectHeaders);
     try {
       await ctx.delete("/api/settings/argocd");
 
@@ -309,7 +324,7 @@ test.describe("ArgoCD Settings", () => {
   test("DELETE /api/settings/argocd returns 204 when no config exists (DB)", async ({}, testInfo) => {
     test.skip(!HAS_DATABASE, "Requires DATABASE_URL");
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const ctx = await authenticatedApiContext(baseURL);
+    const ctx = await authenticatedApiContext(baseURL, projectHeaders);
     try {
       await ctx.delete("/api/settings/argocd");
       const res = await ctx.delete("/api/settings/argocd");
@@ -322,7 +337,7 @@ test.describe("ArgoCD Settings", () => {
   test("POST /api/settings/argocd/test returns JSON response (DB)", async ({}, testInfo) => {
     test.skip(!HAS_DATABASE, "Requires DATABASE_URL");
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const ctx = await authenticatedApiContext(baseURL);
+    const ctx = await authenticatedApiContext(baseURL, projectHeaders);
     try {
       const res = await ctx.post("/api/settings/argocd/test");
 
@@ -337,7 +352,7 @@ test.describe("ArgoCD Settings", () => {
   test("POST /api/settings/argocd/test when not configured returns ok:false (DB)", async ({}, testInfo) => {
     test.skip(!HAS_DATABASE, "Requires DATABASE_URL");
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const ctx = await authenticatedApiContext(baseURL);
+    const ctx = await authenticatedApiContext(baseURL, projectHeaders);
     try {
       await ctx.delete("/api/settings/argocd");
 

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -64,3 +64,61 @@ export async function loginPage(page: Page, baseURL: string): Promise<void> {
   // Set token in localStorage so the React AuthContext considers the user logged in.
   await page.evaluate((t) => localStorage.setItem("auth_token", t), token);
 }
+
+let cachedProjectId: string | null = null;
+
+/**
+ * Ensure a project exists and return the `x-project-id` header object that
+ * every project-scoped `page.request`/API-context call needs (server/
+ * middleware/project.ts: `requireProject` returns 400 without it — auth
+ * alone is not sufficient). `page.request` and standalone
+ * `request.newContext()` calls bypass the browser's client-side fetch
+ * interceptor (client/src/lib/projectHeaders.ts) that normally attaches
+ * this header automatically for in-app fetches, so e2e specs must send it
+ * explicitly. The project id is cached for the worker process (mirrors
+ * `getAuthToken`'s caching above) since almost all specs only need a valid
+ * project to exist, not an isolated one per test.
+ *
+ * Call `loginPage(page, baseURL)` first — this reuses the page's own
+ * authenticated request context to create the project.
+ */
+export async function ensureProjectHeaders(
+  page: Page,
+  baseURL: string,
+): Promise<{ "x-project-id": string }> {
+  if (!cachedProjectId) {
+    const res = await page.request.post(`${baseURL}/api/projects`, {
+      data: { name: `E2E Project ${Date.now()}`, description: "e2e seed project" },
+    });
+    if (res.status() !== 201) {
+      throw new Error(
+        `ensureProjectHeaders: POST /api/projects failed with ${res.status()}: ${await res.text()}`,
+      );
+    }
+    const project = (await res.json()) as { id: string };
+    cachedProjectId = project.id;
+  }
+
+  // Written per-call (not just on creation) because each Playwright test
+  // gets a fresh page/context — localStorage does not carry over — and the
+  // React app's own fetches (triggered by page.goto) read project_id from it.
+  await page.evaluate((pid) => localStorage.setItem("project_id", pid), cachedProjectId);
+
+  return { "x-project-id": cachedProjectId };
+}
+
+/**
+ * Read the already-cached project id synchronously (no page/network access) —
+ * for callers that need `x-project-id` on a request context that isn't the
+ * test's own `page` (e.g. a second `request.newContext()` authenticated as a
+ * different user). Throws if `ensureProjectHeaders` hasn't run yet in this
+ * worker — call it via the page first.
+ */
+export function getCachedProjectHeaders(): { "x-project-id": string } {
+  if (!cachedProjectId) {
+    throw new Error(
+      "getCachedProjectHeaders: no project cached yet — call ensureProjectHeaders(page, baseURL) first.",
+    );
+  }
+  return { "x-project-id": cachedProjectId };
+}

--- a/tests/e2e/knowledge.spec.ts
+++ b/tests/e2e/knowledge.spec.ts
@@ -35,7 +35,7 @@
  * No other file imports this module.
  */
 import { test, expect, request as playwrightRequest } from "@playwright/test";
-import { loginPage, getAuthToken } from "./helpers/auth";
+import { loginPage, getAuthToken, ensureProjectHeaders, getCachedProjectHeaders } from "./helpers/auth";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -72,7 +72,12 @@ async function createWorkspaceViaPage(
   page: Parameters<Parameters<typeof test>[1]>[0]["page"],
   baseURL: string,
 ): Promise<string> {
+  // /api/workspaces is mounted behind requireAuth + requireProject
+  // (server/routes.ts) — page.request bypasses the client's fetch
+  // interceptor that normally attaches x-project-id, so send it explicitly.
+  const projectHeaders = await ensureProjectHeaders(page, baseURL);
   const res = await page.request.post(`${baseURL}/api/workspaces`, {
+    headers: projectHeaders,
     data: {
       type: "remote",
       url: "https://github.com/example/e2e-kb-workspace",
@@ -101,6 +106,7 @@ async function ingestCardsViaPage(
   const res = await page.request.post(
     `${baseURL}/api/workspaces/${workspaceId}/knowledge/practice-cards/ingest`,
     {
+      headers: await ensureProjectHeaders(page, baseURL),
       data: {
         topic: "terraform-module-best-practices",
         ingestedBy: "e2e-researcher-agent",
@@ -177,7 +183,14 @@ async function verifyCardWithToken(
 ): Promise<{ reviewState: string } | null> {
   const ctx = await playwrightRequest.newContext({
     baseURL,
-    extraHTTPHeaders: { Authorization: `Bearer ${verifierToken}` },
+    extraHTTPHeaders: {
+      Authorization: `Bearer ${verifierToken}`,
+      // Different auth context than the seeding page, but the same project —
+      // getCachedProjectHeaders reads the id createWorkspaceViaPage already
+      // cached via ensureProjectHeaders (server/middleware/project.ts
+      // requireProject needs it regardless of which authenticated user calls).
+      ...getCachedProjectHeaders(),
+    },
   });
   try {
     const res = await ctx.post(
@@ -213,7 +226,7 @@ async function acceptCardViaPage(
 ): Promise<void> {
   const res = await page.request.post(
     `${baseURL}/api/workspaces/${workspaceId}/knowledge/practice-cards/${cardId}/review`,
-    { data: { decision: "accept" } },
+    { headers: await ensureProjectHeaders(page, baseURL), data: { decision: "accept" } },
   );
   expect(res.status()).toBe(200);
 }
@@ -733,6 +746,7 @@ test.describe("Journey C — Compliance Panel", () => {
     // Check whether any active card exists in this workspace via API.
     const res = await page.request.get(
       `${url}/api/workspaces/${workspaceId}/knowledge/practice-cards?status=active&limit=1`,
+      { headers: await ensureProjectHeaders(page, url) },
     );
     let hasActiveCard = false;
     if (res.status() === 200) {
@@ -815,6 +829,7 @@ test.describe("Adversarial gate — server enforces verifier != ingester", () =>
     const res = await page.request.post(
       `${url}/api/workspaces/${workspaceId}/knowledge/practice-cards/${cardId}/verify`,
       {
+        headers: await ensureProjectHeaders(page, url),
         data: {
           // A different label is provided to prove the server checks the user id,
           // not just the label string.

--- a/tests/e2e/privacy.spec.ts
+++ b/tests/e2e/privacy.spec.ts
@@ -1,29 +1,53 @@
 /**
  * E2E tests for the Privacy page and API.
+ *
+ * The standalone /privacy page was folded into Settings as a "Privacy &
+ * Compliance" collapsible section (client/src/App.tsx: "/privacy" now
+ * redirects to "/settings" for legacy bookmarks; the actual UI lives in
+ * client/src/components/settings/PrivacySection.tsx, rendered inside a
+ * SettingsSection with defaultOpen=false — same collapsed-by-default
+ * pattern as the ArgoCD section in argocd-settings.spec.ts).
  */
 import { test, expect } from "@playwright/test";
-import { loginPage } from "./helpers/auth";
+import { loginPage, ensureProjectHeaders } from "./helpers/auth";
+
+/** Navigate to Settings and expand the "Privacy & Compliance" collapsible section. */
+async function openPrivacySection(page: import("@playwright/test").Page) {
+  await page.goto("/settings");
+  await page.waitForLoadState("networkidle");
+
+  const sectionTrigger = page.locator("button", { hasText: "Privacy & Compliance" }).first();
+  const expanded = await sectionTrigger.getAttribute("aria-expanded");
+  if (expanded !== "true") {
+    await sectionTrigger.click();
+  }
+  await page.waitForTimeout(300);
+}
 
 test.describe("Privacy", () => {
+  let projectHeaders: { "x-project-id": string };
+
   test.beforeEach(async ({ page }, testInfo) => {
-    await loginPage(page, testInfo.project.use.baseURL ?? "http://localhost:3099");
+    const baseURL = testInfo.project.use.baseURL ?? "http://localhost:3099";
+    await loginPage(page, baseURL);
+    // /api/privacy is mounted behind requireAuth + requireProject (server/routes.ts).
+    projectHeaders = await ensureProjectHeaders(page, baseURL);
   });
 
   // Privacy page rendering ───────────────────────────────────────────────────
 
-  test("privacy page renders at /privacy", async ({ page }) => {
+  test("legacy /privacy bookmark redirects to /settings", async ({ page }) => {
     await page.goto("/privacy");
     await page.waitForLoadState("networkidle");
 
-    expect(page.url()).toContain("/privacy");
+    expect(page.url()).toContain("/settings");
     const body = await page.locator("body").textContent();
     expect(body).toBeTruthy();
     expect(body).not.toContain("Something went wrong");
   });
 
-  test("privacy page does not show a 404 error", async ({ page }) => {
-    await page.goto("/privacy");
-    await page.waitForLoadState("networkidle");
+  test("Privacy & Compliance section renders in Settings without a 404 error", async ({ page }) => {
+    await openPrivacySection(page);
 
     const body = await page.locator("body").textContent();
     expect(body).not.toContain("Page Not Found");
@@ -34,7 +58,7 @@ test.describe("Privacy", () => {
 
   test("GET /api/privacy/patterns returns array", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? "http://localhost:3099";
-    const res = await page.request.get(`${baseURL}/api/privacy/patterns`);
+    const res = await page.request.get(`${baseURL}/api/privacy/patterns`, { headers: projectHeaders });
     expect(res.status()).toBe(200);
     const body = await res.json() as unknown[];
     expect(Array.isArray(body)).toBe(true);
@@ -45,6 +69,7 @@ test.describe("Privacy", () => {
     const text = "my secret api_key=sk-test123";
 
     const res = await page.request.post(`${baseURL}/api/privacy/test`, {
+      headers: projectHeaders,
       data: { text, level: "off" },
     });
     expect(res.status()).toBe(200);
@@ -58,6 +83,7 @@ test.describe("Privacy", () => {
     const text = "OPENAI_KEY=sk-abcdefghijklmnopqrstuvwxyz123456";
 
     const res = await page.request.post(`${baseURL}/api/privacy/test`, {
+      headers: projectHeaders,
       data: { text, level: "standard" },
     });
     expect(res.status()).toBe(200);
@@ -71,6 +97,7 @@ test.describe("Privacy", () => {
     const text = "Please contact admin@example.company.io for access";
 
     const res = await page.request.post(`${baseURL}/api/privacy/test`, {
+      headers: projectHeaders,
       data: { text, level: "standard" },
     });
     expect(res.status()).toBe(200);
@@ -83,6 +110,7 @@ test.describe("Privacy", () => {
     const baseURL = testInfo.project.use.baseURL ?? "http://localhost:3099";
 
     const res = await page.request.post(`${baseURL}/api/privacy/test`, {
+      headers: projectHeaders,
       data: {
         text: "some text",
         level: "standard",
@@ -96,9 +124,8 @@ test.describe("Privacy", () => {
 
   // Privacy page content ────────────────────────────────────────────────────
 
-  test("privacy page body contains privacy-related content", async ({ page }) => {
-    await page.goto("/privacy");
-    await page.waitForLoadState("networkidle");
+  test("Privacy & Compliance section body contains privacy-related content", async ({ page }) => {
+    await openPrivacySection(page);
 
     const body = (await page.locator("body").textContent()) ?? "";
     // Should mention privacy or anonymization

--- a/tests/e2e/remote-agents.spec.ts
+++ b/tests/e2e/remote-agents.spec.ts
@@ -9,7 +9,7 @@
  */
 import { test, expect, request as playwrightRequest } from "@playwright/test";
 import { startTestAgent, type TestAgentHandle } from "../helpers/test-agent";
-import { getAuthToken } from "./helpers/auth";
+import { getAuthToken, loginPage, ensureProjectHeaders } from "./helpers/auth";
 
 const BASE_URL_FALLBACK = "http://localhost:3099";
 const HAS_DATABASE = !!process.env.DATABASE_URL;
@@ -336,12 +336,24 @@ test.describe("Remote Agents — Custom Tools", () => {
 // ─── API Tests (DB required) ──────────────────────────────────────────────────
 
 test.describe("Remote Agents — API (DB)", () => {
+  let projectHeaders: { "x-project-id": string };
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    // /api/remote-agents is mounted behind requireAuth + requireProject
+    // (server/routes.ts) — the standalone request.newContext() below
+    // bypasses the client's fetch interceptor, so x-project-id must be
+    // primed via the page and merged in explicitly at each call site.
+    const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
+    await loginPage(page, baseURL);
+    projectHeaders = await ensureProjectHeaders(page, baseURL);
+  });
+
   /** Create an authenticated API context against the Playwright webServer. */
   async function authenticatedApiContext(baseURL: string) {
     const token = await getAuthToken(baseURL);
     return playwrightRequest.newContext({
       baseURL,
-      extraHTTPHeaders: { Authorization: `Bearer ${token}` },
+      extraHTTPHeaders: { Authorization: `Bearer ${token}`, ...projectHeaders },
     });
   }
 

--- a/tests/e2e/sandbox.spec.ts
+++ b/tests/e2e/sandbox.spec.ts
@@ -1,6 +1,12 @@
 /**
  * E2E tests for sandbox configuration.
- * Tests the sandbox API endpoints and verifies the pipeline detail page loads.
+ * Tests the sandbox API endpoints directly.
+ *
+ * Note: this file previously also covered a pipeline-detail-page rendering
+ * test (`POST /api/pipelines` + `/pipelines/:id`), but both the route and
+ * the client page were retired in PR #525 ("chore: retire legacy pipelines
+ * engine..."). No successor page exists, so that coverage was removed
+ * rather than pointed at broken/missing surface.
  */
 import { test, expect } from "@playwright/test";
 import { loginPage } from "./helpers/auth";
@@ -63,30 +69,6 @@ test.describe("Sandbox", () => {
       data: {},
     });
     expect(res.status()).toBe(400);
-  });
-
-  // Pipeline page with sandbox section ──────────────────────────────────────
-
-  test("pipeline detail page renders without sandbox errors", async ({ page }, testInfo) => {
-    const baseURL = testInfo.project.use.baseURL ?? "http://localhost:3099";
-
-    // Create a pipeline
-    const createRes = await page.request.post(`${baseURL}/api/pipelines`, {
-      data: {
-        name: "Sandbox E2E Pipeline",
-        description: "For sandbox E2E tests",
-        stages: [{ teamId: "development", modelSlug: "mock", enabled: true }],
-      },
-    });
-    expect(createRes.status()).toBe(201);
-    const pipeline = await createRes.json() as { id: string };
-
-    await page.goto(`/pipelines/${pipeline.id}`);
-    await page.waitForLoadState("networkidle");
-
-    const body = await page.locator("body").textContent();
-    expect(body).not.toContain("Something went wrong");
-    expect(page.url()).toContain(pipeline.id);
   });
 
   test("sandbox presets API response is valid JSON (not HTML)", async ({ page }, testInfo) => {

--- a/tests/e2e/skills.spec.ts
+++ b/tests/e2e/skills.spec.ts
@@ -10,13 +10,18 @@
  *   - Export endpoint returns JSON
  */
 import { test, expect } from "@playwright/test";
-import { loginPage } from "./helpers/auth";
+import { loginPage, ensureProjectHeaders } from "./helpers/auth";
 
 const BASE_URL_FALLBACK = "http://localhost:3099";
 
 test.describe("Skills Management", () => {
+  let projectHeaders: { "x-project-id": string };
+
   test.beforeEach(async ({ page }, testInfo) => {
-    await loginPage(page, testInfo.project.use.baseURL ?? BASE_URL_FALLBACK);
+    const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
+    await loginPage(page, baseURL);
+    // /api/skills is mounted behind requireAuth + requireProject (server/routes.ts).
+    projectHeaders = await ensureProjectHeaders(page, baseURL);
   });
 
   // ─── Page rendering ───────────────────────────────────────────────────────
@@ -56,7 +61,7 @@ test.describe("Skills Management", () => {
 
   test("GET /api/skills returns an array", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const res = await page.request.get(`${baseURL}/api/skills`);
+    const res = await page.request.get(`${baseURL}/api/skills`, { headers: projectHeaders });
     expect(res.status()).toBe(200);
 
     const skills = await res.json() as Array<{ id: string; name: string; isBuiltin: boolean }>;
@@ -66,7 +71,7 @@ test.describe("Skills Management", () => {
 
   test("GET /api/skills includes built-in skills", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const res = await page.request.get(`${baseURL}/api/skills`);
+    const res = await page.request.get(`${baseURL}/api/skills`, { headers: projectHeaders });
     const skills = await res.json() as Array<{ id: string; name: string; isBuiltin: boolean }>;
 
     const builtins = skills.filter((s) => s.isBuiltin);
@@ -75,7 +80,7 @@ test.describe("Skills Management", () => {
 
   test("GET /api/skills returns skills with required fields", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const res = await page.request.get(`${baseURL}/api/skills`);
+    const res = await page.request.get(`${baseURL}/api/skills`, { headers: projectHeaders });
     const skills = await res.json() as Array<{ id: string; name: string; description: string; teamId: string }>;
 
     for (const skill of skills.slice(0, 3)) {
@@ -90,6 +95,7 @@ test.describe("Skills Management", () => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
 
     const res = await page.request.post(`${baseURL}/api/skills`, {
+      headers: projectHeaders,
       data: {
         name: "E2E Test Skill",
         description: "Created by E2E test",
@@ -114,6 +120,7 @@ test.describe("Skills Management", () => {
 
     // Create a skill first
     const createRes = await page.request.post(`${baseURL}/api/skills`, {
+      headers: projectHeaders,
       data: {
         name: "E2E Get Skill",
         description: "Test",
@@ -126,7 +133,7 @@ test.describe("Skills Management", () => {
     });
     const skill = await createRes.json() as { id: string };
 
-    const getRes = await page.request.get(`${baseURL}/api/skills/${skill.id}`);
+    const getRes = await page.request.get(`${baseURL}/api/skills/${skill.id}`, { headers: projectHeaders });
     expect(getRes.status()).toBe(200);
 
     const fetched = await getRes.json() as { id: string; name: string };
@@ -139,6 +146,7 @@ test.describe("Skills Management", () => {
 
     // Create then delete
     const createRes = await page.request.post(`${baseURL}/api/skills`, {
+      headers: projectHeaders,
       data: {
         name: "E2E Delete Skill",
         description: "To be deleted",
@@ -151,11 +159,11 @@ test.describe("Skills Management", () => {
     });
     const skill = await createRes.json() as { id: string };
 
-    const deleteRes = await page.request.delete(`${baseURL}/api/skills/${skill.id}`);
+    const deleteRes = await page.request.delete(`${baseURL}/api/skills/${skill.id}`, { headers: projectHeaders });
     expect(deleteRes.status()).toBe(204);
 
     // Verify it's gone
-    const getRes = await page.request.get(`${baseURL}/api/skills/${skill.id}`);
+    const getRes = await page.request.get(`${baseURL}/api/skills/${skill.id}`, { headers: projectHeaders });
     expect(getRes.status()).toBe(404);
   });
 
@@ -163,7 +171,7 @@ test.describe("Skills Management", () => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
 
     // Get a builtin skill id
-    const listRes = await page.request.get(`${baseURL}/api/skills`);
+    const listRes = await page.request.get(`${baseURL}/api/skills`, { headers: projectHeaders });
     const skills = await listRes.json() as Array<{ id: string; isBuiltin: boolean }>;
     const builtin = skills.find((s) => s.isBuiltin);
 
@@ -172,7 +180,7 @@ test.describe("Skills Management", () => {
       return;
     }
 
-    const deleteRes = await page.request.delete(`${baseURL}/api/skills/${builtin.id}`);
+    const deleteRes = await page.request.delete(`${baseURL}/api/skills/${builtin.id}`, { headers: projectHeaders });
     expect(deleteRes.status()).toBe(403);
   });
 
@@ -180,6 +188,7 @@ test.describe("Skills Management", () => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
 
     const res = await page.request.post(`${baseURL}/api/skills`, {
+      headers: projectHeaders,
       data: { description: "Missing name" },
     });
     expect(res.status()).toBe(400);
@@ -188,7 +197,7 @@ test.describe("Skills Management", () => {
   test("GET /api/skills/export returns a downloadable JSON response", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
 
-    const res = await page.request.get(`${baseURL}/api/skills/export`);
+    const res = await page.request.get(`${baseURL}/api/skills/export`, { headers: projectHeaders });
     expect(res.status()).toBe(200);
 
     const contentType = res.headers()["content-type"];

--- a/tests/e2e/statistics.spec.ts
+++ b/tests/e2e/statistics.spec.ts
@@ -12,20 +12,28 @@
  *   - Export endpoint (POST /api/stats/export)
  */
 import { test, expect } from "@playwright/test";
-import { loginPage } from "./helpers/auth";
+import { loginPage, ensureProjectHeaders } from "./helpers/auth";
 
 const BASE_URL_FALLBACK = "http://localhost:3099";
 
 test.describe("Statistics", () => {
+  let projectHeaders: { "x-project-id": string };
+
   test.beforeEach(async ({ page }, testInfo) => {
-    await loginPage(page, testInfo.project.use.baseURL ?? BASE_URL_FALLBACK);
+    const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
+    await loginPage(page, baseURL);
+    // /api/stats/* is mounted behind requireAuth + requireProject
+    // (server/routes.ts) — page.request bypasses the client's fetch
+    // interceptor that normally attaches x-project-id, so it must be sent
+    // explicitly on every call below.
+    projectHeaders = await ensureProjectHeaders(page, baseURL);
   });
 
   // ─── Stats Overview API ───────────────────────────────────────────────────
 
   test("GET /api/stats/overview returns expected shape", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const res = await page.request.get(`${baseURL}/api/stats/overview`);
+    const res = await page.request.get(`${baseURL}/api/stats/overview`, { headers: projectHeaders });
     expect(res.status()).toBe(200);
 
     const body = await res.json() as {
@@ -42,7 +50,7 @@ test.describe("Statistics", () => {
 
   test("GET /api/stats/overview returns non-negative numbers", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const res = await page.request.get(`${baseURL}/api/stats/overview`);
+    const res = await page.request.get(`${baseURL}/api/stats/overview`, { headers: projectHeaders });
     const body = await res.json() as {
       totalRequests: number;
       totalTokens: { input: number; output: number; total: number };
@@ -59,7 +67,7 @@ test.describe("Statistics", () => {
 
   test("GET /api/stats/timeline returns array", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const res = await page.request.get(`${baseURL}/api/stats/timeline?period=7d`);
+    const res = await page.request.get(`${baseURL}/api/stats/timeline?period=7d`, { headers: projectHeaders });
     expect(res.status()).toBe(200);
 
     const body = await res.json() as Array<{
@@ -73,7 +81,7 @@ test.describe("Statistics", () => {
 
   test("GET /api/stats/timeline entries have required fields", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const res = await page.request.get(`${baseURL}/api/stats/timeline?period=7d`);
+    const res = await page.request.get(`${baseURL}/api/stats/timeline?period=7d`, { headers: projectHeaders });
     const body = await res.json() as Array<{
       date: string;
       requests: number;
@@ -92,7 +100,7 @@ test.describe("Statistics", () => {
 
   test("GET /api/stats/timeline with period=30d returns array", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const res = await page.request.get(`${baseURL}/api/stats/timeline?period=30d`);
+    const res = await page.request.get(`${baseURL}/api/stats/timeline?period=30d`, { headers: projectHeaders });
     expect(res.status()).toBe(200);
 
     const body = await res.json() as unknown[];
@@ -103,7 +111,7 @@ test.describe("Statistics", () => {
 
   test("GET /api/stats/by-model returns array", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const res = await page.request.get(`${baseURL}/api/stats/by-model`);
+    const res = await page.request.get(`${baseURL}/api/stats/by-model`, { headers: projectHeaders });
     expect(res.status()).toBe(200);
 
     const body = await res.json() as unknown[];
@@ -112,7 +120,7 @@ test.describe("Statistics", () => {
 
   test("GET /api/stats/by-provider returns array", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const res = await page.request.get(`${baseURL}/api/stats/by-provider`);
+    const res = await page.request.get(`${baseURL}/api/stats/by-provider`, { headers: projectHeaders });
     expect(res.status()).toBe(200);
 
     const body = await res.json() as unknown[];
@@ -121,7 +129,7 @@ test.describe("Statistics", () => {
 
   test("GET /api/stats/by-team returns array", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const res = await page.request.get(`${baseURL}/api/stats/by-team`);
+    const res = await page.request.get(`${baseURL}/api/stats/by-team`, { headers: projectHeaders });
     expect(res.status()).toBe(200);
 
     const body = await res.json() as unknown[];
@@ -130,7 +138,7 @@ test.describe("Statistics", () => {
 
   test("GET /api/stats/by-workspace returns array", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const res = await page.request.get(`${baseURL}/api/stats/by-workspace`);
+    const res = await page.request.get(`${baseURL}/api/stats/by-workspace`, { headers: projectHeaders });
     expect(res.status()).toBe(200);
 
     const body = await res.json() as unknown[];
@@ -141,7 +149,7 @@ test.describe("Statistics", () => {
 
   test("GET /api/stats/requests returns object with rows array", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const res = await page.request.get(`${baseURL}/api/stats/requests`);
+    const res = await page.request.get(`${baseURL}/api/stats/requests`, { headers: projectHeaders });
     expect(res.status()).toBe(200);
 
     const body = await res.json() as { rows: unknown[]; total: number };
@@ -155,6 +163,7 @@ test.describe("Statistics", () => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
     const res = await page.request.post(`${baseURL}/api/stats/export?format=json`, {
       data: {},
+      headers: projectHeaders,
     });
 
     // Export should return 200
@@ -168,6 +177,7 @@ test.describe("Statistics", () => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
     const res = await page.request.post(`${baseURL}/api/stats/export?format=csv`, {
       data: {},
+      headers: projectHeaders,
     });
 
     expect(res.status()).toBe(200);

--- a/tests/e2e/workspaces.spec.ts
+++ b/tests/e2e/workspaces.spec.ts
@@ -11,23 +11,32 @@
  * when it is absent.
  */
 import { test, expect, request as playwrightRequest } from "@playwright/test";
-import { loginPage, getAuthToken } from "./helpers/auth";
+import { loginPage, getAuthToken, ensureProjectHeaders } from "./helpers/auth";
 
 const BASE_URL_FALLBACK = "http://localhost:3099";
 const HAS_DATABASE = !!process.env.DATABASE_URL;
 
-/** Create an authenticated API context against the Playwright webServer. */
-async function authenticatedApiContext(baseURL: string) {
+/**
+ * Create an authenticated API context against the Playwright webServer.
+ * /api/workspaces is mounted behind requireAuth + requireProject
+ * (server/routes.ts) — extraHeaders lets callers merge in x-project-id
+ * since this context bypasses the client's fetch interceptor entirely.
+ */
+async function authenticatedApiContext(baseURL: string, extraHeaders: Record<string, string> = {}) {
   const token = await getAuthToken(baseURL);
   return playwrightRequest.newContext({
     baseURL,
-    extraHTTPHeaders: { Authorization: `Bearer ${token}` },
+    extraHTTPHeaders: { Authorization: `Bearer ${token}`, ...extraHeaders },
   });
 }
 
 test.describe("Workspaces", () => {
+  let projectHeaders: { "x-project-id": string };
+
   test.beforeEach(async ({ page }, testInfo) => {
-    await loginPage(page, testInfo.project.use.baseURL ?? BASE_URL_FALLBACK);
+    const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
+    await loginPage(page, baseURL);
+    projectHeaders = await ensureProjectHeaders(page, baseURL);
   });
 
   // ─── Page rendering ───────────────────────────────────────────────────────
@@ -70,6 +79,7 @@ test.describe("Workspaces", () => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
 
     const res = await page.request.post(`${baseURL}/api/workspaces`, {
+      headers: projectHeaders,
       data: {},
     });
     expect(res.status()).toBe(400);
@@ -82,7 +92,7 @@ test.describe("Workspaces", () => {
   test("GET /api/workspaces returns an array (DB)", async ({}, testInfo) => {
     test.skip(!HAS_DATABASE, "Requires DATABASE_URL");
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const ctx = await authenticatedApiContext(baseURL);
+    const ctx = await authenticatedApiContext(baseURL, projectHeaders);
     try {
       const res = await ctx.get("/api/workspaces");
       expect(res.status()).toBe(200);
@@ -97,7 +107,7 @@ test.describe("Workspaces", () => {
   test("GET /api/workspaces returns valid JSON not HTML (DB)", async ({}, testInfo) => {
     test.skip(!HAS_DATABASE, "Requires DATABASE_URL");
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const ctx = await authenticatedApiContext(baseURL);
+    const ctx = await authenticatedApiContext(baseURL, projectHeaders);
     try {
       const res = await ctx.get("/api/workspaces");
       expect(res.status()).toBe(200);
@@ -115,7 +125,7 @@ test.describe("Workspaces", () => {
   test("POST /api/workspaces with remote URL creates workspace (DB)", async ({}, testInfo) => {
     test.skip(!HAS_DATABASE, "Requires DATABASE_URL");
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const ctx = await authenticatedApiContext(baseURL);
+    const ctx = await authenticatedApiContext(baseURL, projectHeaders);
     try {
       const res = await ctx.post("/api/workspaces", {
         data: {


### PR DESCRIPTION
## Summary

- Corrects the original framing of the ~48 e2e failures: they are **not** caused by routes retired in #525 (pipelines/memories cleanup). Route inventory confirms every route these specs call (stats, workspaces, skills, etc.) still exists.
- Actual root cause: `requireProject` middleware (`server/middleware/project.ts`) hard-requires an `x-project-id` header on most `/api/*` routes — a pre-existing requirement the specs never satisfied, undetected because e2e has been unable to run at all for 82 days.
- Adds shared helpers to `tests/e2e/helpers/auth.ts` — `ensureProjectHeaders(page, baseURL)` creates/caches a project via `POST /api/projects` and seeds `localStorage.project_id` (matching `client/src/lib/projectHeaders.ts`); `getCachedProjectHeaders()` is a sync accessor for specs that spin up a second `request.newContext()` (e.g. a verifier-user flow in knowledge.spec.ts).
- Threads these headers through `statistics`, `knowledge`, `workspaces`, `skills`, `privacy`, `remote-agents`, and `argocd-settings` specs.
- Deletes one genuinely-retired-feature test in `sandbox.spec.ts` (`pipeline detail page renders without sandbox errors`) — it POSTed to `/api/pipelines` and navigated to `/pipelines/:id`, both retired in #525, with no successor page to redirect coverage to. The other 6 `/api/sandbox/*` tests in that file are untouched and already passing.

## Before / after (full local run against a scratch pgvector db, `CI=true`)

- **Before**: 48 failing
- **After**: 101 passed, 6 failed, 1 flaky, 10 skipped (118 total)

## Remaining failures — genuine pre-existing bugs, intentionally NOT papered over

Per the spec-only ground rule, these are flagged for separate follow-up rather than weakened in the specs:

1. **`knowledge.spec.ts:285`, `knowledge.spec.ts:330`** (+ intermittently `:714`) — `GET .../workspaces/:id/knowledge/practice-cards*` 500s with `withProject: table has no "projectId" column`. The `withProject()` guard was blanket-applied to `practiceCards`/`practiceCardRefreshRuns` queries in `storage-pg.ts`, but `shared/schema.ts`'s `practiceCards` table has no `projectId` column (only `workspaceId`). Real backend bug, first surfaced now that e2e can actually reach this code path.
2. **`skills.spec.ts:62`, `skills.spec.ts:72`** — `GET /api/skills` correctly returns `200 []` for a fresh project, but no seed/migration/startup hook anywhere ever creates an `isBuiltin: true` skill row; `POST /api/skills` hardcodes `isBuiltin: false`. Structurally impossible for any fresh environment to have built-in skills to assert against.
3. **`consilium-loop-detail.spec.ts:53`, `:185`** — both already implement the `x-project-id` pattern correctly (this file is the reference implementation the fix above is modeled on) but fail on `POST /api/consilium-loops` → 400 `"repoPath is not in the configured allowlist"`. `config.yaml`'s `pipeline.consiliumLoop.allowedRepoPaths` hardcodes a single personal machine path that won't match any other checkout (CI runner or otherwise). Config/environment bug, not touched here per the standing rule against committing `config.yaml`.

## Test plan

- [x] Full `npx playwright test` run against a scratch `pgvector/pgvector:pg16` container with `CREATE EXTENSION vector` + `db:push`, `CI=true`
- [x] Confirmed `argocd-settings`, `remote-agents`, `privacy`, `statistics`, `workspaces` specs are fully green
- [x] Confirmed the 6 remaining failures + 1 flaky match the documented genuine product/config bugs above, not spec regressions
- [ ] CI run on this PR (gate before merge)