### PR TITLE
feat(consilium): graceful "Finish" action to stop a loop

### DIFF
--- a/client/src/components/consilium/loop-state.tsx
+++ b/client/src/components/consilium/loop-state.tsx
@@ -63,6 +63,7 @@ export const LOOP_STATE_STYLE: Record<ClientLoopState, StateStyle> = {
   escalated: { label: "Escalated", badge: "bg-orange-500 text-white", dot: "bg-orange-500" },
   failed: { label: "Failed", badge: "bg-red-600 text-white", dot: "bg-red-500" },
   cancelled: { label: "Cancelled", badge: "bg-slate-400 text-white", dot: "bg-slate-400" },
+  stopped: { label: "Finished", badge: "bg-slate-600 text-white", dot: "bg-slate-500" },
   // Agent-limit throttling (MVP): a deliberate, non-terminal PAUSE (agent usage/
   // rate limit hit) — amber like `awaiting_merge`, but the dot doesn't pulse
   // (nothing is actively running while paused) so it reads distinctly from the

--- a/client/src/hooks/use-consilium-loops.ts
+++ b/client/src/hooks/use-consilium-loops.ts
@@ -327,6 +327,7 @@ const TERMINAL_STATES: ReadonlySet<ConsiliumLoopState> = new Set<ConsiliumLoopSt
   "escalated",
   "failed",
   "cancelled",
+  "stopped",
 ]);
 
 /**
@@ -422,6 +423,18 @@ export function useCancelLoop() {
   const qc = useQueryClient();
   return useMutation<ConsiliumLoopRow, Error, string>({
     mutationFn: (id) => apiRequest("POST", `${LIST_KEY}/${id}/cancel`),
+    onSuccess: (_data, id) => {
+      qc.invalidateQueries({ queryKey: [LIST_KEY, id] });
+      qc.invalidateQueries({ queryKey: [LIST_KEY] });
+    },
+  });
+}
+
+/** Graceful FINISH — end the loop (state `stopped`), distinct from cancel. */
+export function useStopLoop() {
+  const qc = useQueryClient();
+  return useMutation<ConsiliumLoopRow, Error, string>({
+    mutationFn: (id) => apiRequest("POST", `${LIST_KEY}/${id}/stop`),
     onSuccess: (_data, id) => {
       qc.invalidateQueries({ queryKey: [LIST_KEY, id] });
       qc.invalidateQueries({ queryKey: [LIST_KEY] });

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -33,6 +33,7 @@ import {
   Clock,
   Play,
   Ban,
+  Flag,
   GitMerge,
   Hammer,
   Tag,
@@ -60,6 +61,7 @@ import {
   useConsiliumLoop,
   useStartLoop,
   useCancelLoop,
+  useStopLoop,
   useApproveMerge,
   useDevelopLoop,
   useRequestReReview,
@@ -2732,6 +2734,7 @@ export default function ConsiliumLoopDetail() {
 
   const startLoop = useStartLoop();
   const cancelLoop = useCancelLoop();
+  const stopLoop = useStopLoop();
   const approveMerge = useApproveMerge();
   const developLoop = useDevelopLoop();
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -2806,6 +2809,19 @@ export default function ConsiliumLoopDetail() {
       toast({
         variant: "destructive",
         title: "Could not cancel loop",
+        description: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  async function handleFinish() {
+    try {
+      await stopLoop.mutateAsync(id);
+      toast({ title: "Loop finished" });
+    } catch (err) {
+      toast({
+        variant: "destructive",
+        title: "Could not finish loop",
         description: err instanceof Error ? err.message : String(err),
       });
     }
@@ -2918,6 +2934,22 @@ export default function ConsiliumLoopDetail() {
                   <Hammer className="mr-2 h-4 w-4" />
                 )}
                 Hand off to SDLC
+              </Button>
+            )}
+            {canCancel && (
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={handleFinish}
+                disabled={stopLoop.isPending}
+                title="End the loop and keep what it produced (not an abort)"
+              >
+                {stopLoop.isPending ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Flag className="mr-2 h-4 w-4" />
+                )}
+                Finish
               </Button>
             )}
             {canCancel && (

--- a/server/routes/consilium-loops.ts
+++ b/server/routes/consilium-loops.ts
@@ -641,6 +641,27 @@ export function registerConsiliumLoopRoutes(
     if (!loop) return res.status(409).json({ error: "loop is already terminal" });
     res.json(loop);
   });
+
+  // ── Stop / Finish (any non-terminal → STOPPED) ──────────────────────────────
+  // Graceful operator finish — "I'm satisfied" / "I don't want to continue".
+  // Same body + auth + actor resolution as cancel, but a NON-abort terminal
+  // (`stopped`), so the loop keeps whatever it produced and simply ends.
+  app.post("/api/consilium-loops/:id/stop", async (req: Request, res: Response) => {
+    const auth = await authorizeConsiliumLoop(req, res, storage, String(req.params.id));
+    if (!auth) return;
+    const parsed = CancelLoopSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: "Validation failed",
+        issues: parsed.error.issues.map((i) => ({ path: i.path, message: i.message })),
+      });
+    }
+    const reason = sanitizeReason(parsed.data.reason);
+    const actor = req.user?.name?.trim() || req.user?.email || req.user?.id || undefined;
+    const loop = await controller.stop(auth.loop.id, { reason, actor });
+    if (!loop) return res.status(409).json({ error: "loop is already terminal" });
+    res.json(loop);
+  });
 }
 
 /**

--- a/server/services/consilium/consilium-loop-controller.ts
+++ b/server/services/consilium/consilium-loop-controller.ts
@@ -136,7 +136,13 @@ export type LoopEvent =
   // (both already clamped + control-stripped at the route — untrusted). Absent on
   // an auto-cancel (an API POST with no body); the reducer still records a
   // never-blank terminal explanation. See `composeCancelExplanation`.
-  | { kind: "cancel"; reason?: string; actor?: string };
+  | { kind: "cancel"; reason?: string; actor?: string }
+  // Operator graceful FINISH ("satisfied / don't want to continue") — a TERMINAL,
+  // NON-abort stop from any non-terminal state. Same untrusted `reason`/`actor`
+  // shape as `cancel`; the reducer records a never-blank explanation. Distinct
+  // target (`stopped`) so it is neither an abort (`cancelled`) nor a success
+  // (`converged`). See `composeFinishExplanation`.
+  | { kind: "finish"; reason?: string; actor?: string };
 
 /** A single FSM transition: CAS `from → to`, plus optional column updates. */
 export interface LoopTransition {
@@ -636,6 +642,14 @@ export function composeCancelExplanation(at: Date, actor?: string, reason?: stri
   return r ? `${base} — ${r}` : base;
 }
 
+/** The terminal note recorded on a graceful operator FINISH (see `finish` event). */
+export function composeFinishExplanation(at: Date, actor?: string, reason?: string): string {
+  const who = actor && actor.trim() ? actor.trim() : "system";
+  const base = `Finished by ${who} at ${at.toISOString()}`;
+  const r = reason?.trim();
+  return r ? `${base} — ${r}` : base;
+}
+
 /**
  * PURE reducer (design §3 table). Given the current persisted `state` and an
  * `event`, return the single transition to commit, or `null` for a no-op.
@@ -668,6 +682,19 @@ export function reduce(
       from: state,
       to: "cancelled",
       extra: { completedAt: at, error: composeCancelExplanation(at, event.actor, event.reason) },
+    };
+  }
+
+  // Graceful operator FINISH — symmetric to cancel, but terminates to `stopped`
+  // (a NON-abort, NON-success end). The `error` column carries the note only;
+  // no counter/filter keys off `error != null` — they gate on `state`.
+  if (event.kind === "finish") {
+    if (isTerminal(state)) return null;
+    const at = new Date();
+    return {
+      from: state,
+      to: "stopped",
+      extra: { completedAt: at, error: composeFinishExplanation(at, event.actor, event.reason) },
     };
   }
 
@@ -859,7 +886,8 @@ function isTerminal(state: ConsiliumLoopState): boolean {
     state === "stopped_cap" ||
     state === "escalated" ||
     state === "failed" ||
-    state === "cancelled"
+    state === "cancelled" ||
+    state === "stopped"
   );
 }
 
@@ -1773,6 +1801,29 @@ export class ConsiliumLoopController {
     if (!transition) return null;
     await this.deps.taskOrchestrator.cancelGroup(loop.groupId).catch(() => undefined);
     this.sdlcRuns.delete(loopId); // H-2: drop any in-flight SDLC handle (terminal).
+    return this.commit(loop, transition);
+  }
+
+  /**
+   * Graceful operator FINISH — the "I'm satisfied / don't want to continue"
+   * terminal. Mirrors `cancel()` (stops the child group + drops the SDLC handle,
+   * since `stopped` is terminal) but records a NON-abort explanation and lands in
+   * `stopped`. Returns null if the loop is missing or already terminal.
+   */
+  async stop(
+    loopId: string,
+    opts?: { reason?: string; actor?: string },
+  ): Promise<ConsiliumLoopRow | null> {
+    const loop = await this.storage.getLoop(loopId);
+    if (!loop || isTerminal(loop.state)) return null;
+    const transition = reduce(loop.state, {
+      kind: "finish",
+      reason: opts?.reason,
+      actor: opts?.actor,
+    });
+    if (!transition) return null;
+    await this.deps.taskOrchestrator.cancelGroup(loop.groupId).catch(() => undefined);
+    this.sdlcRuns.delete(loopId); // drop any in-flight SDLC handle (terminal).
     return this.commit(loop, transition);
   }
 

--- a/shared/loop-status.ts
+++ b/shared/loop-status.ts
@@ -291,6 +291,18 @@ export function explainLoopState(loop: LoopStatusInput): LoopStatusExplanation {
           : "This loop was cancelled by an operator. No reason was recorded.",
       };
 
+    case "stopped":
+      return {
+        title: "Finished",
+        // A graceful operator finish ("satisfied / didn't want to continue"):
+        // NOT an abort and NOT a failure — the loop kept whatever it produced.
+        tone: "good",
+        // The composed "Finished by <actor> at <ISO> — <reason>".
+        detail: loop.error
+          ? loop.error
+          : "An operator finished this loop and kept what it produced.",
+      };
+
     case "throttled":
       // Agent usage/rate limit hit during review/develop → NON-terminal RESTING
       // pause (not a failure). The operator retries when their quota resets.

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1782,6 +1782,12 @@ export const CONSILIUM_LOOP_STATES = [
   "escalated",
   "failed",
   "cancelled",
+  // Operator-initiated graceful stop — "I'm satisfied / I don't want to
+  // continue". A TERMINAL, NON-abort finish distinct from `cancelled`: it keeps
+  // whatever the loop produced and simply ends it (no success side-effects like
+  // `converged`, no abort framing like `cancelled`). Reachable from any
+  // non-terminal state via the `finish` event.
+  "stopped",
 ] as const;
 export type ConsiliumLoopState = typeof CONSILIUM_LOOP_STATES[number];
 
@@ -1792,6 +1798,7 @@ export const CONSILIUM_LOOP_TERMINAL_STATES = [
   "escalated",
   "failed",
   "cancelled",
+  "stopped",
 ] as const satisfies readonly ConsiliumLoopState[];
 
 // ADR-0003 I1 (re-scoped, GH #445 P1): the loop's autonomy CLASS — additive

--- a/tests/unit/consilium/consilium-loops-develop-route.test.ts
+++ b/tests/unit/consilium/consilium-loops-develop-route.test.ts
@@ -67,6 +67,13 @@ function makeApp(opts: {
       state: "cancelled",
       error: "recorded",
     })),
+    // Graceful finish → a `stopped` loop; tests assert route wiring + the
+    // session-resolved actor, not controller internals.
+    stop: vi.fn(async (_id: string, _opts?: { reason?: string; actor?: string }) => ({
+      ...DEVELOPING_LOOP,
+      state: "stopped",
+      error: "Finished by user-1 at 2026-01-01T00:00:00.000Z",
+    })),
   } as unknown as ConsiliumLoopController;
 
   const storage = {
@@ -279,6 +286,44 @@ describe("POST /api/consilium-loops/:id/cancel — reason + actor threading", ()
     const { app, controller } = makeApp();
     (controller.cancel as CancelFn).mockResolvedValueOnce(null);
     const res = await request(app).post(`/api/consilium-loops/${LOOP_ID}/cancel`).send();
+    expect(res.status).toBe(409);
+  });
+});
+
+describe("POST /api/consilium-loops/:id/stop (graceful finish)", () => {
+  type StopFn = ReturnType<typeof vi.fn>;
+  beforeEach(() => vi.clearAllMocks());
+
+  it("owner finishes a non-terminal loop → 200 + stopped loop, session-resolved actor", async () => {
+    const { app, controller } = makeApp({ user: { id: OWNER, name: "Ada" } });
+    const res = await request(app)
+      .post(`/api/consilium-loops/${LOOP_ID}/stop`)
+      .send({ reason: "good enough" });
+    expect(res.status).toBe(200);
+    expect(res.body.state).toBe("stopped");
+    const arg = (controller.stop as StopFn).mock.calls[0][1] as { reason?: string; actor?: string };
+    expect(arg.reason).toBe("good enough");
+    expect(arg.actor).toBe("Ada"); // name preferred over id/email
+  });
+
+  it("a non-string reason → 400, controller.stop NOT called", async () => {
+    const { app, controller } = makeApp();
+    const res = await request(app).post(`/api/consilium-loops/${LOOP_ID}/stop`).send({ reason: 123 });
+    expect(res.status).toBe(400);
+    expect(controller.stop as StopFn).not.toHaveBeenCalled();
+  });
+
+  it("a foreign loop → 404, controller.stop NOT called (no existence oracle)", async () => {
+    const { app, controller } = makeApp({ user: { id: "intruder" } });
+    const res = await request(app).post(`/api/consilium-loops/${LOOP_ID}/stop`).send();
+    expect(res.status).toBe(404);
+    expect(controller.stop as StopFn).not.toHaveBeenCalled();
+  });
+
+  it("controller reports already-terminal (null) → 409", async () => {
+    const { app, controller } = makeApp();
+    (controller.stop as StopFn).mockResolvedValueOnce(null);
+    const res = await request(app).post(`/api/consilium-loops/${LOOP_ID}/stop`).send();
     expect(res.status).toBe(409);
   });
 });

--- a/tests/unit/consilium/loop-fsm.test.ts
+++ b/tests/unit/consilium/loop-fsm.test.ts
@@ -49,6 +49,15 @@ describe("reduce — design §3 transition table", () => {
     { name: "no-op: PENDING + context_built", from: "pending", event: { kind: "context_built" }, to: null },
     { name: "no-op: terminal CONVERGED + cancel", from: "converged", event: { kind: "cancel" }, to: null },
     { name: "no-op: terminal CANCELLED + start", from: "cancelled", event: { kind: "start" }, to: null },
+    // Graceful FINISH → STOPPED from any non-terminal state; no-op once terminal.
+    { name: "DECIDING + finish → STOPPED", from: "deciding", event: { kind: "finish" }, to: "stopped" },
+    { name: "REVIEWING + finish → STOPPED (any non-terminal)", from: "reviewing", event: { kind: "finish" }, to: "stopped" },
+    { name: "DEVELOPING + finish → STOPPED", from: "developing", event: { kind: "finish" }, to: "stopped" },
+    { name: "AWAITING_MERGE + finish → STOPPED", from: "awaiting_merge", event: { kind: "finish" }, to: "stopped" },
+    { name: "no-op: terminal CONVERGED + finish", from: "converged", event: { kind: "finish" }, to: null },
+    { name: "no-op: terminal CANCELLED + finish", from: "cancelled", event: { kind: "finish" }, to: null },
+    { name: "no-op: terminal STOPPED + finish (idempotent terminal)", from: "stopped", event: { kind: "finish" }, to: null },
+    { name: "no-op: terminal STOPPED + cancel", from: "stopped", event: { kind: "cancel" }, to: null },
   ];
 
   for (const row of rows) {
@@ -117,6 +126,27 @@ describe("reduce — cancel carries reason + actor into error", () => {
     const t = reduce("reviewing", { kind: "cancel", actor: "   ", reason: "   " });
     const err = t?.extra?.error as string;
     expect(err).toMatch(/^Cancelled by system at /);
+    expect(err).not.toContain("—");
+  });
+});
+
+// ─── Finish explanation: symmetric to cancel, but a NON-abort `stopped` end ───
+
+describe("reduce — finish carries reason + actor into error", () => {
+  it("finish with reason + actor → 'Finished by <who> at <ISO> — <reason>' + completedAt", () => {
+    const t = reduce("deciding", { kind: "finish", actor: "Ada Lovelace", reason: "good enough" });
+    expect(t?.to).toBe("stopped");
+    const err = t?.extra?.error as string;
+    expect(err).toMatch(/^Finished by Ada Lovelace at \d{4}-\d{2}-\d{2}T[\d:.]+Z/);
+    expect(err).toContain(" — good enough");
+    expect(t?.extra?.completedAt).toBeInstanceOf(Date);
+    expect(err).toContain((t?.extra?.completedAt as Date).toISOString());
+  });
+
+  it("finish without reason/actor → 'Finished by system at <ISO>' (never blank, no dash)", () => {
+    const t = reduce("reviewing", { kind: "finish" });
+    const err = t?.extra?.error as string;
+    expect(err).toMatch(/^Finished by system at /);
     expect(err).not.toContain("—");
   });
 });


### PR DESCRIPTION
## What

A **Finish** button on the consilium loop detail page that gracefully ends a loop — the third action the operator was missing at `deciding` (alongside **Develop** and **Cancel**). It's for *"I'm satisfied"* / *"I don't want to continue"*: end the loop, keep whatever it produced.

Deliberately **distinct from Cancel**:
- **Finish → `stopped`** — a NON-abort, NON-success terminal. No success side-effects fire (it's not `converged`), no abort framing (it's not `cancelled`).
- **Cancel → `cancelled`** — unchanged (abort).

Available from **any non-terminal state** (deciding, reviewing, developing, awaiting_merge, throttled).

## How

- **schema**: new terminal state `stopped` (in `CONSILIUM_LOOP_STATES` + `CONSILIUM_LOOP_TERMINAL_STATES`).
- **controller**: a `finish` event in the pure reducer → `stopped` (symmetric to `cancel`); `stop()` method mirroring `cancel()` (cancels the child group + drops the in-flight SDLC handle, since `stopped` is terminal); `composeFinishExplanation` records `Finished by <actor> at <ISO> — <reason>`. `isTerminal` updated.
- **route**: `POST /api/consilium-loops/:id/stop` — same auth (`authorizeConsiliumLoop`, owner-or-admin, 404-on-mismatch), body (`{reason?}` sanitized + clamped), and actor resolution as `/cancel`. 409 if already terminal.
- **ui**: "Finish" button (Flag icon, `secondary`) beside Cancel; `useStopLoop` hook; `stopped` → "Finished" badge; a clear status-callout ("An operator finished this loop and kept what it produced").

Correctness note: every success-only side-effect (`convergedCount`, experience distiller, writeback `prRef`, role track-record) keys off `=== "converged"` — so `stopped` correctly triggers **none** of them. Everything that keys off the central terminal list / `isTerminal` (poller stop, FE poll-stop) now treats `stopped` as terminal.

## No migration

`consilium_loops.state` is a `text` column — the new enum value needs no DDL.

## Verification

- `tsc` (`npm run check`) clean across client + server + shared.
- New tests: reducer `finish` transitions (deciding/reviewing/developing/awaiting_merge → stopped; no-op once terminal) + explanation formatting; `/stop` route (200 + session actor, 400 bad reason, 404 foreign, 409 already-terminal).
- Full consilium unit suite: **1361 passed** (no regression from the new state).

## Constraints honored

Feature branch + Draft PR; no `config.yaml`/`.env` touched; no `any`; commit has no AI/Claude mentions.