### PR TITLE
feat(consilium): exec-time secret lease broker + loop→secret binding (Phase 3a.B)

### DIFF
--- a/client/src/components/consilium/new-review-dialog.tsx
+++ b/client/src/components/consilium/new-review-dialog.tsx
@@ -68,6 +68,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { apiRequest } from "@/hooks/use-api";
+import type { CredentialMetadata } from "@/hooks/use-credentials";
 import { useSkills } from "@/hooks/use-skills";
 import { useToast } from "@/hooks/use-toast";
 import { parseBranchFromUrl } from "@/components/consilium/parse-branch-url";
@@ -123,6 +124,9 @@ const MAX_INSTRUCTION_LEN = 8000;
 
 /** Max skills that may extend one review's instruction (mirrors the server bound). */
 const MAX_REVIEW_SKILLS = 5;
+// Mirrors the server-side cap on `secretNames` (ADR-003 §D2: ≤20, deduped). Each
+// bound secret authorizes the loop to lease that credential at exec time.
+const MAX_REVIEW_SECRETS = 20;
 
 /** The first line of a skill's description — a compact one-line hint in the picker. */
 function firstLine(text: string | null | undefined): string {
@@ -239,6 +243,9 @@ export function NewConsiliumReviewDialog({
   // Optional operator-selected skills whose directives extend the instruction. Sent
   // as `skillIds` (order = priority) only when non-empty; capped at MAX_REVIEW_SKILLS.
   const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>([]);
+  // Operator-authorized secrets (ADR-003 §D2 binding-at-create) → `secretNames`
+  // (credential names) only when non-empty; capped at MAX_REVIEW_SECRETS.
+  const [selectedSecretNames, setSelectedSecretNames] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [, navigate] = useLocation();
   const qc = useQueryClient();
@@ -258,6 +265,29 @@ export function NewConsiliumReviewDialog({
       if (cur.includes(id)) return cur.filter((s) => s !== id);
       if (cur.length >= MAX_REVIEW_SKILLS) return cur;
       return [...cur, id];
+    });
+  };
+
+  // The active project's named secrets (project-scoped via apiRequest's
+  // x-project-id). Metadata only — the secret VALUE is never sent to the client.
+  // Powers the optional multi-select below; absent/empty ⇒ the section is hidden
+  // entirely (never a dead control). Binding is by NAME, so nameless legacy
+  // connection-backed credentials are excluded.
+  const secretsQuery = useQuery<CredentialMetadata[]>({
+    queryKey: ["/api/credentials"],
+    queryFn: () => apiRequest("GET", "/api/credentials"),
+  });
+  const availableSecrets = (secretsQuery.data ?? []).filter(
+    (c): c is CredentialMetadata & { name: string } => Boolean(c.name),
+  );
+  const atSecretCap = selectedSecretNames.length >= MAX_REVIEW_SECRETS;
+
+  // Toggle a secret name in/out of the authorized set, enforcing the cap on add.
+  const toggleSecret = (name: string) => {
+    setSelectedSecretNames((cur) => {
+      if (cur.includes(name)) return cur.filter((s) => s !== name);
+      if (cur.length >= MAX_REVIEW_SECRETS) return cur;
+      return [...cur, name];
     });
   };
 
@@ -423,6 +453,7 @@ export function NewConsiliumReviewDialog({
       ref?: string;
       engineerInstruction?: string;
       skillIds?: string[];
+      secretNames?: string[];
       reviewMode?: "full-dispute" | "single-verifier";
       commitPrefix?: string;
     } = { repoPath: path, preset };
@@ -454,6 +485,12 @@ export function NewConsiliumReviewDialog({
     // server resolves them project-scoped and appends their directives to the
     // instruction under a byte budget (dropping whole skills if it must).
     if (selectedSkillIds.length > 0) body.skillIds = selectedSkillIds;
+    // Secrets → `secretNames` (ADR-003 §D2 binding-at-create = the operator's
+    // approval). Send only when some are selected; absent ⇒ byte-identical to
+    // today. The server resolves each name to a credentialId (metadata only) and
+    // binds it as the loop's authorized set; an unknown name is a 400. No secret
+    // VALUE is ever sent from the client.
+    if (selectedSecretNames.length > 0) body.secretNames = selectedSecretNames;
     // Review mode → `reviewMode` only when an EXPLICIT choice is made; "" leaves it
     // to the server's operator default (verifyReview.enabled), preserving today's flow.
     if (reviewMode) body.reviewMode = reviewMode;
@@ -935,6 +972,70 @@ export function NewConsiliumReviewDialog({
               <p className="text-xs text-muted-foreground">
                 Each selected skill's directive is appended to the instruction above,
                 in the order picked. At most {MAX_REVIEW_SKILLS}.
+              </p>
+            </div>
+          )}
+          {/* Secrets the loop may use (ADR-003 §D2). Selecting a secret binds it as
+              the loop's authorized set — at exec time the loop can lease a short-TTL,
+              audited, revocable handle to that credential; nothing is granted by
+              default. Only credential NAMES are shown; the value never reaches the
+              client. Hidden when the project has no named secrets, so it is never an
+              empty dead control. */}
+          {availableSecrets.length > 0 && (
+            <div className="space-y-2">
+              <div className="flex items-baseline justify-between gap-2">
+                <Label>
+                  Secrets{" "}
+                  <span className="text-muted-foreground">(this loop may use)</span>
+                </Label>
+                <span
+                  className="text-xs tabular-nums text-muted-foreground"
+                  data-testid="new-review-secrets-counter"
+                >
+                  {selectedSecretNames.length}/{MAX_REVIEW_SECRETS}
+                </span>
+              </div>
+              <div
+                className="max-h-40 space-y-1 overflow-y-auto rounded border p-2"
+                data-testid="new-review-secrets"
+              >
+                {availableSecrets.map((secret) => {
+                  const checked = selectedSecretNames.includes(secret.name);
+                  const disabled = !checked && atSecretCap;
+                  const hint = firstLine(secret.description) || secret.provider;
+                  return (
+                    <label
+                      key={secret.id}
+                      className={
+                        "flex items-start gap-2 rounded p-1.5 text-sm " +
+                        (disabled
+                          ? "cursor-not-allowed opacity-50"
+                          : "cursor-pointer hover:bg-muted/50")
+                      }
+                    >
+                      <Checkbox
+                        checked={checked}
+                        disabled={disabled}
+                        onCheckedChange={() => toggleSecret(secret.name)}
+                        data-testid={`new-review-secret-${secret.name}`}
+                        className="mt-0.5"
+                      />
+                      <span className="min-w-0">
+                        <span className="font-medium">{secret.name}</span>
+                        {hint && (
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {hint}
+                          </span>
+                        )}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Each selected secret grants the loop short-lived, audited, revocable
+                access at exec time — never placed in a reviewer's prompt. At most{" "}
+                {MAX_REVIEW_SECRETS}.
               </p>
             </div>
           )}

--- a/server/credentials/db-crypto-provider.ts
+++ b/server/credentials/db-crypto-provider.ts
@@ -22,13 +22,60 @@ import {
   credentialLeases,
   credentialAccessLog,
   secrets,
+  consiliumLoops,
+  consiliumLoopSecrets,
 } from "../../shared/schema.js";
+import type { ConsiliumLoopState } from "../../shared/schema.js";
 import type {
   CredentialMetadata,
   CredentialProvider,
   AccessSecretParams,
 } from "./types.js";
 import { ForbiddenError } from "./types.js";
+
+// ─── issueLease policy (ADR-003 §D) ─────────────────────────────────────────────
+
+/** Loop states in which a secret may be leased (§D1). Everything else fails closed. */
+const LEASE_ELIGIBLE_STATES: readonly ConsiliumLoopState[] = [
+  "reviewing",
+  "developing",
+];
+
+/** TTL clamp (§D — short-TTL leases). */
+const DEFAULT_LEASE_TTL_S = 300;
+const MAX_LEASE_TTL_S = 900;
+
+function clampTtl(ttlSeconds?: number): number {
+  if (
+    ttlSeconds === undefined ||
+    !Number.isFinite(ttlSeconds) ||
+    ttlSeconds <= 0
+  ) {
+    return DEFAULT_LEASE_TTL_S;
+  }
+  return Math.min(Math.floor(ttlSeconds), MAX_LEASE_TTL_S);
+}
+
+// [R3-SEC-10] Per-(projectId, loopId) in-memory sliding-window rate limit. Bounds a
+// compromised loop's burst; best-effort per-process throttle, not a distributed quota.
+const RATE_WINDOW_MS = 60_000;
+const MAX_LEASES_PER_WINDOW = 30;
+const leaseRateWindows = new Map<string, number[]>();
+
+function rateLimitOrThrow(projectId: string, loopId: string): void {
+  const key = `${projectId}:${loopId}`;
+  const now = Date.now();
+  const cutoff = now - RATE_WINDOW_MS;
+  const recent = (leaseRateWindows.get(key) ?? []).filter((t) => t > cutoff);
+  if (recent.length >= MAX_LEASES_PER_WINDOW) {
+    throw new ForbiddenError(
+      `issueLease rate limit exceeded for loop ${loopId} ` +
+        `(${MAX_LEASES_PER_WINDOW} per ${RATE_WINDOW_MS / 1000}s).`,
+    );
+  }
+  recent.push(now);
+  leaseRateWindows.set(key, recent);
+}
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -593,6 +640,122 @@ export class DbCryptoCredentialProvider implements CredentialProvider {
     });
 
     return plaintext;
+  }
+
+  /**
+   * ADR-003 §D1/§D2 — issue a short-TTL, scoped, audited, revocable lease for a
+   * credential a consilium loop is authorized to use. Supersedes ADR-001
+   * [R3-SEC-2]'s pipeline-anchored gate. Every denial is audited
+   * (action='lease_issued', success=false) before the ForbiddenError propagates.
+   */
+  async issueLease(p: {
+    projectId: string;
+    credentialId: string;
+    loopId: string;
+    phase: string;
+    requestedBy: string;
+    ttlSeconds?: number;
+    justification?: string;
+  }): Promise<{ leaseId: string; expiresAt: Date }> {
+    // [R3-SEC-3] project-scope; throws structurally in system context.
+    assertProject(p.projectId);
+
+    const auditDenied = async (errorMessage: string): Promise<void> => {
+      await writeAccessLog({
+        credentialId: p.credentialId,
+        projectId: p.projectId,
+        runId: p.loopId,
+        stageId: p.phase,
+        action: "lease_issued",
+        requestedBy: p.requestedBy,
+        justification: p.justification ?? null,
+        success: false,
+        errorMessage,
+      }).catch((auditErr: unknown) => {
+        console.warn("[credential-broker] audit write failed:", auditErr);
+      });
+    };
+
+    // D1 — run-state gate: loop exists, same project, secret-consuming state.
+    const [loop] = await db
+      .select({
+        state: consiliumLoops.state,
+        projectId: consiliumLoops.projectId,
+      })
+      .from(consiliumLoops)
+      .where(eq(consiliumLoops.id, p.loopId));
+    if (
+      !loop ||
+      loop.projectId !== p.projectId ||
+      !LEASE_ELIGIBLE_STATES.includes(loop.state)
+    ) {
+      const reason = !loop
+        ? `loop ${p.loopId} not found`
+        : loop.projectId !== p.projectId
+          ? `loop ${p.loopId} belongs to a different project`
+          : `loop ${p.loopId} state '${loop.state}' is not lease-eligible`;
+      await auditDenied(reason);
+      throw new ForbiddenError(`issueLease denied: ${reason}.`);
+    }
+
+    // D2 — binding-at-create gate: credential must be in the loop's bound set.
+    const [bound] = await db
+      .select({ credentialId: consiliumLoopSecrets.credentialId })
+      .from(consiliumLoopSecrets)
+      .where(
+        and(
+          eq(consiliumLoopSecrets.loopId, p.loopId),
+          eq(consiliumLoopSecrets.credentialId, p.credentialId),
+        ),
+      );
+    if (!bound) {
+      const reason = `credential ${p.credentialId} is not bound to loop ${p.loopId}`;
+      await auditDenied(reason);
+      throw new ForbiddenError(`issueLease denied: ${reason}.`);
+    }
+
+    // [R3-SEC-10] rate limit — audit the breach before propagating.
+    try {
+      rateLimitOrThrow(p.projectId, p.loopId);
+    } catch (rateErr: unknown) {
+      const reason =
+        rateErr instanceof Error ? rateErr.message : "rate limit exceeded";
+      await auditDenied(reason);
+      throw rateErr;
+    }
+
+    const ttlSeconds = clampTtl(p.ttlSeconds);
+    const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
+
+    const [lease] = await db
+      .insert(credentialLeases)
+      .values({
+        credentialId: p.credentialId,
+        projectId: p.projectId,
+        runId: p.loopId,
+        stageId: p.phase,
+        requestedBy: p.requestedBy,
+        expiresAt,
+        status: "active",
+      })
+      .returning({ id: credentialLeases.id });
+
+    await writeAccessLog({
+      leaseId: lease.id,
+      credentialId: p.credentialId,
+      projectId: p.projectId,
+      runId: p.loopId,
+      stageId: p.phase,
+      action: "lease_issued",
+      requestedBy: p.requestedBy,
+      justification: p.justification ?? null,
+      success: true,
+      ttlSeconds,
+    }).catch((auditErr: unknown) => {
+      console.warn("[credential-broker] audit write failed:", auditErr);
+    });
+
+    return { leaseId: lease.id, expiresAt };
   }
 }
 

--- a/server/credentials/openbao-provider.ts
+++ b/server/credentials/openbao-provider.ts
@@ -176,7 +176,19 @@ export class OpenBaoCredentialProvider implements CredentialProvider {
     return this.metadataStore.accessSecret(params);
   }
 
-  // ── EXEC-TIME lease ops (delegate — unchanged) ──────────────────────────────
+  // ── EXEC-TIME lease ops (delegate — leases are Postgres-backed either way) ───
+
+  issueLease(p: {
+    projectId: string;
+    credentialId: string;
+    loopId: string;
+    phase: string;
+    requestedBy: string;
+    ttlSeconds?: number;
+    justification?: string;
+  }): Promise<{ leaseId: string; expiresAt: Date }> {
+    return this.metadataStore.issueLease(p);
+  }
 
   revokeLease(leaseId: string): Promise<void> {
     return this.metadataStore.revokeLease(leaseId);

--- a/server/credentials/types.ts
+++ b/server/credentials/types.ts
@@ -125,11 +125,17 @@ export interface AccessSecretParams {
  *   enforcing project assertion only in project context and skipping it in system
  *   context (while still auditing the access).
  *
- *   [R3-SEC-2] issueLease reads stage_executions.approvalStatus === 'approved' AND
- *   pipeline_runs.status === 'running' from the DB and throws ForbiddenError
- *   otherwise.  The approval gate is a broker invariant, not a caller convention.
+ *   [R3-SEC-2 / ADR-003 §D1] issueLease gates on the consilium-loop execution
+ *   model (the pipeline_runs / stage_executions tables were removed in PR #525):
+ *   the referenced loop must exist, match the project, and be in a
+ *   secret-consuming state (state ∈ {reviewing, developing}); otherwise
+ *   ForbiddenError.  The gate is a broker invariant, not a caller convention.
  *
- *   [R3-SEC-10] issueLease is rate-limited per (projectId, runId).
+ *   [ADR-003 §D2] issueLease additionally requires the credentialId to be in the
+ *   loop's bound set (consilium_loop_secrets) — the operator's binding-at-create
+ *   IS the approval.  A credential not bound to the loop can never be leased.
+ *
+ *   [R3-SEC-10] issueLease is rate-limited per (projectId, loopId).
  */
 export interface CredentialProvider {
   // ── PLAN-TIME ─────────────────────────────────────────────────────────────
@@ -178,6 +184,29 @@ export interface CredentialProvider {
   }): Promise<string>;
 
   // ── EXEC-TIME ─────────────────────────────────────────────────────────────
+
+  /**
+   * Issue a short-TTL, scoped, audited lease for a credential a consilium loop is
+   * authorized to use (ADR-003 §D1/§D2, supersedes ADR-001 [R3-SEC-2]).
+   *
+   * Fail-closed; audited on failure too (action='lease_issued', success=false):
+   *   [R3-SEC-3]  projectId === getProjectId() (system context throws structurally).
+   *   D1          loop exists, its projectId matches, state ∈ {reviewing, developing}.
+   *   D2          credentialId is in the loop's bound set (consilium_loop_secrets).
+   *   [R3-SEC-10] rate-limited per (projectId, loopId).
+   *
+   * On success writes credential_leases(active, runId=loopId, stageId=phase) and
+   * audits action='lease_issued' with ttlSeconds. TTL is clamped to a safe range.
+   */
+  issueLease(p: {
+    projectId: string;
+    credentialId: string;
+    loopId: string;
+    phase: string;
+    requestedBy: string;
+    ttlSeconds?: number;
+    justification?: string;
+  }): Promise<{ leaseId: string; expiresAt: Date }>;
 
   /** Mark a lease revoked.  No-op if already revoked (idempotent). */
   revokeLease(leaseId: string): Promise<void>;

--- a/server/routes/consilium-reviews.ts
+++ b/server/routes/consilium-reviews.ts
@@ -52,6 +52,9 @@ const CreateReviewSchema = z.object({
   // clean 400 here) and each id length-clamped. The factory resolves them
   // PROJECT-SCOPED — a foreign/unknown id is a 400 naming the offending id.
   skillIds: z.array(z.string().min(1).max(200)).max(5).optional(),
+  // ADR-003 §D2: operator-authorized secret NAMES (resolved + bound by the
+  // factory, which enforces the identifier shape and 400s an unknown name).
+  secretNames: z.array(z.string().min(1).max(64)).max(20).optional(),
   // Single-verifier re-review: OPTIONAL per-loop review mode. Absent ⇒ null ⇒ the
   // server resolves it from the operator default (verifyReview.enabled). A server
   // enum (z.enum) so only the two known values pass; anything else is a clean 400.
@@ -141,6 +144,8 @@ export function registerConsiliumReviewRoutes(app: Express, deps: CreateConsiliu
           engineerInstruction: body.engineerInstruction,
           // Stage 2: operator skill ids — resolved + appended by the factory.
           skillIds: body.skillIds,
+          // ADR-003 §D2: operator-authorized secrets — resolved + bound by factory.
+          secretNames: body.secretNames,
           // Single-verifier re-review: OPTIONAL per-loop mode (persisted on the loop).
           reviewMode: body.reviewMode,
           // OPTIONAL per-loop commit-message/MR-title prefix (sanitized here, same
@@ -162,6 +167,14 @@ export function registerConsiliumReviewRoutes(app: Express, deps: CreateConsiliu
         // actionable ("skill \"<id>\" was not found in this project").
         if (message.includes("[skill-not-found]")) {
           return res.status(400).json({ error: message.replace("[skill-not-found] ", "") });
+        }
+        // ADR-003 §D2: an unknown project secret name, or a malformed/oversized
+        // secretNames set. The factory names the offender (the caller's own input,
+        // a credential NAME — not secret material and not an fs leak).
+        if (message.includes("[secret-not-found]") || message.includes("[secret-invalid]")) {
+          return res.status(400).json({
+            error: message.replace(/\[secret-(?:not-found|invalid)\] /, ""),
+          });
         }
         // The factory STRICT-validates the optional branch/ref (ref-validator.ts)
         // and throws INVALID_REF_MESSAGE on a bad one — surface a clear 400 (the

--- a/server/services/consilium/review-factory.ts
+++ b/server/services/consilium/review-factory.ts
@@ -67,6 +67,7 @@ import { readdirSync, readFileSync, statSync, type Dirent } from "fs";
 import { basename, join } from "path";
 import simpleGit from "simple-git";
 import type { IStorage } from "../../storage.js";
+import { credentialProvider } from "../../credentials/db-crypto-provider.js";
 import type { InsertConsiliumLoop, ConsiliumLoopRow, Skill, AppliedSkillRef } from "@shared/schema";
 import type { ConsiliumReviewPreset, TriggerProvenance, ReviewMode } from "@shared/types";
 import type { TaskOrchestrator, CreateTaskParam } from "../task-orchestrator.js";
@@ -1290,6 +1291,15 @@ export interface CreateConsiliumReviewParams {
    */
   skillIds?: string[];
   /**
+   * ADR-003 §D2 (binding-at-create = approval): OPTIONAL operator-selected secret
+   * NAMES this loop is authorized to lease at exec time. Resolved PROJECT-SCOPED to
+   * credentialIds (metadata only — never a value) and bound to the loop; an unknown
+   * or malformed name THROWS (→ 400) with nothing persisted. Absent/empty ⇒ the loop
+   * has no bound secrets and `issueLease` can lease nothing for it (byte-identical to
+   * today). Names are NOT secret material — they are safe to echo in errors/logs.
+   */
+  secretNames?: string[];
+  /**
    * BRANCH-targeted review: an optional git ref (branch name / revision) the
    * review targets. STRICT-validated here (ref-validator.ts) before it reaches
    * git; persisted as the loop's `reviewRef`. Absent/null ⇒ working-tree HEAD
@@ -1387,6 +1397,53 @@ export async function assertRepoIsProjectWorkspace(
  * (S1), the repoPath is not a workspace of the current project (S5), the preset
  * is unknown, or a non-hex baselineCommit is supplied (S3).
  */
+// ─── ADR-003 §D2: bind operator-authorized secrets to the loop ────────────────
+const SECRET_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/;
+const MAX_BOUND_SECRETS = 20;
+
+/**
+ * Resolve operator-selected secret NAMES to their credentialIds, PROJECT-SCOPED
+ * (listCredentials returns metadata only — never a value). Validates shape and
+ * caps the count; an unknown or malformed name THROWS a tagged error that the
+ * create routes map to 400. Absent/empty ⇒ [] (the loop binds nothing, so
+ * issueLease can lease nothing for it — byte-identical to a no-secrets loop).
+ */
+async function resolveBoundSecretIds(
+  secretNames: string[] | undefined,
+  projectId: string,
+): Promise<string[]> {
+  if (!secretNames || secretNames.length === 0) return [];
+  const deduped = Array.from(new Set(secretNames));
+  if (deduped.length > MAX_BOUND_SECRETS) {
+    throw new Error(
+      `[secret-invalid] at most ${MAX_BOUND_SECRETS} secrets may be bound to a loop`,
+    );
+  }
+  for (const name of deduped) {
+    if (!SECRET_NAME_RE.test(name)) {
+      throw new Error(
+        `[secret-invalid] secret name "${name}" is not a valid identifier`,
+      );
+    }
+  }
+  const metadata = await credentialProvider.listCredentials(projectId);
+  const idByName = new Map<string, string>();
+  for (const m of metadata) {
+    if (m.name) idByName.set(m.name, m.id);
+  }
+  const ids: string[] = [];
+  for (const name of deduped) {
+    const id = idByName.get(name);
+    if (!id) {
+      throw new Error(
+        `[secret-not-found] secret "${name}" was not found in this project`,
+      );
+    }
+    ids.push(id);
+  }
+  return ids;
+}
+
 export async function createConsiliumReview(
   deps: CreateConsiliumReviewDeps,
   params: CreateConsiliumReviewParams,
@@ -1405,6 +1462,14 @@ export async function createConsiliumReview(
   // boundary). A repo must pass BOTH. Fail-closed: no matching workspace ⇒ reject.
   // Runs before createTaskGroup/createLoop ⇒ nothing persisted on rejection.
   await assertRepoIsProjectWorkspace(resolvedRepo, storage);
+
+  // ADR-003 §D2: resolve + validate operator-authorized secret NAMES to
+  // credentialIds BEFORE anything is persisted — an unknown/malformed name throws
+  // here (→ 400) with nothing created. Bound after createLoop (needs loop.id).
+  const boundSecretIds = await resolveBoundSecretIds(
+    params.secretNames,
+    params.projectId,
+  );
 
   const panel = PRESET_PANELS[params.preset];
   if (!panel) throw new Error(`unknown consilium review preset: ${String(params.preset)}`);
@@ -1509,6 +1574,16 @@ export async function createConsiliumReview(
     // Draft-PR capable) ⇒ A; review-only ⇒ R0.
     class: cfg.implement?.enabled ? "A" : "R0",
   } as InsertConsiliumLoop);
+
+  // ADR-003 §D2: persist the loop→secret bindings (the bound set issueLease
+  // consults). Idempotent per (loop, credential). Empty ⇒ no-op.
+  if (boundSecretIds.length > 0) {
+    await storage.bindLoopSecrets({
+      loopId: loop.id,
+      credentialIds: boundSecretIds,
+      createdBy: params.createdBy,
+    });
+  }
 
   // 3) Start it (PENDING → BUILDING_CONTEXT). The poller advances it from there;
   //    `controller.start` returns the ticked row (or null if it could not start,

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -55,6 +55,8 @@ import {
   taskExecutions,
   consiliumLoops,
   consiliumLoopRounds,
+  consiliumLoopSecrets,
+  type ConsiliumLoopSecret,
   experienceItems,
   type ExperienceItemRow,
   type InsertExperienceItem,
@@ -779,6 +781,31 @@ export class PgStorage implements IStorage {
   async getLoop(id: string): Promise<ConsiliumLoopRow | undefined> {
     const [row] = await db.select().from(consiliumLoops).where(withProject(consiliumLoops, eq(consiliumLoops.id, id)));
     return row;
+  }
+
+  async getLoopSecrets(loopId: string): Promise<ConsiliumLoopSecret[]> {
+    return db
+      .select()
+      .from(consiliumLoopSecrets)
+      .where(eq(consiliumLoopSecrets.loopId, loopId));
+  }
+
+  async bindLoopSecrets(p: {
+    loopId: string;
+    credentialIds: string[];
+    createdBy: string;
+  }): Promise<void> {
+    if (p.credentialIds.length === 0) return;
+    await db
+      .insert(consiliumLoopSecrets)
+      .values(
+        p.credentialIds.map((credentialId) => ({
+          loopId: p.loopId,
+          credentialId,
+          createdBy: p.createdBy,
+        })),
+      )
+      .onConflictDoNothing();
   }
 
   async getLoopsByOwner(ownerId: string): Promise<ConsiliumLoopRow[]> {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -23,6 +23,7 @@ import {
   type InsertTaskGroup,
   type ConsiliumLoopRow,
   type InsertConsiliumLoop,
+  type ConsiliumLoopSecret,
   type ConsiliumLoopRoundRow,
   type InsertConsiliumLoopRound,
   type ConsiliumLoopState,
@@ -444,6 +445,14 @@ export interface IStorage {
    *  group (Security H-3) — surfaces as a unique-violation the route maps to 409. */
   createLoop(data: InsertConsiliumLoop): Promise<ConsiliumLoopRow>;
   getLoop(id: string): Promise<ConsiliumLoopRow | undefined>;
+  /** ADR-003 §D2 — the secrets a loop is authorized to lease (its bound set). */
+  getLoopSecrets(loopId: string): Promise<ConsiliumLoopSecret[]>;
+  /** ADR-003 §D2 — bind credentials to a loop at create (idempotent per pair). */
+  bindLoopSecrets(p: {
+    loopId: string;
+    credentialIds: string[];
+    createdBy: string;
+  }): Promise<void>;
   /** Loops created by `ownerId`, newest first (owner-scoped list, mirror task-groups). */
   getLoopsByOwner(ownerId: string): Promise<ConsiliumLoopRow[]>;
   /** All loops (admin list / poller backstop sweep). */
@@ -1400,6 +1409,8 @@ export class MemStorage implements IStorage {
 
   private consiliumLoopsMap: Map<string, ConsiliumLoopRow> = new Map();
   private consiliumLoopRoundsMap: Map<string, ConsiliumLoopRoundRow> = new Map();
+  // ADR-003 §D2 — loop→secret bindings (the bound set consulted by issueLease).
+  private consiliumLoopSecretRows: ConsiliumLoopSecret[] = [];
 
   /** Mirror the DB partial-unique index: at most one non-terminal loop/group. */
   private isLoopActive(row: ConsiliumLoopRow): boolean {
@@ -1475,6 +1486,30 @@ export class MemStorage implements IStorage {
 
   async getLoop(id: string): Promise<ConsiliumLoopRow | undefined> {
     return this.consiliumLoopsMap.get(id);
+  }
+
+  async getLoopSecrets(loopId: string): Promise<ConsiliumLoopSecret[]> {
+    return this.consiliumLoopSecretRows.filter((r) => r.loopId === loopId);
+  }
+
+  async bindLoopSecrets(p: {
+    loopId: string;
+    credentialIds: string[];
+    createdBy: string;
+  }): Promise<void> {
+    const now = new Date();
+    for (const credentialId of p.credentialIds) {
+      const exists = this.consiliumLoopSecretRows.some(
+        (r) => r.loopId === p.loopId && r.credentialId === credentialId,
+      );
+      if (exists) continue;
+      this.consiliumLoopSecretRows.push({
+        loopId: p.loopId,
+        credentialId,
+        createdBy: p.createdBy,
+        createdAt: now,
+      });
+    }
   }
 
   async getLoopsByOwner(ownerId: string): Promise<ConsiliumLoopRow[]> {

--- a/tests/unit/consilium/loop-secret-binding.test.ts
+++ b/tests/unit/consilium/loop-secret-binding.test.ts
@@ -1,0 +1,85 @@
+/**
+ * loop-secret-binding.test.ts — MemStorage loop→secret bound set (ADR-003 §D2).
+ *
+ * `getLoopSecrets` / `bindLoopSecrets` back the D2 gate in the credential broker's
+ * `issueLease` (a credential not in a loop's bound set can never be leased). This
+ * asserts the roundtrip, per-(loop, credential) idempotency, empty no-op, and
+ * per-loop isolation — WITHOUT a database (MemStorage is fully in-memory).
+ *
+ * The full `issueLease` gate matrix (D1 run-state, D2 bound-set, rate limit,
+ * audit-on-failure) and the create-route 400 mapping query Postgres directly and
+ * are covered by the integration suite (tests/integration/credentials-api).
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { MemStorage } from "../../../server/storage.js";
+
+describe("MemStorage loop→secret bindings (ADR-003 §D2)", () => {
+  let storage: MemStorage;
+
+  beforeEach(() => {
+    storage = new MemStorage();
+  });
+
+  it("binds and reads back the authorized set for a loop", async () => {
+    await storage.bindLoopSecrets({
+      loopId: "loop-a",
+      credentialIds: ["cred-1", "cred-2"],
+      createdBy: "user-1",
+    });
+
+    const rows = await storage.getLoopSecrets("loop-a");
+    expect(rows.map((r) => r.credentialId).sort()).toEqual(["cred-1", "cred-2"]);
+    expect(
+      rows.every((r) => r.loopId === "loop-a" && r.createdBy === "user-1"),
+    ).toBe(true);
+  });
+
+  it("is idempotent per (loop, credential) — re-binding never duplicates", async () => {
+    await storage.bindLoopSecrets({
+      loopId: "loop-a",
+      credentialIds: ["cred-1"],
+      createdBy: "u",
+    });
+    // Re-bind with a duplicate in the batch AND a repeat of the existing pair.
+    await storage.bindLoopSecrets({
+      loopId: "loop-a",
+      credentialIds: ["cred-1", "cred-1", "cred-2"],
+      createdBy: "u",
+    });
+
+    const rows = await storage.getLoopSecrets("loop-a");
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.credentialId).sort()).toEqual(["cred-1", "cred-2"]);
+  });
+
+  it("treats an empty credentialIds batch as a no-op", async () => {
+    await storage.bindLoopSecrets({
+      loopId: "loop-a",
+      credentialIds: [],
+      createdBy: "u",
+    });
+    expect(await storage.getLoopSecrets("loop-a")).toHaveLength(0);
+  });
+
+  it("isolates bound sets per loop", async () => {
+    await storage.bindLoopSecrets({
+      loopId: "loop-a",
+      credentialIds: ["cred-1"],
+      createdBy: "u",
+    });
+    await storage.bindLoopSecrets({
+      loopId: "loop-b",
+      credentialIds: ["cred-2"],
+      createdBy: "u",
+    });
+
+    expect((await storage.getLoopSecrets("loop-a")).map((r) => r.credentialId)).toEqual([
+      "cred-1",
+    ]);
+    expect((await storage.getLoopSecrets("loop-b")).map((r) => r.credentialId)).toEqual([
+      "cred-2",
+    ]);
+    // An unbound loop leases nothing — its set is empty.
+    expect(await storage.getLoopSecrets("loop-c")).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Implements **Phase 3a.B** of ADR-003 (`docs/adr/ADR-003-phase3-exec-secret-delivery.md`) — the exec-time credential broker gate + binding-at-create — plus the operator-facing secret multi-select (3a.FE). Builds on the merged foundation #560 (`consilium_loop_secrets` table).

## What's in this PR

**Broker — `issueLease` (ADR-003 §D1/§D2, supersedes ADR-001 [R3-SEC-2])**
Added to the `CredentialProvider` interface, implemented in `DbCryptoCredentialProvider`, delegated by `OpenBaoCredentialProvider` (leases are Postgres-backed in both backends). Every gate is fail-closed and audited on failure:
- **[R3-SEC-3]** `projectId === getProjectId()`; system context throws structurally.
- **D1** run-state: leasable only when the loop exists, its project matches, and `state ∈ {reviewing, developing}`.
- **D2** bound set: the `credentialId` must be bound to the loop (`consilium_loop_secrets`) — a credential not bound can never be leased.
- **[R3-SEC-10]** rate-limited per `(projectId, loopId)`; TTL clamped (300s default / 900s max).
- Audit `lease_issued` with `ttlSeconds` on **success and every denial** (`success=false`).

**Binding-at-create = approval (§D2)**
Optional `secretNames?: string[]` on `POST /api/consilium-reviews`, resolved **project-scoped, metadata only** (never a value) to `credentialId`s and bound to the loop at create. Unknown/malformed names → **400 with nothing persisted**. `MemStorage`/`PgStorage` gain `getLoopSecrets`/`bindLoopSecrets`.

**FE (3a.FE)** — the new-review dialog gains a project-secret multi-select (names only; omitted from the payload when empty ⇒ byte-identical).

## Blast radius
`issueLease` ships **dormant** — no exec-time consumer is wired in this PR, so the ADR §Risk `reviewing`-stage secret surface is **not exercised here**. Absent `secretNames`, every changed path is byte-identical to today.

## Deferred to the 3a.C follow-up (its own security-veto review)
Delivery seam (`deliverLeasedEnv` over coder/cli-spawn/mcp-client), dynamic per-run scrubber, CI `decrypt(` confinement guard, and `markLeaseUsed`/revoke-on-failure wiring. The expiry sweeper is already wired (`server/routes.ts` `lease-sweeper`).

## Migration
None. The bound-set table (`consilium_loop_secrets`, migration 0062) merged in #560 and is human-gated for apply.

## Test plan
- [x] `tsc` (`npm run check`) — clean.
- [x] Unit: `tests/unit/consilium/loop-secret-binding.test.ts` — bound-set roundtrip, per-pair idempotency, empty no-op, per-loop isolation (4/4).
- [x] Regression: `consilium-reviews` route unit suite (11/11).
- [ ] **QA / integration** (needs live Postgres — `tests/integration/credentials-api`): full `issueLease` gate matrix (D1 wrong-state, D2 unbound, rate-limit breach, cross-project), each asserting `ForbiddenError` + a `lease_issued success=false` audit row; and the create-route 400 on an unknown `secretNames`.

## Security review
Self-reviewed against ADR §Risk + preserved R3-SEC invariants: no new `decrypt()` path, no secret material in metadata/logs/responses, all gates fail-closed and audited, all queries Drizzle-parameterized. **No CRITICAL/HIGH.** A dedicated integration gate-matrix test is the open QA item above.