### PR TITLE
fix(config): remove committed local dry-run consilium-loop block (leaked personal path)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,12 +6,11 @@
 server:
   port: 5000
 
-pipeline:
-  # Consilium Loop — LOCAL dry-run config (do NOT commit; feature ships disabled).
-  consiliumLoop:
-    enabled: true
-    allowedRepoPaths:
-      - /Users/lord/Develop/multi-team-agentic/project/Omniscience
+# Consilium Loop ships disabled. It is a local dry-run feature: enable it and set
+# pipeline.consiliumLoop.allowedRepoPaths (the fail-closed repo allowlist, config-only —
+# never widened from the environment per Security H-1) in an untracked local override,
+# NOT here. Committed defaults keep enabled=false / allowedRepoPaths=[] (see
+# server/config/schema.ts consiliumLoop).
 
 features:
   sandbox:


### PR DESCRIPTION
## Problem
The git-tracked `config.yaml` carried a **local dry-run block** — its own comment literally read *"LOCAL dry-run config (do NOT commit; feature ships disabled)"* yet it was committed anyway:

```yaml
pipeline:
  consiliumLoop:
    enabled: true
    allowedRepoPaths:
      - /Users/lord/Develop/multi-team-agentic/project/Omniscience
```

Two problems in one:
1. **Leaked personal path** — an absolute path from one developer's machine baked into a tracked file.
2. **Dead / wrong everywhere else** — `allowedRepoPaths` is a fail-closed allowlist that is deliberately **config-only, never widened from the environment** (Security H-1, see `server/config/schema.ts`). So the hardcoded path matches no CI runner (`/home/runner/work/...`) and no other machine — it can never be corrected via env.

## Fix
Drop the block. Schema defaults then apply automatically — `enabled: false`, `allowedRepoPaths: []` — which is exactly the "feature ships disabled" state the comment claimed. A replacement comment points local dry-run configuration to an **untracked** override instead of the tracked file.

- `enabled` → `false` (schema default; loop controller/routes stay off)
- `allowedRepoPaths` → `[]` (schema default; fail-closed)
- No behavior change for any environment that wasn't that one machine.

## Testing
- `tests/unit/config/config-loader.test.ts` — **16/16 pass** (loader synthesizes fixtures in temp dirs; does not read the real `config.yaml`, so no test depended on the removed values).

## Out of scope (separate follow-ups)
- The e2e `consilium-loop-detail.spec.ts` sends `repoPath: process.cwd()` and still fails against an empty allowlist. That is a **test-design** issue, not a config one — by H-1 the allowlist cannot be supplied from CI env, so the test must set up an allowed path through a supported config path in its own setup (or skip when the allowlist is empty). Not fixed here.
- Two other pre-existing e2e bugs surfaced in the same sweep (no builtin-skill seeding; practiceCards `withProject()` missing column) are tracked separately.