### PR TITLE
test(e2e): fix knowledge.spec.ts full-suite flake at :330/:714

### DIFF
--- a/tests/e2e/knowledge.spec.ts
+++ b/tests/e2e/knowledge.spec.ts
@@ -279,7 +279,18 @@ test.describe("Journey A — Review Queue", () => {
   }
 
   test.beforeEach(async ({ page }, testInfo) => {
-    await loginPage(page, testInfo.project.use.baseURL ?? BASE_URL_FALLBACK);
+    const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
+    await loginPage(page, baseURL);
+    // Each test gets a fresh page/context (no localStorage carried over from
+    // the describe block's lazy seeder, which only runs once). Without this,
+    // the client's own ProjectContext auto-selects "the first project in the
+    // account" on a page with no project_id set — harmless when this file
+    // runs alone (exactly one project exists all-suite), but under a full
+    // suite run other specs' admin-owned projects can sort first, pointing
+    // this page at the wrong project and turning every workspace lookup
+    // into a 404 "Workspace not found". Explicitly (re)writing the cached
+    // project id here, every test, removes that dependency on list order.
+    await ensureProjectHeaders(page, baseURL);
   });
 
   test("navigates to knowledge-base without error (after seeding)", async ({ page }, testInfo) => {
@@ -525,7 +536,18 @@ test.describe("Journey B — Refresh Run Now", () => {
   }
 
   test.beforeEach(async ({ page }, testInfo) => {
-    await loginPage(page, testInfo.project.use.baseURL ?? BASE_URL_FALLBACK);
+    const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
+    await loginPage(page, baseURL);
+    // Each test gets a fresh page/context (no localStorage carried over from
+    // the describe block's lazy seeder, which only runs once). Without this,
+    // the client's own ProjectContext auto-selects "the first project in the
+    // account" on a page with no project_id set — harmless when this file
+    // runs alone (exactly one project exists all-suite), but under a full
+    // suite run other specs' admin-owned projects can sort first, pointing
+    // this page at the wrong project and turning every workspace lookup
+    // into a 404 "Workspace not found". Explicitly (re)writing the cached
+    // project id here, every test, removes that dependency on list order.
+    await ensureProjectHeaders(page, baseURL);
   });
 
   test("Refresh tab renders the Run refresh now button without error", async ({
@@ -694,7 +716,18 @@ test.describe("Journey C — Compliance Panel", () => {
   }
 
   test.beforeEach(async ({ page }, testInfo) => {
-    await loginPage(page, testInfo.project.use.baseURL ?? BASE_URL_FALLBACK);
+    const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
+    await loginPage(page, baseURL);
+    // Each test gets a fresh page/context (no localStorage carried over from
+    // the describe block's lazy seeder, which only runs once). Without this,
+    // the client's own ProjectContext auto-selects "the first project in the
+    // account" on a page with no project_id set — harmless when this file
+    // runs alone (exactly one project exists all-suite), but under a full
+    // suite run other specs' admin-owned projects can sort first, pointing
+    // this page at the wrong project and turning every workspace lookup
+    // into a 404 "Workspace not found". Explicitly (re)writing the cached
+    // project id here, every test, removes that dependency on list order.
+    await ensureProjectHeaders(page, baseURL);
   });
 
   test("Compliance tab renders without error", async ({ page }, testInfo) => {
@@ -816,7 +849,18 @@ test.describe("Adversarial gate — server enforces verifier != ingester", () =>
   }
 
   test.beforeEach(async ({ page }, testInfo) => {
-    await loginPage(page, testInfo.project.use.baseURL ?? BASE_URL_FALLBACK);
+    const baseURL = testInfo.project.use.baseURL ?? BASE_URL_FALLBACK;
+    await loginPage(page, baseURL);
+    // Each test gets a fresh page/context (no localStorage carried over from
+    // the describe block's lazy seeder, which only runs once). Without this,
+    // the client's own ProjectContext auto-selects "the first project in the
+    // account" on a page with no project_id set — harmless when this file
+    // runs alone (exactly one project exists all-suite), but under a full
+    // suite run other specs' admin-owned projects can sort first, pointing
+    // this page at the wrong project and turning every workspace lookup
+    // into a 404 "Workspace not found". Explicitly (re)writing the cached
+    // project id here, every test, removes that dependency on list order.
+    await ensureProjectHeaders(page, baseURL);
   });
 
   test("POST verify with the SAME user id returns 409", async ({ page }, testInfo) => {


### PR DESCRIPTION
## Root cause (not what it looked like at first)

`knowledge.spec.ts`'s four `test.describe` blocks (Journey A/B/C, Adversarial
gate) each use a lazy seeder (`ensureSeeded` / `ensureComplianceSeeded` /
`ensureAdversarialSeeded`) that creates one workspace + calls
`ensureProjectHeaders(page, baseURL)` **once**, on the first test's page,
gated by a `seeded` boolean. `test.beforeEach` in every block only called
`loginPage()` — never `ensureProjectHeaders()`.

Playwright gives every test a brand-new page/context (fresh `localStorage`).
Because the lazy seeder short-circuits after test 1, every later test in the
block never re-writes `localStorage.project_id`. The client's own
`ProjectContext.tsx` handles a missing `project_id` by auto-selecting
`data[0]` from `GET /api/projects` for the logged-in admin user.

- Running `knowledge.spec.ts` alone: exactly one project exists for the
  whole run (the one cached project all specs in this repo share per
  worker process), so `data[0]` always happens to be the right one — no
  failure, matching the "passes in isolation" symptom.
- Running the **full suite**: other spec files also create admin-owned
  projects (via their own `POST /api/projects` calls or their own
  `ensureProjectHeaders` cache misses), so the account can end up with more
  than one project. Whichever project sorts first in that list is no longer
  guaranteed to be the one that owns this file's workspace. When it isn't,
  every request from that page carries the *wrong* (but valid, so not
  400'd) `x-project-id`, and the server's project-scoped `getWorkspace()`
  correctly returns nothing for that project → `404 {"error":"Workspace not
  found"}`.

This is **not** a server bug — `requestContext`/`withProject` scoping
(`server/context.ts`, `server/db.ts`) is properly per-request via
`AsyncLocalStorage`. It's also not really "one shared `workspaceId`" in the
sense of two journeys racing on the same row — it's a missing per-test
project-header hydration on the client causing an unrelated project to be
auto-selected. Reproduced locally with the exact `404: {"error":"Workspace
not found"}` payload at `knowledge.spec.ts:330`/`:714` on a clean DB, full
suite, before the fix; gone after.

## Fix

Add `await ensureProjectHeaders(page, baseURL)` to each of the four
`beforeEach` hooks in `knowledge.spec.ts`, matching the pattern already
established in `statistics.spec.ts`/`workspaces.spec.ts`. This re-hydrates
`localStorage.project_id` on every test's fresh page before any navigation,
independent of list order or how many other projects exist in the account.
Spec-only change; no product/server code touched. No `waitForTimeout`/sleep
added; existing `networkidle` waits left as-is (unrelated to this failure
mode, out of scope for a minimal fix).

## Verification

Full suite (117 tests, `CI=true`, `workers: 1`), against a scratch
`pgvector/pgvector:pg16` Docker DB, **dropped and recreated before each
run** to mirror a fresh CI job:

| Run | Result |
|---|---|
| Baseline (before fix), run 1 | 106 passed / 11 skipped / 0 failed (flake did not reproduce this time) |
| Baseline (before fix), run 2 | 103 passed / 1 failed / **2 flaky** — `knowledge.spec.ts:330` and `:714` both needed retry #1, exact `404 Workspace not found` payload confirmed in the trace |
| Fix, clean-DB run 1 | **106 passed / 11 skipped / 0 failed / 0 flaky** |
| Fix, clean-DB run 2 | **106 passed / 11 skipped / 0 failed / 0 flaky** |
| Fix, clean-DB run 3 | **106 passed / 11 skipped / 0 failed / 0 flaky** |

`:330` and `:714` green in all 3 post-fix runs, no retries, no new failures.

### Unrelated flake observed once, not fixed here

One run against a DB that had already been used for 2-3 consecutive full
suites (not reset in between) showed `remote-agents.spec.ts:374` "POST
/api/remote-agents registers agent (DB)" fail with a `500` on both the
initial attempt and the retry. It did not reproduce in any of the 3
clean-DB runs above (before or after this fix), and it also does not touch
project/workspace headers, so it looks like state accumulation from reusing
one scratch DB across repeated manual runs rather than a real per-CI-job
flake. Flagging for visibility, not fixing as part of this PR.

## Test plan
- [x] `npx tsc --noEmit` clean on the changed file
- [x] Full suite × 3 on a freshly reset scratch DB, all green, `:330`/`:714` stable
- [x] No product/server files touched (`git diff --stat` shows only
      `tests/e2e/knowledge.spec.ts`)