### PR TITLE
feat(consilium): deliver leased secrets into the dev coder spawn (Phase 3a.C pt2)

### DIFF
--- a/server/gateway/providers/cli-spawn.ts
+++ b/server/gateway/providers/cli-spawn.ts
@@ -139,6 +139,13 @@ export interface CliSpawnRequest {
    * (`{...process.env, ...env}`) applies for the short LLM callers.
    */
   envOverride?: NodeJS.ProcessEnv;
+  /**
+   * ADR-003 §D dynamic scrubber: per-run leased secret VALUES to redact from this
+   * child's stderr in error messages — values delivered via `envOverride` that
+   * never sat in the server's process.env (so the env-only scrubber cannot see
+   * them). Default undefined ⇒ env-only scrubbing, byte-identical to today.
+   */
+  scrubValues?: readonly string[];
 }
 
 export interface CliSpawnResult {
@@ -228,6 +235,7 @@ function settleClose(
   stderr: string,
   resolve: (r: CliSpawnResult) => void,
   reject: (e: Error) => void,
+  scrubValues: readonly string[] = [],
 ): void {
   if (code === 0) {
     resolve({ stdout, stderr, exitCode: 0 });
@@ -235,7 +243,7 @@ function settleClose(
   }
   reject(
     new CliExecutionError(
-      `CLI exited with code ${code ?? "null"}${stderr ? `: ${scrubSecrets(stderr.trim())}` : ""}`,
+      `CLI exited with code ${code ?? "null"}${stderr ? `: ${scrubSecrets(stderr.trim(), scrubValues)}` : ""}`,
       code,
       stderr,
     ),
@@ -289,7 +297,9 @@ export function spawnCli(request: CliSpawnRequest): Promise<CliSpawnResult> {
     child.stdout.on("data", (chunk: Buffer) => (stdout += chunk.toString()));
     child.stderr.on("data", (chunk: Buffer) => (stderr += chunk.toString()));
     child.on("close", (code) =>
-      finish(() => settleClose(code, stdout, stderr, resolve, reject)),
+      finish(() =>
+        settleClose(code, stdout, stderr, resolve, reject, request.scrubValues ?? []),
+      ),
     );
 
     child.stdin.end(request.stdin);
@@ -366,7 +376,7 @@ export async function* streamCliLines(
     const err =
       code !== 0 && code !== null
         ? new CliExecutionError(
-            `CLI exited with code ${code}${stderr ? `: ${scrubSecrets(stderr.trim())}` : ""}`,
+            `CLI exited with code ${code}${stderr ? `: ${scrubSecrets(stderr.trim(), request.scrubValues ?? [])}` : ""}`,
             code,
             stderr,
           )

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -48,7 +48,12 @@
  */
 import { z } from "zod";
 import type { IStorage } from "../../storage.js";
-import { runAsSystem, runAsProject } from "../../context.js";
+import { runAsSystem, runAsProject, getProjectId } from "../../context.js";
+import {
+  credentialProvider,
+  markLeaseUsed,
+} from "../../credentials/db-crypto-provider.js";
+import { deliverLeasedEnv } from "../../credentials/deliver-leased-env.js";
 import type { ConsiliumLoopRow, ConsiliumLoopRoundRow, ConsiliumLoopState, TaskGroupIterationRow, InsertTask } from "@shared/schema";
 import { ARCHETYPES } from "@shared/types";
 import type { Archetype } from "@shared/types";
@@ -2561,7 +2566,42 @@ export class ConsiliumLoopController {
     // commits + opens a Draft PR. baseRef defaults to the repo's default-branch
     // HEAD (resolved inside the executor) so the PR diffs cleanly against it.
     // Never throws (degrades to a no-PR result), so the loop is never failed here.
-    return run({
+    // §3a.C: deliver the loop's bound secrets as env for THIS develop round's coder
+    // runs. FAIL-SOFT — a delivery error must NEVER fail the develop path (preserves
+    // the "never throws / degrades to a no-PR result" invariant of this call site);
+    // we then develop WITHOUT secrets. Lease lifecycle is owned here: markUsed before
+    // the run, revoke every lease in the `finally` below. Absent bound secrets ⇒
+    // empty delivery ⇒ byte-identical to today.
+    const secretRequestedBy = loop.createdBy ?? "system";
+    let leased: {
+      env: Record<string, string>;
+      values: string[];
+      leaseIds: string[];
+    } = { env: {}, values: [], leaseIds: [] };
+    try {
+      leased = await deliverLeasedEnv({
+        provider: credentialProvider,
+        storage: this.storage,
+        projectId: getProjectId(),
+        loopId: loop.id,
+        phase: "developing",
+        requestedBy: secretRequestedBy,
+      });
+      for (const id of leased.leaseIds) {
+        await markLeaseUsed(id, secretRequestedBy).catch((e: unknown) =>
+          console.warn("[consilium-loop] markLeaseUsed failed:", e),
+        );
+      }
+    } catch (e: unknown) {
+      // Broker errors carry IDs/names, never secret values — safe to log.
+      console.warn(
+        "[consilium-loop] leased-secret delivery failed; developing WITHOUT secrets:",
+        e instanceof Error ? e.message : e,
+      );
+      leased = { env: {}, values: [], leaseIds: [] };
+    }
+    try {
+      return await run({
       repoPath: loop.repoPath,
       loopId: loop.id,
       round: loop.round,
@@ -2625,12 +2665,27 @@ export class ConsiliumLoopController {
       repoConventions: cfg.repoConventions?.enabled
         ? { enabled: true, maxConventionsBytes: cfg.repoConventions.maxConventionsBytes }
         : null,
+      // §3a.C: leased secret env + scrub value-set for this round's coder runs.
+      // Empty ⇒ omitted ⇒ byte-identical (executor takes the sanitized-env path).
+      leasedEnv: Object.keys(leased.env).length > 0 ? leased.env : undefined,
+      scrubValues: leased.values.length > 0 ? leased.values : undefined,
     }, {
       getSkills: () => this.storage.getSkills(),
       // Stage B: the judge-method verifier seam (wired to the gateway) — provided ONLY when
       // method routing is on AND a gateway is available. Absent ⇒ judge APs degrade safe.
       judgeVerify: perCriterionOn ? this.buildJudgeVerifier() : undefined,
-    }, onProgress);
+      }, onProgress);
+    } finally {
+      // §3a.C: revoke every lease issued for this round, whatever the outcome
+      // (success, no-PR, or throw). Best-effort; the expiry sweeper is the backstop.
+      for (const id of leased.leaseIds) {
+        await credentialProvider
+          .revokeLease(id)
+          .catch((e: unknown) =>
+            console.warn("[consilium-loop] revokeLease failed:", e),
+          );
+      }
+    }
   }
 
   /**

--- a/server/services/sdlc/coder.ts
+++ b/server/services/sdlc/coder.ts
@@ -163,6 +163,12 @@ export interface CoderOptions {
   /** Override the spawned env (tests). Defaults to `sanitizedCoderEnv()` (H-1). */
   env?: NodeJS.ProcessEnv;
   /**
+   * ADR-003 §3a.C dynamic scrubber: per-run leased secret VALUES to redact from
+   * this coder's stderr (delivered via `env`, never in process.env). Absent ⇒
+   * env-only scrubbing (byte-identical).
+   */
+  scrubValues?: readonly string[];
+  /**
    * Stage 2a: the capability-scoped tool allowlist for THIS run (a SkilledStep's
    * `read-only` ⇒ ["Read"], `worktree-write` ⇒ the baseline). Defaults to the
    * baseline {@link ALLOWED_TOOLS}. Hard-filtered to the baseline ceiling in
@@ -315,6 +321,7 @@ export class SdlcCoder {
         stdin: prompt, // UNTRUSTED text — stdin only, never argv/shell.
         cwd: worktreeDir, // confine the agent's working dir to the worktree.
         envOverride: options.env ?? sanitizedCoderEnv(), // H-1: no inherited secrets.
+        scrubValues: options.scrubValues, // §3a.C: redact leased values from stderr.
         timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
         signal: options.signal,
       }),

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -75,7 +75,12 @@ import {
   type GitRunner,
   type CreateWorktreeResult,
 } from "./worktree.js";
-import { SdlcCoder, type CoderResult, type CoderOptions } from "./coder.js";
+import {
+  SdlcCoder,
+  sanitizedCoderEnv,
+  type CoderResult,
+  type CoderOptions,
+} from "./coder.js";
 import { verifyInWorktree, type TestRunResult } from "./test-runner.js";
 import { stripControlMultiline, backtickFence } from "../consilium/review-factory.js";
 import { readConventionsFile } from "../consilium/repo-conventions.js";
@@ -338,6 +343,15 @@ export interface SdlcHandoffRequest {
    * can never inject a flag.
    */
   coderModel?: string;
+  /**
+   * ADR-003 §3a.C: env of the loop's leased secrets (name→value) to layer OVER the
+   * coder's sanitized allowlist, plus the matching value set for the dynamic stderr
+   * scrubber. Set by the consilium controller ONLY for a `developing` loop with
+   * bound secrets; absent/empty ⇒ byte-identical (sanitized env, env-only scrub).
+   * The lease lifecycle (issue → markUsed → revoke) is owned by the controller.
+   */
+  leasedEnv?: Record<string, string>;
+  scrubValues?: readonly string[];
   /**
    * Stage 2a: the loop's Stage-1 archetype. Drives the SKILLED step selection
    * (`selectSkillSet`). null/absent ⇒ NO steps ⇒ today's single unskilled coder
@@ -1006,8 +1020,25 @@ export async function runSdlcHandoff(
   // passed through UNTOUCHED ⇒ no `model` key ⇒ no `--model` flag ⇒ byte-for-byte
   // today's invocation (no regression).
   const baseCoder = deps.runCoder ?? ((dir, aps, opts) => sharedCoder.run(dir, aps, opts));
-  const runCoder: NonNullable<SdlcExecutorDeps["runCoder"]> = (dir, aps, opts) =>
-    baseCoder(dir, aps, req.coderModel ? { ...opts, model: req.coderModel } : opts);
+  // §3a.C: fold the loop's leased secret env + scrub value-set into EVERY coder run
+  // of this round (all coder call sites go through this single seam, same as the
+  // coderModel threading). Absent leasedEnv ⇒ opts untouched ⇒ byte-identical
+  // (sanitizedCoderEnv default, env-only scrub).
+  const hasLeasedEnv =
+    req.leasedEnv !== undefined && Object.keys(req.leasedEnv).length > 0;
+  const runCoder: NonNullable<SdlcExecutorDeps["runCoder"]> = (dir, aps, opts) => {
+    let next: CoderOptions | undefined = req.coderModel
+      ? { ...opts, model: req.coderModel }
+      : opts;
+    if (hasLeasedEnv) {
+      next = {
+        ...next,
+        env: { ...(next?.env ?? sanitizedCoderEnv()), ...req.leasedEnv },
+        scrubValues: req.scrubValues,
+      };
+    }
+    return baseCoder(dir, aps, next);
+  };
   const push = deps.push ?? pushBranch;
   const openPr = deps.openPr ?? openDraftPr;
   const progress = makeProgressTracker(onProgress, req.actionPoints);

--- a/tests/unit/providers/cli-spawn.test.ts
+++ b/tests/unit/providers/cli-spawn.test.ts
@@ -113,6 +113,27 @@ describe("spawnCli", () => {
     await expect(spawnCli({ ...REQ })).rejects.toThrow(/bad input|code 2/);
   });
 
+  it("redacts scrubValues from the CliExecutionError message on non-zero exit (ADR-003 §3a.C)", async () => {
+    const secret = "leased-secret-value-xyz";
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      setImmediate(() => {
+        child.stderr.emit("data", Buffer.from(`auth failed for token ${secret}`));
+        child.emit("close", 1);
+      });
+      return child;
+    });
+
+    let msg = "";
+    try {
+      await spawnCli({ ...REQ, scrubValues: [secret] });
+    } catch (e) {
+      msg = (e as Error).message;
+    }
+    expect(msg).toContain("[REDACTED]");
+    expect(msg).not.toContain(secret);
+  });
+
   it("kills the child and rejects on timeout", async () => {
     vi.useFakeTimers();
     const child = makeChild();


### PR DESCRIPTION
Wires the dormant 3a.C primitives (#562) into the **live develop path** (ADR-003 §D1/§D4). This is the behavioral completion of Phase 3a: a consilium loop with bound secrets now actually receives them at exec time — the ADR's designated **primary security-veto surface**.

## Behavior
When a loop has bound secrets, its `developing` close-out leases them and injects them into that round's coder runs. **Absent bound secrets, every path is byte-identical** (guarded structurally by `hasLeasedEnv`).

## Threading (leaf → owner)
- **`cli-spawn.ts`** — `CliSpawnRequest.scrubValues`; threaded into both stderr scrub sites so a leased value echoed in a failing CLI's stderr is redacted.
- **`coder.ts`** — `CoderOptions.scrubValues` passthrough to `spawnCli`.
- **`executor.ts`** — `SdlcHandoffRequest.leasedEnv` + `scrubValues`, folded at the single `runCoder` seam (same place `coderModel` is folded): leased env layered **OVER** `sanitizedCoderEnv()` (H-1 preserved), scrubValues threaded. Empty ⇒ opts untouched.
- **`consilium-loop-controller.ts`** — the develop close-out owns the lease lifecycle: `deliverLeasedEnv` → `markLeaseUsed` before the run → **revoke every lease in a `finally`** (any outcome, incl. throw). **FAIL-SOFT**: a delivery error develops WITHOUT secrets and never fails the loop (preserves the "never throws / degrades to no-PR" invariant).

## Security review (self, since review agents thrash on this repo's context)
- **Consumer-scoped to `developing` only** — the reviewing LLM never receives a secret (that read-only-infra consumer is 3c). ✅
- Env layered over the H-1 allowlist; no inherited process.env secrets. ✅
- Lease always revoked (finally + `deliverLeasedEnv` self-revoke on partial failure + sweeper backstop). ✅
- Fail-soft; broker errors carry IDs/names only, never values. ✅
- **Residual (MEDIUM, follow-up):** raw coder *stdout* surfaced to a trace/WS sink is not yet value-scrubbed — only the stderr/error vector is. Threading `scrubValues` into those sinks is a follow-up.

## Test plan
- [x] `tsc` clean.
- [x] **1613** gateway + sdlc + consilium unit tests green (no regression — the byte-identical guarantee).
- [x] New `cli-spawn.test.ts`: scrubValues redacts a leased value from the `CliExecutionError` on non-zero exit (21 passed).
- [ ] **QA / integration** (live Postgres + coder): a bound-secret develop round injects the env, `lease_used` is audited, the lease is revoked after the round, and a leaked value is scrubbed from run output.

Depends on `consilium_loop_secrets` (applied). Stacks conceptually on #561/#562 (both merged to main).