### PR TITLE
test(e2e): fix stale built-in-skills assertions in skills.spec.ts

### DIFF
--- a/tests/e2e/skills.spec.ts
+++ b/tests/e2e/skills.spec.ts
@@ -3,7 +3,8 @@
  *
  * Covers:
  *   - /skills page renders without errors
- *   - Skills API returns built-in skills
+ *   - Skills API returns an array (built-in seeding was retired in 297d62d;
+ *     no isBuiltin:true fixture exists anymore — see the array-contract test)
  *   - Skills page shows skill cards
  *   - Skill filtering (all / builtin / custom)
  *   - Custom skill CRUD via API
@@ -59,23 +60,43 @@ test.describe("Skills Management", () => {
 
   // ─── Skills API ───────────────────────────────────────────────────────────
 
-  test("GET /api/skills returns an array", async ({ page }, testInfo) => {
+  // Built-in skill seeding (BUILTIN_SKILLS / server/skills/builtin.ts) was
+  // intentionally retired in "chore: prune skills ecosystem, keep the catalog
+  // narrowing hook (Phase 3b)" (297d62d) — migration 0038 deleted the
+  // builtin-* seed rows and nothing seeds isBuiltin:true rows anymore.
+  // `isBuiltin` on a skill row is still a live, meaningful field (it gates
+  // edit/delete/version/rollback for read-only skills — see
+  // server/routes/skills.ts and the git-registry-sync collision guard), but a
+  // fresh project legitimately has zero skills until one is created via
+  // POST /api/skills (always isBuiltin:false) or a registry sync
+  // (sourceType:'git', also isBuiltin:false). There is no built-in-skill
+  // fixture to assert against, so this test now proves the array contract
+  // (200 + array, includes what we create) instead of a nonexistent seed.
+  test("GET /api/skills returns an array containing created skills", async ({ page }, testInfo) => {
     const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
+
+    const createRes = await page.request.post(`${baseURL}/api/skills`, {
+      headers: projectHeaders,
+      data: {
+        name: "E2E Array Contract Skill",
+        description: "Proves GET /api/skills returns an array containing created rows",
+        teamId: "planning",
+        systemPromptOverride: "You are a test assistant.",
+        tools: [],
+        tags: ["e2e"],
+        sharing: "private",
+      },
+    });
+    expect(createRes.status()).toBe(201);
+    const created = await createRes.json() as { id: string };
+
     const res = await page.request.get(`${baseURL}/api/skills`, { headers: projectHeaders });
     expect(res.status()).toBe(200);
 
     const skills = await res.json() as Array<{ id: string; name: string; isBuiltin: boolean }>;
     expect(Array.isArray(skills)).toBe(true);
     expect(skills.length).toBeGreaterThanOrEqual(1);
-  });
-
-  test("GET /api/skills includes built-in skills", async ({ page }, testInfo) => {
-    const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
-    const res = await page.request.get(`${baseURL}/api/skills`, { headers: projectHeaders });
-    const skills = await res.json() as Array<{ id: string; name: string; isBuiltin: boolean }>;
-
-    const builtins = skills.filter((s) => s.isBuiltin);
-    expect(builtins.length).toBeGreaterThanOrEqual(1);
+    expect(skills.some((s) => s.id === created.id)).toBe(true);
   });
 
   test("GET /api/skills returns skills with required fields", async ({ page }, testInfo) => {


### PR DESCRIPTION
## Classification: STALE TEST

`skills.spec.ts:62` ("GET /api/skills returns an array", asserted `length >= 1`)
and `:72` ("GET /api/skills includes built-in skills", asserted `builtins.length
>= 1`) were failing 100% of the time against current main.

## Evidence

- Built-in skill seeding (`server/skills/builtin.ts`, `BUILTIN_SKILLS`) was
  **intentionally deleted** in `297d62d` ("chore: prune skills ecosystem, keep
  the catalog narrowing hook (Phase 3b)"): "Stop seeding BUILTIN_SKILLS; delete
  builtin.ts." Migration 0038 explicitly deletes the builtin-* seed rows.
- Grepped the whole repo (migrations, `server/skills/*`, `server/routes/skills.ts`,
  package.json scripts) — there is no seed script, migration `INSERT`, or
  startup hook anywhere that creates an `isBuiltin: true` row. `POST
  /api/skills` hardcodes `isBuiltin: false`; the newer git-backed registry sync
  (`server/skills/registry-sync.ts`, #535) also hardcodes `isBuiltin: false`
  for synced (`sourceType: 'git'`) rows.
- `isBuiltin` itself is **not dead** — it still gates edit/delete/version/
  rollback (403s in `server/routes/skills.ts`) and the registry-sync
  name-collision guard references it — there's just no fixture that ever sets
  it `true` in the current codebase.

Since the seeded-builtin-skills concept was deliberately removed and no
successor fixture exists, these are stale tests, not a product regression.

## Fix

Replaced both assertions with one test that proves the *current* contract:
create a skill via `POST /api/skills`, then assert `GET /api/skills` returns
an array containing it (200, `Array.isArray`, contains the created id). Left
the pre-existing self-skip at `:170`
(`DELETE /api/skills/:id on built-in skill → 403` → `test.skip(true, "No
builtin skills found")`) untouched — it already degrades gracefully by
design.

## Verification

- `tsc --noEmit`: clean.
- `tests/e2e/skills.spec.ts` against a scratch `pgvector/pgvector:pg16`
  container (`CREATE EXTENSION vector` + `drizzle-kit push`), `CI=true npx
  playwright test tests/e2e/skills.spec.ts --reporter=line`: **10 passed, 1
  skipped** (the pre-existing self-skip), 0 failed.

## Not touched

- `server/skills/builtin.ts` was not resurrected and no new seed step was
  added — that would be building a feature to satisfy a stale test, which the
  task's ground rule forbids.