### PR TITLE
feat(consilium): Codex as 3rd seat in Large Research review panel

### DIFF
--- a/server/services/consilium/review-factory.ts
+++ b/server/services/consilium/review-factory.ts
@@ -132,6 +132,8 @@ export interface ConsiliumPanel {
 const OPUS: ReviewerModel = { name: "Opus", modelSlug: "claude-opus" };
 /** Gemini 3.1 Pro (high reasoning). */
 const GEMINI: ReviewerModel = { name: "Gemini", modelSlug: "gemini-3-1-pro-high" };
+/** Local Codex CLI seat (uses the user's ~/.codex default model). */
+const CODEX: ReviewerModel = { name: "Codex", modelSlug: "codex" };
 
 /**
  * The proven 2-model cross-review panel (Opus 4.8 + Gemini 3.1 Pro, judge =
@@ -144,6 +146,17 @@ const CROSS_REVIEW_PANEL: ConsiliumPanel = {
   judgeModelSlug: OPUS.modelSlug,
 };
 
+/**
+ * Large Research panel — a 3-model dispute (Opus + Gemini + local Codex), judged
+ * by Opus. The extra seat gives the operator-paced research preset a third
+ * independent perspective; the DAG builder generalises (each seat rebuts every
+ * other, judge waits on all). Standard presets keep the proven 2-model panel.
+ */
+const LARGE_RESEARCH_PANEL: ConsiliumPanel = {
+  reviewers: [OPUS, GEMINI, CODEX],
+  judgeModelSlug: OPUS.modelSlug,
+};
+
 /** Per-preset panel. All three presets share the proven 2-model panel today. */
 export const PRESET_PANELS: Record<ConsiliumReviewPreset, ConsiliumPanel> = {
   "sdlc-cross-review": CROSS_REVIEW_PANEL,
@@ -151,7 +164,7 @@ export const PRESET_PANELS: Record<ConsiliumReviewPreset, ConsiliumPanel> = {
   "full-viability": CROSS_REVIEW_PANEL,
   // MVP: reuse the proven 2-model panel (Opus + Gemini). A future 3rd seat is a
   // one-line addition (see `CROSS_REVIEW_PANEL` comment above).
-  "large-research": CROSS_REVIEW_PANEL,
+  "large-research": LARGE_RESEARCH_PANEL,
 };
 
 // ─── Task descriptions (SERVER CONSTANTS) ───────────────────────────────────

--- a/tests/unit/consilium/review-factory.test.ts
+++ b/tests/unit/consilium/review-factory.test.ts
@@ -988,11 +988,19 @@ describe("composeInstructionWithSkills — delimiter, byte clamp, drop-whole-ski
 // ─── Large Research preset (opt-in, additive): panel + objective + gate ─────
 
 describe("large-research preset — panel selection + objective header (Part 1, additive)", () => {
-  it("PRESET_PANELS['large-research'] is the SAME proven cross-review panel as sdlc-cross-review", () => {
-    expect(PRESET_PANELS["large-research"]).toBe(PRESET_PANELS["sdlc-cross-review"]);
-    const tasks = buildCrossReviewTasks(PRESET_PANELS["large-research"]);
-    expect(tasks).toHaveLength(5);
+  it("PRESET_PANELS['large-research'] is a DISTINCT 3-model panel (Opus + Gemini + Codex, judged by Opus)", () => {
+    const panel = PRESET_PANELS["large-research"];
+    expect(panel).not.toBe(PRESET_PANELS["sdlc-cross-review"]);
+    expect(panel.reviewers.map((r) => r.modelSlug)).toEqual([
+      "claude-opus",
+      "gemini-3-1-pro-high",
+      "codex",
+    ]);
+    expect(panel.judgeModelSlug).toBe("claude-opus");
+    const tasks = buildCrossReviewTasks(panel);
+    // 3 seats → 3 primaries + each seat rebuts the other two + 1 judge.
     expect(tasks.filter((t) => t.name === "Judge verdict")).toHaveLength(1);
+    expect(tasks.length).toBeGreaterThan(5);
   });
 
   it("composeObjective('large-research', ...) emits the large-research header (repo-digest embed)", async () => {


### PR DESCRIPTION
## Summary
The **Large Research** preset now runs a **3-model dispute** — Opus + Gemini + local **Codex** — judged by Opus. The extra seat gives the operator-paced research flow a third independent perspective; the cross-review DAG generalises (each seat rebuts every other, judge waits on all). Standard presets (`sdlc-cross-review`, `diff-pr-review`, `full-viability`) keep the proven 2-model panel — unchanged.

One-line panel addition (`LARGE_RESEARCH_PANEL` in `review-factory.ts`); `PRESET_PANELS["large-research"]` points to it.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run tests/unit/` — 4501 passed, 0 failures (review-factory panel test updated: large-research is a distinct 3-model panel = [claude-opus, gemini-3-1-pro-high, codex], judge claude-opus)