### PR TITLE
feat(consilium): throttled v2 — auto-resume + per-seat model fallback

### DIFF
--- a/client/src/hooks/use-consilium-loops.ts
+++ b/client/src/hooks/use-consilium-loops.ts
@@ -303,6 +303,19 @@ export type ConsiliumLoopDetail = ConsiliumLoopListItem & {
    * `ConsiliumLoopRow` once that lands.
    */
   throttledPhase?: "review" | "develop" | null;
+  /**
+   * Agent-limit throttling v2 (auto-resume): ISO timestamp of when the loop's
+   * worker is expected to auto-retry, or null when no auto-resume is scheduled
+   * (or on a pre-v2 backend) — consumers fall back to the static Retry-only
+   * message. Client-local mirror of the backend's loop-GET field.
+   */
+  throttledUntil?: string | null;
+  /**
+   * Agent-limit throttling v2 (auto-resume): how many auto-resume attempts the
+   * server has already made for the current throttle. Absent/0 when no
+   * auto-resume attempt has happened yet.
+   */
+  resumeAttempts?: number;
 };
 
 export type { ConsiliumLoopState, ConsiliumLoopRow, ConsiliumLoopRoundRow };

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -1049,14 +1049,63 @@ const THROTTLED_PHASE_LABEL: Record<"review" | "develop", string> = {
   develop: "paused during development",
 };
 
+/** 1s tick for the auto-resume countdown — deadlines are shown to the second. */
+const THROTTLED_COUNTDOWN_TICK_MS = 1000;
+
 /**
- * Agent-limit throttling (MVP): the loop hit an agent usage/rate limit and
- * PAUSED (non-terminal) instead of failing outright. `loop.error` carries the
- * server's generic "quota reached" message; the optional phase note comes from
- * `loop.throttledPhase`. Retry (`POST /:id/retry`, owner/admin) resumes the
- * loop from where it paused — a 409 (no longer `throttled`, e.g. another
- * operator already retried it) surfaces the server's error text verbatim via
- * the toast, exactly like the other loop-action handlers below.
+ * Formats the remaining time until `deadlineMs` as "~Xm Ys" (or "~Ns" once
+ * under a minute). Returns null once the deadline is at/past `nowMs` — callers
+ * fall back to the "Auto-resuming…" copy in that case.
+ */
+function formatThrottledCountdown(deadlineMs: number, nowMs: number): string | null {
+  const remainingMs = deadlineMs - nowMs;
+  if (remainingMs <= 0) return null;
+  const totalSeconds = Math.ceil(remainingMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0 ? `~${minutes}m ${seconds}s` : `~${seconds}s`;
+}
+
+/**
+ * Auto-resume status line for the throttled callout:
+ * - `throttledUntil` missing/invalid → null (caller falls back to static copy).
+ * - `throttledUntil` in the future → live "Auto-resuming in ~Xm Ys" countdown.
+ * - `throttledUntil` at/past now (still throttled) → "Auto-resuming…".
+ * Ticks every second via `setInterval`, cleared on unmount/prop change.
+ */
+function useThrottledAutoResumeStatus(throttledUntil: string | null | undefined): string | null {
+  const [now, setNow] = useState(() => Date.now());
+
+  const deadlineMs = (() => {
+    if (!throttledUntil) return null;
+    const parsed = new Date(throttledUntil).getTime();
+    return Number.isNaN(parsed) ? null : parsed;
+  })();
+
+  useEffect(() => {
+    if (deadlineMs === null) return;
+    setNow(Date.now());
+    const intervalId = setInterval(() => setNow(Date.now()), THROTTLED_COUNTDOWN_TICK_MS);
+    return () => clearInterval(intervalId);
+  }, [deadlineMs]);
+
+  if (deadlineMs === null) return null;
+  const countdown = formatThrottledCountdown(deadlineMs, now);
+  return countdown ? `Auto-resuming in ${countdown}` : "Auto-resuming…";
+}
+
+/**
+ * Agent-limit throttling (v2, auto-resume): the loop hit an agent usage/rate
+ * limit and PAUSED (non-terminal) instead of failing outright. `loop.error`
+ * carries the server's generic "quota reached" message; the optional phase
+ * note comes from `loop.throttledPhase`. When the server schedules an
+ * auto-resume (`loop.throttledUntil`), a live countdown replaces the static
+ * message and `loop.resumeAttempts` (when > 0) surfaces how many auto-resume
+ * attempts have already run. Retry (`POST /:id/retry`, owner/admin) still
+ * works as a manual override — a 409 (no longer `throttled`, e.g. another
+ * operator/the auto-resume already retried it) surfaces the server's error
+ * text verbatim via the toast, exactly like the other loop-action handlers
+ * below.
  *
  * SECURITY: `loop.error` is a fixed, server-authored template (never model
  * prose) — rendered as INERT React text, same treatment as every other state's
@@ -1067,6 +1116,8 @@ function ThrottledCallout({ loop }: { loop: ConsiliumLoopDetailRow }) {
   const retryLoop = useRetryThrottledLoop();
   const s = STATUS_TONE_STYLE.warning;
   const phaseLabel = loop.throttledPhase ? THROTTLED_PHASE_LABEL[loop.throttledPhase] : null;
+  const autoResumeStatus = useThrottledAutoResumeStatus(loop.throttledUntil);
+  const resumeAttempts = loop.resumeAttempts ?? 0;
 
   async function handleRetry() {
     try {
@@ -1096,6 +1147,15 @@ function ThrottledCallout({ loop }: { loop: ConsiliumLoopDetailRow }) {
           {loop.error ??
             "Agent usage/rate limit reached — paused; retry when your quota resets."}
         </p>
+        {/* Auto-resume v2: live countdown when the server scheduled one; falls
+            back to nothing (operator-only Retry) when `throttledUntil` is
+            missing/invalid, same as pre-v2 behavior. */}
+        {autoResumeStatus && (
+          <p className={`break-words ${s.body}`} data-testid="loop-throttled-auto-resume">
+            {autoResumeStatus}
+            {resumeAttempts > 0 ? ` (auto-resume attempt ${resumeAttempts})` : ""}
+          </p>
+        )}
       </div>
       <Button
         size="sm"

--- a/migrations/0061_consilium_loops_auto_resume.sql
+++ b/migrations/0061_consilium_loops_auto_resume.sql
@@ -1,0 +1,9 @@
+-- "throttled v2" Part A (additive, non-breaking): bounded AUTO-RESUME bookkeeping for
+-- a consilium loop resting in `throttled` (agent-limit throttling MVP, migration 0060).
+-- `throttled_until` is the deadline stamped at the throttling transition (now + parsed
+-- Retry-After, else the configured cooldown); cleared (NULL) on ANY resume (auto or
+-- operator). `resume_attempts` counts bounded auto-resume attempts for the CURRENT
+-- pause; reset to 0 on every resume (auto or operator). Null/0 for every loop that has
+-- never been throttled. Ship-only: applied by the lead, not by this change.
+ALTER TABLE consilium_loops ADD COLUMN IF NOT EXISTS throttled_until timestamp;
+ALTER TABLE consilium_loops ADD COLUMN IF NOT EXISTS resume_attempts integer NOT NULL DEFAULT 0;

--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -440,6 +440,39 @@ export const ConfigSchema = z.object({
         fallbackModel: z.string().min(1).optional(),
       }).default({}),
       /**
+       * "throttled v2" Part A — bounded AUTO-RESUME for a loop paused in `throttled`
+       * by a CLEAR usage/rate-limit signature (rate-limit.ts / the throttled MVP).
+       * Today the ONLY way out of `throttled` is an operator's manual Retry
+       * (`controller.retryThrottled`); this adds a self-resume once the loop's
+       * `throttledUntil` deadline has passed, bounded so a persistently-limited
+       * loop still falls back to requiring an operator (never retries forever).
+       */
+      throttle: z.object({
+        /** Kill-switch: false → auto-resume is inert; only operator Retry resumes
+         *  a throttled loop (today's behavior, byte-identical). */
+        autoResume: z.boolean().default(true),
+        /**
+         * Default cooldown (seconds) before a throttled loop is eligible for
+         * auto-resume, used when the provider's error text carries no parseable
+         * `Retry-After`/"retry after Ns" hint (see `parseRetryAfterSeconds`).
+         * 30s..24h; default 5min.
+         */
+        cooldownSeconds: z.coerce.number().int().min(30).max(86_400).default(300),
+        /**
+         * Bounded auto-resume attempts per throttled pause before giving up and
+         * resting for the operator's manual Retry (never retries forever). 0
+         * ⇒ auto-resume never fires (operator-only, though `autoResume` is the
+         * primary kill-switch). 0..20; default 3.
+         */
+        maxAutoResumeAttempts: z.coerce.number().int().min(0).max(20).default(3),
+        /**
+         * Optional model slug override for the CODER on an auto-resumed develop-phase
+         * resume (e.g. a fallback model when the primary is the one hitting the usage
+         * limit). Omitted ⇒ the resume re-uses the task's own model, unchanged.
+         */
+        coderFallbackModel: z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/).optional(),
+      }).default({}),
+      /**
        * Stage 1 (design §6): the intent→archetype PLANNER — a single OUT-OF-BAND
        * lightweight model call (NOT a DAG task, NOT an FSM state) that proposes one
        * of a fixed enum of archetypes for a verdict-terminal loop. The whole planner

--- a/server/gateway/rate-limit.ts
+++ b/server/gateway/rate-limit.ts
@@ -42,3 +42,32 @@ export function isRateLimitError(text: string): boolean {
   }
   return RATE_LIMIT_PATTERNS.some((re) => re.test(text));
 }
+
+// Matches a provider's suggested cooldown phrase: "retry after 42s", "retry-after
+// 90 seconds", "Retry-After: 120" (colon, HTTP-header style), "try again in 5m".
+// Group 1 is the integer; group 2 is an optional unit (s/m/h and their long forms).
+const RETRY_AFTER_PATTERN = /(?:retry[\s-]?after|try again in)\s*:?\s*(\d+)\s*([a-z]+)?/i;
+
+/**
+ * Best-effort parse of a provider's suggested cooldown (in whole SECONDS) from raw
+ * error/header text — "retry after 42s", "try again in 5m", "Retry-After: 120",
+ * "retry-after 90 seconds". A bare number with no unit is treated as seconds
+ * (matches the raw HTTP `Retry-After` header semantics); `m` → ×60, `h` → ×3600.
+ * Returns `null` on no match/parse failure — the caller falls back to the
+ * configured cooldown default. Pure, case-insensitive, never throws.
+ */
+export function parseRetryAfterSeconds(text: string): number | null {
+  if (!text) return null;
+  try {
+    const match = RETRY_AFTER_PATTERN.exec(text);
+    if (!match) return null;
+    const value = Number.parseInt(match[1], 10);
+    if (!Number.isFinite(value)) return null;
+    const unit = (match[2] ?? "").toLowerCase();
+    if (unit.startsWith("h")) return value * 3600;
+    if (unit.startsWith("m")) return value * 60;
+    return value; // "s"/"sec(s)"/"second(s)"/no unit → seconds
+  } catch {
+    return null;
+  }
+}

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -76,7 +76,7 @@ import { buildBranchName } from "./pr-wrapper.js";
 import { assertRepoIsProjectWorkspace, backtickFence, stripControlMultiline, buildSingleVerifierTask, VERIFIER_TASK_NAME, buildCrossReviewTasks, PRESET_PANELS, JUDGE_TASK_NAME } from "./review-factory.js";
 import { parseConsiliumPreset } from "./composition.js";
 import { runReviewTasks } from "./review-runner.js";
-import { isRateLimitError } from "../../gateway/rate-limit.js";
+import { isRateLimitError, parseRetryAfterSeconds } from "../../gateway/rate-limit.js";
 
 // ─── FSM events (design §3 "Event / guard" column) ──────────────────────────
 
@@ -636,13 +636,18 @@ export function composeCancelExplanation(at: Date, actor?: string, reason?: stri
 export function reduce(
   state: ConsiliumLoopState,
   event: LoopEvent,
-  opts?: { verifyBeforeMerge?: boolean; reviewGate?: boolean },
+  opts?: { verifyBeforeMerge?: boolean; reviewGate?: boolean; throttleCooldownSeconds?: number },
 ): LoopTransition | null {
   // §3E verify-before-merge (kill-switched, default OFF ⇒ every branch below is
   // byte-identical to today). When ON it (a) routes the CONFIRMATION review BEFORE the
   // human ship gate, (b) lands a converged confirmation at awaiting_merge, and (c) makes
   // the human `merge_approved` the FINAL ship (terminal, NO second review).
   const vbm = opts?.verifyBeforeMerge ?? false;
+  // "throttled v2" Part A: the fallback cooldown (seconds) used to stamp
+  // `throttledUntil` when the throttled event carries no parseable Retry-After hint.
+  // Mirrors the config default (`throttle.cooldownSeconds`) so a caller that omits
+  // this opt (e.g. an existing unit test) still gets a sane, bounded deadline.
+  const throttleCooldownSeconds = opts?.throttleCooldownSeconds ?? 300;
   // `cancel` from any non-terminal state → CANCELLED (design §3 last row). Same
   // target/extra shape as before (NO FSM state-table change) plus the `error`
   // column reused as a terminal explanation so the UI never shows a bare
@@ -699,7 +704,16 @@ export function reduce(
   if (event.kind === "retry_requested") {
     if (state !== "throttled") return null;
     const to = event.throttledPhase === "develop" ? "developing" : "building_context";
-    return { from: "throttled", to, extra: { throttledPhase: null, error: null } };
+    // "throttled v2" Part A: ANY resume (operator retry OR the auto-resume guard in
+    // `tickInner`, both funnel through `retryThrottled` → this SAME branch) clears the
+    // auto-resume deadline and resets the bounded attempt counter — the resumed loop
+    // reads as fully active again, and a LATER throttled pause starts its own fresh
+    // budget rather than inheriting a stale count from a prior pause.
+    return {
+      from: "throttled",
+      to,
+      extra: { throttledPhase: null, error: null, throttledUntil: null, resumeAttempts: 0 },
+    };
   }
 
   switch (state) {
@@ -720,10 +734,18 @@ export function reduce(
       // loop in `throttled` (NON-terminal, resting) INSTEAD OF the review_failed→failed
       // path above. Every non-limit review error still takes review_failed unchanged.
       if (event.kind === "review_throttled") {
+        // "throttled v2" Part A: stamp the auto-resume deadline. `review_throttled`
+        // carries no raw error text (L1 — the review-runner's raw detail is LOGGED
+        // only, never threaded onto the event), so this always uses the configured
+        // cooldown default (no Retry-After to parse).
         return {
           from: "reviewing",
           to: "throttled",
-          extra: { throttledPhase: "review", error: THROTTLED_ERROR_MESSAGE },
+          extra: {
+            throttledPhase: "review",
+            error: THROTTLED_ERROR_MESSAGE,
+            throttledUntil: new Date(Date.now() + 1000 * throttleCooldownSeconds),
+          },
         };
       }
       return null;
@@ -738,10 +760,21 @@ export function reduce(
         // close-out pauses the loop in `throttled` INSTEAD OF the awaiting_merge(error)
         // path below. Every non-limit close-out error is unaffected (byte-identical).
         if (event.rateLimited) {
+          // "throttled v2" Part A: stamp the auto-resume deadline. `event.error` (the
+          // coder close-out's raw text) is parsed ONLY for a Retry-After/"retry after
+          // Ns" hint — never persisted onto `extra.error` (which stays the FIXED
+          // generic `THROTTLED_ERROR_MESSAGE`, L1) — falling back to the configured
+          // cooldown when unparseable/absent.
           return {
             from: "developing",
             to: "throttled",
-            extra: { throttledPhase: "develop", error: THROTTLED_ERROR_MESSAGE },
+            extra: {
+              throttledPhase: "develop",
+              error: THROTTLED_ERROR_MESSAGE,
+              throttledUntil: new Date(
+                Date.now() + 1000 * (parseRetryAfterSeconds(event.error ?? "") ?? throttleCooldownSeconds),
+              ),
+            },
           };
         }
         // H-2: the SDLC close-out ran in the BACKGROUND while the loop sat in
@@ -1772,6 +1805,47 @@ export class ConsiliumLoopController {
     const redriven = await this.redriveStranded(loop);
     if (redriven) return redriven;
 
+    // "throttled v2" Part A: bounded AUTO-RESUME. A loop resting in `throttled` past
+    // its stamped `throttledUntil` deadline resumes ITSELF via the EXISTING
+    // operator-only `retryThrottled` command — no new resume logic, no new FSM event.
+    // `throttled` stays a RESTING state for `deriveEvent`/the poller (only the
+    // `retry_requested` event, injected exclusively by `retryThrottled`, ever advances
+    // it) — this guard just decides WHEN to call that same command autonomously.
+    // Bounded by `maxAutoResumeAttempts` so a persistently-limited loop still falls
+    // back to requiring an operator (never retries forever). The bump below is a
+    // same-state CAS (`throttled`→`throttled`) guarded on the row still being
+    // `throttled` — a loser (e.g. an operator won a concurrent manual Retry) simply
+    // no-ops and is reassessed on the next tick.
+    // Optional chaining below: `throttle` is defaulted by the Zod schema in every REAL
+    // config load, but hand-rolled test `fakeConfig` fixtures predating this feature
+    // omit the key entirely — `?.` keeps every such existing test byte-identical
+    // (auto-resume simply never fires without an explicit `throttle` block) instead of
+    // throwing on `tick()` for an unrelated (non-throttled) loop.
+    const throttleCfg = this.loopConfig().throttle;
+    if (
+      loop.state === "throttled" &&
+      throttleCfg?.autoResume &&
+      loop.throttledUntil &&
+      Date.now() >= loop.throttledUntil.getTime() &&
+      loop.resumeAttempts < throttleCfg.maxAutoResumeAttempts
+    ) {
+      const bumped = await this.storage.casLoopState(loop.id, "throttled", "throttled", {
+        resumeAttempts: loop.resumeAttempts + 1,
+      });
+      if (!bumped) return null; // lost the bump race — reassessed next tick.
+      this.log(
+        loopId,
+        `throttled auto-resume: attempt ${bumped.resumeAttempts}/${throttleCfg.maxAutoResumeAttempts}`,
+      );
+      // `retryThrottled`'s private branches re-check the SAME in-process reentrancy
+      // guard `tick()` already set for this loopId — release it here so the resume
+      // proceeds exactly like the operator path; `tick()`'s outer `finally` re-deletes
+      // it (harmless no-op on an already-absent id) once this returns.
+      this.inFlight.delete(loopId);
+      const result = await this.retryThrottled(loopId);
+      return result.ok ? result.loop : null;
+    }
+
     const event = await this.deriveEvent(loop);
     if (!event) {
       // Bug #7: no event means the review iteration is genuinely still `running`
@@ -1806,6 +1880,7 @@ export class ConsiliumLoopController {
 
     const transition = reduce(loop.state, event, {
       verifyBeforeMerge: this.verifyBeforeMergeEnabled(),
+      throttleCooldownSeconds: throttleCfg?.cooldownSeconds,
     });
     if (!transition) return null;
 
@@ -3113,6 +3188,13 @@ export class ConsiliumLoopController {
       ? [buildSingleVerifierTask({ model: cfg.verifyReview?.model ?? "claude-opus", priorFindings })]
       : buildCrossReviewTasks(panel);
     const judgeTaskName = singleVerifier ? VERIFIER_TASK_NAME : JUDGE_TASK_NAME;
+    // Part B (throttled v2, per-seat fallback): the VISIBLE active-model catalog
+    // lets a rate-limited seat auto-rotate to a different-provider model instead of
+    // failing the whole panel (see review-runner.ts's fallback/drop/quorum gate).
+    const activeModels = (await this.storage.getActiveModels()).map((m) => ({
+      slug: m.slug,
+      provider: m.provider,
+    }));
     return runReviewTasks({
       tasks,
       judgeTaskName,
@@ -3120,6 +3202,7 @@ export class ConsiliumLoopController {
       groupInput: ctx.input,
       gateway,
       timeoutMs: this.deps.config().pipeline.taskGroups.taskTimeoutMs,
+      activeModels,
     });
   }
 

--- a/server/services/consilium/review-runner.ts
+++ b/server/services/consilium/review-runner.ts
@@ -46,6 +46,10 @@ export interface ReviewGateway {
 const MAX_PARTICIPANTS = 24;
 const MAX_PARTICIPANT_TEXT = 8_000;
 
+// Part B (throttled v2, per-seat fallback): fewest surviving NON-judge reviewers
+// after usage-limit seat drops before the WHOLE run throttles (quorum gate below).
+const MIN_REVIEWERS = 2;
+
 /** executeDirectLlm's per-call knobs (reproduced exactly for prompt/behaviour parity). */
 const REVIEW_TEMPERATURE = 0.7;
 const REVIEW_MAX_TOKENS = 4096;
@@ -71,6 +75,12 @@ function degraded(error: string): ReviewRunResult {
   return { converged: false, openP0: 0, openActionPoints: [], verdict: null, participants: null, error };
 }
 
+/** The slice of `Model` (shared/schema.ts) the fallback picker needs. */
+export interface ReviewModelCatalogEntry {
+  slug: string;
+  provider: string;
+}
+
 export interface RunReviewTasksParams {
   /** The review DAG — `buildCrossReviewTasks(panel)`, or `[buildSingleVerifierTask(...)]`. */
   tasks: CreateTaskParam[];
@@ -83,6 +93,29 @@ export interface RunReviewTasksParams {
   gateway: ReviewGateway;
   /** Per-call wall-clock cap (pipeline.taskGroups.taskTimeoutMs), like executeDirectLlm. */
   timeoutMs: number;
+  /**
+   * Part B (throttled v2, per-seat fallback): the VISIBLE active-model catalog
+   * (`storage.getActiveModels()`, mapped to `{slug, provider}`) used to auto-rotate a
+   * seat's model when its assigned model hits a usage/rate limit mid-review. Omitted
+   * (or empty) yields no fallback candidates — a rate-limited seat then has nothing to
+   * rotate to and is dropped (non-judge) / throttles the run (judge), same as before
+   * this catalog is wired through.
+   */
+  activeModels?: ReviewModelCatalogEntry[];
+}
+
+/**
+ * Part B: candidate fallback models for a rate-limited seat — active models on a
+ * DIFFERENT provider than the failing slug, excluding any slug already claimed by
+ * another seat this run. Order preserved from the caller's catalog order.
+ */
+function pickFallbackCandidates(
+  failingSlug: string,
+  activeModels: ReviewModelCatalogEntry[],
+  claimedSlugs: ReadonlySet<string>,
+): ReviewModelCatalogEntry[] {
+  const failingProvider = activeModels.find((m) => m.slug === failingSlug)?.provider;
+  return activeModels.filter((m) => m.provider !== failingProvider && !claimedSlugs.has(m.slug));
 }
 
 /**
@@ -139,18 +172,46 @@ function formatParticipantText(parsed: ReturnType<typeof parseDirectLlmResponse>
 
 export async function runReviewTasks(params: RunReviewTasksParams): Promise<ReviewRunResult> {
   const { tasks, judgeTaskName, groupName, groupInput, gateway, timeoutMs } = params;
+  const activeModels = params.activeModels ?? [];
   const outputs = new Map<string, unknown>(); // task name → its parsed `.output`
-  const participants: RoundParticipant[] = [];
+  const participants: RoundParticipant[] = []; // seats that PRODUCED output — the quorum count
+  const droppedNotes: RoundParticipant[] = []; // informational only — appended AFTER the quorum gate, never counted toward it
+  const dropped = new Set<string>(); // non-judge task names dropped after exhausting all fallback candidates
+  // Part B: each seat's CURRENT model slug — starts as its assigned `modelSlug`,
+  // rotates on a rate limit. Doubles as the "claimed this run" registry so two seats
+  // never fall back onto the SAME model.
+  const seatModel = new Map<string, string>(tasks.map((t) => [t.name, t.modelSlug ?? ""]));
   try {
     const pending = [...tasks];
     while (pending.length > 0) {
-      const ready = pending.filter((t) => (t.dependsOn ?? []).every((d) => outputs.has(d)));
+      // Cascade-drop: a NON-judge task depending on an already-dropped task can
+      // never meaningfully run (its dep's output never lands in `outputs`) — drop it
+      // too (repeat for multi-level deps, e.g. a rebuttal rebutting a dropped
+      // primary). The JUDGE is EXEMPT — it must still run on whatever survived, so a
+      // dropped dep just resolves as "missing" for it (see the ready-filter below),
+      // never cascades the judge itself.
+      let cascaded = true;
+      while (cascaded) {
+        cascaded = false;
+        for (const t of [...pending]) {
+          const deps = t.dependsOn ?? [];
+          if (t.name !== judgeTaskName && !dropped.has(t.name) && deps.some((d) => dropped.has(d))) {
+            dropped.add(t.name);
+            pending.splice(pending.indexOf(t), 1);
+            cascaded = true;
+          }
+        }
+      }
+      if (pending.length === 0) break;
+      // A dropped dep counts as "resolved" (no data, never arrives) so the judge (or
+      // any surviving dependent) can proceed without it instead of deadlocking.
+      const ready = pending.filter((t) => (t.dependsOn ?? []).every((d) => outputs.has(d) || dropped.has(d)));
       if (ready.length === 0) throw new Error("review DAG has an unsatisfiable dependency");
       await Promise.all(
         ready.map(async (t) => {
           const deps = t.dependsOn ?? [];
           const depOutputs: Record<string, unknown> = {};
-          for (const d of deps) depOutputs[d] = outputs.get(d);
+          for (const d of deps) if (outputs.has(d)) depOutputs[d] = outputs.get(d);
           // Reuse buildSystemPrompt VERBATIM (fidelity with executeDirectLlm) — it reads
           // only `.name`/`.description` off the task and `.input` off the iteration, so a
           // minimal cast is safe. objective+diff-context ride the SYSTEM prompt (as the
@@ -162,34 +223,90 @@ export async function runReviewTasks(params: RunReviewTasksParams): Promise<Revi
             depOutputs,
           );
           const userInput = t.input ? JSON.stringify(t.input) : "{}";
-          const res = await gateway.completeStreaming(
-            {
-              modelSlug: t.modelSlug ?? "",
-              messages: [
-                { role: "system", content: system },
-                { role: "user", content: userInput },
-              ],
-              temperature: REVIEW_TEMPERATURE,
-              maxTokens: REVIEW_MAX_TOKENS,
-            },
-            undefined,
-            undefined,
-            { overallTimeoutMs: timeoutMs },
-          );
+          const call = (modelSlug: string): Promise<{ content: string }> =>
+            gateway.completeStreaming(
+              {
+                modelSlug,
+                messages: [
+                  { role: "system", content: system },
+                  { role: "user", content: userInput },
+                ],
+                temperature: REVIEW_TEMPERATURE,
+                maxTokens: REVIEW_MAX_TOKENS,
+              },
+              undefined,
+              undefined,
+              { overallTimeoutMs: timeoutMs },
+            );
+
+          const originalSlug = t.modelSlug ?? "";
+          let res: { content: string };
+          let fallbackNote = "";
+          try {
+            res = await call(originalSlug);
+          } catch (err) {
+            const raw = err instanceof Error ? err.message : String(err);
+            if (!isRateLimitError(raw)) throw err; // NON-rate-limit: rethrow — whole run degrades exactly as before.
+
+            // Part B (throttled v2, per-seat fallback): rate-limited — auto-rotate
+            // through candidate models (different provider, not already claimed by
+            // another seat this run) before giving up on this seat.
+            const isJudge = t.name === judgeTaskName;
+            const claimed = new Set(seatModel.values());
+            const candidates = pickFallbackCandidates(originalSlug, activeModels, claimed);
+            let rotated: { content: string } | null = null;
+            let lastErr: unknown = err;
+            for (const candidate of candidates) {
+              try {
+                rotated = await call(candidate.slug);
+                seatModel.set(t.name, candidate.slug);
+                fallbackNote = `[fell back ${originalSlug}→${candidate.slug}] `;
+                break;
+              } catch (err2) {
+                const raw2 = err2 instanceof Error ? err2.message : String(err2);
+                if (!isRateLimitError(raw2)) throw err2; // non-rate-limit mid-fallback — propagate, degrade whole run.
+                lastErr = err2;
+              }
+            }
+            if (!rotated) {
+              // All candidates (or none available) are ALSO rate-limited.
+              if (isJudge) throw lastErr; // judge can't be dropped — throttles the WHOLE run (outer catch).
+              dropped.add(t.name);
+              droppedNotes.push({
+                name: t.name,
+                model: seatModel.get(t.name) ?? originalSlug,
+                role: deps.length > 0 ? "rebuttal" : "primary",
+                text: `[dropped: usage limit exhausted on ${originalSlug} and all fallback candidates]`,
+              });
+              return;
+            }
+            res = rotated;
+          }
           const parsed = parseDirectLlmResponse(res.content);
           outputs.set(t.name, parsed.output);
           if (t.name !== judgeTaskName) {
             participants.push({
               name: t.name,
-              model: t.modelSlug ?? "",
+              model: seatModel.get(t.name) ?? originalSlug,
               role: deps.length > 0 ? "rebuttal" : "primary",
-              text: formatParticipantText(parsed),
+              text: fallbackNote + formatParticipantText(parsed),
             });
           }
         }),
       );
       for (const t of ready) pending.splice(pending.indexOf(t), 1);
     }
+
+    // Part B quorum gate: only engaged when a usage-limit seat drop actually
+    // happened — a fully-successful cross-review panel and an intentional
+    // single-verifier round (0 non-judge seats BY DESIGN) are UNCHANGED.
+    if (dropped.size > 0 && participants.length < MIN_REVIEWERS) {
+      return {
+        ...degraded("insufficient reviewer quorum after usage-limit seat drops"),
+        rateLimited: true,
+      };
+    }
+
     const judgeOutput = outputs.get(judgeTaskName);
     const convergence = readConvergence(judgeOutput);
     return {
@@ -197,7 +314,7 @@ export async function runReviewTasks(params: RunReviewTasksParams): Promise<Revi
       openP0: convergence.openP0,
       openActionPoints: convergence.openActionPoints,
       verdict: readJudgeVerdict(judgeOutput),
-      participants: boundParticipants(participants),
+      participants: boundParticipants([...participants, ...droppedNotes]),
     };
   } catch (err) {
     const raw = err instanceof Error ? err.message : String(err);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1460,6 +1460,10 @@ export class MemStorage implements IStorage {
       // Agent-limit throttling (migration 0060): which phase to resume when
       // `state === "throttled"`; null for every non-throttled loop.
       throttledPhase: data.throttledPhase ?? null,
+      // "throttled v2" Part A (migration 0061): auto-resume deadline + bounded attempt
+      // counter; null/0 for every loop that has never been throttled.
+      throttledUntil: data.throttledUntil ?? null,
+      resumeAttempts: data.resumeAttempts ?? 0,
       createdBy: data.createdBy ?? null,
       createdAt: now,
       updatedAt: now,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1957,6 +1957,15 @@ export const consiliumLoops = pgTable(
     // cleared (null) on `retryThrottled`'s resume. Null whenever the loop is not
     // (and has never been) throttled.
     throttledPhase: text("throttled_phase").$type<"review" | "develop">(),
+    // "throttled v2" Part A (additive, migration 0061): bounded AUTO-RESUME bookkeeping
+    // for a loop resting in `throttled`. `throttledUntil` is the deadline stamped at the
+    // throttling transition (now + parsed Retry-After, else the configured cooldown);
+    // cleared (null) on ANY resume (auto or operator). `resumeAttempts` counts bounded
+    // auto-resume attempts for the CURRENT pause (reset to 0 on every resume) — an
+    // operator's manual Retry resets it exactly like an auto-resume would, since both
+    // clear the pause. Null/0 for every loop that has never been throttled.
+    throttledUntil: timestamp("throttled_until"),
+    resumeAttempts: integer("resume_attempts").notNull().default(0),
     createdBy: text("created_by").references(() => users.id, { onDelete: "set null" }),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),

--- a/tests/unit/consilium/loop-directreview-straddle.test.ts
+++ b/tests/unit/consilium/loop-directreview-straddle.test.ts
@@ -250,6 +250,7 @@ function makeRunnerController(systems: string[]) {
   const storage = {
     getLoopRounds: vi.fn(async () => []),
     getTaskGroup: vi.fn(async () => ({ id: "grp1", name: "[consilium-review:sdlc-cross-review] x", input: "the objective" })),
+    getActiveModels: vi.fn(async () => []),
   };
   const gateway = {
     completeStreaming: vi.fn(async (req: { messages: Array<{ role: string; content: string }> }) => {

--- a/tests/unit/consilium/loop-runner-operator-note.test.ts
+++ b/tests/unit/consilium/loop-runner-operator-note.test.ts
@@ -116,6 +116,7 @@ describe("#18 — runner-mode carries the operator's steering note into round > 
     const storage = {
       getLoopRounds: vi.fn(async () => [round1]),
       getTaskGroup: vi.fn(async () => ({ id: "grp1", name: "[consilium-review:sdlc-cross-review] x", input: "objective" })),
+      getActiveModels: vi.fn(async () => []),
     };
     const controller = new ConsiliumLoopController({
       storage: storage as never,
@@ -139,6 +140,7 @@ describe("#18 — runner-mode carries the operator's steering note into round > 
     const storage = {
       getLoopRounds: vi.fn(async () => [round1]),
       getTaskGroup: vi.fn(async () => ({ id: "grp1", name: "[consilium-review:sdlc-cross-review] x", input: "objective" })),
+      getActiveModels: vi.fn(async () => []),
     };
     const controller = new ConsiliumLoopController({
       storage: storage as never,
@@ -160,6 +162,7 @@ describe("#18 — runner-mode carries the operator's steering note into round > 
     const storage = {
       getLoopRounds: vi.fn(async () => [round1, round2]),
       getTaskGroup: vi.fn(async () => ({ id: "grp1", name: "[consilium-review:sdlc-cross-review] x", input: "objective" })),
+      getActiveModels: vi.fn(async () => []),
     };
     const controller = new ConsiliumLoopController({
       storage: storage as never,
@@ -179,6 +182,7 @@ describe("#18 — runner-mode carries the operator's steering note into round > 
     const storage = {
       getLoopRounds: vi.fn(async () => []),
       getTaskGroup: vi.fn(async () => ({ id: "grp1", name: "[consilium-review:sdlc-cross-review] x", input: "objective" })),
+      getActiveModels: vi.fn(async () => []),
     };
     const controller = new ConsiliumLoopController({
       storage: storage as never,
@@ -200,6 +204,7 @@ describe("#18 — runner-mode carries the operator's steering note into round > 
         throw new Error("transient storage blip");
       }),
       getTaskGroup: vi.fn(async () => ({ id: "grp1", name: "[consilium-review:sdlc-cross-review] x", input: "objective" })),
+      getActiveModels: vi.fn(async () => []),
     };
     const controller = new ConsiliumLoopController({
       storage: storage as never,
@@ -288,6 +293,7 @@ describe("Large Research gate — buildOperatorNote folds the latest round's Res
     const storage = {
       getLoopRounds: vi.fn(async () => [round1]),
       getTaskGroup: vi.fn(async () => ({ id: "grp1", name: "[consilium-review:large-research] x", input: "objective" })),
+      getActiveModels: vi.fn(async () => []),
     };
     const controller = new ConsiliumLoopController({
       storage: storage as never,
@@ -322,6 +328,7 @@ describe("Large Research gate — buildOperatorNote folds the latest round's Res
     const storage = {
       getLoopRounds: vi.fn(async () => [round1]),
       getTaskGroup: vi.fn(async () => ({ id: "grp1", name: "[consilium-review:large-research] x", input: "objective" })),
+      getActiveModels: vi.fn(async () => []),
     };
     const controller = new ConsiliumLoopController({
       storage: storage as never,
@@ -347,6 +354,7 @@ describe("Large Research gate — buildOperatorNote folds the latest round's Res
     const storage = {
       getLoopRounds: vi.fn(async () => [round1]),
       getTaskGroup: vi.fn(async () => ({ id: "grp1", name: "[consilium-review:sdlc-cross-review] x", input: "objective" })),
+      getActiveModels: vi.fn(async () => []),
     };
     const controller = new ConsiliumLoopController({
       storage: storage as never,
@@ -372,6 +380,7 @@ describe("Large Research gate — buildOperatorNote folds the latest round's Res
     const storage = {
       getLoopRounds: vi.fn(async () => [round1]),
       getTaskGroup: vi.fn(async () => ({ id: "grp1", name: "[consilium-review:large-research] x", input: "objective" })),
+      getActiveModels: vi.fn(async () => []),
     };
     const controller = new ConsiliumLoopController({
       storage: storage as never,

--- a/tests/unit/consilium/loop-throttle-auto-resume.test.ts
+++ b/tests/unit/consilium/loop-throttle-auto-resume.test.ts
@@ -1,0 +1,289 @@
+/**
+ * loop-throttle-auto-resume.test.ts — "throttled v2" Part A: bounded AUTO-RESUME.
+ *
+ * The throttled MVP (state `throttled`, `throttledPhase`, `isRateLimitError`,
+ * `controller.retryThrottled(loopId)`) already pauses a loop that hits an agent
+ * usage/rate limit. This adds a SELF-resume on top: a loop resting in `throttled`
+ * past its stamped `throttledUntil` deadline resumes itself via the EXISTING
+ * `retryThrottled` command — bounded by `resumeAttempts < maxAutoResumeAttempts`
+ * and gated by `throttle.autoResume`.
+ *
+ * These tests prove:
+ *   1. `reduce()` stamps `throttledUntil` on both throttled-entry transitions
+ *      (`review_throttled` cooldown-default; `dev_completed{rateLimited}` parses a
+ *      Retry-After hint from `event.error` when present, else falls back to cooldown).
+ *   2. `reduce()` clears `throttledUntil`/resets `resumeAttempts` on `retry_requested`
+ *      (the SAME branch both operator Retry and the auto-resume guard funnel through).
+ *   3. `tickInner` (via `controller.tick()`) auto-resumes a throttled loop whose
+ *      deadline has passed and whose `resumeAttempts` is under the cap — genuinely
+ *      driving it out of `throttled` (proves the in-process reentrancy guard doesn't
+ *      deadlock the self-call).
+ *   4. `tickInner` does NOT auto-resume once `resumeAttempts >= maxAutoResumeAttempts`.
+ *   5. `tickInner` does NOT auto-resume when `throttle.autoResume === false`.
+ *   6. Operator `retryThrottled` resets `resumeAttempts` to 0 (mirrors #2 end-to-end).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Deterministic review-input build: decouples the review-phase resume
+// (`retryThrottledReview` → `startReviewRound`) from real git, mirroring
+// loop-review-recovery.test.ts's convention.
+vi.mock("../../../server/services/consilium/diff-context.js", () => ({
+  buildDiffContext: vi.fn(async () => ({ ok: true, input: "REVIEW INPUT" })),
+}));
+
+import {
+  ConsiliumLoopController,
+  reduce,
+} from "../../../server/services/consilium/consilium-loop-controller.js";
+import type { ConsiliumLoopRow, ConsiliumLoopState } from "@shared/schema";
+
+const MIN = 60_000;
+
+function makeLoop(over: Partial<ConsiliumLoopRow> = {}): ConsiliumLoopRow {
+  return {
+    id: "loop-1",
+    projectId: "proj1",
+    groupId: "grp1",
+    state: "throttled",
+    round: 1,
+    maxRounds: 6,
+    repoPath: process.cwd(),
+    lastReviewedCommit: null,
+    reviewRef: null,
+    currentIterationNumber: 2,
+    reviewRedrive: null,
+    throttledPhase: "review",
+    throttledUntil: new Date(Date.now() - MIN), // deadline already passed
+    resumeAttempts: 0,
+    devGroupId: null,
+    prRef: null,
+    headCommitAtReview: null,
+    openP0: null,
+    error: "rate limited",
+    createdBy: "user1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    completedAt: null,
+    ...over,
+  } as ConsiliumLoopRow;
+}
+
+interface ThrottleCfg {
+  autoResume?: boolean;
+  cooldownSeconds?: number;
+  maxAutoResumeAttempts?: number;
+}
+const makeConfig =
+  (over: ThrottleCfg = {}) =>
+  () =>
+    ({
+      pipeline: {
+        consiliumLoop: {
+          enabled: true,
+          maxRounds: 6,
+          pollIntervalMs: 5000,
+          maxDiffBytes: 200_000,
+          allowedRepoPaths: [process.cwd()],
+          reviewStallTimeoutMs: 900_000,
+          reviewMaxRedrives: 3,
+          throttle: {
+            autoResume: over.autoResume ?? true,
+            cooldownSeconds: over.cooldownSeconds ?? 300,
+            maxAutoResumeAttempts: over.maxAutoResumeAttempts ?? 3,
+          },
+          implement: {
+            enabled: false,
+            verification: { enabled: false },
+            maxFixIterations: 3,
+            testCommand: null,
+            testRunTimeoutMs: 300_000,
+            research: { enabled: false, maxResearchIterations: 3, model: "claude-sonnet" },
+          },
+        },
+      },
+    }) as never;
+
+function fakeStorage(loop: ConsiliumLoopRow) {
+  let current = loop;
+
+  const startGroupAsync = vi.fn(async () => ({ group: {}, iteration: { iterationNumber: 99 } }));
+
+  const casLoopState = vi.fn(
+    async (id: string, expected: ConsiliumLoopState, next: ConsiliumLoopState, extra?: Record<string, unknown>) => {
+      if (id !== current.id || current.state !== expected) return undefined;
+      current = { ...current, ...(extra ?? {}), state: next };
+      return current;
+    },
+  );
+
+  const updateLoop = vi.fn(async (_id: string, extra?: Record<string, unknown>) => {
+    current = { ...current, ...(extra ?? {}) };
+    return current;
+  });
+
+  const storage = {
+    getLoop: vi.fn(async () => current),
+    getLoops: vi.fn(async () => [current]),
+    getLoopRounds: vi.fn(async () => []),
+    getTaskGroup: vi.fn(async () => ({ id: current.groupId, input: "objective", projectId: current.projectId })),
+    updateTaskGroup: vi.fn(async () => ({})),
+    getIteration: vi.fn(async () => undefined),
+    updateIteration: vi.fn(async () => ({})),
+    getExecutionsByIteration: vi.fn(async () => []),
+    getLlmRequests: vi.fn(async () => ({ rows: [], total: 0 })),
+    claimReviewRedrive: vi.fn(async () => undefined),
+    claimRedrive: vi.fn(async () => undefined),
+    casLoopState,
+    updateLoop,
+    appendLoopRound: vi.fn(async () => ({})),
+  };
+
+  return { storage, startGroupAsync, casLoopState, updateLoop, get: () => current };
+}
+
+function makeController(storage: unknown, startGroupAsync: unknown, config: () => unknown) {
+  return new ConsiliumLoopController({
+    storage: storage as never,
+    taskOrchestrator: {
+      startGroup: startGroupAsync,
+      startGroupAsync,
+      createTaskGroup: vi.fn(),
+      cancelGroup: vi.fn(),
+    } as never,
+    config: config as never,
+    readRepoHead: async () => "abc1234",
+  });
+}
+
+describe('reduce() — "throttled v2" Part A: deadline stamping + clearing', () => {
+  it("review_throttled stamps throttledUntil using the configured cooldown default", () => {
+    const before = Date.now();
+    const t = reduce("reviewing", { kind: "review_throttled" }, { throttleCooldownSeconds: 120 });
+    expect(t?.to).toBe("throttled");
+    expect(t?.extra?.throttledPhase).toBe("review");
+    const stamped = (t?.extra as { throttledUntil?: Date })?.throttledUntil;
+    expect(stamped).toBeInstanceOf(Date);
+    const deltaMs = (stamped as Date).getTime() - before;
+    expect(deltaMs).toBeGreaterThan(119_000);
+    expect(deltaMs).toBeLessThan(121_000);
+  });
+
+  it("dev_completed{rateLimited} parses a Retry-After hint from event.error over the cooldown default", () => {
+    const before = Date.now();
+    const t = reduce(
+      "developing",
+      { kind: "dev_completed", prRef: null, headCommit: "c", error: "Retry-After: 45", rateLimited: true },
+      { throttleCooldownSeconds: 300 },
+    );
+    expect(t?.to).toBe("throttled");
+    expect(t?.extra?.throttledPhase).toBe("develop");
+    const stamped = (t?.extra as { throttledUntil?: Date })?.throttledUntil;
+    const deltaMs = (stamped as Date).getTime() - before;
+    expect(deltaMs).toBeGreaterThan(44_000);
+    expect(deltaMs).toBeLessThan(46_000); // ~45s, NOT the 300s cooldown default
+  });
+
+  it("dev_completed{rateLimited} falls back to the cooldown default when event.error has no parseable hint", () => {
+    const before = Date.now();
+    const t = reduce(
+      "developing",
+      { kind: "dev_completed", prRef: null, headCommit: "c", error: "agent usage limit hit", rateLimited: true },
+      { throttleCooldownSeconds: 300 },
+    );
+    const stamped = (t?.extra as { throttledUntil?: Date })?.throttledUntil;
+    const deltaMs = (stamped as Date).getTime() - before;
+    expect(deltaMs).toBeGreaterThan(299_000);
+    expect(deltaMs).toBeLessThan(301_000);
+  });
+
+  it("dev_completed{rateLimited} NEVER threads the raw error text onto loop.error (Security L1)", () => {
+    const t = reduce(
+      "developing",
+      { kind: "dev_completed", prRef: null, headCommit: "c", error: "Retry-After: 45", rateLimited: true },
+      { throttleCooldownSeconds: 300 },
+    );
+    expect(t?.extra?.error).not.toContain("Retry-After");
+  });
+
+  it("retry_requested clears throttledUntil and resets resumeAttempts (operator OR auto-resume path)", () => {
+    const t = reduce("throttled", { kind: "retry_requested", throttledPhase: "develop" });
+    expect(t?.extra?.throttledUntil).toBeNull();
+    expect(t?.extra?.resumeAttempts).toBe(0);
+  });
+});
+
+describe('tickInner — "throttled v2" Part A: bounded auto-resume guard', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("auto-resumes a throttled loop past its deadline & under the cap (drives it OUT of throttled)", async () => {
+    const loop = makeLoop({ throttledUntil: new Date(Date.now() - MIN), resumeAttempts: 0 });
+    const { storage, startGroupAsync, casLoopState } = fakeStorage(loop);
+    const controller = makeController(storage, startGroupAsync, makeConfig({ maxAutoResumeAttempts: 3 }));
+
+    const res = await controller.tick(loop.id);
+
+    // The bump (throttled -> throttled, resumeAttempts: 1) genuinely fired...
+    expect(casLoopState).toHaveBeenCalledWith("loop-1", "throttled", "throttled", { resumeAttempts: 1 });
+    // ...and the resume itself actually ran (review resume dispatches a review round),
+    // proving the reentrancy guard was released before the self-call, not deadlocked.
+    expect(startGroupAsync).toHaveBeenCalledTimes(1);
+    expect(res?.state).toBe("reviewing");
+    // Resume (via retry_requested) clears the pause bookkeeping for the NEXT throttle.
+    expect(res?.throttledUntil).toBeNull();
+    expect(res?.resumeAttempts).toBe(0);
+  });
+
+  it("does NOT auto-resume once resumeAttempts is at the cap (stays throttled, no resume side effect)", async () => {
+    const loop = makeLoop({ throttledUntil: new Date(Date.now() - MIN), resumeAttempts: 3 });
+    const { storage, startGroupAsync, casLoopState } = fakeStorage(loop);
+    const controller = makeController(storage, startGroupAsync, makeConfig({ maxAutoResumeAttempts: 3 }));
+
+    const res = await controller.tick(loop.id);
+
+    expect(casLoopState).not.toHaveBeenCalled();
+    expect(startGroupAsync).not.toHaveBeenCalled();
+    expect(res).toBeNull();
+
+    const stillThrottled = await storage.getLoop(loop.id);
+    expect(stillThrottled.state).toBe("throttled");
+    expect(stillThrottled.resumeAttempts).toBe(3);
+  });
+
+  it("does NOT auto-resume when throttle.autoResume is false (stays throttled for operator Retry)", async () => {
+    const loop = makeLoop({ throttledUntil: new Date(Date.now() - MIN), resumeAttempts: 0 });
+    const { storage, startGroupAsync, casLoopState } = fakeStorage(loop);
+    const controller = makeController(storage, startGroupAsync, makeConfig({ autoResume: false }));
+
+    const res = await controller.tick(loop.id);
+
+    expect(casLoopState).not.toHaveBeenCalled();
+    expect(startGroupAsync).not.toHaveBeenCalled();
+    expect(res).toBeNull();
+    expect((await storage.getLoop(loop.id)).state).toBe("throttled");
+  });
+
+  it("does NOT auto-resume before the deadline has passed", async () => {
+    const loop = makeLoop({ throttledUntil: new Date(Date.now() + MIN), resumeAttempts: 0 });
+    const { storage, startGroupAsync, casLoopState } = fakeStorage(loop);
+    const controller = makeController(storage, startGroupAsync, makeConfig());
+
+    const res = await controller.tick(loop.id);
+
+    expect(casLoopState).not.toHaveBeenCalled();
+    expect(startGroupAsync).not.toHaveBeenCalled();
+    expect(res).toBeNull();
+  });
+
+  it("operator retryThrottled resets resumeAttempts to 0 (same clearing branch as auto-resume)", async () => {
+    const loop = makeLoop({ throttledUntil: new Date(Date.now() - MIN), resumeAttempts: 2 });
+    const { storage, startGroupAsync } = fakeStorage(loop);
+    const controller = makeController(storage, startGroupAsync, makeConfig());
+
+    const result = await controller.retryThrottled(loop.id);
+
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.loop.resumeAttempts).toBe(0);
+    expect(result.ok && result.loop.throttledUntil).toBeNull();
+    expect(result.ok && result.loop.state).toBe("reviewing");
+  });
+});

--- a/tests/unit/consilium/review-runner-fallback.test.ts
+++ b/tests/unit/consilium/review-runner-fallback.test.ts
@@ -1,0 +1,245 @@
+/**
+ * review-runner-fallback.test.ts — Part B (throttled v2, per-seat model fallback)
+ * unit coverage for `runReviewTasks`. Drives the DAG with a fake gateway keyed by
+ * (task name, model slug) so a seat's ORIGINAL model can rate-limit while its
+ * fallback candidate (a DIFFERENT slug, same task) succeeds. Asserts:
+ *   (a) a non-judge seat rate-limits on its original model → auto-rotates to a
+ *       different-provider candidate, verdict still returned;
+ *   (b) ALL candidates for a seat rate-limit too → the seat is DROPPED, but the
+ *       run proceeds because quorum (2 other reviewers) still holds;
+ *   (c) too many seats drop (quorum < MIN_REVIEWERS) → the WHOLE run throttles;
+ *   (d) the JUDGE seat rate-limits with no fallback candidate → the WHOLE run
+ *       throttles (the judge can never be dropped);
+ *   (e) a NON-rate-limit seat error still degrades the WHOLE run immediately,
+ *       UNCHANGED — no fallback is attempted;
+ *   (f) a rebuttal depending on a dropped primary is cascade-dropped too, without
+ *       deadlocking the judge (the DAG-guard).
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  runReviewTasks,
+  type ReviewGateway,
+  type ReviewModelCatalogEntry,
+} from "../../../server/services/consilium/review-runner.js";
+import type { CreateTaskParam } from "../../../server/services/task-orchestrator.js";
+
+const RATE_LIMIT = new Error("usage limit exceeded (429 too many requests)");
+
+const primaryReply = (name: string): string =>
+  JSON.stringify({ summary: `${name} prose`, output: { note: name }, decisions: [] });
+
+const judgeReply = (converged: boolean, openP0: number): string =>
+  JSON.stringify({
+    summary: "judge summary",
+    output: {
+      verdict: "the verdict prose",
+      pros: [],
+      cons: [],
+      action_points: openP0 > 0 ? [{ title: "fix it", priority: "P0" }] : [],
+      convergence: {
+        converged,
+        open_p0: openP0,
+        open_action_points: openP0 > 0 ? [{ title: "fix it", priority: "P0" }] : [],
+      },
+    },
+  });
+
+type Outcome = string | Error;
+
+/**
+ * Fake gateway keyed by (task name, model slug) — a per-task entry can be a FLAT
+ * `Outcome` (every model call for that task gets the same result — used to
+ * simulate "every candidate also rate-limits") or a `Record<slug, Outcome>` (used
+ * to make ONE specific model rate-limit while another succeeds, driving rotation).
+ * `calls` (optional) records every (task, model) attempt in order, for assertions
+ * on rotation/no-fallback-attempted behaviour.
+ */
+function seatGateway(
+  byTaskModel: Record<string, Record<string, Outcome> | Outcome>,
+  calls: Array<{ task: string; model: string }> = [],
+): ReviewGateway {
+  return {
+    completeStreaming: vi.fn(
+      async (req: { modelSlug: string; messages: Array<{ role: string; content: string }> }) => {
+        const system = req.messages.find((m) => m.role === "system")?.content ?? "";
+        const taskName = Object.keys(byTaskModel).find((n) => system.includes(`Your specific task: ${n}`)) ?? "";
+        calls.push({ task: taskName, model: req.modelSlug });
+        const entry = byTaskModel[taskName];
+        const outcome = typeof entry === "string" || entry instanceof Error ? entry : entry?.[req.modelSlug];
+        if (outcome === undefined) throw new Error(`no canned reply for ${taskName}/${req.modelSlug}`);
+        if (outcome instanceof Error) throw outcome;
+        return { content: outcome };
+      },
+    ),
+  };
+}
+
+/** 3 independent primaries (no rebuttals) + a judge depending on all 3. */
+const panelTasks = (): CreateTaskParam[] => [
+  { name: "P-A", description: "primary A", executionMode: "direct_llm", modelSlug: "anthropic-a", dependsOn: [] },
+  { name: "P-B", description: "primary B", executionMode: "direct_llm", modelSlug: "google-b", dependsOn: [] },
+  { name: "P-C", description: "primary C", executionMode: "direct_llm", modelSlug: "openai-c", dependsOn: [] },
+  {
+    name: "Judge",
+    description: "judge",
+    executionMode: "direct_llm",
+    modelSlug: "anthropic-a",
+    dependsOn: ["P-A", "P-B", "P-C"],
+  },
+];
+
+const catalog: ReviewModelCatalogEntry[] = [
+  { slug: "anthropic-a", provider: "anthropic" },
+  { slug: "anthropic-a2", provider: "anthropic" },
+  { slug: "google-b", provider: "google" },
+  { slug: "google-b2", provider: "google" },
+  { slug: "openai-c", provider: "openai" },
+];
+
+const base = {
+  judgeTaskName: "Judge",
+  groupName: "grp",
+  groupInput: "THE OBJECTIVE AND DIFF",
+  timeoutMs: 1000,
+  activeModels: catalog,
+};
+
+describe("runReviewTasks — Part B per-seat fallback: auto-rotation", () => {
+  it("(a) a non-judge seat rate-limits on its original model → rotates to a different-provider candidate, verdict still returned", async () => {
+    const calls: Array<{ task: string; model: string }> = [];
+    const gateway = seatGateway(
+      {
+        "P-A": { "anthropic-a": RATE_LIMIT, "google-b2": primaryReply("P-A") },
+        "P-B": primaryReply("P-B"),
+        "P-C": primaryReply("P-C"),
+        Judge: judgeReply(true, 0),
+      },
+      calls,
+    );
+    const r = await runReviewTasks({ ...base, tasks: panelTasks(), gateway });
+
+    expect(r.error).toBeUndefined();
+    expect(r.rateLimited).toBeUndefined();
+    expect(r.converged).toBe(true);
+    const pa = (r.participants ?? []).find((p) => p.name === "P-A");
+    expect(pa?.model).toBe("google-b2"); // rotated off "anthropic-a" (different provider)
+    expect(pa?.text).toContain("[fell back anthropic-a→google-b2]");
+    expect(calls.filter((c) => c.task === "P-A").map((c) => c.model)).toEqual(["anthropic-a", "google-b2"]);
+  });
+});
+
+describe("runReviewTasks — Part B per-seat fallback: drop + quorum", () => {
+  it("(b) drops a seat once ALL fallback candidates ALSO rate-limit, but proceeds because quorum (2 others) holds", async () => {
+    const gateway = seatGateway({
+      "P-A": primaryReply("P-A"),
+      "P-B": RATE_LIMIT, // every model tried for P-B rate-limits (original + its only candidate)
+      "P-C": primaryReply("P-C"),
+      Judge: judgeReply(false, 1),
+    });
+    const r = await runReviewTasks({ ...base, tasks: panelTasks(), gateway });
+
+    expect(r.error).toBeUndefined();
+    expect(r.rateLimited).toBeUndefined();
+    expect(r.converged).toBe(false);
+    expect(r.openP0).toBe(1);
+    const byName = Object.fromEntries((r.participants ?? []).map((p) => [p.name, p]));
+    expect(byName["P-A"]).toBeTruthy();
+    expect(byName["P-C"]).toBeTruthy();
+    expect(byName["P-B"].text).toContain("[dropped:");
+  });
+
+  it("(c) too many seats drop (quorum < MIN_REVIEWERS) → the WHOLE run throttles", async () => {
+    const gateway = seatGateway({
+      "P-A": primaryReply("P-A"),
+      "P-B": RATE_LIMIT,
+      "P-C": RATE_LIMIT,
+      Judge: judgeReply(true, 0),
+    });
+    const r = await runReviewTasks({ ...base, tasks: panelTasks(), gateway });
+
+    expect(r.rateLimited).toBe(true);
+    expect(r.error).toBeTruthy();
+    expect(r.converged).toBe(false);
+    expect(r.verdict).toBeNull();
+    expect(r.participants).toBeNull();
+  });
+
+  it("(d) the JUDGE seat rate-limits with no fallback candidate available → the WHOLE run throttles", async () => {
+    const gateway = seatGateway({
+      "P-A": primaryReply("P-A"),
+      "P-B": primaryReply("P-B"),
+      "P-C": primaryReply("P-C"),
+      Judge: RATE_LIMIT,
+    });
+    const r = await runReviewTasks({ ...base, tasks: panelTasks(), gateway, activeModels: [] });
+
+    expect(r.rateLimited).toBe(true);
+    expect(r.error).toBeTruthy();
+    expect(r.converged).toBe(false);
+    expect(r.verdict).toBeNull();
+    expect(r.participants).toBeNull();
+  });
+});
+
+describe("runReviewTasks — Part B: non-rate-limit path stays UNCHANGED", () => {
+  it("(e) a NON-rate-limit seat error still degrades the WHOLE run immediately — no fallback attempted", async () => {
+    const calls: Array<{ task: string; model: string }> = [];
+    const gateway = seatGateway(
+      {
+        "P-A": primaryReply("P-A"),
+        "P-B": new Error("gateway timed out reading /Users/secret/key.pem"),
+        "P-C": primaryReply("P-C"),
+        Judge: judgeReply(true, 0),
+      },
+      calls,
+    );
+    const r = await runReviewTasks({ ...base, tasks: panelTasks(), gateway });
+
+    expect(r.error).toBeTruthy();
+    expect(r.error).not.toContain("/Users"); // fs path scrubbed
+    expect(r.rateLimited).toBeUndefined();
+    expect(r.converged).toBe(false);
+    expect(r.verdict).toBeNull();
+    expect(r.participants).toBeNull();
+    // NOT rate-limited — rethrown immediately, no rotation attempt (exactly one call).
+    expect(calls.filter((c) => c.task === "P-B")).toHaveLength(1);
+  });
+});
+
+describe("runReviewTasks — Part B: DAG cascade-drop guard", () => {
+  it("(f) a rebuttal depending on a dropped primary is cascade-dropped too, without deadlocking the judge", async () => {
+    const tasks: CreateTaskParam[] = [
+      { name: "P-A", description: "primary A", executionMode: "direct_llm", modelSlug: "anthropic-a", dependsOn: [] },
+      { name: "R-A", description: "rebuts P-A", executionMode: "direct_llm", modelSlug: "anthropic-a2", dependsOn: ["P-A"] },
+      { name: "P-B", description: "primary B", executionMode: "direct_llm", modelSlug: "google-b", dependsOn: [] },
+      { name: "P-C", description: "primary C", executionMode: "direct_llm", modelSlug: "openai-c", dependsOn: [] },
+      {
+        name: "Judge",
+        description: "judge",
+        executionMode: "direct_llm",
+        modelSlug: "google-b2",
+        dependsOn: ["P-A", "R-A", "P-B", "P-C"],
+      },
+    ];
+    const calls: Array<{ task: string; model: string }> = [];
+    const gateway = seatGateway(
+      {
+        "P-A": RATE_LIMIT, // exhausts every candidate too — dropped
+        "R-A": primaryReply("R-A"), // must NEVER be called — cascade-dropped before scheduling
+        "P-B": primaryReply("P-B"),
+        "P-C": primaryReply("P-C"),
+        Judge: judgeReply(true, 0),
+      },
+      calls,
+    );
+    const r = await runReviewTasks({ ...base, tasks, gateway });
+
+    expect(r.error).toBeUndefined();
+    expect(r.converged).toBe(true);
+    const names = (r.participants ?? []).map((p) => p.name);
+    expect(names).toContain("P-B");
+    expect(names).toContain("P-C");
+    expect(names).not.toContain("R-A");
+    expect(calls.some((c) => c.task === "R-A")).toBe(false); // never scheduled — cascade-dropped
+  });
+});

--- a/tests/unit/gateway/rate-limit.test.ts
+++ b/tests/unit/gateway/rate-limit.test.ts
@@ -6,7 +6,7 @@
  * worse than false negative — see rate-limit.ts's header).
  */
 import { describe, it, expect } from "vitest";
-import { isRateLimitError } from "../../../server/gateway/rate-limit.js";
+import { isRateLimitError, parseRetryAfterSeconds } from "../../../server/gateway/rate-limit.js";
 
 describe("isRateLimitError — positive (CLEAR signatures)", () => {
   const positives = [
@@ -52,4 +52,41 @@ describe("isRateLimitError — negative (ambiguous / unrelated — keeps existin
       expect(isRateLimitError(text)).toBe(false);
     });
   }
+});
+
+describe("parseRetryAfterSeconds — best-effort cooldown parse (throttled v2 auto-resume)", () => {
+  const positives: Array<[string, number]> = [
+    ["retry after 42s", 42],
+    ["Retry-After: 120", 120],
+    ["retry-after 90 seconds", 90],
+    ["try again in 5m", 300],
+    ["try again in 2 minutes", 120],
+    ["retry after 1h", 3600],
+    ["please retry-after 3 hours", 10800],
+    ["Retry-After:120", 120], // no space after colon
+    ["RATE LIMITED. Retry-After: 30", 30],
+  ];
+  for (const [text, seconds] of positives) {
+    it(`parses ${JSON.stringify(text)} -> ${seconds}s`, () => {
+      expect(parseRetryAfterSeconds(text)).toBe(seconds);
+    });
+  }
+
+  const negatives = [
+    "",
+    "429 Too Many Requests",
+    "rate limit exceeded, please slow down",
+    "CLI timed out after 1429ms",
+    "connection reset by peer",
+    "quota exceeded for this project",
+  ];
+  for (const text of negatives) {
+    it(`returns null for ${JSON.stringify(text.slice(0, 60))}`, () => {
+      expect(parseRetryAfterSeconds(text)).toBeNull();
+    });
+  }
+
+  it("never throws on garbage input", () => {
+    expect(() => parseRetryAfterSeconds("retry after " + "9".repeat(400) + "s")).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
Builds on the throttled MVP (#555): a rate-limited loop no longer just waits for a manual Retry, and a single limited reviewer seat no longer pauses the whole panel.

### Auto-resume
- A `throttled` loop resumes itself after a cooldown. New `throttled_until` + `resume_attempts` columns (**migration 0061**, additive) and config `pipeline.consiliumLoop.throttle` — `autoResume` (default **true**, kill-switch), `cooldownSeconds` (300), `maxAutoResumeAttempts` (3), optional `coderFallbackModel`.
- The poller resumes via the existing `retryThrottled` once `throttled_until` passes, bounded by the attempt cap; past the cap it stays paused for the operator (manual Retry resets the counter). `throttled` stays a resting state in `deriveEvent` — auto-resume lives in `tickInner`, preserving the "poller never emits retry_requested" invariant.
- Deadline honours a best-effort `Retry-After` parsed from the CLI error text (`parseRetryAfterSeconds`), else the cooldown. (CLI providers expose no structured Retry-After header — text-only.)

### Per-seat model fallback
- When ONE reviewer seat hits a usage limit, the runner **auto-rotates** that seat to another visible/active model on a **different provider** (from `getActiveModels()`), instead of rejecting the whole wave. If all candidates are limited the seat is **dropped** (with a DAG-safe cascade so dependent rebuttals don't deadlock), and the round proceeds while a **quorum (≥2 reviewers) + the judge** remain. The judge can only swap (never drop). Only when the quorum/judge can't be met does the whole run throttle (→ auto-resume).
- Non-rate-limit errors **rethrow** → the existing whole-run degrade/fail path is byte-identical.

### UI
- The throttled callout shows a live **auto-resume countdown** ("Auto-resuming in ~Xm Ys") + an attempt hint; manual Retry unchanged.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run tests/unit/` — 4559 passed, 0 real failures (parseRetryAfterSeconds formats/null; auto-resume: deadline+attempts<cap→retryThrottled, ≥cap→stays, autoResume off→no-op; fallback: seat swap/drop/quorum, judge-swap, non-limit path unchanged)
- [x] Migration 0061 applied to dev; server healthy
- [ ] Migration 0061 applied in target env (`ADD COLUMN IF NOT EXISTS`)