### PR TITLE
feat(consilium): read-only infra-refresh runner (Phase 3c pt1 — security core)

### DIFF
--- a/server/services/consilium/infra-refresh.ts
+++ b/server/services/consilium/infra-refresh.ts
@@ -1,0 +1,171 @@
+/**
+ * infra-refresh.ts — ADR-003 §D1/§D4 Phase 3c: read-only infra reconcile step.
+ *
+ * At the `reviewing` stage, an OPT-IN loop may run a READ/PLAN-ONLY infra command
+ * (e.g. `terraform plan -refresh-only`, `kubectl diff`) against the live target,
+ * using secrets LEASED for the reviewing phase, to reconcile remembered vs. actual
+ * infrastructure. Only the SCRUBBED, bounded summary is returned — it feeds the
+ * dispute context. The raw secret is delivered ONLY to this controlled subprocess,
+ * NEVER to a reviewer/debater LLM prompt or env.
+ *
+ * Security invariants:
+ *   - NEVER mutating: the command argv is a fixed read/plan-only allowlist, and a
+ *     defense-in-depth deny-guard rejects any mutating token (apply/destroy/…).
+ *   - No shell: argv-array `execFile` only — no interpolation, no injection.
+ *   - Fail-soft: any error (binary missing, no creds, timeout, non-zero exit) yields
+ *     a bounded note, never throws — the review proceeds without a drift summary.
+ *   - Output is value-scrubbed with the per-run leased set before it leaves here.
+ */
+import { execFile } from "node:child_process";
+import { readdir } from "node:fs/promises";
+import { scrubSecrets } from "../../gateway/secret-scrub.js";
+
+export type InfraRepoKind = "terraform" | "kubernetes";
+
+export interface InfraRefreshResult {
+  /** True when a read-only command actually ran (regardless of drift found). */
+  ran: boolean;
+  kind?: InfraRepoKind;
+  /** Scrubbed, bounded drift/plan summary for the dispute context ("" when not run). */
+  summary: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+const MAX_SUMMARY_CHARS = 4_000;
+
+/** Binary per repo kind. */
+const BINARY: Record<InfraRepoKind, string> = {
+  terraform: "terraform",
+  kubernetes: "kubectl",
+};
+
+/**
+ * READ/PLAN-ONLY command sequence per repo kind (ADR-003 §D4 — never apply/destroy).
+ * Each entry is a full argv (no shell). Steps run in order; a non-zero exit is
+ * captured as best-effort output, not thrown (e.g. `kubectl diff` exits 1 on drift).
+ * The exact incantation is infra-specific and may need per-repo tuning by the
+ * operator; the security guarantee (read-only) is enforced here regardless.
+ */
+export const READ_ONLY_STEPS: Record<
+  InfraRepoKind,
+  readonly (readonly string[])[]
+> = {
+  terraform: [
+    ["init", "-input=false", "-no-color", "-lock=false"],
+    ["plan", "-refresh-only", "-input=false", "-no-color", "-lock=false"],
+  ],
+  kubernetes: [["diff", "-R", "-f", "."]],
+};
+
+/**
+ * Defense-in-depth: reject any mutating token even though the argv is a fixed
+ * allowlist above. A single match aborts the whole refresh (fail-closed on intent).
+ */
+const MUTATION_DENY =
+  /^(apply|destroy|delete|replace|patch|edit|create|rollout|scale|drain|cordon|uncordon|taint|annotate|label|set|exec|cp|attach|port-forward|--?auto-approve)$/i;
+
+export function assertReadOnly(argv: readonly string[]): void {
+  for (const tok of argv) {
+    if (MUTATION_DENY.test(tok)) {
+      throw new Error(
+        `infra-refresh: refusing mutating token "${tok}" — read/plan-only only`,
+      );
+    }
+  }
+}
+
+/**
+ * Best-effort repo-kind detection. Conservative: returns null (⇒ no refresh) unless
+ * a clear marker is present at the repo root. `.tf` ⇒ terraform; a kustomization ⇒
+ * kubernetes. Never throws.
+ */
+export async function detectRepoKind(
+  repoDir: string,
+): Promise<InfraRepoKind | null> {
+  let entries: string[];
+  try {
+    entries = await readdir(repoDir);
+  } catch {
+    return null;
+  }
+  if (entries.some((f) => f.endsWith(".tf"))) return "terraform";
+  if (
+    entries.some((f) => f === "kustomization.yaml" || f === "kustomization.yml")
+  ) {
+    return "kubernetes";
+  }
+  return null;
+}
+
+function execReadOnly(
+  binary: string,
+  argv: readonly string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  timeoutMs: number,
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    execFile(
+      binary,
+      [...argv],
+      { cwd, env, timeout: timeoutMs, maxBuffer: 8 * 1024 * 1024, shell: false },
+      (err, stdout, stderr) => {
+        // Non-zero exit (err set) still carries useful drift output (e.g. kubectl
+        // diff exits 1 when drift exists). Capture both streams either way.
+        resolve({
+          stdout: stdout?.toString() ?? "",
+          stderr: stderr?.toString() ?? (err ? String(err.message ?? err) : ""),
+        });
+      },
+    );
+  });
+}
+
+/**
+ * Run the read-only reconcile for a repo, delivering `env` (leased secrets layered
+ * by the caller over a sanitized allowlist) to the subprocess. Returns a scrubbed,
+ * bounded summary. Fail-soft: never throws.
+ */
+export async function runInfraRefresh(p: {
+  repoDir: string;
+  /** Env for the subprocess — caller layers leased secrets over a sanitized base. */
+  env: NodeJS.ProcessEnv;
+  /** Per-run leased secret values to scrub from the summary (ADR-003 §D). */
+  scrubValues: readonly string[];
+  kindOverride?: InfraRepoKind;
+  timeoutMs?: number;
+}): Promise<InfraRefreshResult> {
+  try {
+    const kind = p.kindOverride ?? (await detectRepoKind(p.repoDir));
+    if (!kind) return { ran: false, summary: "" };
+
+    const steps = READ_ONLY_STEPS[kind];
+    const timeout = p.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    let raw = "";
+    for (const argv of steps) {
+      assertReadOnly(argv); // fail-closed on any mutating token
+      const { stdout, stderr } = await execReadOnly(
+        BINARY[kind],
+        argv,
+        p.repoDir,
+        p.env,
+        timeout,
+      );
+      raw += `$ ${BINARY[kind]} ${argv.join(" ")}\n${stdout}${stderr ? `\n${stderr}` : ""}\n`;
+    }
+
+    const scrubbed = scrubSecrets(raw, p.scrubValues).trim();
+    const summary =
+      scrubbed.length > MAX_SUMMARY_CHARS
+        ? `${scrubbed.slice(0, MAX_SUMMARY_CHARS)}\n… [truncated]`
+        : scrubbed;
+    return { ran: true, kind, summary };
+  } catch (err: unknown) {
+    // Fail-soft: the review proceeds without a drift summary. Scrub the message too.
+    const msg = scrubSecrets(
+      err instanceof Error ? err.message : String(err),
+      p.scrubValues,
+    );
+    return { ran: false, summary: `infra-refresh unavailable: ${msg}` };
+  }
+}

--- a/tests/unit/consilium/infra-refresh.test.ts
+++ b/tests/unit/consilium/infra-refresh.test.ts
@@ -1,0 +1,124 @@
+/**
+ * infra-refresh.test.ts — ADR-003 §D4 Phase 3c read-only reconcile runner.
+ * fs + child_process are mocked, so no live infra / binaries are needed.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const fsState = vi.hoisted(() => ({
+  entries: [] as string[],
+  throwOnRead: false,
+}));
+vi.mock("node:fs/promises", () => ({
+  readdir: vi.fn(async () => {
+    if (fsState.throwOnRead) throw new Error("readdir failed");
+    return fsState.entries;
+  }),
+}));
+
+const execState = vi.hoisted(() => ({
+  impl: null as
+    | null
+    | ((
+        binary: string,
+        argv: string[],
+        opts: unknown,
+        cb: (e: Error | null, o: string, s: string) => void,
+      ) => void),
+}));
+vi.mock("node:child_process", () => ({
+  execFile: (
+    binary: string,
+    argv: string[],
+    opts: unknown,
+    cb: (e: Error | null, o: string, s: string) => void,
+  ) => {
+    if (execState.impl) return execState.impl(binary, argv, opts, cb);
+    cb(new Error("spawn ENOENT"), "", "");
+  },
+}));
+
+import {
+  assertReadOnly,
+  READ_ONLY_STEPS,
+  detectRepoKind,
+  runInfraRefresh,
+} from "../../../server/services/consilium/infra-refresh.js";
+
+beforeEach(() => {
+  fsState.entries = [];
+  fsState.throwOnRead = false;
+  execState.impl = null;
+});
+
+describe("infra-refresh — read-only guard (ADR-003 §D4)", () => {
+  it("every shipped command is read/plan-only (no mutating token)", () => {
+    for (const steps of Object.values(READ_ONLY_STEPS)) {
+      for (const argv of steps) {
+        expect(() => assertReadOnly(argv)).not.toThrow();
+      }
+    }
+  });
+
+  it.each(["apply", "destroy", "delete", "replace", "patch", "-auto-approve"])(
+    "rejects the mutating token %s",
+    (tok) => {
+      expect(() => assertReadOnly(["plan", tok])).toThrow(/read\/plan-only/);
+    },
+  );
+});
+
+describe("infra-refresh — detectRepoKind", () => {
+  it("detects terraform from a .tf file", async () => {
+    fsState.entries = ["main.tf", "README.md"];
+    expect(await detectRepoKind("/repo")).toBe("terraform");
+  });
+
+  it("detects kubernetes from a kustomization.yaml", async () => {
+    fsState.entries = ["kustomization.yaml"];
+    expect(await detectRepoKind("/repo")).toBe("kubernetes");
+  });
+
+  it("returns null with no infra marker", async () => {
+    fsState.entries = ["src", "package.json"];
+    expect(await detectRepoKind("/repo")).toBeNull();
+  });
+
+  it("returns null (fail-soft) when the dir cannot be read", async () => {
+    fsState.throwOnRead = true;
+    expect(await detectRepoKind("/repo")).toBeNull();
+  });
+});
+
+describe("infra-refresh — runInfraRefresh", () => {
+  it("does not run and returns an empty summary when no infra marker is present", async () => {
+    fsState.entries = ["package.json"];
+    const r = await runInfraRefresh({ repoDir: "/repo", env: {}, scrubValues: [] });
+    expect(r).toEqual({ ran: false, summary: "" });
+  });
+
+  it("scrubs a leased value from the command output", async () => {
+    const secret = "leased-tf-secret-value-987";
+    execState.impl = (_b, _a, _o, cb) => cb(null, `Plan token ${secret} here`, "");
+    const r = await runInfraRefresh({
+      repoDir: "/repo",
+      env: {},
+      scrubValues: [secret],
+      kindOverride: "terraform",
+    });
+    expect(r.ran).toBe(true);
+    expect(r.summary).not.toContain(secret);
+    expect(r.summary).toContain("[REDACTED]");
+  });
+
+  it("is fail-soft: never throws when the binary/exec errors", async () => {
+    execState.impl = (_b, _a, _o, cb) =>
+      cb(new Error("spawn terraform ENOENT"), "", "");
+    const r = await runInfraRefresh({
+      repoDir: "/repo",
+      env: {},
+      scrubValues: [],
+      kindOverride: "kubernetes",
+    });
+    expect(typeof r.summary).toBe("string"); // returned instead of throwing
+  });
+});


### PR DESCRIPTION
**Phase 3c** (ADR-003 §D1/§D4) — reviewing-stage infra reconcile, split into the **security core** (this PR, dormant) and the **reviewing-dispatch wiring** (pt2, spec below). Built on 3a-static delivery (3b skipped per decision).

## What's here — `server/services/consilium/infra-refresh.ts` (no runtime behavior yet)
`runInfraRefresh()`: detect repo kind (terraform `*.tf` / kubernetes `kustomization.yaml`) → run a READ/PLAN-ONLY command sequence (`terraform plan -refresh-only` / `kubectl diff`) via **argv-array `execFile` (no shell)**, with a caller-supplied env (leased secrets layered over a sanitized base) → **value-scrub + clamp** the output into a bounded drift summary.

**Security invariants (the reason this is its own carefully-reviewed unit):**
- **Never mutating** — fixed read-only allowlist + a `MUTATION_DENY` deny-guard that fail-closes on any mutating token (`apply`/`destroy`/`delete`/`-auto-approve`/…).
- **No shell** — argv-array only, no interpolation/injection.
- **Fail-soft** — never throws (binary missing / no creds / timeout / drift non-zero exit all degrade to a bounded note).
- **Scrubbed** — output value-scrubbed with the per-run leased set before it leaves.

## Test plan
- [x] `tsc` clean.
- [x] `infra-refresh.test.ts` (14): **every shipped command passes the read-only guard**; mutating tokens rejected; detection (tf/k8s/none/unreadable); no-marker skip; leased value scrubbed from output; fail-soft on exec error. fs + child_process mocked — no live infra.

## pt2 — reviewing-dispatch wiring (deliberately deferred; ADR's PRIMARY veto surface)
Wire the runner into the reviewing entry, delivering secrets leased for the **reviewing** phase and feeding the SCRUBBED drift summary into the dispute — the raw secret reaching ONLY this subprocess, NEVER the reviewer/debater LLM prompt/env. Exact anchors:
1. **Config opt-in** — add `pipeline.consiliumLoop.infraRefresh.enabled` (default false) to `server/config/schema.ts` (per-loop granularity optional later).
2. **`consilium-loop-controller.ts` `dispatchReview` (:3178)** — before the review input is assembled (near `buildReviewRepoMap`/`buildReviewConventions` at :2842/:3263): if opt-in, `deliverLeasedEnv({ provider: credentialProvider, storage, projectId: getProjectId(), loopId: loop.id, phase: "reviewing", requestedBy: loop.createdBy })` → `runInfraRefresh({ repoDir: loop.repoPath, env: { ...sanitized base, ...leased.env }, scrubValues: leased.values })` → `markLeaseUsed` each → carry `result.summary` into the review context → **revoke every lease in a `finally`**. Fail-soft.
3. **Review input** — add a `driftSummary?: string` context field alongside repoMap/conventions and thread it into the review-runner's system prompt (`review-runner.ts` / `direct-llm-prompt.ts`) as read-only reconcile context. NEVER place the raw secret there — only the scrubbed summary.
4. Tests: opt-in off ⇒ byte-identical (no delivery, no refresh); opt-in on with a bound secret ⇒ refresh runs, `lease_used` audited, lease revoked after, drift summary in the review context, secret value absent from it.

Consumer-scoped to `reviewing` read-only exec only (ADR §D1). Requires a `reviewing`-eligible lease — already allowed by the 3a.B `issueLease` D1 gate (`{reviewing, developing}`).