### PR TITLE
feat(credentials): Phase 3a.C pt1 — dynamic scrubber + leased-env delivery + decrypt guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run check
+      - name: decrypt-confinement (ADR-003 §D3)
+        run: bash scripts/check-decrypt-confined.sh
 
   unit-integration:
     needs: guard

--- a/client/src/components/consilium/new-review-dialog.tsx
+++ b/client/src/components/consilium/new-review-dialog.tsx
@@ -68,6 +68,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { apiRequest } from "@/hooks/use-api";
+import type { CredentialMetadata } from "@/hooks/use-credentials";
 import { useSkills } from "@/hooks/use-skills";
 import { useToast } from "@/hooks/use-toast";
 import { parseBranchFromUrl } from "@/components/consilium/parse-branch-url";
@@ -123,6 +124,9 @@ const MAX_INSTRUCTION_LEN = 8000;
 
 /** Max skills that may extend one review's instruction (mirrors the server bound). */
 const MAX_REVIEW_SKILLS = 5;
+// Mirrors the server-side cap on `secretNames` (ADR-003 §D2: ≤20, deduped). Each
+// bound secret authorizes the loop to lease that credential at exec time.
+const MAX_REVIEW_SECRETS = 20;
 
 /** The first line of a skill's description — a compact one-line hint in the picker. */
 function firstLine(text: string | null | undefined): string {
@@ -239,6 +243,9 @@ export function NewConsiliumReviewDialog({
   // Optional operator-selected skills whose directives extend the instruction. Sent
   // as `skillIds` (order = priority) only when non-empty; capped at MAX_REVIEW_SKILLS.
   const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>([]);
+  // Operator-authorized secrets (ADR-003 §D2 binding-at-create) → `secretNames`
+  // (credential names) only when non-empty; capped at MAX_REVIEW_SECRETS.
+  const [selectedSecretNames, setSelectedSecretNames] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [, navigate] = useLocation();
   const qc = useQueryClient();
@@ -258,6 +265,29 @@ export function NewConsiliumReviewDialog({
       if (cur.includes(id)) return cur.filter((s) => s !== id);
       if (cur.length >= MAX_REVIEW_SKILLS) return cur;
       return [...cur, id];
+    });
+  };
+
+  // The active project's named secrets (project-scoped via apiRequest's
+  // x-project-id). Metadata only — the secret VALUE is never sent to the client.
+  // Powers the optional multi-select below; absent/empty ⇒ the section is hidden
+  // entirely (never a dead control). Binding is by NAME, so nameless legacy
+  // connection-backed credentials are excluded.
+  const secretsQuery = useQuery<CredentialMetadata[]>({
+    queryKey: ["/api/credentials"],
+    queryFn: () => apiRequest("GET", "/api/credentials"),
+  });
+  const availableSecrets = (secretsQuery.data ?? []).filter(
+    (c): c is CredentialMetadata & { name: string } => Boolean(c.name),
+  );
+  const atSecretCap = selectedSecretNames.length >= MAX_REVIEW_SECRETS;
+
+  // Toggle a secret name in/out of the authorized set, enforcing the cap on add.
+  const toggleSecret = (name: string) => {
+    setSelectedSecretNames((cur) => {
+      if (cur.includes(name)) return cur.filter((s) => s !== name);
+      if (cur.length >= MAX_REVIEW_SECRETS) return cur;
+      return [...cur, name];
     });
   };
 
@@ -423,6 +453,7 @@ export function NewConsiliumReviewDialog({
       ref?: string;
       engineerInstruction?: string;
       skillIds?: string[];
+      secretNames?: string[];
       reviewMode?: "full-dispute" | "single-verifier";
       commitPrefix?: string;
     } = { repoPath: path, preset };
@@ -454,6 +485,12 @@ export function NewConsiliumReviewDialog({
     // server resolves them project-scoped and appends their directives to the
     // instruction under a byte budget (dropping whole skills if it must).
     if (selectedSkillIds.length > 0) body.skillIds = selectedSkillIds;
+    // Secrets → `secretNames` (ADR-003 §D2 binding-at-create = the operator's
+    // approval). Send only when some are selected; absent ⇒ byte-identical to
+    // today. The server resolves each name to a credentialId (metadata only) and
+    // binds it as the loop's authorized set; an unknown name is a 400. No secret
+    // VALUE is ever sent from the client.
+    if (selectedSecretNames.length > 0) body.secretNames = selectedSecretNames;
     // Review mode → `reviewMode` only when an EXPLICIT choice is made; "" leaves it
     // to the server's operator default (verifyReview.enabled), preserving today's flow.
     if (reviewMode) body.reviewMode = reviewMode;
@@ -935,6 +972,70 @@ export function NewConsiliumReviewDialog({
               <p className="text-xs text-muted-foreground">
                 Each selected skill's directive is appended to the instruction above,
                 in the order picked. At most {MAX_REVIEW_SKILLS}.
+              </p>
+            </div>
+          )}
+          {/* Secrets the loop may use (ADR-003 §D2). Selecting a secret binds it as
+              the loop's authorized set — at exec time the loop can lease a short-TTL,
+              audited, revocable handle to that credential; nothing is granted by
+              default. Only credential NAMES are shown; the value never reaches the
+              client. Hidden when the project has no named secrets, so it is never an
+              empty dead control. */}
+          {availableSecrets.length > 0 && (
+            <div className="space-y-2">
+              <div className="flex items-baseline justify-between gap-2">
+                <Label>
+                  Secrets{" "}
+                  <span className="text-muted-foreground">(this loop may use)</span>
+                </Label>
+                <span
+                  className="text-xs tabular-nums text-muted-foreground"
+                  data-testid="new-review-secrets-counter"
+                >
+                  {selectedSecretNames.length}/{MAX_REVIEW_SECRETS}
+                </span>
+              </div>
+              <div
+                className="max-h-40 space-y-1 overflow-y-auto rounded border p-2"
+                data-testid="new-review-secrets"
+              >
+                {availableSecrets.map((secret) => {
+                  const checked = selectedSecretNames.includes(secret.name);
+                  const disabled = !checked && atSecretCap;
+                  const hint = firstLine(secret.description) || secret.provider;
+                  return (
+                    <label
+                      key={secret.id}
+                      className={
+                        "flex items-start gap-2 rounded p-1.5 text-sm " +
+                        (disabled
+                          ? "cursor-not-allowed opacity-50"
+                          : "cursor-pointer hover:bg-muted/50")
+                      }
+                    >
+                      <Checkbox
+                        checked={checked}
+                        disabled={disabled}
+                        onCheckedChange={() => toggleSecret(secret.name)}
+                        data-testid={`new-review-secret-${secret.name}`}
+                        className="mt-0.5"
+                      />
+                      <span className="min-w-0">
+                        <span className="font-medium">{secret.name}</span>
+                        {hint && (
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {hint}
+                          </span>
+                        )}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Each selected secret grants the loop short-lived, audited, revocable
+                access at exec time — never placed in a reviewer's prompt. At most{" "}
+                {MAX_REVIEW_SECRETS}.
               </p>
             </div>
           )}

--- a/scripts/check-decrypt-confined.sh
+++ b/scripts/check-decrypt-confined.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# check-decrypt-confined.sh — ADR-003 §D3 decrypt-confinement CI guard.
+#
+# The shared credential decrypt primitive (`server/crypto.ts` `decrypt`) may be
+# IMPORTED only by the credential broker (`db-crypto-provider.ts`) and by rekey /
+# migration scripts under `scripts/`. Every other credential-secret decryption
+# must route through the broker (accessSecret / getSecretValue) so the single
+# sanctioned decrypt site stays auditable.
+#
+# Scope note: the federation subsystem (`federation/encryption.ts`) and the
+# trigger-secret subsystem (`services/trigger-crypto.ts`) have their OWN, separate
+# encryption and are NOT credential secrets — this guard matches only IMPORTS of
+# `decrypt` from a `crypto` module, so those are correctly out of scope.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Path fragments allowed to import the crypto decrypt primitive.
+ALLOW_RE='(server/credentials/db-crypto-provider\.ts|scripts/)'
+
+violations="$(
+  grep -rnE --include='*.ts' \
+    "import[^;]*\bdecrypt\b[^;]*from[^;]*['\"][^'\"]*crypto" \
+    server shared scripts 2>/dev/null \
+    | grep -vE '\.test\.' \
+    | grep -vE "$ALLOW_RE" \
+    || true
+)"
+
+if [ -n "$violations" ]; then
+  echo "ERROR: the crypto decrypt primitive is imported outside the credential broker (ADR-003 §D3)." >&2
+  echo "Route credential-secret decryption through the broker (accessSecret / getSecretValue)." >&2
+  echo "Offending imports:" >&2
+  echo "$violations" >&2
+  exit 1
+fi
+
+echo "decrypt-confinement OK: crypto.decrypt is imported only by the credential broker."

--- a/server/credentials/db-crypto-provider.ts
+++ b/server/credentials/db-crypto-provider.ts
@@ -22,13 +22,60 @@ import {
   credentialLeases,
   credentialAccessLog,
   secrets,
+  consiliumLoops,
+  consiliumLoopSecrets,
 } from "../../shared/schema.js";
+import type { ConsiliumLoopState } from "../../shared/schema.js";
 import type {
   CredentialMetadata,
   CredentialProvider,
   AccessSecretParams,
 } from "./types.js";
 import { ForbiddenError } from "./types.js";
+
+// ─── issueLease policy (ADR-003 §D) ─────────────────────────────────────────────
+
+/** Loop states in which a secret may be leased (§D1). Everything else fails closed. */
+const LEASE_ELIGIBLE_STATES: readonly ConsiliumLoopState[] = [
+  "reviewing",
+  "developing",
+];
+
+/** TTL clamp (§D — short-TTL leases). */
+const DEFAULT_LEASE_TTL_S = 300;
+const MAX_LEASE_TTL_S = 900;
+
+function clampTtl(ttlSeconds?: number): number {
+  if (
+    ttlSeconds === undefined ||
+    !Number.isFinite(ttlSeconds) ||
+    ttlSeconds <= 0
+  ) {
+    return DEFAULT_LEASE_TTL_S;
+  }
+  return Math.min(Math.floor(ttlSeconds), MAX_LEASE_TTL_S);
+}
+
+// [R3-SEC-10] Per-(projectId, loopId) in-memory sliding-window rate limit. Bounds a
+// compromised loop's burst; best-effort per-process throttle, not a distributed quota.
+const RATE_WINDOW_MS = 60_000;
+const MAX_LEASES_PER_WINDOW = 30;
+const leaseRateWindows = new Map<string, number[]>();
+
+function rateLimitOrThrow(projectId: string, loopId: string): void {
+  const key = `${projectId}:${loopId}`;
+  const now = Date.now();
+  const cutoff = now - RATE_WINDOW_MS;
+  const recent = (leaseRateWindows.get(key) ?? []).filter((t) => t > cutoff);
+  if (recent.length >= MAX_LEASES_PER_WINDOW) {
+    throw new ForbiddenError(
+      `issueLease rate limit exceeded for loop ${loopId} ` +
+        `(${MAX_LEASES_PER_WINDOW} per ${RATE_WINDOW_MS / 1000}s).`,
+    );
+  }
+  recent.push(now);
+  leaseRateWindows.set(key, recent);
+}
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -593,6 +640,122 @@ export class DbCryptoCredentialProvider implements CredentialProvider {
     });
 
     return plaintext;
+  }
+
+  /**
+   * ADR-003 §D1/§D2 — issue a short-TTL, scoped, audited, revocable lease for a
+   * credential a consilium loop is authorized to use. Supersedes ADR-001
+   * [R3-SEC-2]'s pipeline-anchored gate. Every denial is audited
+   * (action='lease_issued', success=false) before the ForbiddenError propagates.
+   */
+  async issueLease(p: {
+    projectId: string;
+    credentialId: string;
+    loopId: string;
+    phase: string;
+    requestedBy: string;
+    ttlSeconds?: number;
+    justification?: string;
+  }): Promise<{ leaseId: string; expiresAt: Date }> {
+    // [R3-SEC-3] project-scope; throws structurally in system context.
+    assertProject(p.projectId);
+
+    const auditDenied = async (errorMessage: string): Promise<void> => {
+      await writeAccessLog({
+        credentialId: p.credentialId,
+        projectId: p.projectId,
+        runId: p.loopId,
+        stageId: p.phase,
+        action: "lease_issued",
+        requestedBy: p.requestedBy,
+        justification: p.justification ?? null,
+        success: false,
+        errorMessage,
+      }).catch((auditErr: unknown) => {
+        console.warn("[credential-broker] audit write failed:", auditErr);
+      });
+    };
+
+    // D1 — run-state gate: loop exists, same project, secret-consuming state.
+    const [loop] = await db
+      .select({
+        state: consiliumLoops.state,
+        projectId: consiliumLoops.projectId,
+      })
+      .from(consiliumLoops)
+      .where(eq(consiliumLoops.id, p.loopId));
+    if (
+      !loop ||
+      loop.projectId !== p.projectId ||
+      !LEASE_ELIGIBLE_STATES.includes(loop.state)
+    ) {
+      const reason = !loop
+        ? `loop ${p.loopId} not found`
+        : loop.projectId !== p.projectId
+          ? `loop ${p.loopId} belongs to a different project`
+          : `loop ${p.loopId} state '${loop.state}' is not lease-eligible`;
+      await auditDenied(reason);
+      throw new ForbiddenError(`issueLease denied: ${reason}.`);
+    }
+
+    // D2 — binding-at-create gate: credential must be in the loop's bound set.
+    const [bound] = await db
+      .select({ credentialId: consiliumLoopSecrets.credentialId })
+      .from(consiliumLoopSecrets)
+      .where(
+        and(
+          eq(consiliumLoopSecrets.loopId, p.loopId),
+          eq(consiliumLoopSecrets.credentialId, p.credentialId),
+        ),
+      );
+    if (!bound) {
+      const reason = `credential ${p.credentialId} is not bound to loop ${p.loopId}`;
+      await auditDenied(reason);
+      throw new ForbiddenError(`issueLease denied: ${reason}.`);
+    }
+
+    // [R3-SEC-10] rate limit — audit the breach before propagating.
+    try {
+      rateLimitOrThrow(p.projectId, p.loopId);
+    } catch (rateErr: unknown) {
+      const reason =
+        rateErr instanceof Error ? rateErr.message : "rate limit exceeded";
+      await auditDenied(reason);
+      throw rateErr;
+    }
+
+    const ttlSeconds = clampTtl(p.ttlSeconds);
+    const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
+
+    const [lease] = await db
+      .insert(credentialLeases)
+      .values({
+        credentialId: p.credentialId,
+        projectId: p.projectId,
+        runId: p.loopId,
+        stageId: p.phase,
+        requestedBy: p.requestedBy,
+        expiresAt,
+        status: "active",
+      })
+      .returning({ id: credentialLeases.id });
+
+    await writeAccessLog({
+      leaseId: lease.id,
+      credentialId: p.credentialId,
+      projectId: p.projectId,
+      runId: p.loopId,
+      stageId: p.phase,
+      action: "lease_issued",
+      requestedBy: p.requestedBy,
+      justification: p.justification ?? null,
+      success: true,
+      ttlSeconds,
+    }).catch((auditErr: unknown) => {
+      console.warn("[credential-broker] audit write failed:", auditErr);
+    });
+
+    return { leaseId: lease.id, expiresAt };
   }
 }
 

--- a/server/credentials/deliver-leased-env.ts
+++ b/server/credentials/deliver-leased-env.ts
@@ -1,0 +1,89 @@
+/**
+ * deliver-leased-env.ts — ADR-003 Phase 3a.C exec-time secret delivery helper.
+ *
+ * For a consilium loop's bound secrets, issue a short-TTL lease per secret,
+ * decrypt its value through the broker, and shape an env map keyed by the secret
+ * NAME (a STATIC raw string — typed AWS/Kubernetes shaping is Phase 3b). The
+ * caller layers `env` OVER the sanitized allowlist env of a server-controlled
+ * subprocess (the dev coder / built-in MCP server), marks each lease used before
+ * spawn, and MUST revoke every lease in a `finally`. `values` feeds the dynamic
+ * scrubber (secret-scrub.ts `extraValues`) so a leased value that never sat in
+ * this server's process.env is still redacted from the run's output.
+ *
+ * Returns empty ({}, [], []) when the loop has no bound secrets ⇒ the caller's
+ * spawn path is byte-identical to today. On a partial failure it revokes the
+ * leases it already issued before rethrowing, so no active lease is orphaned.
+ */
+import type { CredentialProvider } from "./types.js";
+import type { IStorage } from "../storage.js";
+
+export interface LeasedEnvDelivery {
+  /** Env entries keyed by secret name (raw static value). Layer OVER the allowlist. */
+  env: Record<string, string>;
+  /** Leased raw values for the per-run dynamic scrubber (ADR-003 §D). */
+  values: string[];
+  /** Lease ids the caller MUST revoke in a `finally` (and should markLeaseUsed). */
+  leaseIds: string[];
+}
+
+export async function deliverLeasedEnv(p: {
+  provider: CredentialProvider;
+  storage: Pick<IStorage, "getLoopSecrets">;
+  projectId: string;
+  loopId: string;
+  phase: string;
+  requestedBy: string;
+  ttlSeconds?: number;
+}): Promise<LeasedEnvDelivery> {
+  const bound = await p.storage.getLoopSecrets(p.loopId);
+  if (bound.length === 0) return { env: {}, values: [], leaseIds: [] };
+
+  // Resolve credentialId → name (METADATA only) to key the env var. A credential
+  // deleted since binding resolves to no name and is skipped (defense-in-depth).
+  const metadata = await p.provider.listCredentials(p.projectId);
+  const nameById = new Map<string, string>();
+  for (const m of metadata) {
+    if (m.name) nameById.set(m.id, m.name);
+  }
+
+  const env: Record<string, string> = {};
+  const values: string[] = [];
+  const leaseIds: string[] = [];
+
+  try {
+    for (const b of bound) {
+      const name = nameById.get(b.credentialId);
+      if (!name) continue; // credential removed since binding — nothing to deliver.
+
+      // issueLease enforces D1 (loop state) + D2 (bound set) + rate limit + audit.
+      const { leaseId } = await p.provider.issueLease({
+        projectId: p.projectId,
+        credentialId: b.credentialId,
+        loopId: p.loopId,
+        phase: p.phase,
+        requestedBy: p.requestedBy,
+        ttlSeconds: p.ttlSeconds,
+      });
+      leaseIds.push(leaseId);
+
+      const value = await p.provider.getSecretValue({
+        projectId: p.projectId,
+        credentialId: b.credentialId,
+        purpose: `consilium-loop:${p.loopId}:${p.phase}`,
+        requestedBy: p.requestedBy,
+      });
+      // The name was identifier-validated at bind time ⇒ a valid env var name.
+      env[name] = value;
+      values.push(value);
+    }
+  } catch (err) {
+    // Partial failure: revoke everything issued so far so nothing is orphaned
+    // (best-effort — the expiry sweeper is the backstop). Then rethrow.
+    for (const id of leaseIds) {
+      await p.provider.revokeLease(id).catch(() => undefined);
+    }
+    throw err;
+  }
+
+  return { env, values, leaseIds };
+}

--- a/server/credentials/openbao-provider.ts
+++ b/server/credentials/openbao-provider.ts
@@ -176,7 +176,19 @@ export class OpenBaoCredentialProvider implements CredentialProvider {
     return this.metadataStore.accessSecret(params);
   }
 
-  // ── EXEC-TIME lease ops (delegate — unchanged) ──────────────────────────────
+  // ── EXEC-TIME lease ops (delegate — leases are Postgres-backed either way) ───
+
+  issueLease(p: {
+    projectId: string;
+    credentialId: string;
+    loopId: string;
+    phase: string;
+    requestedBy: string;
+    ttlSeconds?: number;
+    justification?: string;
+  }): Promise<{ leaseId: string; expiresAt: Date }> {
+    return this.metadataStore.issueLease(p);
+  }
 
   revokeLease(leaseId: string): Promise<void> {
     return this.metadataStore.revokeLease(leaseId);

--- a/server/credentials/types.ts
+++ b/server/credentials/types.ts
@@ -125,11 +125,17 @@ export interface AccessSecretParams {
  *   enforcing project assertion only in project context and skipping it in system
  *   context (while still auditing the access).
  *
- *   [R3-SEC-2] issueLease reads stage_executions.approvalStatus === 'approved' AND
- *   pipeline_runs.status === 'running' from the DB and throws ForbiddenError
- *   otherwise.  The approval gate is a broker invariant, not a caller convention.
+ *   [R3-SEC-2 / ADR-003 §D1] issueLease gates on the consilium-loop execution
+ *   model (the pipeline_runs / stage_executions tables were removed in PR #525):
+ *   the referenced loop must exist, match the project, and be in a
+ *   secret-consuming state (state ∈ {reviewing, developing}); otherwise
+ *   ForbiddenError.  The gate is a broker invariant, not a caller convention.
  *
- *   [R3-SEC-10] issueLease is rate-limited per (projectId, runId).
+ *   [ADR-003 §D2] issueLease additionally requires the credentialId to be in the
+ *   loop's bound set (consilium_loop_secrets) — the operator's binding-at-create
+ *   IS the approval.  A credential not bound to the loop can never be leased.
+ *
+ *   [R3-SEC-10] issueLease is rate-limited per (projectId, loopId).
  */
 export interface CredentialProvider {
   // ── PLAN-TIME ─────────────────────────────────────────────────────────────
@@ -178,6 +184,29 @@ export interface CredentialProvider {
   }): Promise<string>;
 
   // ── EXEC-TIME ─────────────────────────────────────────────────────────────
+
+  /**
+   * Issue a short-TTL, scoped, audited lease for a credential a consilium loop is
+   * authorized to use (ADR-003 §D1/§D2, supersedes ADR-001 [R3-SEC-2]).
+   *
+   * Fail-closed; audited on failure too (action='lease_issued', success=false):
+   *   [R3-SEC-3]  projectId === getProjectId() (system context throws structurally).
+   *   D1          loop exists, its projectId matches, state ∈ {reviewing, developing}.
+   *   D2          credentialId is in the loop's bound set (consilium_loop_secrets).
+   *   [R3-SEC-10] rate-limited per (projectId, loopId).
+   *
+   * On success writes credential_leases(active, runId=loopId, stageId=phase) and
+   * audits action='lease_issued' with ttlSeconds. TTL is clamped to a safe range.
+   */
+  issueLease(p: {
+    projectId: string;
+    credentialId: string;
+    loopId: string;
+    phase: string;
+    requestedBy: string;
+    ttlSeconds?: number;
+    justification?: string;
+  }): Promise<{ leaseId: string; expiresAt: Date }>;
 
   /** Mark a lease revoked.  No-op if already revoked (idempotent). */
   revokeLease(leaseId: string): Promise<void>;

--- a/server/gateway/secret-scrub.ts
+++ b/server/gateway/secret-scrub.ts
@@ -68,14 +68,36 @@ function collectSecretValues(): string[] {
 }
 
 /**
+ * Merge the process.env secret values with a caller-supplied per-run value set,
+ * longest-first. `extraValues` (ADR-003 §D dynamic scrubber) carries values that
+ * were LEASED into a subprocess env but never sat in this server's process.env —
+ * e.g. a freshly issued credential delivered to a consilium dev coder — so they
+ * are still redacted from that run's stdout/stderr/trace. Short values (< 6
+ * chars) are dropped to avoid mass false-positive redaction, same as env values.
+ */
+function scrubValueSet(extraValues: readonly string[]): string[] {
+  if (extraValues.length === 0) return collectSecretValues();
+  const extra = extraValues.filter(
+    (v) => typeof v === "string" && v.length >= MIN_SECRET_LENGTH,
+  );
+  return [...collectSecretValues(), ...extra].sort((a, b) => b.length - a.length);
+}
+
+/**
  * Replace every occurrence of a known secret env value in `input` with
  * [REDACTED]. Non-string input coerces to "" (never throws).
+ *
+ * `extraValues` (default empty ⇒ byte-identical to the env-only behavior) adds a
+ * per-run leased value set to the scrub (ADR-003 §D dynamic scrubber).
  */
-export function scrubSecrets(input: string): string {
+export function scrubSecrets(
+  input: string,
+  extraValues: readonly string[] = [],
+): string {
   if (typeof input !== "string") return "";
   if (input.length === 0) return input;
   let out = input;
-  for (const secret of collectSecretValues()) {
+  for (const secret of scrubValueSet(extraValues)) {
     if (!out.includes(secret)) continue;
     out = out.replace(new RegExp(escapeRegExp(secret), "g"), REDACTION);
   }
@@ -85,9 +107,15 @@ export function scrubSecrets(input: string): string {
 /**
  * Scrub secrets, then truncate to MAX_PREVIEW_CHARS. Use for any partial-output
  * preview / stderr fragment that enters an error, WS payload, log, or trace.
+ *
+ * `extraValues` (default empty ⇒ byte-identical) threads a per-run leased value
+ * set into the scrub (ADR-003 §D dynamic scrubber).
  */
-export function scrubAndTruncate(input: string): string {
-  const scrubbed = scrubSecrets(input);
+export function scrubAndTruncate(
+  input: string,
+  extraValues: readonly string[] = [],
+): string {
+  const scrubbed = scrubSecrets(input, extraValues);
   return scrubbed.length > MAX_PREVIEW_CHARS
     ? scrubbed.slice(0, MAX_PREVIEW_CHARS)
     : scrubbed;

--- a/server/routes/consilium-reviews.ts
+++ b/server/routes/consilium-reviews.ts
@@ -52,6 +52,9 @@ const CreateReviewSchema = z.object({
   // clean 400 here) and each id length-clamped. The factory resolves them
   // PROJECT-SCOPED — a foreign/unknown id is a 400 naming the offending id.
   skillIds: z.array(z.string().min(1).max(200)).max(5).optional(),
+  // ADR-003 §D2: operator-authorized secret NAMES (resolved + bound by the
+  // factory, which enforces the identifier shape and 400s an unknown name).
+  secretNames: z.array(z.string().min(1).max(64)).max(20).optional(),
   // Single-verifier re-review: OPTIONAL per-loop review mode. Absent ⇒ null ⇒ the
   // server resolves it from the operator default (verifyReview.enabled). A server
   // enum (z.enum) so only the two known values pass; anything else is a clean 400.
@@ -141,6 +144,8 @@ export function registerConsiliumReviewRoutes(app: Express, deps: CreateConsiliu
           engineerInstruction: body.engineerInstruction,
           // Stage 2: operator skill ids — resolved + appended by the factory.
           skillIds: body.skillIds,
+          // ADR-003 §D2: operator-authorized secrets — resolved + bound by factory.
+          secretNames: body.secretNames,
           // Single-verifier re-review: OPTIONAL per-loop mode (persisted on the loop).
           reviewMode: body.reviewMode,
           // OPTIONAL per-loop commit-message/MR-title prefix (sanitized here, same
@@ -162,6 +167,14 @@ export function registerConsiliumReviewRoutes(app: Express, deps: CreateConsiliu
         // actionable ("skill \"<id>\" was not found in this project").
         if (message.includes("[skill-not-found]")) {
           return res.status(400).json({ error: message.replace("[skill-not-found] ", "") });
+        }
+        // ADR-003 §D2: an unknown project secret name, or a malformed/oversized
+        // secretNames set. The factory names the offender (the caller's own input,
+        // a credential NAME — not secret material and not an fs leak).
+        if (message.includes("[secret-not-found]") || message.includes("[secret-invalid]")) {
+          return res.status(400).json({
+            error: message.replace(/\[secret-(?:not-found|invalid)\] /, ""),
+          });
         }
         // The factory STRICT-validates the optional branch/ref (ref-validator.ts)
         // and throws INVALID_REF_MESSAGE on a bad one — surface a clear 400 (the

--- a/server/services/consilium/review-factory.ts
+++ b/server/services/consilium/review-factory.ts
@@ -67,6 +67,7 @@ import { readdirSync, readFileSync, statSync, type Dirent } from "fs";
 import { basename, join } from "path";
 import simpleGit from "simple-git";
 import type { IStorage } from "../../storage.js";
+import { credentialProvider } from "../../credentials/db-crypto-provider.js";
 import type { InsertConsiliumLoop, ConsiliumLoopRow, Skill, AppliedSkillRef } from "@shared/schema";
 import type { ConsiliumReviewPreset, TriggerProvenance, ReviewMode } from "@shared/types";
 import type { TaskOrchestrator, CreateTaskParam } from "../task-orchestrator.js";
@@ -1290,6 +1291,15 @@ export interface CreateConsiliumReviewParams {
    */
   skillIds?: string[];
   /**
+   * ADR-003 §D2 (binding-at-create = approval): OPTIONAL operator-selected secret
+   * NAMES this loop is authorized to lease at exec time. Resolved PROJECT-SCOPED to
+   * credentialIds (metadata only — never a value) and bound to the loop; an unknown
+   * or malformed name THROWS (→ 400) with nothing persisted. Absent/empty ⇒ the loop
+   * has no bound secrets and `issueLease` can lease nothing for it (byte-identical to
+   * today). Names are NOT secret material — they are safe to echo in errors/logs.
+   */
+  secretNames?: string[];
+  /**
    * BRANCH-targeted review: an optional git ref (branch name / revision) the
    * review targets. STRICT-validated here (ref-validator.ts) before it reaches
    * git; persisted as the loop's `reviewRef`. Absent/null ⇒ working-tree HEAD
@@ -1387,6 +1397,53 @@ export async function assertRepoIsProjectWorkspace(
  * (S1), the repoPath is not a workspace of the current project (S5), the preset
  * is unknown, or a non-hex baselineCommit is supplied (S3).
  */
+// ─── ADR-003 §D2: bind operator-authorized secrets to the loop ────────────────
+const SECRET_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/;
+const MAX_BOUND_SECRETS = 20;
+
+/**
+ * Resolve operator-selected secret NAMES to their credentialIds, PROJECT-SCOPED
+ * (listCredentials returns metadata only — never a value). Validates shape and
+ * caps the count; an unknown or malformed name THROWS a tagged error that the
+ * create routes map to 400. Absent/empty ⇒ [] (the loop binds nothing, so
+ * issueLease can lease nothing for it — byte-identical to a no-secrets loop).
+ */
+async function resolveBoundSecretIds(
+  secretNames: string[] | undefined,
+  projectId: string,
+): Promise<string[]> {
+  if (!secretNames || secretNames.length === 0) return [];
+  const deduped = Array.from(new Set(secretNames));
+  if (deduped.length > MAX_BOUND_SECRETS) {
+    throw new Error(
+      `[secret-invalid] at most ${MAX_BOUND_SECRETS} secrets may be bound to a loop`,
+    );
+  }
+  for (const name of deduped) {
+    if (!SECRET_NAME_RE.test(name)) {
+      throw new Error(
+        `[secret-invalid] secret name "${name}" is not a valid identifier`,
+      );
+    }
+  }
+  const metadata = await credentialProvider.listCredentials(projectId);
+  const idByName = new Map<string, string>();
+  for (const m of metadata) {
+    if (m.name) idByName.set(m.name, m.id);
+  }
+  const ids: string[] = [];
+  for (const name of deduped) {
+    const id = idByName.get(name);
+    if (!id) {
+      throw new Error(
+        `[secret-not-found] secret "${name}" was not found in this project`,
+      );
+    }
+    ids.push(id);
+  }
+  return ids;
+}
+
 export async function createConsiliumReview(
   deps: CreateConsiliumReviewDeps,
   params: CreateConsiliumReviewParams,
@@ -1405,6 +1462,14 @@ export async function createConsiliumReview(
   // boundary). A repo must pass BOTH. Fail-closed: no matching workspace ⇒ reject.
   // Runs before createTaskGroup/createLoop ⇒ nothing persisted on rejection.
   await assertRepoIsProjectWorkspace(resolvedRepo, storage);
+
+  // ADR-003 §D2: resolve + validate operator-authorized secret NAMES to
+  // credentialIds BEFORE anything is persisted — an unknown/malformed name throws
+  // here (→ 400) with nothing created. Bound after createLoop (needs loop.id).
+  const boundSecretIds = await resolveBoundSecretIds(
+    params.secretNames,
+    params.projectId,
+  );
 
   const panel = PRESET_PANELS[params.preset];
   if (!panel) throw new Error(`unknown consilium review preset: ${String(params.preset)}`);
@@ -1509,6 +1574,16 @@ export async function createConsiliumReview(
     // Draft-PR capable) ⇒ A; review-only ⇒ R0.
     class: cfg.implement?.enabled ? "A" : "R0",
   } as InsertConsiliumLoop);
+
+  // ADR-003 §D2: persist the loop→secret bindings (the bound set issueLease
+  // consults). Idempotent per (loop, credential). Empty ⇒ no-op.
+  if (boundSecretIds.length > 0) {
+    await storage.bindLoopSecrets({
+      loopId: loop.id,
+      credentialIds: boundSecretIds,
+      createdBy: params.createdBy,
+    });
+  }
 
   // 3) Start it (PENDING → BUILDING_CONTEXT). The poller advances it from there;
   //    `controller.start` returns the ticked row (or null if it could not start,

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -55,6 +55,8 @@ import {
   taskExecutions,
   consiliumLoops,
   consiliumLoopRounds,
+  consiliumLoopSecrets,
+  type ConsiliumLoopSecret,
   experienceItems,
   type ExperienceItemRow,
   type InsertExperienceItem,
@@ -779,6 +781,31 @@ export class PgStorage implements IStorage {
   async getLoop(id: string): Promise<ConsiliumLoopRow | undefined> {
     const [row] = await db.select().from(consiliumLoops).where(withProject(consiliumLoops, eq(consiliumLoops.id, id)));
     return row;
+  }
+
+  async getLoopSecrets(loopId: string): Promise<ConsiliumLoopSecret[]> {
+    return db
+      .select()
+      .from(consiliumLoopSecrets)
+      .where(eq(consiliumLoopSecrets.loopId, loopId));
+  }
+
+  async bindLoopSecrets(p: {
+    loopId: string;
+    credentialIds: string[];
+    createdBy: string;
+  }): Promise<void> {
+    if (p.credentialIds.length === 0) return;
+    await db
+      .insert(consiliumLoopSecrets)
+      .values(
+        p.credentialIds.map((credentialId) => ({
+          loopId: p.loopId,
+          credentialId,
+          createdBy: p.createdBy,
+        })),
+      )
+      .onConflictDoNothing();
   }
 
   async getLoopsByOwner(ownerId: string): Promise<ConsiliumLoopRow[]> {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -23,6 +23,7 @@ import {
   type InsertTaskGroup,
   type ConsiliumLoopRow,
   type InsertConsiliumLoop,
+  type ConsiliumLoopSecret,
   type ConsiliumLoopRoundRow,
   type InsertConsiliumLoopRound,
   type ConsiliumLoopState,
@@ -444,6 +445,14 @@ export interface IStorage {
    *  group (Security H-3) — surfaces as a unique-violation the route maps to 409. */
   createLoop(data: InsertConsiliumLoop): Promise<ConsiliumLoopRow>;
   getLoop(id: string): Promise<ConsiliumLoopRow | undefined>;
+  /** ADR-003 §D2 — the secrets a loop is authorized to lease (its bound set). */
+  getLoopSecrets(loopId: string): Promise<ConsiliumLoopSecret[]>;
+  /** ADR-003 §D2 — bind credentials to a loop at create (idempotent per pair). */
+  bindLoopSecrets(p: {
+    loopId: string;
+    credentialIds: string[];
+    createdBy: string;
+  }): Promise<void>;
   /** Loops created by `ownerId`, newest first (owner-scoped list, mirror task-groups). */
   getLoopsByOwner(ownerId: string): Promise<ConsiliumLoopRow[]>;
   /** All loops (admin list / poller backstop sweep). */
@@ -1400,6 +1409,8 @@ export class MemStorage implements IStorage {
 
   private consiliumLoopsMap: Map<string, ConsiliumLoopRow> = new Map();
   private consiliumLoopRoundsMap: Map<string, ConsiliumLoopRoundRow> = new Map();
+  // ADR-003 §D2 — loop→secret bindings (the bound set consulted by issueLease).
+  private consiliumLoopSecretRows: ConsiliumLoopSecret[] = [];
 
   /** Mirror the DB partial-unique index: at most one non-terminal loop/group. */
   private isLoopActive(row: ConsiliumLoopRow): boolean {
@@ -1475,6 +1486,30 @@ export class MemStorage implements IStorage {
 
   async getLoop(id: string): Promise<ConsiliumLoopRow | undefined> {
     return this.consiliumLoopsMap.get(id);
+  }
+
+  async getLoopSecrets(loopId: string): Promise<ConsiliumLoopSecret[]> {
+    return this.consiliumLoopSecretRows.filter((r) => r.loopId === loopId);
+  }
+
+  async bindLoopSecrets(p: {
+    loopId: string;
+    credentialIds: string[];
+    createdBy: string;
+  }): Promise<void> {
+    const now = new Date();
+    for (const credentialId of p.credentialIds) {
+      const exists = this.consiliumLoopSecretRows.some(
+        (r) => r.loopId === p.loopId && r.credentialId === credentialId,
+      );
+      if (exists) continue;
+      this.consiliumLoopSecretRows.push({
+        loopId: p.loopId,
+        credentialId,
+        createdBy: p.createdBy,
+        createdAt: now,
+      });
+    }
   }
 
   async getLoopsByOwner(ownerId: string): Promise<ConsiliumLoopRow[]> {

--- a/tests/unit/consilium/loop-secret-binding.test.ts
+++ b/tests/unit/consilium/loop-secret-binding.test.ts
@@ -1,0 +1,85 @@
+/**
+ * loop-secret-binding.test.ts — MemStorage loop→secret bound set (ADR-003 §D2).
+ *
+ * `getLoopSecrets` / `bindLoopSecrets` back the D2 gate in the credential broker's
+ * `issueLease` (a credential not in a loop's bound set can never be leased). This
+ * asserts the roundtrip, per-(loop, credential) idempotency, empty no-op, and
+ * per-loop isolation — WITHOUT a database (MemStorage is fully in-memory).
+ *
+ * The full `issueLease` gate matrix (D1 run-state, D2 bound-set, rate limit,
+ * audit-on-failure) and the create-route 400 mapping query Postgres directly and
+ * are covered by the integration suite (tests/integration/credentials-api).
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { MemStorage } from "../../../server/storage.js";
+
+describe("MemStorage loop→secret bindings (ADR-003 §D2)", () => {
+  let storage: MemStorage;
+
+  beforeEach(() => {
+    storage = new MemStorage();
+  });
+
+  it("binds and reads back the authorized set for a loop", async () => {
+    await storage.bindLoopSecrets({
+      loopId: "loop-a",
+      credentialIds: ["cred-1", "cred-2"],
+      createdBy: "user-1",
+    });
+
+    const rows = await storage.getLoopSecrets("loop-a");
+    expect(rows.map((r) => r.credentialId).sort()).toEqual(["cred-1", "cred-2"]);
+    expect(
+      rows.every((r) => r.loopId === "loop-a" && r.createdBy === "user-1"),
+    ).toBe(true);
+  });
+
+  it("is idempotent per (loop, credential) — re-binding never duplicates", async () => {
+    await storage.bindLoopSecrets({
+      loopId: "loop-a",
+      credentialIds: ["cred-1"],
+      createdBy: "u",
+    });
+    // Re-bind with a duplicate in the batch AND a repeat of the existing pair.
+    await storage.bindLoopSecrets({
+      loopId: "loop-a",
+      credentialIds: ["cred-1", "cred-1", "cred-2"],
+      createdBy: "u",
+    });
+
+    const rows = await storage.getLoopSecrets("loop-a");
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.credentialId).sort()).toEqual(["cred-1", "cred-2"]);
+  });
+
+  it("treats an empty credentialIds batch as a no-op", async () => {
+    await storage.bindLoopSecrets({
+      loopId: "loop-a",
+      credentialIds: [],
+      createdBy: "u",
+    });
+    expect(await storage.getLoopSecrets("loop-a")).toHaveLength(0);
+  });
+
+  it("isolates bound sets per loop", async () => {
+    await storage.bindLoopSecrets({
+      loopId: "loop-a",
+      credentialIds: ["cred-1"],
+      createdBy: "u",
+    });
+    await storage.bindLoopSecrets({
+      loopId: "loop-b",
+      credentialIds: ["cred-2"],
+      createdBy: "u",
+    });
+
+    expect((await storage.getLoopSecrets("loop-a")).map((r) => r.credentialId)).toEqual([
+      "cred-1",
+    ]);
+    expect((await storage.getLoopSecrets("loop-b")).map((r) => r.credentialId)).toEqual([
+      "cred-2",
+    ]);
+    // An unbound loop leases nothing — its set is empty.
+    expect(await storage.getLoopSecrets("loop-c")).toHaveLength(0);
+  });
+});

--- a/tests/unit/credentials/deliver-leased-env.test.ts
+++ b/tests/unit/credentials/deliver-leased-env.test.ts
@@ -1,0 +1,123 @@
+/**
+ * deliver-leased-env.test.ts — ADR-003 Phase 3a.C delivery helper.
+ *
+ * Verifies the exec-time delivery contract with a fake broker + storage:
+ *   - no bound secrets ⇒ empty result, NO lease issued (byte-identical spawn);
+ *   - bound secrets ⇒ env keyed by secret NAME, values + leaseIds collected,
+ *     one issueLease + one getSecretValue per bound credential;
+ *   - a credential removed since binding (no metadata name) is skipped;
+ *   - a mid-loop failure revokes the leases already issued, then rethrows
+ *     (no orphaned active lease).
+ */
+import { describe, it, expect, vi } from "vitest";
+import { deliverLeasedEnv } from "../../../server/credentials/deliver-leased-env.js";
+import type { CredentialProvider } from "../../../server/credentials/types.js";
+
+type BoundRow = {
+  loopId: string;
+  credentialId: string;
+  createdBy: string;
+  createdAt: Date;
+};
+
+function fakeStorage(rows: BoundRow[]) {
+  return {
+    getLoopSecrets: vi.fn(async (loopId: string) =>
+      rows.filter((r) => r.loopId === loopId),
+    ),
+  };
+}
+
+function fakeProvider(over: Partial<CredentialProvider> = {}): CredentialProvider {
+  return {
+    listCredentials: vi.fn(async () => [
+      { id: "cred-1", name: "AWS_KEY" },
+      { id: "cred-2", name: "KUBE" },
+    ]),
+    getCredentialMetadata: vi.fn(),
+    accessSecret: vi.fn(),
+    getSecretValue: vi.fn(async (q: { credentialId: string }) => `value-of-${q.credentialId}`),
+    issueLease: vi.fn(async (q: { credentialId: string }) => ({
+      leaseId: `lease-${q.credentialId}`,
+      expiresAt: new Date(0),
+    })),
+    revokeLease: vi.fn(async () => undefined),
+    revokeRunLeases: vi.fn(async () => undefined),
+    putCredential: vi.fn(),
+    deleteCredential: vi.fn(),
+    ...over,
+  } as unknown as CredentialProvider;
+}
+
+const base = {
+  projectId: "p",
+  loopId: "loop-a",
+  phase: "developing",
+  requestedBy: "user-1",
+};
+
+describe("deliverLeasedEnv (ADR-003 §3a.C)", () => {
+  it("returns empty and issues no lease when the loop has no bound secrets", async () => {
+    const provider = fakeProvider();
+    const storage = fakeStorage([]);
+
+    const out = await deliverLeasedEnv({ provider, storage, ...base });
+
+    expect(out).toEqual({ env: {}, values: [], leaseIds: [] });
+    expect(provider.issueLease).not.toHaveBeenCalled();
+    expect(provider.getSecretValue).not.toHaveBeenCalled();
+  });
+
+  it("issues a lease + delivers env keyed by secret name for each bound secret", async () => {
+    const provider = fakeProvider();
+    const storage = fakeStorage([
+      { loopId: "loop-a", credentialId: "cred-1", createdBy: "u", createdAt: new Date(0) },
+      { loopId: "loop-a", credentialId: "cred-2", createdBy: "u", createdAt: new Date(0) },
+    ]);
+
+    const out = await deliverLeasedEnv({ provider, storage, ...base });
+
+    expect(out.env).toEqual({ AWS_KEY: "value-of-cred-1", KUBE: "value-of-cred-2" });
+    expect(out.values.sort()).toEqual(["value-of-cred-1", "value-of-cred-2"]);
+    expect(out.leaseIds.sort()).toEqual(["lease-cred-1", "lease-cred-2"]);
+    expect(provider.issueLease).toHaveBeenCalledTimes(2);
+    expect(provider.getSecretValue).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips a credential removed since binding (no metadata name)", async () => {
+    const provider = fakeProvider({
+      listCredentials: vi.fn(async () => [{ id: "cred-1", name: "AWS_KEY" }]),
+    });
+    const storage = fakeStorage([
+      { loopId: "loop-a", credentialId: "cred-1", createdBy: "u", createdAt: new Date(0) },
+      { loopId: "loop-a", credentialId: "cred-2", createdBy: "u", createdAt: new Date(0) },
+    ]);
+
+    const out = await deliverLeasedEnv({ provider, storage, ...base });
+
+    expect(out.env).toEqual({ AWS_KEY: "value-of-cred-1" });
+    expect(out.leaseIds).toEqual(["lease-cred-1"]);
+    expect(provider.issueLease).toHaveBeenCalledTimes(1);
+  });
+
+  it("revokes already-issued leases and rethrows on a mid-loop failure", async () => {
+    const provider = fakeProvider({
+      // Second secret's value decrypt fails after both leases were issued.
+      getSecretValue: vi
+        .fn()
+        .mockResolvedValueOnce("value-of-cred-1")
+        .mockRejectedValueOnce(new Error("decrypt boom")),
+    });
+    const storage = fakeStorage([
+      { loopId: "loop-a", credentialId: "cred-1", createdBy: "u", createdAt: new Date(0) },
+      { loopId: "loop-a", credentialId: "cred-2", createdBy: "u", createdAt: new Date(0) },
+    ]);
+
+    await expect(deliverLeasedEnv({ provider, storage, ...base })).rejects.toThrow(
+      "decrypt boom",
+    );
+    // Both leases were issued before the failure; both must be revoked.
+    expect(provider.revokeLease).toHaveBeenCalledWith("lease-cred-1");
+    expect(provider.revokeLease).toHaveBeenCalledWith("lease-cred-2");
+  });
+});

--- a/tests/unit/gateway/secret-scrub.test.ts
+++ b/tests/unit/gateway/secret-scrub.test.ts
@@ -60,6 +60,34 @@ describe("scrubSecrets", () => {
   });
 });
 
+describe("scrubSecrets — per-run leased value set (ADR-003 §D dynamic scrubber)", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("redacts a leased value that never sat in process.env", () => {
+    const leased = "leased-aws-secret-value-abcdef";
+    const out = scrubSecrets(`AWS_SECRET_ACCESS_KEY=${leased} in output`, [leased]);
+    expect(out).not.toContain(leased);
+    expect(out).toContain("[REDACTED]");
+  });
+
+  it("is byte-identical when no extra values are passed (leased value NOT redacted)", () => {
+    const leased = "leased-only-value-xyz123";
+    // Not in process.env and no extraValues ⇒ unchanged (proves opt-in default).
+    expect(scrubSecrets(`echo ${leased}`)).toBe(`echo ${leased}`);
+  });
+
+  it("drops short extra values to avoid mass false-positive redaction", () => {
+    const out = scrubSecrets("the id ab12 appears in prose", ["ab12"]);
+    expect(out).toBe("the id ab12 appears in prose");
+  });
+
+  it("scrubAndTruncate threads the leased value set", () => {
+    const leased = "leased-kubeconfig-token-998877";
+    const out = scrubAndTruncate(`KUBECONFIG token ${leased}`, [leased]);
+    expect(out).not.toContain(leased);
+  });
+});
+
 describe("scrubAndTruncate", () => {
   beforeEach(() => vi.stubEnv("OMNISCIENCE_TOKEN", "tok-secret-9999"));
   afterEach(() => vi.unstubAllEnvs());


### PR DESCRIPTION
**Stacked on #561** (base `feat/phase3a-secret-delivery`). Phase 3a.C of ADR-003, split into a **dormant-primitives** part (this PR) and the **hot-path wiring** (pt2, spec below). This PR changes **no runtime behavior**.

## What's here (all additive / opt-in)
- **Dynamic scrubber** (`secret-scrub.ts`): `scrubSecrets`/`scrubAndTruncate` gain an optional `extraValues` per-run set (ADR §D). Default empty ⇒ byte-identical. Lets a leased value that never sat in `process.env` still be redacted from run output.
- **`deliverLeasedEnv` helper** (new): per bound loop secret → `issueLease` → `getSecretValue` → `env` keyed by secret name (static raw string; typed shaping is 3b). Returns `{ env, values, leaseIds }`; empty when nothing bound; **revokes its own leases on a partial failure** so none is orphaned.
- **CI decrypt-guard** (`scripts/check-decrypt-confined.sh` + `lint-typecheck` step, ADR §D3): fails the build if the crypto `decrypt` primitive is imported outside the broker (`db-crypto-provider.ts`) or `scripts/`. Federation/trigger crypto have their own decrypt and are scoped out (verified: only the broker imports `decrypt` from `crypto.ts` today).

## Test plan
- [x] `tsc` clean.
- [x] Unit `deliver-leased-env.test.ts` (4): empty/deliver/skip-deleted-credential/revoke-on-partial-failure.
- [x] Unit `secret-scrub.test.ts` (+4): redacts leased value, opt-in default, short-value drop, `scrubAndTruncate` threads values. **18 passed.**
- [x] `check-decrypt-confined.sh` passes on the current tree.

## pt2 — hot-path wiring (deliberately deferred, its own security-veto review)
The behavioral injection into the live dev-coder spawn. Exact anchors:
1. **`gateway/providers/cli-spawn.ts`** — add `scrubValues?: readonly string[]` to `CliSpawnRequest` (~:141); pass it into the two `scrubSecrets(stderr...)` calls (~:238, ~:369). Env already flows via `envOverride`.
2. **`services/sdlc/coder.ts`** — add `scrubValues?` to `CoderOptions`; pass to `spawnCli({...})` (~:317). Env via `options.env` (already layered by caller).
3. **`services/sdlc/executor.ts`** — add optional `leasedEnv?: Record<string,string>` + `scrubValues?: readonly string[]` to the handoff request; at the single `runCoder` seam (:1009–1010, same place `coderModel` is folded), set `env: { ...sanitizedCoderEnv(), ...req.leasedEnv }` and `scrubValues: req.scrubValues` when present. All coder call sites (:1353/:1385/:1135) go through this seam.
4. **`services/consilium/consilium-loop-controller.ts`** (:2564 `return run({...})`) — before the call: `deliverLeasedEnv({ provider: credentialProvider, storage, projectId: getProjectId(), loopId: loop.id, phase: "developing", requestedBy: loop.createdBy })`; `markLeaseUsed` each; pass `leasedEnv`/`scrubValues` into the request; **revoke every lease in a `finally`**. **Fail-soft**: wrap delivery so a delivery error logs a scrubbed warning and proceeds with NO leased env — must preserve the site's "never throws / degrades to no-PR" invariant (:2563).
5. Consumer-scoping (ADR §D1): wire ONLY the `developing` path here; the `reviewing` read-only-infra consumer is 3c.

Integration (needs live Postgres): a bound-secret develop round injects the env into the coder spawn, `lease_used` is audited, the lease is revoked after, and the value is scrubbed from run output.