### PR TITLE
feat(consilium): honor repo AGENTS.md/CLAUDE.md in review + dev

### DIFF
--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -364,6 +364,25 @@ export const ConfigSchema = z.object({
         maxRepoMapBytes: z.coerce.number().int().min(512).max(200_000).default(6_000),
       }).default({}),
       /**
+       * Workspace repo-conventions preamble: reads a workspace repo's OWN convention file
+       * (`AGENTS.md`, falling back to `CLAUDE.md` — the first that exists wins, never
+       * concatenated) and injects it into BOTH the REVIEW input and the DEV (coder) system
+       * prompt, so the loop honours the repo's own agent conventions the same way a human
+       * contributor would. Read-only, best-effort (`repo-conventions.ts`): hard byte-bounded,
+       * secret-redacted, and fenced as data (same discipline as `repoMap`). Default OFF ⇒
+       * BYTE-IDENTICAL: no review section is added and no dev systemPrompt changes. Also
+       * gated (like every enhancement here) under the parent `consiliumLoop.enabled`.
+       */
+      repoConventions: z.object({
+        /** Kill-switch: false (default) → no conventions read anywhere (byte-identical off). */
+        enabled: z.boolean().default(false),
+        /**
+         * Hard byte cap on the read convention file, checked via `statSync` before the
+         * secret-redaction/fencing pass. 512B..64KB.
+         */
+        maxConventionsBytes: z.coerce.number().int().min(512).max(65_536).default(8_000),
+      }).default({}),
+      /**
        * Phase 2 (defect-B): run the per-round review via the DIRECT in-process
        * review-runner (`review-runner.ts`) instead of the task-group
        * `startGroupAsync` engine. Default OFF ⇒ BYTE-IDENTICAL to today: the review

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -61,6 +61,7 @@ import { effectiveVerificationEnabled, resolveImplementForRepo } from "../../con
 import { readConvergence, readJudgeVerdict, extractActionPoints, normalizeActionPointMethods, applyCriteriaQa } from "../orchestrator/convergence.js";
 import { buildDiffContext } from "./diff-context.js";
 import { buildRepoMap, createDbRepoMapSource, listTouchedFiles, repoMapGit } from "./repo-map.js";
+import { readConventionsFile } from "./repo-conventions.js";
 import { findLoopWorkspace } from "./workspace-bind.js";
 import type { DevCloseoutResult } from "./dev-closeout.js";
 import { runSdlcHandoff, type SdlcProgress, type JudgeVerifyFn, type JudgeVerifyInput } from "../sdlc/executor.js";
@@ -2616,6 +2617,14 @@ export class ConsiliumLoopController {
       parallel: parallelOn
         ? { enabled: true, maxConcurrency: cfg.implement.parallel.maxConcurrency }
         : null,
+      // Repo-conventions preamble (AGENTS.md / CLAUDE.md) for the DEV/coder system
+      // prompt. Gated by its OWN kill-switch on TOP of the parent consiliumLoop.enabled
+      // — null when off ⇒ the executor reads no convention file, byte-for-byte
+      // unchanged. The executor resolves the worktree dir itself (server-minted, no
+      // allowlist check needed) and reads ONCE per round.
+      repoConventions: cfg.repoConventions?.enabled
+        ? { enabled: true, maxConventionsBytes: cfg.repoConventions.maxConventionsBytes }
+        : null,
     }, {
       getSkills: () => this.storage.getSkills(),
       // Stage B: the judge-method verifier seam (wired to the gateway) — provided ONLY when
@@ -2776,6 +2785,7 @@ export class ConsiliumLoopController {
     // exported symbols + 1-hop importers), read-only over the workspace symbol index.
     // Kill-switched (default OFF ⇒ undefined ⇒ byte-identical review input).
     const repoMap = await this.buildReviewRepoMap(loop, cfg);
+    const repoConventions = await this.buildReviewConventions(loop, cfg);
     const ctx = await buildDiffContext({
       repoPath: loop.repoPath,
       baselineCommit: loop.lastReviewedCommit,
@@ -2788,6 +2798,7 @@ export class ConsiliumLoopController {
       priorFindings,
       testSummary,
       repoMap,
+      repoConventions,
     });
     if (!ctx.ok) {
       // A DETERMINISTIC unresolved ref (the diff baseline/head sha is absent from
@@ -2880,6 +2891,36 @@ export class ConsiliumLoopController {
       this.log(
         loop.id,
         `repoMap skipped (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    }
+  }
+
+  /**
+   * Repo-conventions preamble for the REVIEW input: the workspace repo's OWN
+   * `AGENTS.md` (falling back to `CLAUDE.md`), read via `repo-conventions.ts`.
+   * Kill-switched (`consiliumLoop.repoConventions.enabled`, default OFF ⇒
+   * `undefined` ⇒ byte-identical review input) and gated under the parent
+   * `consiliumLoop.enabled` (this method is only ever reached through the loop
+   * controller). Reads the WORKING TREE at `loop.repoPath` — a branch/ref-targeted
+   * at-ref read (`git show <ref>:AGENTS.md`) is OUT OF SCOPE for this change.
+   * BEST-EFFORT: absent files or ANY failure ⇒ `undefined`, never throws, and a
+   * conventions problem must never fail a review round.
+   */
+  private async buildReviewConventions(
+    loop: ConsiliumLoopRow,
+    cfg: AppConfig["pipeline"]["consiliumLoop"],
+  ): Promise<string | undefined> {
+    const rc = cfg.repoConventions;
+    if (!rc?.enabled) return undefined;
+    try {
+      // H-1 parity: re-validate the persisted repoPath ourselves before touching disk.
+      const resolvedRepo = assertAllowedRepoPath(loop.repoPath, cfg.allowedRepoPaths);
+      return readConventionsFile(resolvedRepo, rc.maxConventionsBytes) ?? undefined;
+    } catch (err) {
+      this.log(
+        loop.id,
+        `repoConventions skipped (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
       );
       return undefined;
     }
@@ -3165,6 +3206,7 @@ export class ConsiliumLoopController {
         ? await this.latestRoundTestSummary(loop)
         : undefined;
     const repoMap = await this.buildReviewRepoMap(loop, cfg);
+    const repoConventions = await this.buildReviewConventions(loop, cfg);
     const ctx = await buildDiffContext({
       repoPath: loop.repoPath,
       baselineCommit: loop.lastReviewedCommit,
@@ -3175,6 +3217,7 @@ export class ConsiliumLoopController {
       priorFindings,
       testSummary,
       repoMap,
+      repoConventions,
     });
     if (!ctx.ok) return degradedReviewResult(ctx.message);
     // Panel from the group's preset (recovered from the group NAME — the SAME source

--- a/server/services/consilium/diff-context.ts
+++ b/server/services/consilium/diff-context.ts
@@ -93,6 +93,15 @@ export interface DiffContextRequest {
    * section (byte-identical to today). Never executed, never logged.
    */
   repoMap?: string;
+  /**
+   * Workspace repo-conventions preamble: the workspace repo's OWN `AGENTS.md` (falling
+   * back to `CLAUDE.md`), read by `repo-conventions.ts`. Placed AFTER the objective and
+   * BEFORE the repo map so debaters read the repo's own conventions first. Already hard
+   * byte-bounded, secret-redacted, and fenced by the builder — NOT folded into the
+   * `truncated` flag (that flag tracks diff clipping only). Absent/blank ⇒ NO section
+   * (byte-identical to today). Never executed, never logged.
+   */
+  repoConventions?: string;
   /** Injected git client (tests pass a fake); defaults to simple-git(repoPath). */
   gitClient?: GitDiffClient;
 }
@@ -315,10 +324,27 @@ function assembleInput(
   priorFindings: string | undefined,
   maxDiffBytes: number,
   repoMap: string | undefined,
+  repoConventions: string | undefined,
 ): { input: string; truncated: boolean } {
   const obj = objective.trim();
   const sections = [obj.length > 0 ? obj : "_No objective supplied; review the changes below._"];
   let truncated = parts?.truncated ?? false;
+  // Workspace repo-conventions preamble (AGENTS.md / CLAUDE.md, read by
+  // repo-conventions.ts): placed right after the objective and BEFORE the repo map so
+  // debaters read the repo's own conventions before structural context. Already hard
+  // byte-bounded, secret-redacted, and fenced by the builder; we apply the SAME
+  // defensive re-redact + maxDiffBytes clamp used for repoMap below (H-4 parity). Its
+  // own internal omission note carries any file truncation, so — like repoMap — we
+  // deliberately do NOT fold it into the shared `truncated` flag. Absent/blank ⇒ no
+  // section (byte-identical to before).
+  if (repoConventions && repoConventions.trim().length > 0) {
+    const redacted = redactSecrets(repoConventions.trim());
+    const overflow = Buffer.byteLength(redacted, "utf8") > maxDiffBytes;
+    const text = overflow
+      ? Buffer.from(redacted, "utf8").subarray(0, maxDiffBytes).toString("utf8")
+      : redacted;
+    sections.push(`## Repository conventions (AGENTS.md / CLAUDE.md)\n\n${text}`);
+  }
   // OPTION A: the scoped repository map goes BETWEEN the objective and the diff so
   // the model reads structural context (touched files → symbols + importers) before
   // the changes. The builder already redacted + byte-bounded it; we re-run
@@ -428,7 +454,7 @@ export async function buildDiffContext(
       return fail("unknown", "objective is empty and there is no diff (round 1); refusing to emit a blank review input");
     }
     // Round 1 has no diff, so there are no "touched files" to map ⇒ no repoMap.
-    const built = assembleInput(req.objective, null, req.testSummary, undefined, req.maxDiffBytes, undefined);
+    const built = assembleInput(req.objective, null, req.testSummary, undefined, req.maxDiffBytes, undefined, undefined);
     return { ok: true, input: built.input, headCommit: head, baselineCommit: null, truncated: built.truncated };
   }
 
@@ -438,7 +464,7 @@ export async function buildDiffContext(
   const parts = await collectDiff(git, baseline, head, req.maxDiffBytes);
   if (!("stat" in parts)) return parts;
 
-  const built = assembleInput(req.objective, parts, req.testSummary, req.priorFindings, req.maxDiffBytes, req.repoMap);
+  const built = assembleInput(req.objective, parts, req.testSummary, req.priorFindings, req.maxDiffBytes, req.repoMap, req.repoConventions);
   return {
     ok: true,
     input: built.input,

--- a/server/services/consilium/repo-conventions.ts
+++ b/server/services/consilium/repo-conventions.ts
@@ -1,0 +1,68 @@
+/**
+ * repo-conventions.ts — reads a workspace repo's convention file (`AGENTS.md`, falling
+ * back to `CLAUDE.md`) so the consilium loop's REVIEW and DEV (coder) stages can honor
+ * repo-local conventions the same way a human contributor would.
+ *
+ * SCOPE: read-only, best-effort, kill-switched (config `consiliumLoop.repoConventions`,
+ * default OFF ⇒ byte-identical). `AGENTS.md` is preferred; `CLAUDE.md` is the fallback —
+ * the FIRST one that exists wins (never concatenated).
+ *
+ * BOUNDS / SAFETY (mirrors repo-map.ts / diff-context.ts):
+ *   - Hard byte cap (`budgetBytes`): the file size is checked via `statSync` BEFORE
+ *     `readFileSync` so the overflow decision never depends on re-measuring an already
+ *     fully-buffered string; a file over budget is clamped (UTF-8-safe: `Buffer.subarray`
+ *     then re-decode, same idiom as `diff-context.ts`'s repoMap/priorFindings clamps) and a
+ *     one-line omission note is appended.
+ *   - Secret redaction: the (possibly clamped) content is run through the SAME
+ *     `redactSecrets` pass the diff uses (H-4 parity) before it is returned.
+ *   - Fenced as DATA: the result is wrapped in `backtickFence` (a delimiter strictly longer
+ *     than any backtick run inside the content) so the embedded file — raw, repo-authored
+ *     text, unlike the derived repo-map — cannot break out of its own fence and smuggle
+ *     instructions into the surrounding review/coder prompt.
+ *   - Best-effort: neither file present, a stat/read error, or ANY other failure yields
+ *     `null` (the caller omits the section/prompt block) — this NEVER throws.
+ *
+ * PATH SAFETY: `dirPath` is caller-resolved and ALREADY SAFE before this module ever sees
+ * it — the review caller passes an `assertAllowedRepoPath`-resolved repo path, the dev
+ * (SDLC) caller passes a server-minted worktree directory. The filename joined onto it is a
+ * HARDCODED STRING LITERAL (`"AGENTS.md"` / `"CLAUDE.md"`), never derived from any input, so
+ * `join(dirPath, "AGENTS.md")` carries no path-traversal risk.
+ */
+import { readFileSync, statSync } from "fs";
+import { join } from "path";
+import { redactSecrets } from "./diff-redactor.js";
+import { backtickFence } from "./review-factory.js";
+
+/** Preference order — the FIRST file that exists wins; never concatenated. */
+const CONVENTION_FILENAMES = ["AGENTS.md", "CLAUDE.md"] as const;
+
+/**
+ * Read the first present convention file (`AGENTS.md`, else `CLAUDE.md`) under `dirPath`,
+ * clamp it to `budgetBytes`, redact secrets, and fence it as data. Returns `null` when
+ * neither file exists or ANY error occurs (best-effort — never throws).
+ */
+export function readConventionsFile(dirPath: string, budgetBytes: number): string | null {
+  try {
+    for (const filename of CONVENTION_FILENAMES) {
+      const filePath = join(dirPath, filename);
+      let size: number;
+      try {
+        size = statSync(filePath).size;
+      } catch {
+        continue; // this candidate doesn't exist (or isn't stat-able) — try the next.
+      }
+      const raw = readFileSync(filePath, "utf8");
+      const overflow = size > budgetBytes;
+      const clamped = overflow
+        ? Buffer.from(raw, "utf8").subarray(0, budgetBytes).toString("utf8")
+        : raw;
+      const note = overflow ? `\n\n_(${filename} truncated to the configured byte budget)_` : "";
+      const redacted = redactSecrets(clamped.trim()) + note;
+      const fence = backtickFence(redacted);
+      return `${fence}\n${redacted}\n${fence}`;
+    }
+    return null; // neither AGENTS.md nor CLAUDE.md present.
+  } catch {
+    return null; // best-effort: any unexpected failure omits the section, never throws.
+  }
+}

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -78,6 +78,7 @@ import {
 import { SdlcCoder, type CoderResult, type CoderOptions } from "./coder.js";
 import { verifyInWorktree, type TestRunResult } from "./test-runner.js";
 import { stripControlMultiline, backtickFence } from "../consilium/review-factory.js";
+import { readConventionsFile } from "../consilium/repo-conventions.js";
 import { isRateLimitError } from "../../gateway/rate-limit.js";
 
 const COMMIT_SUBJECT_TITLE_MAX = 100;
@@ -392,6 +393,27 @@ export interface SdlcHandoffRequest {
    * it NEVER pushes a broken merge (adversarial risk: silent dropped changes).
    */
   integrateBase?: boolean;
+  /**
+   * Repo-conventions preamble (`AGENTS.md`, falling back to `CLAUDE.md`) for the DEV
+   * (coder) system prompt — read ONCE per round from the round's worktree (server-
+   * minted, no allowlist check needed) and merged ahead of the role/skill system
+   * prompt at every coder call site (initial skilled/unskilled coder, verify→fix
+   * iterations, AND the final-state fix coder) so all of them see the same repo
+   * conventions a human contributor would. ABSENT or `{ enabled: false }` ⇒ NO
+   * conventions are read and NO systemPrompt changes anywhere (byte-for-byte today's
+   * develop path). Threaded by the controller ONLY when
+   * `consiliumLoop.repoConventions.enabled` is true.
+   */
+  repoConventions?: RepoConventionsConfig | null;
+}
+
+/** Repo-conventions config threaded into {@link runSdlcHandoff} (mirror of
+ *  `pipeline.consiliumLoop.repoConventions`). */
+export interface RepoConventionsConfig {
+  /** Master kill-switch (default false at the config layer). */
+  enabled: boolean;
+  /** Hard byte cap on the read convention file (config-clamped 512B..64KB). */
+  maxConventionsBytes: number;
 }
 
 /** Parallel-develop config threaded into {@link runSdlcHandoff} (mirror of
@@ -1009,6 +1031,16 @@ export async function runSdlcHandoff(
       gitRaw,
     });
     try {
+      // Repo-conventions preamble (`AGENTS.md` / `CLAUDE.md`): read ONCE per round from
+      // the round's worktree (server-minted — no allowlist check needed, unlike the
+      // review side's caller-supplied repoPath) so every coder call site below (skilled
+      // + unskilled initial coder, verify→fix iterations, final-state fix coder) reuses
+      // the SAME string rather than re-reading per invocation. ABSENT/disabled ⇒
+      // `undefined` ⇒ every downstream systemPrompt stays byte-for-byte unchanged.
+      const repoConventions = req.repoConventions?.enabled
+        ? (readConventionsFile(wt.worktreeDir, req.repoConventions.maxConventionsBytes) ?? undefined)
+        : undefined;
+
       // Stage 2a: resolve the archetype's ordered skilled steps ONCE for the round.
       // Empty (research / infra / null / unknown, or the kill-switch off ⇒ archetype
       // is null) ⇒ runActionPoint takes the UNCHANGED single unskilled coder path.
@@ -1042,7 +1074,7 @@ export async function runSdlcHandoff(
       // Stage B: per-criterion method routing context (INERT unless perCriterionMethod on).
       const routing = { enabled: req.perCriterionMethod ?? false, judgeVerify: deps.judgeVerify };
       // The per-AP IO shared by the fan-out workers, the sequential default, and the fallback.
-      const apIo: ApImplementIo = { gitRaw, runCoder, progress, skilledSteps, verify: verifyCtx, routing };
+      const apIo: ApImplementIo = { gitRaw, runCoder, progress, skilledSteps, verify: verifyCtx, routing, repoConventions };
 
       // Parallel-develop (design §4): when the switch is on AND there is >1 AP to fan out,
       // run the round in DEPENDENCY-AWARE WAVES — each AP in its OWN worktree branched off
@@ -1104,7 +1136,7 @@ export async function runSdlcHandoff(
           progress,
           total,
           completedBefore: committedCount,
-        });
+        }, repoConventions);
         if (await commitFinalFixes(gitRaw, wt, req)) committedCount += 1;
       }
 
@@ -1190,6 +1222,25 @@ export async function runSdlcHandoff(
  * outcome so the round continues and partial work is preserved. Emits a `coding`
  * beat before the coder runs and a `committing` beat before the commit.
  */
+/**
+ * Merge the round's repo-conventions preamble (already byte-bounded, secret-redacted,
+ * and fenced-as-data by `repo-conventions.ts`) ahead of a role/skill system prompt:
+ * conventions first, a blank line, then the role prompt — mirroring `buildCoderPrompt`'s
+ * own systemPrompt-prepend convention so the conventions read as an outer preamble.
+ * Absent conventions ⇒ `rolePrompt` passes through UNCHANGED (byte-for-byte). Absent
+ * `rolePrompt` (the unskilled coder path, which sends none today) ⇒ the conventions
+ * alone become the systemPrompt; both absent ⇒ `undefined` (no systemPrompt at all,
+ * today's unskilled-path behavior).
+ */
+function withRepoConventions(
+  conventions: string | null | undefined,
+  rolePrompt: string | undefined,
+): string | undefined {
+  const conv = conventions?.trim();
+  if (!conv) return rolePrompt;
+  return rolePrompt && rolePrompt.trim().length > 0 ? `${conv}\n\n${rolePrompt}` : conv;
+}
+
 async function runActionPoint(
   io: {
     gitRaw: GitRunner;
@@ -1205,6 +1256,13 @@ async function runActionPoint(
     verify: VerifyContext | null;
     /** Stage B: per-criterion method routing (enabled + the judge verifier seam). */
     routing: { enabled: boolean; judgeVerify?: JudgeVerifyFn };
+    /**
+     * Repo-conventions preamble (`AGENTS.md` / `CLAUDE.md`), read ONCE per round by the
+     * caller. Merged ahead of the role/skill system prompt at every coder call site
+     * below (`withRepoConventions`). Absent/disabled ⇒ every systemPrompt stays
+     * byte-for-byte unchanged.
+     */
+    repoConventions?: string;
   },
   wt: CreateWorktreeResult,
   req: SdlcHandoffRequest,
@@ -1295,7 +1353,9 @@ async function runActionPoint(
         coder = await io.runCoder(wt.worktreeDir, [ap], {
           timeoutMs: req.coderTimeoutMs,
           allowedTools: bound.allowedTools, // capability-scoped (NARROWS only).
-          systemPrompt: bound.systemPrompt, // baked-in default (+ skill override).
+          // baked-in default (+ skill override), preceded by the repo-conventions
+          // preamble when present (conventions first, blank line, then the role prompt).
+          systemPrompt: withRepoConventions(io.repoConventions, bound.systemPrompt),
         });
       } catch (err) {
         threw = true;
@@ -1322,7 +1382,12 @@ async function runActionPoint(
       fixBudget,
     });
     try {
-      coder = await io.runCoder(wt.worktreeDir, [ap], { timeoutMs: req.coderTimeoutMs });
+      coder = await io.runCoder(wt.worktreeDir, [ap], {
+        timeoutMs: req.coderTimeoutMs,
+        // No role prompt on the unskilled path — conventions (if any) become the
+        // WHOLE systemPrompt; absent ⇒ `undefined` (byte-for-byte today's call).
+        systemPrompt: withRepoConventions(io.repoConventions, undefined),
+      });
     } catch (err) {
       threw = true;
       const raw = err instanceof Error ? err.message : String(err);
@@ -1354,7 +1419,7 @@ async function runActionPoint(
       total,
       title: progressTitle,
       completedBefore: io.completedBefore,
-    });
+    }, io.repoConventions);
   }
 
   // Outcome base (incl. the Stage-2a skills audit — undefined on the unskilled path
@@ -1426,6 +1491,9 @@ interface ApImplementIo {
   skilledSteps: readonly BoundSkillStep[];
   verify: VerifyContext | null;
   routing: { enabled: boolean; judgeVerify?: JudgeVerifyFn };
+  /** Repo-conventions preamble, read ONCE per round — reused across every fan-out
+   *  worker/worktree via this shared IO shape (never re-read per AP). */
+  repoConventions?: string;
 }
 
 /** Context for the wave executor — the per-AP IO plus the worktree fan-out machinery. */
@@ -1906,6 +1974,9 @@ async function runFinalVerification(
     /** Commits produced by the action points before final verification. */
     completedBefore: number;
   },
+  /** Repo-conventions preamble, read ONCE per round by the caller (undefined ⇒ the
+   *  fix coder's systemPrompt stays byte-for-byte unchanged). */
+  repoConventions?: string,
 ): Promise<FinalVerification> {
   // Live progress beat for the FINAL phase (was silent → looked like a frozen
   // `committing`). `fixIteration` = 0 for the initial whole-suite run, 1..N per fix.
@@ -1942,7 +2013,10 @@ async function runFinalVerification(
       const fixed = await runCoder(wt.worktreeDir, req.actionPoints, {
         timeoutMs: req.coderTimeoutMs,
         allowedTools: vc.fixerStep.allowedTools, // capability ceiling (no widening).
-        systemPrompt: buildFixPrompt(vc.fixerStep.systemPrompt, result.summary, result.phase),
+        systemPrompt: withRepoConventions(
+          repoConventions,
+          buildFixPrompt(vc.fixerStep.systemPrompt, result.summary, result.phase),
+        ),
       });
       if (!fixed.ok) break; // a fix coder that errored stops the loop; work preserved.
     } catch {
@@ -2024,6 +2098,9 @@ async function runVerifyFixLoop(
     title: string;
     completedBefore: number;
   },
+  /** Repo-conventions preamble, read ONCE per round by the caller (undefined ⇒ the
+   *  fix coder's systemPrompt stays byte-for-byte unchanged). */
+  repoConventions?: string,
 ): Promise<ApVerification> {
   const criterion = sanitizeLine(ap.acceptanceCriterion ?? "", CRITERION_MAX);
   // Emit a verification beat (test-runner / fix-coder) for the ACTIVE AP; the tracker
@@ -2066,7 +2143,10 @@ async function runVerifyFixLoop(
       const fixed = await runCoder(wt.worktreeDir, [ap], {
         timeoutMs: req.coderTimeoutMs,
         allowedTools: vc.fixerStep.allowedTools, // capability ceiling (no widening).
-        systemPrompt: buildFixPrompt(vc.fixerStep.systemPrompt, result.summary, result.phase),
+        systemPrompt: withRepoConventions(
+          repoConventions,
+          buildFixPrompt(vc.fixerStep.systemPrompt, result.summary, result.phase),
+        ),
       });
       if (!fixed.ok) break; // a fix coder that errored stops the loop; work preserved.
     } catch {

--- a/tests/unit/consilium/diff-context.test.ts
+++ b/tests/unit/consilium/diff-context.test.ts
@@ -402,3 +402,66 @@ describe("buildDiffContext — Option A repository-map section", () => {
     expect(res.input).not.toContain("## Repository map");
   });
 });
+
+describe("buildDiffContext — repo-conventions section", () => {
+  const CONV = "```\nBe kind to tests.\n```";
+  const MAP = "- `server/a.ts`: `foo` [function]\n  imported by: `server/b.ts`";
+
+  it("injects conventions AFTER the objective and BEFORE the repo map", async () => {
+    const res = await buildDiffContext({
+      repoPath: REPO,
+      baselineCommit: BASE_SHA,
+      objective: "Obj",
+      allowedRepoPaths: ALLOW,
+      maxDiffBytes: 10_000,
+      repoMap: MAP,
+      repoConventions: CONV,
+      gitClient: fakeGit(),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.input).toContain("## Repository conventions (AGENTS.md / CLAUDE.md)");
+    expect(res.input).toContain("Be kind to tests.");
+    // ordering: objective < conventions < repo map < changes
+    const iObj = res.input.indexOf("Obj");
+    const iConv = res.input.indexOf("## Repository conventions");
+    const iMap = res.input.indexOf("## Repository map");
+    const iDiff = res.input.indexOf("## Changes since last review");
+    expect(iObj).toBeGreaterThanOrEqual(0);
+    expect(iConv).toBeGreaterThan(iObj);
+    expect(iMap).toBeGreaterThan(iConv);
+    expect(iDiff).toBeGreaterThan(iMap);
+  });
+
+  it("absent repoConventions ⇒ NO section (byte-identical to before)", async () => {
+    const withArg = await buildDiffContext({ repoPath: REPO, baselineCommit: BASE_SHA, objective: "Obj", allowedRepoPaths: ALLOW, maxDiffBytes: 10_000, repoConventions: undefined, gitClient: fakeGit() });
+    const without = await buildDiffContext({ repoPath: REPO, baselineCommit: BASE_SHA, objective: "Obj", allowedRepoPaths: ALLOW, maxDiffBytes: 10_000, gitClient: fakeGit() });
+    expect(withArg.ok && without.ok).toBe(true);
+    if (!withArg.ok || !without.ok) return;
+    expect(withArg.input).toBe(without.input);
+    expect(withArg.input).not.toContain("## Repository conventions");
+  });
+
+  it("a blank repoConventions emits NO section", async () => {
+    const res = await buildDiffContext({ repoPath: REPO, baselineCommit: BASE_SHA, objective: "Obj", allowedRepoPaths: ALLOW, maxDiffBytes: 10_000, repoConventions: "   \n  ", gitClient: fakeGit() });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.input).not.toContain("## Repository conventions");
+  });
+
+  it("defensively redacts a secret that reaches assembly in the conventions text", async () => {
+    const secret = "AKIAIOSFODNN7EXAMPLEKEYDATA1234567890";
+    const res = await buildDiffContext({ repoPath: REPO, baselineCommit: BASE_SHA, objective: "Obj", allowedRepoPaths: ALLOW, maxDiffBytes: 10_000, repoConventions: `AWS_SECRET_ACCESS_KEY=${secret}`, gitClient: fakeGit() });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.input).not.toContain(secret);
+    expect(res.input).toContain("<REDACTED:");
+  });
+
+  it("round 1 (null baseline) never emits a conventions section even if one is passed", async () => {
+    const res = await buildDiffContext({ repoPath: REPO, baselineCommit: null, objective: "Obj", allowedRepoPaths: ALLOW, maxDiffBytes: 10_000, repoConventions: CONV, gitClient: fakeGit() });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.input).not.toContain("## Repository conventions");
+  });
+});

--- a/tests/unit/consilium/repo-conventions.test.ts
+++ b/tests/unit/consilium/repo-conventions.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for server/services/consilium/repo-conventions.ts — reads a workspace
+ * repo's convention file (`AGENTS.md`, falling back to `CLAUDE.md`) for the consilium
+ * loop's REVIEW and DEV (coder) stages. Uses REAL files under a temp dir (mkdtempSync)
+ * rather than mocking fs, since the module's own statSync/readFileSync ordering is
+ * part of its contract. Covers:
+ *   - AGENTS.md preferred over CLAUDE.md when both exist (never concatenated).
+ *   - CLAUDE.md fallback when only it exists.
+ *   - neither present ⇒ null.
+ *   - oversize file ⇒ clamped to the byte budget + an omission note appended.
+ *   - content is fenced (backtick-delimited) and secret-redacted.
+ *   - never throws on a bad/missing directory.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { readConventionsFile } from "../../../server/services/consilium/repo-conventions.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "repo-conventions-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("readConventionsFile — preference order", () => {
+  it("prefers AGENTS.md over CLAUDE.md when both exist (never concatenated)", () => {
+    writeFileSync(join(dir, "AGENTS.md"), "Agents rules here.");
+    writeFileSync(join(dir, "CLAUDE.md"), "Claude rules here.");
+    const result = readConventionsFile(dir, 8_000);
+    expect(result).not.toBeNull();
+    expect(result).toContain("Agents rules here.");
+    expect(result).not.toContain("Claude rules here.");
+  });
+
+  it("falls back to CLAUDE.md when AGENTS.md is absent", () => {
+    writeFileSync(join(dir, "CLAUDE.md"), "Claude rules here.");
+    const result = readConventionsFile(dir, 8_000);
+    expect(result).not.toBeNull();
+    expect(result).toContain("Claude rules here.");
+  });
+
+  it("returns null when neither file is present", () => {
+    const result = readConventionsFile(dir, 8_000);
+    expect(result).toBeNull();
+  });
+});
+
+describe("readConventionsFile — byte budget", () => {
+  it("clamps an oversized file to the budget and appends an omission note", () => {
+    const big = "x".repeat(5_000);
+    writeFileSync(join(dir, "AGENTS.md"), big);
+    const result = readConventionsFile(dir, 100);
+    expect(result).not.toBeNull();
+    expect(result).toContain("truncated to the configured byte budget");
+    // The full 5000-char body must NOT be present verbatim (it was clamped).
+    expect(result).not.toContain(big);
+  });
+
+  it("does not clamp / add a note when the file is within budget", () => {
+    writeFileSync(join(dir, "AGENTS.md"), "Small conventions file.");
+    const result = readConventionsFile(dir, 8_000);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain("truncated to the configured byte budget");
+  });
+});
+
+describe("readConventionsFile — fenced + secret-redacted", () => {
+  it("wraps the content in a matching backtick fence", () => {
+    writeFileSync(join(dir, "AGENTS.md"), "Some conventions.");
+    const result = readConventionsFile(dir, 8_000);
+    expect(result).not.toBeNull();
+    const fenceMatch = result!.match(/^(`{3,})/);
+    expect(fenceMatch).not.toBeNull();
+    const fence = fenceMatch![1];
+    // starts AND ends with the same fence.
+    expect(result!.startsWith(fence)).toBe(true);
+    expect(result!.trim().endsWith(fence)).toBe(true);
+  });
+
+  it("redacts a secret embedded in the convention file before returning", () => {
+    const secret = "AKIAIOSFODNN7EXAMPLEKEYDATA1234567890";
+    writeFileSync(join(dir, "AGENTS.md"), `Use this key: AWS_SECRET_ACCESS_KEY=${secret}`);
+    const result = readConventionsFile(dir, 8_000);
+    expect(result).not.toBeNull();
+    expect(result).not.toContain(secret);
+    expect(result).toContain("<REDACTED:");
+  });
+});
+
+describe("readConventionsFile — never throws", () => {
+  it("returns null (never throws) for a non-existent directory", () => {
+    expect(() => readConventionsFile(join(dir, "does-not-exist"), 8_000)).not.toThrow();
+    expect(readConventionsFile(join(dir, "does-not-exist"), 8_000)).toBeNull();
+  });
+
+  it("returns null (never throws) for a nonsense path", () => {
+    expect(() => readConventionsFile("\0invalid", 8_000)).not.toThrow();
+    expect(readConventionsFile("\0invalid", 8_000)).toBeNull();
+  });
+});

--- a/tests/unit/sdlc/coder.test.ts
+++ b/tests/unit/sdlc/coder.test.ts
@@ -153,6 +153,41 @@ describe("buildCoderPrompt — untrusted text stays in the prompt only", () => {
   });
 });
 
+// The repo-conventions preamble (AGENTS.md / CLAUDE.md, read by repo-conventions.ts)
+// is merged into `systemPrompt` on the EXECUTOR side (executor.ts's `withRepoConventions`
+// helper: conventions, a blank line, then the role prompt) BEFORE it ever reaches
+// `buildCoderPrompt` — this file adds NO new merging logic (per the "no CLI flag,
+// untrusted text stays on stdin" constraint). These tests verify the EXISTING
+// `opts.systemPrompt` prepend-and-clamp behavior continues to work correctly for that
+// already-merged (conventions + role prompt) string.
+describe("buildCoderPrompt — systemPrompt carries an executor-merged repo-conventions block", () => {
+  const aps: ActionPoint[] = [{ title: "Add the redactor", priority: "P1" }];
+
+  it("prepends the merged conventions+role-prompt block ahead of the action points", () => {
+    const merged = "```\nRepo convention: no console.log.\n```\n\nYou are the coder skill.";
+    const prompt = buildCoderPrompt(aps, { systemPrompt: merged });
+    expect(prompt).toContain("Repo convention: no console.log.");
+    expect(prompt).toContain("You are the coder skill.");
+    const iConv = prompt.indexOf("Repo convention:");
+    const iRole = prompt.indexOf("You are the coder skill.");
+    const iBody = prompt.indexOf("Add the redactor");
+    expect(iConv).toBeGreaterThanOrEqual(0);
+    expect(iRole).toBeGreaterThan(iConv); // conventions precede the role prompt
+    expect(iBody).toBeGreaterThan(iRole); // both precede the action-point body
+  });
+
+  it("clamps an over-long merged (conventions + role prompt) block", () => {
+    const merged = "x".repeat(10_000);
+    const prompt = buildCoderPrompt(aps, { systemPrompt: merged });
+    expect(prompt).not.toContain("x".repeat(5_000));
+  });
+
+  it("absent systemPrompt ⇒ prompt is BYTE-FOR-BYTE identical to the legacy (no-conventions) call", () => {
+    expect(buildCoderPrompt(aps)).toBe(buildCoderPrompt(aps, {}));
+    expect(buildCoderPrompt(aps)).toBe(buildCoderPrompt(aps, { systemPrompt: undefined }));
+  });
+});
+
 describe("parseCoderOutput", () => {
   it("ok on a clean result JSON, with token accounting", () => {
     const stdout = JSON.stringify({


### PR DESCRIPTION
## What

The consilium loop now reads a workspace repo's own convention file — **`AGENTS.md`, falling back to `CLAUDE.md`** — and honors it at **both** stages, so reviewers and the coder follow repo-local rules the way a human contributor would.

- **Review**: a `Repository conventions` section is injected into the reviewer/debater input (after the objective, before the repo map), re-read **every round**.
- **Dev (coder)**: the convention text is read once per round at worktree creation and merged into the coder's existing `systemPrompt` seam at every call site (skilled, unskilled, and the fix loops). No new CLI flag — untrusted text stays on stdin.

## How

- New `server/services/consilium/repo-conventions.ts` → `readConventionsFile(dir, budget)`: prefer `AGENTS.md`, fall back to `CLAUDE.md` (first that exists wins, never concatenated). `statSync` size-check **before** read, UTF-8-safe byte clamp, `redactSecrets` + `backtickFence` (the embedded file is treated as data and cannot break its fence to inject instructions), best-effort → `null`, never throws.
- Review wiring: `buildReviewConventions()` in the loop controller (sibling to `buildReviewRepoMap`), threaded into `DiffContextRequest.repoConventions` on both review paths.
- Config kill-switch `consiliumLoop.repoConventions { enabled: false, maxConventionsBytes: 8000 }` — **default OFF ⇒ byte-identical** (no review section, no unskilled-path systemPrompt block).

## Security posture

Mirrors the existing repo-map / diff embedding (H-4 / MED-1): every embedded blob is secret-redacted and backtick-fenced; path is caller-resolved (`assertAllowedRepoPath` on the review side, server-minted worktree on the dev side) and the filename is a hardcoded literal (no traversal). The file is inert context, never executed.

## Limitations

- Working-tree read only; branch/ref-targeted reads (`git show <ref>:AGENTS.md`) are out of scope for this PR (documented in `buildReviewConventions`).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run tests/unit/consilium/ tests/unit/sdlc/` → 105 files / 1512 tests green
- [x] New `repo-conventions.test.ts` (AGENTS.md preferred, CLAUDE.md fallback, neither → null, oversize → clamp+note, fenced+redacted, never throws) + extended diff-context and coder prompt tests
- [x] OFF-by-default verified byte-identical (no section / no prompt block when disabled)