### PR TITLE
feat(consilium): surface the workspace name on loops

### DIFF
--- a/client/src/hooks/use-workspaces.ts
+++ b/client/src/hooks/use-workspaces.ts
@@ -1,0 +1,18 @@
+/**
+ * use-workspaces.ts — the active project's workspaces (`GET /api/workspaces`).
+ *
+ * Shared by the Consilium loop LIST (group / filter by workspace name + seed the
+ * New-review dialog) and the loop DETAIL (label the loop with its workspace).
+ * Uses the shared `apiRequest` transport so `x-project-id` is attached, exactly
+ * like every other project-scoped query.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { apiRequest } from "@/hooks/use-api";
+import type { WorkspaceRow } from "@shared/schema";
+
+export function useWorkspaces() {
+  return useQuery<WorkspaceRow[]>({
+    queryKey: ["/api/workspaces"],
+    queryFn: () => apiRequest("GET", "/api/workspaces"),
+  });
+}

--- a/client/src/lib/workspace-name.ts
+++ b/client/src/lib/workspace-name.ts
@@ -1,0 +1,42 @@
+/**
+ * workspace-name.ts — resolve the human WORKSPACE NAME a consilium loop runs in.
+ *
+ * A loop only carries its `repoPath` (there is no `workspaceId` on the loop row).
+ * The loop↔workspace link is BY PATH: the server binds a loop to the `local`
+ * workspace whose `path` equals the loop's realpath'd repo (see
+ * server/services/consilium/workspace-bind.ts). This mirrors that match on the
+ * client — trailing-slash-insensitive, `local`-only — so the list page can group
+ * / filter by workspace name and the detail page can label the loop with it.
+ *
+ * Falls back to the repo basename when no workspace row matches (a loop may run
+ * on an allowlisted repo that was never saved as a workspace). Pure, no I/O.
+ */
+import type { WorkspaceRow } from "@shared/schema";
+
+/** Trailing-slash-insensitive path key, so `/repo` and `/repo/` match. */
+export function normalizePath(p: string): string {
+  return p.replace(/\/+$/, "");
+}
+
+/** Last path segment of a repo path, for a compact fallback label. */
+export function repoBasename(repoPath: string): string {
+  const trimmed = repoPath.replace(/\/+$/, "");
+  const seg = trimmed.split("/").pop();
+  return seg || repoPath;
+}
+
+/**
+ * Resolve the workspace NAME for a loop's `repoPath`: match it (normalized,
+ * `local`-only) against the project's workspaces by `path` and return that
+ * workspace's `name`; fall back to the repo basename when nothing matches.
+ */
+export function resolveWorkspaceName(
+  repoPath: string,
+  workspaces: readonly WorkspaceRow[] | undefined,
+): string {
+  const target = normalizePath(repoPath);
+  const match = workspaces?.find(
+    (w) => w.type === "local" && normalizePath(w.path) === target,
+  );
+  return match?.name || repoBasename(repoPath);
+}

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -126,6 +126,8 @@ import {
 } from "@/components/ui/select";
 import type { ConsiliumLoopState, ClientLoopState } from "@/hooks/use-consilium-loops";
 import { useAddRoundComment } from "@/hooks/use-consilium-loops";
+import { useWorkspaces } from "@/hooks/use-workspaces";
+import { resolveWorkspaceName } from "@/lib/workspace-name";
 import { IterationDetailView } from "@/components/task-groups/iterations-panel";
 import type { ActionPoint, Archetype, OpenRemainder, RoundParticipant, RoundComment } from "@shared/types";
 import { ARCHETYPES } from "@shared/types";
@@ -2381,7 +2383,13 @@ function fmtRelative(raw: string | Date | null | undefined): { rel: string; abs:
   return { rel: formatDistanceToNow(d, { addSuffix: true }), abs: d.toLocaleString() };
 }
 
-function LaunchPassportCard({ loop }: { loop: ConsiliumLoopDetailRow }) {
+function LaunchPassportCard({
+  loop,
+  workspaceName,
+}: {
+  loop: ConsiliumLoopDetailRow;
+  workspaceName: string;
+}) {
   const created = fmtRelative(loop.createdAt);
   const preset = loop.composition?.preset ?? null;
   return (
@@ -2429,6 +2437,11 @@ function LaunchPassportCard({ loop }: { loop: ConsiliumLoopDetailRow }) {
             ) : (
               <span className="text-xs text-muted-foreground">working-tree HEAD</span>
             )}
+          </Fact>
+          <Fact label="Workspace">
+            <span className="font-medium text-xs" data-testid="launch-workspace-name">
+              {workspaceName}
+            </span>
           </Fact>
           <Fact label="Repo">
             <span className="font-mono text-xs break-all" title={loop.repoPath}>
@@ -2711,6 +2724,11 @@ export default function ConsiliumLoopDetail() {
   const { user } = useAuth();
   const { toast } = useToast();
   const { data: loop, isLoading, error } = useConsiliumLoop(id);
+  const { data: workspaceData } = useWorkspaces();
+  // Human WORKSPACE NAME this loop runs in, resolved from its repoPath (fallback:
+  // repo basename). Empty while the loop is still loading — the header/passport
+  // that read it only render once `loop` is present.
+  const workspaceLabel = loop ? resolveWorkspaceName(loop.repoPath, workspaceData) : "";
 
   const startLoop = useStartLoop();
   const cancelLoop = useCancelLoop();
@@ -2855,6 +2873,10 @@ export default function ConsiliumLoopDetail() {
               <LoopStateBadgeFor loop={loop} />
             </div>
             <p className="font-mono text-[11px] text-muted-foreground">{loop.id}</p>
+            <p className="text-[11px] text-muted-foreground" data-testid="loop-workspace-name">
+              Workspace:{" "}
+              <span className="font-medium text-foreground/80">{workspaceLabel}</span>
+            </p>
           </div>
 
           {/* Actions */}
@@ -2952,7 +2974,7 @@ export default function ConsiliumLoopDetail() {
         )}
 
         {/* GAP 1 — Launch passport: HOW this loop was launched, consolidated. */}
-        <LaunchPassportCard loop={loop} />
+        <LaunchPassportCard loop={loop} workspaceName={workspaceLabel} />
 
         {/* FSM progress */}
         <Card>

--- a/client/src/pages/ConsiliumLoopList.tsx
+++ b/client/src/pages/ConsiliumLoopList.tsx
@@ -26,17 +26,18 @@
  * `openActionPoints`/`createdAt`. Nothing invented.
  *
  * P4 — the workspace name is a human label. Loops only carry `repoPath` (no
- * workspaceId), so we fetch the workspaces list (shared apiRequest transport,
- * which attaches `x-project-id`) and match by `path`, falling back to the repo
- * basename. The first workspace's path also seeds the New-review dialog. A
- * top filter bar (local state) narrows the tree to a single workspace.
+ * workspaceId), so we fetch the workspaces list (shared `useWorkspaces`, which
+ * attaches `x-project-id`) and resolve each loop's workspace NAME via
+ * `resolveWorkspaceName` (match by `path`, falling back to the repo basename).
+ * Sections + the top filter bar are keyed by that resolved workspace name; the
+ * bar narrows the tree to a single workspace. The first workspace's path also
+ * seeds the New-review dialog.
  *
  * SECURITY: loop-derived text (repoPath, prRef) and the workspace name are
  * rendered as INERT React text; the PR link uses rel="noopener noreferrer".
  */
 import { useState } from "react";
 import { useLocation } from "wouter";
-import { useQuery } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import {
   Repeat,
@@ -53,22 +54,10 @@ import {
   type ConsiliumLoopListItem,
   type ConsiliumLoopRoundRow,
 } from "@/hooks/use-consilium-loops";
-import { apiRequest } from "@/hooks/use-api";
 import { LoopStateChipFor } from "@/components/consilium/loop-state";
 import { NewConsiliumReviewDialog } from "@/components/consilium/new-review-dialog";
-import type { WorkspaceRow } from "@shared/schema";
-
-/** Last path segment of an allowlisted repo path, for a compact display. */
-function repoBasename(repoPath: string): string {
-  const trimmed = repoPath.replace(/\/+$/, "");
-  const seg = trimmed.split("/").pop();
-  return seg || repoPath;
-}
-
-/** Trailing-slash-insensitive path key, so `/repo` and `/repo/` match. */
-function normalizePath(p: string): string {
-  return p.replace(/\/+$/, "");
-}
+import { useWorkspaces } from "@/hooks/use-workspaces";
+import { resolveWorkspaceName } from "@/lib/workspace-name";
 
 /** Relative "2h ago" label; empty string for missing/unparseable timestamps. */
 function whenLabel(ts: string | Date | null | undefined): string {
@@ -97,19 +86,6 @@ function OpenP0({ openP0 }: { openP0: number | null | undefined }) {
       {openP0}
     </span>
   );
-}
-
-/**
- * Workspaces for the active project — used to resolve a human name for a loop's
- * repoPath AND to seed the New-review dialog's repo path. Uses the shared
- * apiRequest transport so `x-project-id` is attached (same as every other
- * project-scoped hook).
- */
-function useWorkspaces() {
-  return useQuery<WorkspaceRow[]>({
-    queryKey: ["/api/workspaces"],
-    queryFn: () => apiRequest("GET", "/api/workspaces"),
-  });
 }
 
 type LoopGroup = {
@@ -347,11 +323,12 @@ export default function ConsiliumLoopList() {
   // Active workspace filter (by resolved name); null = show all.
   const [activeWorkspace, setActiveWorkspace] = useState<string | null>(null);
 
-  // Loop sections are keyed by the CLEAN repo basename (last path segment), not the
-  // workspace label — a workspace named e.g. "werush-terraform" must still surface as
-  // the bare repo target "terraform". Path-derived so it holds for every repo,
-  // independent of how any workspace was named.
-  const workspaceName = (repoPath: string): string => repoBasename(repoPath);
+  // Loop sections + filter chips are keyed by the loop's WORKSPACE NAME, resolved
+  // from its repoPath against the project's workspaces (fallback: the repo
+  // basename when no workspace row matches). This is the label the operator named
+  // and recognizes — see resolveWorkspaceName.
+  const workspaceName = (repoPath: string): string =>
+    resolveWorkspaceName(repoPath, workspaceData);
 
   // Hand the New-review dialog the project.s workspaces so the user PICKS a repo
   // (dropdown) instead of free-typing a possibly-unallowlisted path.

--- a/tests/unit/workspace-name.test.ts
+++ b/tests/unit/workspace-name.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizePath,
+  repoBasename,
+  resolveWorkspaceName,
+} from "../../client/src/lib/workspace-name.js";
+import type { WorkspaceRow } from "@shared/schema";
+
+/** Minimal WorkspaceRow factory — only the fields the resolver reads. */
+function ws(name: string, path: string, type = "local"): WorkspaceRow {
+  return { name, path, type } as unknown as WorkspaceRow;
+}
+
+describe("normalizePath", () => {
+  it("strips trailing slashes so /repo and /repo/ compare equal", () => {
+    expect(normalizePath("/a/b/")).toBe("/a/b");
+    expect(normalizePath("/a/b///")).toBe("/a/b");
+    expect(normalizePath("/a/b")).toBe("/a/b");
+  });
+});
+
+describe("repoBasename", () => {
+  it("returns the last path segment", () => {
+    expect(repoBasename("/x/y/iac")).toBe("iac");
+    expect(repoBasename("/x/y/iac/")).toBe("iac");
+  });
+  it("falls back to the raw input when there is no segment", () => {
+    expect(repoBasename("")).toBe("");
+  });
+});
+
+describe("resolveWorkspaceName", () => {
+  const workspaces = [
+    ws("multiqlti-smoke-test", "/Users/dev/project/multiqlti"),
+    ws("iac", "/Users/dev/project/werush/iac"),
+    ws("remote-thing", "/Users/dev/project/multiqlti", "remote"),
+  ];
+
+  it("returns the workspace NAME when the loop path matches by path", () => {
+    // Name deliberately differs from the basename ("multiqlti") — proves we use
+    // the workspace's own name, not the repo folder.
+    expect(resolveWorkspaceName("/Users/dev/project/multiqlti", workspaces)).toBe(
+      "multiqlti-smoke-test",
+    );
+    expect(resolveWorkspaceName("/Users/dev/project/werush/iac", workspaces)).toBe("iac");
+  });
+
+  it("matches trailing-slash-insensitively", () => {
+    expect(resolveWorkspaceName("/Users/dev/project/werush/iac/", workspaces)).toBe("iac");
+  });
+
+  it("ignores non-local workspaces at the same path", () => {
+    // Only the `local` row (multiqlti-smoke-test) should ever match a repoPath;
+    // the remote row sharing the path must not win.
+    expect(resolveWorkspaceName("/Users/dev/project/multiqlti", [workspaces[2]])).toBe(
+      "multiqlti",
+    );
+  });
+
+  it("falls back to the repo basename when no workspace matches", () => {
+    expect(resolveWorkspaceName("/Users/dev/project/unregistered", workspaces)).toBe(
+      "unregistered",
+    );
+  });
+
+  it("falls back to the basename when the workspace list is undefined", () => {
+    expect(resolveWorkspaceName("/Users/dev/project/werush/iac", undefined)).toBe("iac");
+  });
+});


### PR DESCRIPTION
## What

Loops only carry `repoPath` (there is no `workspaceId` on the loop row). This surfaces the human **workspace name** a loop runs in — the same name shown on the Workspaces page — on both the loop **list** and **detail**.

- **List** (`/consilium-loops`): sections + the filter bar are now keyed by the resolved **workspace name** (was the bare repo basename). Loops group under their workspace, and each workspace is a filter chip.
- **Detail**: the workspace name appears in the header (`Workspace: …`) and as a `Workspace` fact in the Launch passport.

## How

- Loop↔workspace is **by path** (mirrors the server's `workspace-bind`): match `repoPath` against the project's `local` workspaces by `path` (trailing-slash-insensitive) → return that workspace's `name`; fall back to the repo basename when no workspace row matches.
- New `client/src/lib/workspace-name.ts` — pure `resolveWorkspaceName` (+ `normalizePath`/`repoBasename`, previously duplicated inline in the list page).
- New `client/src/hooks/use-workspaces.ts` — shared `useWorkspaces` query, extracted from the list page so the detail page reuses it.

No schema/migration/server change — purely presentational, resolved client-side against the already-fetched workspaces.

## Notes / limitations (by design)

- The loop list is project-scoped (`x-project-id`), so the multi-chip filter bar appears when a project has loops across ≥2 workspaces.
- The name resolves against the **active** project's workspaces; a loop from another project falls back to the repo basename.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run tests/unit/` — new `workspace-name.test.ts` (8 cases: exact match, trailing-slash, non-local ignored, no-match fallback, undefined list) + full unit suite green (1318 tests)
- [x] Manual UI: list shows workspace-named groups + filter chips; detail shows the workspace name in header + Launch fact (verified a name that differs from the repo basename resolves to the workspace's own name)