### PR TITLE
feat(consilium): scrub leased secrets from run output tail + broker gate-matrix tests (Phase 3a tails)

### DIFF
--- a/server/services/consilium/execution-trace.ts
+++ b/server/services/consilium/execution-trace.ts
@@ -27,6 +27,7 @@ import type {
   ExecutionSkill,
   ExecutionCriterion,
 } from "@shared/types";
+import { scrubSecrets } from "../../gateway/secret-scrub.js";
 
 // ─── Bounds (counts) ─────────────────────────────────────────────────────────
 const MAX_WORKERS = 200; // one per action point / research step — generously bounded
@@ -66,8 +67,21 @@ function sanitizeLine(value: string, max: number): string {
  * replace path-like runs with `<path>`, collapse whitespace, clamp. Mirrors the
  * executor's `scrub` (defense-in-depth over the single-line sanitize).
  */
-function scrub(value: string, max: number): string {
-  return (value ?? "")
+/**
+ * Value-scrub with the per-run LEASED secret set (ADR-003 §D dynamic scrubber).
+ * Empty set ⇒ unchanged (byte-identical). Applied to the trace's free text so a
+ * leased value echoed in test output never persists to `_trace`.
+ */
+function leasedScrub(value: string, secretValues: readonly string[]): string {
+  return secretValues.length ? scrubSecrets(value, secretValues) : value;
+}
+
+function scrub(
+  value: string,
+  max: number,
+  secretValues: readonly string[] = [],
+): string {
+  return leasedScrub(value ?? "", secretValues)
     .replace(/\/[^\s'"]+/g, "<path>")
     .replace(/\s+/g, " ")
     .trim()
@@ -84,7 +98,10 @@ function clampSkill(s: ExecutionSkill): ExecutionSkill {
   };
 }
 
-function clampCriterion(c: ExecutionCriterion): ExecutionCriterion {
+function clampCriterion(
+  c: ExecutionCriterion,
+  secretValues: readonly string[] = [],
+): ExecutionCriterion {
   const out: ExecutionCriterion = {
     criterion: sanitizeLine(c.criterion, CRITERION_MAX),
     method: c.method, // fixed union (test-run | web-evidence | judge | none)
@@ -94,7 +111,9 @@ function clampCriterion(c: ExecutionCriterion): ExecutionCriterion {
   if (typeof c.fixIterations === "number" && Number.isFinite(c.fixIterations)) {
     out.fixIterations = Math.max(0, Math.trunc(c.fixIterations));
   }
-  if (c.summary !== undefined) out.summary = scrub(c.summary, SUMMARY_MAX);
+  if (c.summary !== undefined) {
+    out.summary = scrub(c.summary, SUMMARY_MAX, secretValues);
+  }
   // Stage A: additive final-state flag — carried through the clamp verbatim (boolean).
   if (typeof c.passedAtFinal === "boolean") out.passedAtFinal = c.passedAtFinal;
   // Timeout policy: additive NOT-ADJUDICATED flag — carried verbatim (boolean).
@@ -104,16 +123,23 @@ function clampCriterion(c: ExecutionCriterion): ExecutionCriterion {
   return out;
 }
 
-function clampWorker(w: ExecutionWorker): ExecutionWorker {
+function clampWorker(
+  w: ExecutionWorker,
+  secretValues: readonly string[] = [],
+): ExecutionWorker {
   const out: ExecutionWorker = {
     index: Number.isFinite(w.index) ? Math.trunc(w.index) : 0,
     priority: sanitizeLine(w.priority, PRIORITY_MAX),
     title: sanitizeLine(w.title, TITLE_MAX),
     status: w.status, // fixed union (completed | partial | failed)
     skills: w.skills.slice(0, MAX_SKILLS_PER_WORKER).map(clampSkill),
-    criteria: w.criteria.slice(0, MAX_CRITERIA_PER_WORKER).map(clampCriterion),
+    criteria: w.criteria
+      .slice(0, MAX_CRITERIA_PER_WORKER)
+      .map((c) => clampCriterion(c, secretValues)),
   };
-  if (w.note !== undefined) out.note = sanitizeLine(w.note, NOTE_MAX);
+  if (w.note !== undefined) {
+    out.note = sanitizeLine(leasedScrub(w.note, secretValues), NOTE_MAX);
+  }
   return out;
 }
 
@@ -123,15 +149,22 @@ function clampWorker(w: ExecutionWorker): ExecutionWorker {
  * excess whitespace. Idempotent. The builders (executor / research-runner) call this
  * as the LAST step so the persisted jsonb is provably inert + size-bounded.
  */
-export function clampTrace(trace: ExecutionTrace): ExecutionTrace {
+export function clampTrace(
+  trace: ExecutionTrace,
+  secretValues: readonly string[] = [],
+): ExecutionTrace {
   const c: ExecutionController = trace.controller;
   const controller: ExecutionController = {
     kind: c.kind, // fixed union (sdlc-executor | research-runner)
     label: sanitizeLine(c.label, LABEL_MAX),
     green: c.green === true,
-    workers: c.workers.slice(0, MAX_WORKERS).map(clampWorker),
+    workers: c.workers
+      .slice(0, MAX_WORKERS)
+      .map((w) => clampWorker(w, secretValues)),
   };
-  if (c.note !== undefined) controller.note = sanitizeLine(c.note, NOTE_MAX);
+  if (c.note !== undefined) {
+    controller.note = sanitizeLine(leasedScrub(c.note, secretValues), NOTE_MAX);
+  }
   return {
     schemaVersion: 1,
     archetype: trace.archetype ?? null,
@@ -210,6 +243,7 @@ export function buildSdlcTrace(
   result: { prRef: string | null; error?: string },
   finalPassed?: boolean,
   finalTimedOut?: boolean,
+  secretValues: readonly string[] = [],
 ): ExecutionTrace {
   const unmetP0 = outcomes.some(
     (o) => o.priority.toUpperCase().startsWith("P0") && o.verification !== undefined && !o.verification.passed,
@@ -258,7 +292,7 @@ export function buildSdlcTrace(
     workers,
   };
   if (result.error !== undefined) controller.note = result.error;
-  return clampTrace({ schemaVersion: 1, archetype, controller });
+  return clampTrace({ schemaVersion: 1, archetype, controller }, secretValues);
 }
 
 /** The subset of a research P0-criterion evidence the research trace needs. */

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -58,6 +58,7 @@ import type { ActionPoint, Archetype, ExecutionTrace } from "@shared/types";
 import type { Skill } from "@shared/schema";
 import { selectSkillSet, bindSkillStep, type BoundSkillStep } from "../consilium/skills/catalog.js";
 import { buildSdlcTrace } from "../consilium/execution-trace.js";
+import { scrubSecrets } from "../../gateway/secret-scrub.js";
 import {
   buildBranchName,
   buildApBranchName,
@@ -1212,7 +1213,14 @@ export async function runSdlcHandoff(
       // its whole-suite result into the SAME summary (so the next review sees regressions).
       if (verifyCtx) {
         const summary = aggregateTestSummary(outcomes, finalVerification);
-        if (summary) result.testSummary = summary;
+        if (summary) {
+          // §3a.C: value-scrub the aggregated test-output tail with the round's
+          // leased secrets before it reaches the PR body / persisted testSummary /
+          // next judge. Empty leased set ⇒ unchanged (byte-identical).
+          result.testSummary = req.scrubValues?.length
+            ? scrubSecrets(summary, req.scrubValues)
+            : summary;
+        }
       }
       // Stage A: surface the structured final-verification outcome (observability/tests).
       if (finalVerification) result.finalVerification = finalVerification;
@@ -1226,6 +1234,7 @@ export async function runSdlcHandoff(
         result,
         finalVerification?.passed,
         finalVerification?.timedOut,
+        req.scrubValues ?? [],
       );
       // Terminal beat — the executor finished its work for this round (the SERVICE
       // separately classifies done/failed from the result; this is phase-only).

--- a/tests/unit/consilium/execution-trace.test.ts
+++ b/tests/unit/consilium/execution-trace.test.ts
@@ -141,6 +141,57 @@ describe("execution-trace — buildSdlcTrace (coder path)", () => {
   });
 });
 
+describe("execution-trace — §3a.C leased-value scrub", () => {
+  const secret = "leaked-secret-value-abc123";
+  const outcomes = [
+    {
+      index: 1,
+      priority: "P0",
+      title: "t",
+      status: "completed" as const,
+      verification: {
+        method: "test-run" as const,
+        ran: true,
+        passed: true,
+        summary: `token ${secret} in output`,
+        fixIterations: 1,
+        criterion: "c",
+      },
+    },
+  ];
+
+  it("redacts a leased value from the criterion summary when secretValues is provided", () => {
+    const t = buildSdlcTrace(
+      "repo-assessment",
+      outcomes,
+      { prRef: "x" },
+      undefined,
+      undefined,
+      [secret],
+    );
+    const crit = t.controller.workers[0].criteria[0];
+    expect(crit.summary).not.toContain(secret);
+    expect(crit.summary).toContain("[REDACTED]");
+  });
+
+  it("redacts a leased value from the controller error note", () => {
+    const t = buildSdlcTrace(
+      "repo-assessment",
+      outcomes,
+      { prRef: null, error: `boom ${secret}` },
+      undefined,
+      undefined,
+      [secret],
+    );
+    expect(t.controller.note ?? "").not.toContain(secret);
+  });
+
+  it("is byte-identical (leased value NOT redacted) when secretValues is omitted", () => {
+    const t = buildSdlcTrace("repo-assessment", outcomes, { prRef: "x" });
+    expect(t.controller.workers[0].criteria[0].summary).toContain(secret);
+  });
+});
+
 describe("execution-trace — buildResearchTrace (research path)", () => {
   it("builds a research-runner controller with research→synthesize→verify + web-evidence criteria", () => {
     const t = buildResearchTrace(

--- a/tests/unit/credentials/issue-lease.test.ts
+++ b/tests/unit/credentials/issue-lease.test.ts
@@ -1,0 +1,144 @@
+/**
+ * issue-lease.test.ts — ADR-003 §D1/§D2 credential-broker gate matrix.
+ *
+ * `server/db.js` is mocked (a queue of select results + an insert capture) so the
+ * test is DB-free, mirroring tests/integration/credentials-api.test.ts. Project
+ * context is established with the REAL `runAsProject`, so `getProjectId()` /
+ * [R3-SEC-3] is exercised for real. Each denial must be audited
+ * (action='lease_issued', success=false) EXCEPT the structural project-mismatch
+ * (which throws before any DB access).
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const dbState = vi.hoisted(() => ({
+  selectQueue: [] as unknown[][],
+  audit: [] as Array<Record<string, unknown>>,
+  leaseId: "lease-1",
+}));
+
+vi.mock("../../../server/db.js", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => Promise.resolve(dbState.selectQueue.shift() ?? []),
+      }),
+    }),
+    insert: () => ({
+      values: (v: Record<string, unknown>) => {
+        // writeAccessLog inserts carry `action`; the lease insert does not.
+        if (v && v.action !== undefined) {
+          dbState.audit.push(v);
+          return Promise.resolve(undefined);
+        }
+        return { returning: () => Promise.resolve([{ id: dbState.leaseId }]) };
+      },
+    }),
+  },
+}));
+
+import { DbCryptoCredentialProvider } from "../../../server/credentials/db-crypto-provider.js";
+import { ForbiddenError } from "../../../server/credentials/types.js";
+import { runAsProject } from "../../../server/context.js";
+
+const PROJECT = "proj-1";
+const provider = new DbCryptoCredentialProvider();
+
+function lease(overrides: Record<string, unknown> = {}) {
+  return provider.issueLease({
+    projectId: PROJECT,
+    credentialId: "cred-1",
+    loopId: "loop-1",
+    phase: "developing",
+    requestedBy: "user-1",
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  dbState.selectQueue = [];
+  dbState.audit = [];
+});
+
+describe("issueLease — ADR-003 gate matrix", () => {
+  it("[R3-SEC-3] denies on project mismatch, structurally, with NO audit", async () => {
+    await expect(
+      runAsProject("other-project", () => lease()),
+    ).rejects.toBeInstanceOf(ForbiddenError);
+    expect(dbState.audit).toHaveLength(0);
+  });
+
+  it("D1 denies + audits when the loop is not in a lease-eligible state", async () => {
+    dbState.selectQueue = [[{ state: "pending", projectId: PROJECT }]];
+    await expect(runAsProject(PROJECT, () => lease())).rejects.toBeInstanceOf(
+      ForbiddenError,
+    );
+    expect(dbState.audit).toHaveLength(1);
+    expect(dbState.audit[0]).toMatchObject({
+      action: "lease_issued",
+      success: false,
+    });
+  });
+
+  it("D1 denies when the loop belongs to a different project", async () => {
+    dbState.selectQueue = [[{ state: "developing", projectId: "someone-else" }]];
+    await expect(runAsProject(PROJECT, () => lease())).rejects.toBeInstanceOf(
+      ForbiddenError,
+    );
+    expect(dbState.audit[0]).toMatchObject({ success: false });
+  });
+
+  it("D2 denies + audits when the credential is not bound to the loop", async () => {
+    dbState.selectQueue = [
+      [{ state: "developing", projectId: PROJECT }], // loop eligible
+      [], // bound set: empty
+    ];
+    await expect(runAsProject(PROJECT, () => lease())).rejects.toBeInstanceOf(
+      ForbiddenError,
+    );
+    expect(dbState.audit).toHaveLength(1);
+    expect(dbState.audit[0]).toMatchObject({
+      action: "lease_issued",
+      success: false,
+    });
+  });
+
+  it("issues + audits (success + ttlSeconds) on the happy path", async () => {
+    dbState.selectQueue = [
+      [{ state: "developing", projectId: PROJECT }],
+      [{ credentialId: "cred-1" }],
+    ];
+    const out = await runAsProject(PROJECT, () => lease({ ttlSeconds: 120 }));
+    expect(out.leaseId).toBe("lease-1");
+    expect(out.expiresAt).toBeInstanceOf(Date);
+    const success = dbState.audit.find((a) => a.success === true);
+    expect(success).toMatchObject({ action: "lease_issued", ttlSeconds: 120 });
+  });
+
+  it("clamps an over-long TTL to the max (900s)", async () => {
+    dbState.selectQueue = [
+      [{ state: "developing", projectId: PROJECT }],
+      [{ credentialId: "cred-1" }],
+    ];
+    await runAsProject(PROJECT, () => lease({ ttlSeconds: 99_999 }));
+    const success = dbState.audit.find((a) => a.success === true);
+    expect(success?.ttlSeconds).toBe(900);
+  });
+
+  it("[R3-SEC-10] rate-limits repeated leases for the same (project, loop)", async () => {
+    // Isolated loop id so the window is not polluted by the happy/clamp cases.
+    for (let i = 0; i < 40; i++) {
+      dbState.selectQueue.push([{ state: "developing", projectId: PROJECT }]);
+      dbState.selectQueue.push([{ credentialId: "cred-1" }]);
+    }
+    let denied = 0;
+    for (let i = 0; i < 40; i++) {
+      try {
+        await runAsProject(PROJECT, () => lease({ loopId: "loop-rate-limit" }));
+      } catch {
+        denied++;
+      }
+    }
+    // MAX_LEASES_PER_WINDOW is 30, so at least the last 10 are denied.
+    expect(denied).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
Closes the **two remaining loose ends** of Phase 3a — nothing else outstanding except the separate future `3c` ADR phase.

## T1 — close the dynamic-scrubber residual (security MEDIUM, from #563)
3a.C pt2 only scrubbed leased secret VALUES from the coder's **stderr** (cli-spawn). This threads the per-run leased value set into the OTHER coder-output sinks, so a leased value echoed in test output is redacted **everywhere it crosses a trust boundary**:
- **`executor.ts`** — value-scrub the aggregated `testSummary` (→ Draft-PR body, persisted `consilium_loop_rounds.testSummary`, and the next review round's judge) with `req.scrubValues` before emit.
- **`execution-trace.ts`** — thread a secret-value set through `clampTrace → clampWorker → clampCriterion → scrub` (criterion summary) + the worker/controller `note` fields, so the persisted `_trace` never carries a leased value.

Both guarded on a **non-empty** leased set ⇒ **byte-identical** when a loop has no bound secrets. `buildResearchTrace` keeps the default (no coder secrets). **Combined with #563's stderr scrub, the coder-output leak vectors (stderr errors + test-output tail + trace) are now covered.**

## T2 — real broker gate-matrix coverage (QA sign-off)
`issue-lease.test.ts` exercises `issueLease` DB-free (mocked `db`, **real `runAsProject` context** so `getProjectId()`/[R3-SEC-3] runs for real):
- `[R3-SEC-3]` project mismatch → `ForbiddenError`, **no audit** (structural, pre-DB).
- D1 non-eligible loop state → deny + `lease_issued success=false` audit.
- D1 cross-project loop → deny + audit.
- D2 unbound credential → deny + audit.
- Happy path → `{leaseId, expiresAt}` + `lease_issued success=true` with `ttlSeconds`.
- TTL clamp (99 999 → 900s max).
- `[R3-SEC-10]` rate limit trips for repeated `(project, loop)`.

## Test plan
- [x] `tsc` clean.
- [x] T1: `execution-trace.test.ts` +3 (summary redaction, controller-note redaction, byte-identical when omitted). 15 passed.
- [x] T2: `issue-lease.test.ts` 7/7 gate-matrix.
- [x] Regression: **1662** consilium + credentials + sdlc + gateway unit tests green (no behavior change).

## Scope note
Create-route unknown-`secretNames` → 400 is a thin deterministic message-prefix mapping over `resolveBoundSecretIds` (whose regex/dedupe/cap/resolve logic runs at the factory choke point); the security-critical resolution + broker gates are the covered surface above. `3c` (reviewing read-only infra consumer) is a separate future ADR phase — out of scope.