### PR TITLE
feat(consilium): wire read-only infra reconcile into the reviewing dispute (Phase 3c pt2)

### DIFF
--- a/server/config/schema.ts
+++ b/server/config/schema.ts
@@ -343,6 +343,18 @@ export const ConfigSchema = z.object({
        */
       allowedRepoPaths: z.array(z.string()).default([]),
       /**
+       * Phase 3c (ADR-003 §D1/§D4): OPT-IN read-only infra reconcile at the
+       * `reviewing` stage. When enabled AND a loop has bound secrets, a read/plan-only
+       * command (terraform plan -refresh-only / kubectl diff) runs with secrets LEASED
+       * for the reviewing phase; only the SCRUBBED drift summary enters the dispute
+       * context — the raw secret reaches ONLY the subprocess, never a reviewer LLM.
+       * Default OFF ⇒ byte-identical (no delivery, no refresh). Gated under
+       * `consiliumLoop.enabled`.
+       */
+      infraRefresh: z
+        .object({ enabled: z.boolean().default(false) })
+        .default({}),
+      /**
        * OPTION A (codegraph research): a scoped, READ-ONLY "repository map" preamble
        * injected into the REVIEW input. For the files each round's diff TOUCHES, a
        * compact `file → exported symbols + 1-hop importers` map is built from the

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -54,6 +54,8 @@ import {
   markLeaseUsed,
 } from "../../credentials/db-crypto-provider.js";
 import { deliverLeasedEnv } from "../../credentials/deliver-leased-env.js";
+import { runInfraRefresh } from "./infra-refresh.js";
+import { sanitizedCoderEnv } from "../sdlc/coder.js";
 import type { ConsiliumLoopRow, ConsiliumLoopRoundRow, ConsiliumLoopState, TaskGroupIterationRow, InsertTask } from "@shared/schema";
 import { ARCHETYPES } from "@shared/types";
 import type { Archetype } from "@shared/types";
@@ -3175,6 +3177,62 @@ export class ConsiliumLoopController {
    * for developing), so the null-ref stranded check (Round-2 B4) still recognises an
    * in-flight runner review and the client never mounts a broken iteration view.
    */
+  /**
+   * Phase 3c (ADR-003 §D1/§D4): read-only infra reconcile for a `reviewing` loop.
+   * Leases the loop's bound secrets for the REVIEWING phase, runs a read/plan-only
+   * command (delivered over the H-1 sanitized env), and returns the SCRUBBED drift
+   * summary (or undefined). FAIL-SOFT — never throws; a failure reviews without a
+   * drift summary. Leases are revoked as soon as the summary is captured, so the raw
+   * secret lives only inside the subprocess, never a reviewer LLM prompt/env. Caller
+   * gates on `cfg.infraRefresh.enabled`.
+   */
+  private async maybeInfraDrift(
+    loop: ConsiliumLoopRow,
+  ): Promise<string | undefined> {
+    const requestedBy = loop.createdBy ?? "system";
+    let delivered: {
+      env: Record<string, string>;
+      values: string[];
+      leaseIds: string[];
+    } = { env: {}, values: [], leaseIds: [] };
+    try {
+      delivered = await deliverLeasedEnv({
+        provider: credentialProvider,
+        storage: this.storage,
+        projectId: getProjectId(),
+        loopId: loop.id,
+        phase: "reviewing",
+        requestedBy,
+      });
+      if (delivered.leaseIds.length === 0) return undefined;
+      for (const id of delivered.leaseIds) {
+        await markLeaseUsed(id, requestedBy).catch((e: unknown) =>
+          console.warn("[consilium-loop] markLeaseUsed failed:", e),
+        );
+      }
+      const refresh = await runInfraRefresh({
+        repoDir: loop.repoPath,
+        env: { ...sanitizedCoderEnv(), ...delivered.env },
+        scrubValues: delivered.values,
+      });
+      return refresh.ran && refresh.summary ? refresh.summary : undefined;
+    } catch (e: unknown) {
+      console.warn(
+        "[consilium-loop] infra-refresh failed; reviewing WITHOUT drift:",
+        e instanceof Error ? e.message : e,
+      );
+      return undefined;
+    } finally {
+      for (const id of delivered.leaseIds) {
+        await credentialProvider
+          .revokeLease(id)
+          .catch((e: unknown) =>
+            console.warn("[consilium-loop] revokeLease failed:", e),
+          );
+      }
+    }
+  }
+
   private dispatchReview(loop: ConsiliumLoopRow): void {
     const run: ReviewRun = { round: loop.round, done: false };
     this.reviewRuns.set(loop.id, run);
@@ -3273,6 +3331,12 @@ export class ConsiliumLoopController {
       testSummary,
       repoMap,
       repoConventions,
+      // Phase 3c (ADR-003 §D1/§D4): opt-in read-only infra reconcile. Only the
+      // SCRUBBED drift summary enters the dispute — the raw secret reaches ONLY the
+      // subprocess, never a reviewer LLM. FAIL-SOFT; absent ⇒ no section.
+      infraDrift: cfg.infraRefresh?.enabled
+        ? await this.maybeInfraDrift(loop)
+        : undefined,
     });
     if (!ctx.ok) return degradedReviewResult(ctx.message);
     // Panel from the group's preset (recovered from the group NAME — the SAME source

--- a/server/services/consilium/diff-context.ts
+++ b/server/services/consilium/diff-context.ts
@@ -102,6 +102,13 @@ export interface DiffContextRequest {
    * (byte-identical to today). Never executed, never logged.
    */
   repoConventions?: string;
+  /**
+   * Phase 3c (ADR-003 §D4): a SCRUBBED read-only infra-reconcile drift summary
+   * (terraform plan -refresh-only / kubectl diff), produced by `infra-refresh.ts`
+   * for opt-in loops. Placed with the other preambles. Already leased-value-scrubbed
+   * by the runner; assembly re-redacts (env parity) + clamps. Absent ⇒ no section.
+   */
+  infraDrift?: string;
   /** Injected git client (tests pass a fake); defaults to simple-git(repoPath). */
   gitClient?: GitDiffClient;
 }
@@ -325,6 +332,7 @@ function assembleInput(
   maxDiffBytes: number,
   repoMap: string | undefined,
   repoConventions: string | undefined,
+  infraDrift: string | undefined,
 ): { input: string; truncated: boolean } {
   const obj = objective.trim();
   const sections = [obj.length > 0 ? obj : "_No objective supplied; review the changes below._"];
@@ -359,6 +367,18 @@ function assembleInput(
       ? Buffer.from(redacted, "utf8").subarray(0, maxDiffBytes).toString("utf8")
       : redacted;
     sections.push(`## Repository map (files touched by this diff + their importers)\n\n${text}`);
+  }
+  // Phase 3c (ADR-003 §D4): the SCRUBBED read-only infra-reconcile drift summary,
+  // placed with the other preambles so debaters weigh remembered-vs-actual infra
+  // before the diff. Already leased-value-scrubbed by the runner; re-run redactSecrets
+  // (env parity) + defensive clamp. Absent/blank ⇒ no section (byte-identical).
+  if (infraDrift && infraDrift.trim().length > 0) {
+    const redacted = redactSecrets(infraDrift.trim());
+    const overflow = Buffer.byteLength(redacted, "utf8") > maxDiffBytes;
+    const text = overflow
+      ? Buffer.from(redacted, "utf8").subarray(0, maxDiffBytes).toString("utf8")
+      : redacted;
+    sections.push(`## Live infrastructure drift (read-only reconcile)\n\n${text}`);
   }
   if (parts) {
     const note = parts.truncated ? "\n\n_(diff truncated to the configured byte limit)_" : "";
@@ -454,7 +474,7 @@ export async function buildDiffContext(
       return fail("unknown", "objective is empty and there is no diff (round 1); refusing to emit a blank review input");
     }
     // Round 1 has no diff, so there are no "touched files" to map ⇒ no repoMap.
-    const built = assembleInput(req.objective, null, req.testSummary, undefined, req.maxDiffBytes, undefined, undefined);
+    const built = assembleInput(req.objective, null, req.testSummary, undefined, req.maxDiffBytes, undefined, undefined, undefined);
     return { ok: true, input: built.input, headCommit: head, baselineCommit: null, truncated: built.truncated };
   }
 
@@ -464,7 +484,7 @@ export async function buildDiffContext(
   const parts = await collectDiff(git, baseline, head, req.maxDiffBytes);
   if (!("stat" in parts)) return parts;
 
-  const built = assembleInput(req.objective, parts, req.testSummary, req.priorFindings, req.maxDiffBytes, req.repoMap, req.repoConventions);
+  const built = assembleInput(req.objective, parts, req.testSummary, req.priorFindings, req.maxDiffBytes, req.repoMap, req.repoConventions, req.infraDrift);
   return {
     ok: true,
     input: built.input,

--- a/tests/unit/consilium/diff-context.test.ts
+++ b/tests/unit/consilium/diff-context.test.ts
@@ -61,6 +61,17 @@ describe("buildDiffContext — assembly & rounds", () => {
     expect(res.input).toContain("12 passed, 0 failed");
   });
 
+  it("includes the infra-drift section (ADR-003 §3c) when infraDrift is provided", async () => {
+    const res = await buildDiffContext({ repoPath: REPO, baselineCommit: BASE_SHA, objective: "Obj", allowedRepoPaths: ALLOW, maxDiffBytes: 10_000, infraDrift: "~ aws_instance.web will be updated in-place", gitClient: fakeGit() });
+    expect(res.input).toContain("## Live infrastructure drift (read-only reconcile)");
+    expect(res.input).toContain("aws_instance.web will be updated in-place");
+  });
+
+  it("omits the infra-drift section when infraDrift is absent (byte-identical)", async () => {
+    const res = await buildDiffContext({ repoPath: REPO, baselineCommit: BASE_SHA, objective: "Obj", allowedRepoPaths: ALLOW, maxDiffBytes: 10_000, gitClient: fakeGit() });
+    expect(res.input).not.toContain("## Live infrastructure drift");
+  });
+
   it("byte-bounds the diff and sets truncated", async () => {
     const big = "x".repeat(5000);
     const git = fakeGit({ diff: vi.fn(async (args: string[]) => (args.includes("--stat") ? "stat" : big)) });


### PR DESCRIPTION
Wires the 3c runner (#565) into the **reviewing** stage — the behavioral completion of Phase 3c and the ADR's **primary security-veto surface**. Built on 3a-static delivery.

## Behavior (opt-in, default OFF ⇒ byte-identical)
When `consiliumLoop.infraRefresh.enabled` AND a loop has bound secrets, its review round:
1. `deliverLeasedEnv({ phase: "reviewing" })` — leases the loop's bound secrets (issueLease's D1 gate already allows `reviewing`).
2. `runInfraRefresh` — read/plan-only reconcile with the leased env **layered over the H-1 sanitized base**.
3. Feeds ONLY the **SCRUBBED** drift summary into the dispute context.
4. **Revokes every lease in a `finally`** as soon as the summary is captured.

**The raw secret reaches ONLY the subprocess — NEVER a reviewer/debater LLM prompt or env** (ADR-003 §D1). **FAIL-SOFT:** any failure reviews without a drift summary (never throws).

## Files
- `config/schema.ts` — `pipeline.consiliumLoop.infraRefresh.enabled` (default false), gated under `consiliumLoop.enabled`.
- `consilium-loop-controller.ts` — `maybeInfraDrift()` (lease → markUsed → refresh → revoke-in-finally, fail-soft); called from `runReviewFromLoop` only when opt-in; empty bound set ⇒ `undefined`.
- `diff-context.ts` — optional `infraDrift` threaded into the review input as a `## Live infrastructure drift (read-only reconcile)` preamble (`redactSecrets` + clamp). Absent ⇒ no section.

## Security review (self)
- **Consumer-scoped to `reviewing` read-only exec** — reviewer LLM sees only the scrubbed summary (runner-scrubbed + assembly `redactSecrets`); raw secret never in the prompt. ✅
- Lease always revoked (finally + `deliverLeasedEnv` self-revoke + sweeper backstop). ✅
- Read-only enforced by the runner's allowlist + deny-guard (#565). ✅
- Opt-in + bound-secret gated ⇒ byte-identical default. ✅

## Test plan
- [x] `tsc` clean.
- [x] `diff-context.test.ts` +2: infra-drift section present when provided, absent by default.
- [x] **1347** consilium unit tests green (no regression — byte-identical default).
- [ ] **QA / live** (needs real terraform/kubectl + creds + target infra): a bound-secret opt-in review round runs the reconcile, `lease_used` audited, lease revoked after, scrubbed drift summary in the review input, secret value absent from it. (Exec path can't be validated headless.)

**Phase 3c complete** with this PR. `3b` (typed AWS/K8s secrets) remains a separate optional ergonomics phase (not required — operators bind env-var-named secrets today).