### PR TITLE
feat(credentials): typed secret delivery + create path (Phase 3b pt2)

### DIFF
--- a/server/credentials/db-crypto-provider.ts
+++ b/server/credentials/db-crypto-provider.ts
@@ -32,6 +32,7 @@ import type {
   AccessSecretParams,
 } from "./types.js";
 import { ForbiddenError } from "./types.js";
+import type { SecretType } from "./typed-secret.js";
 
 // ─── issueLease policy (ADR-003 §D) ─────────────────────────────────────────────
 
@@ -195,6 +196,7 @@ export function toSecretMetadata(
     lastRotatedAt: row.rotatedAt ?? row.createdAt,
     name: row.name,
     version: row.version,
+    type: row.type,
   };
 }
 
@@ -491,6 +493,7 @@ export class DbCryptoCredentialProvider implements CredentialProvider {
     description: string;
     secret: string;
     name?: string;
+    type?: SecretType;
   }): Promise<CredentialMetadata> {
     assertProject(p.projectId);
 
@@ -516,6 +519,7 @@ export class DbCryptoCredentialProvider implements CredentialProvider {
             provider: p.provider,
             scope: p.scope,
             description: p.description,
+            ...(p.type !== undefined ? { type: p.type } : {}),
             valueEncrypted: ciphertext,
             version: existing.version + 1,
             rotatedAt: now,
@@ -530,6 +534,7 @@ export class DbCryptoCredentialProvider implements CredentialProvider {
             provider: p.provider,
             scope: p.scope,
             description: p.description,
+            type: p.type ?? "static",
             valueEncrypted: ciphertext,
             version: 1,
             createdBy: p.projectId,

--- a/server/credentials/deliver-leased-env.ts
+++ b/server/credentials/deliver-leased-env.ts
@@ -1,29 +1,44 @@
 /**
- * deliver-leased-env.ts — ADR-003 Phase 3a.C exec-time secret delivery helper.
+ * deliver-leased-env.ts — ADR-003 Phase 3a.C / 3b exec-time secret delivery.
  *
- * For a consilium loop's bound secrets, issue a short-TTL lease per secret,
- * decrypt its value through the broker, and shape an env map keyed by the secret
- * NAME (a STATIC raw string — typed AWS/Kubernetes shaping is Phase 3b). The
- * caller layers `env` OVER the sanitized allowlist env of a server-controlled
- * subprocess (the dev coder / built-in MCP server), marks each lease used before
- * spawn, and MUST revoke every lease in a `finally`. `values` feeds the dynamic
- * scrubber (secret-scrub.ts `extraValues`) so a leased value that never sat in
- * this server's process.env is still redacted from the run's output.
+ * For a consilium loop's bound secrets, issue a short-TTL lease per secret, decrypt
+ * its value through the broker, and shape it into its typed delivery form (§D3/§D4):
+ *   - static     → an env var keyed by the secret name (today's behavior).
+ *   - aws        → the standard AWS_* env vars.
+ *   - kubernetes → a per-run 0600 kubeconfig temp file + `KUBECONFIG=<path>`.
+ * The caller layers `env` OVER the sanitized allowlist env of a server-controlled
+ * subprocess, marks each lease used before spawn, MUST revoke every lease AND call
+ * `cleanup()` in a `finally`. `values` feeds the dynamic scrubber (secret-scrub.ts
+ * `extraValues`) so leased material (and any kubeconfig temp path) that never sat in
+ * process.env is still redacted from run output.
  *
- * Returns empty ({}, [], []) when the loop has no bound secrets ⇒ the caller's
- * spawn path is byte-identical to today. On a partial failure it revokes the
- * leases it already issued before rethrowing, so no active lease is orphaned.
+ * Returns an empty delivery when the loop has no bound secrets ⇒ byte-identical. A
+ * malformed typed payload drops THAT secret (fail-soft), not the run. On a partial
+ * failure it cleans up + revokes what it already issued before rethrowing.
  */
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { CredentialProvider } from "./types.js";
 import type { IStorage } from "../storage.js";
+import { shapeTypedSecret, type SecretType } from "./typed-secret.js";
 
 export interface LeasedEnvDelivery {
-  /** Env entries keyed by secret name (raw static value). Layer OVER the allowlist. */
+  /** Env entries to layer OVER the sanitized allowlist. */
   env: Record<string, string>;
-  /** Leased raw values for the per-run dynamic scrubber (ADR-003 §D). */
+  /** Leased raw values (+ any kubeconfig temp path) for the dynamic scrubber. */
   values: string[];
   /** Lease ids the caller MUST revoke in a `finally` (and should markLeaseUsed). */
   leaseIds: string[];
+  /**
+   * Remove any per-run temp files (e.g. a kubeconfig). The caller MUST call this in
+   * its `finally` alongside revoking leases. No-op when nothing was materialized.
+   */
+  cleanup: () => Promise<void>;
+}
+
+function emptyDelivery(): LeasedEnvDelivery {
+  return { env: {}, values: [], leaseIds: [], cleanup: async () => undefined };
 }
 
 export async function deliverLeasedEnv(p: {
@@ -36,24 +51,36 @@ export async function deliverLeasedEnv(p: {
   ttlSeconds?: number;
 }): Promise<LeasedEnvDelivery> {
   const bound = await p.storage.getLoopSecrets(p.loopId);
-  if (bound.length === 0) return { env: {}, values: [], leaseIds: [] };
+  if (bound.length === 0) return emptyDelivery();
 
-  // Resolve credentialId → name (METADATA only) to key the env var. A credential
-  // deleted since binding resolves to no name and is skipped (defense-in-depth).
+  // Resolve credentialId → name + type (METADATA only). A credential deleted since
+  // binding resolves to no name and is skipped (defense-in-depth).
   const metadata = await p.provider.listCredentials(p.projectId);
   const nameById = new Map<string, string>();
+  const typeById = new Map<string, SecretType>();
   for (const m of metadata) {
-    if (m.name) nameById.set(m.id, m.name);
+    if (m.name) {
+      nameById.set(m.id, m.name);
+      typeById.set(m.id, m.type ?? "static");
+    }
   }
 
   const env: Record<string, string> = {};
   const values: string[] = [];
   const leaseIds: string[] = [];
+  const tempDirs: string[] = [];
+
+  const cleanup = async (): Promise<void> => {
+    for (const dir of tempDirs) {
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  };
 
   try {
     for (const b of bound) {
       const name = nameById.get(b.credentialId);
       if (!name) continue; // credential removed since binding — nothing to deliver.
+      const type = typeById.get(b.credentialId) ?? "static";
 
       // issueLease enforces D1 (loop state) + D2 (bound set) + rate limit + audit.
       const { leaseId } = await p.provider.issueLease({
@@ -66,24 +93,48 @@ export async function deliverLeasedEnv(p: {
       });
       leaseIds.push(leaseId);
 
-      const value = await p.provider.getSecretValue({
+      const raw = await p.provider.getSecretValue({
         projectId: p.projectId,
         credentialId: b.credentialId,
         purpose: `consilium-loop:${p.loopId}:${p.phase}`,
         requestedBy: p.requestedBy,
       });
-      // The name was identifier-validated at bind time ⇒ a valid env var name.
-      env[name] = value;
-      values.push(value);
+
+      let shaped;
+      try {
+        shaped = shapeTypedSecret({ name, type, value: raw });
+      } catch (shapeErr: unknown) {
+        // Fail-soft: a malformed typed payload drops THIS secret, not the run. Its
+        // lease is already issued and is revoked with the rest by the caller/partial-
+        // failure path. Message carries the name/type only, never the value.
+        console.warn(
+          `[credential-broker] typed secret "${name}" (${type}) malformed; skipping:`,
+          shapeErr instanceof Error ? shapeErr.message : shapeErr,
+        );
+        continue;
+      }
+
+      Object.assign(env, shaped.env);
+      values.push(...shaped.scrubExtra);
+
+      if (shaped.kubeconfig !== undefined) {
+        // Per-run kubeconfig in a private 0600 temp dir; KUBECONFIG points at it.
+        // The path is scrubbed from output too; cleanup() removes the dir.
+        const dir = await mkdtemp(join(tmpdir(), "mq-kubeconfig-"));
+        tempDirs.push(dir);
+        const path = join(dir, "config");
+        await writeFile(path, shaped.kubeconfig, { mode: 0o600 });
+        env.KUBECONFIG = path;
+        values.push(path);
+      }
     }
   } catch (err) {
-    // Partial failure: revoke everything issued so far so nothing is orphaned
-    // (best-effort — the expiry sweeper is the backstop). Then rethrow.
+    await cleanup();
     for (const id of leaseIds) {
       await p.provider.revokeLease(id).catch(() => undefined);
     }
     throw err;
   }
 
-  return { env, values, leaseIds };
+  return { env, values, leaseIds, cleanup };
 }

--- a/server/credentials/types.ts
+++ b/server/credentials/types.ts
@@ -239,6 +239,8 @@ export interface CredentialProvider {
     description: string;
     secret: string;
     name?: string;
+    /** ADR-003 §D3 (Phase 3b): typed-delivery discriminator; default "static". */
+    type?: SecretType;
   }): Promise<CredentialMetadata>;
 
   /** Delete a credential for the project (project-scoped write). */

--- a/server/routes/credentials.ts
+++ b/server/routes/credentials.ts
@@ -23,6 +23,7 @@ import {
   secrets,
 } from "../../shared/schema.js";
 import { credentialProvider } from "../credentials/db-crypto-provider.js";
+import { SECRET_TYPES, shapeTypedSecret } from "../credentials/typed-secret.js";
 import { getProjectId } from "../context.js";
 import { requireRole } from "../auth/middleware.js";
 import { desc, eq, and } from "drizzle-orm";
@@ -39,6 +40,9 @@ const MAX_META_LEN = 256;
 const CreateSecretBodySchema = z.object({
   name: z.string().regex(SECRET_NAME_RE, "invalid secret name"),
   value: z.string().min(1).max(8192),
+  // ADR-003 §D3: typed delivery — "static" (default), "aws" (JSON creds), or
+  // "kubernetes" (kubeconfig). The value shape is validated in the handler.
+  type: z.enum(SECRET_TYPES).default("static"),
   description: z.string().max(MAX_META_LEN).optional(),
   scope: z.string().max(MAX_META_LEN).optional(),
   provider: z.string().max(MAX_META_LEN).optional(),
@@ -230,6 +234,25 @@ export function registerCredentialRoutes(app: Express): void {
         return;
       }
 
+      // §3b: shape-validate the typed value (aws JSON / kubeconfig) before storing —
+      // reuse the exact delivery shaper so a malformed payload is a 400, not a
+      // runtime delivery failure. Never echoes the value (shaper errors carry name/type).
+      try {
+        shapeTypedSecret({
+          name: body.data.name,
+          type: body.data.type,
+          value: body.data.value,
+        });
+      } catch (shapeErr: unknown) {
+        res.status(400).json({
+          error:
+            shapeErr instanceof Error
+              ? shapeErr.message
+              : "invalid typed secret value",
+        });
+        return;
+      }
+
       const metadata = await credentialProvider.putCredential({
         projectId,
         name: body.data.name,
@@ -237,6 +260,7 @@ export function registerCredentialRoutes(app: Express): void {
         description: sanitizeMeta(body.data.description) ?? "",
         scope: sanitizeMeta(body.data.scope) ?? "",
         provider: sanitizeMeta(body.data.provider) ?? "",
+        type: body.data.type,
       });
 
       const [row] = await db

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -2579,7 +2579,8 @@ export class ConsiliumLoopController {
       env: Record<string, string>;
       values: string[];
       leaseIds: string[];
-    } = { env: {}, values: [], leaseIds: [] };
+      cleanup: () => Promise<void>;
+    } = { env: {}, values: [], leaseIds: [], cleanup: async () => undefined };
     try {
       leased = await deliverLeasedEnv({
         provider: credentialProvider,
@@ -2600,7 +2601,8 @@ export class ConsiliumLoopController {
         "[consilium-loop] leased-secret delivery failed; developing WITHOUT secrets:",
         e instanceof Error ? e.message : e,
       );
-      leased = { env: {}, values: [], leaseIds: [] };
+      // deliverLeasedEnv already revoked + cleaned up any partial delivery on throw.
+      leased = { env: {}, values: [], leaseIds: [], cleanup: async () => undefined };
     }
     try {
       return await run({
@@ -2687,6 +2689,8 @@ export class ConsiliumLoopController {
             console.warn("[consilium-loop] revokeLease failed:", e),
           );
       }
+      // §3b: remove any per-run typed-secret temp files (e.g. kubeconfig).
+      await leased.cleanup();
     }
   }
 
@@ -3194,7 +3198,8 @@ export class ConsiliumLoopController {
       env: Record<string, string>;
       values: string[];
       leaseIds: string[];
-    } = { env: {}, values: [], leaseIds: [] };
+      cleanup: () => Promise<void>;
+    } = { env: {}, values: [], leaseIds: [], cleanup: async () => undefined };
     try {
       delivered = await deliverLeasedEnv({
         provider: credentialProvider,
@@ -3230,6 +3235,8 @@ export class ConsiliumLoopController {
             console.warn("[consilium-loop] revokeLease failed:", e),
           );
       }
+      // §3b: remove any per-run typed-secret temp files (e.g. kubeconfig).
+      await delivered.cleanup();
     }
   }
 

--- a/tests/unit/credentials/deliver-leased-env.test.ts
+++ b/tests/unit/credentials/deliver-leased-env.test.ts
@@ -11,6 +11,7 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import { deliverLeasedEnv } from "../../../server/credentials/deliver-leased-env.js";
+import { readFile, stat } from "node:fs/promises";
 import type { CredentialProvider } from "../../../server/credentials/types.js";
 
 type BoundRow = {
@@ -56,6 +57,64 @@ const base = {
   requestedBy: "user-1",
 };
 
+describe("deliverLeasedEnv — typed delivery (ADR-003 §3b)", () => {
+  const one = { loopId: "loop-a", credentialId: "cred-1", createdBy: "u", createdAt: new Date(0) };
+
+  it("shapes an aws secret into the AWS_* env vars", async () => {
+    const provider = fakeProvider({
+      listCredentials: vi.fn(async () => [{ id: "cred-1", name: "aws-prod", type: "aws" }]),
+      getSecretValue: vi.fn(async () =>
+        JSON.stringify({ accessKeyId: "AKIA", secretAccessKey: "secretval", region: "eu-central-1" }),
+      ),
+    });
+    const out = await deliverLeasedEnv({ provider, storage: fakeStorage([one]), ...base });
+    expect(out.env).toMatchObject({
+      AWS_ACCESS_KEY_ID: "AKIA",
+      AWS_SECRET_ACCESS_KEY: "secretval",
+      AWS_DEFAULT_REGION: "eu-central-1",
+    });
+    expect(out.values).toContain("secretval");
+    await out.cleanup();
+  });
+
+  it("writes a kubernetes secret to a 0600 temp file + KUBECONFIG, removed by cleanup()", async () => {
+    const kubeconfig = "apiVersion: v1\nkind: Config";
+    const provider = fakeProvider({
+      listCredentials: vi.fn(async () => [{ id: "cred-1", name: "kube", type: "kubernetes" }]),
+      getSecretValue: vi.fn(async () => kubeconfig),
+    });
+    const out = await deliverLeasedEnv({ provider, storage: fakeStorage([one]), ...base });
+    const path = out.env.KUBECONFIG;
+    expect(path).toBeTruthy();
+    expect(await readFile(path, "utf8")).toBe(kubeconfig);
+    expect((await stat(path)).mode & 0o777).toBe(0o600);
+    expect(out.values).toContain(kubeconfig);
+    await out.cleanup();
+    await expect(stat(path)).rejects.toThrow(); // removed
+  });
+
+  it("fail-soft: drops a malformed aws secret (empty env), lease still issued", async () => {
+    const provider = fakeProvider({
+      listCredentials: vi.fn(async () => [{ id: "cred-1", name: "aws", type: "aws" }]),
+      getSecretValue: vi.fn(async () => "not json"),
+    });
+    const out = await deliverLeasedEnv({ provider, storage: fakeStorage([one]), ...base });
+    expect(out.env).toEqual({});
+    expect(out.leaseIds).toHaveLength(1);
+    await out.cleanup();
+  });
+
+  it("static (no type) is byte-identical — env keyed by name", async () => {
+    const provider = fakeProvider({
+      listCredentials: vi.fn(async () => [{ id: "cred-1", name: "TOK" }]),
+      getSecretValue: vi.fn(async () => "rawtoken"),
+    });
+    const out = await deliverLeasedEnv({ provider, storage: fakeStorage([one]), ...base });
+    expect(out.env).toEqual({ TOK: "rawtoken" });
+    await out.cleanup();
+  });
+});
+
 describe("deliverLeasedEnv (ADR-003 §3a.C)", () => {
   it("returns empty and issues no lease when the loop has no bound secrets", async () => {
     const provider = fakeProvider();
@@ -63,7 +122,9 @@ describe("deliverLeasedEnv (ADR-003 §3a.C)", () => {
 
     const out = await deliverLeasedEnv({ provider, storage, ...base });
 
-    expect(out).toEqual({ env: {}, values: [], leaseIds: [] });
+    expect(out.env).toEqual({});
+    expect(out.values).toEqual([]);
+    expect(out.leaseIds).toEqual([]);
     expect(provider.issueLease).not.toHaveBeenCalled();
     expect(provider.getSecretValue).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
Wires the 3b shaper (#567) into exec-time delivery + the create surface — a secret's `type` now actually shapes how it's delivered (ADR-003 §D3/§D4). **Phase 3b functionally complete** with this PR (API-level; the create-form UI selector is optional polish).

## Behavior (default `static` ⇒ byte-identical)
- **`deliver-leased-env.ts`** — per bound secret, read `type` from metadata → `shapeTypedSecret()`:
  - `static` → `{ [name]: value }`
  - `aws` → `AWS_*` env vars
  - `kubernetes` → a per-run **0600** kubeconfig temp file + `KUBECONFIG=<path>`
  Threads shaped `scrubExtra` (and any kubeconfig temp path) into the run's dynamic scrub set. New `cleanup()` on the delivery result. Malformed typed payload drops THAT secret (fail-soft), not the run; partial failure cleans up + revokes before rethrow.
- **`consilium-loop-controller.ts`** — both delivery callers (developing coder path #563, reviewing infra path #566) call `delivered.cleanup()` in their `finally` alongside revoke.
- **`db-crypto-provider.ts` / `types.ts`** — `putCredential` accepts `type` (→ `secrets.type`); `listCredentials` metadata carries `type`.
- **`routes/credentials.ts`** — `POST /api/credentials` accepts `type` and **shape-validates** the value via the same shaper (400 on malformed aws JSON; never echoes the value).

## Security review (self)
- Typed material scrubbed from output (`scrubExtra` → `values` → the run scrubber). ✅
- Kubeconfig: 0600, private per-run dir, removed via `cleanup()` in the caller `finally`; path also scrubbed. ✅
- Fail-soft (malformed secret dropped, lease still revoked); no new `decrypt()` path. ✅

## Test plan
- [x] `tsc` clean.
- [x] `deliver-leased-env.test.ts` +4: aws→`AWS_*`; kube→0600 temp file + `KUBECONFIG` + `cleanup()` removes it; malformed aws fail-soft; static parity.
- [x] **1403** credentials + consilium unit tests green (3 route-test flakes were load-order, pass in isolation — unrelated to this change).
- [ ] **QA / live**: real aws/kube secret delivered into a bound-secret run (needs live creds/cluster).

Requires migration 0063 (`secrets.type`, #567) applied. Optional follow-up: type selector + typed value fields in the credential create UI.