### PR TITLE
feat(consilium): re-run a terminal loop + explain the Failed state

### DIFF
--- a/client/src/hooks/use-consilium-loops.ts
+++ b/client/src/hooks/use-consilium-loops.ts
@@ -448,6 +448,31 @@ export function useRetryThrottledLoop() {
   });
 }
 
+/** The `POST /:id/rerun` response — the freshly-cloned loop's id. */
+export interface RerunLoopResult {
+  id: string;
+}
+
+/**
+ * Clone a TERMINAL loop (failed/cancelled/stopped_cap/escalated/converged) into
+ * a brand-new loop with the same inputs, so an operator can retry a dead-end run
+ * without re-entering the launch form by hand. Owner-or-admin, same shape as
+ * `useCancelLoop`/`useRetryThrottledLoop`. Server-enforced: 409 (WRONG_STATE)
+ * when the source loop isn't actually terminal — `apiRequest` throws that as an
+ * Error whose message is the server's `error` string, surfaced verbatim by the
+ * caller's toast. On success we invalidate the LIST (the new loop shows up
+ * there); the caller is responsible for navigating to the new loop's id.
+ */
+export function useRerunLoop() {
+  const qc = useQueryClient();
+  return useMutation<RerunLoopResult, Error, string>({
+    mutationFn: (id) => apiRequest("POST", `${LIST_KEY}/${id}/rerun`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [LIST_KEY] });
+    },
+  });
+}
+
 /**
  * The HITL gate. Server-enforced maintainer/admin only — a plain owner gets 403,
  * which `apiRequest` throws as an Error (the caller surfaces a role-aware toast).

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -19,7 +19,7 @@
  * Every external link (PR + citations + sources) uses rel="noopener noreferrer".
  */
 import { useEffect, useRef, useState } from "react";
-import { useParams, Link } from "wouter";
+import { useParams, Link, useLocation } from "wouter";
 import { formatDistanceToNow } from "date-fns";
 import {
   Repeat,
@@ -54,6 +54,7 @@ import {
   CheckCircle2,
   MessageSquare,
   PauseCircle,
+  RotateCcw,
 } from "lucide-react";
 import {
   useConsiliumLoop,
@@ -65,6 +66,7 @@ import {
   usePlanLoop,
   useSetArchetype,
   useRetryThrottledLoop,
+  useRerunLoop,
   isTerminalLoopState,
   isVerdictTerminalLoopState,
   type ConsiliumLoopRoundRow,
@@ -1020,6 +1022,21 @@ const STATUS_TONE_STYLE: Record<
   },
 };
 
+/**
+ * Terminal states where cloning into a fresh run is a sensible next action —
+ * every dead-end (failed/cancelled/capped/escalated) plus a clean `converged`
+ * run an operator wants to redo (e.g. against new commits). Read alongside
+ * `explainLoopState`, never a replacement for it — the button AUGMENTS the
+ * existing title/detail message, it never hides it.
+ */
+const RERUNNABLE_STATES: ReadonlySet<ConsiliumLoopState> = new Set<ConsiliumLoopState>([
+  "failed",
+  "cancelled",
+  "stopped_cap",
+  "escalated",
+  "converged",
+]);
+
 function LoopStatusCallout({ loop }: { loop: ConsiliumLoopDetailRow }) {
   // Agent-limit throttling (MVP): `throttled` gets a dedicated INTERACTIVE
   // callout (it carries a Retry action, which the pure `explainLoopState` text
@@ -1031,15 +1048,63 @@ function LoopStatusCallout({ loop }: { loop: ConsiliumLoopDetailRow }) {
   const { title, tone, detail } = explainLoopState(loop);
   const s = STATUS_TONE_STYLE[tone];
   const Icon = s.Icon;
+  const canRerun = RERUNNABLE_STATES.has(loop.state as ConsiliumLoopState);
   return (
     <div className={`flex items-start gap-2 rounded-md border p-3 text-sm ${s.card}`}>
       <Icon className={`h-4 w-4 shrink-0 mt-0.5 ${s.icon}`} aria-hidden="true" />
-      <div className="min-w-0">
+      <div className="min-w-0 flex-1">
         <p className={`font-medium ${s.title}`}>{title}</p>
         {/* INERT loop/user-authored text (error/cancellation note) or a code template. */}
         <p className={`break-words ${s.body}`}>{detail}</p>
       </div>
+      {canRerun && <RerunLoopButton loopId={loop.id} />}
     </div>
+  );
+}
+
+/**
+ * Re-run action appended to a TERMINAL loop's status callout: clones the loop
+ * into a fresh run (`POST /:id/rerun`) and navigates to the new loop on
+ * success, so an operator doesn't have to re-enter the launch form by hand
+ * after a failed/cancelled/capped/escalated/converged run. Server-enforced:
+ * 409 (WRONG_STATE — the loop is no longer terminal, e.g. another operator
+ * already re-ran it) surfaces the server's `error` text verbatim via toast,
+ * the same treatment as the other loop-action handlers on this page.
+ */
+function RerunLoopButton({ loopId }: { loopId: string }) {
+  const { toast } = useToast();
+  const [, navigate] = useLocation();
+  const rerunLoop = useRerunLoop();
+
+  async function handleRerun() {
+    try {
+      const { id } = await rerunLoop.mutateAsync(loopId);
+      navigate(`/consilium-loops/${id}`);
+    } catch (err) {
+      toast({
+        variant: "destructive",
+        title: "Could not re-run loop",
+        description: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      onClick={handleRerun}
+      disabled={rerunLoop.isPending}
+      className="shrink-0"
+      data-testid="loop-rerun-button"
+    >
+      {rerunLoop.isPending ? (
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+      ) : (
+        <RotateCcw className="mr-2 h-4 w-4" />
+      )}
+      Re-run
+    </Button>
   );
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -305,7 +305,13 @@ export async function registerRoutes(
         await flipSpecStatus({ specPath, specRepoPath, from: "in-progress", to: target.to, reason: target.reason });
       },
     });
-    registerConsiliumLoopRoutes(app, storage, consiliumLoopController, () => appConfigLoader.get());
+    registerConsiliumLoopRoutes(
+      app,
+      storage,
+      consiliumLoopController,
+      () => appConfigLoader.get(),
+      taskOrchestrator,
+    );
     // POST /api/consilium-reviews — the UI "New consilium review" button. Same
     // factory + same fail-closed allowlist as the trigger path. Registered ONLY
     // inside the kill-switch block (inert otherwise), mounted behind

--- a/server/routes/consilium-loops.ts
+++ b/server/routes/consilium-loops.ts
@@ -22,7 +22,7 @@ import type {
   ReReviewErrorCode,
   RetryThrottledErrorCode,
 } from "../services/consilium/consilium-loop-controller.js";
-import { ARCHETYPES } from "@shared/types";
+import { ARCHETYPES, type ConsiliumReviewPreset } from "@shared/types";
 import { CONSILIUM_LOOP_TERMINAL_STATES } from "@shared/schema";
 import { computeOpenRemainder } from "@shared/consilium-remainder";
 import { isPrBearingLoop, type PrQueueItem } from "@shared/pr-queue";
@@ -38,6 +38,11 @@ import {
   parseConsiliumPreset,
   type LoopComposition,
 } from "../services/consilium/composition.js";
+import {
+  createConsiliumReview,
+  type CreateConsiliumReviewDeps,
+} from "../services/consilium/review-factory.js";
+import type { TaskOrchestrator } from "../services/task-orchestrator.js";
 
 const SHA_RE = /^[0-9a-f]{7,64}$/;
 
@@ -139,6 +144,14 @@ export function registerConsiliumLoopRoutes(
   storage: IStorage,
   controller: ConsiliumLoopController,
   config: () => AppConfig,
+  // Re-run (POST /:id/rerun) clones a TERMINAL loop's config through the SAME
+  // `createConsiliumReview` factory the normal /api/consilium-reviews create path
+  // uses (reviewGate/panel/objective/large-research re-derived from the preset,
+  // never hand-rolled) — that factory needs the task orchestrator dep. OPTIONAL
+  // so the pre-existing 4-arg call sites (tests) keep compiling untouched; the
+  // real `routes.ts` registration always passes it, and the rerun route itself
+  // 500s (rather than crashing) if it's somehow absent.
+  orchestrator?: TaskOrchestrator,
 ): void {
   // ── Create ────────────────────────────────────────────────────────────────
   app.post(
@@ -420,6 +433,80 @@ export function registerConsiliumLoopRoutes(
       return res.json(maskLoop({ ...result.loop }, !!isAdmin));
     }
     return mapRetryThrottledError(res, result.code);
+  });
+
+  // ── Re-run (clone a TERMINAL loop's config into a brand-new loop) ───────────
+  // Owner-or-admin (authorizeConsiliumLoop, 404-on-mismatch, mirrors /develop).
+  // A terminal loop is a dead end today: /develop only re-opens the VERDICT
+  // terminals (converged/stopped_cap/escalated) and /retry only resumes
+  // `throttled` (non-terminal) — `failed`/`cancelled` (and any other terminal
+  // state an operator just wants a clean do-over of) have no path forward.
+  // Rerun refuses (409) unless the SOURCE loop is terminal, then clones its
+  // config — repoPath, preset (recovered from its group NAME, same recovery
+  // the GET :id `composition` block uses; a legacy/unparseable name falls back
+  // to the safe default preset rather than failing), maxRounds, commitPrefix —
+  // through the SAME `createConsiliumReview` factory the normal create paths
+  // use, so reviewGate/panel/objective/large-research are re-derived from the
+  // preset exactly as a fresh create would (never a hand-rolled loop insert).
+  // The factory always starts what it builds, so the new loop autostarts.
+  app.post("/api/consilium-loops/:id/rerun", async (req: Request, res: Response) => {
+    const auth = await authorizeConsiliumLoop(req, res, storage, String(req.params.id));
+    if (!auth) return;
+    if (!req.user?.id) return res.status(401).json({ error: "Authentication required" });
+    if (!req.projectId) return res.status(400).json({ error: "x-project-id header is required" });
+    if (!orchestrator) {
+      return res.status(500).json({ error: "rerun is not available (task orchestrator not wired)" });
+    }
+
+    const source = auth.loop;
+    if (!(CONSILIUM_LOOP_TERMINAL_STATES as readonly string[]).includes(source.state)) {
+      return res.status(409).json({
+        error:
+          "loop is not in a terminal state (failed / cancelled / converged / stopped_cap / escalated) — rerun is not applicable",
+      });
+    }
+
+    // Recover the preset from the source loop's group NAME. A group whose name
+    // predates (or was never given) the `[consilium-review:<preset>]` prefix
+    // falls back to the safe default preset — a legacy loop can still be
+    // rerun, just without a guaranteed byte-identical panel/objective.
+    let preset: ConsiliumReviewPreset;
+    try {
+      const group = await storage.getTaskGroup(source.groupId);
+      preset = parseConsiliumPreset(group?.name) ?? "sdlc-cross-review";
+    } catch {
+      preset = "sdlc-cross-review";
+    }
+
+    try {
+      const reviewFactoryDeps: CreateConsiliumReviewDeps = { storage, orchestrator, controller, config };
+      const newLoop = await createConsiliumReview(reviewFactoryDeps, {
+        projectId: req.projectId,
+        repoPath: source.repoPath,
+        preset,
+        createdBy: req.user.id,
+        maxRounds: source.maxRounds,
+        commitPrefix: source.commitPrefix ?? undefined,
+      });
+      return res.status(201).json({ id: newLoop.id });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // The source loop's repoPath may no longer be allowlisted / a registered
+      // workspace by the time it's rerun (config or workspace list can drift
+      // between the original run and now) — surface an ACTIONABLE 400 mirroring
+      // the create route's own mapping, rather than an opaque 500.
+      if (/is not a workspace of this project/i.test(message)) {
+        return res.status(400).json({
+          error: `repoPath "${source.repoPath}" is no longer a registered workspace of this project.`,
+        });
+      }
+      if (/allowlist|outside every allowed|denied system|traversal|fail-closed/i.test(message)) {
+        return res.status(400).json({
+          error: `repoPath "${source.repoPath}" is no longer in the allowed repo paths — add it to consiliumLoop.allowedRepoPaths in config.yaml (then restart).`,
+        });
+      }
+      return res.status(500).json({ error: "Failed to re-run loop" });
+    }
   });
 
   // ── Plan (Stage 1 §6: OUT-OF-BAND intent→archetype planner) ─────────────────

--- a/shared/loop-status.ts
+++ b/shared/loop-status.ts
@@ -123,6 +123,18 @@ function openWorkClause(loop: LoopStatusInput): string {
   return "some items may still be open";
 }
 
+/**
+ * The GENERIC failure text the controller stamps on `loop.error` when a review
+ * run dies with no more specific message (`REVIEW_RUN_FAILED` in
+ * consilium-loop-controller.ts). Detected here so `failed` can hand the
+ * operator an ACTIONABLE explanation of what that opaque three words actually
+ * means, instead of just echoing them back verbatim.
+ */
+const GENERIC_REVIEW_RUN_FAILED = "review run failed";
+
+/** Appended to every `failed` explanation — the loop has no in-place resume. */
+const RERUN_SUGGESTION = "Re-run to start a fresh loop with the same settings.";
+
 /** Humanize a raw state token as a last-resort title (never render blank). */
 function humanizeState(state: string): string {
   return state
@@ -238,15 +250,34 @@ export function explainLoopState(loop: LoopStatusInput): LoopStatusExplanation {
       };
     }
 
-    case "failed":
+    case "failed": {
+      // A `failed` loop has no in-place resume (unlike `throttled`, which
+      // retries, or the verdict terminals, which develop) — a re-run cloning
+      // the SAME config into a fresh loop is the only way forward, so every
+      // branch below ends with that suggestion.
+      if (!loop.error) {
+        return {
+          title: "Failed",
+          tone: "bad",
+          detail: `The last round failed with an unrecoverable error. See the round details below. ${RERUN_SUGGESTION}`,
+        };
+      }
+      if (loop.error === GENERIC_REVIEW_RUN_FAILED) {
+        // The generic controller-authored message names no specific cause —
+        // explain what it actually covers instead of echoing three opaque words.
+        return {
+          title: "Failed",
+          tone: "bad",
+          detail: `The review run failed — a reviewer model errored or the run was interrupted (e.g. a restart mid-review). ${RERUN_SUGGESTION}`,
+        };
+      }
+      // A specific error (#466-style): surface it verbatim, then the suggestion.
       return {
         title: "Failed",
         tone: "bad",
-        // Reuse #466: render the loop's own error as the explanation.
-        detail: loop.error
-          ? loop.error
-          : "The last round failed with an unrecoverable error. See the round details below.",
+        detail: `${loop.error} — re-run to start a fresh loop.`,
       };
+    }
 
     case "cancelled":
       return {

--- a/tests/unit/consilium/consilium-loops-rerun-route.test.ts
+++ b/tests/unit/consilium/consilium-loops-rerun-route.test.ts
@@ -1,0 +1,186 @@
+/**
+ * consilium-loops-rerun-route.test.ts — POST /api/consilium-loops/:id/rerun.
+ *
+ * A `failed` (or any other TERMINAL) loop is a dead end today: `/develop` only
+ * re-opens the verdict terminals (converged/stopped_cap/escalated) and `/retry`
+ * only resumes `throttled` (non-terminal). Rerun clones the SOURCE loop's config
+ * — repoPath / preset (recovered from its group name) / maxRounds / commitPrefix
+ * — through the SAME `createConsiliumReview` factory the normal create paths use,
+ * and returns the NEW loop id.
+ *
+ * The factory is mocked (same resolved module the route imports), mirroring
+ * consilium-reviews-route.test.ts — we assert the route's refusal/recovery/wiring
+ * logic, not the factory internals (covered in review-factory.test.ts).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import request from "supertest";
+
+vi.mock("../../../server/services/consilium/review-factory.js", () => ({
+  createConsiliumReview: vi.fn(),
+}));
+
+import type { AppConfig } from "../../../server/config/schema.js";
+import type { IStorage } from "../../../server/storage.js";
+import type { ConsiliumLoopController } from "../../../server/services/consilium/consilium-loop-controller.js";
+import { registerConsiliumLoopRoutes } from "../../../server/routes/consilium-loops.js";
+import { createConsiliumReview } from "../../../server/services/consilium/review-factory.js";
+
+const mockedCreate = vi.mocked(createConsiliumReview);
+
+const LOOP_ID = "loop-1";
+const OWNER = "user-1";
+const PROJECT_ID = "project-1";
+
+const FAILED_LOOP = {
+  id: LOOP_ID,
+  groupId: "grp-1",
+  state: "failed",
+  round: 2,
+  maxRounds: 4,
+  createdBy: OWNER,
+  repoPath: "/repos/widget",
+  commitPrefix: "JIRA-42",
+  error: "review run failed",
+};
+
+const config = () => ({ pipeline: { consiliumLoop: {} } }) as unknown as AppConfig;
+
+function makeApp(opts: {
+  loop?: Record<string, unknown>;
+  group?: { name: string } | undefined;
+  user?: { id: string; role?: string } | undefined;
+  projectId?: string | undefined;
+} = {}) {
+  const {
+    loop = { ...FAILED_LOOP },
+    group = { name: "[consilium-review:sdlc-cross-review] widget" },
+  } = opts;
+  const user = "user" in opts ? opts.user : { id: OWNER };
+  // Same pitfall as `user` above: an explicit `projectId: undefined` must NOT
+  // be swallowed back to the default by destructuring — distinguish "key
+  // absent" (use the default) from "explicitly unset" (simulate a missing
+  // x-project-id header).
+  const projectId = "projectId" in opts ? opts.projectId : PROJECT_ID;
+
+  const storage = {
+    getLoop: vi.fn(async () => loop),
+    getTaskGroup: vi.fn(async () => group),
+  } as unknown as IStorage;
+
+  const controller = {} as unknown as ConsiliumLoopController;
+  const orchestrator = {} as never;
+
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (user) (req as unknown as { user: typeof user }).user = user;
+    if (projectId !== undefined) (req as unknown as { projectId: string }).projectId = projectId;
+    next();
+  });
+  registerConsiliumLoopRoutes(app, storage, controller, config, orchestrator);
+  return { app, storage };
+}
+
+describe("POST /api/consilium-loops/:id/rerun", () => {
+  beforeEach(() => mockedCreate.mockReset());
+
+  it("refuses a NON-terminal loop with 409, createConsiliumReview NOT called", async () => {
+    const { app } = makeApp({ loop: { ...FAILED_LOOP, state: "developing" } });
+    const res = await request(app).post(`/api/consilium-loops/${LOOP_ID}/rerun`).send();
+    expect(res.status).toBe(409);
+    expect(mockedCreate).not.toHaveBeenCalled();
+  });
+
+  it("clones a TERMINAL (failed) loop's config through createConsiliumReview → 201 { id }", async () => {
+    mockedCreate.mockResolvedValueOnce({ id: "loop-new" } as never);
+    const { app } = makeApp();
+    const res = await request(app).post(`/api/consilium-loops/${LOOP_ID}/rerun`).send();
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ id: "loop-new" });
+    expect(mockedCreate).toHaveBeenCalledTimes(1);
+    expect(mockedCreate.mock.calls[0][1]).toMatchObject({
+      projectId: PROJECT_ID,
+      repoPath: "/repos/widget",
+      preset: "sdlc-cross-review",
+      createdBy: OWNER,
+      maxRounds: 4,
+      commitPrefix: "JIRA-42",
+    });
+  });
+
+  it("accepts every OTHER terminal state too (converged / stopped_cap / escalated / cancelled)", async () => {
+    for (const state of ["converged", "stopped_cap", "escalated", "cancelled"]) {
+      mockedCreate.mockReset();
+      mockedCreate.mockResolvedValueOnce({ id: `loop-${state}` } as never);
+      const { app } = makeApp({ loop: { ...FAILED_LOOP, state } });
+      const res = await request(app).post(`/api/consilium-loops/${LOOP_ID}/rerun`).send();
+      expect(res.status, `state=${state}`).toBe(201);
+      expect(mockedCreate).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("a legacy/unparseable group name falls back to the safe default preset", async () => {
+    mockedCreate.mockResolvedValueOnce({ id: "loop-new" } as never);
+    const { app } = makeApp({ group: { name: "some legacy group name" } });
+    const res = await request(app).post(`/api/consilium-loops/${LOOP_ID}/rerun`).send();
+    expect(res.status).toBe(201);
+    expect(mockedCreate.mock.calls[0][1]).toMatchObject({ preset: "sdlc-cross-review" });
+  });
+
+  it("recovers a NON-default preset from the group name (e.g. diff-pr-review)", async () => {
+    mockedCreate.mockResolvedValueOnce({ id: "loop-new" } as never);
+    const { app } = makeApp({ group: { name: "[consilium-review:diff-pr-review] widget" } });
+    const res = await request(app).post(`/api/consilium-loops/${LOOP_ID}/rerun`).send();
+    expect(res.status).toBe(201);
+    expect(mockedCreate.mock.calls[0][1]).toMatchObject({ preset: "diff-pr-review" });
+  });
+
+  it("a foreign loop → 404 (owner-or-admin, no existence oracle), createConsiliumReview NOT called", async () => {
+    const { app } = makeApp({ user: { id: "intruder" } });
+    const res = await request(app).post(`/api/consilium-loops/${LOOP_ID}/rerun`).send();
+    expect(res.status).toBe(404);
+    expect(mockedCreate).not.toHaveBeenCalled();
+  });
+
+  it("401 when unauthenticated", async () => {
+    const { app } = makeApp({ user: undefined });
+    const res = await request(app).post(`/api/consilium-loops/${LOOP_ID}/rerun`).send();
+    expect(res.status).toBe(401);
+    expect(mockedCreate).not.toHaveBeenCalled();
+  });
+
+  it("400 when x-project-id is missing", async () => {
+    const { app } = makeApp({ projectId: undefined });
+    const res = await request(app).post(`/api/consilium-loops/${LOOP_ID}/rerun`).send();
+    expect(res.status).toBe(400);
+    expect(mockedCreate).not.toHaveBeenCalled();
+  });
+
+  it("maps a repoPath-no-longer-allowlisted factory error to an actionable 400", async () => {
+    mockedCreate.mockRejectedValueOnce(
+      new Error(`[repo-allowlist] Path "/repos/widget" is outside every allowed repo root`),
+    );
+    const { app } = makeApp();
+    const res = await request(app).post(`/api/consilium-loops/${LOOP_ID}/rerun`).send();
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/no longer in the allowed repo paths/i);
+  });
+
+  it("maps a repoPath-no-longer-a-workspace factory error to an actionable 400", async () => {
+    mockedCreate.mockRejectedValueOnce(
+      new Error(`[project-workspace] repoPath "/repos/widget" is not a workspace of this project`),
+    );
+    const { app } = makeApp();
+    const res = await request(app).post(`/api/consilium-loops/${LOOP_ID}/rerun`).send();
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/no longer a registered workspace/i);
+  });
+
+  it("an unexpected factory error → 500", async () => {
+    mockedCreate.mockRejectedValueOnce(new Error("boom"));
+    const { app } = makeApp();
+    const res = await request(app).post(`/api/consilium-loops/${LOOP_ID}/rerun`).send();
+    expect(res.status).toBe(500);
+  });
+});

--- a/tests/unit/consilium/loop-status.test.ts
+++ b/tests/unit/consilium/loop-status.test.ts
@@ -201,17 +201,35 @@ describe("explainLoopState — escalated", () => {
 });
 
 describe("explainLoopState — failed / cancelled reuse the loop error (#466, not regressed)", () => {
-  it("failed → bad tone, detail IS the loop error", () => {
+  it("failed with a SPECIFIC error → bad tone, surfaces the error verbatim + suggests a re-run", () => {
     const out = explainLoopState(loop({ state: "failed", error: "worker crashed at step 3" }));
     expect(out.tone).toBe("bad");
     expect(out.title).toBe("Failed");
-    expect(out.detail).toBe("worker crashed at step 3");
+    expect(out.detail).toContain("worker crashed at step 3");
+    expect(out.detail).toMatch(/re-run/i);
   });
 
-  it("failed with no error → a safe fallback (still non-blank)", () => {
+  it("failed with the GENERIC controller message → an actionable explanation, not the opaque three words", () => {
+    const out = explainLoopState(loop({ state: "failed", error: "review run failed" }));
+    expect(out.tone).toBe("bad");
+    expect(out.title).toBe("Failed");
+    expect(out.detail).toMatch(/reviewer model errored|interrupted/i);
+    expect(out.detail).toMatch(/re-run/i);
+  });
+
+  it("failed with no error → a safe fallback (still non-blank), also suggests a re-run", () => {
     const out = explainLoopState(loop({ state: "failed", error: null }));
     expect(out.tone).toBe("bad");
     expect(out.detail).toMatch(/unrecoverable error/i);
+    expect(out.detail).toMatch(/re-run/i);
+  });
+
+  it("every failed variant's detail is non-blank and mentions re-running", () => {
+    for (const error of [null, "review run failed", "some other specific error"]) {
+      const out = explainLoopState(loop({ state: "failed", error }));
+      expect(out.detail.length).toBeGreaterThan(0);
+      expect(out.detail.toLowerCase()).toContain("re-run");
+    }
   });
 
   it("cancelled → neutral (NOT a failure), detail IS the cancellation note", () => {


### PR DESCRIPTION
## Summary
A terminal consilium loop (esp. `failed`) used to show only a bare status + a generic `loop.error` with no why and no way to retry. Now the operator gets an explanation and a one-click re-run.

- **`POST /api/consilium-loops/:id/rerun`** (owner/admin): clones a TERMINAL loop's config — `repoPath`, preset (recovered from the group name via `parseConsiliumPreset`), `maxRounds`, `commitPrefix` — into a fresh loop through the **same `createConsiliumReview` factory** (so `reviewGate`/panel/objective, incl. Large Research, are re-derived correctly). Returns `201 { id }`. `409` when the source loop is not terminal.
- **Richer `explainLoopState("failed")`**: instead of echoing the generic "review run failed", explains what it means (a reviewer model errored or the run was interrupted — e.g. a restart mid-review) and suggests re-running.
- **UI**: the terminal-loop status callout shows that explanation + a **Re-run** button (clones + navigates to the new loop); the Result / rounds / dispute transcript stay visible below.

Terminal states can't resume in place (develop only re-opens verdict-terminals, retry only throttled) — re-run creates a fresh loop with the same settings, which is the safe, honest "restart".

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run tests/unit/` — 4572 passed, 0 real failures (rerun refuses non-terminal → 409; clones config with the recovered preset; failed explanation non-blank + mentions re-run)
- [x] Live: `POST /rerun` on a real `failed` large-research loop → new loop correctly gated + maxRounds 4