### PR TITLE
feat(credentials): typed secret foundation — type field + shaper (Phase 3b pt1)

### DIFF
--- a/migrations/0063_secret_type.sql
+++ b/migrations/0063_secret_type.sql
@@ -1,0 +1,7 @@
+-- Phase 3b (ADR-003 §D3, additive/non-breaking): how a secret's `value_encrypted`
+-- is interpreted at exec-time delivery. "static" (a raw string keyed by name; the
+-- default and today's behavior), "aws" (JSON creds → AWS_* env), "kubernetes"
+-- (kubeconfig → per-run 0600 temp file + KUBECONFIG). Existing rows default to
+-- "static" ⇒ byte-identical. Ship-only: applied by the lead, not by this change.
+ALTER TABLE secrets
+  ADD COLUMN IF NOT EXISTS type text NOT NULL DEFAULT 'static';

--- a/server/credentials/typed-secret.ts
+++ b/server/credentials/typed-secret.ts
@@ -1,0 +1,79 @@
+/**
+ * typed-secret.ts — ADR-003 §D3 Phase 3b: typed secret shaping.
+ *
+ * A secret carries a `type`; its decrypted `value` is interpreted accordingly and
+ * shaped into the delivery form the exec-time consumer expects:
+ *   - `static`     → a single env var keyed by the secret name (today's behavior).
+ *   - `aws`        → JSON `{ accessKeyId, secretAccessKey, sessionToken?, region? }`
+ *                    → the standard AWS_* env vars (ADR-003 §D4).
+ *   - `kubernetes` → the kubeconfig YAML → written by the caller to a per-run 0600
+ *                    temp file with `KUBECONFIG=<path>` (the caller owns the file's
+ *                    lifecycle: create in the sandbox, remove in `finally`).
+ *
+ * PURE: no fs / no env access. The caller (deliverLeasedEnv) materializes any
+ * kubeconfig temp file and threads `scrubExtra` into the run's dynamic scrubber so
+ * a typed value that never sat in process.env is still redacted from run output.
+ */
+import { z } from "zod";
+
+export const SECRET_TYPES = ["static", "aws", "kubernetes"] as const;
+export type SecretType = (typeof SECRET_TYPES)[number];
+
+export interface ShapedSecret {
+  /** Env vars to layer OVER the sanitized allowlist. */
+  env: Record<string, string>;
+  /**
+   * Kubernetes only: kubeconfig YAML the caller must write to a per-run temp file
+   * (mode 0600) and expose as `KUBECONFIG=<path>`, removing it in `finally`.
+   */
+  kubeconfig?: string;
+  /** Raw secret material for the per-run dynamic scrub set (ADR-003 §D). */
+  scrubExtra: string[];
+}
+
+const AwsCredsSchema = z.object({
+  accessKeyId: z.string().min(1),
+  secretAccessKey: z.string().min(1),
+  sessionToken: z.string().min(1).optional(),
+  region: z.string().min(1).optional(),
+});
+
+/**
+ * Shape a decrypted secret value into its typed delivery form. Throws on a malformed
+ * typed payload (e.g. non-JSON / missing fields for `aws`) — the caller
+ * (deliverLeasedEnv) is fail-soft and drops the offending secret rather than the run.
+ */
+export function shapeTypedSecret(p: {
+  name: string;
+  type: SecretType;
+  value: string;
+}): ShapedSecret {
+  switch (p.type) {
+    case "static":
+      return { env: { [p.name]: p.value }, scrubExtra: [p.value] };
+
+    case "aws": {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(p.value);
+      } catch {
+        throw new Error(`typed-secret "${p.name}" (aws): value is not valid JSON`);
+      }
+      const creds = AwsCredsSchema.parse(parsed);
+      const env: Record<string, string> = {
+        AWS_ACCESS_KEY_ID: creds.accessKeyId,
+        AWS_SECRET_ACCESS_KEY: creds.secretAccessKey,
+      };
+      if (creds.sessionToken) env.AWS_SESSION_TOKEN = creds.sessionToken;
+      if (creds.region) env.AWS_DEFAULT_REGION = creds.region;
+      // Region is not secret; the key material is. Scrub the credential parts.
+      const scrubExtra = [creds.accessKeyId, creds.secretAccessKey];
+      if (creds.sessionToken) scrubExtra.push(creds.sessionToken);
+      return { env, scrubExtra };
+    }
+
+    case "kubernetes":
+      // The value IS the kubeconfig YAML; the caller writes it to a temp file.
+      return { env: {}, kubeconfig: p.value, scrubExtra: [p.value] };
+  }
+}

--- a/server/credentials/types.ts
+++ b/server/credentials/types.ts
@@ -15,6 +15,8 @@
  * `aws-sts` and `github-app-token` variants are reserved for Wave 2 (Vault backend).
  */
 
+import type { SecretType } from "./typed-secret.js";
+
 // ─── Error types ─────────────────────────────────────────────────────────────
 
 /** Thrown when an operation is denied due to project context mismatch,
@@ -54,6 +56,12 @@ export interface CredentialMetadata {
   name?: string;
   /** Vault secret version, bumped on every rotate. Undefined for connection-backed credentials. */
   version?: number;
+  /**
+   * ADR-003 §D3 (Phase 3b): typed-delivery discriminator — how the secret value is
+   * shaped at exec time ("static" | "aws" | "kubernetes"). Metadata only (never the
+   * value). Absent ⇒ treat as "static" (byte-identical to pre-3b).
+   */
+  type?: SecretType;
 }
 
 // ─── Exec-time shapes ────────────────────────────────────────────────────────

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -2206,6 +2206,15 @@ export const secrets = pgTable(
     description: text("description"),
     scope: text("scope"),
     provider: text("provider"),
+    /**
+     * ADR-003 §D3: how `valueEncrypted` is interpreted at exec-time delivery —
+     * "static" (a raw string keyed by name; default / today), "aws" (JSON creds →
+     * AWS_* env), "kubernetes" (kubeconfig → per-run 0600 temp file + KUBECONFIG).
+     */
+    type: text("type")
+      .notNull()
+      .default("static")
+      .$type<"static" | "aws" | "kubernetes">(),
     /** AES-256-GCM ciphertext (crypto.ts `v2:` format). Null until first rotate. */
     valueEncrypted: text("value_encrypted"),
     version: integer("version").notNull().default(1),

--- a/tests/unit/credentials/typed-secret.test.ts
+++ b/tests/unit/credentials/typed-secret.test.ts
@@ -1,0 +1,69 @@
+/**
+ * typed-secret.test.ts — ADR-003 §D3 Phase 3b typed secret shaping.
+ */
+import { describe, it, expect } from "vitest";
+import { shapeTypedSecret } from "../../../server/credentials/typed-secret.js";
+
+describe("shapeTypedSecret — static", () => {
+  it("keys the raw value by the secret name", () => {
+    const s = shapeTypedSecret({ name: "MY_TOKEN", type: "static", value: "abc123xyz" });
+    expect(s.env).toEqual({ MY_TOKEN: "abc123xyz" });
+    expect(s.kubeconfig).toBeUndefined();
+    expect(s.scrubExtra).toEqual(["abc123xyz"]);
+  });
+});
+
+describe("shapeTypedSecret — aws", () => {
+  it("maps JSON creds to the standard AWS_* env (full)", () => {
+    const value = JSON.stringify({
+      accessKeyId: "AKIAEXAMPLE",
+      secretAccessKey: "s3cretKEYvalue",
+      sessionToken: "sessTOKENvalue",
+      region: "eu-central-1",
+    });
+    const s = shapeTypedSecret({ name: "aws-prod", type: "aws", value });
+    expect(s.env).toEqual({
+      AWS_ACCESS_KEY_ID: "AKIAEXAMPLE",
+      AWS_SECRET_ACCESS_KEY: "s3cretKEYvalue",
+      AWS_SESSION_TOKEN: "sessTOKENvalue",
+      AWS_DEFAULT_REGION: "eu-central-1",
+    });
+    // Region is not secret; key material is scrubbed.
+    expect(s.scrubExtra).toContain("s3cretKEYvalue");
+    expect(s.scrubExtra).toContain("sessTOKENvalue");
+    expect(s.scrubExtra).not.toContain("eu-central-1");
+  });
+
+  it("omits optional session token / region when absent", () => {
+    const value = JSON.stringify({ accessKeyId: "AKIA", secretAccessKey: "secretval" });
+    const s = shapeTypedSecret({ name: "aws", type: "aws", value });
+    expect(s.env).toEqual({
+      AWS_ACCESS_KEY_ID: "AKIA",
+      AWS_SECRET_ACCESS_KEY: "secretval",
+    });
+    expect(s.env.AWS_SESSION_TOKEN).toBeUndefined();
+    expect(s.env.AWS_DEFAULT_REGION).toBeUndefined();
+  });
+
+  it("throws on non-JSON value", () => {
+    expect(() =>
+      shapeTypedSecret({ name: "aws", type: "aws", value: "not json" }),
+    ).toThrow(/not valid JSON/);
+  });
+
+  it("throws on a JSON payload missing required fields", () => {
+    expect(() =>
+      shapeTypedSecret({ name: "aws", type: "aws", value: JSON.stringify({ region: "x" }) }),
+    ).toThrow();
+  });
+});
+
+describe("shapeTypedSecret — kubernetes", () => {
+  it("returns the kubeconfig for a per-run temp file (no env var)", () => {
+    const kubeconfig = "apiVersion: v1\nkind: Config\n...";
+    const s = shapeTypedSecret({ name: "kube-prod", type: "kubernetes", value: kubeconfig });
+    expect(s.env).toEqual({});
+    expect(s.kubeconfig).toBe(kubeconfig);
+    expect(s.scrubExtra).toEqual([kubeconfig]);
+  });
+});


### PR DESCRIPTION
**Phase 3b** (ADR-003 §D3/§D4) — typed secrets (static / aws / kubernetes), split into the **pure foundation** (this PR, dormant) and the **delivery integration + UI** (pt2, spec below). Delivery stays static until pt2 ⇒ no runtime behavior change.

## What's here (dormant / byte-identical)
- **`typed-secret.ts`** — `shapeTypedSecret()`, a PURE transform from a decrypted value + type to its delivery form:
  - `static` → `{ [name]: value }`
  - `aws` → JSON `{accessKeyId, secretAccessKey, sessionToken?, region?}` → the standard `AWS_*` env vars (§D4); key material → `scrubExtra`.
  - `kubernetes` → the kubeconfig YAML for a caller-materialized per-run 0600 temp file (`KUBECONFIG`); value → `scrubExtra`.
  Throws on a malformed typed payload (non-JSON / missing aws fields) — the future caller is fail-soft (drops the offending secret, not the run).
- **`shared/schema.ts` + `migrations/0063`** (generated, human-applied) — `secrets.type` (`NOT NULL DEFAULT 'static'`) ⇒ existing rows byte-identical.
- **`types.ts`** — `CredentialMetadata.type` (metadata only, never the value).

## Test plan
- [x] `tsc` clean.
- [x] `typed-secret.test.ts` (6): static; aws full/minimal/non-JSON/missing-fields; kubernetes. Region excluded from the scrub set; key material included.

## pt2 — delivery integration + create UI (deferred)
1. **Provider metadata** — `listCredentials` populates `CredentialMetadata.type` from `secrets.type` (`db-crypto-provider.ts` / OpenBao); connection-backed ⇒ `static`.
2. **`deliverLeasedEnv`** — per bound secret: read `type` from metadata → `shapeTypedSecret(name, type, getSecretValue())` → merge `env`, thread `scrubExtra` into `values`. For `kubernetes`, write the kubeconfig to a per-run **0600 temp file** and set `KUBECONFIG=<path>`; return a `cleanup()` handle. Malformed typed payload ⇒ fail-soft skip (log scrubbed).
3. **Temp-file lifecycle** — extend the delivery result with `cleanup(): Promise<void>` (rm the kubeconfig temp files); both callers (`executor` developing path via #563, `maybeInfraDrift` reviewing path via #566) call `cleanup()` in their existing `finally` alongside `revokeLease`. Add the temp-file path to the run's scrub set too.
4. **Create-secret surface** — `POST /api/credentials` accepts `type` (zod enum, default `static`) + shape-validates the value (aws JSON / kubeconfig non-empty); persist to `secrets.type`. Typed selector in the credential create UI.
5. Tests: deliverLeasedEnv aws→AWS_* env + kube→temp-file+KUBECONFIG+cleanup; create-route type validation.

`consilium_loop_secrets` unaffected. 3b is an **ergonomics** layer over 3a-static (operators can still bind env-var-named static secrets); the exec-time gates/scrub/lifecycle are unchanged.