### PR TITLE
feat(consilium-loop): clickable PR/MR link, result comments, worktree isolation, commit-prefix

### DIFF
--- a/client/src/components/consilium/new-review-dialog.tsx
+++ b/client/src/components/consilium/new-review-dialog.tsx
@@ -4,7 +4,7 @@
  * shared Dialog primitive + a controlled form + a toast on settle).
  *
  * It POSTs `{ repoPath, preset, maxRounds?, baselineCommit?, ref?, engineerInstruction?,
- * skillIds? }` to `/api/consilium-reviews` via the shared apiRequest transport
+ * skillIds?, commitPrefix? }` to `/api/consilium-reviews` via the shared apiRequest transport
  * (carries auth + `x-project-id`, same as every project-scoped call). The optional
  * `skillIds` are operator-selected skills whose directives the server appends to the
  * engineer instruction (fenced-as-data, byte-budgeted).
@@ -211,6 +211,13 @@ export function NewConsiliumReviewDialog({
   // `reviewMode` only when a non-empty explicit choice is made (additive/back-compat).
   const [reviewMode, setReviewMode] = useState<"" | "full-dispute" | "single-verifier">("");
   const [baselineCommit, setBaselineCommit] = useState("");
+  // Optional Jira issue key (e.g. "PROJ-123") — becomes the `commitPrefix` sent
+  // to the create endpoint, which the server prepends to every commit the loop
+  // makes. Needed by GitLab repos whose pre-receive hook requires a Jira key.
+  // No workspace-scoped Jira projectKey is available at create time (tracker
+  // connections are keyed by task group, which doesn't exist yet here), so this
+  // is a free-text fallback rather than a prefilled prefix + number input.
+  const [jiraIssue, setJiraIssue] = useState("");
   // Optional free-text instruction (tone / requirements for the evaluation). Sent
   // as `engineerInstruction` only when non-empty; the server fences it as data. This
   // is ALWAYS the canonical field that is submitted — in "magic" mode it is
@@ -411,6 +418,7 @@ export function NewConsiliumReviewDialog({
       engineerInstruction?: string;
       skillIds?: string[];
       reviewMode?: "full-dispute" | "single-verifier";
+      commitPrefix?: string;
     } = { repoPath: path, preset };
 
     const rounds = Number(maxRounds);
@@ -443,6 +451,11 @@ export function NewConsiliumReviewDialog({
     // Review mode → `reviewMode` only when an EXPLICIT choice is made; "" leaves it
     // to the server's operator default (verifyReview.enabled), preserving today's flow.
     if (reviewMode) body.reviewMode = reviewMode;
+
+    // Jira issue → `commitPrefix`. Trimmed; omitted entirely when blank (optional
+    // field, never blocks submit).
+    const jiraPrefix = jiraIssue.trim();
+    if (jiraPrefix) body.commitPrefix = jiraPrefix;
 
     try {
       setSubmitting(true);
@@ -663,6 +676,28 @@ export function NewConsiliumReviewDialog({
               onChange={(e) => setMaxRounds(e.target.value)}
               data-testid="new-review-max-rounds"
             />
+          </div>
+
+          {/* Jira issue — OPTIONAL commit-message prefix. Some GitLab repos gate
+              pushes on a pre-receive hook requiring a Jira key in the commit
+              message; this lets the operator attach one at create time. Sent as
+              `commitPrefix` (trimmed, omitted when blank) — the server threads it
+              through to every commit the loop makes. */}
+          <div className="space-y-2">
+            <Label htmlFor="new-review-jira-issue">
+              Jira issue <span className="text-muted-foreground">(optional)</span>
+            </Label>
+            <Input
+              id="new-review-jira-issue"
+              value={jiraIssue}
+              onChange={(e) => setJiraIssue(e.target.value)}
+              placeholder="PROJ-123"
+              data-testid="new-review-jira-issue"
+            />
+            <p className="text-xs text-muted-foreground">
+              Prepended to every commit — required by repos with a Jira-key commit
+              hook. Leave empty if not required.
+            </p>
           </div>
 
           {/* Re-review mode — HOW rounds AFTER the first are run. Optional: the

--- a/client/src/hooks/use-consilium-loops.ts
+++ b/client/src/hooks/use-consilium-loops.ts
@@ -25,11 +25,13 @@ import type {
   Archetype,
   OpenRemainder,
   RoundParticipant,
+  RoundComment,
   ResearchReport,
   ResearchClaim,
   ResearchCitation,
   ResearchSource,
 } from "@shared/types";
+export type { RoundComment };
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 // Re-export the schema row types under client-facing names. The list endpoint
@@ -177,6 +179,11 @@ export type ConsiliumLoopRoundDetail = ConsiliumLoopRoundRow & {
   /** The round-sourced dispute transcript — see {@link RoundParticipant}. Null on
    *  old pre-Phase-2 rounds (they fall back to the iteration-sourced view). */
   participants?: RoundParticipant[] | null;
+  /**
+   * Result comments — the operator's thread-like notes on this round's Result.
+   * Absent/null when the column doesn't exist yet or no comment was added.
+   */
+  comments?: RoundComment[] | null;
 };
 
 // ─── Composition (Observability GAP 2 — the "who does what" of a round) ───────
@@ -333,6 +340,11 @@ export interface CreateLoopInput {
   repoPath: string;
   maxRounds?: number;
   lastReviewedCommit?: string;
+  // Optional Jira issue key (e.g. "PROJ-123") prepended to every commit the loop
+  // makes — required by repos whose pre-receive hook gates on a Jira key. Not on
+  // the shared ConsiliumLoop type; client-local until the backend contract lands
+  // there too.
+  commitPrefix?: string;
 }
 
 export function useCreateConsiliumLoop() {
@@ -454,6 +466,27 @@ export function useSetArchetype() {
     onSuccess: (_data, { id }) => {
       qc.invalidateQueries({ queryKey: [LIST_KEY, id] });
       qc.invalidateQueries({ queryKey: [LIST_KEY] });
+    },
+  });
+}
+
+/**
+ * Result comments — add an operator's thread-like note to a round's Result
+ * (POST .../rounds/:round/comments). On success we invalidate the loop detail
+ * query so the new comment rides back on the existing `rounds[].comments` wire
+ * (no local cache surgery — the round row is small and refetch is cheap).
+ */
+export function useAddRoundComment() {
+  const qc = useQueryClient();
+  return useMutation<
+    { round: number; comment: RoundComment },
+    Error,
+    { id: string; round: number; body: string }
+  >({
+    mutationFn: ({ id, round, body }) =>
+      apiRequest("POST", `${LIST_KEY}/${id}/rounds/${round}/comments`, { body }),
+    onSuccess: (_data, { id }) => {
+      qc.invalidateQueries({ queryKey: [LIST_KEY, id] });
     },
   });
 }

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -52,6 +52,7 @@ import {
   Radio,
   Info,
   CheckCircle2,
+  MessageSquare,
 } from "lucide-react";
 import {
   useConsiliumLoop,
@@ -111,6 +112,15 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -118,8 +128,9 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type { ConsiliumLoopState } from "@/hooks/use-consilium-loops";
+import { useAddRoundComment } from "@/hooks/use-consilium-loops";
 import { IterationDetailView } from "@/components/task-groups/iterations-panel";
-import type { ActionPoint, Archetype, OpenRemainder, RoundParticipant } from "@shared/types";
+import type { ActionPoint, Archetype, OpenRemainder, RoundParticipant, RoundComment } from "@shared/types";
 import { ARCHETYPES } from "@shared/types";
 import { summarizeNonP0Remainder } from "@shared/consilium-remainder";
 import {
@@ -1030,6 +1041,34 @@ function LoopStatusCallout({ loop }: { loop: ConsiliumLoopDetailRow }) {
   );
 }
 
+// `loop.prRef` is set by the server (dev-closeout/pr-wrapper) to the PR/MR URL
+// returned by `gh`/`glab`, so it is normally already an `https://` URL. This
+// resolver is a defensive layer: it (a) accepts a bare `owner/repo#N` (GitHub)
+// or `.../proj!N` (GitLab) short ref and turns it into a real URL, and (b)
+// refuses to hand back anything that isn't an http(s) URL — guarding against a
+// `javascript:`/`data:` (or otherwise malformed) prRef ever being used as an
+// href. Returns null when the value can't be resolved to a safe http(s) URL,
+// in which case callers should fall back to plain text.
+function resolvePrUrl(prRef: string | null | undefined): string | null {
+  if (!prRef) return null;
+  const trimmed = prRef.trim();
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+
+  const mrMatch = trimmed.match(/^([\w.-]+(?:\/[\w.-]+)*)!(\d+)$/);
+  if (mrMatch) {
+    const [, project, num] = mrMatch;
+    return `https://gitlab.com/${project}/-/merge_requests/${num}`;
+  }
+
+  const prMatch = trimmed.match(/^([\w.-]+)\/([\w.-]+)#(\d+)$/);
+  if (prMatch) {
+    const [, owner, repo, num] = prMatch;
+    return `https://github.com/${owner}/${repo}/pull/${num}`;
+  }
+
+  return null;
+}
+
 // What did the latest SDLC round actually produce? The stepper shows WHERE the
 // loop is; this panel shows WHAT to decide on. It is rendered near the top so a
 // human arriving at `awaiting_merge` is never met with a blank gate. Every field
@@ -1037,7 +1076,8 @@ function LoopStatusCallout({ loop }: { loop: ConsiliumLoopDetailRow }) {
 // openP0 / openActionPoints) — nothing is invented.
 //
 // SECURITY: error text and action-point titles are model/loop-authored and are
-// rendered as INERT React text; the PR link uses rel="noopener noreferrer".
+// rendered as INERT React text; the PR link is resolved through resolvePrUrl
+// (http/https only) and uses rel="noopener noreferrer".
 function ResultPanel({
   loop,
   terminal,
@@ -1060,8 +1100,16 @@ function ResultPanel({
 
   return (
     <Card className="border-amber-500/40">
-      <CardHeader className="pb-3">
+      <CardHeader className="pb-3 flex flex-row items-center justify-between gap-2">
         <CardTitle className="text-sm">Result</CardTitle>
+        {/* Result comments — only meaningful once there's a round to attach to. */}
+        {latest && (
+          <ResultComments
+            loopId={loop.id}
+            round={latest.round}
+            comments={Array.isArray(latest.comments) ? latest.comments : []}
+          />
+        )}
       </CardHeader>
       <CardContent className="space-y-4">
         {/* Last-round degradation signal from `loop.error`. The CANCELLED and
@@ -1088,15 +1136,17 @@ function ResultPanel({
               <p className="text-sm font-medium">Draft PR ready for review</p>
               <p className="font-mono text-xs text-muted-foreground truncate">{loop.prRef}</p>
             </div>
-            <a
-              href={loop.prRef}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 shrink-0"
-            >
-              <ExternalLink className="h-4 w-4" />
-              Open Draft PR
-            </a>
+            {resolvePrUrl(loop.prRef) ? (
+              <a
+                href={resolvePrUrl(loop.prRef)!}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 shrink-0"
+              >
+                <ExternalLink className="h-4 w-4" />
+                Open Draft PR
+              </a>
+            ) : null}
           </div>
         ) : awaiting ? (
           <div className="rounded-md border border-border bg-muted/30 p-3 text-sm text-muted-foreground">
@@ -1168,6 +1218,107 @@ function ResultPanel({
         )}
       </CardContent>
     </Card>
+  );
+}
+
+// ─── Result comments (button + dialog) ─────────────────────────────────────────
+//
+// A thread-like note surface attached to a round's Result: a "Comments (N)"
+// button opens a Dialog listing existing comments (author + relative time +
+// body) with a Textarea + "Add comment" action underneath. POSTs via
+// `useAddRoundComment`, which invalidates the loop detail query on success so
+// the new comment rides back on the next `rounds[].comments` read.
+//
+// SECURITY: `body` is UNTRUSTED operator free text — rendered as INERT plain
+// text (`whitespace-pre-wrap`), never `dangerouslySetInnerHTML`/HTML/eval.
+// `author` is server-derived (never client-supplied).
+function ResultComments({
+  loopId,
+  round,
+  comments,
+}: {
+  loopId: string;
+  round: number;
+  comments: RoundComment[];
+}) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState("");
+  const addComment = useAddRoundComment();
+  const { toast } = useToast();
+
+  const handleAdd = async () => {
+    const body = draft.trim();
+    if (!body) return;
+    try {
+      await addComment.mutateAsync({ id: loopId, round, body });
+      setDraft("");
+    } catch (e) {
+      toast({
+        title: "Failed to add comment",
+        description: e instanceof Error ? e.message : undefined,
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" className="shrink-0" data-testid="result-comments-button">
+          <MessageSquare className="h-4 w-4 mr-2" />
+          Comments{comments.length > 0 ? ` (${comments.length})` : ""}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Result comments</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-2">
+          {comments.length > 0 ? (
+            <ul className="max-h-72 space-y-3 overflow-y-auto" data-testid="result-comments-list">
+              {comments.map((c) => (
+                <li key={c.id} className="rounded-md border p-3 text-sm" data-testid="result-comment-item">
+                  <div className="mb-1 flex items-baseline justify-between gap-2">
+                    {/* author is server-derived; createdAt is server-generated — INERT text */}
+                    <span className="font-medium">{c.author}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {formatDistanceToNow(new Date(c.createdAt), { addSuffix: true })}
+                    </span>
+                  </div>
+                  {/* UNTRUSTED operator text — inert plain text, never HTML/eval */}
+                  <p className="whitespace-pre-wrap break-words text-muted-foreground">{c.body}</p>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-muted-foreground">No comments yet.</p>
+          )}
+          <div className="space-y-2">
+            <Textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              placeholder="Add a thought on this result…"
+              rows={3}
+              maxLength={8000}
+              data-testid="result-comment-input"
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Close
+          </Button>
+          <Button
+            onClick={handleAdd}
+            disabled={!draft.trim() || addComment.isPending}
+            data-testid="result-comment-submit"
+          >
+            {addComment.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Add comment
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -1685,9 +1836,9 @@ function DevelopProgressPanel({
       </p>
 
       {/* Draft PR link appears once the executor has opened it (near completion). */}
-      {loop.prRef && (
+      {loop.prRef && resolvePrUrl(loop.prRef) && (
         <a
-          href={loop.prRef}
+          href={resolvePrUrl(loop.prRef)!}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex items-center gap-1 text-sm font-medium text-primary underline underline-offset-2"
@@ -2645,15 +2796,19 @@ export default function ConsiliumLoopDetail() {
                   </span>
                 )}
                 {loop.prRef && (
-                  <a
-                    href={loop.prRef}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 text-primary hover:underline text-sm font-mono break-all"
-                  >
-                    <ExternalLink className="h-3.5 w-3.5 shrink-0" />
-                    {loop.prRef}
-                  </a>
+                  resolvePrUrl(loop.prRef) ? (
+                    <a
+                      href={resolvePrUrl(loop.prRef)!}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1.5 text-primary hover:underline text-sm font-mono break-all"
+                    >
+                      <ExternalLink className="h-3.5 w-3.5 shrink-0" />
+                      {loop.prRef}
+                    </a>
+                  ) : (
+                    <span className="block font-mono text-sm break-all">{loop.prRef}</span>
+                  )
                 )}
                 <span className="block text-xs text-muted-foreground">
                   Requires the maintainer or admin role

--- a/migrations/0056_consilium_loop_rounds_comments.sql
+++ b/migrations/0056_consilium_loop_rounds_comments.sql
@@ -1,0 +1,22 @@
+-- migration: 0056_consilium_loop_rounds_comments
+-- Result comments — operator thread-like notes on a consilium round's Result.
+--
+-- consilium_loop_rounds.comments → new JSONB (nullable).
+--   An append-only array of { id, author, body, createdAt } (shared RoundComment
+--   type), written by POST /api/consilium-loops/:id/rounds/:round/comments.
+--   Mirrors the out-of-band settle discipline of human_note/report/execution_trace
+--   on this same table: additive, no-op when the (loop, round) row is absent.
+--   NULL for every pre-existing round (no backfill) and for any round with no
+--   comments yet — every consumer guards on NULL/empty before reading it.
+--
+-- SECURITY: `body`/`author` are operator-authored strings, bounded server-side
+-- before write; rendered client-side as inert plain text only (never HTML/eval).
+--
+-- Additive + idempotent (ADD COLUMN IF NOT EXISTS): metadata-only, no rewrite, no
+-- data loss. Re-applying against a push-managed dev DB is safe.
+
+ALTER TABLE consilium_loop_rounds
+  ADD COLUMN IF NOT EXISTS comments jsonb;
+
+-- Rollback:
+--   ALTER TABLE consilium_loop_rounds DROP COLUMN comments;

--- a/migrations/0057_consilium_loops_commit_prefix.sql
+++ b/migrations/0057_consilium_loops_commit_prefix.sql
@@ -1,0 +1,3 @@
+-- Per-loop commit-message/MR-title prefix (additive, nullable). See
+-- shared/schema.ts consiliumLoops.commitPrefix for the full rationale.
+ALTER TABLE consilium_loops ADD COLUMN IF NOT EXISTS commit_prefix text;

--- a/server/routes/consilium-loops.ts
+++ b/server/routes/consilium-loops.ts
@@ -12,6 +12,7 @@
  * only registers it (and the poller) behind the kill-switch.
  */
 import type { Express, Request, Response } from "express";
+import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import type { IStorage } from "../storage.js";
 import type {
@@ -44,7 +45,14 @@ const CreateLoopSchema = z.object({
   maxRounds: z.coerce.number().int().min(1).max(6).optional(),
   // H-2: a baseline supplied at create time MUST be a strict hex sha (no refs).
   lastReviewedCommit: z.string().regex(SHA_RE).optional(),
+  // OPTIONAL per-loop commit-message/MR-title prefix (e.g. a Jira issue key) —
+  // sanitized by `sanitizeCommitPrefix` below; empty/whitespace-only is stored as
+  // absent (no prefix).
+  commitPrefix: z.string().optional(),
 });
+
+/** Max stored commit prefix (control-stripped, collapsed, trimmed, then clamped). */
+const MAX_COMMIT_PREFIX = 64;
 
 // Stage 1 (§6): the human archetype OVERRIDE body — enum-clamped (no model call).
 /** Max stored cancellation reason (truncated, not rejected — see `sanitizeReason`). */
@@ -76,6 +84,26 @@ function sanitizeReason(raw: unknown): string | undefined {
   return cleaned.length ? cleaned : undefined;
 }
 
+/**
+ * Sanitize an untrusted per-loop commit-message/MR-title prefix: control-strip
+ * (C0/DEL/C1), collapse whitespace, trim, then CLAMP (not reject) to
+ * {@link MAX_COMMIT_PREFIX}. Returns undefined for a non-string or
+ * empty-after-strip input so the loop is created with NO prefix (byte-identical
+ * to today's commit subjects/PR title). Mirrors `sanitizeReason` above; this
+ * value is later re-sanitized defensively at every git-commit/MR-title call site
+ * (never a shell string — argv/body-file only).
+ */
+export function sanitizeCommitPrefix(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const cleaned = raw
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001F\u007F-\u009F]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, MAX_COMMIT_PREFIX);
+  return cleaned.length ? cleaned : undefined;
+}
+
 const ArchetypeOverrideSchema = z.object({
   archetype: z.enum(ARCHETYPES),
 });
@@ -87,6 +115,14 @@ const ArchetypeOverrideSchema = z.object({
  */
 const RoundNoteSchema = z.object({
   humanNote: z.string().max(20_000),
+});
+
+/** Max stored Result comment body (mirrors the client's soft counter). */
+const MAX_COMMENT_LEN = 8_000;
+
+/** Body for POST round comment. UNTRUSTED operator free text; stored as-is. */
+const RoundCommentSchema = z.object({
+  body: z.string().trim().min(1).max(MAX_COMMENT_LEN),
 });
 
 /** Mask the loop row for non-admins: hide createdBy attribution. */
@@ -138,6 +174,7 @@ export function registerConsiliumLoopRoutes(
           repoPath: body.repoPath,
           maxRounds: body.maxRounds ?? cfg.maxRounds,
           lastReviewedCommit: body.lastReviewedCommit ?? null,
+          commitPrefix: sanitizeCommitPrefix(body.commitPrefix) ?? null,
           createdBy: req.user.id,
           // ADR-0003 I1 (re-scoped, GH #445 P1): additive class metadata only —
           // no escalation, no gating reads this yet. Coder-enabled (worktree
@@ -416,6 +453,43 @@ export function registerConsiliumLoopRoutes(
         return res.json({ round, humanNote });
       } catch {
         return res.status(500).json({ error: "Failed to save round note" });
+      }
+    },
+  );
+
+  // ── Result comments ──────────────────────────────────────────────────────────
+  // Owner-or-admin. Thread-like operator notes on a round's Result (verdict/PR
+  // outcome), appended (never edited/removed) to `consilium_loop_rounds.comments`.
+  // Mirrors the round-note route's auth + round-existence-check shape. The
+  // `body` is UNTRUSTED operator free text — stored as-is; the client renders it
+  // as inert plain text (whitespace-pre-wrap), never HTML/eval. The comment rides
+  // back on the existing loop GET's `rounds[].comments` wire — no new read route.
+  app.post(
+    "/api/consilium-loops/:id/rounds/:round/comments",
+    validateBody(RoundCommentSchema),
+    async (req: Request, res: Response) => {
+      const auth = await authorizeConsiliumLoop(req, res, storage, String(req.params.id));
+      if (!auth) return;
+      const round = Number(req.params.round);
+      if (!Number.isInteger(round) || round < 1) {
+        return res.status(404).json({ error: "Round not found" });
+      }
+      const body = req.body as z.infer<typeof RoundCommentSchema>;
+      try {
+        const rounds = await storage.getLoopRounds(auth.loop.id);
+        if (!rounds.some((r) => r.round === round)) {
+          return res.status(404).json({ error: "Round not found" });
+        }
+        const comment = {
+          id: randomUUID(),
+          author: req.user?.name || req.user?.email || "Unknown",
+          body: body.body,
+          createdAt: new Date().toISOString(),
+        };
+        await storage.addLoopRoundComment(auth.loop.id, round, comment);
+        return res.status(201).json({ round, comment });
+      } catch {
+        return res.status(500).json({ error: "Failed to save comment" });
       }
     },
   );

--- a/server/routes/consilium-reviews.ts
+++ b/server/routes/consilium-reviews.ts
@@ -26,6 +26,7 @@ import {
   MAX_RAW_WANT_LEN,
 } from "../services/consilium/reformulate.js";
 import { REVIEW_REF_RE, INVALID_REF_MESSAGE } from "../services/consilium/ref-validator.js";
+import { sanitizeCommitPrefix } from "./consilium-loops.js";
 
 const SHA_RE = /^[0-9a-f]{7,64}$/;
 
@@ -55,6 +56,10 @@ const CreateReviewSchema = z.object({
   // server resolves it from the operator default (verifyReview.enabled). A server
   // enum (z.enum) so only the two known values pass; anything else is a clean 400.
   reviewMode: z.enum(REVIEW_MODES).optional(),
+  // OPTIONAL per-loop commit-message/MR-title prefix (e.g. a Jira issue key) --
+  // sanitized by the SAME sanitizeCommitPrefix helper the loops route uses;
+  // empty/whitespace-only is treated as absent (no prefix).
+  commitPrefix: z.string().optional(),
 });
 
 /**
@@ -138,6 +143,9 @@ export function registerConsiliumReviewRoutes(app: Express, deps: CreateConsiliu
           skillIds: body.skillIds,
           // Single-verifier re-review: OPTIONAL per-loop mode (persisted on the loop).
           reviewMode: body.reviewMode,
+          // OPTIONAL per-loop commit-message/MR-title prefix (sanitized here, same
+          // helper + clamp as the /api/consilium-loops create route).
+          commitPrefix: sanitizeCommitPrefix(body.commitPrefix),
         });
         return res.status(201).json(loop);
       } catch (err) {

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -2125,6 +2125,9 @@ export class ConsiliumLoopController {
       repoPath: loop.repoPath,
       loopId: loop.id,
       round: loop.round,
+      // OPTIONAL per-loop prefix (e.g. a Jira key), threaded to every SDLC-coder
+      // git subject line + the Merge-Request title.
+      commitPrefix: loop.commitPrefix ?? undefined,
       actionPoints: routedActionPoints,
       allowedRepoPaths: cfg.allowedRepoPaths,
       ownerId: loop.createdBy ?? "",

--- a/server/services/consilium/dev-closeout.ts
+++ b/server/services/consilium/dev-closeout.ts
@@ -124,6 +124,36 @@ export interface DevCloseoutRequest {
   openActionPoints: readonly ActionPoint[];
   /** Default PR base; falls back to "main" (the repo's main branch). */
   base?: string;
+  /**
+   * OPTIONAL per-loop commit-message/MR-title prefix (e.g. a Jira issue key) --
+   * prepended (single space) to the pushed commit subject AND the Draft-PR/MR
+   * title below. Absent/empty => byte-identical to today's subject/title.
+   */
+  commitPrefix?: string;
+}
+
+const COMMIT_PREFIX_MAX = 64;
+
+/**
+* Defensively re-sanitize an already-persisted commitPrefix before it enters a
+* commit subject / MR title (argv element via simple-git/gh/glab -- never a
+* shell string). Empty-after-clean => undefined (no-prefix path unchanged).
+*/
+function sanitizedCommitPrefix(prefix?: string): string | undefined {
+  if (!prefix) return undefined;
+  const cleaned = prefix
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001f\u007f-\u009f]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, COMMIT_PREFIX_MAX);
+  return cleaned.length ? cleaned : undefined;
+}
+
+/** Prepend a sanitized commit prefix to a subject/title (single space) when present. */
+function withCommitPrefix(subject: string, prefix?: string): string {
+  const p = sanitizedCommitPrefix(prefix);
+  return p ? `${p} ${subject}` : subject;
 }
 
 const ARTIFACT_TITLE_MAX = 200;
@@ -229,7 +259,7 @@ export class DevPrCloseout {
     await this.deps.manager.writeFile(ws, fileName, renderArtifact(req.round, req.openActionPoints));
     const git = this.gitFor(ws.path);
     await git.add(["--", fileName]); // B-5: stage EXACTLY the one artifact.
-    await git.commit(`consilium round ${req.round}: open action points`);
+    await git.commit(withCommitPrefix(`consilium round ${req.round}: open action points`, req.commitPrefix));
   }
 
   /** M-6: a re-driven round may already hold the branch — switch, don't fail. */
@@ -268,7 +298,7 @@ export class DevPrCloseout {
     const pr = await this.openPr(req.repoPath, {
       base,
       head: branchName,
-      title: `Consilium round ${req.round}: open action points`,
+      title: withCommitPrefix(`Consilium round ${req.round}: open action points`, req.commitPrefix),
       body: renderArtifact(req.round, req.openActionPoints),
     });
     if (!pr.ok) {

--- a/server/services/consilium/pr-wrapper.ts
+++ b/server/services/consilium/pr-wrapper.ts
@@ -43,6 +43,21 @@
  *          are SERVER CONSTANTS (never model text). Applying them is BEST-EFFORT:
  *          a `gh` that rejects them degrades to a plain Draft PR — metadata never
  *          fails the PR.
+ *
+ * GitLab (Wglab): `openDraftPr` first runs `detectForge` (origin URL host
+ * sniff, conservative default "github") and, for a "gitlab" origin, takes a
+ * SEPARATE `glab`-based path (`openDraftMr`) instead of the `gh` path above —
+ * the `gh` path below this point is UNCHANGED for github origins. `glab mr
+ * create` resolves the (possibly nested-group) GitLab project from `origin`
+ * via `cwd: repoPath`, so there is no owner/repo slug to parse/validate for
+ * gitlab (H-7's `OWNER_REPO_RE`/`resolveOwnerRepo` stay github-only). Same
+ * B-3/B-3+ gates apply (checked once, before the forge branch); env is
+ * sanitized the same way (`sanitizedGitlabEnv` strips inherited `GITLAB_*`,
+ * re-adds only `GITLAB_TOKEN`/`GITLAB_HOST`); `glab` absent/unauth/failing
+ * never throws — same branch-only-fallback posture as `gh`. M-6/M-7 mirror:
+ * `glab mr view <branch>` (accepts a branch name directly) reuses an existing
+ * MR before create, and recovers the URL the same way on an already-exists
+ * create race.
  */
 import { execFile } from "child_process";
 import { promisify } from "util";
@@ -80,7 +95,7 @@ export interface GitPushClient {
 export type ExecFileFn = (
   file: string,
   args: string[],
-  options?: { timeout?: number; env?: NodeJS.ProcessEnv },
+  options?: { timeout?: number; env?: NodeJS.ProcessEnv; cwd?: string },
 ) => Promise<{ stdout: string; stderr: string }>;
 
 const execFileAsync: ExecFileFn = promisify(execFile);
@@ -248,6 +263,141 @@ async function resolveOwnerRepo(git: GitPushClient): Promise<string | WrapFail> 
   return slug;
 }
 
+// ─── GitLab (glab) outbound Draft-MR path — mirrors the gh path above ─────────
+//
+// `glab` resolves the (possibly nested-group) GitLab project from the CWD's
+// `origin` remote itself, so unlike `gh` there is no owner/repo slug to parse
+// or validate here (H-7's `OWNER_REPO_RE`/`resolveOwnerRepo` stay github-only,
+// used only by the gh path below).
+
+export type Forge = "github" | "gitlab";
+
+/** glab's own token/host vars — kept, mirroring gh's `KEEP_TOKEN_VARS`. */
+const KEEP_GITLAB_VARS = ["GITLAB_TOKEN", "GITLAB_HOST"] as const;
+
+/**
+ * H-7b mirror for glab: strip every inherited `GITLAB_*` the wrapper didn't
+ * set (a poisoned `GITLAB_HOST` could redirect `glab` to an attacker host and
+ * leak the token), then re-add only the intended token/host vars. PATH/HOME
+ * etc. are left untouched so `glab` still finds its own config file.
+ */
+function sanitizedGitlabEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (k.startsWith("GITLAB_")) continue; // drop ALL inherited GITLAB_* first.
+    env[k] = v;
+  }
+  for (const tokenVar of KEEP_GITLAB_VARS) {
+    if (process.env[tokenVar]) env[tokenVar] = process.env[tokenVar];
+  }
+  return env;
+}
+
+/**
+ * Sniff the forge from the repo's `origin` remote URL. Conservative: only a
+ * URL host containing "gitlab" resolves to `"gitlab"`; missing origin, a read
+ * error, or any other host (incl. github.com) resolves to `"github"` — the
+ * pre-existing gh path's behavior is UNCHANGED for every caller that doesn't
+ * have a gitlab origin.
+ */
+export async function detectForge(repoPath: string, gitClient?: GitPushClient): Promise<Forge> {
+  const git = gitClient ?? makeGit(repoPath);
+  try {
+    const remotes = await git.getRemotes(true);
+    const origin = remotes.find((r) => r.name === "origin");
+    const url = origin?.refs.push ?? origin?.refs.fetch ?? "";
+    return /gitlab/i.test(url) ? "gitlab" : "github";
+  } catch {
+    return "github";
+  }
+}
+
+/** Pull the first http(s) URL out of `glab` stdout (mirrors `parsePrUrl`). */
+function parseMrUrl(stdout: string): string | undefined {
+  return stdout.match(/https?:\/\/\S+/)?.[0];
+}
+
+/** True when a `glab mr create` error means an MR for the branch already exists (M-7 mirror). */
+function isAlreadyExistsMr(message: string): boolean {
+  return /already (exists|has an open|been created)|open merge request already exists/i.test(message);
+}
+
+/**
+ * M-6 mirror: return the URL of an existing MR for `branch` via
+ * `glab mr view <branch>` — `glab` accepts a branch name directly (no
+ * owner/repo needed). Run with `cwd: repoPath` so `glab` resolves the project
+ * from origin. Not-found / `glab` absent/unauth is NOT fatal — treated as "no
+ * existing MR" (the caller decides what happens next).
+ */
+async function findExistingMr(
+  repoPath: string,
+  branch: string,
+  run: ExecFileFn,
+  env: NodeJS.ProcessEnv,
+): Promise<string | undefined> {
+  try {
+    const { stdout } = await run("glab", ["mr", "view", branch], { timeout: 30_000, env, cwd: repoPath });
+    return parseMrUrl(stdout);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The `glab mr create` call + M-7-mirror already-exists recovery. `glab` has
+ * no `--body-file`/`-F` equivalent for the description, so `--description`
+ * takes the body string directly as an argv element — still `execFile` with
+ * an args array (never a shell string), so this carries no injection risk;
+ * it only differs from gh's `--body-file` in not hiding the content from
+ * `ps`. Server-fixed flags first; `--draft` (H-6 mirror) so a human always
+ * merges. Never throws.
+ */
+async function createDraftMr(
+  repoPath: string,
+  opts: OpenDraftPrOptions,
+  run: ExecFileFn,
+  env: NodeJS.ProcessEnv,
+): Promise<PrResult> {
+  const args = [
+    "mr", "create", "--draft",
+    "--source-branch", opts.head,
+    "--target-branch", opts.base,
+    "--title", opts.title,
+    "--description", opts.body,
+  ];
+  try {
+    const { stdout } = await run("glab", args, { timeout: 60_000, env, cwd: repoPath });
+    const mrUrl = parseMrUrl(stdout);
+    if (!mrUrl) return { ok: false, kind: "gh-failed", message: "glab returned no MR URL" };
+    return { ok: true, prUrl: mrUrl };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (isAlreadyExistsMr(message)) {
+      const recovered = await findExistingMr(repoPath, opts.head, run, env); // M-7 mirror.
+      if (recovered) return { ok: true, prUrl: recovered };
+    }
+    return { ok: false, kind: "gh-failed", message: scrub(message) };
+  }
+}
+
+/**
+ * GitLab counterpart of the gh path in `openDraftPr`: B-3/B-3+ gates already
+ * ran in the caller before the forge branch, so `opts` is already safe here.
+ * No origin/owner-repo derivation (H-7a is github-only) — `cwd: repoPath` lets
+ * `glab` resolve the project itself. Never throws; `glab` absent/unauth/
+ * failing degrades the same way `gh` does (caller falls back to branch-only).
+ */
+async function openDraftMr(
+  repoPath: string,
+  opts: OpenDraftPrOptions,
+  execFileFn: ExecFileFn,
+): Promise<PrResult> {
+  const env = sanitizedGitlabEnv();
+  const existing = await findExistingMr(repoPath, opts.head, execFileFn, env); // M-6 mirror.
+  if (existing) return { ok: true, prUrl: existing };
+  return createDraftMr(repoPath, opts, execFileFn, env);
+}
+
 // ─── pushBranch (B-4 / B-3+ / H-7b) ─────────────────────────────────────────────
 
 /**
@@ -350,6 +500,13 @@ export async function openDraftPr(
   // so a malformed/poisoned base can't be parsed by `gh` as a flag (option injection).
   if (opts.base.startsWith("-")) {
     return { ok: false, kind: "bad-title", message: "rejected leading-dash base (B-3+ flag injection)" };
+  }
+
+  // GitLab origin → the glab Draft-MR path above; conservative default is
+  // "github" (see `detectForge`), so this is a no-op branch for every github
+  // caller — the rest of this function (the gh path) is UNCHANGED.
+  if ((await detectForge(repoPath, gitClient)) === "gitlab") {
+    return openDraftMr(repoPath, opts, execFileFn);
   }
 
   const env = sanitizedEnv(); // H-7b

--- a/server/services/consilium/review-factory.ts
+++ b/server/services/consilium/review-factory.ts
@@ -1264,6 +1264,14 @@ export interface CreateConsiliumReviewParams {
    * shell/branch/PR sink.
    */
   reviewMode?: ReviewMode;
+  /**
+   * OPTIONAL per-loop commit-message/MR-title prefix (e.g. a Jira issue key) --
+   * persisted on the loop's `commit_prefix` column and prepended (single space)
+   * to every SDLC-coder commit subject AND the Draft-PR/MR title for this loop.
+   * Already sanitized by the caller (route); absent/undefined => null (byte-
+   * identical subjects/title, no prefix).
+   */
+  commitPrefix?: string;
 }
 
 /** Clamp a caller-supplied round count into the schema's 1..6 window. */
@@ -1431,6 +1439,9 @@ export async function createConsiliumReview(
     // Single-verifier re-review: the per-loop mode (null ⇒ operator default resolves
     // it at round time; an explicit value always wins). INERT dispatch selector.
     reviewMode: params.reviewMode ?? null,
+    // OPTIONAL per-loop commit-message/MR-title prefix (already sanitized by
+    // the caller); null => byte-identical commit subjects/PR-MR title.
+    commitPrefix: params.commitPrefix ?? null,
     createdBy: params.createdBy,
     // ADR-0003 I1 (re-scoped, GH #445 P1): additive class metadata only — no
     // escalation, no gating reads this yet. Coder-enabled (worktree write /

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -298,6 +298,15 @@ export interface SdlcHandoffRequest {
   loopId: string;
   /** Round number — feeds the branch + commit/PR title. */
   round: number;
+  /**
+   * OPTIONAL per-loop commit-message/MR-title prefix (e.g. a Jira issue key,
+   * `consilium_loops.commit_prefix`) — prepended (single space) to every commit
+   * subject this executor writes AND the Draft-PR/MR title, so a push to a repo
+   * whose pre-receive hook requires an issue key can land. Absent/empty ⇒
+   * byte-identical to today's subjects/title (no prefix). Already sanitized at
+   * the create route; re-sanitized defensively at each call site below.
+   */
+  commitPrefix?: string;
   /** The round's open action points to implement (one coder run EACH). */
   actionPoints: readonly ActionPoint[];
   /** Fail-closed repo allowlist (H-5). */
@@ -612,9 +621,30 @@ function sanitizeLine(value: string, max: number): string {
     .slice(0, max);
 }
 
+/** Max applied commit-prefix length (mirrors the create-route clamp). */
+const COMMIT_PREFIX_MAX = 64;
+
+/**
+ * Defensively re-sanitize an already-persisted `commitPrefix` immediately before
+ * it enters a commit subject / PR title (argv element via simple-git / gh / glab
+ * -- never a shell string). Empty-after-clean => undefined (no-prefix path stays
+ * byte-identical).
+ */
+function sanitizedCommitPrefix(prefix?: string): string | undefined {
+  if (!prefix) return undefined;
+  const cleaned = sanitizeLine(prefix, COMMIT_PREFIX_MAX);
+  return cleaned.length ? cleaned : undefined;
+}
+
+/** Prepend a sanitized commit prefix to a subject/title (single space) when present. */
+function withCommitPrefix(subject: string, prefix?: string): string {
+  const p = sanitizedCommitPrefix(prefix);
+  return p ? `${p} ${subject}` : subject;
+}
+
 /** Build the server-derived PR title (NO model text — B-3 class guard). */
-export function buildPrTitle(round: number): string {
-  return `Consilium round ${round}: SDLC changes`;
+export function buildPrTitle(round: number, commitPrefix?: string): string {
+  return withCommitPrefix(`Consilium round ${round}: SDLC changes`, commitPrefix);
 }
 
 /**
@@ -630,6 +660,7 @@ export function buildApCommitMessage(
   total: number,
   isPartial: boolean,
   note?: string,
+  commitPrefix?: string,
 ): { subject: string; body: string } {
   const priority = sanitizeLine(ap.priority ?? "-", PRIORITY_MAX) || "-";
   const subject = `Consilium round ${round}: ${priority} ${sanitizeLine(ap.title ?? "", COMMIT_SUBJECT_TITLE_MAX)}`.trim();
@@ -644,7 +675,7 @@ export function buildApCommitMessage(
   if (note) lines.push(`Note: ${sanitizeLine(note, 200)}`);
   const rationale = sanitizeLine(ap.rationale ?? "", COMMIT_BODY_RATIONALE_MAX);
   if (rationale) lines.push(`Rationale: ${rationale}`);
-  return { subject: subject.slice(0, 200), body: lines.join("\n").slice(0, COMMIT_BODY_MAX) };
+  return { subject: withCommitPrefix(subject, commitPrefix).slice(0, 200), body: lines.join("\n").slice(0, COMMIT_BODY_MAX) };
 }
 
 /** Inputs to the enriched Draft-PR body (all values server-controlled EXCEPT the
@@ -1336,7 +1367,7 @@ async function runActionPoint(
   //     timed-out/errored run that still produced edits → "partial".
   const isPartial = threw || (coder !== null && !coder.ok);
   const note = isPartial ? (runNote ?? coder?.error ?? "coder did not finish") : undefined;
-  const { subject, body } = buildApCommitMessage(req.round, ap, index, total, isPartial, note);
+  const { subject, body } = buildApCommitMessage(req.round, ap, index, total, isPartial, note, req.commitPrefix);
   // Beat: about to commit THIS action point's work (still the active row).
   io.progress.beat({
     phase: "committing",
@@ -1931,7 +1962,7 @@ async function commitFinalFixes(
     await gitRaw(wt.worktreeDir, [
       "commit",
       "-m",
-      `Consilium round ${req.round}: final-state re-verification fixes`,
+      withCommitPrefix(`Consilium round ${req.round}: final-state re-verification fixes`, req.commitPrefix),
       "-m",
       "Fixes applied by the final-state re-verification loop after all action points were implemented (Stage A).",
     ]);
@@ -2213,7 +2244,7 @@ async function pushAndOpenPr(
   const pr = await io.openPr(wt.worktreeDir, {
     base,
     head: branch,
-    title: buildPrTitle(req.round), // server-derived; NO model text.
+    title: buildPrTitle(req.round, req.commitPrefix), // server-derived; NO model text.
     body: buildPrStatusBody({
       loopId: req.loopId,
       round: req.round,

--- a/server/services/sdlc/worktree.ts
+++ b/server/services/sdlc/worktree.ts
@@ -152,11 +152,30 @@ export async function createSdlcWorktree(opts: CreateWorktreeOptions): Promise<C
   }
 }
 
+const WORKTREE_COLLISION_RE = /already (exists|used by worktree|checked out)/i;
+
 /**
  * `git worktree add -b <branch> <path> <baseRef>`. Options precede the
- * positionals so an (already-gated) value can never be mis-parsed as a flag. If
- * the branch already exists (a re-driven round / a stale ref), recover by
- * force-recreating it from `baseRef` with `-B` so the round is coherent.
+ * positionals so an (already-gated) value can never be mis-parsed as a flag.
+ *
+ * Recovery ladder on an "already used by worktree" collision (a re-driven
+ * round, a killed run, or a stale ref):
+ *   1. `worktree prune` + retry with `-B` — handles the common case where the
+ *      OLD worktree's on-disk directory is already gone (prune drops its now-
+ *      dangling admin entry, `-B` force-recreates the branch ref).
+ *   2. If the collision persists, the old directory is still PRESENT on disk
+ *      (a killed run whose `removeSdlcWorktree` `finally` never got to run) —
+ *      `prune` alone cannot clear that. Look up whichever worktree currently
+ *      holds THIS branch (`worktree list --porcelain`) and force-drop it
+ *      (`worktree remove --force` + `rm -rf` belt-and-braces), then retry once
+ *      more. This is safe to do unconditionally here: `createSdlcWorktree` is
+ *      only re-invoked for a given loop+round once the caller's in-process
+ *      registry / cross-instance DB claim (see BUG-1 in
+ *      consilium-loop-controller.ts) has already ruled out a LIVE concurrent
+ *      run on that exact branch — so any worktree still holding it at this
+ *      point is abandoned, never a live sibling run.
+ *   3. If it STILL collides, bubble the error up untouched (fail-closed —
+ *      never silently widen or clobber past this point).
  */
 async function addWorktree(
   gitRaw: GitRunner,
@@ -167,11 +186,52 @@ async function addWorktree(
 ): Promise<void> {
   try {
     await gitRaw(repo, ["worktree", "add", "-b", branch, worktreeDir, baseRef]);
+    return;
   } catch (err) {
-    if (!/already (exists|used by worktree|checked out)/i.test(errMsg(err))) throw err;
-    await gitRaw(repo, ["worktree", "prune"]).catch(() => undefined);
-    await gitRaw(repo, ["worktree", "add", "-B", branch, worktreeDir, baseRef]);
+    if (!WORKTREE_COLLISION_RE.test(errMsg(err))) throw err;
   }
+
+  await gitRaw(repo, ["worktree", "prune"]).catch(() => undefined);
+  try {
+    await gitRaw(repo, ["worktree", "add", "-B", branch, worktreeDir, baseRef]);
+    return;
+  } catch (err) {
+    if (!WORKTREE_COLLISION_RE.test(errMsg(err))) throw err;
+  }
+
+  const stalePath = await findWorktreePathForBranch(gitRaw, repo, branch);
+  if (stalePath) {
+    await gitRaw(repo, ["worktree", "remove", "--force", stalePath]).catch(() => undefined);
+    await rm(stalePath, { recursive: true, force: true }).catch(() => undefined);
+    await gitRaw(repo, ["worktree", "prune"]).catch(() => undefined);
+  }
+  // Final attempt — a remaining failure here is a genuine, unrecoverable
+  // collision (or the branch is checked out somewhere we couldn't locate);
+  // let it bubble up rather than loop or clobber further.
+  await gitRaw(repo, ["worktree", "add", "-B", branch, worktreeDir, baseRef]);
+}
+
+/**
+ * Find the absolute path of the worktree (if any) currently checked out on
+ * `branch`, via `git worktree list --porcelain` (stable machine format: blocks
+ * separated by blank lines, each with a `worktree <path>` line and, when the
+ * worktree has a branch checked out, a `branch refs/heads/<name>` line).
+ * Best-effort — a parse/exec failure yields `null` (no stale path found), never
+ * throws, so a lookup miss just falls through to the final plain retry above.
+ */
+async function findWorktreePathForBranch(
+  gitRaw: GitRunner,
+  repo: string,
+  branch: string,
+): Promise<string | null> {
+  const out = await gitRaw(repo, ["worktree", "list", "--porcelain"]).catch(() => "");
+  const wantRef = `refs/heads/${branch}`;
+  for (const block of out.split(/\n{2,}/)) {
+    const pathLine = block.match(/^worktree (.+)$/m)?.[1];
+    const branchLine = block.match(/^branch (.+)$/m)?.[1];
+    if (pathLine && branchLine === wantRef) return pathLine;
+  }
+  return null;
 }
 
 /**

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -111,7 +111,7 @@ import {
 // import so the shared `@shared/schema` import block above stays a single merge point.
 import { standingRoles, type StandingRoleRow, type InsertStandingRole } from "@shared/schema";
 import type { LessonRecallFilter } from "./memory/lessons/types";
-import type { TraceSpan, SkillVersionRecord, InsertSkillVersion, SharedSession, CreateSharedSessionInput, ShareRole, WorkspaceConnection, CreateWorkspaceConnectionInput, UpdateWorkspaceConnectionInput, McpToolCall, ConnectionUsageMetrics, RecordMcpToolCallInput, SessionConflict, DecisionLogEntry, RaiseConflictInput, CastConflictVoteInput, DebateJudgement, ExperimentBranchResult, ResolutionOutcome, ResearchReport, ExecutionTrace, ActionPoint, SkillProposalStatus } from "@shared/types";
+import type { TraceSpan, SkillVersionRecord, InsertSkillVersion, SharedSession, CreateSharedSessionInput, ShareRole, WorkspaceConnection, CreateWorkspaceConnectionInput, UpdateWorkspaceConnectionInput, McpToolCall, ConnectionUsageMetrics, RecordMcpToolCallInput, SessionConflict, DecisionLogEntry, RaiseConflictInput, CastConflictVoteInput, DebateJudgement, ExperimentBranchResult, ResolutionOutcome, ResearchReport, ExecutionTrace, ActionPoint, SkillProposalStatus, RoundComment } from "@shared/types";
 
 import { encrypt } from "./crypto";
 // [ADR-001 Wave-2] credentialProvider routes all decrypt() calls through the broker.
@@ -1051,6 +1051,18 @@ export class PgStorage implements IStorage {
     await db
       .update(consiliumLoopRounds)
       .set({ humanNote })
+      .where(and(eq(consiliumLoopRounds.loopId, loopId), eq(consiliumLoopRounds.round, round)));
+  }
+
+  async addLoopRoundComment(loopId: string, round: number, comment: RoundComment): Promise<void> {
+    // Result comments: same (loop, round) scoping as humanNote/report. Appends
+    // atomically via jsonb `||` concat (coalesce guards a NULL existing array) so
+    // two concurrent adds never clobber each other (unlike a read-modify-write).
+    await db
+      .update(consiliumLoopRounds)
+      .set({
+        comments: drizzleSql`coalesce(${consiliumLoopRounds.comments}, '[]'::jsonb) || ${JSON.stringify([comment])}::jsonb`,
+      })
       .where(and(eq(consiliumLoopRounds.loopId, loopId), eq(consiliumLoopRounds.round, round)));
   }
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -70,7 +70,7 @@ import {
   type PracticeCardReviewState,
   type PracticeCardStatus,
 } from "@shared/schema";
-import type { McpServerConfig, TraceSpan, TaskTraceSpan, SkillVersionRecord, InsertSkillVersion as InsertSkillVersionType, SharedSession, CreateSharedSessionInput, SharePermissions, ShareRole, WorkspaceConnection, CreateWorkspaceConnectionInput, UpdateWorkspaceConnectionInput, McpToolCall, ConnectionUsageMetrics, RecordMcpToolCallInput, SessionConflict, DecisionLogEntry, RaiseConflictInput, CastConflictVoteInput, DebateJudgement, ExperimentBranchResult, ResolutionOutcome, ResearchReport, ExecutionTrace, ActionPoint, SkillProposalStatus } from "@shared/types";
+import type { McpServerConfig, TraceSpan, TaskTraceSpan, SkillVersionRecord, InsertSkillVersion as InsertSkillVersionType, SharedSession, CreateSharedSessionInput, SharePermissions, ShareRole, WorkspaceConnection, CreateWorkspaceConnectionInput, UpdateWorkspaceConnectionInput, McpToolCall, ConnectionUsageMetrics, RecordMcpToolCallInput, SessionConflict, DecisionLogEntry, RaiseConflictInput, CastConflictVoteInput, DebateJudgement, ExperimentBranchResult, ResolutionOutcome, ResearchReport, ExecutionTrace, ActionPoint, SkillProposalStatus, RoundComment } from "@shared/types";
 import type { LessonRecallFilter } from "./memory/lessons/types";
 // ROLE-1 (standing-role.md §3/§8): the StandingRole record types. Separate localized
 // import so the shared `@shared/schema` import block above stays a single merge point.
@@ -562,6 +562,15 @@ export interface IStorage {
    * row is absent. Idempotent / best-effort (mirror of updateLoopRoundTestSummary).
    */
   updateLoopRoundHumanNote(loopId: string, round: number, humanNote: string | null): Promise<void>;
+
+  /**
+   * Result comments: append an operator's thread-like comment to a round's
+   * Result. Additive over the audit row recorded on entering `developing`;
+   * no-op when the (loop, round) row is absent. Idempotent / best-effort (mirror
+   * of updateLoopRoundHumanNote) — appends to the existing `comments` array,
+   * creating it when absent.
+   */
+  addLoopRoundComment(loopId: string, round: number, comment: RoundComment): Promise<void>;
 
   // Experience plane — the "Dream" distillation, WRITE side (DREAM-1).
   // The distiller observer reads terminal loops read-only and writes verification-grounded
@@ -1420,6 +1429,8 @@ export class MemStorage implements IStorage {
       repoPath: data.repoPath,
       lastReviewedCommit: data.lastReviewedCommit ?? null,
       reviewRef: data.reviewRef ?? null,
+      // Per-loop commit-message/MR-title prefix (migration 0057, nullable).
+      commitPrefix: data.commitPrefix ?? null,
       // ADR-0003 I1 (re-scoped, GH #445 P1): additive class metadata (mirrors the
       // DB default). Nothing reads either field yet.
       class: data.class ?? "R0",
@@ -1631,6 +1642,7 @@ export class MemStorage implements IStorage {
       humanNote: data.humanNote ?? null,
       report: data.report ?? null,
       executionTrace: data.executionTrace ?? null,
+      comments: data.comments ?? null,
       createdAt: new Date(),
     };
     this.consiliumLoopRoundsMap.set(row.id, row);
@@ -1683,6 +1695,18 @@ export class MemStorage implements IStorage {
     for (const r of this.consiliumLoopRoundsMap.values()) {
       if (r.loopId === loopId && r.round === round) {
         this.consiliumLoopRoundsMap.set(r.id, { ...r, humanNote });
+        return;
+      }
+    }
+  }
+
+  async addLoopRoundComment(loopId: string, round: number, comment: RoundComment): Promise<void> {
+    for (const r of this.consiliumLoopRoundsMap.values()) {
+      if (r.loopId === loopId && r.round === round) {
+        const existing = Array.isArray((r as { comments?: RoundComment[] | null }).comments)
+          ? ((r as { comments?: RoundComment[] | null }).comments as RoundComment[])
+          : [];
+        this.consiliumLoopRoundsMap.set(r.id, { ...r, comments: [...existing, comment] });
         return;
       }
     }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -17,7 +17,7 @@ import {
 import { vector } from "drizzle-orm/pg-core/columns/vector_extension/vector";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
-import type { TriggerConfig, TriggerType, TriggerProvenance, TraceSpan, SkillVersionConfig, TaskTraceSpan, TrackerProvider, ActionPoint, Archetype, ArchetypeSource, ResearchReport, RoundVerdict, RoundParticipant, ExecutionTrace, ReviewMode, ExperienceScope, ExperienceEvidence, ExperienceVerification, ExperienceProvenance, ExperienceFreshness, ExperienceConfidence, ExperienceConsolidation, SkillProposalStatus, SkillProposalProvenance, SkillProposalEvidence } from "./types.js";
+import type { TriggerConfig, TriggerType, TriggerProvenance, TraceSpan, SkillVersionConfig, TaskTraceSpan, TrackerProvider, ActionPoint, Archetype, ArchetypeSource, ResearchReport, RoundVerdict, RoundParticipant, RoundComment, ExecutionTrace, ReviewMode, ExperienceScope, ExperienceEvidence, ExperienceVerification, ExperienceProvenance, ExperienceFreshness, ExperienceConfidence, ExperienceConsolidation, SkillProposalStatus, SkillProposalProvenance, SkillProposalEvidence } from "./types.js";
 
 // ─── RBAC ────────────────────────────────────────────
 
@@ -1876,6 +1876,15 @@ export const consiliumLoops = pgTable(
     // tip + tree this review targets (content read AT THAT REF, no checkout).
     // null ⇒ working-tree HEAD (existing behavior; full back-compat).
     reviewRef: text("review_ref"),
+    // Per-loop commit-message/MR-title prefix (migration 0057): OPTIONAL operator
+    // string prepended (single space) to every SDLC-coder git commit subject AND the
+    // Merge-Request title for THIS loop — lets a loop targeting a repo whose
+    // pre-receive hook requires an issue key (e.g. a Jira key) pass the push.
+    // Sanitized (control-stripped/collapsed/trimmed/clamped ≤64) at write time in the
+    // create route AND defensively re-sanitized at every git-commit/MR-title call
+    // site (never a shell string — argv/body-file only). Null/absent ⇒ byte-identical
+    // to today's subjects/titles (no prefix).
+    commitPrefix: text("commit_prefix"),
     // Single-verifier re-review (migration 0044): HOW rounds AFTER the first are
     // run — 'full-dispute' (the default) or 'single-verifier'. NULLABLE; null ⇒
     // resolve from the operator default (pipeline.consiliumLoop.verifyReview.enabled).
@@ -2001,6 +2010,12 @@ export const consiliumLoopRounds = pgTable(
     // by `updateLoopRoundExecutionTrace` after settle (mirror of report/testSummary).
     // NULL for pre-Stage-4 rounds / rounds with no skilled run. Clamped before write.
     executionTrace: jsonb("execution_trace").$type<ExecutionTrace>(),
+    // Result comments: an operator's thread-like notes on this round's Result,
+    // appended (never edited/removed) by POST .../rounds/:round/comments. Nullable
+    // jsonb array — absent on pre-column rounds, additive over every other field
+    // above (same out-of-band settle discipline as humanNote/report). UNTRUSTED
+    // operator free text; rendered client-side as inert plain text only.
+    comments: jsonb("comments").$type<RoundComment[]>(),
     createdAt: timestamp("created_at").notNull().defaultNow(),
   },
   (table) => ({

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -2446,6 +2446,24 @@ export interface RoundParticipant {
 }
 
 /**
+ * Result comments — an operator's thread-like note attached to a round's Result
+ * (verdict/PR outcome), persisted alongside the round on `consilium_loop_rounds.
+ * comments` (jsonb array, additive/nullable — absent on pre-column rounds).
+ * Appended, never edited/removed, by `POST .../rounds/:round/comments`.
+ *
+ * SECURITY: `body` is UNTRUSTED operator free text — stored as-is (server bounds
+ * length), rendered as INERT plain text (whitespace-pre-wrap), never HTML/eval.
+ * `author` is the server-derived display name/email of the authenticated caller,
+ * never client-supplied.
+ */
+export interface RoundComment {
+  id: string;
+  author: string;
+  body: string;
+  createdAt: string;
+}
+
+/**
  * Finding #5 — the READ-TIME (never-persisted) summary of the STILL-OPEN action
  * points carried by a TERMINAL loop's LAST recorded round. Convergence is keyed
  * on `P0` BY DESIGN (a loop converges the moment no P0 remains), but the judge

--- a/tests/unit/sdlc/worktree.test.ts
+++ b/tests/unit/sdlc/worktree.test.ts
@@ -149,6 +149,56 @@ describe("createSdlcWorktree — happy path", () => {
     const forced = git.calls.find((c) => c[0] === "worktree" && c[1] === "add" && c[2] === "-B");
     expect(forced).toEqual(["worktree", "add", "-B", BRANCH, res.worktreeDir, "main"]);
   });
+
+  it("force-removes a STILL-PRESENT stale worktree dir when prune alone can't clear it (killed-run recovery)", async () => {
+    // Arrange: the branch is registered to an abandoned worktree whose on-disk
+    // dir is still there (a killed run that never reached `removeSdlcWorktree`),
+    // so `prune` (no-op — the dir exists) + the first `-B` retry BOTH still
+    // collide. Only a `worktree list` lookup + a forced `remove` of the stale
+    // path should let the FINAL `-B` attempt succeed.
+    const stalePath = "/tmp/sdlc-wt-OLD/tree";
+    let addAttempts = 0;
+    const git = fakeGit((args) => {
+      if (args[0] === "worktree" && args[1] === "add") {
+        addAttempts += 1;
+        if (addAttempts < 3) {
+          throw new Error(`fatal: '${BRANCH}' is already used by worktree at '${stalePath}'`);
+        }
+        return "";
+      }
+      if (args[0] === "worktree" && args[1] === "list") {
+        return [
+          "worktree /allowlisted/omniscience",
+          "HEAD 0000000000000000000000000000000000000000",
+          "branch refs/heads/main",
+          "",
+          `worktree ${stalePath}`,
+          "HEAD 1111111111111111111111111111111111111111",
+          `branch refs/heads/${BRANCH}`,
+          "",
+        ].join("\n");
+      }
+      return "";
+    });
+
+    // Act
+    const res = await createSdlcWorktree({
+      repoPath: REPO,
+      branch: BRANCH,
+      baseRef: "main",
+      allowedRepoPaths: ROOTS,
+      gitRaw: git.raw,
+      mkdtempFn: fakeMkdtemp,
+    });
+
+    // Assert: it located + force-removed the stale worktree, then succeeded.
+    expect(res.branch).toBe(BRANCH);
+    const forcedRemove = git.calls.find(
+      (c) => c[0] === "worktree" && c[1] === "remove" && c[2] === "--force",
+    );
+    expect(forcedRemove).toEqual(["worktree", "remove", "--force", stalePath]);
+    expect(addAttempts).toBe(3);
+  });
 });
 
 describe("resolveDefaultBranch", () => {


### PR DESCRIPTION
## Summary
Bundled consilium-loop UX + reliability fixes (no schema pollution — only the loop-scoped additions).

- **Clickable Result PR/MR** — `ResultPanel` resolves `prRef` (GitHub PR `owner/repo#N`, GitLab MR `grp/proj!N`, or a plain `https://` URL) to a browsable URL and renders a clickable external link. URL resolution is **http/https only** (`new URL().protocol` guard) with `rel="noopener noreferrer"` — a `javascript:`/`data:` `prRef` can never become an href.
- **Result comments** — operators add threaded notes to a round result: `comments` jsonb column on `consilium_loop_rounds` (migration 0056), `POST /api/consilium-loops/:id/rounds/:round/comments` (owner/admin, body ≤8KB, author server-derived, rendered as plain text), and a dialog on the Result panel.
- **SDLC worktree isolation** — `git worktree prune` + force-remove a stale worktree holding the target branch + unique per-attempt worktree paths + robust cleanup in `finally`. Fixes `fatal: '…' is already used by worktree at '…'` on redrive/concurrent loops. Branch-shape validation (B-3) unchanged.
- **Commit-prefix** — optional per-loop prefix prepended to every commit subject and the MR/PR title (migration 0057, `commit_prefix` column), for repos whose commit hook requires an issue key.
- **Loop list** — section title now shows the clean repo basename.

## Test plan
- [x] `tsc --noEmit` clean (0 errors)
- [x] `resolvePrUrl` rejects non-http(s) schemes; renders link for GitHub/GitLab/https prRef
- [x] worktree unit test (`tests/unit/sdlc/worktree.test.ts`)
- [ ] Migrations 0056 + 0057 applied in target env (additive `ADD COLUMN IF NOT EXISTS`)
- [ ] Manual: add a comment on a round result; open a loop with a real prRef and click through