### PR TITLE
fix: scope practiceCards through parent workspace (real bug)

### DIFF
--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -2227,8 +2227,42 @@ export class PgStorage implements IStorage {
 
   // ─── Practice Cards (Active Knowledge Base) ───────────────────────────────
 
+  // practiceCards / practiceCardRefreshRuns carry only `workspaceId` — no
+  // `project_id` column of their own (shared/schema.ts) — so `withProject`
+  // (which requires the column) threw "table has no projectId column" on
+  // every call, 500ing the knowledge-base page. Scope through the parent
+  // `workspaces` row instead, which IS project-scoped: same
+  // subquery-through-parent shape as getLoops()'s consilium_loops→task_groups
+  // scoping, and exactly what withProjectList's own doc recommends ("table has
+  // no projectId column — use a subquery through a project-scoped parent
+  // table instead"). Every practice-card route already resolves+validates the
+  // parent workspace via storage.getWorkspace() (itself withProject-scoped)
+  // before reaching these queries, so this is belt-and-suspenders for the
+  // workspaceId-filtered methods and the ONLY DB-level guard for the by-id
+  // lookups (getPracticeCard/updatePracticeCardState/getRefreshRun/
+  // updateRefreshRun), which take no workspaceId at all.
+  private practiceCardsInScope(condition?: SQL): SQL {
+    return and(
+      inArray(practiceCards.workspaceId, db.select({ id: workspaces.id }).from(workspaces).where(withProjectList(workspaces))),
+      condition,
+    )!;
+  }
+
+  private refreshRunsInScope(condition?: SQL): SQL {
+    return and(
+      inArray(practiceCardRefreshRuns.workspaceId, db.select({ id: workspaces.id }).from(workspaces).where(withProjectList(workspaces))),
+      condition,
+    )!;
+  }
+
   async createPracticeCard(data: InsertPracticeCard): Promise<PracticeCardRow> {
     // Idempotent: ON CONFLICT (workspace_id, content_hash) DO NOTHING.
+    // NOTE: withProjectInsert stamps a `projectId` field onto the insert
+    // payload, but practiceCards has no such column — Drizzle's insert only
+    // serializes columns present in the table definition, so the extra field
+    // is silently dropped (harmless no-op, verified: seeding via this path
+    // already worked before this fix). Left as-is to keep this change scoped
+    // to the actually-broken read/update paths below.
     const [inserted] = await db
       .insert(practiceCards)
       .values(withProjectInsert(practiceCards, data as typeof practiceCards.$inferInsert))
@@ -2239,15 +2273,15 @@ export class PgStorage implements IStorage {
     const [existing] = await db
       .select()
       .from(practiceCards)
-      .where(withProject(practiceCards, and(
+      .where(this.practiceCardsInScope(and(
           eq(practiceCards.workspaceId, data.workspaceId),
           eq(practiceCards.contentHash, data.contentHash),
-        ),));
+        )));
     return existing;
   }
 
   async getPracticeCard(id: string): Promise<PracticeCardRow | null> {
-    const [row] = await db.select().from(practiceCards).where(withProject(practiceCards, eq(practiceCards.id, id)));
+    const [row] = await db.select().from(practiceCards).where(this.practiceCardsInScope(eq(practiceCards.id, id)));
     return row ?? null;
   }
 
@@ -2270,12 +2304,12 @@ export class PgStorage implements IStorage {
     const [{ count }] = await db
       .select({ count: drizzleSql<number>`count(*)::int` })
       .from(practiceCards)
-      .where(withProject(practiceCards, where));
+      .where(this.practiceCardsInScope(where));
 
     const cards = await db
       .select()
       .from(practiceCards)
-      .where(withProject(practiceCards, where))
+      .where(this.practiceCardsInScope(where))
       .orderBy(desc(practiceCards.createdAt))
       .limit(filters.limit ?? 50)
       .offset(filters.offset ?? 0);
@@ -2284,7 +2318,7 @@ export class PgStorage implements IStorage {
   }
 
   async getPracticeCardsByWorkspace(workspaceId: string): Promise<PracticeCardRow[]> {
-    return db.select().from(practiceCards).where(withProject(practiceCards, eq(practiceCards.workspaceId, workspaceId)));
+    return db.select().from(practiceCards).where(this.practiceCardsInScope(eq(practiceCards.workspaceId, workspaceId)));
   }
 
   async updatePracticeCardState(
@@ -2295,7 +2329,7 @@ export class PgStorage implements IStorage {
     const [row] = await db
       .update(practiceCards)
       .set({ ...rest, updatedAt: new Date() } as Partial<typeof practiceCards.$inferInsert>)
-      .where(withProject(practiceCards, eq(practiceCards.id, id)))
+      .where(this.practiceCardsInScope(eq(practiceCards.id, id)))
       .returning();
     if (!row) throw new Error(`Practice card not found: ${id}`);
     return row;
@@ -2317,7 +2351,7 @@ export class PgStorage implements IStorage {
     const [row] = await db
       .select()
       .from(practiceCardRefreshRuns)
-      .where(withProject(practiceCardRefreshRuns, eq(practiceCardRefreshRuns.id, id)));
+      .where(this.refreshRunsInScope(eq(practiceCardRefreshRuns.id, id)));
     return row ?? null;
   }
 
@@ -2329,7 +2363,7 @@ export class PgStorage implements IStorage {
     const [row] = await db
       .update(practiceCardRefreshRuns)
       .set(rest as Partial<typeof practiceCardRefreshRuns.$inferInsert>)
-      .where(withProject(practiceCardRefreshRuns, eq(practiceCardRefreshRuns.id, id)))
+      .where(this.refreshRunsInScope(eq(practiceCardRefreshRuns.id, id)))
       .returning();
     if (!row) throw new Error(`Refresh run not found: ${id}`);
     return row;


### PR DESCRIPTION
## Classification: REAL PRODUCT BUG

`practiceCards` and `practiceCardRefreshRuns` (shared/schema.ts) have no
`projectId` column of their own — only `workspaceId`. Commit `8feca06`'s
blanket project-scoping refactor wrapped their queries in `withProject()`,
which hard-throws `'withProject: table has no "projectId" column'` any time
these methods run, 500ing the knowledge-base page:

- `knowledge.spec.ts:285` — navigates to knowledge-base without error
- `knowledge.spec.ts:330` — Review tab renders the review-queue container

## Fix

Added `practiceCardsInScope()` / `refreshRunsInScope()` helpers on
`PgStorage` that scope through the parent `workspaces` row (which IS
project-scoped) via a subquery, exactly mirroring the existing
`getLoops()` pattern (`consilium_loops` -> `task_groups`) and exactly what
`withProjectList`'s own docstring recommends: *"table has no projectId
column — use a subquery through a project-scoped parent table instead."*

Replaced all 8 call sites that used `withProject(practiceCards*, ...)`
with the new helpers. Left `withProjectInsert(practiceCards, ...)` /
`withProjectInsert(practiceCardRefreshRuns, ...)` untouched — it's a
harmless no-op for these tables (Drizzle silently drops the extra
`projectId` key on insert since there's no matching column).

**Project isolation preserved**: `practiceCardsInScope`/`refreshRunsInScope`
only match rows whose `workspaceId` is in the set of workspaces visible
under `withProjectList(workspaces)` for the current project — a practice
card belonging to another project's workspace can never be returned.
Every practice-card route also independently resolves+validates the
parent workspace via `storage.getWorkspace()` (itself `withProject`-scoped)
before reaching these queries, so this is belt-and-suspenders for the
`workspaceId`-filtered methods and the only DB-level guard for the
by-id lookups (`getPracticeCard`/`updatePracticeCardState`/`getRefreshRun`/
`updateRefreshRun`), which take no `workspaceId` at all.

## Verification

- `tsc --noEmit`: clean
- Targeted run (scratch pgvector docker) — both originally-failing tests
  pass reliably in isolation/repeat: `2 passed` (repeated 1x + repeated
  3x separately, 0 failures)
- Full `knowledge.spec.ts` suite: `9 passed / 8 skipped / 2 flaky` (exit 0).
  The "8 skipped" are pre-existing, gated on the embedder being
  unavailable in this sandbox (`ensureComplianceSeeded` design, unrelated
  to this fix).

### Note — NOT fixed here (flagging, not silently dropping)

In the full-suite run only (not in isolation), `:330` and `:714`
("renders gracefully when graph is disabled") show up as **flaky**
(fail once, pass on retry) with an unrelated failure signature —
a transient `"Workspace not found"` 404 / missing-testid race, not the
`withProject` column error this PR fixes. This reproduces with or
without this fix and looks like pre-existing test-order/shared-state
coupling in `knowledge.spec.ts` (tests share a single `workspaceId`
across the file). Recommend a follow-up: give Journey C its own
workspace fixture instead of reusing Journey A's, and/or replace
`waitForLoadState("networkidle")` with a deterministic wait for the
compliance query to settle. Out of scope for this PR since it's not the
`withProject` bug and predates this change.