### PR TITLE
feat(credentials): secrets manager — vault CRUD + pluggable OpenBao backend

### DIFF
--- a/client/src/components/credentials/CredentialDialogs.tsx
+++ b/client/src/components/credentials/CredentialDialogs.tsx
@@ -1,0 +1,516 @@
+/**
+ * CredentialDialogs — create / rotate / edit / delete dialogs for the
+ * Credentials (Secrets) table on client/src/pages/CredentialAccess.tsx.
+ *
+ * Mirrors the AddEditDialog / DeleteConfirmDialog patterns in
+ * client/src/pages/Connections.tsx (~:771-916): controlled Dialog/AlertDialog
+ * open state driven by the parent, local form state reset on close, toast on
+ * success/failure so a 403 (non-admin) surfaces as a message instead of a crash.
+ */
+import { useEffect, useState } from "react";
+import { Loader2, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { SecretInput } from "@/components/credentials/SecretInput";
+import { useToast } from "@/hooks/use-toast";
+import {
+  useCreateCredential,
+  useUpdateCredential,
+  useDeleteCredential,
+  type CredentialMetadata,
+} from "@/hooks/use-credentials";
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : "Unexpected error";
+}
+
+// ── Create ────────────────────────────────────────────────────────────────────
+
+interface CreateCredentialDialogProps {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+}
+
+export function CreateCredentialDialog({
+  open,
+  onOpenChange,
+}: CreateCredentialDialogProps) {
+  const { toast } = useToast();
+  const createCredential = useCreateCredential();
+  const [name, setName] = useState("");
+  const [value, setValue] = useState("");
+  const [description, setDescription] = useState("");
+  const [provider, setProvider] = useState("");
+  const [scope, setScope] = useState("");
+
+  function reset() {
+    setName("");
+    setValue("");
+    setDescription("");
+    setProvider("");
+    setScope("");
+  }
+
+  function handleOpenChange(v: boolean) {
+    if (!v) {
+      reset();
+      createCredential.reset();
+    }
+    onOpenChange(v);
+  }
+
+  async function handleSubmit() {
+    if (!name.trim() || !value) return;
+    try {
+      const created = await createCredential.mutateAsync({
+        name: name.trim(),
+        value,
+        description: description.trim() || undefined,
+        provider: provider.trim() || undefined,
+        scope: scope.trim() || undefined,
+      });
+      toast({ title: "Secret created", description: created.name ?? name.trim() });
+      handleOpenChange(false);
+    } catch (err) {
+      toast({
+        title: "Create failed",
+        description: errorMessage(err),
+        variant: "destructive",
+      });
+    }
+  }
+
+  const canSubmit = name.trim().length > 0 && value.length > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-sm">Add Secret</DialogTitle>
+          <DialogDescription className="text-xs text-muted-foreground">
+            Register a new credential for this project. The value is encrypted
+            at rest and is never displayed again.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="cred-name" className="text-xs font-medium">
+              Name
+            </Label>
+            <Input
+              id="cred-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. github-deploy-token"
+              className="text-sm"
+            />
+          </div>
+
+          <SecretInput
+            id="cred-value"
+            label="Value"
+            value={value}
+            onChange={setValue}
+            placeholder="Paste secret value"
+          />
+
+          <div className="space-y-1.5">
+            <Label htmlFor="cred-description" className="text-xs font-medium">
+              Description
+            </Label>
+            <Input
+              id="cred-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What is this secret used for?"
+              className="text-sm"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="cred-provider" className="text-xs font-medium">
+                Provider
+              </Label>
+              <Input
+                id="cred-provider"
+                value={provider}
+                onChange={(e) => setProvider(e.target.value)}
+                placeholder="generic / jira / gitlab"
+                className="text-sm"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="cred-scope" className="text-xs font-medium">
+                Scope
+              </Label>
+              <Input
+                id="cred-scope"
+                value={scope}
+                onChange={(e) => setScope(e.target.value)}
+                placeholder="optional scope"
+                className="text-sm"
+              />
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={createCredential.isPending}
+            className="text-xs"
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={!canSubmit || createCredential.isPending}
+            className="text-xs"
+          >
+            {createCredential.isPending ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 mr-2 animate-spin" />
+                Creating…
+              </>
+            ) : (
+              "Create"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Rotate ────────────────────────────────────────────────────────────────────
+
+interface RotateCredentialDialogProps {
+  credential: CredentialMetadata | null;
+  onOpenChange: (v: boolean) => void;
+}
+
+export function RotateCredentialDialog({
+  credential,
+  onOpenChange,
+}: RotateCredentialDialogProps) {
+  const { toast } = useToast();
+  const updateCredential = useUpdateCredential();
+  const [value, setValue] = useState("");
+
+  useEffect(() => {
+    setValue("");
+    updateCredential.reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [credential?.id]);
+
+  function handleOpenChange(v: boolean) {
+    if (!v) {
+      setValue("");
+      updateCredential.reset();
+    }
+    onOpenChange(v);
+  }
+
+  async function handleSubmit() {
+    if (!credential || !value) return;
+    try {
+      await updateCredential.mutateAsync({ id: credential.id, value });
+      toast({
+        title: "Secret rotated",
+        description: credential.name ?? credential.provider,
+      });
+      handleOpenChange(false);
+    } catch (err) {
+      toast({
+        title: "Rotate failed",
+        description: errorMessage(err),
+        variant: "destructive",
+      });
+    }
+  }
+
+  return (
+    <Dialog open={!!credential} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="text-sm">Rotate Secret</DialogTitle>
+          <DialogDescription className="text-xs text-muted-foreground">
+            Paste a new value for{" "}
+            <span className="font-semibold text-foreground">
+              {credential?.name ?? credential?.provider}
+            </span>
+            . The previous value is discarded immediately.
+          </DialogDescription>
+        </DialogHeader>
+
+        <SecretInput
+          id="cred-rotate-value"
+          label="New value"
+          value={value}
+          onChange={setValue}
+          existingHasSecret={credential?.hasSecret}
+        />
+
+        <DialogFooter className="gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={updateCredential.isPending}
+            className="text-xs"
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={!value || updateCredential.isPending}
+            className="text-xs"
+          >
+            {updateCredential.isPending ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 mr-2 animate-spin" />
+                Rotating…
+              </>
+            ) : (
+              "Rotate"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Edit ──────────────────────────────────────────────────────────────────────
+
+interface EditCredentialDialogProps {
+  credential: CredentialMetadata | null;
+  onOpenChange: (v: boolean) => void;
+}
+
+export function EditCredentialDialog({
+  credential,
+  onOpenChange,
+}: EditCredentialDialogProps) {
+  const { toast } = useToast();
+  const updateCredential = useUpdateCredential();
+  const [description, setDescription] = useState("");
+  const [provider, setProvider] = useState("");
+  const [scope, setScope] = useState("");
+
+  useEffect(() => {
+    setDescription(credential?.description ?? "");
+    setProvider(credential?.provider ?? "");
+    setScope(credential?.scope ?? "");
+    updateCredential.reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [credential?.id]);
+
+  function handleOpenChange(v: boolean) {
+    if (!v) updateCredential.reset();
+    onOpenChange(v);
+  }
+
+  async function handleSubmit() {
+    if (!credential) return;
+    try {
+      await updateCredential.mutateAsync({
+        id: credential.id,
+        description: description.trim(),
+        provider: provider.trim(),
+        scope: scope.trim(),
+      });
+      toast({
+        title: "Secret updated",
+        description: credential.name ?? credential.provider,
+      });
+      handleOpenChange(false);
+    } catch (err) {
+      toast({
+        title: "Update failed",
+        description: errorMessage(err),
+        variant: "destructive",
+      });
+    }
+  }
+
+  return (
+    <Dialog open={!!credential} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-sm">
+            Edit — {credential?.name ?? credential?.provider}
+          </DialogTitle>
+          <DialogDescription className="text-xs text-muted-foreground">
+            Update metadata. To change the secret value, use Rotate instead.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="cred-edit-description" className="text-xs font-medium">
+              Description
+            </Label>
+            <Input
+              id="cred-edit-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="text-sm"
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="cred-edit-provider" className="text-xs font-medium">
+                Provider
+              </Label>
+              <Input
+                id="cred-edit-provider"
+                value={provider}
+                onChange={(e) => setProvider(e.target.value)}
+                className="text-sm"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="cred-edit-scope" className="text-xs font-medium">
+                Scope
+              </Label>
+              <Input
+                id="cred-edit-scope"
+                value={scope}
+                onChange={(e) => setScope(e.target.value)}
+                className="text-sm"
+              />
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={updateCredential.isPending}
+            className="text-xs"
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={updateCredential.isPending}
+            className="text-xs"
+          >
+            {updateCredential.isPending ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 mr-2 animate-spin" />
+                Saving…
+              </>
+            ) : (
+              "Save"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Delete ────────────────────────────────────────────────────────────────────
+
+interface DeleteCredentialDialogProps {
+  credential: CredentialMetadata | null;
+  onOpenChange: (v: boolean) => void;
+}
+
+export function DeleteCredentialDialog({
+  credential,
+  onOpenChange,
+}: DeleteCredentialDialogProps) {
+  const { toast } = useToast();
+  const deleteCredential = useDeleteCredential();
+
+  async function handleConfirm() {
+    if (!credential) return;
+    try {
+      await deleteCredential.mutateAsync(credential.id);
+      toast({
+        title: "Secret deleted",
+        description: credential.name ?? credential.provider,
+      });
+      onOpenChange(false);
+    } catch (err) {
+      toast({
+        title: "Delete failed",
+        description: errorMessage(err),
+        variant: "destructive",
+      });
+    }
+  }
+
+  return (
+    <AlertDialog open={!!credential} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="max-w-sm">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="text-sm">Delete Secret</AlertDialogTitle>
+          <AlertDialogDescription className="text-xs">
+            Are you sure you want to delete{" "}
+            <span className="font-semibold text-foreground">
+              {credential?.name ?? credential?.provider}
+            </span>
+            ? This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={deleteCredential.isPending}>
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault();
+              void handleConfirm();
+            }}
+            disabled={deleteCredential.isPending}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {deleteCredential.isPending ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 mr-2 animate-spin" />
+                Deleting…
+              </>
+            ) : (
+              <>
+                <Trash2 className="h-3.5 w-3.5 mr-1.5" />
+                Delete
+              </>
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/client/src/components/credentials/SecretInput.tsx
+++ b/client/src/components/credentials/SecretInput.tsx
@@ -1,0 +1,72 @@
+/**
+ * SecretInput — masked value input with reveal toggle.
+ *
+ * Lifted from client/src/pages/Connections.tsx (~:424-473) so the same
+ * "masked by default, paste to rotate" affordance is shared between the
+ * connections config forms and the credentials (secrets) CRUD dialogs.
+ */
+import { useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface SecretInputProps {
+  id: string;
+  label: string;
+  value: string;
+  placeholder?: string;
+  onChange: (val: string) => void;
+  /** True when the credential already has a stored secret — shows the "paste to rotate" hint. */
+  existingHasSecret?: boolean;
+}
+
+export function SecretInput({
+  id,
+  label,
+  value,
+  placeholder,
+  onChange,
+  existingHasSecret,
+}: SecretInputProps) {
+  const [revealed, setRevealed] = useState(false);
+
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id} className="text-xs font-medium">
+        {label}
+        {existingHasSecret && !value && (
+          <span className="ml-2 text-[10px] text-muted-foreground font-normal">
+            (secret already stored — paste to rotate)
+          </span>
+        )}
+      </Label>
+      <div className="relative">
+        <Input
+          id={id}
+          type={revealed ? "text" : "password"}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={
+            existingHasSecret && !value
+              ? "Leave blank to keep existing secret"
+              : (placeholder ?? "")
+          }
+          className="pr-9 text-sm font-mono"
+          autoComplete="new-password"
+        />
+        <button
+          type="button"
+          onClick={() => setRevealed((v) => !v)}
+          aria-label={revealed ? "Hide secret" : "Reveal secret"}
+          className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {revealed ? (
+            <EyeOff className="h-3.5 w-3.5" />
+          ) : (
+            <Eye className="h-3.5 w-3.5" />
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/layout/MainLayout.tsx
+++ b/client/src/components/layout/MainLayout.tsx
@@ -98,7 +98,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
         ]
       : []),
     { icon: BarChart3, label: "Statistics", href: "/" },
-    { icon: KeyRound, label: "Credential Access", href: "/credentials" },
+    { icon: KeyRound, label: "Secrets", href: "/credentials" },
     { icon: Settings, label: "Settings", href: "/settings" },
     { icon: Radio, label: "Config Sync", href: "/settings/peers" },
     // Admin-only: User Management

--- a/client/src/hooks/use-credentials.ts
+++ b/client/src/hooks/use-credentials.ts
@@ -1,0 +1,110 @@
+/**
+ * use-credentials — create/rotate/edit/delete mutations for the project
+ * credential (secrets) vault, mirroring the mutation + invalidation shape of
+ * client/src/hooks/use-connections.ts but wired through the shared
+ * lib/queryClient apiRequest helper (Bearer + x-project-id headers are
+ * injected automatically by buildAuthHeaders).
+ *
+ * Reads are handled directly in CredentialAccess.tsx via useQuery — this file
+ * only owns the write path.
+ */
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/queryClient";
+import { useProjects } from "@/hooks/use-projects";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** Credential metadata as returned by the broker API. The secret value is never included. */
+export interface CredentialMetadata {
+  id: string;
+  projectId: string;
+  name: string | null;
+  provider: string;
+  scope: string;
+  description: string;
+  hasSecret: boolean;
+  version: number;
+  createdAt?: string | null;
+  rotatedAt?: string | null;
+}
+
+export interface CreateCredentialInput {
+  name: string;
+  value: string;
+  description?: string;
+  scope?: string;
+  provider?: string;
+}
+
+export interface UpdateCredentialInput {
+  value?: string;
+  description?: string;
+  scope?: string;
+  provider?: string;
+}
+
+// ── Query keys ────────────────────────────────────────────────────────────────
+
+function credentialsKey(projectId: string | null) {
+  return ["/api/credentials", projectId] as const;
+}
+
+function accessLogKeyPrefix(projectId: string | null) {
+  return ["/api/credentials/access-log", projectId] as const;
+}
+
+// ── Mutations ─────────────────────────────────────────────────────────────────
+
+export function useCreateCredential() {
+  const qc = useQueryClient();
+  const { currentProject } = useProjects();
+  const projectId = currentProject?.id ?? null;
+
+  return useMutation<CredentialMetadata, Error, CreateCredentialInput>({
+    mutationFn: async (input) => {
+      const res = await apiRequest("POST", "/api/credentials", input);
+      return (await res.json()) as CredentialMetadata;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: credentialsKey(projectId) });
+      qc.invalidateQueries({ queryKey: accessLogKeyPrefix(projectId) });
+    },
+  });
+}
+
+export function useUpdateCredential() {
+  const qc = useQueryClient();
+  const { currentProject } = useProjects();
+  const projectId = currentProject?.id ?? null;
+
+  return useMutation<
+    CredentialMetadata,
+    Error,
+    { id: string } & UpdateCredentialInput
+  >({
+    mutationFn: async ({ id, ...updates }) => {
+      const res = await apiRequest("PATCH", `/api/credentials/${id}`, updates);
+      return (await res.json()) as CredentialMetadata;
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: credentialsKey(projectId) });
+      qc.invalidateQueries({ queryKey: accessLogKeyPrefix(projectId) });
+    },
+  });
+}
+
+export function useDeleteCredential() {
+  const qc = useQueryClient();
+  const { currentProject } = useProjects();
+  const projectId = currentProject?.id ?? null;
+
+  return useMutation<void, Error, string>({
+    mutationFn: async (id) => {
+      await apiRequest("DELETE", `/api/credentials/${id}`);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: credentialsKey(projectId) });
+      qc.invalidateQueries({ queryKey: accessLogKeyPrefix(projectId) });
+    },
+  });
+}

--- a/client/src/pages/CredentialAccess.tsx
+++ b/client/src/pages/CredentialAccess.tsx
@@ -18,6 +18,13 @@ import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
 import { useProjects } from "@/hooks/use-projects";
+import type { CredentialMetadata } from "@/hooks/use-credentials";
+import {
+  CreateCredentialDialog,
+  DeleteCredentialDialog,
+  EditCredentialDialog,
+  RotateCredentialDialog,
+} from "@/components/credentials/CredentialDialogs";
 import {
   Card,
   CardContent,
@@ -26,6 +33,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Table,
   TableBody,
@@ -55,22 +63,19 @@ import {
   FileText,
   KeyRound,
   Lock,
+  Pencil,
+  Plus,
+  RotateCw,
   ShieldOff,
+  Trash2,
   XCircle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 // ── API types ─────────────────────────────────────────────────────────────────
 
-interface Credential {
-  id: string;
-  projectId: string;
-  provider: string;
-  scope: string;
-  description: string;
-  hasSecret: boolean;
-  lastRotatedAt?: string | null;
-}
+/** Credential metadata (see hooks/use-credentials.ts for the canonical shape). */
+type Credential = CredentialMetadata;
 
 interface AccessLogEntry {
   id: string;
@@ -198,6 +203,10 @@ export default function CredentialAccess() {
   const projectId = currentProject?.id ?? null;
 
   const [logLimit, setLogLimit] = useState<number>(100);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [rotateTarget, setRotateTarget] = useState<Credential | null>(null);
+  const [editTarget, setEditTarget] = useState<Credential | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Credential | null>(null);
 
   // ── Credential inventory ────────────────────────────────────────────────
   // projectId is included in the queryKey so react-query automatically refetches
@@ -249,11 +258,11 @@ export default function CredentialAccess() {
         <div className="flex items-start gap-3">
           <Lock className="h-6 w-6 text-primary mt-0.5 shrink-0" />
           <div>
-            <h1 className="text-xl font-semibold">Credential Access</h1>
+            <h1 className="text-xl font-semibold">Secrets</h1>
             <p className="text-sm text-muted-foreground mt-0.5">
-              Per-project credential inventory, audit log, and active leases.
-              Secret values are <strong>never</strong> exposed here — metadata
-              only.
+              Manage project secrets — create, rotate, and revoke credentials
+              used by pipelines and integrations. Secret values are{" "}
+              <strong>never</strong> exposed here — metadata only.
             </p>
           </div>
         </div>
@@ -261,9 +270,20 @@ export default function CredentialAccess() {
         {/* ── Section 1: Credential inventory ──────────────────────────────── */}
         <Card>
           <CardHeader className="pb-3">
-            <div className="flex items-center gap-2">
-              <KeyRound className="h-4 w-4 text-muted-foreground" />
-              <CardTitle className="text-base">Credentials</CardTitle>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <KeyRound className="h-4 w-4 text-muted-foreground" />
+                <CardTitle className="text-base">Credentials</CardTitle>
+              </div>
+              <Button
+                size="sm"
+                variant="outline"
+                className="text-xs h-7"
+                onClick={() => setCreateOpen(true)}
+              >
+                <Plus className="h-3.5 w-3.5 mr-1.5" />
+                Add secret
+              </Button>
             </div>
             <CardDescription>
               Registered credentials for this project. The secret value is
@@ -284,17 +304,22 @@ export default function CredentialAccess() {
                 <Table>
                   <TableHeader>
                     <TableRow>
+                      <TableHead>Name</TableHead>
                       <TableHead>Provider</TableHead>
                       <TableHead>Scope</TableHead>
                       <TableHead>Description</TableHead>
                       <TableHead>Secret</TableHead>
                       <TableHead>Last Rotated</TableHead>
+                      <TableHead className="text-right">Actions</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
                     {credentialsQuery.data.map((cred) => (
                       <TableRow key={cred.id}>
-                        <TableCell className="font-medium font-mono text-xs">
+                        <TableCell className="font-medium text-xs">
+                          {cred.name ?? "—"}
+                        </TableCell>
+                        <TableCell className="font-mono text-xs text-muted-foreground">
                           {cred.provider}
                         </TableCell>
                         <TableCell className="font-mono text-xs text-muted-foreground">
@@ -321,7 +346,38 @@ export default function CredentialAccess() {
                           )}
                         </TableCell>
                         <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
-                          {formatDateTime(cred.lastRotatedAt)}
+                          {formatDateTime(cred.rotatedAt)}
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center justify-end gap-1">
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className="h-7 w-7"
+                              aria-label="Rotate secret"
+                              onClick={() => setRotateTarget(cred)}
+                            >
+                              <RotateCw className="h-3.5 w-3.5" />
+                            </Button>
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className="h-7 w-7"
+                              aria-label="Edit secret"
+                              onClick={() => setEditTarget(cred)}
+                            >
+                              <Pencil className="h-3.5 w-3.5" />
+                            </Button>
+                            <Button
+                              size="icon"
+                              variant="ghost"
+                              className="h-7 w-7 text-destructive hover:text-destructive"
+                              aria-label="Delete secret"
+                              onClick={() => setDeleteTarget(cred)}
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </Button>
+                          </div>
                         </TableCell>
                       </TableRow>
                     ))}
@@ -542,6 +598,20 @@ export default function CredentialAccess() {
         </Card>
 
       </div>
+
+      <CreateCredentialDialog open={createOpen} onOpenChange={setCreateOpen} />
+      <RotateCredentialDialog
+        credential={rotateTarget}
+        onOpenChange={(v) => !v && setRotateTarget(null)}
+      />
+      <EditCredentialDialog
+        credential={editTarget}
+        onOpenChange={(v) => !v && setEditTarget(null)}
+      />
+      <DeleteCredentialDialog
+        credential={deleteTarget}
+        onOpenChange={(v) => !v && setDeleteTarget(null)}
+      />
     </ScrollArea>
   );
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -217,6 +217,27 @@ services:
       start_period: 30s
     restart: unless-stopped
 
+  # ── OpenBao (Vault-compatible secrets backend, OPTIONAL — secrets-manager Phase 2) ──
+  # Dev-mode only (in-memory, unsealed on boot, single root token). NOT started by
+  # any of the default profiles (full/cloud-only/dev) -- opt in with:
+  #   docker compose --profile secrets up -d openbao
+  # Then set MULTI_CREDENTIALS_BACKEND=openbao, MULTI_CREDENTIALS_OPENBAO_ADDR=http://openbao:8200,
+  # and OPENBAO_TOKEN=dev-root-token on the multiqlti service.
+  openbao:
+    image: openbao/openbao:latest
+    profiles: [secrets]
+    cap_add:
+      - IPC_LOCK
+    environment:
+      OPENBAO_DEV_ROOT_TOKEN_ID: dev-root-token
+      OPENBAO_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
+    command: server -dev
+    ports:
+      - "8200:8200"
+    networks:
+      - internal
+    restart: unless-stopped
+
   # ── Prometheus ──────────────────────────────────────────────────────────────
   prometheus:
     image: prom/prometheus:latest

--- a/migrations/0058_secrets_vault.sql
+++ b/migrations/0058_secrets_vault.sql
@@ -1,0 +1,47 @@
+-- migration: 0058_secrets_vault
+-- Phase 1 secrets manager — project-scoped secrets vault table.
+--
+-- Purpose:
+--   Introduces `secrets`, a named/versioned credential store owned directly by
+--   a project (distinct from the workspaceConnections-backed credentials that
+--   DbCryptoCredentialProvider also serves). `value_encrypted` holds AES-256-GCM
+--   ciphertext (crypto.ts `v2:` format) and is written/read ONLY inside
+--   server/credentials/db-crypto-provider.ts. project_id NOT NULL → projects(id)
+--   enforces hard project isolation; the application layer additionally asserts
+--   projectId === getProjectId() on every broker method.
+--
+-- Deploy sequence (push-based):
+--   1. psql "$DATABASE_URL" -f migrations/0058_secrets_vault.sql
+--   2. npm run db:push   (schema.ts already declares the table; push is a no-op
+--      for the DDL once the DB has it; safe to run regardless)
+--
+-- Idempotent: all DDL uses IF NOT EXISTS.
+-- Transactional: wrapped in BEGIN/COMMIT.
+-- Additive only — no existing table/column touched.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS secrets (
+  id               TEXT        PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+  project_id       TEXT        NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  name             TEXT        NOT NULL,
+  description      TEXT,
+  scope            TEXT,
+  provider         TEXT,
+  value_encrypted  TEXT,
+  version          INTEGER     NOT NULL DEFAULT 1,
+  created_by       TEXT,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  rotated_at       TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS secrets_project_name_idx
+  ON secrets (project_id, name);
+
+COMMIT;
+
+-- ─── Rollback (for reference — not auto-applied) ───────────────────────────────
+--
+--   BEGIN;
+--   DROP TABLE IF EXISTS secrets;
+--   COMMIT;

--- a/server/config/loader.ts
+++ b/server/config/loader.ts
@@ -115,6 +115,14 @@ const ENV_MAPPINGS: EnvMapping[] = [
   { envKey: "MULTI_PROVIDERS_ANTIGRAVITY_TIMEOUT_MS",configPath: ["providers", "antigravity", "timeoutMs"],       kind: "number"  },
   { envKey: "MULTI_FEATURES_SANDBOX_ENABLED",        configPath: ["features", "sandbox", "enabled"],              kind: "boolean" },
   { envKey: "MULTI_ENCRYPTION_KEY",                  configPath: ["encryption", "key"],                           kind: "string"  },
+  // Credential VALUE store backend selection (secrets-manager Phase 2).
+  // NOTE: the OpenBao TOKEN is NOT env-mapped here -- it is read directly from
+  // process.env at call time (see schema `credentials.openbao.tokenEnv`).
+  { envKey: "MULTI_CREDENTIALS_BACKEND",             configPath: ["credentials", "backend"],                       kind: "string"  },
+  { envKey: "MULTI_CREDENTIALS_OPENBAO_ADDR",        configPath: ["credentials", "openbao", "addr"],              kind: "string"  },
+  { envKey: "MULTI_CREDENTIALS_OPENBAO_MOUNT",       configPath: ["credentials", "openbao", "mount"],             kind: "string"  },
+  { envKey: "MULTI_CREDENTIALS_OPENBAO_NAMESPACE",   configPath: ["credentials", "openbao", "namespace"],         kind: "string"  },
+  { envKey: "MULTI_CREDENTIALS_OPENBAO_TOKEN_ENV",   configPath: ["credentials", "openbao", "tokenEnv"],          kind: "string"  },
   { envKey: "MULTI_FEDERATION_ENABLED",              configPath: ["federation", "enabled"],                       kind: "boolean" },
   { envKey: "MULTI_FEDERATION_INSTANCE_ID",          configPath: ["federation", "instanceId"],                    kind: "string"  },
   { envKey: "MULTI_FEDERATION_INSTANCE_NAME",        configPath: ["federation", "instanceName"],                  kind: "string"  },

--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -197,6 +197,35 @@ export const ConfigSchema = z.object({
     key: z.string().min(32).optional(),
   }).default({}),
   /**
+   * Credential/secrets VALUE store backend selection (secrets-manager Phase 2).
+   *
+   * `credentials.backend` selects where secret VALUES live:
+   *   - "db"      — existing AES-encrypted `secrets.valueEncrypted` column (default).
+   *   - "openbao" — OpenBao (Vault-compatible) KV v2 store; the `secrets` table still
+   *                 holds METADATA only (valueEncrypted stays NULL for openbao rows).
+   *
+   * Nothing changes by default: the backend is "db" unless explicitly switched.
+   *
+   * The OpenBao auth token is NEVER stored in config — it is read at call time from
+   * the environment variable named by `openbao.tokenEnv` (defaults to OPENBAO_TOKEN).
+   */
+  credentials: z.object({
+    backend: z.enum(["db", "openbao"]).default("db"),
+    openbao: z.object({
+      /** OpenBao server address, e.g. "http://127.0.0.1:8200". Required when backend=openbao. */
+      addr: z.string().url().optional(),
+      /** KV v2 mount path (no leading/trailing slash). */
+      mount: z.string().default("secret"),
+      /** Optional OpenBao namespace (Enterprise-compatible; usually unset in dev). */
+      namespace: z.string().optional(),
+      /**
+       * Name of the environment variable that holds the OpenBao auth token. The
+       * token value itself is never persisted in config. Defaults to OPENBAO_TOKEN.
+       */
+      tokenEnv: z.string().default("OPENBAO_TOKEN"),
+    }).default({}),
+  }).default({}),
+  /**
    * Memory / retrieval backend selection (memory-architecture ADR, Track A).
    *
    * `retrieval.backend` selects the world-knowledge retrieval path:

--- a/server/credentials/db-crypto-provider.ts
+++ b/server/credentials/db-crypto-provider.ts
@@ -15,12 +15,13 @@
 import { eq, and, lt } from "drizzle-orm";
 import { db } from "../db.js";
 import { getProjectId, requestContext } from "../context.js";
-import { decrypt } from "../crypto.js";
+import { encrypt, decrypt } from "../crypto.js";
 import {
   workspaceConnections,
   workspaces,
   credentialLeases,
   credentialAccessLog,
+  secrets,
 } from "../../shared/schema.js";
 import type {
   CredentialMetadata,
@@ -37,7 +38,7 @@ import { ForbiddenError } from "./types.js";
  * getProjectId() already throws in system context and when context is absent —
  * those errors propagate as-is (they are also security barriers).
  */
-function assertProject(projectId: string): void {
+export function assertProject(projectId: string): void {
   const ctx = getProjectId();
   if (ctx !== projectId) {
     throw new ForbiddenError(
@@ -51,7 +52,7 @@ function assertProject(projectId: string): void {
  * Write one row to credential_access_log.  Uses db directly (no withProject) so
  * it works both from project-context methods and from the system-scoped sweeper.
  */
-async function writeAccessLog(entry: {
+export async function writeAccessLog(entry: {
   leaseId?: string | null;
   credentialId: string;
   projectId: string;
@@ -132,6 +133,36 @@ function toMetadata(
   };
 }
 
+/** Convert a `secrets` vault row to CredentialMetadata. NEVER includes valueEncrypted. */
+export function toSecretMetadata(
+  row: typeof secrets.$inferSelect,
+  projectId: string,
+): CredentialMetadata {
+  return {
+    id: row.id,
+    projectId,
+    provider: row.provider ?? "vault",
+    scope: row.scope ?? "",
+    description: row.description ?? "",
+    hasSecret: row.valueEncrypted !== null,
+    lastRotatedAt: row.rotatedAt ?? row.createdAt,
+    name: row.name,
+    version: row.version,
+  };
+}
+
+/** Resolve a vault secret row that belongs to the given project, or null. */
+export async function getSecretForProject(
+  credentialId: string,
+  projectId: string,
+): Promise<typeof secrets.$inferSelect | null> {
+  const [row] = await db
+    .select()
+    .from(secrets)
+    .where(and(eq(secrets.id, credentialId), eq(secrets.projectId, projectId)));
+  return row ?? null;
+}
+
 // ─── DbCryptoCredentialProvider ───────────────────────────────────────────────
 
 export class DbCryptoCredentialProvider implements CredentialProvider {
@@ -163,7 +194,13 @@ export class DbCryptoCredentialProvider implements CredentialProvider {
       .innerJoin(workspaces, eq(workspaces.id, workspaceConnections.workspaceId))
       .where(eq(workspaces.projectId, projectId));
 
-    const metadata = rows.map((r) => toMetadata(r, projectId));
+    const connectionMetadata = rows.map((r) => toMetadata(r, projectId));
+
+    const secretRows = await db
+      .select()
+      .from(secrets)
+      .where(eq(secrets.projectId, projectId));
+    const secretMetadata = secretRows.map((r) => toSecretMetadata(r, projectId));
 
     await writeAccessLog({
       credentialId: "*",
@@ -173,7 +210,7 @@ export class DbCryptoCredentialProvider implements CredentialProvider {
       success: true,
     });
 
-    return metadata;
+    return [...connectionMetadata, ...secretMetadata];
   }
 
   /**
@@ -188,16 +225,19 @@ export class DbCryptoCredentialProvider implements CredentialProvider {
     assertProject(projectId);
 
     const row = await getConnectionForProject(credentialId, projectId);
+    const secretRow = row ? null : await getSecretForProject(credentialId, projectId);
 
     await writeAccessLog({
       credentialId,
       projectId,
       action: "get_metadata",
       requestedBy: projectId,
-      success: row !== null,
+      success: row !== null || secretRow !== null,
     });
 
-    return row ? toMetadata(row, projectId) : null;
+    if (row) return toMetadata(row, projectId);
+    if (secretRow) return toSecretMetadata(secretRow, projectId);
+    return null;
   }
 
   // ── EXEC-TIME ───────────────────────────────────────────────────────────────
@@ -386,42 +426,173 @@ export class DbCryptoCredentialProvider implements CredentialProvider {
     return plaintext;
   }
 
-  // ── CREDENTIAL STORE ─────────────────────────────────────────────────────────
+  // ── CREDENTIAL STORE (Secrets Vault, Phase 1) ────────────────────────────────
 
   /**
-   * putCredential — not implemented in Wave 1.
+   * Create or rotate a vault secret, upserted by (projectId, name).
    *
-   * The `workspaceConnections` store requires a `workspaceId` that the broker
-   * interface does not carry.  This method will be fully implemented in Wave 2
-   * when the Vault backend (which has its own key-value store) is wired in.
-   *
-   * Callers who need to create workspace connections should use the workspace
-   * connections API directly (POST /api/workspaces/:id/connections).
+   * `name` is required — vault secrets are named; connection-backed credentials
+   * (workspaceConnections) are managed via the workspace connections API instead.
+   * Every call encrypts `secret` and writes it to `valueEncrypted`, bumping
+   * `version` and setting `rotatedAt` on update (version starts at 1 on create).
+   * Writes a credential_access_log row (action='secret_created'|'secret_rotated').
    */
-  async putCredential(_p: {
+  async putCredential(p: {
     projectId: string;
     provider: string;
     scope: string;
     description: string;
     secret: string;
+    name?: string;
   }): Promise<CredentialMetadata> {
-    throw new Error(
-      "putCredential is not implemented in Wave 1. " +
-        "Use the workspace connections API to create credentials. " +
-        "This method will be implemented in Wave 2 (Vault backend).",
-    );
+    assertProject(p.projectId);
+
+    if (!p.name) {
+      throw new Error(
+        "putCredential: `name` is required to create/rotate a vault secret. " +
+          "Connection-backed credentials are managed via the workspace connections API.",
+      );
+    }
+
+    const ciphertext = encrypt(p.secret);
+    const existing = await db
+      .select()
+      .from(secrets)
+      .where(and(eq(secrets.projectId, p.projectId), eq(secrets.name, p.name)))
+      .then(([row]) => row ?? null);
+
+    const now = new Date();
+    const [row] = existing
+      ? await db
+          .update(secrets)
+          .set({
+            provider: p.provider,
+            scope: p.scope,
+            description: p.description,
+            valueEncrypted: ciphertext,
+            version: existing.version + 1,
+            rotatedAt: now,
+          })
+          .where(eq(secrets.id, existing.id))
+          .returning()
+      : await db
+          .insert(secrets)
+          .values({
+            projectId: p.projectId,
+            name: p.name,
+            provider: p.provider,
+            scope: p.scope,
+            description: p.description,
+            valueEncrypted: ciphertext,
+            version: 1,
+            createdBy: p.projectId,
+          })
+          .returning();
+
+    await writeAccessLog({
+      credentialId: row.id,
+      projectId: p.projectId,
+      action: existing ? "secret_rotated" : "secret_created",
+      requestedBy: p.projectId,
+      success: true,
+    });
+
+    return toSecretMetadata(row, p.projectId);
   }
 
   /**
-   * deleteCredential — not implemented in Wave 1.
-   * Use the workspace connections DELETE endpoint instead.
+   * Delete a vault secret (project-scoped). Throws if the secret does not
+   * exist in this project (no cross-project deletion, no silent no-op).
+   * Writes a credential_access_log row (action='secret_deleted').
    */
-  async deleteCredential(_projectId: string, _credentialId: string): Promise<void> {
-    throw new Error(
-      "deleteCredential is not implemented in Wave 1. " +
-        "Use the workspace connections API to delete credentials. " +
-        "This method will be implemented in Wave 2 (Vault backend).",
-    );
+  async deleteCredential(projectId: string, credentialId: string): Promise<void> {
+    assertProject(projectId);
+
+    const existing = await getSecretForProject(credentialId, projectId);
+    if (!existing) {
+      throw new Error(
+        `deleteCredential: secret ${credentialId} not found in project ${projectId}.`,
+      );
+    }
+
+    await db.delete(secrets).where(eq(secrets.id, credentialId));
+
+    await writeAccessLog({
+      credentialId,
+      projectId,
+      action: "secret_deleted",
+      requestedBy: projectId,
+      success: true,
+    });
+  }
+
+  /**
+   * Decrypt and return the current value of a vault secret.
+   * Writes a credential_access_log row (action='secret_accessed'), including
+   * on failure (not-found / decrypt error), mirroring accessSecret's audit
+   * discipline. This is a sanctioned crypto.decrypt() call site.
+   */
+  async getSecretValue(p: {
+    projectId: string;
+    credentialId: string;
+    purpose: string;
+    requestedBy?: string;
+  }): Promise<string> {
+    assertProject(p.projectId);
+    const requestedBy = p.requestedBy ?? p.projectId;
+
+    const row = await getSecretForProject(p.credentialId, p.projectId);
+    if (!row || row.valueEncrypted === null) {
+      await writeAccessLog({
+        credentialId: p.credentialId,
+        projectId: p.projectId,
+        action: "secret_accessed",
+        requestedBy,
+        justification: p.purpose,
+        success: false,
+        errorMessage: "secret not found or has no value",
+      }).catch((auditErr: unknown) => {
+        console.warn("[credential-broker] audit write failed:", auditErr);
+      });
+      throw new Error(
+        `getSecretValue: secret ${p.credentialId} not found in project ${p.projectId}, or has no value.`,
+      );
+    }
+
+    let plaintext: string;
+    try {
+      // ─── Sanctioned crypto.decrypt() call site (kept inside db-crypto-provider). ───
+      plaintext = decrypt(row.valueEncrypted);
+    } catch (e) {
+      await writeAccessLog({
+        credentialId: p.credentialId,
+        projectId: p.projectId,
+        action: "secret_accessed",
+        requestedBy,
+        justification: p.purpose,
+        success: false,
+        errorMessage: (e as Error).message,
+      }).catch((auditErr: unknown) => {
+        console.warn(
+          "[credential-broker] audit write failed on decrypt error:",
+          auditErr,
+        );
+      });
+      throw e;
+    }
+
+    await writeAccessLog({
+      credentialId: p.credentialId,
+      projectId: p.projectId,
+      action: "secret_accessed",
+      requestedBy,
+      justification: p.purpose,
+      success: true,
+    }).catch((auditErr: unknown) => {
+      console.warn("[credential-broker] audit write failed:", auditErr);
+    });
+
+    return plaintext;
   }
 }
 
@@ -506,5 +677,16 @@ export async function expireStaleLeases(): Promise<number> {
 
 // ─── Singleton export ─────────────────────────────────────────────────────────
 
-/** Default singleton — import this in Wave-2 wiring. */
-export const credentialProvider: CredentialProvider = new DbCryptoCredentialProvider();
+/**
+ * Default singleton — import this in Wave-2 wiring.
+ *
+ * Phase 2 (secrets-manager pluggable backend): the concrete implementation
+ * (DbCryptoCredentialProvider vs OpenBaoCredentialProvider) is now selected by
+ * `createCredentialProvider` (see factory.ts) based on `config.credentials.backend`.
+ * Re-exported here — rather than constructed here — so every existing importer
+ * of `credentialProvider` from this module path keeps working unchanged.
+ * (This creates an intentional import cycle between db-crypto-provider.ts and
+ * factory.ts; safe because DbCryptoCredentialProvider is fully defined, above,
+ * before this re-export is evaluated.)
+ */
+export { credentialProvider } from "./factory.js";

--- a/server/credentials/factory.ts
+++ b/server/credentials/factory.ts
@@ -1,0 +1,57 @@
+/**
+ * factory.ts — Phase 2 pluggable credential provider selection (secrets-manager
+ * Phase 2). Chooses the concrete `CredentialProvider` implementation based on
+ * `config.credentials.backend`:
+ *   - "db"      (default) → DbCryptoCredentialProvider (AES-in-Postgres, Phase 1).
+ *   - "openbao" → OpenBaoCredentialProvider (OpenBao KV v2 for values, Postgres
+ *                 for metadata/audit — see openbao-provider.ts).
+ *
+ * The module-level `credentialProvider` singleton is defined HERE (not in
+ * db-crypto-provider.ts) and re-exported from db-crypto-provider.ts, to avoid a
+ * hard circular-import cycle between "this factory needs the DbCrypto class"
+ * and "db-crypto-provider.ts needs to export the singleton". Every existing
+ * importer keeps importing `credentialProvider` from
+ * `./credentials/db-crypto-provider.js` unchanged.
+ */
+
+import { configLoader } from "../config/loader.js";
+import type { AppConfig } from "../config/schema.js";
+import { DbCryptoCredentialProvider } from "./db-crypto-provider.js";
+import { OpenBaoCredentialProvider } from "./openbao-provider.js";
+import type { CredentialProvider } from "./types.js";
+
+/** Build a CredentialProvider for the configured backend. Pure function — no caching. */
+export function createCredentialProvider(config: AppConfig): CredentialProvider {
+  const backend = config.credentials?.backend ?? "db";
+  if (backend === "openbao") {
+    return new OpenBaoCredentialProvider(config);
+  }
+  return new DbCryptoCredentialProvider();
+}
+
+/**
+ * Default singleton, resolved LAZILY on first use (not at module load) from the
+ * process config. Re-exported from db-crypto-provider.ts so existing importers
+ * are unaffected. Lazy resolution is required to break the ESM cycle
+ * factory.ts ⇄ db-crypto-provider.ts: an eager top-level `new
+ * DbCryptoCredentialProvider()` here runs while db-crypto-provider.ts is still
+ * mid-load, hitting the class binding in its temporal dead zone. The Proxy
+ * instantiates on the first method/property access — well after all modules
+ * have finished loading.
+ */
+let resolvedProvider: CredentialProvider | null = null;
+
+function getProvider(): CredentialProvider {
+  return (resolvedProvider ??= createCredentialProvider(configLoader.get()));
+}
+
+export const credentialProvider: CredentialProvider = new Proxy(
+  {} as CredentialProvider,
+  {
+    get(_target, prop) {
+      const instance = getProvider() as unknown as Record<string | symbol, unknown>;
+      const value = instance[prop];
+      return typeof value === "function" ? value.bind(instance) : value;
+    },
+  },
+);

--- a/server/credentials/openbao-provider.ts
+++ b/server/credentials/openbao-provider.ts
@@ -1,0 +1,374 @@
+/**
+ * OpenBaoCredentialProvider — Phase 2 pluggable VALUE store (secrets-manager Phase 2).
+ *
+ * Secret METADATA (id, projectId, name, description, scope, provider, version,
+ * createdBy, createdAt, rotatedAt) still lives in the Postgres `secrets` table —
+ * this class WRAPS a DbCryptoCredentialProvider for ALL metadata / lease /
+ * non-lease-decrypt / audit operations, and only overrides the vault-secret
+ * VALUE read/write/delete path. `valueEncrypted` is always left NULL for
+ * openbao-backed rows: the plaintext never touches Postgres.
+ *
+ * Secret VALUES live in OpenBao (Vault-compatible) KV v2, at:
+ *   <mount>/data/<projectId>/<name>          (payload: { data: { value: <secret> } })
+ *
+ * Auth: `X-Vault-Token` is read from `process.env[tokenEnv]` at call time — the
+ * token is NEVER stored in config and NEVER logged. Fail-closed: if `addr` or the
+ * token env var is missing, the request is not attempted and a clear error is
+ * thrown. SSRF containment: the request origin comes ONLY from operator config
+ * (`config.credentials.openbao.addr`); path segments are the already-validated
+ * `projectId`/`name` (URI-encoded), never raw pass-through user input.
+ *
+ * Mirrors the transport discipline of
+ * server/services/consilium/trackers/gitlab-exec.ts (AbortController timeout,
+ * scrubbed errors, no secret material logged).
+ */
+
+import { eq, and } from "drizzle-orm";
+import { db } from "../db.js";
+import { secrets } from "../../shared/schema.js";
+import {
+  DbCryptoCredentialProvider,
+  assertProject,
+  writeAccessLog,
+  getSecretForProject,
+  toSecretMetadata,
+} from "./db-crypto-provider.js";
+import type {
+  CredentialMetadata,
+  CredentialProvider,
+  AccessSecretParams,
+} from "./types.js";
+import type { AppConfig } from "../config/schema.js";
+
+/** Per-call wall-clock budget for an OpenBao request. */
+const OPENBAO_TIMEOUT_MS = 15_000;
+
+/** Resolved OpenBao connection settings (addr may be absent → fail-closed). */
+export interface OpenBaoConnectionConfig {
+  addr?: string;
+  mount: string;
+  namespace?: string;
+  tokenEnv: string;
+}
+
+/** Scrub any absolute path + collapse whitespace from an error string, then clamp. */
+function scrub(raw: string): string {
+  return raw.replace(/\/[^\s'"]+/g, "<path>").replace(/\s+/g, " ").trim().slice(0, 300);
+}
+
+/** Read the OpenBao auth token from ENV (fail-closed). NEVER logged by this module. */
+function readOpenBaoToken(
+  tokenEnv: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const token = (env[tokenEnv] ?? "").trim();
+  return token.length > 0 ? token : null;
+}
+
+/** Build the KV v2 data path for a project-scoped secret (project/name are pre-validated). */
+function kvDataPath(mount: string, projectId: string, name: string): string {
+  const cleanMount = mount.replace(/^\/+|\/+$/g, "");
+  return `${cleanMount}/data/${encodeURIComponent(projectId)}/${encodeURIComponent(name)}`;
+}
+
+/**
+ * Minimal hand-rolled OpenBao HTTP client (no `node-vault` dependency).
+ * NEVER logs the token or any response body (which may carry secret material).
+ * Throws a scrubbed error on network failure / timeout / non-2xx status.
+ */
+async function openBaoRequest(
+  cfg: OpenBaoConnectionConfig,
+  method: "GET" | "POST" | "DELETE",
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; json: unknown }> {
+  if (!cfg.addr) {
+    throw new Error(
+      "OpenBaoCredentialProvider: credentials.openbao.addr is not configured " +
+        "(set MULTI_CREDENTIALS_OPENBAO_ADDR). Fail-closed — request not attempted.",
+    );
+  }
+  const token = readOpenBaoToken(cfg.tokenEnv);
+  if (!token) {
+    throw new Error(
+      `OpenBaoCredentialProvider: auth token missing — set the ${cfg.tokenEnv} ` +
+        "environment variable. Fail-closed — request not attempted.",
+    );
+  }
+
+  // SSRF containment: origin is operator-config-only; `path` is server-derived
+  // (URI-encoded projectId/name), never a raw externally-supplied URL/path.
+  const url = new URL(`/v1/${path}`, cfg.addr);
+
+  const headers: Record<string, string> = {
+    "X-Vault-Token": token,
+    "Content-Type": "application/json",
+  };
+  if (cfg.namespace) {
+    headers["X-Vault-Namespace"] = cfg.namespace;
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), OPENBAO_TIMEOUT_MS);
+  try {
+    let res: Response;
+    try {
+      res = await fetch(url.toString(), {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+    } catch (e) {
+      // NEVER include the token/url query or response text in the thrown error.
+      throw new Error(
+        `OpenBaoCredentialProvider: request failed: ${scrub((e as Error).message)}`,
+      );
+    }
+    // NEVER log the parsed body — it may contain secret material.
+    const json = await res.json().catch(() => null);
+    if (res.status < 200 || res.status >= 300) {
+      throw new Error(
+        `OpenBaoCredentialProvider: OpenBao responded with status ${res.status}`,
+      );
+    }
+    return { status: res.status, json };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function resolveConnectionConfig(config: AppConfig): OpenBaoConnectionConfig {
+  const openbao = config.credentials.openbao;
+  return {
+    addr: openbao.addr,
+    mount: openbao.mount,
+    namespace: openbao.namespace,
+    tokenEnv: openbao.tokenEnv,
+  };
+}
+
+export class OpenBaoCredentialProvider implements CredentialProvider {
+  private readonly metadataStore: DbCryptoCredentialProvider;
+  private readonly connection: OpenBaoConnectionConfig;
+
+  constructor(config: AppConfig) {
+    this.metadataStore = new DbCryptoCredentialProvider();
+    this.connection = resolveConnectionConfig(config);
+  }
+
+  // ── PLAN-TIME (delegate to DB metadata — unchanged) ─────────────────────────
+
+  listCredentials(projectId: string): Promise<CredentialMetadata[]> {
+    return this.metadataStore.listCredentials(projectId);
+  }
+
+  getCredentialMetadata(
+    projectId: string,
+    credentialId: string,
+  ): Promise<CredentialMetadata | null> {
+    return this.metadataStore.getCredentialMetadata(projectId, credentialId);
+  }
+
+  // ── NON-LEASE DIRECT ACCESS (delegate — ciphertext path is unaffected) ──────
+
+  accessSecret(params: AccessSecretParams): Promise<string> {
+    return this.metadataStore.accessSecret(params);
+  }
+
+  // ── EXEC-TIME lease ops (delegate — unchanged) ──────────────────────────────
+
+  revokeLease(leaseId: string): Promise<void> {
+    return this.metadataStore.revokeLease(leaseId);
+  }
+
+  revokeRunLeases(runId: string): Promise<void> {
+    return this.metadataStore.revokeRunLeases(runId);
+  }
+
+  // ── CREDENTIAL STORE (override VALUE path — OpenBao KV v2) ──────────────────
+
+  /**
+   * Create or rotate a vault secret. Writes the plaintext value to OpenBao KV v2
+   * FIRST (fail before touching Postgres), then upserts a METADATA-only row in
+   * `secrets` (valueEncrypted stays NULL). Writes the same credential_access_log
+   * audit row as DbCryptoCredentialProvider.putCredential.
+   */
+  async putCredential(p: {
+    projectId: string;
+    provider: string;
+    scope: string;
+    description: string;
+    secret: string;
+    name?: string;
+  }): Promise<CredentialMetadata> {
+    assertProject(p.projectId);
+
+    if (!p.name) {
+      throw new Error(
+        "putCredential: `name` is required to create/rotate a vault secret. " +
+          "Connection-backed credentials are managed via the workspace connections API.",
+      );
+    }
+
+    await openBaoRequest(
+      this.connection,
+      "POST",
+      kvDataPath(this.connection.mount, p.projectId, p.name),
+      { data: { value: p.secret } },
+    );
+
+    const existing = await db
+      .select()
+      .from(secrets)
+      .where(and(eq(secrets.projectId, p.projectId), eq(secrets.name, p.name)))
+      .then(([row]) => row ?? null);
+
+    const now = new Date();
+    const [row] = existing
+      ? await db
+          .update(secrets)
+          .set({
+            provider: p.provider,
+            scope: p.scope,
+            description: p.description,
+            valueEncrypted: null,
+            version: existing.version + 1,
+            rotatedAt: now,
+          })
+          .where(eq(secrets.id, existing.id))
+          .returning()
+      : await db
+          .insert(secrets)
+          .values({
+            projectId: p.projectId,
+            name: p.name,
+            provider: p.provider,
+            scope: p.scope,
+            description: p.description,
+            valueEncrypted: null,
+            version: 1,
+            createdBy: p.projectId,
+          })
+          .returning();
+
+    await writeAccessLog({
+      credentialId: row.id,
+      projectId: p.projectId,
+      action: existing ? "secret_rotated" : "secret_created",
+      requestedBy: p.projectId,
+      success: true,
+    });
+
+    return toSecretMetadata(row, p.projectId);
+  }
+
+  /**
+   * Delete a vault secret (project-scoped): deletes the OpenBao KV v2 value,
+   * then the metadata row. Throws if the secret does not exist in this project.
+   * Writes the same credential_access_log audit row as
+   * DbCryptoCredentialProvider.deleteCredential.
+   */
+  async deleteCredential(projectId: string, credentialId: string): Promise<void> {
+    assertProject(projectId);
+
+    const existing = await getSecretForProject(credentialId, projectId);
+    if (!existing) {
+      throw new Error(
+        `deleteCredential: secret ${credentialId} not found in project ${projectId}.`,
+      );
+    }
+
+    await openBaoRequest(
+      this.connection,
+      "DELETE",
+      kvDataPath(this.connection.mount, projectId, existing.name),
+    );
+
+    await db.delete(secrets).where(eq(secrets.id, credentialId));
+
+    await writeAccessLog({
+      credentialId,
+      projectId,
+      action: "secret_deleted",
+      requestedBy: projectId,
+      success: true,
+    });
+  }
+
+  /**
+   * Read the current value of a vault secret from OpenBao KV v2 (no
+   * crypto.decrypt() call — the value arrives as plaintext over TLS). Writes
+   * the same credential_access_log audit row as
+   * DbCryptoCredentialProvider.getSecretValue, including on failure.
+   */
+  async getSecretValue(p: {
+    projectId: string;
+    credentialId: string;
+    purpose: string;
+    requestedBy?: string;
+  }): Promise<string> {
+    assertProject(p.projectId);
+    const requestedBy = p.requestedBy ?? p.projectId;
+
+    const row = await getSecretForProject(p.credentialId, p.projectId);
+    if (!row) {
+      await writeAccessLog({
+        credentialId: p.credentialId,
+        projectId: p.projectId,
+        action: "secret_accessed",
+        requestedBy,
+        justification: p.purpose,
+        success: false,
+        errorMessage: "secret not found",
+      }).catch((auditErr: unknown) => {
+        console.warn("[credential-broker] audit write failed:", auditErr);
+      });
+      throw new Error(
+        `getSecretValue: secret ${p.credentialId} not found in project ${p.projectId}.`,
+      );
+    }
+
+    try {
+      const { json } = await openBaoRequest(
+        this.connection,
+        "GET",
+        kvDataPath(this.connection.mount, p.projectId, row.name),
+      );
+      const value = (json as { data?: { data?: { value?: unknown } } } | null)?.data?.data
+        ?.value;
+      if (typeof value !== "string") {
+        throw new Error("OpenBao KV response missing data.data.value");
+      }
+
+      await writeAccessLog({
+        credentialId: p.credentialId,
+        projectId: p.projectId,
+        action: "secret_accessed",
+        requestedBy,
+        justification: p.purpose,
+        success: true,
+      }).catch((auditErr: unknown) => {
+        console.warn("[credential-broker] audit write failed:", auditErr);
+      });
+
+      return value;
+    } catch (e) {
+      await writeAccessLog({
+        credentialId: p.credentialId,
+        projectId: p.projectId,
+        action: "secret_accessed",
+        requestedBy,
+        justification: p.purpose,
+        success: false,
+        errorMessage: (e as Error).message,
+      }).catch((auditErr: unknown) => {
+        console.warn(
+          "[credential-broker] audit write failed on OpenBao read error:",
+          auditErr,
+        );
+      });
+      throw e;
+    }
+  }
+}

--- a/server/credentials/types.ts
+++ b/server/credentials/types.ts
@@ -50,6 +50,10 @@ export interface CredentialMetadata {
   hasSecret: boolean;
   /** Last time the connection (and thus its secrets) was updated. */
   lastRotatedAt?: Date;
+  /** Vault secret name (secrets.name). Undefined for connection-backed credentials. */
+  name?: string;
+  /** Vault secret version, bumped on every rotate. Undefined for connection-backed credentials. */
+  version?: number;
 }
 
 // ─── Exec-time shapes ────────────────────────────────────────────────────────
@@ -160,6 +164,19 @@ export interface CredentialProvider {
    */
   accessSecret(params: AccessSecretParams): Promise<string>;
 
+  /**
+   * Decrypt and return the current value of a vault secret (the `secrets`
+   * table), scoped to the project and audited (action='secret_accessed').
+   * Distinct from accessSecret: this resolves the ciphertext itself (by
+   * credentialId) rather than taking a pre-fetched ciphertext.
+   */
+  getSecretValue(p: {
+    projectId: string;
+    credentialId: string;
+    purpose: string;
+    requestedBy?: string;
+  }): Promise<string>;
+
   // ── EXEC-TIME ─────────────────────────────────────────────────────────────
 
   /** Mark a lease revoked.  No-op if already revoked (idempotent). */
@@ -173,13 +190,18 @@ export interface CredentialProvider {
 
   // ── CREDENTIAL STORE ──────────────────────────────────────────────────────
 
-  /** Create or update a credential for the project (project-scoped write). */
+  /**
+   * Create or update a credential for the project (project-scoped write).
+   * `name` identifies a vault secret (upserted by (projectId, name)); omit it
+   * only for legacy/connection-backed callers that do not target the vault.
+   */
   putCredential(p: {
     projectId: string;
     provider: string;
     scope: string;
     description: string;
     secret: string;
+    name?: string;
   }): Promise<CredentialMetadata>;
 
   /** Delete a credential for the project (project-scoped write). */

--- a/server/routes/credentials.ts
+++ b/server/routes/credentials.ts
@@ -14,16 +14,93 @@
  */
 
 import type { Express } from "express";
+import { z } from "zod";
 import { db, withProject } from "../db.js";
 import {
   credentialLeases,
   credentialAccessLog,
   CREDENTIAL_LEASE_STATUSES,
+  secrets,
 } from "../../shared/schema.js";
 import { credentialProvider } from "../credentials/db-crypto-provider.js";
 import { getProjectId } from "../context.js";
+import { requireRole } from "../auth/middleware.js";
 import { desc, eq, and } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
+
+// ─── Write-endpoint schemas (Secrets Vault, Phase 1) ───────────────────────────
+
+const CONTROL_CHARS_RE = new RegExp("[\\u0000-\\u001F\\u007F-\\u009F]", "g");
+
+/** Vault secret name: leading letter/underscore, then word chars/./-, <=129 chars. */
+const SECRET_NAME_RE = /^[A-Za-z_][A-Za-z0-9_.-]{0,128}$/;
+const MAX_META_LEN = 256;
+
+const CreateSecretBodySchema = z.object({
+  name: z.string().regex(SECRET_NAME_RE, "invalid secret name"),
+  value: z.string().min(1).max(8192),
+  description: z.string().max(MAX_META_LEN).optional(),
+  scope: z.string().max(MAX_META_LEN).optional(),
+  provider: z.string().max(MAX_META_LEN).optional(),
+});
+
+const UpdateSecretBodySchema = z.object({
+  value: z.string().min(1).max(8192).optional(),
+  description: z.string().max(MAX_META_LEN).optional(),
+  scope: z.string().max(MAX_META_LEN).optional(),
+  provider: z.string().max(MAX_META_LEN).optional(),
+});
+
+const SecretIdParamsSchema = z.object({
+  id: z.string().min(1),
+});
+
+/**
+ * Control-strip (C0/DEL/C1) + collapse whitespace + trim + clamp an untrusted
+ * metadata field (description/scope/provider). Mirrors the pattern used by
+ * consilium-loops.ts's sanitizeReason/sanitizeCommitPrefix. Returns undefined
+ * for a non-string or empty-after-strip input.
+ */
+function sanitizeMeta(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const cleaned = raw
+    .replace(CONTROL_CHARS_RE, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, MAX_META_LEN);
+  return cleaned.length ? cleaned : undefined;
+}
+
+/** The metadata shape returned by every write endpoint. VALUE is never included. */
+interface SecretMetadataResponse {
+  id: string;
+  projectId: string;
+  name: string;
+  provider: string;
+  scope: string;
+  description: string;
+  hasSecret: boolean;
+  version: number;
+  createdAt: Date;
+  rotatedAt: Date | null;
+}
+
+function toSecretResponse(
+  row: typeof secrets.$inferSelect,
+): SecretMetadataResponse {
+  return {
+    id: row.id,
+    projectId: row.projectId,
+    name: row.name,
+    provider: row.provider ?? "vault",
+    scope: row.scope ?? "",
+    description: row.description ?? "",
+    hasSecret: row.valueEncrypted !== null,
+    version: row.version,
+    createdAt: row.createdAt,
+    rotatedAt: row.rotatedAt,
+  };
+}
 
 export function registerCredentialRoutes(app: Express): void {
   // ── GET /api/credentials ──────────────────────────────────────────────────────
@@ -122,6 +199,153 @@ export function registerCredentialRoutes(app: Express): void {
         .orderBy(desc(credentialLeases.issuedAt));
 
       res.json(rows);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  // ── POST /api/credentials ─────────────────────────────────────────────────────
+  // Create a new vault secret. Admin only. VALUE is never returned.
+  app.post("/api/credentials", requireRole("admin"), async (req, res) => {
+    const body = CreateSecretBodySchema.safeParse(req.body);
+    if (!body.success) {
+      res.status(400).json({ error: body.error.message });
+      return;
+    }
+
+    try {
+      const projectId = getProjectId();
+
+      const [existing] = await db
+        .select({ id: secrets.id })
+        .from(secrets)
+        .where(
+          and(eq(secrets.projectId, projectId), eq(secrets.name, body.data.name)),
+        );
+      if (existing) {
+        res.status(409).json({
+          error: `Secret with name "${body.data.name}" already exists`,
+        });
+        return;
+      }
+
+      const metadata = await credentialProvider.putCredential({
+        projectId,
+        name: body.data.name,
+        secret: body.data.value,
+        description: sanitizeMeta(body.data.description) ?? "",
+        scope: sanitizeMeta(body.data.scope) ?? "",
+        provider: sanitizeMeta(body.data.provider) ?? "",
+      });
+
+      const [row] = await db
+        .select()
+        .from(secrets)
+        .where(and(eq(secrets.id, metadata.id), eq(secrets.projectId, projectId)));
+      res.status(201).json(toSecretResponse(row));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  // ── PATCH /api/credentials/:id ─────────────────────────────────────────────────
+  // Update metadata and/or rotate a vault secret (value present = rotate).
+  // Admin only. VALUE is never returned.
+  app.patch("/api/credentials/:id", requireRole("admin"), async (req, res) => {
+    const params = SecretIdParamsSchema.safeParse(req.params);
+    if (!params.success) {
+      res.status(400).json({ error: params.error.message });
+      return;
+    }
+    const body = UpdateSecretBodySchema.safeParse(req.body);
+    if (!body.success) {
+      res.status(400).json({ error: body.error.message });
+      return;
+    }
+
+    try {
+      const projectId = getProjectId();
+
+      const [existing] = await db
+        .select()
+        .from(secrets)
+        .where(and(eq(secrets.id, params.data.id), eq(secrets.projectId, projectId)));
+      if (!existing) {
+        res.status(404).json({ error: "Secret not found" });
+        return;
+      }
+
+      if (body.data.value !== undefined) {
+        // Rotate (+ optionally update metadata) through the broker — bumps
+        // version and rotatedAt, and writes a 'secret_rotated' audit row.
+        const metadata = await credentialProvider.putCredential({
+          projectId,
+          name: existing.name,
+          secret: body.data.value,
+          description: sanitizeMeta(body.data.description) ?? existing.description ?? "",
+          scope: sanitizeMeta(body.data.scope) ?? existing.scope ?? "",
+          provider: sanitizeMeta(body.data.provider) ?? existing.provider ?? "",
+        });
+        const [row] = await db
+          .select()
+          .from(secrets)
+          .where(and(eq(secrets.id, metadata.id), eq(secrets.projectId, projectId)));
+        res.json(toSecretResponse(row));
+        return;
+      }
+
+      // Metadata-only update — no rotation, no crypto touch, no version bump.
+      const [updated] = await db
+        .update(secrets)
+        .set({
+          description:
+            body.data.description !== undefined
+              ? sanitizeMeta(body.data.description) ?? null
+              : existing.description,
+          scope:
+            body.data.scope !== undefined
+              ? sanitizeMeta(body.data.scope) ?? null
+              : existing.scope,
+          provider:
+            body.data.provider !== undefined
+              ? sanitizeMeta(body.data.provider) ?? null
+              : existing.provider,
+        })
+        .where(and(eq(secrets.id, params.data.id), eq(secrets.projectId, projectId)))
+        .returning();
+
+      res.json(toSecretResponse(updated));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: message });
+    }
+  });
+
+  // ── DELETE /api/credentials/:id ────────────────────────────────────────────────
+  // Delete a vault secret. Admin only.
+  app.delete("/api/credentials/:id", requireRole("admin"), async (req, res) => {
+    const params = SecretIdParamsSchema.safeParse(req.params);
+    if (!params.success) {
+      res.status(400).json({ error: params.error.message });
+      return;
+    }
+
+    try {
+      const projectId = getProjectId();
+
+      const [existing] = await db
+        .select({ id: secrets.id })
+        .from(secrets)
+        .where(and(eq(secrets.id, params.data.id), eq(secrets.projectId, projectId)));
+      if (!existing) {
+        res.status(404).json({ error: "Secret not found" });
+        return;
+      }
+
+      await credentialProvider.deleteCredential(projectId, params.data.id);
+      res.status(204).end();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       res.status(500).json({ error: message });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -2054,6 +2054,10 @@ export const CREDENTIAL_ACCESS_ACTIONS = [
   "lease_expired",
   // [Wave-2] Non-lease direct secret accesses through the broker (ADR-001 PR-1d).
   "secret_accessed",
+  // [Secrets Vault Phase 1] Credential-store writes against the `secrets` table.
+  "secret_created",
+  "secret_rotated",
+  "secret_deleted",
 ] as const;
 export type CredentialAccessAction = typeof CREDENTIAL_ACCESS_ACTIONS[number];
 
@@ -2123,6 +2127,57 @@ export const credentialAccessLog = pgTable(
 
 export type CredentialAccessLogRow = typeof credentialAccessLog.$inferSelect;
 export type InsertCredentialAccessLog = typeof credentialAccessLog.$inferInsert;
+
+// ─── Secrets Vault (Phase 1 — project-scoped credential store) ──────────────
+//
+// Named, versioned secrets owned directly by a project (distinct from the
+// workspaceConnections-backed credentials).  `valueEncrypted` is written and
+// read ONLY inside server/credentials/db-crypto-provider.ts (the sanctioned
+// crypto.encrypt()/decrypt() call site) — never accepted as plaintext input
+// from a Zod-validated insert, hence the insert schema below omits it.
+//
+// Deploy: psql "$DATABASE_URL" -f migrations/0058_secrets_vault.sql
+
+export const secrets = pgTable(
+  "secrets",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    projectId: text("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    description: text("description"),
+    scope: text("scope"),
+    provider: text("provider"),
+    /** AES-256-GCM ciphertext (crypto.ts `v2:` format). Null until first rotate. */
+    valueEncrypted: text("value_encrypted"),
+    version: integer("version").notNull().default(1),
+    createdBy: text("created_by"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    rotatedAt: timestamp("rotated_at"),
+  },
+  (table) => ({
+    projectNameIdx: uniqueIndex("secrets_project_name_idx").on(
+      table.projectId,
+      table.name,
+    ),
+  }),
+);
+
+export const insertSecretSchema = createInsertSchema(secrets).omit({
+  id: true,
+  projectId: true,
+  valueEncrypted: true,
+  version: true,
+  createdBy: true,
+  createdAt: true,
+  rotatedAt: true,
+});
+
+export type SecretRow = typeof secrets.$inferSelect;
+export type InsertSecretRow = z.infer<typeof insertSecretSchema>;
 
 // ─── Standing Roles (ROLE-1 — standing-role.md §3/§8) ────────────────────────
 //

--- a/tests/unit/credentials/db-crypto-provider.test.ts
+++ b/tests/unit/credentials/db-crypto-provider.test.ts
@@ -36,10 +36,13 @@ const MOCK_DB = vi.hoisted(() => ({
   workspaceConnectionsRows: [] as Record<string, unknown>[],
   workspacesRows: [] as Record<string, unknown>[],
   credentialLeasesRows: [] as Record<string, unknown>[],
+  // Secrets Vault Phase 1 — rows resolved by db.select().from(secrets)....
+  secretsRows: [] as Record<string, unknown>[],
 
   // Spy arrays for write operations.
   inserted: [] as { table: string; values: Record<string, unknown> }[],
   updated: [] as { table: string; set: Record<string, unknown>; where: unknown }[],
+  deleted: [] as { table: string; where: unknown }[],
 
   // Next UUID to return from insert().returning()
   nextLeaseId: "lease-uuid-1",
@@ -111,14 +114,25 @@ vi.mock("../../../server/db.js", () => {
           const rowsForTable = () => {
             if (tableName === "workspaces")           return MOCK_DB.workspacesRows;
             if (tableName === "credential_leases")    return MOCK_DB.credentialLeasesRows;
+            if (tableName === "secrets")               return MOCK_DB.secretsRows;
             return [];
           };
 
           innerChain.where = vi.fn().mockImplementation(() => innerChain);
           innerChain.orderBy = vi.fn().mockImplementation(() => rowsForTable());
-          (innerChain as any).then = (resolve: (v: unknown) => void) => {
-            resolve(rowsForTable());
-            return Promise.resolve(rowsForTable());
+          // Propagate the resolver's return value (not just the raw rows) so
+          // explicit `.then(([row]) => row ?? null)` call sites (Secrets Vault
+          // Phase 1: putCredential/getSecretForProject) get the *transformed*
+          // value, not the raw array (which is always truthy, even empty).
+          (innerChain as any).then = (
+            resolve: (v: unknown) => unknown,
+            reject?: (e: unknown) => unknown,
+          ) => {
+            try {
+              return Promise.resolve(resolve(rowsForTable()));
+            } catch (e) {
+              return reject ? Promise.resolve(reject(e)) : Promise.reject(e);
+            }
           };
           return innerChain;
         });
@@ -136,6 +150,9 @@ vi.mock("../../../server/db.js", () => {
             const returning = () => {
               if (tableName === "credential_leases") {
                 return [{ ...vals, id: MOCK_DB.nextLeaseId }];
+              }
+              if (tableName === "secrets") {
+                return [{ ...vals, id: "secret-uuid-1" }];
               }
               return [{ ...vals, id: "log-uuid-1" }];
             };
@@ -170,7 +187,16 @@ vi.mock("../../../server/db.js", () => {
           updateEntry.where = w;
           return chain;
         });
-        chain.returning = vi.fn().mockReturnValue([]);
+        chain.returning = vi.fn().mockImplementation(() => {
+          // Secrets Vault Phase 1 — rotate path: merge the pre-existing row
+          // (set by the test via MOCK_DB.secretsRows) with the .set() patch so
+          // putCredential's `const [row] = await db.update(secrets)....returning()`
+          // gets a realistic post-update row back (id, version, rotatedAt, etc).
+          if (tableName === "secrets" && MOCK_DB.secretsRows[0]) {
+            return [{ ...MOCK_DB.secretsRows[0], ...updateEntry.set }];
+          }
+          return [];
+        });
         (chain as any).then = (resolve: (v: unknown) => void) => {
           resolve(undefined);
           return Promise.resolve(undefined);
@@ -179,9 +205,15 @@ vi.mock("../../../server/db.js", () => {
         return chain;
       }),
 
-      delete: vi.fn().mockImplementation(() => ({
-        where: vi.fn().mockReturnValue(Promise.resolve()),
-      })),
+      delete: vi.fn().mockImplementation((table: unknown) => {
+        const tableName = (table as Record<symbol, string>)[TABLE] ?? "";
+        return {
+          where: vi.fn().mockImplementation((w: unknown) => {
+            MOCK_DB.deleted.push({ table: tableName, where: w });
+            return Promise.resolve();
+          }),
+        };
+      }),
     },
     pool: { on: vi.fn() },
     withProject: (_t: unknown, cond?: unknown) => cond ?? {},
@@ -264,14 +296,34 @@ function makeLease(overrides: Partial<Record<string, unknown>> = {}) {
   };
 }
 
+/** Secrets Vault (Phase 1) row fixture — matches `shared/schema.ts`'s `secrets` table. */
+function makeSecret(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "secret-uuid-1",
+    projectId: PROJECT_A,
+    name: "API_KEY",
+    description: "An API key",
+    scope: "runtime",
+    provider: "vault",
+    valueEncrypted: "v2:enc-existing-value",
+    version: 1,
+    createdBy: PROJECT_A,
+    createdAt: new Date("2026-01-01"),
+    rotatedAt: null,
+    ...overrides,
+  };
+}
+
 // ─── Test helpers ─────────────────────────────────────────────────────────────
 
 function resetMock() {
   MOCK_DB.workspaceConnectionsRows = [];
   MOCK_DB.workspacesRows = [];
   MOCK_DB.credentialLeasesRows = [];
+  MOCK_DB.secretsRows = [];
   MOCK_DB.inserted = [];
   MOCK_DB.updated = [];
+  MOCK_DB.deleted = [];
   MOCK_DB.nextLeaseId = "lease-uuid-1";
 }
 
@@ -678,6 +730,209 @@ describe("DbCryptoCredentialProvider", () => {
         (i) => i.table === "credential_access_log",
       );
       expect(auditRows).toHaveLength(0);
+    });
+  });
+
+  // ── Secrets Vault Phase 1: putCredential / deleteCredential / getSecretValue ──
+  //
+  // putCredential/deleteCredential used to throw "not implemented" for the
+  // `secrets` (vault) table; Phase 1 unstubbed them into a real
+  // upsert-by-(projectId, name) / project-scoped delete against the `secrets`
+  // table, each writing a credential_access_log audit row. These tests assert
+  // the real new behavior end-to-end against the mocked db.
+
+  describe("putCredential (vault secrets)", () => {
+    it("creates a new secret (version 1) when no row exists for (projectId, name)", async () => {
+      MOCK_DB.secretsRows = [];
+
+      const result = await runAsProject(PROJECT_A, () =>
+        provider.putCredential({
+          projectId: PROJECT_A,
+          provider: "vault",
+          scope: "runtime",
+          description: "An API key",
+          secret: "sk-plaintext-123",
+          name: "API_KEY",
+        }),
+      );
+
+      // Encrypted via the mocked crypto.encrypt(), never the raw plaintext.
+      const insertRows = MOCK_DB.inserted.filter((i) => i.table === "secrets");
+      expect(insertRows).toHaveLength(1);
+      expect(insertRows[0].values.valueEncrypted).toBe("v2:sk-plaintext-123");
+      expect(insertRows[0].values.version).toBe(1);
+      expect(insertRows[0].values.name).toBe("API_KEY");
+
+      expect(result.hasSecret).toBe(true);
+      expect(result.version).toBe(1);
+      expect(result.name).toBe("API_KEY");
+
+      const auditRows = MOCK_DB.inserted.filter(
+        (i) => i.table === "credential_access_log",
+      );
+      expect(auditRows).toHaveLength(1);
+      expect(auditRows[0].values.action).toBe("secret_created");
+      expect(auditRows[0].values.success).toBe(true);
+    });
+
+    it("rotates an existing secret: bumps version, sets rotatedAt, audits secret_rotated", async () => {
+      MOCK_DB.secretsRows = [makeSecret({ version: 2, rotatedAt: null })];
+
+      const result = await runAsProject(PROJECT_A, () =>
+        provider.putCredential({
+          projectId: PROJECT_A,
+          provider: "vault",
+          scope: "runtime",
+          description: "Rotated key",
+          secret: "sk-new-plaintext",
+          name: "API_KEY",
+        }),
+      );
+
+      const updateRows = MOCK_DB.updated.filter((u) => u.table === "secrets");
+      expect(updateRows).toHaveLength(1);
+      expect(updateRows[0].set.version).toBe(3);
+      expect(updateRows[0].set.valueEncrypted).toBe("v2:sk-new-plaintext");
+      expect(updateRows[0].set.rotatedAt).toBeInstanceOf(Date);
+
+      expect(result.version).toBe(3);
+      expect(result.hasSecret).toBe(true);
+
+      const auditRows = MOCK_DB.inserted.filter(
+        (i) => i.table === "credential_access_log",
+      );
+      expect(auditRows).toHaveLength(1);
+      expect(auditRows[0].values.action).toBe("secret_rotated");
+      expect(auditRows[0].values.success).toBe(true);
+    });
+
+    it("throws when `name` is omitted (connection-backed credentials use a different API)", async () => {
+      await runAsProject(PROJECT_A, async () => {
+        await expect(
+          provider.putCredential({
+            projectId: PROJECT_A,
+            provider: "vault",
+            scope: "runtime",
+            description: "no name",
+            secret: "sk-x",
+          }),
+        ).rejects.toThrow(/name/i);
+      });
+    });
+
+    it("throws ForbiddenError when projectId !== context", async () => {
+      await runAsProject(PROJECT_A, async () => {
+        await expect(
+          provider.putCredential({
+            projectId: PROJECT_B,
+            provider: "vault",
+            scope: "runtime",
+            description: "cross-project",
+            secret: "sk-x",
+            name: "API_KEY",
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+  });
+
+  describe("deleteCredential (vault secrets)", () => {
+    it("deletes an existing secret (project-scoped) and audits secret_deleted", async () => {
+      MOCK_DB.secretsRows = [makeSecret()];
+
+      await runAsProject(PROJECT_A, () =>
+        provider.deleteCredential(PROJECT_A, "secret-uuid-1"),
+      );
+
+      const deleteRows = MOCK_DB.deleted.filter((d) => d.table === "secrets");
+      expect(deleteRows).toHaveLength(1);
+
+      const auditRows = MOCK_DB.inserted.filter(
+        (i) => i.table === "credential_access_log",
+      );
+      expect(auditRows).toHaveLength(1);
+      expect(auditRows[0].values.action).toBe("secret_deleted");
+      expect(auditRows[0].values.credentialId).toBe("secret-uuid-1");
+      expect(auditRows[0].values.success).toBe(true);
+    });
+
+    it("throws when the secret does not exist in this project (no silent no-op)", async () => {
+      MOCK_DB.secretsRows = [];
+
+      await runAsProject(PROJECT_A, async () => {
+        await expect(
+          provider.deleteCredential(PROJECT_A, "unknown-secret"),
+        ).rejects.toThrow(/not found/i);
+      });
+
+      expect(MOCK_DB.deleted.filter((d) => d.table === "secrets")).toHaveLength(0);
+    });
+
+    it("throws ForbiddenError when projectId !== context", async () => {
+      await runAsProject(PROJECT_A, async () => {
+        await expect(
+          provider.deleteCredential(PROJECT_B, "secret-uuid-1"),
+        ).rejects.toThrow(ForbiddenError);
+      });
+    });
+  });
+
+  describe("getSecretValue", () => {
+    it("decrypts and returns the plaintext value, auditing secret_accessed", async () => {
+      MOCK_DB.secretsRows = [makeSecret()];
+
+      const result = await runAsProject(PROJECT_A, () =>
+        provider.getSecretValue({
+          projectId: PROJECT_A,
+          credentialId: "secret-uuid-1",
+          purpose: "test-purpose",
+          requestedBy: USER,
+        }),
+      );
+
+      // decrypt mock returns JSON.stringify({ API_TOKEN: "secret-value-123" })
+      expect(result).toBe(JSON.stringify({ API_TOKEN: "secret-value-123" }));
+
+      const auditRows = MOCK_DB.inserted.filter(
+        (i) => i.table === "credential_access_log",
+      );
+      expect(auditRows).toHaveLength(1);
+      expect(auditRows[0].values.action).toBe("secret_accessed");
+      expect(auditRows[0].values.success).toBe(true);
+      expect(auditRows[0].values.requestedBy).toBe(USER);
+    });
+
+    it("throws and audits a failure when the secret is not found or has no value", async () => {
+      MOCK_DB.secretsRows = [];
+
+      await runAsProject(PROJECT_A, async () => {
+        await expect(
+          provider.getSecretValue({
+            projectId: PROJECT_A,
+            credentialId: "unknown-secret",
+            purpose: "test-purpose",
+          }),
+        ).rejects.toThrow(/not found/i);
+      });
+
+      const auditRows = MOCK_DB.inserted.filter(
+        (i) => i.table === "credential_access_log",
+      );
+      expect(auditRows).toHaveLength(1);
+      expect(auditRows[0].values.action).toBe("secret_accessed");
+      expect(auditRows[0].values.success).toBe(false);
+    });
+
+    it("throws ForbiddenError when projectId !== context", async () => {
+      await runAsProject(PROJECT_A, async () => {
+        await expect(
+          provider.getSecretValue({
+            projectId: PROJECT_B,
+            credentialId: "secret-uuid-1",
+            purpose: "test-purpose",
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
Turns the read-only Wave-1 credential broker into a full secrets manager.

**Phase 1 — vault + CRUD (AES-in-Postgres)**
- New project-scoped `secrets` table (migration 0058); `DbCryptoCredentialProvider` implements `putCredential`/`deleteCredential`/`getSecretValue` (previously threw "not implemented"). Values AES-256-GCM at rest.
- Write API `POST`/`PATCH`/`DELETE /api/credentials` — **admin-only** (`requireRole("admin")`); secret values are **never returned** by any endpoint. Access-log audit on every op.
- `/credentials` UI is now full CRUD: add / rotate / delete secrets via a masked `SecretInput` (reveal toggle, paste-to-rotate); nav renamed to “Secrets”.

**Phase 2 — pluggable backend + OpenBao**
- `config.credentials.backend` = `db` (default) | `openbao`, resolved by a lazy factory (breaks the ESM cycle via a deferred singleton). All importers unchanged.
- `OpenBaoCredentialProvider`: secret **values** in OpenBao KV v2 (`<mount>/data/<projectId>/<name>`), **metadata + leases + audit stay in Postgres**. Hand-rolled fetch client (no new dep); `X-Vault-Token` from `process.env[tokenEnv]` only, fail-closed, never logged; no `crypto.decrypt` in this path (value is plaintext over TLS). Optional `openbao` docker-compose service (default backend stays `db`).

## Security
- Writes admin-gated; values never echoed; `decrypt()` stays solely in `db-crypto-provider`; OpenBao token env-only + fail-closed.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run tests/unit/` — 4455 passed, 0 failures (db-crypto-provider tests updated for the implemented put/delete/getSecretValue)
- [ ] Migration 0058 applied in target env (`CREATE TABLE IF NOT EXISTS secrets`)
- [ ] Manual: add/rotate/delete a secret on /credentials; flip `backend=openbao` with an OpenBao instance and confirm value round-trip