### PR TITLE
feat(consilium): pause loop in throttled state on agent usage-limit (MVP)

### DIFF
--- a/client/src/components/consilium/loop-state.tsx
+++ b/client/src/components/consilium/loop-state.tsx
@@ -12,7 +12,7 @@
  * SECURITY: pure presentation. No model-authored text passes through here.
  */
 import { Badge } from "@/components/ui/badge";
-import type { ConsiliumLoopState } from "@/hooks/use-consilium-loops";
+import type { ConsiliumLoopState, ClientLoopState } from "@/hooks/use-consilium-loops";
 import { isTerminalLoopState } from "@/hooks/use-consilium-loops";
 
 interface StateStyle {
@@ -24,7 +24,14 @@ interface StateStyle {
   dot: string;
 }
 
-export const LOOP_STATE_STYLE: Record<ConsiliumLoopState, StateStyle> = {
+/** Never-crash fallback for a state token this map doesn't (yet) know about. */
+const UNKNOWN_STATE_STYLE: StateStyle = {
+  label: "Unknown",
+  badge: "bg-slate-500 text-white",
+  dot: "bg-slate-400",
+};
+
+export const LOOP_STATE_STYLE: Record<ClientLoopState, StateStyle> = {
   pending: { label: "Pending", badge: "bg-slate-500 text-white", dot: "bg-slate-400" },
   building_context: {
     label: "Building context",
@@ -56,6 +63,11 @@ export const LOOP_STATE_STYLE: Record<ConsiliumLoopState, StateStyle> = {
   escalated: { label: "Escalated", badge: "bg-orange-500 text-white", dot: "bg-orange-500" },
   failed: { label: "Failed", badge: "bg-red-600 text-white", dot: "bg-red-500" },
   cancelled: { label: "Cancelled", badge: "bg-slate-400 text-white", dot: "bg-slate-400" },
+  // Agent-limit throttling (MVP): a deliberate, non-terminal PAUSE (agent usage/
+  // rate limit hit) — amber like `awaiting_merge`, but the dot doesn't pulse
+  // (nothing is actively running while paused) so it reads distinctly from the
+  // "in progress" states.
+  throttled: { label: "Throttled", badge: "bg-amber-500 text-black", dot: "bg-amber-500" },
 };
 
 /** The non-terminal lifecycle, in FSM order — drives the detail-page stepper. */
@@ -73,7 +85,7 @@ export const LOOP_LIFECYCLE: ConsiliumLoopState[] = [
  * the detail row satisfy this structurally.
  */
 export interface LoopStateContext {
-  state: ConsiliumLoopState;
+  state: ClientLoopState;
   maxRounds: number;
   openP0: number | null;
 }
@@ -105,19 +117,19 @@ export function loopStateLabel(loop: LoopStateContext): StateStyle {
       };
     }
   }
-  return LOOP_STATE_STYLE[loop.state];
+  return LOOP_STATE_STYLE[loop.state] ?? UNKNOWN_STATE_STYLE;
 }
 
 // ─── State-only variants (no loop context available) ────────────────────────
 
-export function LoopStateBadge({ state }: { state: ConsiliumLoopState }) {
-  const style = LOOP_STATE_STYLE[state];
+export function LoopStateBadge({ state }: { state: ClientLoopState }) {
+  const style = LOOP_STATE_STYLE[state] ?? UNKNOWN_STATE_STYLE;
   return <Badge className={style.badge}>{style.label}</Badge>;
 }
 
 /** Compact dot + label, matching the pipeline rail's chip style. */
-export function LoopStateChip({ state }: { state: ConsiliumLoopState }) {
-  const style = LOOP_STATE_STYLE[state];
+export function LoopStateChip({ state }: { state: ClientLoopState }) {
+  const style = LOOP_STATE_STYLE[state] ?? UNKNOWN_STATE_STYLE;
   return <ChipBody style={style} terminal={isTerminalLoopState(state)} />;
 }
 

--- a/client/src/hooks/use-consilium-loops.ts
+++ b/client/src/hooks/use-consilium-loops.ts
@@ -37,8 +37,20 @@ export type { RoundComment };
 // Re-export the schema row types under client-facing names. The list endpoint
 // masks `createdBy` for non-admins, so that field is optional on the wire.
 
-export type ConsiliumLoopListItem = Omit<ConsiliumLoopRow, "createdBy"> & {
+/**
+ * Agent-limit throttling (MVP): a loop can PAUSE in a `throttled` state when an
+ * agent usage/rate limit is hit mid-review or mid-develop, instead of failing
+ * outright. `"throttled"` is a parallel BACKEND schema addition (`shared/
+ * schema.ts` CONSILIUM_LOOP_STATES) that hasn't landed on this branch yet, so it
+ * is mirrored CLIENT-SIDE here (same pattern as the Stage-4 `ExecutionTrace`
+ * mirror above) to keep this branch `tsc --noEmit`-clean in isolation. Collapse
+ * into `ConsiliumLoopState` directly once the backend change merges.
+ */
+export type ClientLoopState = ConsiliumLoopState | "throttled";
+
+export type ConsiliumLoopListItem = Omit<ConsiliumLoopRow, "createdBy" | "state"> & {
   createdBy?: string | null;
+  state: ClientLoopState;
 };
 
 /**
@@ -282,6 +294,15 @@ export type ConsiliumLoopDetail = ConsiliumLoopListItem & {
    * on every other preset, so the gate UI simply doesn't render.
    */
   reviewGate?: boolean | null;
+  /**
+   * Agent-limit throttling (MVP): WHICH phase the loop was mid-way through when
+   * the agent usage/rate limit paused it — `"review"` (building_context/
+   * reviewing/deciding) or `"develop"` (developing). Null/absent when the loop
+   * isn't `throttled` (or on a pre-throttling backend). Client-local mirror of
+   * the parallel backend's loop-GET field — collapse into the canonical
+   * `ConsiliumLoopRow` once that lands.
+   */
+  throttledPhase?: "review" | "develop" | null;
 };
 
 export type { ConsiliumLoopState, ConsiliumLoopRow, ConsiliumLoopRoundRow };
@@ -295,7 +316,13 @@ const TERMINAL_STATES: ReadonlySet<ConsiliumLoopState> = new Set<ConsiliumLoopSt
   "cancelled",
 ]);
 
-export function isTerminalLoopState(state: ConsiliumLoopState): boolean {
+/**
+ * `throttled` is a deliberate PAUSE (agent usage/rate limit), never terminal —
+ * the loop resumes via `POST /:id/retry`, so the page must keep polling and
+ * show it as active-but-paused, never as a stopped/finished loop.
+ */
+export function isTerminalLoopState(state: ClientLoopState): boolean {
+  if (state === "throttled") return false;
   return TERMINAL_STATES.has(state);
 }
 
@@ -308,7 +335,8 @@ export function isTerminalLoopState(state: ConsiliumLoopState): boolean {
 const VERDICT_TERMINAL_STATES: ReadonlySet<ConsiliumLoopState> =
   new Set<ConsiliumLoopState>(["converged", "stopped_cap", "escalated"]);
 
-export function isVerdictTerminalLoopState(state: ConsiliumLoopState): boolean {
+export function isVerdictTerminalLoopState(state: ClientLoopState): boolean {
+  if (state === "throttled") return false;
   return VERDICT_TERMINAL_STATES.has(state);
 }
 
@@ -381,6 +409,25 @@ export function useCancelLoop() {
   const qc = useQueryClient();
   return useMutation<ConsiliumLoopRow, Error, string>({
     mutationFn: (id) => apiRequest("POST", `${LIST_KEY}/${id}/cancel`),
+    onSuccess: (_data, id) => {
+      qc.invalidateQueries({ queryKey: [LIST_KEY, id] });
+      qc.invalidateQueries({ queryKey: [LIST_KEY] });
+    },
+  });
+}
+
+/**
+ * Agent-limit throttling (MVP): resume a loop PAUSED in `throttled` (an agent
+ * usage/rate limit was hit mid-review or mid-develop). Owner-or-admin, same
+ * shape as `useCancelLoop`/`useDevelopLoop`. Server-enforced: 409 (WRONG_STATE)
+ * when the loop isn't actually `throttled` — `apiRequest` throws that as an
+ * Error whose message is the server's `error` string, surfaced verbatim by the
+ * caller's toast.
+ */
+export function useRetryThrottledLoop() {
+  const qc = useQueryClient();
+  return useMutation<ConsiliumLoopRow, Error, string>({
+    mutationFn: (id) => apiRequest("POST", `${LIST_KEY}/${id}/retry`),
     onSuccess: (_data, id) => {
       qc.invalidateQueries({ queryKey: [LIST_KEY, id] });
       qc.invalidateQueries({ queryKey: [LIST_KEY] });

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -53,6 +53,7 @@ import {
   Info,
   CheckCircle2,
   MessageSquare,
+  PauseCircle,
 } from "lucide-react";
 import {
   useConsiliumLoop,
@@ -63,6 +64,7 @@ import {
   useRequestReReview,
   usePlanLoop,
   useSetArchetype,
+  useRetryThrottledLoop,
   isTerminalLoopState,
   isVerdictTerminalLoopState,
   type ConsiliumLoopRoundRow,
@@ -120,7 +122,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { ConsiliumLoopState } from "@/hooks/use-consilium-loops";
+import type { ConsiliumLoopState, ClientLoopState } from "@/hooks/use-consilium-loops";
 import { useAddRoundComment } from "@/hooks/use-consilium-loops";
 import { IterationDetailView } from "@/components/task-groups/iterations-panel";
 import type { ActionPoint, Archetype, OpenRemainder, RoundParticipant, RoundComment } from "@shared/types";
@@ -244,7 +246,7 @@ const ROUND_STEP_IDX: Record<string, number> = {
 
 // Verdict-terminal states all exit FROM "deciding" — they never developed in the
 // final round (distinct from failed/cancelled, which can stop anywhere).
-const VERDICT_TERMINAL: ReadonlySet<ConsiliumLoopState> = new Set<ConsiliumLoopState>([
+const VERDICT_TERMINAL: ReadonlySet<ClientLoopState> = new Set<ClientLoopState>([
   "converged",
   "stopped_cap",
   "escalated",
@@ -253,7 +255,7 @@ const VERDICT_TERMINAL: ReadonlySet<ConsiliumLoopState> = new Set<ConsiliumLoopS
 function roundStepStatuses(args: {
   isLast: boolean;
   hasRoundRow: boolean;
-  state: ConsiliumLoopState;
+  state: ClientLoopState;
   prRef: string | null | undefined;
 }): StepStatus[] {
   const { isLast, hasRoundRow, state, prRef } = args;
@@ -1019,6 +1021,13 @@ const STATUS_TONE_STYLE: Record<
 };
 
 function LoopStatusCallout({ loop }: { loop: ConsiliumLoopDetailRow }) {
+  // Agent-limit throttling (MVP): `throttled` gets a dedicated INTERACTIVE
+  // callout (it carries a Retry action, which the pure `explainLoopState` text
+  // helper can't). The message itself stays single-source — both this callout
+  // and `explainLoopState`'s `throttled` case surface the server's `loop.error`.
+  if (loop.state === "throttled") {
+    return <ThrottledCallout loop={loop} />;
+  }
   const { title, tone, detail } = explainLoopState(loop);
   const s = STATUS_TONE_STYLE[tone];
   const Icon = s.Icon;
@@ -1030,6 +1039,79 @@ function LoopStatusCallout({ loop }: { loop: ConsiliumLoopDetailRow }) {
         {/* INERT loop/user-authored text (error/cancellation note) or a code template. */}
         <p className={`break-words ${s.body}`}>{detail}</p>
       </div>
+    </div>
+  );
+}
+
+/** Plain-English note for WHICH phase the loop was paused mid-way through. */
+const THROTTLED_PHASE_LABEL: Record<"review" | "develop", string> = {
+  review: "paused during review",
+  develop: "paused during development",
+};
+
+/**
+ * Agent-limit throttling (MVP): the loop hit an agent usage/rate limit and
+ * PAUSED (non-terminal) instead of failing outright. `loop.error` carries the
+ * server's generic "quota reached" message; the optional phase note comes from
+ * `loop.throttledPhase`. Retry (`POST /:id/retry`, owner/admin) resumes the
+ * loop from where it paused — a 409 (no longer `throttled`, e.g. another
+ * operator already retried it) surfaces the server's error text verbatim via
+ * the toast, exactly like the other loop-action handlers below.
+ *
+ * SECURITY: `loop.error` is a fixed, server-authored template (never model
+ * prose) — rendered as INERT React text, same treatment as every other state's
+ * `detail`.
+ */
+function ThrottledCallout({ loop }: { loop: ConsiliumLoopDetailRow }) {
+  const { toast } = useToast();
+  const retryLoop = useRetryThrottledLoop();
+  const s = STATUS_TONE_STYLE.warning;
+  const phaseLabel = loop.throttledPhase ? THROTTLED_PHASE_LABEL[loop.throttledPhase] : null;
+
+  async function handleRetry() {
+    try {
+      await retryLoop.mutateAsync(loop.id);
+      toast({ title: "Loop resumed" });
+    } catch (err) {
+      toast({
+        variant: "destructive",
+        title: "Could not retry loop",
+        description: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return (
+    <div
+      className={`flex items-start gap-2 rounded-md border p-3 text-sm ${s.card}`}
+      data-testid="loop-throttled-callout"
+    >
+      <PauseCircle className={`h-4 w-4 shrink-0 mt-0.5 ${s.icon}`} aria-hidden="true" />
+      <div className="min-w-0 flex-1">
+        <p className={`font-medium ${s.title}`}>
+          Paused — agent limit reached{phaseLabel ? ` (${phaseLabel})` : ""}
+        </p>
+        {/* INERT server-authored text (generic quota message). */}
+        <p className={`break-words ${s.body}`}>
+          {loop.error ??
+            "Agent usage/rate limit reached — paused; retry when your quota resets."}
+        </p>
+      </div>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={handleRetry}
+        disabled={retryLoop.isPending}
+        className="shrink-0"
+        data-testid="loop-throttled-retry-button"
+      >
+        {retryLoop.isPending ? (
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        ) : (
+          <RefreshCw className="mr-2 h-4 w-4" />
+        )}
+        Retry
+      </Button>
     </div>
   );
 }
@@ -2466,7 +2548,7 @@ function CompositionCard({ composition }: { composition: LoopComposition }) {
 // Mounted ONLY while `reviewing`/`deciding` (so it unmounts — and stops polling —
 // the moment the round settles into a row); IterationDetailView fetches lazily and
 // polls on its own 3s cadence, so this adds no new polling machinery.
-const LIVE_ROUND_STATES: ReadonlySet<ConsiliumLoopState> = new Set<ConsiliumLoopState>([
+const LIVE_ROUND_STATES: ReadonlySet<ClientLoopState> = new Set<ClientLoopState>([
   "reviewing",
   "deciding",
 ]);

--- a/migrations/0060_consilium_loops_throttled_phase.sql
+++ b/migrations/0060_consilium_loops_throttled_phase.sql
@@ -1,0 +1,4 @@
+-- Agent-limit throttling (additive, non-breaking): which phase to resume when a
+-- consilium loop pauses in `throttled` — "review" or "develop". Null for every
+-- non-throttled loop. Ship-only: applied by the lead, not by this change.
+ALTER TABLE consilium_loops ADD COLUMN IF NOT EXISTS throttled_phase text;

--- a/server/gateway/providers/cli-spawn.ts
+++ b/server/gateway/providers/cli-spawn.ts
@@ -19,6 +19,7 @@
  */
 import { spawn, type ChildProcess } from "node:child_process";
 import { scrubSecrets } from "../secret-scrub";
+import { isRateLimitError } from "../rate-limit.js";
 
 const DEFAULT_MAX_CONCURRENCY = 4;
 const DEFAULT_TIMEOUT_MS = 120_000;
@@ -45,6 +46,16 @@ export class CliExecutionError extends Error {
   ) {
     super(message);
     this.name = "CliExecutionError";
+  }
+
+  /**
+   * CONSERVATIVE: true only when the message+stderr carries a CLEAR
+   * usage/rate-limit signature (see `isRateLimitError`). Callers use this to
+   * route a review/develop failure to the loop's `throttled` pause instead of
+   * the existing degrade/fail path; every other failure is unaffected.
+   */
+  get rateLimited(): boolean {
+    return isRateLimitError(`${this.message}\n${this.stderr}`);
   }
 }
 

--- a/server/gateway/rate-limit.ts
+++ b/server/gateway/rate-limit.ts
@@ -1,0 +1,44 @@
+/**
+ * rate-limit.ts — CONSERVATIVE classifier for "agent usage/rate limit exhausted"
+ * errors surfaced by a model/CLI provider during REVIEW or DEVELOP.
+ *
+ * ⚠️ CONSERVATIVE BY DESIGN: only a CLEAR limit signature classifies as a rate
+ * limit. Anything ambiguous returns false, so the caller keeps the EXISTING
+ * degrade/fail path unchanged. A false positive (pausing a loop forever on a
+ * non-limit error) is worse than a false negative (one more degrade/fail that
+ * an operator can already see and retry manually).
+ *
+ * Pure, case-insensitive, substring/regex matching over the raw error text
+ * (message + stderr). Never throws.
+ */
+
+// Word-boundary match for the bare HTTP status — avoids false positives like
+// "timeout after 1429ms" or a stray "...1429..." inside an unrelated number.
+const RATE_LIMIT_PATTERNS: RegExp[] = [
+  /rate[\s_-]?limit/i,
+  /\b429\b/,
+  /too many requests/i,
+  /usage limit/i,
+  /resource_exhausted/i,
+  /insufficient_quota/i,
+  /overloaded_error/i,
+  /retry-after/i,
+];
+
+/**
+ * Returns true iff `text` contains a CLEAR rate-limit/usage-quota signature.
+ * Conservative: only the fixed signature list above matches; everything else
+ * (timeouts, spawn failures, parse errors, generic 5xx, network errors, …)
+ * returns false and keeps the existing degrade/fail path byte-identical.
+ */
+export function isRateLimitError(text: string): boolean {
+  if (!text) return false;
+  // "quota" + "exceed/exhaust" in ANY order/wording (e.g. "exceeded quota for
+  // requests per day", "quota exhausted") — a clear usage-limit signature that a
+  // fixed-distance regex misses when word suffixes sit between the two tokens.
+  const lower = text.toLowerCase();
+  if (lower.includes("quota") && (lower.includes("exceed") || lower.includes("exhaust"))) {
+    return true;
+  }
+  return RATE_LIMIT_PATTERNS.some((re) => re.test(text));
+}

--- a/server/routes/consilium-loops.ts
+++ b/server/routes/consilium-loops.ts
@@ -20,6 +20,7 @@ import type {
   DevelopErrorCode,
   PlanErrorCode,
   ReReviewErrorCode,
+  RetryThrottledErrorCode,
 } from "../services/consilium/consilium-loop-controller.js";
 import { ARCHETYPES } from "@shared/types";
 import { CONSILIUM_LOOP_TERMINAL_STATES } from "@shared/schema";
@@ -404,6 +405,23 @@ export function registerConsiliumLoopRoutes(
     return mapReReviewError(res, result.code);
   });
 
+  // ── Retry (agent-limit throttling: operator resumes a `throttled` loop) ────
+  // Owner-or-admin (authorizeConsiliumLoop, 404-on-mismatch, mirrors /develop).
+  // Refuses (typed → HTTP) unless the loop is RESTING in `throttled`. On success
+  // the loop is already back in `building_context`/`developing` (whichever phase
+  // it paused in) by the time this responds — the client polls GET
+  // /api/consilium-loops/:id as usual.
+  app.post("/api/consilium-loops/:id/retry", async (req: Request, res: Response) => {
+    const auth = await authorizeConsiliumLoop(req, res, storage, String(req.params.id));
+    if (!auth) return;
+    const result = await controller.retryThrottled(auth.loop.id);
+    if (result.ok) {
+      const isAdmin = req.user?.role === "admin";
+      return res.json(maskLoop({ ...result.loop }, !!isAdmin));
+    }
+    return mapRetryThrottledError(res, result.code);
+  });
+
   // ── Plan (Stage 1 §6: OUT-OF-BAND intent→archetype planner) ─────────────────
   // Owner-or-admin (authorizeConsiliumLoop, 404-on-mismatch). Idempotent: a no-op
   // returning the existing archetype unless `?replan=1`. NO_VERDICT (409) when the
@@ -666,6 +684,41 @@ function mapReReviewError(res: Response, code: ReReviewErrorCode): Response {
       return res.status(404).json({ error: "Consilium loop not found" });
     default:
       return res.status(400).json({ error: "re-review rejected" });
+  }
+}
+
+/**
+ * Map a typed {@link RetryThrottledErrorCode} to HTTP. Mirrors `mapDevelopError`'s
+ * shape — the develop-phase resume re-checks the SAME repo/action-point/busy guards
+ * `develop()` enforces (a real coder run is about to be re-launched).
+ */
+function mapRetryThrottledError(res: Response, code: RetryThrottledErrorCode): Response {
+  switch (code) {
+    case "WRONG_STATE":
+      return res.status(409).json({ error: "loop is not resting in throttled — retry is not applicable" });
+    case "CAS_LOST":
+      return res.status(409).json({ error: "retry could not be applied (concurrent update)" });
+    case "BUSY":
+      res.setHeader("Retry-After", "30");
+      return res.status(429).json({
+        error: "SDLC executor busy — too many concurrent dev runs, retry shortly.",
+      });
+    case "NO_ACTION_POINTS":
+      return res
+        .status(400)
+        .json({ error: "no action points to develop: this loop's verdict has no action points." });
+    case "REPO_NOT_WORKSPACE":
+      return res
+        .status(400)
+        .json({ error: "the loop's repoPath is not a registered workspace of this project." });
+    case "REPO_NOT_ALLOWED":
+      return res
+        .status(400)
+        .json({ error: "the loop's repoPath is not in the configured allowlist." });
+    case "NOT_FOUND":
+      return res.status(404).json({ error: "Consilium loop not found" });
+    default:
+      return res.status(400).json({ error: "retry rejected" });
   }
 }
 

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -76,6 +76,7 @@ import { buildBranchName } from "./pr-wrapper.js";
 import { assertRepoIsProjectWorkspace, backtickFence, stripControlMultiline, buildSingleVerifierTask, VERIFIER_TASK_NAME, buildCrossReviewTasks, PRESET_PANELS, JUDGE_TASK_NAME } from "./review-factory.js";
 import { parseConsiliumPreset } from "./composition.js";
 import { runReviewTasks } from "./review-runner.js";
+import { isRateLimitError } from "../../gateway/rate-limit.js";
 
 // ─── FSM events (design §3 "Event / guard" column) ──────────────────────────
 
@@ -85,8 +86,23 @@ export type LoopEvent =
   | { kind: "context_built" }
   | { kind: "review_completed"; verdict: ConvergenceVerdict }
   | { kind: "review_failed"; error: string }
+  // CONSERVATIVE (rate-limit.ts): the review-runner's catch classified the error as a
+  // CLEAR usage/rate-limit signature. Routes reviewing→throttled (a NON-terminal,
+  // resting state) INSTEAD OF review_failed→failed — everything else (any other error)
+  // still emits `review_failed` unchanged (byte-identical).
+  | { kind: "review_throttled" }
   | { kind: "decided"; verdict: ConvergenceVerdict; priorOpenP0: number[] }
-  | { kind: "dev_completed"; prRef: string | null; headCommit: string; error?: string; integrationBase?: string }
+  | {
+      kind: "dev_completed";
+      prRef: string | null;
+      headCommit: string;
+      error?: string;
+      integrationBase?: string;
+      // CONSERVATIVE (rate-limit.ts): set only when the coder close-out degraded
+      // because of a CLEAR usage/rate-limit signature — routes developing→throttled
+      // instead of the existing developing→awaiting_merge(error) path.
+      rateLimited?: boolean;
+    }
   | { kind: "merge_approved" }
   // HUMAN-only: an authorized re-open of a verdict-terminal loop back to
   // DEVELOPING (injected ONLY by `controller.develop`, NEVER by `deriveEvent` —
@@ -101,6 +117,13 @@ export type LoopEvent =
   // the round bump happens downstream at the sole bump site (`startReviewRound`,
   // building_context → reviewing).
   | { kind: "rereview_requested" }
+  // HUMAN-only: an authorized RESUME of a `throttled` loop (injected ONLY by
+  // `controller.retryThrottled`, NEVER by `deriveEvent` — `throttled` is a RESTING
+  // state the poller never advances). `throttledPhase` says which phase to resume —
+  // "review" re-enters `building_context` (SAME round, no bump — mirrors
+  // `rereview_requested`'s round-preservation); "develop" re-enters `developing`
+  // directly (mirrors `develop_requested`'s round-preservation).
+  | { kind: "retry_requested"; throttledPhase: "review" | "develop" }
   // A cancel MAY carry a human-supplied `reason` and the resolved `actor` label
   // (both already clamped + control-stripped at the route — untrusted). Absent on
   // an auto-cancel (an API POST with no body); the reducer still records a
@@ -142,6 +165,21 @@ export type ReReviewErrorCode =
 export type ReReviewResult =
   | { ok: true; loop: ConsiliumLoopRow }
   | { ok: false; code: ReReviewErrorCode };
+
+/** Stable, route-mappable failure codes for {@link ConsiliumLoopController.retryThrottled}. */
+export type RetryThrottledErrorCode =
+  | "NOT_FOUND" // loop vanished between auth and the controller read → 404
+  | "WRONG_STATE" // loop is not resting in `throttled` → 409
+  | "NO_ACTION_POINTS" // develop-phase resume: the verdict carries no action points → 400
+  | "REPO_NOT_ALLOWED" // develop-phase resume: repoPath outside the allowlist → 400
+  | "REPO_NOT_WORKSPACE" // develop-phase resume: allowlisted but not a project workspace → 400
+  | "CAS_LOST" // concurrent op won the throttled→X CAS / in-process lock → 409
+  | "BUSY"; // develop-phase resume: R1 global human-dev concurrency cap reached → 429
+
+/** Typed result of an authorized THROTTLED-RESUME (no exceptions on the happy path). */
+export type RetryThrottledResult =
+  | { ok: true; loop: ConsiliumLoopRow }
+  | { ok: false; code: RetryThrottledErrorCode };
 
 // ─── Intent→archetype PLANNER (Stage 1, design §6) ──────────────────────────
 
@@ -491,6 +529,9 @@ export interface ReviewRunResult {
   verdict: RoundVerdict | null;
   participants: RoundParticipant[] | null;
   error?: string;
+  /** CONSERVATIVE (rate-limit.ts): set only when `error` is a CLEAR usage/rate-limit
+   *  signature — routes the reviewing→throttled pause instead of review_failed. */
+  rateLimited?: boolean;
 }
 
 /**
@@ -529,6 +570,14 @@ function degradedReviewResult(error: string): ReviewRunResult {
  * (the peer of the other curated terminal explanations), NOT the raw reason.
  */
 const REVIEW_RUN_FAILED = "review run failed";
+
+/**
+ * Security L1: the FIXED GENERIC explanation surfaced to `consilium_loops.error`
+ * when a loop PAUSES in `throttled` (a CLEAR usage/rate-limit signature during
+ * review or develop). The raw model/CLI stderr is LOGGED only (`this.log`) — it
+ * must never reach the persisted, UI-rendered `loop.error`.
+ */
+const THROTTLED_ERROR_MESSAGE = "Agent usage/rate limit reached — paused; retry when your quota resets.";
 
 /**
  * Decide whether the open-P0 count failed to decrease across two consecutive
@@ -638,6 +687,21 @@ export function reduce(
     return null;
   }
 
+  // HUMAN re-open: an authorized `retry_requested` resumes a `throttled` loop into
+  // the phase it paused in. `throttledPhase` is CLEARED (null) along with `error` so
+  // the resumed loop reads as active again — mirrors `develop_requested`'s
+  // completedAt/error clear. `controller.retryThrottled` is the SOLE caller (never
+  // `deriveEvent` — `throttled` is a RESTING state the poller never advances).
+  // ROUND-PRESERVING: the review-phase resume does NOT pass through
+  // `startReviewRound`'s default bump (the caller relaunches with `{relaunch:true}`,
+  // M-2), and the develop-phase resume re-enters `developing` directly (round
+  // unchanged), exactly like `develop_requested`.
+  if (event.kind === "retry_requested") {
+    if (state !== "throttled") return null;
+    const to = event.throttledPhase === "develop" ? "developing" : "building_context";
+    return { from: "throttled", to, extra: { throttledPhase: null, error: null } };
+  }
+
   switch (state) {
     case "pending":
       if (event.kind === "start") return { from: "pending", to: "building_context" };
@@ -652,6 +716,16 @@ export function reduce(
       if (event.kind === "review_failed") {
         return { from: "reviewing", to: "failed", extra: { error: event.error, completedAt: new Date() } };
       }
+      // CONSERVATIVE (rate-limit.ts): a CLEAR usage/rate-limit signature pauses the
+      // loop in `throttled` (NON-terminal, resting) INSTEAD OF the review_failed→failed
+      // path above. Every non-limit review error still takes review_failed unchanged.
+      if (event.kind === "review_throttled") {
+        return {
+          from: "reviewing",
+          to: "throttled",
+          extra: { throttledPhase: "review", error: THROTTLED_ERROR_MESSAGE },
+        };
+      }
       return null;
 
     case "deciding":
@@ -660,6 +734,16 @@ export function reduce(
 
     case "developing":
       if (event.kind === "dev_completed") {
+        // CONSERVATIVE (rate-limit.ts): a CLEAR usage/rate-limit signature on the coder
+        // close-out pauses the loop in `throttled` INSTEAD OF the awaiting_merge(error)
+        // path below. Every non-limit close-out error is unaffected (byte-identical).
+        if (event.rateLimited) {
+          return {
+            from: "developing",
+            to: "throttled",
+            extra: { throttledPhase: "develop", error: THROTTLED_ERROR_MESSAGE },
+          };
+        }
         // H-2: the SDLC close-out ran in the BACKGROUND while the loop sat in
         // `developing`; the event carries the REAL prRef/headCommit (+ optional
         // error) the coder produced. The CAS persists them atomically with the
@@ -1225,6 +1309,122 @@ export class ConsiliumLoopController {
       return { ok: true, loop: updated };
     } finally {
       this.inFlight.delete(loopId);
+    }
+  }
+
+  /**
+   * Authorized HUMAN resume of a loop RESTING in `throttled` (a CLEAR usage/rate-limit
+   * pause — see rate-limit.ts). Resumes into the phase it paused in
+   * (`loop.throttledPhase`, persisted at the throttling transition):
+   *   - "review": re-enters `building_context`→`reviewing` SYNCHRONOUSLY (mirrors
+   *     `requestReReview`), then relaunches the SAME round DIRECTLY via
+   *     `startReviewRound(loop, { relaunch: true })` — bypassing the generic
+   *     `runSideEffect` building_context→reviewing leg (which always bumps the round,
+   *     M-2: a throttled resume must not buy another `maxRounds`).
+   *   - "develop": re-enters `developing` directly (mirrors `develop()`'s terminal
+   *     re-open) and re-dispatches the SAME action points — subject to the same R1
+   *     BUSY cap + repo re-validation `develop()` enforces (a real coder run is about
+   *     to be re-launched).
+   *
+   * Refuses (typed → 409 at the route) unless the loop is resting in `throttled`.
+   * Never called by `deriveEvent`/the poller — `throttled` is a RESTING state.
+   */
+  async retryThrottled(loopId: string): Promise<RetryThrottledResult> {
+    const loop = await this.storage.getLoop(loopId);
+    if (!loop) return { ok: false, code: "NOT_FOUND" };
+    if (loop.state !== "throttled") return { ok: false, code: "WRONG_STATE" };
+    return loop.throttledPhase === "develop"
+      ? this.retryThrottledDevelop(loop)
+      : this.retryThrottledReview(loop);
+  }
+
+  /** Review-phase branch of {@link retryThrottled} — mirrors `requestReReview()`'s shape. */
+  private async retryThrottledReview(loop: ConsiliumLoopRow): Promise<RetryThrottledResult> {
+    if (this.inFlight.has(loop.id)) return { ok: false, code: "CAS_LOST" };
+    this.inFlight.add(loop.id);
+    try {
+      const toBuilding = reduce(loop.state, { kind: "retry_requested", throttledPhase: "review" });
+      if (!toBuilding) return { ok: false, code: "WRONG_STATE" };
+      const wonBuilding = await this.commit(loop, toBuilding);
+      if (!wonBuilding) return { ok: false, code: "CAS_LOST" };
+      this.log(
+        wonBuilding.id,
+        `retryThrottled: CAS won throttled->building_context (round ${wonBuilding.round}, review resume)`,
+      );
+
+      const toReviewing = reduce(wonBuilding.state, { kind: "context_built" });
+      if (!toReviewing) return { ok: true, loop: wonBuilding }; // defensive; should not happen
+      const wonReviewing = await this.commit(wonBuilding, toReviewing);
+      if (!wonReviewing) return { ok: false, code: "CAS_LOST" };
+
+      // M-2 round-preservation: relaunch the SAME round DIRECTLY, bypassing the generic
+      // `runSideEffect` leg (`startReviewRound(loop)` with no `relaunch` bumps the round —
+      // a throttled resume must not buy another round).
+      const extra = await this.startReviewRound(wonReviewing, { relaunch: true });
+      if (extra.terminal) {
+        const failed = await this.failUnresolvedReview(
+          wonReviewing,
+          String(extra.error ?? "diff ref unresolvable"),
+        );
+        return failed ? { ok: true, loop: failed } : { ok: false, code: "CAS_LOST" };
+      }
+      const updated =
+        Object.keys(extra).length === 0 ? wonReviewing : await this.storage.updateLoop(wonReviewing.id, extra);
+      return { ok: true, loop: updated };
+    } finally {
+      this.inFlight.delete(loop.id);
+    }
+  }
+
+  /** Develop-phase branch of {@link retryThrottled} — mirrors `develop()`'s guards/CAS. */
+  private async retryThrottledDevelop(loop: ConsiliumLoopRow): Promise<RetryThrottledResult> {
+    const actionPoints = await this.resolveDevActionPoints(loop);
+    if (actionPoints.length === 0) return { ok: false, code: "NO_ACTION_POINTS" };
+
+    const cfg = this.loopConfig();
+    let resolvedRepo: string;
+    try {
+      resolvedRepo = assertAllowedRepoPath(loop.repoPath, cfg.allowedRepoPaths);
+    } catch {
+      return { ok: false, code: "REPO_NOT_ALLOWED" };
+    }
+    try {
+      await assertRepoIsProjectWorkspace(resolvedRepo, this.storage);
+    } catch {
+      return { ok: false, code: "REPO_NOT_WORKSPACE" };
+    }
+
+    // R1: same global human-dev concurrency cap `develop()` enforces — a throttled
+    // resume is about to re-launch a real coder run.
+    if (this.inFlightDevCommandCount() + this.devCommandReservations >= MAX_CONCURRENT_DEV_HANDOFFS) {
+      return { ok: false, code: "BUSY" };
+    }
+    this.devCommandReservations += 1;
+    try {
+      if (this.inFlight.has(loop.id)) return { ok: false, code: "CAS_LOST" };
+      this.inFlight.add(loop.id);
+      try {
+        const transition = reduce(loop.state, { kind: "retry_requested", throttledPhase: "develop" });
+        if (!transition) return { ok: false, code: "WRONG_STATE" };
+        const verdict: ConvergenceVerdict = {
+          converged: false,
+          openP0: actionPoints.filter((ap) => ap.priority === P0_PRIORITY).length,
+          openActionPoints: [...actionPoints],
+        };
+        const won = await this.commit(loop, transition);
+        if (!won) return { ok: false, code: "CAS_LOST" };
+        this.log(
+          won.id,
+          `retryThrottled: CAS won ${transition.from}->developing (round ${won.round}, develop resume)`,
+        );
+        const extra = await this.startDevHandoff(won, verdict, true);
+        const updated = Object.keys(extra).length === 0 ? won : await this.storage.updateLoop(won.id, extra);
+        return { ok: true, loop: updated };
+      } finally {
+        this.inFlight.delete(loop.id);
+      }
+    } finally {
+      this.devCommandReservations -= 1;
     }
   }
 
@@ -1962,6 +2162,13 @@ export class ConsiliumLoopController {
       if (!run.done || !run.result) return null; // in-flight ⇒ wait (no transition yet)
       const result = run.result;
       if (result.error) {
+        // CONSERVATIVE (rate-limit.ts): a CLEAR usage/rate-limit signature pauses the
+        // loop (throttled) instead of failing it — L1: raw scrubbed detail → LOGS
+        // only either way; `loop.error` never carries it.
+        if (result.rateLimited) {
+          this.log(loop.id, `review run rate-limited (round ${loop.round}): ${result.error}`);
+          return { kind: "review_throttled" };
+        }
         // L1: raw scrubbed detail → LOGS only; `loop.error` gets the fixed generic.
         this.log(loop.id, `review run degraded (round ${loop.round}): ${result.error}`);
         return { kind: "review_failed", error: REVIEW_RUN_FAILED };
@@ -2022,11 +2229,13 @@ export class ConsiliumLoopController {
   private deriveDevEvent(loop: ConsiliumLoopRow): LoopEvent | null {
     const run = this.sdlcRuns.get(loop.id);
     if (!run || run.round !== loop.round || !run.done || !run.result) return null;
-    const { prRef, headCommit, error, integrationBase } = run.result;
+    const { prRef, headCommit, error, integrationBase, rateLimited } = run.result;
     // §3E: `integrationBase` (the base sha merged into the round branch) rides the event so
     // the developing→building_context side effect can baseline the confirmation review at
     // `base..roundBranch`. Undefined when verify-before-merge is off ⇒ unused (byte-identical).
-    return { kind: "dev_completed", prRef, headCommit, error, integrationBase };
+    // `rateLimited` (rate-limit.ts): CONSERVATIVE flag from a zero-commit close-out —
+    // routes developing→throttled instead of awaiting_merge(error) in `reduce`.
+    return { kind: "dev_completed", prRef, headCommit, error, integrationBase, rateLimited };
   }
 
   /**
@@ -2804,13 +3013,14 @@ export class ConsiliumLoopController {
     const runner = this.deps.runReview ?? ((l: ConsiliumLoopRow) => this.runReviewFromLoop(l));
     void runner(loop)
       .then((result) => this.settleReviewRun(loop.id, run, result))
-      .catch((err: unknown) =>
-        this.settleReviewRun(
-          loop.id,
-          run,
-          degradedReviewResult(scrubErr(err instanceof Error ? err.message : String(err))),
-        ),
-      );
+      .catch((err: unknown) => {
+        const raw = err instanceof Error ? err.message : String(err);
+        const result = degradedReviewResult(scrubErr(raw));
+        // Defense-in-depth: `runReviewTasks` already never throws (its own catch
+        // classifies rate-limit), but a `deps.runReview` test fake or an out-of-band
+        // rejection lands here too — CONSERVATIVE, same classifier, same fixed shape.
+        this.settleReviewRun(loop.id, run, isRateLimitError(raw) ? { ...result, rateLimited: true } : result);
+      });
   }
 
   /**

--- a/server/services/consilium/dev-closeout.ts
+++ b/server/services/consilium/dev-closeout.ts
@@ -82,6 +82,15 @@ export interface DevCloseoutResult {
    * _trace` on the same settle wire as `testSummary`/`report`. Display-only.
    */
   executionTrace?: ExecutionTrace;
+  /**
+   * CONSERVATIVE (rate-limit.ts): set only when the SDLC close-out this result wraps
+   * (`runSdlcHandoff`'s `SdlcHandoffResult`) degraded on a CLEAR usage/rate-limit
+   * signature. Routes the controller's developing→throttled pause instead of the
+   * existing awaiting_merge(error) path; every other degraded close-out is
+   * unaffected (byte-identical). Absent for this file's own D.5 artifact-only path
+   * (it does not call a coder, so it can never be rate-limited itself).
+   */
+  rateLimited?: boolean;
 }
 
 // ─── Injectable seams (unit tests inject fakes — no real repo / gh) ──────────

--- a/server/services/consilium/review-runner.ts
+++ b/server/services/consilium/review-runner.ts
@@ -23,6 +23,7 @@ import type { RoundParticipant } from "@shared/types";
 import type { ReviewRunResult } from "./consilium-loop-controller.js";
 import { buildSystemPrompt, parseDirectLlmResponse } from "../orchestrator/direct-llm-prompt.js";
 import { readConvergence, readJudgeVerdict } from "../orchestrator/convergence.js";
+import { isRateLimitError } from "../../gateway/rate-limit.js";
 
 /** The gateway slice the runner needs — the completeStreaming shape of PlannerGateway. */
 export interface ReviewGateway {
@@ -199,6 +200,11 @@ export async function runReviewTasks(params: RunReviewTasksParams): Promise<Revi
       participants: boundParticipants(participants),
     };
   } catch (err) {
-    return degraded(scrub(err instanceof Error ? err.message : String(err)));
+    const raw = err instanceof Error ? err.message : String(err);
+    const result = degraded(scrub(raw));
+    // CONSERVATIVE: only a CLEAR usage/rate-limit signature sets `rateLimited` —
+    // every other failure keeps the existing degraded/`review_failed` path
+    // byte-identical (see rate-limit.ts).
+    return isRateLimitError(raw) ? { ...result, rateLimited: true } : result;
   }
 }

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -78,6 +78,7 @@ import {
 import { SdlcCoder, type CoderResult, type CoderOptions } from "./coder.js";
 import { verifyInWorktree, type TestRunResult } from "./test-runner.js";
 import { stripControlMultiline, backtickFence } from "../consilium/review-factory.js";
+import { isRateLimitError } from "../../gateway/rate-limit.js";
 
 const COMMIT_SUBJECT_TITLE_MAX = 100;
 const COMMIT_BODY_TITLE_MAX = 120;
@@ -141,6 +142,12 @@ export interface ApOutcome {
    * so the legacy outcome shape is preserved byte-for-byte when verification is off.
    */
   verification?: ApVerification;
+  /**
+   * CONSERVATIVE (rate-limit.ts): set only when this AP's coder invocation threw with
+   * a CLEAR usage/rate-limit signature. Aggregated by `pushAndOpenPr`'s zero-commit
+   * branch into `SdlcHandoffResult.rateLimited` — every other failure is unaffected.
+   */
+  rateLimited?: boolean;
 }
 
 /**
@@ -480,6 +487,14 @@ export interface SdlcHandoffResult {
    * field surfaces it structurally for observability/tests. NEVER blocks PR creation.
    */
   finalVerification?: FinalVerification;
+  /**
+   * CONSERVATIVE (rate-limit.ts): set only on the ZERO-commit degraded close-out
+   * (`prRef: null`) when EVERY outcome that recorded a rate-limit signature — i.e.
+   * the coder invocation(s) failed on a CLEAR usage/rate-limit signature, not any
+   * other failure. Routes the loop's developing→throttled pause; every other
+   * degraded/no-PR close-out is unaffected (byte-identical).
+   */
+  rateLimited?: boolean;
 }
 
 /** Injectable seams (unit tests inject fakes — no real repo / claude / gh). */
@@ -1257,6 +1272,10 @@ async function runActionPoint(
   let threw = false;
   let coder: CoderResult | null = null;
   let runNote: string | undefined;
+  // CONSERVATIVE (rate-limit.ts): only a CLEAR usage/rate-limit signature on a THROWN
+  // coder invocation sets this — every other failure (timeout, spawn error, non-limit
+  // CLI error) leaves it false and keeps the existing degraded/no-PR path unchanged.
+  let apRateLimited = false;
   const ranSkills: string[] = [];
   if (io.skilledSteps.length > 0) {
     for (const bound of io.skilledSteps) {
@@ -1280,7 +1299,9 @@ async function runActionPoint(
         });
       } catch (err) {
         threw = true;
-        runNote = scrub(err instanceof Error ? err.message : String(err));
+        const raw = err instanceof Error ? err.message : String(err);
+        runNote = scrub(raw);
+        if (isRateLimitError(raw)) apRateLimited = true;
         break; // a crashed step stops the chain; partial edits still committed
       }
       if (!coder.ok) {
@@ -1304,7 +1325,9 @@ async function runActionPoint(
       coder = await io.runCoder(wt.worktreeDir, [ap], { timeoutMs: req.coderTimeoutMs });
     } catch (err) {
       threw = true;
-      runNote = scrub(err instanceof Error ? err.message : String(err));
+      const raw = err instanceof Error ? err.message : String(err);
+      runNote = scrub(raw);
+      if (isRateLimitError(raw)) apRateLimited = true;
     }
   }
 
@@ -1343,6 +1366,7 @@ async function runActionPoint(
     title,
     skills: ranSkills.length > 0 ? ranSkills : undefined,
     verification,
+    rateLimited: apRateLimited ? true : undefined,
   };
 
   // 2. Stage whatever the run produced (partial or complete) and check for change.
@@ -2211,7 +2235,17 @@ async function pushAndOpenPr(
   if (committedCount === 0) {
     // Every action point failed / produced nothing — no branch to PR (as today).
     const failed = outcomes.find((o) => o.note)?.note;
-    return { prRef: null, headCommit: "", error: failed ? `no commits produced: ${failed}` : "no changes produced" };
+    // CONSERVATIVE (rate-limit.ts): only when EVERY outcome hit a CLEAR usage/rate-limit
+    // signature do we flag the whole close-out as rate-limited — a mix of a rate-limited
+    // AP and an unrelated failure is NOT a clear signal, so it keeps today's degraded
+    // no-PR path unchanged (byte-identical).
+    const rateLimited = outcomes.length > 0 && outcomes.every((o) => o.rateLimited === true);
+    return {
+      prRef: null,
+      headCommit: "",
+      error: failed ? `no commits produced: ${failed}` : "no changes produced",
+      ...(rateLimited ? { rateLimited: true } : {}),
+    };
   }
 
   const headCommit = (await io.gitRaw(wt.worktreeDir, ["rev-parse", "HEAD"])).trim();

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -1,4 +1,4 @@
-import { eq, desc, and, or, ilike, lt, ne, gte, lte, asc, isNull, isNotNull, inArray, sql as drizzleSql } from "drizzle-orm";
+import { eq, desc, and, or, ilike, lt, ne, gte, lte, asc, isNull, isNotNull, inArray, notInArray, sql as drizzleSql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { db, withProject, withProjectList, withProjectInsert, withProjectOrGlobal } from "./db";
 import { unscopedSystemQuery, getProjectId } from "./context";
@@ -812,10 +812,10 @@ export class PgStorage implements IStorage {
       .from(consiliumLoops)
       .where(withProject(consiliumLoops, and(
           eq(consiliumLoops.groupId, groupId),
-          inArray(
-            consiliumLoops.state,
-            ["pending", "building_context", "reviewing", "deciding", "developing", "awaiting_merge"],
-          ),
+          // Derived from the terminal-state list (not a hardcoded allowlist) so any
+          // new non-terminal RESTING state — e.g. `throttled` — is automatically
+          // treated as "active", matching MemStorage's dynamic check.
+          notInArray(consiliumLoops.state, [...CONSILIUM_LOOP_TERMINAL_STATES]),
         ),))
       .limit(1);
     return row;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1457,6 +1457,9 @@ export class MemStorage implements IStorage {
       headCommitAtReview: data.headCommitAtReview ?? null,
       openP0: data.openP0 ?? null,
       error: data.error ?? null,
+      // Agent-limit throttling (migration 0060): which phase to resume when
+      // `state === "throttled"`; null for every non-throttled loop.
+      throttledPhase: data.throttledPhase ?? null,
       createdBy: data.createdBy ?? null,
       createdAt: now,
       updatedAt: now,

--- a/shared/loop-status.ts
+++ b/shared/loop-status.ts
@@ -260,6 +260,17 @@ export function explainLoopState(loop: LoopStatusInput): LoopStatusExplanation {
           : "This loop was cancelled by an operator. No reason was recorded.",
       };
 
+    case "throttled":
+      // Agent usage/rate limit hit during review/develop → NON-terminal RESTING
+      // pause (not a failure). The operator retries when their quota resets.
+      return {
+        title: "Throttled",
+        tone: "warning",
+        detail: loop.error
+          ? loop.error
+          : "An agent usage/rate limit was reached — the loop is paused. Retry when your quota resets.",
+      };
+
     default: {
       // Exhaustive over the current union; a future/unknown token still gets a
       // safe, non-blank explanation so the callout NEVER renders empty.

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1771,6 +1771,12 @@ export const CONSILIUM_LOOP_STATES = [
   "deciding",
   "developing",
   "awaiting_merge",
+  // CONSERVATIVE agent-limit throttling: NON-terminal, RESTING pause (see
+  // rate-limit.ts / `throttledPhase`) entered from `reviewing`/`developing` on a
+  // CLEAR usage/rate-limit signature. An operator resumes it (`POST /retry`,
+  // `controller.retryThrottled`); the poller never advances it (a RESTING state,
+  // like `deciding` under the review gate).
+  "throttled",
   "converged",
   "stopped_cap",
   "escalated",
@@ -1946,6 +1952,11 @@ export const consiliumLoops = pgTable(
     // Latest convergence count (anti-stall mirror of the per-round history).
     openP0: integer("open_p0"),
     error: text("error"),
+    // Agent-limit throttling (additive, migration 0060): which phase to resume when
+    // `state === "throttled"` — set on the reviewing/developing→throttled transition,
+    // cleared (null) on `retryThrottled`'s resume. Null whenever the loop is not
+    // (and has never been) throttled.
+    throttledPhase: text("throttled_phase").$type<"review" | "develop">(),
     createdBy: text("created_by").references(() => users.id, { onDelete: "set null" }),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),

--- a/tests/unit/gateway/rate-limit.test.ts
+++ b/tests/unit/gateway/rate-limit.test.ts
@@ -1,0 +1,55 @@
+/**
+ * rate-limit.test.ts — unit coverage for the CONSERVATIVE `isRateLimitError`
+ * classifier (agent-limit throttling MVP). Every positive case is a CLEAR
+ * usage/rate-limit signature; every negative case is an AMBIGUOUS/unrelated
+ * failure that MUST keep the existing degrade/fail path (false positive is
+ * worse than false negative — see rate-limit.ts's header).
+ */
+import { describe, it, expect } from "vitest";
+import { isRateLimitError } from "../../../server/gateway/rate-limit.js";
+
+describe("isRateLimitError — positive (CLEAR signatures)", () => {
+  const positives = [
+    "Error: rate limit exceeded, please try again later",
+    "rate_limit_error: you have hit the rate limit",
+    "Request failed with status code 429",
+    "429 Too Many Requests",
+    "too many requests — slow down",
+    "You have exceeded your usage limit for this billing period",
+    "quota exceeded for this project",
+    "daily quota exhausted, resets at midnight UTC",
+    "exceeded quota for requests per day",
+    "google.api_core.exceptions.ResourceExhausted: 429 Resource has been exhausted",
+    "insufficient_quota: You exceeded your current quota",
+    '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+    "Retry-After: 30",
+    "RATE LIMIT REACHED",
+  ];
+  for (const text of positives) {
+    it(`classifies: ${JSON.stringify(text.slice(0, 60))}`, () => {
+      expect(isRateLimitError(text)).toBe(true);
+    });
+  }
+});
+
+describe("isRateLimitError — negative (ambiguous / unrelated — keeps existing path)", () => {
+  const negatives = [
+    "",
+    "CLI exited with code 1: syntax error in file foo.ts",
+    "CLI timed out after 1429ms", // must NOT match on "429" substring inside a number
+    "ENOENT: no such file or directory, open 'claude'",
+    "connection reset by peer",
+    "500 Internal Server Error",
+    "TypeError: Cannot read properties of undefined",
+    "spawn claude ENOENT",
+    "the model returned an unparseable response",
+    "network timeout while contacting the gateway",
+    "permission denied: worktree not writable",
+    "fatal: not a git repository",
+  ];
+  for (const text of negatives) {
+    it(`does NOT classify: ${JSON.stringify(text.slice(0, 60))}`, () => {
+      expect(isRateLimitError(text)).toBe(false);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
When a model/agent CLI call fails because a **usage / rate limit** is exhausted mid-review or mid-development, the loop now **pauses** in a new non-terminal `throttled` state (round progress preserved) instead of degrading/failing, and an operator resumes it with a Retry button.

- **Conservative classifier** (`server/gateway/rate-limit.ts`): only CLEAR signatures — `rate limit`, `429`, `too many requests`, `usage limit`, `quota exceeded/exhausted`, `resource_exhausted`, `overloaded`, `retry-after` — classify as a limit. Anything ambiguous keeps the existing degrade/fail path **byte-identical** (a false positive that pauses forever is worse than a manual retry).
- **`rateLimited` flag** threaded from the review runner and the coder close-out.
- **New `throttled` FSM state** (non-terminal) + `throttled_phase` column (**migration 0060**, nullable). `reviewing`/`developing` → `throttled` on a classified limit; the poller rests it (no auto-resume in this MVP — operator-driven).
- **`POST /api/consilium-loops/:id/retry`** (owner/admin) resumes the paused phase — without consuming a `maxRounds` budget.
- Raw model/CLI stderr **never reaches `loop.error`** (fixed generic message; Security L1).
- **UI**: a `throttled` status callout (warning tone) with a **Retry** button; the state is labelled/coloured and treated as non-terminal (page keeps polling).

Scope is the MVP the operator asked for: classification + `throttled` pause + operator Retry. Auto-resume (cooldown / `Retry-After`) and fallback-to-available-model seat are deliberate follow-ups.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run tests/unit/` — 4527 passed, 0 failures (classifier positives/negatives incl. "exceeded quota for requests per day"; `throttled` FSM: limit→throttled, non-limit→existing path unchanged, retry resumes; explainLoopState covers `throttled`)
- [ ] Migration 0060 applied in target env (`ADD COLUMN IF NOT EXISTS throttled_phase`)