### PR TITLE
feat(consult): standalone multi-model Q&A with loop handoff

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -32,6 +32,7 @@ import Roles from "@/pages/Roles";
 import PrReviewQueue from "@/pages/PrReviewQueue";
 import TrustTelemetry from "@/pages/TrustTelemetry";
 import CredentialAccess from "@/pages/CredentialAccess";
+import Consult from "@/pages/Consult";
 
 function ProtectedRouter() {
   const { user, isLoading } = useAuth();
@@ -65,6 +66,12 @@ function ProtectedRouter() {
         )} />
         <Route path="/consilium-loops" component={() => (
           <ErrorBoundary><ConsiliumLoopList /></ErrorBoundary>
+        )} />
+        <Route path="/consult/:id" component={() => (
+          <ErrorBoundary><Consult /></ErrorBoundary>
+        )} />
+        <Route path="/consult" component={() => (
+          <ErrorBoundary><Consult /></ErrorBoundary>
         )} />
         <Route path="/trust" component={() => (
           <ErrorBoundary><TrustTelemetry /></ErrorBoundary>

--- a/client/src/components/layout/MainLayout.tsx
+++ b/client/src/components/layout/MainLayout.tsx
@@ -19,6 +19,7 @@ import {
   ShieldCheck,
   KeyRound,
   UserCog,
+  MessagesSquare,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/hooks/use-auth";
@@ -58,6 +59,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
     { icon: Zap, label: "Triggers", href: "/triggers" },
     { icon: UserCog, label: "Roles", href: "/roles" },
     { icon: Repeat, label: "Consilium Loops", href: "/consilium-loops" },
+    { icon: MessagesSquare, label: "Consult", href: "/consult" },
     { icon: GitPullRequest, label: "PR Queue", href: "/pr-queue" },
     { icon: ShieldCheck, label: "Trust", href: "/trust" },
     { icon: FolderGit2, label: "Workspace", href: "/workspaces" },

--- a/client/src/hooks/use-consult.ts
+++ b/client/src/hooks/use-consult.ts
@@ -1,0 +1,92 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiRequest } from "./use-api";
+
+/** Mirrors the server's ConsultSession row (dates arrive as ISO strings). */
+export interface ConsultSessionDto {
+  id: string;
+  projectId: string;
+  question: string;
+  modelSlugs: string[];
+  status: "created" | "answered" | "debated" | "handed_off";
+  createdBy: string;
+  createdAt: string;
+  loopId: string | null;
+  workspaceId: string | null;
+}
+
+export interface ConsultAnswerDto {
+  id: string;
+  sessionId: string;
+  modelSlug: string;
+  round: number;
+  content: string | null;
+  errorMessage: string | null;
+  createdAt: string;
+}
+
+export interface ConsultRoundResult {
+  round: number;
+  answers: ConsultAnswerDto[];
+}
+
+const LIST_KEY = ["/api/consult"] as const;
+
+export function useConsultSessions() {
+  return useQuery<{ sessions: ConsultSessionDto[] }>({
+    queryKey: LIST_KEY,
+    queryFn: () => apiRequest("GET", "/api/consult"),
+  });
+}
+
+export function useConsultSession(id: string | null) {
+  return useQuery<{ session: ConsultSessionDto; answers: ConsultAnswerDto[] }>({
+    queryKey: ["/api/consult", id],
+    queryFn: () => apiRequest("GET", `/api/consult/${id}`),
+    enabled: Boolean(id),
+  });
+}
+
+export function useCreateConsult() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { question: string; modelSlugs: string[] }) =>
+      apiRequest("POST", "/api/consult", data) as Promise<ConsultSessionDto>,
+    onSuccess: () => qc.invalidateQueries({ queryKey: LIST_KEY }),
+  });
+}
+
+/** Invalidate both the session detail and the history list after a mutation. */
+function invalidateSession(qc: ReturnType<typeof useQueryClient>, sessionId: string) {
+  qc.invalidateQueries({ queryKey: ["/api/consult", sessionId] });
+  qc.invalidateQueries({ queryKey: LIST_KEY });
+}
+
+export function useConsultAnswer(sessionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      apiRequest("POST", `/api/consult/${sessionId}/answer`, {}) as Promise<ConsultRoundResult>,
+    onSuccess: () => invalidateSession(qc, sessionId),
+  });
+}
+
+export function useConsultDebate(sessionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      apiRequest("POST", `/api/consult/${sessionId}/debate`, {}) as Promise<ConsultRoundResult>,
+    onSuccess: () => invalidateSession(qc, sessionId),
+  });
+}
+
+export function useConsultHandoff(sessionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { repoPath: string; instruction: string }) =>
+      apiRequest("POST", `/api/consult/${sessionId}/handoff`, data) as Promise<{
+        loopId: string;
+        workspaceId: string;
+      }>,
+    onSuccess: () => invalidateSession(qc, sessionId),
+  });
+}

--- a/client/src/pages/Consult.tsx
+++ b/client/src/pages/Consult.tsx
@@ -1,0 +1,452 @@
+import { useEffect, useMemo, useState } from "react";
+import { useLocation, useRoute } from "wouter";
+import {
+  MessagesSquare,
+  Send,
+  Users,
+  GitBranch,
+  Loader2,
+  Plus,
+  AlertTriangle,
+  CheckCircle2,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { Card, CardContent } from "@/components/ui/card";
+import { useToast } from "@/hooks/use-toast";
+import { useModels } from "@/hooks/use-models";
+import {
+  useConsultSessions,
+  useConsultSession,
+  useCreateConsult,
+  useConsultAnswer,
+  useConsultDebate,
+  useConsultHandoff,
+  type ConsultAnswerDto,
+  type ConsultSessionDto,
+} from "@/hooks/use-consult";
+
+interface ModelLite {
+  slug: string;
+  name?: string;
+  isActive?: boolean;
+}
+
+/** Client-side prefill for the handoff objective (server rebuilds authoritatively). */
+function buildInstruction(question: string, answers: ConsultAnswerDto[]): string {
+  const usable = answers.filter((a) => a.content);
+  const body = usable.length
+    ? usable.map((a) => `## ${a.modelSlug}\n${a.content}`).join("\n\n")
+    : "(no model answers were captured)";
+  return `# Consult question\n${question}\n\n# Model answers\n${body}\n\n# Task\nUsing the question and the model answers above as context, implement the recommended approach. Validate the assumptions against the actual repository before making changes.`;
+}
+
+const STATUS_LABEL: Record<ConsultSessionDto["status"], string> = {
+  created: "Awaiting answers",
+  answered: "Answered",
+  debated: "Debated",
+  handed_off: "Handed off",
+};
+
+// ─── Step 1: compose a new question ─────────────────────────────────────────
+function Composer({ onCreated }: { onCreated: (id: string) => void }) {
+  const { data: models } = useModels();
+  const create = useCreateConsult();
+  const { toast } = useToast();
+  const [question, setQuestion] = useState("");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const active = useMemo<ModelLite[]>(
+    () => ((models as ModelLite[] | undefined) ?? []).filter((m) => m.isActive),
+    [models],
+  );
+
+  function toggle(slug: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(slug)) next.delete(slug);
+      else next.add(slug);
+      return next;
+    });
+  }
+
+  async function submit() {
+    const slugs = [...selected];
+    if (!question.trim() || slugs.length === 0) return;
+    try {
+      const session = await create.mutateAsync({ question: question.trim(), modelSlugs: slugs });
+      onCreated(session.id);
+    } catch (err) {
+      toast({
+        title: "Could not start consult",
+        description: err instanceof Error ? err.message : String(err),
+        variant: "destructive",
+      });
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Label className="text-sm font-medium">Your question</Label>
+        <Textarea
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          placeholder="e.g. Should I use Cloud WAN for a small three-account infra, or plain TGW peering?"
+          rows={5}
+          className="mt-2 resize-y"
+          data-testid="consult-question"
+        />
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between">
+          <Label className="text-sm font-medium">Models</Label>
+          <span className="text-xs text-muted-foreground">{selected.size} selected</span>
+        </div>
+        {active.length === 0 ? (
+          <p className="mt-2 text-sm text-muted-foreground">
+            No active models in the catalog — enable one in Settings first.
+          </p>
+        ) : (
+          <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {active.map((m) => (
+              <label
+                key={m.slug}
+                className="flex cursor-pointer items-center gap-2 rounded-md border border-border/60 px-3 py-2 hover:bg-accent/40"
+              >
+                <Checkbox checked={selected.has(m.slug)} onCheckedChange={() => toggle(m.slug)} />
+                <span className="truncate text-sm">{m.name ?? m.slug}</span>
+                <span className="ml-auto truncate text-xs text-muted-foreground">{m.slug}</span>
+              </label>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <Button
+        onClick={submit}
+        disabled={!question.trim() || selected.size === 0 || create.isPending}
+        data-testid="consult-ask"
+      >
+        {create.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Send className="mr-2 h-4 w-4" />}
+        Ask {selected.size > 0 ? `${selected.size} model${selected.size > 1 ? "s" : ""}` : "models"}
+      </Button>
+    </div>
+  );
+}
+
+// ─── Step 2: one model's answer card ────────────────────────────────────────
+function AnswerCard({ answer }: { answer: ConsultAnswerDto }) {
+  return (
+    <Card className="overflow-hidden">
+      <div className="flex items-center gap-2 border-b border-border/60 bg-muted/40 px-4 py-2">
+        <span className="truncate text-sm font-medium">{answer.modelSlug}</span>
+        {answer.errorMessage ? (
+          <Badge variant="destructive" className="ml-auto gap-1">
+            <AlertTriangle className="h-3 w-3" /> failed
+          </Badge>
+        ) : (
+          <Badge variant="secondary" className="ml-auto">
+            round {answer.round}
+          </Badge>
+        )}
+      </div>
+      <CardContent className="p-4">
+        {answer.errorMessage ? (
+          <p className="text-sm text-destructive">{answer.errorMessage}</p>
+        ) : (
+          <pre className="whitespace-pre-wrap break-words font-sans text-sm leading-relaxed">
+            {answer.content}
+          </pre>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── The active session (steps 2 + 3) ───────────────────────────────────────
+function SessionView({ sessionId }: { sessionId: string }) {
+  const { data, isLoading } = useConsultSession(sessionId);
+  const answerMut = useConsultAnswer(sessionId);
+  const debateMut = useConsultDebate(sessionId);
+  const handoff = useConsultHandoff(sessionId);
+  const { toast } = useToast();
+  const [, navigate] = useLocation();
+  const [repoPath, setRepoPath] = useState("");
+  const [instruction, setInstruction] = useState("");
+  const [instructionTouched, setInstructionTouched] = useState(false);
+
+  const session = data?.session;
+  const answers = data?.answers ?? [];
+  const latestRound = answers.reduce((m, a) => Math.max(m, a.round), 0);
+  const latestAnswers = answers.filter((a) => a.round === latestRound);
+  const hasAnswers = answers.length > 0;
+
+  // Keep the handoff objective in sync with the latest answers until the user edits it.
+  useEffect(() => {
+    if (!instructionTouched && session) {
+      setInstruction(buildInstruction(session.question, answers));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session?.question, answers.length, latestRound, instructionTouched]);
+
+  async function run(mut: typeof answerMut, label: string) {
+    try {
+      await mut.mutateAsync();
+    } catch (err) {
+      toast({
+        title: `${label} failed`,
+        description: err instanceof Error ? err.message : String(err),
+        variant: "destructive",
+      });
+    }
+  }
+
+  async function doHandoff() {
+    if (!repoPath.trim() || !instruction.trim()) return;
+    try {
+      const { loopId } = await handoff.mutateAsync({
+        repoPath: repoPath.trim(),
+        instruction: instruction.trim(),
+      });
+      toast({ title: "Loop started", description: "Opening the consilium loop…" });
+      navigate(`/consilium-loops/${loopId}`);
+    } catch (err) {
+      toast({
+        title: "Handoff failed",
+        description: err instanceof Error ? err.message : String(err),
+        variant: "destructive",
+      });
+    }
+  }
+
+  if (isLoading || !session) {
+    return <p className="text-sm text-muted-foreground">Loading session…</p>;
+  }
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <div className="flex items-center gap-2">
+          <Badge variant="outline">{STATUS_LABEL[session.status]}</Badge>
+          <span className="text-xs text-muted-foreground">
+            {session.modelSlugs.length} model{session.modelSlugs.length > 1 ? "s" : ""}
+          </span>
+        </div>
+        <p className="mt-3 whitespace-pre-wrap text-base font-medium leading-relaxed">
+          {session.question}
+        </p>
+      </div>
+
+      {/* Step 2 — answers */}
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            Answers
+          </h2>
+          <div className="ml-auto flex gap-2">
+            <Button
+              size="sm"
+              variant={hasAnswers ? "outline" : "default"}
+              onClick={() => run(answerMut, "Answering")}
+              disabled={answerMut.isPending}
+              data-testid="consult-answer"
+            >
+              {answerMut.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="mr-2 h-4 w-4" />
+              )}
+              {hasAnswers ? "Re-run" : "Get answers"}
+            </Button>
+            {hasAnswers && (
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => run(debateMut, "Debate")}
+                disabled={debateMut.isPending}
+                data-testid="consult-debate"
+              >
+                {debateMut.isPending ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Users className="mr-2 h-4 w-4" />
+                )}
+                Debate
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {!hasAnswers ? (
+          <p className="text-sm text-muted-foreground">
+            No answers yet — each selected model will answer independently.
+          </p>
+        ) : (
+          <>
+            {latestRound > 0 && (
+              <p className="text-xs text-muted-foreground">
+                Showing round {latestRound} (debate). Earlier rounds are kept in history.
+              </p>
+            )}
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+              {latestAnswers.map((a) => (
+                <AnswerCard key={a.id} answer={a} />
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Step 3 — handoff */}
+      <Separator />
+      <div className="space-y-4">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Hand off to a loop
+        </h2>
+        {session.loopId ? (
+          <div className="flex items-center gap-2 rounded-md border border-border/60 bg-muted/30 px-4 py-3">
+            <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+            <span className="text-sm">This consult started a loop.</span>
+            <Button
+              size="sm"
+              variant="link"
+              className="ml-auto"
+              onClick={() => navigate(`/consilium-loops/${session.loopId}`)}
+            >
+              Open loop
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div>
+              <Label className="text-sm">Repository path</Label>
+              <Input
+                value={repoPath}
+                onChange={(e) => setRepoPath(e.target.value)}
+                placeholder="/absolute/path/to/repo (must be in the allowlist)"
+                className="mt-1 font-mono text-sm"
+                data-testid="consult-repo"
+              />
+            </div>
+            <div>
+              <Label className="text-sm">Objective (editable)</Label>
+              <Textarea
+                value={instruction}
+                onChange={(e) => {
+                  setInstruction(e.target.value);
+                  setInstructionTouched(true);
+                }}
+                rows={8}
+                className="mt-1 resize-y font-mono text-xs"
+                data-testid="consult-instruction"
+              />
+            </div>
+            <Button
+              onClick={doHandoff}
+              disabled={!repoPath.trim() || !instruction.trim() || handoff.isPending}
+              data-testid="consult-handoff"
+            >
+              {handoff.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <GitBranch className="mr-2 h-4 w-4" />
+              )}
+              Create workspace &amp; start loop
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── History rail ───────────────────────────────────────────────────────────
+function HistoryRail({
+  activeId,
+  onSelect,
+  onNew,
+}: {
+  activeId: string | null;
+  onSelect: (id: string) => void;
+  onNew: () => void;
+}) {
+  const { data } = useConsultSessions();
+  const sessions = data?.sessions ?? [];
+
+  return (
+    <aside className="w-full shrink-0 space-y-3 lg:w-72">
+      <Button variant="outline" className="w-full justify-start" onClick={onNew} data-testid="consult-new">
+        <Plus className="mr-2 h-4 w-4" /> New consult
+      </Button>
+      <div className="space-y-1">
+        {sessions.length === 0 && (
+          <p className="px-1 text-xs text-muted-foreground">No past consults yet.</p>
+        )}
+        {sessions.map((s) => (
+          <button
+            key={s.id}
+            onClick={() => onSelect(s.id)}
+            className={`w-full rounded-md px-3 py-2 text-left text-sm transition-colors ${
+              s.id === activeId ? "bg-accent text-accent-foreground" : "hover:bg-accent/40"
+            }`}
+          >
+            <span className="line-clamp-2">{s.question}</span>
+            <span className="mt-1 block text-xs text-muted-foreground">
+              {STATUS_LABEL[s.status]} · {s.modelSlugs.length}m
+            </span>
+          </button>
+        ))}
+      </div>
+    </aside>
+  );
+}
+
+export default function Consult() {
+  const [, routeParams] = useRoute("/consult/:id");
+  const [, navigate] = useLocation();
+  const [activeId, setActiveId] = useState<string | null>(routeParams?.id ?? null);
+
+  useEffect(() => {
+    if (routeParams?.id && routeParams.id !== activeId) setActiveId(routeParams.id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [routeParams?.id]);
+
+  function select(id: string) {
+    setActiveId(id);
+    navigate(`/consult/${id}`);
+  }
+  function startNew() {
+    setActiveId(null);
+    navigate("/consult");
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl px-6 py-8">
+      <header className="mb-6 flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <MessagesSquare className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-xl font-semibold">Consult</h1>
+          <p className="text-sm text-muted-foreground">
+            Ask several models, compare their answers, then hand off to a standard loop.
+          </p>
+        </div>
+      </header>
+
+      <div className="flex flex-col gap-8 lg:flex-row">
+        <HistoryRail activeId={activeId} onSelect={select} onNew={startNew} />
+        <main className="min-w-0 flex-1">
+          {activeId ? <SessionView sessionId={activeId} /> : <Composer onCreated={select} />}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/migrations/0064_consult.sql
+++ b/migrations/0064_consult.sql
@@ -1,0 +1,27 @@
+-- Consult: standalone multi-model Q&A (workspace-independent). Additive/non-breaking.
+-- A session holds a strategic question + the operator-selected model slugs; answers
+-- accrue per model per round (0 = independent, 1+ = debate). On handoff the session
+-- records the consilium loop + workspace it became. Ship-only: applied by the lead.
+CREATE TABLE IF NOT EXISTS consult_sessions (
+  id text PRIMARY KEY,
+  project_id text NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  question text NOT NULL,
+  model_slugs jsonb NOT NULL DEFAULT '[]'::jsonb,
+  status text NOT NULL DEFAULT 'created',
+  created_by text NOT NULL,
+  created_at timestamp NOT NULL DEFAULT now(),
+  loop_id text,
+  workspace_id text
+);
+
+CREATE TABLE IF NOT EXISTS consult_answers (
+  id text PRIMARY KEY,
+  session_id text NOT NULL REFERENCES consult_sessions(id) ON DELETE CASCADE,
+  model_slug text NOT NULL,
+  round integer NOT NULL DEFAULT 0,
+  content text,
+  error_message text,
+  created_at timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS consult_answers_session_id_idx ON consult_answers (session_id);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -55,6 +55,8 @@ import { registerTaskGroupRoutes } from "./routes/task-groups";
 import { registerTaskGroupResolveRoute } from "./routes/task-group-resolve";
 import { registerConsiliumLoopRoutes } from "./routes/consilium-loops";
 import { registerConsiliumReviewRoutes } from "./routes/consilium-reviews";
+import { registerConsultRoutes } from "./routes/consult";
+import { WorkspaceManager } from "./workspace/manager";
 import { registerStandingRoleRoutes } from "./routes/standing-roles";
 import { createConsiliumReview } from "./services/consilium/review-factory";
 import { maybeLaunchConsiliumReview, maybeLaunchGitHubReview, maybeLaunchGitLabReview, maybeLaunchRoleWake, resolveSpecWatchConfig, deriveRepoRoot } from "./services/consilium/trigger-dispatch";
@@ -151,6 +153,7 @@ export async function registerRoutes(
   // route is unauthenticated (the /api/pr-queue class of bug). Do not drop it.
   app.use("/api/telemetry", requireAuth, requireProject);
   app.use("/api/consilium-reviews", requireAuth, requireProject);
+  app.use("/api/consult", requireAuth, requireProject);
   // DREAM-4 (experience-plane-dream §5/§9): Experience → SKILL.md feedback proposals review
   // surface. Project-scoped — the mount carries auth (the /api/pr-queue 401 lesson); the
   // routes register inside the experiencePlane.skillFeedback.enabled kill-switch. The PATCH
@@ -324,6 +327,23 @@ export async function registerRoutes(
       // "Magic mode" reformulate endpoint uses the SAME gateway path (completeStreaming)
       // direct_llm/planner use. Gated by consiliumLoop.reformulate.enabled in the route.
       gateway,
+    });
+    // Consult — standalone multi-model Q&A. Registered inside the SAME kill-switch
+    // (its step-3 handoff reuses the `createConsiliumReview` factory), given the same
+    // review deps + the gateway (answer/debate) + wsManager (repo → workspace).
+    const consultWorkspaceManager = new WorkspaceManager();
+    registerConsultRoutes(app, {
+      storage,
+      gateway,
+      reviewDeps: {
+        storage,
+        orchestrator: taskOrchestrator,
+        controller: consiliumLoopController,
+        config: () => appConfigLoader.get(),
+        gateway,
+      },
+      connectWorkspace: (repoPath: string) =>
+        consultWorkspaceManager.connectLocal(repoPath),
     });
     // ROLE-1 — StandingRole CRUD + manual wake. Registered inside the SAME kill-switch
     // (inert otherwise) and given the SAME deps as the review routes: wake reuses the

--- a/server/routes/consult.ts
+++ b/server/routes/consult.ts
@@ -1,0 +1,244 @@
+/**
+ * Consult routes — standalone multi-model Q&A (workspace-independent).
+ *
+ * Three MANUAL steps, one endpoint each, all project-scoped and mounted behind
+ * `requireAuth + requireProject` in routes.ts (so `req.user` + `req.projectId`
+ * are set and the ALS project context createConsiliumReview relies on is live):
+ *
+ *   1. POST /api/consult                 — create a session (question + models)
+ *   2. POST /api/consult/:id/answer      — each model answers independently (round 0)
+ *      POST /api/consult/:id/debate      — models see each other, refine (round N+1)
+ *   3. POST /api/consult/:id/handoff     — connect repo → workspace → start a loop
+ *
+ *   GET  /api/consult      — history (newest first)
+ *   GET  /api/consult/:id  — session + all answer rounds
+ *
+ * The heavy lifting lives in ../services/consult/consult-service (pure, fail-soft
+ * over a narrow gateway). This file owns validation, persistence, and access.
+ */
+import type { Express, Request, Response } from "express";
+import { z } from "zod";
+import { CONSILIUM_REVIEW_PRESETS } from "@shared/types";
+import type { ConsultSession, ConsultAnswer } from "@shared/schema";
+import type { IStorage } from "../storage.js";
+import { validateBody } from "../middleware/validate.js";
+import {
+  answerIndependently,
+  debate,
+  type ConsultGateway,
+  type ConsultModelAnswer,
+} from "../services/consult/consult-service.js";
+import {
+  createConsiliumReview,
+  type CreateConsiliumReviewDeps,
+} from "../services/consilium/review-factory.js";
+
+/** Everything the consult routes need, injected from routes.ts (testable). */
+export interface ConsultRouteDeps {
+  storage: IStorage;
+  /** Model gateway for the answer/debate steps (the real Gateway satisfies it). */
+  gateway: ConsultGateway;
+  /** Reused verbatim by the handoff step to start a standard consilium loop. */
+  reviewDeps: CreateConsiliumReviewDeps;
+  /** Connect a local repo path as a workspace (wsManager.connectLocal). */
+  connectWorkspace: (repoPath: string) => Promise<{ id: string; path: string }>;
+}
+
+const MAX_QUESTION = 8_000;
+const MAX_MODELS = 6;
+const MAX_INSTRUCTION = 60_000;
+
+const CreateConsultSchema = z.object({
+  question: z.string().trim().min(1).max(MAX_QUESTION),
+  modelSlugs: z.array(z.string().trim().min(1)).min(1).max(MAX_MODELS),
+});
+
+const HandoffSchema = z.object({
+  repoPath: z.string().trim().min(1),
+  instruction: z.string().trim().min(1).max(MAX_INSTRUCTION),
+  preset: z.enum(CONSILIUM_REVIEW_PRESETS).optional(),
+  maxRounds: z.number().int().min(1).max(6).optional(),
+});
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+/** Persist a batch of service answers for one round; returns the insert rows. */
+function toInsertRows(
+  sessionId: string,
+  round: number,
+  answers: ConsultModelAnswer[],
+) {
+  return answers.map((a) => ({
+    sessionId,
+    modelSlug: a.modelSlug,
+    round,
+    content: a.content,
+    errorMessage: a.errorMessage,
+  }));
+}
+
+/** The newest stored answer per model (rows arrive createdAt-ascending). */
+function latestPerModel(answers: ConsultAnswer[]): ConsultAnswer[] {
+  const byModel = new Map<string, ConsultAnswer>();
+  for (const a of answers) byModel.set(a.modelSlug, a);
+  return [...byModel.values()];
+}
+
+export function registerConsultRoutes(app: Express, deps: ConsultRouteDeps): void {
+  const { storage, gateway, reviewDeps, connectWorkspace } = deps;
+
+  /** Load a session, enforcing project scope + owner-or-admin. Sends the error. */
+  async function loadSession(
+    req: Request,
+    res: Response,
+  ): Promise<ConsultSession | null> {
+    const session = await storage.getConsultSession(String(req.params.id));
+    // 404 (not 403) on a project mismatch so we never leak cross-project existence.
+    if (!session || session.projectId !== req.projectId) {
+      res.status(404).json({ error: "consult session not found" });
+      return null;
+    }
+    const isAdmin = req.user?.role === "admin";
+    if (!isAdmin && session.createdBy !== req.user?.id) {
+      res.status(403).json({ error: "not your consult session" });
+      return null;
+    }
+    return session;
+  }
+
+  // 1 — create a session (validate models against the ACTIVE catalog).
+  app.post(
+    "/api/consult",
+    validateBody(CreateConsultSchema),
+    async (req: Request, res: Response) => {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: "Authentication required" });
+      if (!req.projectId) return res.status(400).json({ error: "x-project-id header is required" });
+
+      const body = req.body as z.infer<typeof CreateConsultSchema>;
+      const modelSlugs = [...new Set(body.modelSlugs.map((s) => s.trim()))];
+      const active = new Set((await storage.getActiveModels()).map((m) => m.slug));
+      const unknown = modelSlugs.filter((s) => !active.has(s));
+      if (unknown.length > 0) {
+        return res
+          .status(400)
+          .json({ error: `unknown or inactive model(s): ${unknown.join(", ")}` });
+      }
+
+      const session = await storage.createConsultSession({
+        projectId: req.projectId,
+        question: body.question,
+        modelSlugs,
+        createdBy: userId,
+      });
+      return res.status(201).json(session);
+    },
+  );
+
+  // 2a — independent answers (round 0). Manual; re-running regenerates round 0.
+  app.post("/api/consult/:id/answer", async (req: Request, res: Response) => {
+    const session = await loadSession(req, res);
+    if (!session) return;
+    const answers = await answerIndependently(
+      gateway,
+      session.question,
+      session.modelSlugs,
+    );
+    const saved = await storage.addConsultAnswers(
+      toInsertRows(session.id, 0, answers),
+    );
+    await storage.updateConsultStatus(session.id, "answered");
+    return res.json({ round: 0, answers: saved });
+  });
+
+  // 2b — one debate round: models see each other's latest answers, refine. Manual.
+  app.post("/api/consult/:id/debate", async (req: Request, res: Response) => {
+    const session = await loadSession(req, res);
+    if (!session) return;
+    const existing = await storage.getConsultAnswers(session.id);
+    if (existing.length === 0) {
+      return res
+        .status(400)
+        .json({ error: "run the independent answers first (POST /answer)" });
+    }
+    const maxRound = existing.reduce((m, a) => Math.max(m, a.round), 0);
+    const prior: ConsultModelAnswer[] = latestPerModel(existing).map((a) => ({
+      modelSlug: a.modelSlug,
+      content: a.content,
+      errorMessage: a.errorMessage,
+    }));
+    const refined = await debate(
+      gateway,
+      session.question,
+      prior,
+      session.modelSlugs,
+    );
+    const round = maxRound + 1;
+    const saved = await storage.addConsultAnswers(
+      toInsertRows(session.id, round, refined),
+    );
+    await storage.updateConsultStatus(session.id, "debated");
+    return res.json({ round, answers: saved });
+  });
+
+  // 3 — handoff: connect the repo as a workspace, then start a standard loop.
+  app.post(
+    "/api/consult/:id/handoff",
+    validateBody(HandoffSchema),
+    async (req: Request, res: Response) => {
+      const session = await loadSession(req, res);
+      if (!session) return;
+      const userId = req.user!.id;
+      const body = req.body as z.infer<typeof HandoffSchema>;
+
+      let workspace: { id: string; path: string };
+      try {
+        workspace = await connectWorkspace(body.repoPath);
+      } catch (err) {
+        // The path is the caller's own input — safe to echo (not an fs leak).
+        return res
+          .status(400)
+          .json({ error: `could not connect workspace: ${errMsg(err)}` });
+      }
+
+      let loop;
+      try {
+        loop = await createConsiliumReview(reviewDeps, {
+          projectId: session.projectId,
+          repoPath: workspace.path,
+          createdBy: userId,
+          engineerInstruction: body.instruction,
+          preset: body.preset ?? "sdlc-cross-review",
+          maxRounds: body.maxRounds,
+        });
+      } catch (err) {
+        // The factory re-validates repoPath against the allowlist ∩ workspaces and
+        // names the rejected path (caller's own input) — surface it verbatim.
+        return res.status(400).json({ error: errMsg(err) });
+      }
+
+      await storage.setConsultHandoff(session.id, {
+        loopId: loop.id,
+        workspaceId: workspace.id,
+      });
+      return res.status(201).json({ loopId: loop.id, workspaceId: workspace.id });
+    },
+  );
+
+  // History — list (newest first).
+  app.get("/api/consult", async (req: Request, res: Response) => {
+    if (!req.projectId) return res.status(400).json({ error: "x-project-id header is required" });
+    const sessions = await storage.listConsultSessions(req.projectId);
+    return res.json({ sessions });
+  });
+
+  // History — one session + all answer rounds.
+  app.get("/api/consult/:id", async (req: Request, res: Response) => {
+    const session = await loadSession(req, res);
+    if (!session) return;
+    const answers = await storage.getConsultAnswers(session.id);
+    return res.json({ session, answers });
+  });
+}

--- a/server/services/consult/consult-service.ts
+++ b/server/services/consult/consult-service.ts
@@ -1,0 +1,187 @@
+/**
+ * Consult — standalone multi-model Q&A orchestration (workspace-independent).
+ *
+ * Pure orchestration over a NARROW gateway interface (mirrors reformulate.ts's
+ * ReformulateGateway) so this module never imports the heavy Gateway class and
+ * is trivially testable with a fake. No DB, no HTTP, no auth — the route layer
+ * owns persistence and access control; this file only turns a question + a set
+ * of model slugs into answers.
+ *
+ * Fail-soft is the core contract: one model failing (throwing, timing out, or
+ * returning empty) produces an errorMessage for THAT model only and never fails
+ * the batch — the operator still gets every other model's answer.
+ */
+
+/** The single gateway method this service needs (structurally compatible with Gateway). */
+export interface ConsultGateway {
+  completeStreaming(
+    request: {
+      modelSlug: string;
+      messages: Array<{ role: string; content: string }>;
+      temperature?: number;
+      maxTokens?: number;
+    },
+    privacyOptions?: unknown,
+    loggingOptions?: unknown,
+    streamOptions?: { overallTimeoutMs?: number },
+  ): Promise<{ content: string }>;
+}
+
+/** One model's output for a single round — content XOR errorMessage. */
+export interface ConsultModelAnswer {
+  modelSlug: string;
+  content: string | null;
+  errorMessage: string | null;
+}
+
+const ADVISOR_SYSTEM =
+  "You are a concise infrastructure & software-architecture advisor. Answer the " +
+  "operator's question directly: lead with a clear recommendation, then the key " +
+  "trade-offs and caveats. Prefer specifics over generalities. Do not ask " +
+  "clarifying questions — reason from the stated assumptions.";
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+const MAX_TOKENS = 2048;
+const TEMPERATURE = 0.4;
+const EMPTY_ANSWER = "the model returned an empty answer";
+
+function errText(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+/** Turn settled gateway results into fail-soft answers, order preserved. */
+function finalizeAnswers(
+  settled: PromiseSettledResult<{ content: string }>[],
+  modelSlugs: string[],
+): ConsultModelAnswer[] {
+  return settled.map((r, i) => {
+    const modelSlug = modelSlugs[i];
+    if (r.status === "rejected") {
+      return { modelSlug, content: null, errorMessage: errText(r.reason) };
+    }
+    const content = r.value.content?.trim();
+    if (!content) {
+      return { modelSlug, content: null, errorMessage: EMPTY_ANSWER };
+    }
+    return { modelSlug, content, errorMessage: null };
+  });
+}
+
+/**
+ * Ask each selected model the question INDEPENDENTLY, in parallel. Returns one
+ * answer per input slug, in input order.
+ */
+export async function answerIndependently(
+  gateway: ConsultGateway,
+  question: string,
+  modelSlugs: string[],
+  opts: { timeoutMs?: number } = {},
+): Promise<ConsultModelAnswer[]> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const settled = await Promise.allSettled(
+    modelSlugs.map((modelSlug) =>
+      gateway.completeStreaming(
+        {
+          modelSlug,
+          messages: [
+            { role: "system", content: ADVISOR_SYSTEM },
+            { role: "user", content: question },
+          ],
+          temperature: TEMPERATURE,
+          maxTokens: MAX_TOKENS,
+        },
+        undefined,
+        undefined,
+        { overallTimeoutMs: timeoutMs },
+      ),
+    ),
+  );
+  return finalizeAnswers(settled, modelSlugs);
+}
+
+function buildDebatePrompt(
+  question: string,
+  self: string,
+  others: Array<{ modelSlug: string; content: string }>,
+): string {
+  const peer = others.length
+    ? others.map((o) => `### Peer model ${o.modelSlug} answered:\n${o.content}`).join("\n\n")
+    : "(no other answers available)";
+  return [
+    `Original question:\n${question}`,
+    "",
+    "Your own previous answer:",
+    self || "(you did not produce a usable answer)",
+    "",
+    "Other models' answers:",
+    peer,
+    "",
+    "Now critique the other answers where you disagree, concede where they are " +
+      "stronger, and give your refined final recommendation. Be explicit about what " +
+      "you changed and why.",
+  ].join("\n");
+}
+
+/**
+ * One debate round: each model sees the OTHER models' latest answers (and its
+ * own) and returns a refined recommendation. Same fail-soft contract.
+ */
+export async function debate(
+  gateway: ConsultGateway,
+  question: string,
+  priorAnswers: ConsultModelAnswer[],
+  modelSlugs: string[],
+  opts: { timeoutMs?: number } = {},
+): Promise<ConsultModelAnswer[]> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const byModel = new Map(priorAnswers.map((a) => [a.modelSlug, a]));
+  const settled = await Promise.allSettled(
+    modelSlugs.map((modelSlug) => {
+      const self = byModel.get(modelSlug)?.content ?? "";
+      const others = priorAnswers
+        .filter((a) => a.modelSlug !== modelSlug && a.content)
+        .map((a) => ({ modelSlug: a.modelSlug, content: a.content as string }));
+      return gateway.completeStreaming(
+        {
+          modelSlug,
+          messages: [
+            { role: "system", content: ADVISOR_SYSTEM },
+            { role: "user", content: buildDebatePrompt(question, self, others) },
+          ],
+          temperature: TEMPERATURE,
+          maxTokens: MAX_TOKENS,
+        },
+        undefined,
+        undefined,
+        { overallTimeoutMs: timeoutMs },
+      );
+    }),
+  );
+  return finalizeAnswers(settled, modelSlugs);
+}
+
+/**
+ * Build the editable objective handed to the consilium loop on step 3. Carries
+ * the question plus each model's latest usable answer; the FE prefills this and
+ * the operator may trim/edit before starting the loop.
+ */
+export function buildHandoffInstruction(
+  question: string,
+  answers: ConsultModelAnswer[],
+): string {
+  const usable = answers.filter((a) => a.content);
+  const body = usable.length
+    ? usable.map((a) => `## ${a.modelSlug}\n${a.content}`).join("\n\n")
+    : "(no model answers were captured)";
+  return [
+    `# Consult question\n${question}`,
+    "",
+    "# Model answers",
+    body,
+    "",
+    "# Task",
+    "Using the question and the model answers above as context, implement the " +
+      "recommended approach. Validate the assumptions against the actual repository " +
+      "before making changes.",
+  ].join("\n");
+}

--- a/server/storage-pg.ts
+++ b/server/storage-pg.ts
@@ -57,6 +57,13 @@ import {
   consiliumLoopRounds,
   consiliumLoopSecrets,
   type ConsiliumLoopSecret,
+  consultSessions,
+  consultAnswers,
+  type ConsultSession,
+  type InsertConsultSession,
+  type ConsultAnswer,
+  type InsertConsultAnswer,
+  type ConsultStatus,
   experienceItems,
   type ExperienceItemRow,
   type InsertExperienceItem,
@@ -806,6 +813,65 @@ export class PgStorage implements IStorage {
         })),
       )
       .onConflictDoNothing();
+  }
+
+  async createConsultSession(
+    data: InsertConsultSession,
+  ): Promise<ConsultSession> {
+    const [row] = await db.insert(consultSessions).values(data).returning();
+    return row;
+  }
+
+  async getConsultSession(id: string): Promise<ConsultSession | undefined> {
+    const [row] = await db
+      .select()
+      .from(consultSessions)
+      .where(eq(consultSessions.id, id));
+    return row;
+  }
+
+  async listConsultSessions(projectId: string): Promise<ConsultSession[]> {
+    return db
+      .select()
+      .from(consultSessions)
+      .where(eq(consultSessions.projectId, projectId))
+      .orderBy(desc(consultSessions.createdAt));
+  }
+
+  async getConsultAnswers(sessionId: string): Promise<ConsultAnswer[]> {
+    return db
+      .select()
+      .from(consultAnswers)
+      .where(eq(consultAnswers.sessionId, sessionId))
+      .orderBy(asc(consultAnswers.createdAt));
+  }
+
+  async addConsultAnswers(
+    rows: InsertConsultAnswer[],
+  ): Promise<ConsultAnswer[]> {
+    if (rows.length === 0) return [];
+    return db.insert(consultAnswers).values(rows).returning();
+  }
+
+  async updateConsultStatus(id: string, status: ConsultStatus): Promise<void> {
+    await db
+      .update(consultSessions)
+      .set({ status })
+      .where(eq(consultSessions.id, id));
+  }
+
+  async setConsultHandoff(
+    id: string,
+    p: { loopId: string; workspaceId: string },
+  ): Promise<void> {
+    await db
+      .update(consultSessions)
+      .set({
+        loopId: p.loopId,
+        workspaceId: p.workspaceId,
+        status: "handed_off",
+      })
+      .where(eq(consultSessions.id, id));
   }
 
   async getLoopsByOwner(ownerId: string): Promise<ConsiliumLoopRow[]> {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -24,6 +24,11 @@ import {
   type ConsiliumLoopRow,
   type InsertConsiliumLoop,
   type ConsiliumLoopSecret,
+  type ConsultSession,
+  type InsertConsultSession,
+  type ConsultAnswer,
+  type InsertConsultAnswer,
+  type ConsultStatus,
   type ConsiliumLoopRoundRow,
   type InsertConsiliumLoopRound,
   type ConsiliumLoopState,
@@ -453,6 +458,18 @@ export interface IStorage {
     credentialIds: string[];
     createdBy: string;
   }): Promise<void>;
+  // ─── Consult — standalone multi-model Q&A (workspace-independent) ───────────
+  createConsultSession(data: InsertConsultSession): Promise<ConsultSession>;
+  getConsultSession(id: string): Promise<ConsultSession | undefined>;
+  listConsultSessions(projectId: string): Promise<ConsultSession[]>;
+  getConsultAnswers(sessionId: string): Promise<ConsultAnswer[]>;
+  addConsultAnswers(rows: InsertConsultAnswer[]): Promise<ConsultAnswer[]>;
+  updateConsultStatus(id: string, status: ConsultStatus): Promise<void>;
+  /** Step 3 handoff — record the loop + workspace this session became. */
+  setConsultHandoff(
+    id: string,
+    p: { loopId: string; workspaceId: string },
+  ): Promise<void>;
   /** Loops created by `ownerId`, newest first (owner-scoped list, mirror task-groups). */
   getLoopsByOwner(ownerId: string): Promise<ConsiliumLoopRow[]>;
   /** All loops (admin list / poller backstop sweep). */
@@ -1411,6 +1428,9 @@ export class MemStorage implements IStorage {
   private consiliumLoopRoundsMap: Map<string, ConsiliumLoopRoundRow> = new Map();
   // ADR-003 §D2 — loop→secret bindings (the bound set consulted by issueLease).
   private consiliumLoopSecretRows: ConsiliumLoopSecret[] = [];
+  // Consult — standalone multi-model Q&A sessions + their per-round answers.
+  private consultSessionsRows: ConsultSession[] = [];
+  private consultAnswersRows: ConsultAnswer[] = [];
 
   /** Mirror the DB partial-unique index: at most one non-terminal loop/group. */
   private isLoopActive(row: ConsiliumLoopRow): boolean {
@@ -1509,6 +1529,74 @@ export class MemStorage implements IStorage {
         createdBy: p.createdBy,
         createdAt: now,
       });
+    }
+  }
+
+  async createConsultSession(
+    data: InsertConsultSession,
+  ): Promise<ConsultSession> {
+    const row: ConsultSession = {
+      id: data.id ?? randomUUID(),
+      projectId: data.projectId,
+      question: data.question,
+      modelSlugs: data.modelSlugs ?? [],
+      status: data.status ?? "created",
+      createdBy: data.createdBy,
+      createdAt: data.createdAt ?? new Date(),
+      loopId: data.loopId ?? null,
+      workspaceId: data.workspaceId ?? null,
+    };
+    this.consultSessionsRows.push(row);
+    return row;
+  }
+
+  async getConsultSession(id: string): Promise<ConsultSession | undefined> {
+    return this.consultSessionsRows.find((r) => r.id === id);
+  }
+
+  async listConsultSessions(projectId: string): Promise<ConsultSession[]> {
+    return this.consultSessionsRows
+      .filter((r) => r.projectId === projectId)
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  }
+
+  async getConsultAnswers(sessionId: string): Promise<ConsultAnswer[]> {
+    return this.consultAnswersRows
+      .filter((r) => r.sessionId === sessionId)
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  }
+
+  async addConsultAnswers(
+    rows: InsertConsultAnswer[],
+  ): Promise<ConsultAnswer[]> {
+    const now = new Date();
+    const created: ConsultAnswer[] = rows.map((r) => ({
+      id: r.id ?? randomUUID(),
+      sessionId: r.sessionId,
+      modelSlug: r.modelSlug,
+      round: r.round ?? 0,
+      content: r.content ?? null,
+      errorMessage: r.errorMessage ?? null,
+      createdAt: r.createdAt ?? now,
+    }));
+    this.consultAnswersRows.push(...created);
+    return created;
+  }
+
+  async updateConsultStatus(id: string, status: ConsultStatus): Promise<void> {
+    const row = this.consultSessionsRows.find((r) => r.id === id);
+    if (row) row.status = status;
+  }
+
+  async setConsultHandoff(
+    id: string,
+    p: { loopId: string; workspaceId: string },
+  ): Promise<void> {
+    const row = this.consultSessionsRows.find((r) => r.id === id);
+    if (row) {
+      row.loopId = p.loopId;
+      row.workspaceId = p.workspaceId;
+      row.status = "handed_off";
     }
   }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -2441,3 +2441,61 @@ export const insertSkillProposalSchema = createInsertSchema(skillProposals).omit
 });
 export type InsertSkillProposal = typeof skillProposals.$inferInsert;
 export type SkillProposalRow = typeof skillProposals.$inferSelect;
+
+// ─── Consult — standalone multi-model Q&A (workspace-independent) ──────────────
+// A lightweight "ask several models a strategic question, compare answers, then
+// optionally hand off into a standard consilium loop" flow. Not repo-bound.
+export const CONSULT_STATUSES = [
+  "created",
+  "answered",
+  "debated",
+  "handed_off",
+] as const;
+export type ConsultStatus = (typeof CONSULT_STATUSES)[number];
+
+export const consultSessions = pgTable("consult_sessions", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  projectId: text("project_id")
+    .references(() => projects.id, { onDelete: "cascade" })
+    .notNull(),
+  question: text("question").notNull(),
+  /** The operator-selected model slugs for this session. */
+  modelSlugs: jsonb("model_slugs")
+    .notNull()
+    .default(sql`'[]'::jsonb`)
+    .$type<string[]>(),
+  status: text("status").notNull().default("created").$type<ConsultStatus>(),
+  createdBy: text("created_by").notNull(),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  /** Set on handoff (step 3) — the consilium loop + workspace this became. */
+  loopId: text("loop_id"),
+  workspaceId: text("workspace_id"),
+});
+export type ConsultSession = typeof consultSessions.$inferSelect;
+export type InsertConsultSession = typeof consultSessions.$inferInsert;
+
+export const consultAnswers = pgTable(
+  "consult_answers",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    sessionId: text("session_id")
+      .references(() => consultSessions.id, { onDelete: "cascade" })
+      .notNull(),
+    modelSlug: text("model_slug").notNull(),
+    /** 0 = independent answer; 1+ = debate rounds. */
+    round: integer("round").notNull().default(0),
+    /** Model output; null when this model failed (see errorMessage). */
+    content: text("content"),
+    errorMessage: text("error_message"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (table) => ({
+    sessionIdx: index("consult_answers_session_id_idx").on(table.sessionId),
+  }),
+);
+export type ConsultAnswer = typeof consultAnswers.$inferSelect;
+export type InsertConsultAnswer = typeof consultAnswers.$inferInsert;

--- a/tests/unit/consult/consult-route.test.ts
+++ b/tests/unit/consult/consult-route.test.ts
@@ -1,0 +1,236 @@
+/**
+ * consult-route.test.ts — the standalone multi-model Q&A endpoints, end-to-end
+ * through the real route → service path with a FAKE gateway/storage/workspace.
+ *
+ * Covers the contract that matters at the HTTP boundary:
+ *   - create validates models against the active catalog (unknown ⇒ 400, nothing saved);
+ *   - /answer runs one gateway call per model and persists round 0 (status → answered);
+ *   - /debate refuses before any answers (400), else persists the next round;
+ *   - /handoff connects a workspace, starts a loop, and records loopId/workspaceId;
+ *   - access is project-scoped + owner-or-admin (403 for a stranger, 404 cross-project).
+ *
+ * createConsiliumReview is module-mocked — the handoff wiring is what we assert, not
+ * the (separately tested) loop factory.
+ */
+import { describe, it, expect, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+
+vi.mock("../../../server/services/consilium/review-factory.js", () => ({
+  createConsiliumReview: vi.fn(async () => ({ id: "loop-1" })),
+}));
+
+import { registerConsultRoutes } from "../../../server/routes/consult.js";
+import { createConsiliumReview } from "../../../server/services/consilium/review-factory.js";
+import type { ConsultGateway } from "../../../server/services/consult/consult-service.js";
+import type { IStorage } from "../../../server/storage.js";
+
+/** Minimal in-memory storage covering only the methods the routes touch. */
+function makeStorage(activeSlugs: string[]) {
+  const sessions = new Map<string, Record<string, unknown>>();
+  const answers: Array<Record<string, unknown>> = [];
+  let seq = 0;
+  const store = {
+    async getActiveModels() {
+      return activeSlugs.map((slug) => ({ slug }));
+    },
+    async createConsultSession(data: Record<string, unknown>) {
+      const row = {
+        id: `s${++seq}`,
+        status: "created",
+        createdAt: new Date(),
+        loopId: null,
+        workspaceId: null,
+        ...data,
+      };
+      sessions.set(row.id as string, row);
+      return row;
+    },
+    async getConsultSession(id: string) {
+      return sessions.get(id);
+    },
+    async listConsultSessions(projectId: string) {
+      return [...sessions.values()].filter((s) => s.projectId === projectId);
+    },
+    async getConsultAnswers(sessionId: string) {
+      return answers.filter((a) => a.sessionId === sessionId);
+    },
+    async addConsultAnswers(rows: Array<Record<string, unknown>>) {
+      const created = rows.map((r) => ({ id: `a${++seq}`, createdAt: new Date(), ...r }));
+      answers.push(...created);
+      return created;
+    },
+    async updateConsultStatus(id: string, status: string) {
+      const s = sessions.get(id);
+      if (s) s.status = status;
+    },
+    async setConsultHandoff(id: string, p: { loopId: string; workspaceId: string }) {
+      const s = sessions.get(id);
+      if (s) {
+        s.loopId = p.loopId;
+        s.workspaceId = p.workspaceId;
+        s.status = "handed_off";
+      }
+    },
+  };
+  return { store: store as unknown as IStorage, sessions, answers };
+}
+
+type Requester = { userId?: string; role?: string; projectId?: string };
+
+/** Mount the consult routes over a given store, impersonating one requester. */
+function mount(store: IStorage, who: Requester = {}) {
+  const gatewaySpy = vi.fn(async () => ({ content: "recommendation" }));
+  const connectSpy = vi.fn(async () => ({ id: "ws-1", path: "/canon/repo" }));
+  const app = express();
+  app.use(express.json());
+  // Stand in for requireAuth + requireProject (applied at mount in routes.ts).
+  app.use((req, _res, next) => {
+    (req as unknown as { user: { id: string; role: string } }).user = {
+      id: who.userId ?? "user-1",
+      role: who.role ?? "member",
+    };
+    (req as unknown as { projectId: string }).projectId = who.projectId ?? "project-1";
+    next();
+  });
+  registerConsultRoutes(app, {
+    storage: store,
+    gateway: { completeStreaming: gatewaySpy } as unknown as ConsultGateway,
+    reviewDeps: {} as never,
+    connectWorkspace: connectSpy,
+  });
+  return { app, gatewaySpy, connectSpy };
+}
+
+function makeApp(opts: { activeSlugs?: string[] } & Requester = {}) {
+  const { store, sessions } = makeStorage(opts.activeSlugs ?? ["m1", "m2"]);
+  const { app, gatewaySpy, connectSpy } = mount(store, opts);
+  return { app, store, sessions, gatewaySpy, connectSpy };
+}
+
+async function createSession(app: express.Express, modelSlugs = ["m1", "m2"]) {
+  return request(app)
+    .post("/api/consult")
+    .send({ question: "should I use cloud WAN?", modelSlugs });
+}
+
+describe("POST /api/consult", () => {
+  it("creates a session for models in the active catalog", async () => {
+    const { app } = makeApp();
+    const res = await createSession(app);
+    expect(res.status).toBe(201);
+    expect(res.body.question).toBe("should I use cloud WAN?");
+    expect(res.body.modelSlugs).toEqual(["m1", "m2"]);
+    expect(res.body.status).toBe("created");
+  });
+
+  it("rejects an unknown/inactive model with 400 and persists nothing", async () => {
+    const { app, sessions } = makeApp({ activeSlugs: ["m1"] });
+    const res = await createSession(app, ["m1", "ghost"]);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("ghost");
+    expect(sessions.size).toBe(0);
+  });
+
+  it("rejects an empty question with 400 (zod, before catalog lookup)", async () => {
+    const { app } = makeApp();
+    const res = await request(app).post("/api/consult").send({ question: "  ", modelSlugs: ["m1"] });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/consult/:id/answer", () => {
+  it("runs one gateway call per model, persists round 0, marks answered", async () => {
+    const { app, gatewaySpy } = makeApp();
+    const { body: session } = await createSession(app);
+    const res = await request(app).post(`/api/consult/${session.id}/answer`).send({});
+    expect(res.status).toBe(200);
+    expect(res.body.round).toBe(0);
+    expect(res.body.answers).toHaveLength(2);
+    expect(gatewaySpy).toHaveBeenCalledTimes(2);
+
+    const get = await request(app).get(`/api/consult/${session.id}`);
+    expect(get.body.session.status).toBe("answered");
+    expect(get.body.answers).toHaveLength(2);
+  });
+
+  it("404s cross-project (same store, different project context)", async () => {
+    const { store } = makeApp();
+    const owner = mount(store, { projectId: "project-1" });
+    const { body: session } = await createSession(owner.app);
+    const stranger = mount(store, { projectId: "project-2" });
+    const res = await request(stranger.app).post(`/api/consult/${session.id}/answer`).send({});
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/consult/:id/debate", () => {
+  it("refuses before any answers (400)", async () => {
+    const { app } = makeApp();
+    const { body: session } = await createSession(app);
+    const res = await request(app).post(`/api/consult/${session.id}/debate`).send({});
+    expect(res.status).toBe(400);
+  });
+
+  it("persists the next round after answers exist", async () => {
+    const { app, gatewaySpy } = makeApp();
+    const { body: session } = await createSession(app);
+    await request(app).post(`/api/consult/${session.id}/answer`).send({});
+    gatewaySpy.mockClear();
+    const res = await request(app).post(`/api/consult/${session.id}/debate`).send({});
+    expect(res.status).toBe(200);
+    expect(res.body.round).toBe(1);
+    expect(res.body.answers).toHaveLength(2);
+    expect(gatewaySpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("POST /api/consult/:id/handoff", () => {
+  it("connects a workspace, starts a loop, records the ids", async () => {
+    const { app, connectSpy, store } = makeApp();
+    const { body: session } = await createSession(app);
+    const res = await request(app)
+      .post(`/api/consult/${session.id}/handoff`)
+      .send({ repoPath: "/my/repo", instruction: "do the thing" });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ loopId: "loop-1", workspaceId: "ws-1" });
+    expect(connectSpy).toHaveBeenCalledWith("/my/repo");
+    expect(vi.mocked(createConsiliumReview)).toHaveBeenCalledTimes(1);
+
+    const persisted = await store.getConsultSession(session.id);
+    expect(persisted?.loopId).toBe("loop-1");
+    expect(persisted?.status).toBe("handed_off");
+  });
+
+  it("rejects an empty instruction with 400 before any side effect", async () => {
+    const { app, connectSpy } = makeApp();
+    const { body: session } = await createSession(app);
+    const res = await request(app)
+      .post(`/api/consult/${session.id}/handoff`)
+      .send({ repoPath: "/my/repo", instruction: "" });
+    expect(res.status).toBe(400);
+    expect(connectSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("access control", () => {
+  it("403s for a non-owner non-admin viewing the session", async () => {
+    const { store } = makeApp();
+    const owner = mount(store, { userId: "user-1" });
+    const { body: session } = await createSession(owner.app);
+    const stranger = mount(store, { userId: "user-2", role: "member" });
+    const res = await request(stranger.app).get(`/api/consult/${session.id}`);
+    expect(res.status).toBe(403);
+  });
+
+  it("lets an admin view another user's session", async () => {
+    const { store } = makeApp();
+    const owner = mount(store, { userId: "user-1" });
+    const { body: session } = await createSession(owner.app);
+    const admin = mount(store, { userId: "admin-9", role: "admin" });
+    const res = await request(admin.app).get(`/api/consult/${session.id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.session.id).toBe(session.id);
+  });
+});

--- a/tests/unit/consult/consult-service.test.ts
+++ b/tests/unit/consult/consult-service.test.ts
@@ -1,0 +1,127 @@
+/**
+ * consult-service.test.ts — the standalone multi-model Q&A orchestration.
+ *
+ * Drives the service with a FAKE gateway (no real LLM), asserting the contract:
+ *   - answers run in parallel, one per selected model, in input order;
+ *   - one model failing (throw / empty) isolates to that model's errorMessage —
+ *     the batch still returns every other model's answer;
+ *   - a debate round feeds each model the OTHER models' answers (not its own);
+ *   - the handoff instruction carries the question + usable answers.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  answerIndependently,
+  debate,
+  buildHandoffInstruction,
+  type ConsultGateway,
+  type ConsultModelAnswer,
+} from "../../../server/services/consult/consult-service";
+
+type Handler = (modelSlug: string, userContent: string) => Promise<{ content: string }>;
+
+/** A fake gateway that records calls and delegates to a per-model handler. */
+class FakeGateway implements ConsultGateway {
+  public readonly calls: Array<{ modelSlug: string; user: string; system: string }> = [];
+  constructor(private readonly handler: Handler) {}
+
+  async completeStreaming(request: {
+    modelSlug: string;
+    messages: Array<{ role: string; content: string }>;
+  }): Promise<{ content: string }> {
+    const user = request.messages.find((m) => m.role === "user")?.content ?? "";
+    const system = request.messages.find((m) => m.role === "system")?.content ?? "";
+    this.calls.push({ modelSlug: request.modelSlug, user, system });
+    return this.handler(request.modelSlug, user);
+  }
+}
+
+describe("answerIndependently", () => {
+  it("returns one answer per model, in input order", async () => {
+    const gw = new FakeGateway(async (slug) => ({ content: `answer from ${slug}` }));
+    const out = await answerIndependently(gw, "use cloud WAN?", ["gpt-x", "claude-y"]);
+
+    expect(out.map((a) => a.modelSlug)).toEqual(["gpt-x", "claude-y"]);
+    expect(out[0]).toEqual({ modelSlug: "gpt-x", content: "answer from gpt-x", errorMessage: null });
+    expect(out[1].content).toBe("answer from claude-y");
+    expect(out.every((a) => a.errorMessage === null)).toBe(true);
+  });
+
+  it("isolates a failing model without failing the batch", async () => {
+    const gw = new FakeGateway(async (slug) => {
+      if (slug === "bad") throw new Error("provider exploded");
+      return { content: `ok ${slug}` };
+    });
+    const out = await answerIndependently(gw, "q", ["good", "bad", "also-good"]);
+
+    expect(out[0]).toMatchObject({ modelSlug: "good", content: "ok good", errorMessage: null });
+    expect(out[1]).toMatchObject({ modelSlug: "bad", content: null });
+    expect(out[1].errorMessage).toContain("provider exploded");
+    expect(out[2]).toMatchObject({ modelSlug: "also-good", content: "ok also-good" });
+  });
+
+  it("treats empty/whitespace output as a per-model error", async () => {
+    const gw = new FakeGateway(async () => ({ content: "   " }));
+    const out = await answerIndependently(gw, "q", ["m1"]);
+    expect(out[0].content).toBeNull();
+    expect(out[0].errorMessage).toBe("the model returned an empty answer");
+  });
+});
+
+describe("debate", () => {
+  it("feeds each model the OTHER models' answers, not its own", async () => {
+    const prior: ConsultModelAnswer[] = [
+      { modelSlug: "alpha", content: "ALPHA_SAYS_YES", errorMessage: null },
+      { modelSlug: "beta", content: "BETA_SAYS_NO", errorMessage: null },
+    ];
+    const gw = new FakeGateway(async (slug) => ({ content: `refined ${slug}` }));
+    await debate(gw, "the question", prior, ["alpha", "beta"]);
+
+    const alphaCall = gw.calls.find((c) => c.modelSlug === "alpha")!;
+    const betaCall = gw.calls.find((c) => c.modelSlug === "beta")!;
+
+    // alpha sees beta's answer but not its own text quoted as a "peer"
+    expect(alphaCall.user).toContain("BETA_SAYS_NO");
+    expect(alphaCall.user).toContain("Peer model beta");
+    expect(alphaCall.user).not.toContain("Peer model alpha");
+    // beta sees alpha's answer
+    expect(betaCall.user).toContain("ALPHA_SAYS_YES");
+    expect(betaCall.user).toContain("the question");
+  });
+
+  it("still runs a model whose prior answer errored", async () => {
+    const prior: ConsultModelAnswer[] = [
+      { modelSlug: "alpha", content: null, errorMessage: "timed out" },
+      { modelSlug: "beta", content: "BETA_ANSWER", errorMessage: null },
+    ];
+    const gw = new FakeGateway(async (slug) => ({ content: `refined ${slug}` }));
+    const out = await debate(gw, "q", prior, ["alpha", "beta"]);
+
+    expect(out.map((a) => a.modelSlug)).toEqual(["alpha", "beta"]);
+    const alphaCall = gw.calls.find((c) => c.modelSlug === "alpha")!;
+    expect(alphaCall.user).toContain("BETA_ANSWER");
+    expect(out[0].content).toBe("refined alpha");
+  });
+});
+
+describe("buildHandoffInstruction", () => {
+  it("carries the question and each usable answer, skips failed ones", () => {
+    const answers: ConsultModelAnswer[] = [
+      { modelSlug: "alpha", content: "recommend option A", errorMessage: null },
+      { modelSlug: "beta", content: null, errorMessage: "failed" },
+    ];
+    const text = buildHandoffInstruction("should I use cloud WAN?", answers);
+
+    expect(text).toContain("should I use cloud WAN?");
+    expect(text).toContain("## alpha");
+    expect(text).toContain("recommend option A");
+    expect(text).not.toContain("## beta");
+    expect(text).toContain("# Task");
+  });
+
+  it("degrades gracefully when no answers are usable", () => {
+    const text = buildHandoffInstruction("q", [
+      { modelSlug: "m", content: null, errorMessage: "x" },
+    ]);
+    expect(text).toContain("(no model answers were captured)");
+  });
+});


### PR DESCRIPTION
## What

A new **workspace-independent "Consult"** surface (left-nav item), like "Large research" but not repo-bound. Three **manual** steps:

1. **Ask** — type a strategic question (e.g. *"should I use Cloud WAN for a small infra?"*), multi-select models from the **active catalog**.
2. **Answers** — each selected model answers **independently** (side-by-side). An optional **Debate** button runs one round where each model sees the others' answers and refines (re-runnable).
3. **Handoff** — enter a repo path → connect a **workspace** → start a **standard consilium loop**, carrying the question + answers as the editable objective.

Sessions are **persisted** (history rail). Composes existing primitives — no new gateway/model/loop infra.

## How

- **schema** (`shared/schema.ts`): `consult_sessions` + `consult_answers`; migration `0064_consult.sql`.
- **storage**: consult CRUD across `IStorage` + `MemStorage` + `PgStorage`.
- **service** (`server/services/consult/consult-service.ts`): pure orchestration over a narrow gateway iface (mirrors `reformulate.ts`); **fail-soft** — one model failing isolates to its own `errorMessage`, never fails the batch. `answerIndependently` / `debate` / `buildHandoffInstruction`.
- **routes** (`server/routes/consult.ts`): `POST /api/consult`, `/:id/answer`, `/:id/debate`, `/:id/handoff`, `GET /api/consult[/:id]`. Mounted behind `requireAuth + requireProject`; project-scoped + owner-or-admin; models validated against the active catalog; handoff reuses `createConsiliumReview` (its allowlist ∩ workspace check still applies) + `WorkspaceManager.connectLocal`.
- **ui**: `Consult.tsx` (3-step + history), `use-consult.ts` hooks, nav item.

## ⚠️ Human gate

- **`migrations/0064_consult.sql` is generated, NOT applied.** Apply it to the target DB before the routes are exercised (additive `CREATE TABLE IF NOT EXISTS` + one index; no data).

## Verification

- `tsc` (`npm run check`) clean across client + server + shared.
- `vitest --project unit tests/unit/consult/` → **18 passed** (7 service + 11 route), deterministic ×3.
- Adjacent route-registration tests (`reformulate-route`, `consilium-reviews-route`) → 19 passed (no regression).
- Live end-to-end smoke (create → answer → debate → handoff on :5050) is **pending merge + migration apply + server restart from this branch**.

## Constraints honored

Feature branch + Draft PR (no direct-to-main); no `config.yaml`/`.env` touched; no `terraform/apply`; migration generated-not-applied; no `any` in production files.