### PR TITLE
feat(triggers): gitlab_event trigger + clean repo basename in loop list

### DIFF
--- a/client/src/components/triggers/TriggerCard.tsx
+++ b/client/src/components/triggers/TriggerCard.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useLocation } from "wouter";
 import { formatDistanceToNow } from "date-fns";
 import {
-  Pencil, Trash2, Zap, Clock, Github, FolderSearch,
+  Pencil, Trash2, Zap, Clock, Github, Gitlab, FolderSearch,
   ChevronRight, ChevronDown, GitPullRequest, ArrowUpRight, AlertTriangle,
 } from "lucide-react";
 import { Card } from "@/components/ui/card";
@@ -31,6 +31,11 @@ const TYPE_META: Record<TriggerType, { label: string; className: string; Icon: R
     label: "GitHub Event",
     className: "bg-gray-500/15 text-gray-700 border-gray-500/30",
     Icon: Github,
+  },
+  gitlab_event: {
+    label: "GitLab Event",
+    className: "bg-orange-500/15 text-orange-700 border-orange-500/30",
+    Icon: Gitlab,
   },
   file_change: {
     label: "File Change",

--- a/client/src/components/triggers/TriggerForm.tsx
+++ b/client/src/components/triggers/TriggerForm.tsx
@@ -24,8 +24,11 @@ import {
   LOOP_FIRING_TYPES,
   GITHUB_EVENT_MAPPINGS,
   GITHUB_DEFAULT_EVENTS,
+  GITLAB_EVENT_MAPPINGS,
+  GITLAB_DEFAULT_EVENTS,
   isTriggerFormValid,
   isGitHubRepoValid,
+  isGitLabProjectValid,
   buildLoopTemplate,
   formatValidationIssues,
   type LoopTemplateState,
@@ -40,6 +43,7 @@ import {
   type ConsiliumReviewTriggerAction,
   type ScheduleTriggerConfig,
   type GitHubEventTriggerConfig,
+  type GitLabEventTriggerConfig,
   type FileChangeTriggerConfig,
 } from "@shared/types";
 
@@ -99,6 +103,12 @@ const GITHUB_EVENT_OPTIONS = [
   "workflow_run",
   "create",
   "delete",
+] as const;
+
+const GITLAB_EVENT_OPTIONS = [
+  "Merge Request Hook",
+  "Push Hook",
+  "Pipeline Hook",
 ] as const;
 
 // ─── Loop-template sub-form (schedule + file_change) ────────────────────────────
@@ -424,6 +434,146 @@ function GitHubConfigFields({
   );
 }
 
+function GitLabConfigFields({
+  project,
+  events,
+  secret,
+  onSecretChange,
+  onChange,
+}: {
+  project: string;
+  events: string[];
+  secret: string;
+  onSecretChange: (v: string) => void;
+  onChange: (patch: Partial<GitLabEventTriggerConfig>) => void;
+}) {
+  function toggleEvent(ev: string) {
+    const next = events.includes(ev)
+      ? events.filter((e) => e !== ev)
+      : [...events, ev];
+    onChange({ events: next });
+  }
+
+  // Inline format feedback: empty is "not yet an error" (the * still gates submit),
+  // a non-empty malformed path shows the error immediately.
+  const projectTouched = project.trim().length > 0;
+  const projectFormatValid = !projectTouched || isGitLabProjectValid(project);
+  const noEvents = events.length === 0;
+
+  return (
+    <div className="space-y-3">
+      <p className="text-[11px] text-muted-foreground">
+        A matching GitLab event fires a consilium review. After you create the trigger you get
+        a webhook URL and token to paste into the project&apos;s{" "}
+        <span className="font-mono">Settings → Webhooks</span>.
+      </p>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="gl-project" className="text-xs">
+          Project <span className="text-destructive">*</span>
+        </Label>
+        <Input
+          id="gl-project"
+          value={project}
+          onChange={(e) => onChange({ project: e.target.value })}
+          placeholder="group/subgroup/project"
+          className="text-xs h-8"
+          required
+          aria-invalid={!projectFormatValid}
+          aria-describedby="gl-project-help"
+        />
+        <p id="gl-project-help" className="text-[10px] text-muted-foreground">
+          Format <span className="font-mono">group/.../project</span> — e.g.{" "}
+          <span className="font-mono">100rd/multiqlti</span>. This is the GitLab
+          project (`path_with_namespace`) whose webhook events fire the review.
+        </p>
+        {!projectFormatValid && (
+          <p className="text-[10px] text-destructive" role="alert">
+            Project must be in <span className="font-mono">group/.../project</span> format
+            (at least one <span className="font-mono">/</span>, no spaces).
+          </p>
+        )}
+      </div>
+
+      <fieldset>
+        <legend className="text-xs font-medium mb-2">
+          Events <span className="text-destructive">*</span>
+        </legend>
+        <div className="grid grid-cols-1 gap-1.5">
+          {GITLAB_EVENT_OPTIONS.map((ev) => (
+            <div key={ev} className="flex items-center gap-2">
+              <Checkbox
+                id={`gl-event-${ev}`}
+                checked={events.includes(ev)}
+                onCheckedChange={() => toggleEvent(ev)}
+              />
+              <Label
+                htmlFor={`gl-event-${ev}`}
+                className="text-xs font-mono cursor-pointer"
+              >
+                {ev}
+              </Label>
+            </div>
+          ))}
+        </div>
+        {noEvents && (
+          <p className="mt-1.5 text-[10px] text-destructive" role="alert">
+            Select at least one event for the trigger to fire.
+          </p>
+        )}
+      </fieldset>
+
+      <div className="rounded-md border border-border p-2.5">
+        <p className="text-[11px] font-medium mb-1">What fires a review</p>
+        <ul className="space-y-0.5">
+          {GITLAB_EVENT_MAPPINGS.map((m) => (
+            <li key={m.event} className="text-[10px] text-muted-foreground">
+              <span className="font-mono">{m.event}</span> → {m.effect}
+            </li>
+          ))}
+        </ul>
+        <p className="text-[10px] text-muted-foreground mt-1">
+          Other events (e.g. Pipeline Hook) are received and acknowledged but launch
+          nothing.
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="gl-secret-input" className="text-xs">
+          Webhook Token <span className="text-muted-foreground">(recommended)</span>
+        </Label>
+        <div className="flex gap-2">
+          <Input
+            id="gl-secret-input"
+            type="password"
+            value={secret}
+            onChange={(e) => onSecretChange(e.target.value)}
+            placeholder="Paste into GitLab → Webhooks → Secret token"
+            className="font-mono text-xs h-8"
+            autoComplete="new-password"
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 px-3 shrink-0"
+            onClick={() => onSecretChange(generateSecret())}
+            aria-label="Generate random secret"
+          >
+            <RefreshCw className="h-3.5 w-3.5 mr-1" />
+            Generate
+          </Button>
+        </div>
+        <p className="text-[10px] text-muted-foreground">
+          Sent verbatim as the{" "}
+          <span className="font-mono font-semibold">X-Gitlab-Token</span> header; the
+          receiver rejects any request whose token does not match.
+        </p>
+      </div>
+    </div>
+  );
+}
+
 function FileChangeConfigFields({
   watchPath,
   patterns,
@@ -494,6 +644,9 @@ export function TriggerForm({
   const [ghRepo, setGhRepo] = useState("");
   // Server requires events.min(1); a fresh github trigger must not start empty.
   const [ghEvents, setGhEvents] = useState<string[]>([...GITHUB_DEFAULT_EVENTS]);
+  const [glProject, setGlProject] = useState("");
+  // Server requires events.min(1); a fresh gitlab trigger must not start empty.
+  const [glEvents, setGlEvents] = useState<string[]>([...GITLAB_DEFAULT_EVENTS]);
   const [watchPath, setWatchPath] = useState("");
   const [filePatterns, setFilePatterns] = useState<string[]>([]);
   const [template, setTemplate] = useState<LoopTemplateState>({
@@ -535,6 +688,17 @@ export function TriggerForm({
           (trigger.config as GitHubEventTriggerConfig).events ?? []
         : [...GITHUB_DEFAULT_EVENTS],
     );
+    setGlProject(
+      trigger?.type === "gitlab_event"
+        ? (trigger.config as GitLabEventTriggerConfig).project
+        : "",
+    );
+    setGlEvents(
+      trigger?.type === "gitlab_event"
+        ? // Mirrors the ghEvents fallback above (an API-created trigger can omit it).
+          (trigger.config as GitLabEventTriggerConfig).events ?? []
+        : [...GITLAB_DEFAULT_EVENTS],
+    );
     setWatchPath(
       trigger?.type === "file_change"
         ? (trigger.config as FileChangeTriggerConfig).watchPath
@@ -555,10 +719,13 @@ export function TriggerForm({
     });
   }, [open, trigger, workspaces]);
 
-  // github triggers also carry a loop template (the review's target repo), but the
-  // preset is derived per-event, so its picker is hidden and a repo IS required.
-  const showLoopTemplate = LOOP_FIRING_TYPES.has(type) || type === "github_event";
-  const repoRequired = type === "schedule" || type === "github_event";
+  // github/gitlab triggers also carry a loop template (the review's target repo),
+  // but the preset is derived per-event, so its picker is hidden and a repo IS
+  // required.
+  const showLoopTemplate =
+    LOOP_FIRING_TYPES.has(type) || type === "github_event" || type === "gitlab_event";
+  const repoRequired =
+    type === "schedule" || type === "github_event" || type === "gitlab_event";
 
   // ── Build config ────────────────────────────────────────────────────────────
   function buildConfig(): Record<string, unknown> {
@@ -573,6 +740,14 @@ export function TriggerForm({
         return {
           repository: ghRepo,
           events: ghEvents,
+          action: buildLoopTemplate({ ...template, preset: "diff-pr-review" }),
+        };
+      case "gitlab_event":
+        // GitLab mirror of github_event above: the event mapping overrides the
+        // preset at fire time; we persist a sensible default so the shape validates.
+        return {
+          project: glProject,
+          events: glEvents,
           action: buildLoopTemplate({ ...template, preset: "diff-pr-review" }),
         };
       case "file_change":
@@ -591,6 +766,8 @@ export function TriggerForm({
       cron,
       ghRepo,
       ghEvents,
+      glProject,
+      glEvents,
       watchPath,
       preset: template.preset,
       repoPath: template.repoPath,
@@ -616,10 +793,11 @@ export function TriggerForm({
       };
       createTrigger.mutate(payload, {
         onSuccess: (created) => {
-          // Both webhook and github_event triggers get a synthesized URL; reveal it
-          // (+ the secret to paste into GitHub) when a secret was set.
+          // webhook, github_event, and gitlab_event triggers all get a synthesized
+          // URL; reveal it (+ the secret/token to paste into GitHub/GitLab) when a
+          // secret was set.
           if (
-            (type === "webhook" || type === "github_event") &&
+            (type === "webhook" || type === "github_event" || type === "gitlab_event") &&
             created.webhookUrl &&
             webhookSecret
           ) {
@@ -687,6 +865,7 @@ export function TriggerForm({
                 <SelectItem value="file_change" className="text-xs">File Change</SelectItem>
                 <SelectItem value="webhook" className="text-xs">Webhook</SelectItem>
                 <SelectItem value="github_event" className="text-xs">GitHub Event</SelectItem>
+                <SelectItem value="gitlab_event" className="text-xs">GitLab Event</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -713,6 +892,18 @@ export function TriggerForm({
               }}
             />
           )}
+          {type === "gitlab_event" && (
+            <GitLabConfigFields
+              project={glProject}
+              events={glEvents}
+              secret={webhookSecret}
+              onSecretChange={setWebhookSecret}
+              onChange={(patch) => {
+                if (patch.project !== undefined) setGlProject(patch.project);
+                if (patch.events !== undefined) setGlEvents(patch.events);
+              }}
+            />
+          )}
           {type === "file_change" && (
             <FileChangeConfigFields
               watchPath={watchPath}
@@ -724,13 +915,13 @@ export function TriggerForm({
             />
           )}
 
-          {/* Loop template (schedule + file_change + github_event) */}
+          {/* Loop template (schedule + file_change + github_event + gitlab_event) */}
           {showLoopTemplate && (
             <LoopTemplateFields
               state={template}
               workspaces={workspaces}
               repoRequired={repoRequired}
-              hidePreset={type === "github_event"}
+              hidePreset={type === "github_event" || type === "gitlab_event"}
               onChange={(patch) => setTemplate((prev) => ({ ...prev, ...patch }))}
             />
           )}

--- a/client/src/components/triggers/trigger-form-logic.ts
+++ b/client/src/components/triggers/trigger-form-logic.ts
@@ -13,6 +13,7 @@ import type {
   ConsiliumReviewTriggerAction,
   ScheduleTriggerConfig,
   GitHubEventTriggerConfig,
+  GitLabEventTriggerConfig,
   FileChangeTriggerConfig,
   TrackerEventTriggerConfig,
 } from "@shared/types";
@@ -39,6 +40,26 @@ export function isGitHubRepoValid(repo: string): boolean {
  * with nothing selected. These two cover the mapped review-firing events.
  */
 export const GITHUB_DEFAULT_EVENTS: readonly string[] = ["pull_request", "push"];
+
+/**
+ * group/.../project format — MIRRORS `GitLabConfigSchema.project` on the server
+ * (`server/routes/triggers.ts`). Kept in sync so the form rejects a malformed
+ * project path BEFORE it hits the API (and the submit button reflects it), instead
+ * of relying on a round-trip 400.
+ */
+export const GITLAB_PROJECT_REGEX = /^[^/]+(\/[^/]+)+$/;
+
+/** Whether `project` is a valid `group/.../project` path (trimmed). */
+export function isGitLabProjectValid(project: string): boolean {
+  return GITLAB_PROJECT_REGEX.test(project.trim());
+}
+
+/**
+ * Events pre-selected for a NEW gitlab_event trigger (GitLab mirror of
+ * GITHUB_DEFAULT_EVENTS). The server schema requires `events.min(1)`, so a fresh
+ * form MUST NOT start empty. These cover the mapped review-firing events.
+ */
+export const GITLAB_DEFAULT_EVENTS: readonly string[] = ["Merge Request Hook", "Push Hook"];
 
 /** A server-side zod issue, as surfaced in the 400 body's `issues[]`. */
 export interface TriggerValidationIssue {
@@ -90,11 +111,13 @@ export function isTriggerFormValid(input: {
   cron: string;
   ghRepo: string;
   ghEvents: string[];
+  glProject: string;
+  glEvents: string[];
   watchPath: string;
   preset: string;
   repoPath: string;
 }): boolean {
-  const { type, cron, ghRepo, ghEvents, watchPath, preset, repoPath } = input;
+  const { type, cron, ghRepo, ghEvents, glProject, glEvents, watchPath, preset, repoPath } = input;
   if (type === "schedule") {
     return cron.trim().length > 0 && preset.length > 0 && repoPath.trim().length > 0;
   }
@@ -109,6 +132,11 @@ export function isTriggerFormValid(input: {
     // so a malformed value is caught here instead of via a round-trip 400.
     return isGitHubRepoValid(ghRepo) && ghEvents.length > 0 && repoPath.trim().length > 0;
   }
+  if (type === "gitlab_event") {
+    // GitLab mirror of the github_event check above: a project path (server enforces
+    // the same regex), at least one event, and a target repoPath for the loop.
+    return isGitLabProjectValid(glProject) && glEvents.length > 0 && repoPath.trim().length > 0;
+  }
   return true; // webhook
 }
 
@@ -120,6 +148,17 @@ export function isTriggerFormValid(input: {
 export const GITHUB_EVENT_MAPPINGS: ReadonlyArray<{ event: string; effect: string }> = [
   { event: "pull_request (opened / synchronize / reopened)", effect: "diff-PR review of the PR head vs its base" },
   { event: "push to the default branch", effect: "post-merge review of the merged diff" },
+];
+
+/**
+ * Human summary of which consilium loop each GitLab event launches (mirror of
+ * GITHUB_EVENT_MAPPINGS) — shown in the form so the operator knows what a
+ * subscription actually does. Events not listed here are received + acknowledged
+ * (200) but launch nothing.
+ */
+export const GITLAB_EVENT_MAPPINGS: ReadonlyArray<{ event: string; effect: string }> = [
+  { event: "Merge Request Hook (open / update / reopen)", effect: "diff-PR review of the MR head vs its base" },
+  { event: "Push Hook to the default branch", effect: "post-merge review of the merged diff" },
 ];
 
 /**
@@ -172,6 +211,11 @@ export function configSummary(trigger: Trigger): string {
       const cfg = trigger.config as GitHubEventTriggerConfig;
       const events = (cfg.events ?? []).join(", ");
       return events ? `${cfg.repository} · ${events}` : cfg.repository;
+    }
+    case "gitlab_event": {
+      const cfg = trigger.config as GitLabEventTriggerConfig;
+      const events = (cfg.events ?? []).join(", ");
+      return events ? `${cfg.project} · ${events}` : cfg.project;
     }
     case "file_change": {
       const cfg = trigger.config as FileChangeTriggerConfig;

--- a/client/src/pages/ConsiliumLoopList.tsx
+++ b/client/src/pages/ConsiliumLoopList.tsx
@@ -347,13 +347,11 @@ export default function ConsiliumLoopList() {
   // Active workspace filter (by resolved name); null = show all.
   const [activeWorkspace, setActiveWorkspace] = useState<string | null>(null);
 
-  // path → workspace name lookup (trailing-slash-insensitive).
-  const nameByPath = new Map<string, string>();
-  if (Array.isArray(workspaceData)) {
-    for (const ws of workspaceData) nameByPath.set(normalizePath(ws.path), ws.name);
-  }
-  const workspaceName = (repoPath: string): string =>
-    nameByPath.get(normalizePath(repoPath)) ?? repoBasename(repoPath);
+  // Loop sections are keyed by the CLEAN repo basename (last path segment), not the
+  // workspace label — a workspace named e.g. "werush-terraform" must still surface as
+  // the bare repo target "terraform". Path-derived so it holds for every repo,
+  // independent of how any workspace was named.
+  const workspaceName = (repoPath: string): string => repoBasename(repoPath);
 
   // Hand the New-review dialog the project.s workspaces so the user PICKS a repo
   // (dropdown) instead of free-typing a possibly-unallowlisted path.

--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -123,6 +123,15 @@ export const ConfigSchema = z.object({
         intervalSec: z.number().int().min(60).max(3600).default(300),
       }).default({}),
       /**
+       * gitlab_event opt-in (GitLab mirror of the github_event webhook path). A
+       * brand-new externally-reachable endpoint (/api/gitlab-events) — defaults to
+       * OFF even once the master `enabled` switch above is on, so an operator must
+       * explicitly opt in before any gitlab_event trigger can fire a loop.
+       */
+      gitlabEvents: z.object({
+        enabled: z.boolean().default(false),
+      }).default({}),
+      /**
        * TRACK-1 (github-issues -> committed spec PR). A tracker poller PULLS a
        * GitHub repo's ISSUES via `gh` and, for each labelled + spec-ready issue,
        * opens a committed-spec PR (which SPEC-1's spec-watch fires the loop off on

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -57,7 +57,7 @@ import { registerConsiliumLoopRoutes } from "./routes/consilium-loops";
 import { registerConsiliumReviewRoutes } from "./routes/consilium-reviews";
 import { registerStandingRoleRoutes } from "./routes/standing-roles";
 import { createConsiliumReview } from "./services/consilium/review-factory";
-import { maybeLaunchConsiliumReview, maybeLaunchGitHubReview, maybeLaunchRoleWake, resolveSpecWatchConfig, deriveRepoRoot } from "./services/consilium/trigger-dispatch";
+import { maybeLaunchConsiliumReview, maybeLaunchGitHubReview, maybeLaunchGitLabReview, maybeLaunchRoleWake, resolveSpecWatchConfig, deriveRepoRoot } from "./services/consilium/trigger-dispatch";
 import { ConsiliumLoopController, ConsiliumLoopPoller } from "./services/consilium/consilium-loop-controller";
 import {
   writeSpecStatusRemote,
@@ -500,10 +500,25 @@ export async function registerRoutes(
         // file_change binding is NOT gated here (it stays under consiliumLoop.enabled),
         // so the one live prototype binding is unchanged.
         if (
-          (trigger.type === "schedule" || trigger.type === "github_event" || roleBinding) &&
+          (trigger.type === "schedule" ||
+            trigger.type === "github_event" ||
+            trigger.type === "gitlab_event" ||
+            roleBinding) &&
           !appConfigLoader.get().features.triggers.enabled
         ) {
           log(`[triggers] ${trigger.type} trigger ${trigger.id} not fired — features.triggers.enabled is off`, "triggers");
+          return "recorded" as const;
+        }
+
+        // gitlab_event has its OWN opt-in flag on top of the master switch above —
+        // a brand-new externally-reachable endpoint (/api/gitlab-events) defaults to
+        // off even once features.triggers.enabled is flipped on, so an operator must
+        // explicitly enable GitLab event triggers.
+        if (
+          trigger.type === "gitlab_event" &&
+          !appConfigLoader.get().features.triggers.gitlabEvents?.enabled
+        ) {
+          log(`[triggers] gitlab_event trigger ${trigger.id} not fired — features.triggers.gitlabEvents.enabled is off`, "triggers");
           return "recorded" as const;
         }
 
@@ -570,7 +585,9 @@ export async function registerRoutes(
           ? await maybeLaunchRoleWake(dispatchDeps, trigger, payload)
           : trigger.type === "github_event"
             ? await maybeLaunchGitHubReview(dispatchDeps, trigger, payload)
-            : await maybeLaunchConsiliumReview(dispatchDeps, trigger, payload);
+            : trigger.type === "gitlab_event"
+              ? await maybeLaunchGitLabReview(dispatchDeps, trigger, payload)
+              : await maybeLaunchConsiliumReview(dispatchDeps, trigger, payload);
 
         // T1 policy rail (§4): a fire suppressed by a rail bumps the trigger's
         // suppressed counter (surfaced on the triggers page) instead of blindly

--- a/server/routes/triggers.ts
+++ b/server/routes/triggers.ts
@@ -98,6 +98,18 @@ const GitHubConfigSchema = z.object({
   action: LoopTemplateActionSchema.optional(),
 });
 
+// A gitlab_event trigger — the GitLab mirror of GitHubConfigSchema. `project` is a
+// GitLab path_with_namespace (group/[subgroup/]project, ≥2 segments). `events` are
+// X-Gitlab-Event kinds (e.g. "Merge Request Hook", "Push Hook"). The shared-secret
+// token lives encrypted in secretEncrypted (sent as X-Gitlab-Token) — not here. The
+// factory RE-VALIDATES action.repoPath against the fail-closed allowlist.
+const GitLabConfigSchema = z.object({
+  project: z.string().min(1).max(500).regex(/^[^/]+(\/[^/]+)+$/, "Must be a GitLab project path (group/.../project)"),
+  events: z.array(z.string().min(1).max(100)).min(1).max(50),
+  refFilter: z.string().max(500).optional(),
+  action: LoopTemplateActionSchema.optional(),
+});
+
 // A file_change trigger MAY carry an embedded loop template (`action`). The factory
 // RE-VALIDATES `repoPath` against the fail-closed allowlist, so this schema only
 // shape-checks it — it is NOT the security boundary. Without this field the strict
@@ -183,7 +195,7 @@ const TrackerConfigSchema = z.discriminatedUnion("tracker", [
   ClickUpTrackerConfigSchema,
 ]);
 
-type TriggerTypeValue = "webhook" | "schedule" | "github_event" | "file_change" | "tracker_event";
+type TriggerTypeValue = "webhook" | "schedule" | "github_event" | "gitlab_event" | "file_change" | "tracker_event";
 
 /**
  * Fix 3: Discriminated union validator — picks the correct schema based on type.
@@ -197,6 +209,8 @@ function validateTriggerConfig(type: TriggerTypeValue, config: unknown): unknown
       return ScheduleConfigSchema.parse(config);
     case "github_event":
       return GitHubConfigSchema.parse(config);
+    case "gitlab_event":
+      return GitLabConfigSchema.parse(config);
     case "file_change":
       return FileChangeConfigSchema.parse(config);
     case "tracker_event":
@@ -206,7 +220,7 @@ function validateTriggerConfig(type: TriggerTypeValue, config: unknown): unknown
 
 // ─── Top-level request schemas ────────────────────────────────────────────────
 
-const TriggerTypeEnum = z.enum(["webhook", "schedule", "github_event", "file_change", "tracker_event"]);
+const TriggerTypeEnum = z.enum(["webhook", "schedule", "github_event", "gitlab_event", "file_change", "tracker_event"]);
 
 const CreateTriggerSchema = z.object({
   type: TriggerTypeEnum,

--- a/server/routes/webhooks.ts
+++ b/server/routes/webhooks.ts
@@ -3,6 +3,7 @@
  *
  * POST /api/webhooks/:triggerId        — receive a generic webhook
  * POST /api/github-events              — receive a GitHub event (routes to all matching triggers)
+ * POST /api/gitlab-events              — receive a GitLab event (routes to all matching triggers)
  */
 import type { Express } from "express";
 import { randomUUID } from "crypto";
@@ -15,6 +16,7 @@ import {
   startRateLimitCleanup,
 } from "../services/webhook-handler.js";
 import { handleGitHubEvent } from "../services/github-event-handler.js";
+import { handleGitLabEvent } from "../services/gitlab-event-handler.js";
 import { runAsSystem } from "../context.js";
 
 function correlationId(): string {
@@ -95,6 +97,46 @@ export function registerWebhookRoutes(
       }
       const cid = correlationId();
       console.error(`[webhooks] POST github-events error cid=${cid}`, e);
+      return res.status(500).json({ error: "Internal server error", correlationId: cid });
+    }
+  });
+
+  // POST /api/gitlab-events — GitLab webhook event router (mirror of /api/github-events)
+  app.post("/api/gitlab-events", async (req, res) => {
+    try {
+      // CONTEXT FIX (mirrors github-events): this public endpoint has no ALS context.
+      // `getAllEnabledTriggersByType` (cross-project) AND `getSecret` (→
+      // storage.getTrigger → withProject) BOTH require a system context. Wrap the
+      // whole handler in ONE system context so both reads succeed; fireTrigger nests
+      // its own context.
+      const result = await runAsSystem("gitlab-webhook-event", () =>
+        handleGitLabEvent(
+          req.rawBody,
+          req.headers as Record<string, string | string[] | undefined>,
+          req.body as unknown,
+          {
+            getEnabledTriggersByType: (type) => storage.getAllEnabledTriggersByType(type),
+            getSecret: (id) => triggerService.getSecret(id),
+            fireTrigger,
+          },
+        ),
+      );
+
+      // VETO-3 fix (mirrors github-events): do NOT return internal trigger IDs or raw
+      // error strings to the unauthenticated caller. Log the full result server-side
+      // for audit purposes and return only aggregate counts so callers can confirm
+      // delivery.
+      const cid = correlationId();
+      if (result.errors && result.errors.length > 0) {
+        console.error({ cid, fired: result.fired?.length, errors: result.errors }, "gitlab-events partial failure");
+      }
+      return res.json({ fired: result.fired?.length ?? 0 });
+    } catch (e) {
+      if (e instanceof ZodError) {
+        return res.status(400).json({ error: "Validation failed", issues: e.issues });
+      }
+      const cid = correlationId();
+      console.error(`[webhooks] POST gitlab-events error cid=${cid}`, e);
       return res.status(500).json({ error: "Internal server error", correlationId: cid });
     }
   });

--- a/server/services/consilium/gitlab-event-map.ts
+++ b/server/services/consilium/gitlab-event-map.ts
@@ -1,0 +1,179 @@
+/**
+ * gitlab-event-map.ts — PURE mapping from a GitLab webhook event to a consilium
+ * review plan (loop-triggers.md §3.1, GitLab mirror of github-event-map.ts). No I/O,
+ * no DB, no factory — so the event→(preset, ref, baseline, label) decision is
+ * unit-testable in isolation.
+ *
+ * The `fireTrigger` gitlab path (server/routes.ts → trigger-dispatch.ts) calls this
+ * AFTER the token check (gitlab-event-handler.ts) has already passed, then hands the
+ * plan to the SAME `createConsiliumReview` factory the file_change / schedule / UI /
+ * github paths use. This module ONLY decides the shape of the review.
+ *
+ * SECURITY (flagged for the adversarial reviewer — mirrors github-event-map.ts G1/G2):
+ *   G1. Every value read off the payload is UNTRUSTED. Only two SHAPES of value are
+ *       ever emitted downstream:
+ *         - `ref` / `baselineCommit`: gated to a strict git object id
+ *           (`^[0-9a-f]{7,64}$`, non-zero) HERE, and re-validated at the factory
+ *           boundary (ref-validator / SHA_RE) before either reaches git — always as
+ *           an arg-array element behind `--end-of-options`. A non-hex head/base ⇒
+ *           no-op, never a review with an attacker-shaped ref.
+ *         - `eventLabel`: a single-line, control-stripped, byte-clamped human summary
+ *           (MR !N: title). It flows ONLY into the review objective via the factory's
+ *           `engineerInstruction`/`objectiveExtra` seam, which additionally fences +
+ *           clamps it. Never a shell string, branch, or MR title sink.
+ *   G2. An event we do not map (Pipeline Hook, an MR action other than
+ *       open/update/reopen, a push to a non-default branch, …) is a NO-OP with a
+ *       reason — NEVER an error and NEVER a review. Accept + log, so a misconfigured
+ *       GitLab webhook (subscribed to everything) cannot fan out into unwanted loops.
+ */
+import type { ConsiliumReviewPreset } from "@shared/types";
+
+/** A git object id: 7–64 lowercase hex chars (matches the factory's SHA_RE). */
+const SHA_RE = /^[0-9a-f]{7,64}$/;
+/** The all-zero object id GitLab sends for a created/deleted ref (no baseline). */
+const ZERO_SHA_RE = /^0+$/;
+/** Single-line clamp for the UNTRUSTED event label (re-fenced by the factory). */
+const EVENT_LABEL_MAX = 200;
+
+/** The concrete review a mapped GitLab event launches. */
+export interface GitLabReviewMapping {
+  /** Server-chosen preset (event-derived; OVERRIDES the trigger action's default). */
+  preset: ConsiliumReviewPreset;
+  /** HEAD side of the review — an MR head sha / push `after` sha (strict hex). */
+  ref: string;
+  /** diff baseline (MR base sha / push `before` sha); absent ⇒ objective-only. */
+  baselineCommit?: string;
+  /** Single-line, control-stripped human summary for the objective + provenance. */
+  eventLabel: string;
+}
+
+export type GitLabMapResult =
+  | { kind: "review"; mapping: GitLabReviewMapping }
+  | { kind: "noop"; reason: string };
+
+/** Narrow an `unknown` to a plain object without trusting its shape. */
+function asRecord(v: unknown): Record<string, unknown> | undefined {
+  return typeof v === "object" && v !== null ? (v as Record<string, unknown>) : undefined;
+}
+
+/** Read a nested string field defensively (never trusts the shape). */
+function str(obj: Record<string, unknown> | undefined, key: string): string | undefined {
+  const v = obj?.[key];
+  return typeof v === "string" ? v : undefined;
+}
+
+/** A finite number OR a numeric string → number; else undefined (MR iid). */
+function num(obj: Record<string, unknown> | undefined, key: string): number | undefined {
+  const v = obj?.[key];
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string" && /^\d+$/.test(v)) return Number.parseInt(v, 10);
+  return undefined;
+}
+
+/** True for a real, non-zero git object id (a usable ref/baseline). */
+function isRealSha(v: string | undefined): v is string {
+  return typeof v === "string" && SHA_RE.test(v) && !ZERO_SHA_RE.test(v);
+}
+
+/**
+ * Single-line, control-stripped, whitespace-collapsed, byte-clamped label from
+ * UNTRUSTED text (an MR title). Mirrors the review-factory's `sanitizeLine` intent
+ * so the label is safe to compose into the objective (which fences it again).
+ */
+export function sanitizeEventLabel(value: string, max: number = EVENT_LABEL_MAX): string {
+  return value
+    // eslint-disable-next-line no-control-regex
+    .replace(/[ -]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, max);
+}
+
+/** The merge_request actions that launch a review (an update to code under review). */
+const MR_REVIEWABLE_ACTIONS: ReadonlySet<string> = new Set(["open", "update", "reopen"]);
+
+/**
+ * Map a verified GitLab event to a review plan, or a no-op with a reason.
+ * `eventType` is the `X-Gitlab-Event` value; `glPayload` is the parsed JSON body.
+ *
+ * Mappings (loop-triggers.md §3.1, GitLab mirror):
+ *   - "Merge Request Hook" (action open/update/reopen) → `diff-pr-review` on the MR
+ *     head (ref = object_attributes.last_commit.id, baseline =
+ *     object_attributes.diff_refs.base_sha when present), label `MR !<iid>: <title>`.
+ *   - "Push Hook" to the DEFAULT branch → post-merge review of `before..after`
+ *     (`diff-pr-review`); a branch-create push (before = 0…0) falls back to an
+ *     `sdlc-cross-review` at `after`.
+ *   - anything else (Pipeline Hook, other MR actions, non-default-branch push, …) →
+ *     no-op with a reason.
+ */
+export function mapGitLabEventToReview(eventType: string, glPayload: unknown): GitLabMapResult {
+  const body = asRecord(glPayload);
+
+  if (eventType === "Merge Request Hook") {
+    const attrs = asRecord(body?.object_attributes);
+    const action = str(attrs, "action") ?? "";
+    if (!MR_REVIEWABLE_ACTIONS.has(action)) {
+      return { kind: "noop", reason: `merge_request action "${action || "?"}" is not reviewable` };
+    }
+    const lastCommit = asRecord(attrs?.last_commit);
+    const head = str(lastCommit, "id");
+    if (!isRealSha(head)) {
+      return { kind: "noop", reason: "merge_request last_commit id missing or not a valid commit id" };
+    }
+    const diffRefs = asRecord(attrs?.diff_refs);
+    const base = str(diffRefs, "base_sha");
+    const iid = num(attrs, "iid");
+    const title = str(attrs, "title") ?? "";
+    const label = sanitizeEventLabel(`MR !${iid ?? "?"}${title ? `: ${title}` : ""}`);
+    return {
+      kind: "review",
+      mapping: {
+        preset: "diff-pr-review",
+        ref: head,
+        baselineCommit: isRealSha(base) ? base : undefined,
+        eventLabel: label,
+      },
+    };
+  }
+
+  if (eventType === "Push Hook") {
+    const ref = str(body, "ref") ?? "";
+    const branch = ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : "";
+    if (!branch) {
+      return { kind: "noop", reason: `push ref "${ref || "?"}" is not a branch ref` };
+    }
+    const defaultBranch = str(asRecord(body?.project), "default_branch");
+    if (!defaultBranch || branch !== defaultBranch) {
+      return { kind: "noop", reason: `push to non-default branch "${branch}" is not reviewed` };
+    }
+    const after = str(body, "after");
+    if (!isRealSha(after)) {
+      return { kind: "noop", reason: "push after sha missing or not a valid commit id" };
+    }
+    const before = str(body, "before");
+    const shortAfter = after.slice(0, 7);
+    if (isRealSha(before)) {
+      // A normal push/merge to the default branch → review the merged diff.
+      return {
+        kind: "review",
+        mapping: {
+          preset: "diff-pr-review",
+          ref: after,
+          baselineCommit: before,
+          eventLabel: sanitizeEventLabel(`post-merge push to ${branch} (${shortAfter})`),
+        },
+      };
+    }
+    // Branch-create / no usable baseline → whole-repo review at the new tip.
+    return {
+      kind: "review",
+      mapping: {
+        preset: "sdlc-cross-review",
+        ref: after,
+        eventLabel: sanitizeEventLabel(`push to ${branch} (${shortAfter})`),
+      },
+    };
+  }
+
+  return { kind: "noop", reason: `event "${eventType || "?"}" is not mapped to a review` };
+}

--- a/server/services/consilium/trigger-dispatch.ts
+++ b/server/services/consilium/trigger-dispatch.ts
@@ -82,6 +82,7 @@ import type {
   ConsiliumReviewTriggerAction,
   ConsiliumReviewPreset,
   GitHubEventTriggerConfig,
+  GitLabEventTriggerConfig,
   TriggerProvenance,
   RoleProvenance,
   SpecProvenance,
@@ -90,6 +91,7 @@ import type {
   StandingRoleConcern,
 } from "@shared/types";
 import { mapGitHubEventToReview } from "./github-event-map.js";
+import { mapGitLabEventToReview } from "./gitlab-event-map.js";
 import { composeRoleTriggerInstruction } from "./role-compose.js";
 import {
   readSpecFile,
@@ -910,6 +912,99 @@ export async function maybeLaunchGitHubReview(
     engineerInstruction,
     objectiveExtra,
     // §6: a human passport label so #457 shows "fired by github trigger: PR #N".
+    eventSummary: eventLabel,
+    payload,
+  });
+}
+
+// ─── GitLab-event trigger → consilium review (GitLab mirror of the GitHub seam) ─
+//
+// The `payload` the gitlab-event-handler hands to `fireTrigger` is the ENVELOPE
+// `{ event, delivery, payload }` — the raw GitLab JSON body is under `.payload`.
+// The shared-secret token has ALREADY been verified upstream (gitlab-event-handler.ts /
+// webhook-handler.ts) — this seam NEVER runs before a good token. The
+// event→(preset, ref, baseline, label) decision is the PURE `mapGitLabEventToReview`;
+// the launch itself reuses the SAME dedup/owner/factory core as every other trigger.
+
+/** Extract the raw GitLab JSON body from the `{ event, delivery, payload }` envelope. */
+function gitlabBody(payload: unknown): unknown {
+  if (typeof payload !== "object" || payload === null) return undefined;
+  return (payload as Record<string, unknown>).payload;
+}
+
+/**
+ * Launch a consilium review for a matching GitLab webhook event.
+ *   - "noop-event"  → the event is not mapped to a review (other MR action, push to
+ *                     a non-default branch, Pipeline Hook, …) — logged, NOT an error,
+ *                     NOT a review (a webhook subscribed to everything is safe).
+ *   - "skipped"     → subsystem off / no projectId / no repoPath in the loop template
+ *                     / no resolvable owner — logged.
+ *   - "skipped-dedup"→ a non-terminal loop already runs for this repo (T5 dedup).
+ *   - "launched"    → the factory was invoked (diff-pr-review on the MR head, or a
+ *                     post-merge review on the default branch).
+ *   - "failed"      → the factory threw (allowlist/workspace rejection, bad ref) —
+ *                     caught + logged (never crashes the receiver).
+ *
+ * The kill-switch (`features.triggers.enabled`) is enforced by the route BEFORE this
+ * is called, mirroring the schedule/github gate — a running server never silently
+ * starts firing gitlab loops.
+ */
+export async function maybeLaunchGitLabReview(
+  deps: ConsiliumTriggerDispatchDeps,
+  trigger: TriggerRow,
+  payload: unknown,
+): Promise<ConsiliumDispatchResult> {
+  const eventType = payloadString(payload, "event") ?? "";
+  const body = gitlabBody(payload);
+
+  // PURE mapping: decide the review shape (or a no-op reason) from the event.
+  const mapped = mapGitLabEventToReview(eventType, body);
+  if (mapped.kind === "noop") {
+    deps.log(`gitlab trigger ${trigger.id} — no-op for ${eventType || "?"}: ${mapped.reason}`);
+    return "noop-event";
+  }
+
+  if (!deps.reviewDeps) {
+    deps.log(`gitlab trigger ${trigger.id} skipped — consilium loop disabled`);
+    return "skipped";
+  }
+
+  const projectId = trigger.projectId;
+  if (!projectId) {
+    deps.log(`gitlab trigger ${trigger.id} skipped — trigger has no projectId`);
+    return "skipped";
+  }
+
+  // The loop template (embedded in the gitlab config) supplies the TARGET repo. A
+  // gitlab trigger has no watchPath to derive it from, so repoPath is REQUIRED; the
+  // factory re-validates it against the fail-closed allowlist + the project's
+  // workspaces. The action.preset is IGNORED — the event mapping chooses the preset.
+  const config = trigger.config as GitLabEventTriggerConfig;
+  const action = config.action;
+  const repoPath = action?.repoPath;
+  if (!repoPath) {
+    deps.log(`gitlab trigger ${trigger.id} skipped — loop template has no repoPath`);
+    return "skipped";
+  }
+
+  const { preset, ref, baselineCommit, eventLabel } = mapped.mapping;
+
+  // G1: the UNTRUSTED event label (MR !N: title) enters the objective ONLY via the
+  // sanitized engineerInstruction/objectiveExtra seam (interpolate `${event}` into the
+  // operator instruction when present, else pass the bare label). The factory
+  // control-strips + byte-clamps + fences it — same discipline as the file_change path.
+  const engineerInstruction = interpolateEvent(action?.engineerInstruction, eventLabel);
+  const objectiveExtra = engineerInstruction ? undefined : eventLabel;
+
+  return launchReviewWithDedup(deps, trigger, {
+    projectId,
+    repoPath,
+    preset: preset as ConsiliumReviewPreset,
+    ref,
+    baselineCommit,
+    engineerInstruction,
+    objectiveExtra,
+    // §6: a human passport label so #457 shows "fired by gitlab trigger: MR !N".
     eventSummary: eventLabel,
     payload,
   });

--- a/server/services/gitlab-event-handler.ts
+++ b/server/services/gitlab-event-handler.ts
@@ -1,0 +1,82 @@
+/**
+ * GitLabEventHandler — routes GitLab webhook events to matching triggers.
+ *
+ * GitLab sends a JSON payload with an X-Gitlab-Event header.
+ * We match the event type against each trigger's configured events array.
+ */
+import type { TriggerRow } from "@shared/schema";
+import type { GitLabEventTriggerConfig } from "@shared/types";
+import { verifyGitlabToken } from "./webhook-handler.js";
+
+export interface GitLabEventHandlerDeps {
+  getEnabledTriggersByType: (type: "gitlab_event") => Promise<TriggerRow[]>;
+  getSecret: (id: string) => Promise<string | null>;
+  // Returns the shared TriggerFireResult (widened to `unknown` — ignored here).
+  fireTrigger: (trigger: TriggerRow, payload: unknown) => Promise<unknown>;
+}
+
+/**
+ * Process an incoming GitLab webhook event.
+ * Finds all enabled gitlab_event triggers whose project and events match,
+ * verifies the shared-secret token if configured, then fires each match.
+ */
+export async function handleGitLabEvent(
+  rawBody: Buffer | unknown,
+  headers: Record<string, string | string[] | undefined>,
+  payload: unknown,
+  deps: GitLabEventHandlerDeps,
+): Promise<{ fired: string[]; errors: string[] }> {
+  const eventType = String(headers["x-gitlab-event"] ?? "");
+  const deliveryId = String(headers["x-gitlab-event-uuid"] ?? "unknown");
+
+  if (!eventType) {
+    return { fired: [], errors: ["Missing X-Gitlab-Event header"] };
+  }
+
+  // CONCERN-2 note (mirrors github-event-handler.ts): routing (project/ref matching)
+  // uses pre-auth payload fields. This is a deliberate architectural trade-off: the
+  // per-trigger-secret design requires us to identify candidate triggers before we
+  // can look up their individual secrets. This is safe because fireTrigger is NEVER
+  // called before a successful token check — an attacker can influence which
+  // triggers are *evaluated* but cannot fire any trigger without possessing the
+  // corresponding secret token.
+  const body = payload as Record<string, unknown>;
+  const project = (body.project as Record<string, unknown> | undefined)?.path_with_namespace;
+  const ref = String((body.ref as string | undefined) ?? "");
+
+  const triggers = await deps.getEnabledTriggersByType("gitlab_event");
+  const fired: string[] = [];
+  const errors: string[] = [];
+
+  for (const trigger of triggers) {
+    const config = trigger.config as GitLabEventTriggerConfig;
+
+    // Match project
+    if (config.project && project !== config.project) continue;
+
+    // Match event type
+    if (!config.events.includes(eventType)) continue;
+
+    // Match optional ref filter
+    if (config.refFilter && ref && !ref.startsWith(config.refFilter)) continue;
+
+    // Verify shared-secret token if configured
+    const secret = await deps.getSecret(trigger.id);
+    if (secret) {
+      const token = headers["x-gitlab-token"] as string | undefined;
+      if (!verifyGitlabToken(token, secret)) {
+        errors.push(`Trigger ${trigger.id}: invalid token (delivery ${deliveryId})`);
+        continue;
+      }
+    }
+
+    try {
+      await deps.fireTrigger(trigger, { event: eventType, delivery: deliveryId, payload });
+      fired.push(trigger.id);
+    } catch (e) {
+      errors.push(`Trigger ${trigger.id}: ${(e as Error).message}`);
+    }
+  }
+
+  return { fired, errors };
+}

--- a/server/services/trigger-service.ts
+++ b/server/services/trigger-service.ts
@@ -58,7 +58,11 @@ export class TriggerService {
       updatedAt: row.updatedAt,
     };
 
-    if (trigger.type === "webhook" || trigger.type === "github_event") {
+    if (
+      trigger.type === "webhook" ||
+      trigger.type === "github_event" ||
+      trigger.type === "gitlab_event"
+    ) {
       trigger.webhookUrl = this.webhookUrl(row.id);
     }
 

--- a/server/services/webhook-handler.ts
+++ b/server/services/webhook-handler.ts
@@ -103,6 +103,25 @@ export function verifyHmacSignature(
   }
 }
 
+/**
+ * Verify a GitLab webhook token (`X-Gitlab-Token`) via constant-time comparison.
+ * GitLab does NOT sign the body — it sends a static secret token verbatim, so this
+ * is a plain equality check (not HMAC). Fail-closed: missing token/secret or a
+ * length mismatch is treated as a mismatch (never falls through to a truthy compare).
+ */
+export function verifyGitlabToken(
+  headerToken: string | undefined,
+  secret: string | undefined,
+): boolean {
+  if (!headerToken || !secret) return false;
+
+  const headerBuf = Buffer.from(headerToken, "utf8");
+  const secretBuf = Buffer.from(secret, "utf8");
+  if (headerBuf.length !== secretBuf.length) return false;
+
+  return timingSafeEqual(headerBuf, secretBuf);
+}
+
 // ─── Rate limiting ────────────────────────────────────────────────────────────
 
 /**
@@ -164,18 +183,29 @@ export async function handleWebhookRequest(
   // `X-Webhook-Signature`. Unsigned/tampered request ⇒ 401, fireTrigger NOT called.
   const secret = await deps.getSecret(triggerId);
   if (secret) {
-    const sig = req.headers["x-hub-signature-256"] ?? req.headers["x-webhook-signature"];
-    if (!verifyHmacSignature(req.rawBody, secret, sig as string | undefined)) {
-      res.status(401).json({ error: "Invalid signature" });
-      return;
+    if (trigger.type === "gitlab_event") {
+      // GitLab sends a static token verbatim (no body signing) — constant-time
+      // equality check, NOT HMAC.
+      const token = req.headers["x-gitlab-token"];
+      if (!verifyGitlabToken(token as string | undefined, secret)) {
+        res.status(401).json({ error: "Invalid token" });
+        return;
+      }
+    } else {
+      const sig = req.headers["x-hub-signature-256"] ?? req.headers["x-webhook-signature"];
+      if (!verifyHmacSignature(req.rawBody, secret, sig as string | undefined)) {
+        res.status(401).json({ error: "Invalid signature" });
+        return;
+      }
     }
   }
 
-  // A github_event trigger fires off the GitHub event TYPE (from the X-GitHub-Event
-  // header), so wrap the body in the `{ event, delivery, payload }` envelope the
-  // github dispatch reads (mapping PR/push → a review). Every other trigger type
-  // keeps receiving the bare body. The header is only trusted to SELECT the mapping;
-  // no review fires without the HMAC check above having passed.
+  // A github_event/gitlab_event trigger fires off the provider event TYPE (from the
+  // X-GitHub-Event / X-Gitlab-Event header), so wrap the body in the
+  // `{ event, delivery, payload }` envelope the provider dispatch reads (mapping
+  // PR/push → a review). Every other trigger type keeps receiving the bare body.
+  // The header is only trusted to SELECT the mapping; no review fires without the
+  // signature/token check above having passed.
   const payload: unknown =
     trigger.type === "github_event"
       ? {
@@ -183,7 +213,13 @@ export async function handleWebhookRequest(
           delivery: String(req.headers["x-github-delivery"] ?? "unknown"),
           payload: req.body,
         }
-      : (req.body as unknown);
+      : trigger.type === "gitlab_event"
+        ? {
+            event: String(req.headers["x-gitlab-event"] ?? ""),
+            delivery: String(req.headers["x-gitlab-event-uuid"] ?? "unknown"),
+            payload: req.body,
+          }
+        : (req.body as unknown);
   await deps.fireTrigger(trigger, payload);
   res.status(200).json({ ok: true });
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -465,7 +465,7 @@ export type SkillVersionRow = typeof skillVersions.$inferSelect;
 
 // ─── Pipeline Triggers (Phase 6.3) ───────────────────────────────────────────
 
-export const TRIGGER_TYPES = ["webhook", "schedule", "github_event", "file_change", "tracker_event"] as const;
+export const TRIGGER_TYPES = ["webhook", "schedule", "github_event", "gitlab_event", "file_change", "tracker_event"] as const;
 
 
 export const triggers = pgTable(

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1310,7 +1310,7 @@ export interface PipelineDAG {
 
 // ─── Trigger Types (Phase 6.3) ────────────────────────────────────────────────
 
-export type TriggerType = "webhook" | "schedule" | "github_event" | "file_change" | "tracker_event";
+export type TriggerType = "webhook" | "schedule" | "github_event" | "gitlab_event" | "file_change" | "tracker_event";
 
 // Per-type discriminated union for the config JSONB column
 export interface WebhookTriggerConfig {
@@ -1384,6 +1384,29 @@ export interface GitHubEventTriggerConfig {
    * trigger-dispatch.ts `maybeLaunchRoleWake`. Absent ⇒ the legacy github path is
    * BYTE-IDENTICAL.
    */
+  roleConcern?: RoleConcernBinding;
+}
+
+/**
+ * GitLab-native trigger config — the GitLab mirror of GitHubEventTriggerConfig.
+ * GitLab webhooks authenticate with a plain shared-secret token (X-Gitlab-Token),
+ * NOT an HMAC signature, so the secretEncrypted column holds that token verbatim.
+ */
+export interface GitLabEventTriggerConfig {
+  project: string;      // "group/subgroup/repo" — GitLab project.path_with_namespace
+  events: string[];     // GitLab X-Gitlab-Event kinds: "Push Hook" | "Merge Request Hook" | "Pipeline Hook"
+  refFilter?: string;   // optional, e.g. "refs/heads/main"
+  // shared-secret token stored encrypted in secretEncrypted; sent by GitLab as X-Gitlab-Token
+  /**
+   * Loop template a matching GitLab event fires (mirror of the github action).
+   * `repoPath` REQUIRED to launch (re-validated against the fail-closed allowlist
+   * inside the factory); `engineerInstruction` (may embed `${event}`) is UNTRUSTED —
+   * fenced/clamped by the factory. Preset is a DEFAULT; the per-event mapping
+   * (Merge Request Hook → diff-pr-review, Push Hook → post-merge review) overrides it.
+   * Absent ⇒ record-only (events received/recorded, nothing launched).
+   */
+  action?: ConsiliumReviewTriggerAction;
+  /** ROLE-2: when present, a matching event WAKES the named standing role instead of `action`. */
   roleConcern?: RoleConcernBinding;
 }
 
@@ -1911,6 +1934,7 @@ export type TriggerConfig =
   | WebhookTriggerConfig
   | ScheduleTriggerConfig
   | GitHubEventTriggerConfig
+  | GitLabEventTriggerConfig
   | FileChangeTriggerConfig
   | TrackerEventTriggerConfig;
 


### PR DESCRIPTION
## What

Adds a **`gitlab_event`** trigger — the GitLab mirror of the existing `github_event` trigger — so consilium loops can be launched from GitLab repo events (IaC lives on GitLab, not GitHub). Plus a small UX fix to the Consilium Loops list.

### gitlab_event (mirror of github_event, GitLab semantics)
- **Auth**: webhook receiver verifies a shared-secret **`X-Gitlab-Token`** (constant-time `timingSafeEqual`, fail-closed on missing/length-mismatch) — GitLab does not HMAC-sign like GitHub.
- **Headers**: `X-Gitlab-Event` (kind) / `X-Gitlab-Event-UUID` (delivery).
- **Match**: `project.path_with_namespace` + configured events + optional `refFilter`.
- **Event map** (`gitlab-event-map.ts`, pure): `Merge Request Hook` (open/update/reopen) → `diff-pr-review` on the MR head sha; `Push Hook` to default branch → post-merge review, branch-create → `sdlc-cross-review`; `Pipeline Hook`/other → noop. Same untrusted-text discipline as the github map (SHA_RE gate on all refs, control-stripped + 200-byte-clamped event label, fenced-as-data in the instruction).
- **Route**: `POST /api/gitlab-events` (fan-out over enabled gitlab_event triggers, `runAsSystem`).
- **Kill-switch**: `features.triggers.gitlabEvents.enabled` (default **off**) on top of the master `features.triggers.enabled` — defense-in-depth for the new externally-reachable endpoint.
- **Outbound API** (MR diff fetch) reuses the existing PAT path (`gitlab-exec.ts`, `PRIVATE-TOKEN`); OAuth not required.

Touch map: `shared/schema.ts` + `shared/types.ts` (types/enum/config), `server/routes/triggers.ts` (schema+validate), new `server/services/gitlab-event-handler.ts` + `server/services/consilium/gitlab-event-map.ts`, `server/services/webhook-handler.ts` (`verifyGitlabToken`), `server/services/trigger-service.ts` (webhookUrl), `server/services/consilium/trigger-dispatch.ts` (`maybeLaunchGitLabReview`), `server/routes.ts` (gate+branch+route), `server/config/schema.ts` (flag), UI `TriggerForm` / `trigger-form-logic` / `TriggerCard`. No DB migration (`triggers.type` is free text, `config` is JSONB).

### Fix: clean repo target name in Consilium Loops list
`ConsiliumLoopList` grouped loops by **workspace name**, so a workspace named e.g. `werush-terraform` surfaced as a `werush-`-prefixed section header. Now the section target is the **clean repo basename** (`iac`/`terraform`/`kubernetes`/`cicd`) for every repo, path-derived and independent of workspace naming.

## Testing
- `npx tsc --noEmit` — clean (0 errors).
- Live smoke against a running dev server (`/api/gitlab-events`): trigger create OK (webhookUrl synthesized); route mounted; **wrong `X-Gitlab-Token` → 0 fired** (fail-closed); **correct token + Merge Request Hook payload → matched + dispatched**, and the dedup rail correctly `suppressed` a second loop on a repo that already had an active one (§4.1 of loop-triggers.md).
- **TODO (follow-up):** unit tests mirroring `github-trigger-dispatch.test.ts` / `webhook-handler.test.ts` / github-event-map tests / `triggers-ui.test.ts` for the gitlab path (token-verify, event-map MR/Push/Pipeline, dispatch dedup, UI form validity).

## Notes
- Out of scope (GitHub-only, separate subsystems): github polling analogue, ROLE-2 Standing-Role concern binding, Roles UI trigger picker — flagged for a follow-up if GitLab parity is wanted there.