### PR TITLE
feat(trackers): Jira Server/DC dialect (apiVersion 2) for the Jira intake connector

### DIFF
--- a/server/services/consilium/trackers/jira-connector.ts
+++ b/server/services/consilium/trackers/jira-connector.ts
@@ -149,6 +149,14 @@ export interface JiraConnectorConfig {
   extraJql?: string;
   /** Optional transition name/id to move the ticket to on pickup (best-effort). */
   transitionTo?: string;
+  /**
+   * Jira REST dialect: `"3"` (Cloud, default — ADF comment bodies) or `"2"`
+   * (Server/Data Center — only `/rest/api/2` exists there and comment bodies are
+   * PLAIN STRINGS, not ADF). Reads are dialect-agnostic (`adfToText` passes a v2
+   * string description/comment through unchanged); only the request paths and the
+   * comment POST body change. Absent ⇒ `"3"` (byte-identical for existing configs).
+   */
+  apiVersion?: "2" | "3";
 }
 
 /** Map a Jira REST issue → the normalised `Ticket` (description flattened from ADF). */
@@ -172,12 +180,16 @@ export class JiraTrackerConnector implements TrackerConnector {
   private readonly cfg: JiraConnectorConfig;
   private readonly exec: JiraExecDeps;
   private readonly browseBase: string;
+  /** `rest/api/2` or `rest/api/3` — every request path is built off this. */
+  private readonly api: string;
 
   constructor(cfg: JiraConnectorConfig, exec: JiraExecDeps) {
     this.cfg = cfg;
     this.exec = exec;
     // Human browse links live at the site origin (strip any trailing slash).
     this.browseBase = cfg.baseUrl.replace(/\/+$/, "");
+    // Anything but an explicit "2" stays on the Cloud dialect (fail-safe default).
+    this.api = cfg.apiVersion === "2" ? "rest/api/2" : "rest/api/3";
     this.writeback = {
       comment: (ticketId, body, marker) => this.postComment(ticketId, body, marker),
       transition: (ticketId, state) => this.doTransition(ticketId, state),
@@ -201,7 +213,7 @@ export class JiraTrackerConnector implements TrackerConnector {
    * watermark (one spec per ticket), exactly as the GitHub path does.
    */
   async pollTickets(_sinceWatermark?: string): Promise<Ticket[] | null> {
-    const result = await jiraGetJson<JiraSearchResult>(this.exec, this.cfg.baseUrl, "rest/api/3/search", {
+    const result = await jiraGetJson<JiraSearchResult>(this.exec, this.cfg.baseUrl, `${this.api}/search`, {
       jql: this.buildJql(),
       fields: "summary,description,labels,updated",
       maxResults: "100",
@@ -222,7 +234,7 @@ export class JiraTrackerConnector implements TrackerConnector {
     const issue = await jiraGetJson<JiraIssue>(
       this.exec,
       this.cfg.baseUrl,
-      `rest/api/3/issue/${encodeURIComponent(key)}`,
+      `${this.api}/issue/${encodeURIComponent(key)}`,
       { fields: "summary,description,labels,updated" },
     );
     if (!issue) return null;
@@ -251,7 +263,7 @@ export class JiraTrackerConnector implements TrackerConnector {
     const existing = await jiraGetJson<JiraCommentsResult>(
       this.exec,
       this.cfg.baseUrl,
-      `rest/api/3/issue/${encodeURIComponent(key)}/comment`,
+      `${this.api}/issue/${encodeURIComponent(key)}/comment`,
       { maxResults: "200" },
     );
     if (!existing || !Array.isArray(existing.comments)) {
@@ -260,11 +272,14 @@ export class JiraTrackerConnector implements TrackerConnector {
     const already = existing.comments.some((c) => adfToText(c.body).includes(marker));
     if (already) return { posted: false, reason: "already-commented" };
 
+    // v2 (Server/DC) takes a PLAIN STRING body; v3 (Cloud) takes an ADF doc.
+    const commentBody =
+      this.cfg.apiVersion === "2" ? [marker, body].join("\n") : textToAdf([marker, body]);
     const res = await jiraPostJson(
       this.exec,
       this.cfg.baseUrl,
-      `rest/api/3/issue/${encodeURIComponent(key)}/comment`,
-      { body: textToAdf([marker, body]) },
+      `${this.api}/issue/${encodeURIComponent(key)}/comment`,
+      { body: commentBody },
     );
     return res.ok ? { posted: true } : { posted: false, reason: res.reason };
   }
@@ -281,7 +296,7 @@ export class JiraTrackerConnector implements TrackerConnector {
     const avail = await jiraGetJson<JiraTransitionsResult>(
       this.exec,
       this.cfg.baseUrl,
-      `rest/api/3/issue/${encodeURIComponent(key)}/transitions`,
+      `${this.api}/issue/${encodeURIComponent(key)}/transitions`,
     );
     if (!avail || !Array.isArray(avail.transitions)) return { posted: false, reason: "transitions-unreadable" };
     const match = avail.transitions.find(
@@ -291,7 +306,7 @@ export class JiraTrackerConnector implements TrackerConnector {
     const res = await jiraPostJson(
       this.exec,
       this.cfg.baseUrl,
-      `rest/api/3/issue/${encodeURIComponent(key)}/transitions`,
+      `${this.api}/issue/${encodeURIComponent(key)}/transitions`,
       { transition: { id: match.id } },
     );
     return res.ok ? { posted: true } : { posted: false, reason: res.reason };

--- a/server/services/consilium/trackers/jira-exec.ts
+++ b/server/services/consilium/trackers/jira-exec.ts
@@ -40,23 +40,29 @@ export type JiraHttpFn = (req: {
   timeoutMs: number;
 }) => Promise<JiraHttpResult>;
 
-/** Resolved auth material (basic email:token). `null` ⇒ fail-closed (not configured). */
+/**
+ * Resolved auth material. `null` ⇒ fail-closed (not configured).
+ * Two dialects share this shape:
+ *   - Atlassian Cloud: `email` + API token ⇒ `Basic base64(email:token)`
+ *   - Jira Data Center/Server PAT: `email` EMPTY ⇒ `Bearer <token>`
+ */
 export interface JiraAuth {
   email: string;
   token: string;
 }
 
 /**
- * Read the Jira auth from ENV (fail-closed). Returns `null` when either var is absent
- * or blank so the caller degrades WITHOUT attempting an unauthenticated call. The
- * token value is returned but NEVER logged by this module.
+ * Read the Jira auth from ENV (fail-closed). Returns `null` when the token is absent
+ * or blank so the caller degrades WITHOUT attempting an unauthenticated call. An
+ * absent `JIRA_EMAIL` selects the Bearer (Data Center PAT) dialect. The token value
+ * is returned but NEVER logged by this module.
  */
 export function readJiraAuthFromEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): JiraAuth | null {
   const email = (env[JIRA_EMAIL_ENV] ?? "").trim();
   const token = (env[JIRA_TOKEN_ENV] ?? "").trim();
-  if (email.length === 0 || token.length === 0) return null;
+  if (token.length === 0) return null;
   return { email, token };
 }
 
@@ -83,8 +89,12 @@ const defaultHttp: JiraHttpFn = async (req) => {
   }
 };
 
-/** Build the `Authorization: Basic <base64(email:token)>` header value. */
-function basicAuthHeader(auth: JiraAuth): string {
+/**
+ * Build the `Authorization` header value. With an email: Cloud-style
+ * `Basic base64(email:token)`; without one: Data Center PAT `Bearer <token>`.
+ */
+function authHeader(auth: JiraAuth): string {
+  if (auth.email.length === 0) return `Bearer ${auth.token}`;
   return "Basic " + Buffer.from(`${auth.email}:${auth.token}`, "utf8").toString("base64");
 }
 
@@ -147,7 +157,7 @@ export async function jiraGetJson<T>(
 ): Promise<T | null> {
   const auth = deps.auth ?? readJiraAuthFromEnv();
   if (!auth) {
-    deps.log("jira-exec: no JIRA_EMAIL/JIRA_API_TOKEN configured — skipping (fail-closed)");
+    deps.log("jira-exec: no JIRA_API_TOKEN configured — skipping (fail-closed)");
     return null;
   }
   const url = buildUrl(baseUrl, path, query);
@@ -160,7 +170,7 @@ export async function jiraGetJson<T>(
     const res = await http({
       method: "GET",
       url,
-      headers: { Authorization: basicAuthHeader(auth), Accept: "application/json" },
+      headers: { Authorization: authHeader(auth), Accept: "application/json" },
       timeoutMs: JIRA_TIMEOUT_MS,
     });
     if (res.status < 200 || res.status >= 300) {
@@ -187,7 +197,7 @@ export async function jiraPostJson(
 ): Promise<{ ok: true; body: string } | { ok: false; status?: number; reason: string }> {
   const auth = deps.auth ?? readJiraAuthFromEnv();
   if (!auth) {
-    deps.log("jira-exec: no JIRA_EMAIL/JIRA_API_TOKEN configured — skipping (fail-closed)");
+    deps.log("jira-exec: no JIRA_API_TOKEN configured — skipping (fail-closed)");
     return { ok: false, reason: "no-auth" };
   }
   const url = buildUrl(baseUrl, path);
@@ -201,7 +211,7 @@ export async function jiraPostJson(
       method: "POST",
       url,
       headers: {
-        Authorization: basicAuthHeader(auth),
+        Authorization: authHeader(auth),
         Accept: "application/json",
         "Content-Type": "application/json",
       },

--- a/server/services/consilium/trackers/jira-issues-poller.ts
+++ b/server/services/consilium/trackers/jira-issues-poller.ts
@@ -44,9 +44,11 @@ import { extractSpecFromIssue } from "./issue-spec.js";
 import { crystallizeTicket } from "./spec-intake.js";
 import { JiraTrackerConnector, type JiraConnectorConfig } from "./jira-connector.js";
 import { readJiraAuthFromEnv, type JiraAuth, type JiraHttpFn } from "./jira-exec.js";
+import type { GitlabAuth, GitlabHttpFn } from "./gitlab-exec.js";
 
-/** `owner/repo` — conservative charset (no leading dash / no flag). */
-const OWNER_REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+/** `owner/repo` (GitHub) or `group/subgroup/project` (GitLab nested groups) —
+ *  conservative charset (no leading dash / no flag), 2+ segments. */
+const OWNER_REPO_RE = /^[A-Za-z0-9._-]+(\/[A-Za-z0-9._-]+)+$/;
 /** Max NEW intakes opened per poll cycle (bounds blast radius). */
 const MAX_PER_CYCLE = 20;
 /** Cap on tracked intakes per trigger (bounds the watermark jsonb). */
@@ -84,6 +86,10 @@ export interface JiraIssuesPollerDeps {
   jiraHttp?: JiraHttpFn;
   /** Injectable Jira auth (tests pass a fake; prod reads env at call time). */
   jiraAuth?: JiraAuth | null;
+  /** Injectable GitLab transport/auth for a gitlab-origin `targetRepoPath` (the
+   *  spec lands as a GitLab MR). Prod reads GITLAB_TOKEN from env at call time. */
+  gitlabHttp?: GitlabHttpFn;
+  gitlabAuth?: GitlabAuth | null;
   /** Injectable git-remote reader for the owner/repo derivation (default: real `git`). */
   gitRemoteUrl?: (repoPath: string) => Promise<string | null>;
   log: (message: string) => void;
@@ -255,6 +261,7 @@ export class JiraIssuesPoller {
       label,
       extraJql: config.jql,
       transitionTo: config.transitionTo,
+      apiVersion: config.jiraApiVersion,
     };
     const connector = new JiraTrackerConnector(connectorCfg, {
       http: this.deps.jiraHttp,
@@ -319,6 +326,8 @@ export class JiraIssuesPoller {
         const result = await crystallizeTicket(
           {
             runGh: this.deps.runGh, // spec PR uses the shared gh writer (injectable).
+            gitlabHttp: this.deps.gitlabHttp, // gitlab-origin target ⇒ spec lands as an MR.
+            gitlabAuth: this.deps.gitlabAuth,
             gitRemoteUrl: this.gitRemoteUrl,
             log: this.deps.log,
             writeback: {

--- a/server/services/consilium/trackers/spec-intake.ts
+++ b/server/services/consilium/trackers/spec-intake.ts
@@ -23,6 +23,8 @@
 import type { ExecFileFn } from "../../github-status.js";
 import { renderSpecMarkdown, type TicketSource } from "./issue-spec.js";
 import { writeSpecPr } from "./spec-writer.js";
+import { writeSpecMr } from "./spec-writer-gitlab.js";
+import type { GitlabHttpFn, GitlabAuth } from "./gitlab-exec.js";
 
 /** The two write-back actions the crystallise step needs, supplied per connector. */
 export interface CrystallizeWriteback {
@@ -41,6 +43,10 @@ export interface CrystallizeDeps {
   writeback: CrystallizeWriteback;
   /** Structured logger. */
   log: (message: string) => void;
+  /** Injectable GitLab transport/auth for a gitlab-origin target (tests pass fakes;
+   *  prod reads GITLAB_TOKEN from env at call time). Unused for github origins. */
+  gitlabHttp?: GitlabHttpFn;
+  gitlabAuth?: GitlabAuth | null;
 }
 
 export interface CrystallizeTicketInput {
@@ -102,19 +108,34 @@ export async function crystallizeTicket(
     skills: input.skills,
   });
 
-  // 3) Open the spec PR remotely (SHARED writer; never touches the working tree).
-  const res = await writeSpecPr(
-    { runGh: deps.runGh, gitRemoteUrl: deps.gitRemoteUrl, log: deps.log },
-    {
-      targetRepoPath: input.targetRepoPath,
-      branch: input.branch,
-      filePath: input.filePath,
-      fileContent: markdown,
-      commitMessage: input.commitMessage,
-      prTitle: input.prTitle,
-      prBody: input.prBody,
-    },
-  );
+  // 3) Open the spec PR/MR remotely (SHARED writers; never touch the working tree).
+  //    FORGE SNIFF (mirrors pr-wrapper's detectForge): a gitlab-hosted origin takes
+  //    the GitLab MR dialect; everything else (incl. missing origin) stays on the
+  //    pre-existing gh path — byte-identical for every github target.
+  const writeParams = {
+    targetRepoPath: input.targetRepoPath,
+    branch: input.branch,
+    filePath: input.filePath,
+    fileContent: markdown,
+    commitMessage: input.commitMessage,
+    prTitle: input.prTitle,
+    prBody: input.prBody,
+  };
+  const originUrl = await deps.gitRemoteUrl(input.targetRepoPath).catch(() => null);
+  const res = /gitlab/i.test(originUrl ?? "")
+    ? await writeSpecMr(
+        {
+          gitlabHttp: deps.gitlabHttp,
+          gitlabAuth: deps.gitlabAuth,
+          gitRemoteUrl: deps.gitRemoteUrl,
+          log: deps.log,
+        },
+        writeParams,
+      )
+    : await writeSpecPr(
+        { runGh: deps.runGh, gitRemoteUrl: deps.gitRemoteUrl, log: deps.log },
+        writeParams,
+      );
   if (!res.ok) {
     return { outcome: "failed", reason: res.reason };
   }

--- a/server/services/consilium/trackers/spec-writer-gitlab.ts
+++ b/server/services/consilium/trackers/spec-writer-gitlab.ts
@@ -1,0 +1,231 @@
+/**
+ * spec-writer-gitlab.ts — the GitLab dialect of `spec-writer.ts`: open the tracker
+ * spec MR REMOTELY, via the GitLab REST API (never a local git checkout/commit).
+ * NEVER throws.
+ *
+ * WHY REMOTE (no local git) — same contract as the gh writer: the poller runs in the
+ * operator's server process; `targetRepoPath` is a live working tree they may be
+ * editing. Every write goes through the sanitized `gitlab-exec` HTTP seam:
+ *   1. GET  /projects/:path              → project id + default branch,
+ *   2. GET  /merge_requests?source_branch → dedup (never a 2nd MR for the branch),
+ *   3. GET  /repository/branches/:branch  → branch-exists probe (idempotent re-run),
+ *   4. POST /repository/branches          → create the spec branch server-side,
+ *   5. POST /repository/files/:path       → commit the spec file (base64) on it,
+ *   6. POST /merge_requests               → open the MR.
+ * The operator's working tree is never touched.
+ *
+ * WHY REST (not `glab`, which the loop's pr-wrapper shells out to): `glab mr create`
+ * needs an already-pushed branch — i.e. LOCAL git mutations — while the REST calls
+ * above create the branch and file entirely server-side, mirroring the gh writer's
+ * `gh api` flow. The seam also keeps the PAT out of argv/logs.
+ *
+ * SECURITY — same discipline as the gh writer:
+ *   - `branch` is SERVER-DERIVED and re-validated with SPEC_BRANCH_RE.
+ *   - The MR title is control-stripped/clamped and leading-dash-rejected (it only
+ *     travels as a JSON body value here, but the shared gate stays).
+ *   - The GitLab project path is ORIGIN-DERIVED (`parseGitlabRemote`) and
+ *     shape-validated; nested groups (`group/subgroup/project`) are supported.
+ *   - Every call is never-throw via gitlab-exec (degrades to typed failures the
+ *     poller logs + retries next cycle).
+ */
+import {
+  gitlabGetJson,
+  gitlabSendJson,
+  type GitlabHttpFn,
+  type GitlabAuth,
+} from "./gitlab-exec.js";
+import {
+  isValidSpecBranch,
+  sanitizeSpecTitle,
+  type WriteSpecPrParams,
+  type WriteSpecPrResult,
+} from "./spec-writer.js";
+
+/** Nested-group GitLab project path (2+ segments, conservative charset, no flags —
+ *  a segment may not START with a dash, so a path can never be argv-flag-shaped). */
+const GITLAB_PROJECT_PATH_RE = /^[A-Za-z0-9._][A-Za-z0-9._-]*(\/[A-Za-z0-9._][A-Za-z0-9._-]*)+$/;
+
+/**
+ * Parse a GitLab `origin` remote URL into the API base + project path.
+ * Accepts `git@host:group/sub/project.git` and `https://host/group/sub/project(.git)`.
+ * Returns `null` (fail-closed) for anything else — the caller degrades.
+ */
+export function parseGitlabRemote(
+  remoteUrl: string,
+): { baseUrl: string; projectPath: string } | null {
+  let host: string | undefined;
+  let path: string | undefined;
+
+  const ssh = remoteUrl.match(/^(?:ssh:\/\/)?git@([^:/]+)[:/](.+)$/);
+  if (ssh) {
+    host = ssh[1];
+    path = ssh[2];
+  } else {
+    try {
+      const u = new URL(remoteUrl);
+      if (u.protocol !== "https:" && u.protocol !== "http:") return null;
+      host = u.hostname;
+      path = u.pathname.replace(/^\/+/, "");
+    } catch {
+      return null;
+    }
+  }
+  if (!host || !path) return null;
+
+  const projectPath = path.replace(/\.git$/, "").replace(/\/+$/, "");
+  if (!GITLAB_PROJECT_PATH_RE.test(projectPath)) return null;
+  // The API base is always https regardless of the remote transport.
+  return { baseUrl: `https://${host}`, projectPath };
+}
+
+export interface GitlabSpecWriterDeps {
+  /** Injectable GitLab HTTP transport (tests pass a fake — no real network). */
+  gitlabHttp?: GitlabHttpFn;
+  /** Injectable GitLab auth (tests pass a fake; prod reads env at call time). */
+  gitlabAuth?: GitlabAuth | null;
+  /** Read the TARGET git repo's `origin` URL (→ base + project path). */
+  gitRemoteUrl: (repoPath: string) => Promise<string | null>;
+  /** Structured logger. */
+  log: (message: string) => void;
+}
+
+interface GitlabMr {
+  web_url?: string;
+  state?: string;
+}
+
+/**
+ * Create the spec MR remotely (see module header for the flow). Never throws; every
+ * failure is a typed `{ ok: false, reason }` sharing the gh writer's reason strings
+ * so the pollers stay dialect-blind. `reused: true` ⇒ an MR for the branch already
+ * existed (dedup) and was returned instead of creating a new one.
+ */
+export async function writeSpecMr(
+  deps: GitlabSpecWriterDeps,
+  params: WriteSpecPrParams,
+): Promise<WriteSpecPrResult> {
+  const { gitRemoteUrl, log } = deps;
+  const exec = { http: deps.gitlabHttp, auth: deps.gitlabAuth, log };
+  const { targetRepoPath, branch, filePath, fileContent, commitMessage, prTitle, prBody } = params;
+
+  try {
+    // 1) Validate the server-derived branch + reject a flag-shaped title.
+    if (!isValidSpecBranch(branch)) {
+      log(`spec-writer-gitlab: rejected branch (SPEC_BRANCH_RE): ${branch}`);
+      return { ok: false, reason: "bad-branch" };
+    }
+    if (prTitle.startsWith("-")) {
+      log("spec-writer-gitlab: rejected leading-dash MR title (flag injection)");
+      return { ok: false, reason: "bad-title" };
+    }
+    const title = sanitizeSpecTitle(prTitle);
+    if (title.length === 0 || title.startsWith("-")) {
+      return { ok: false, reason: "bad-title" };
+    }
+
+    // 2) Origin-derived, validated base + project path (nested groups OK).
+    const remoteUrl = await gitRemoteUrl(targetRepoPath);
+    const parsed = remoteUrl ? parseGitlabRemote(remoteUrl) : null;
+    if (!parsed) {
+      log(`spec-writer-gitlab: no gitlab project path for ${targetRepoPath} — skip`);
+      return { ok: false, reason: "bad-origin" };
+    }
+    const { baseUrl, projectPath } = parsed;
+    const proj = `api/v4/projects/${encodeURIComponent(projectPath)}`;
+
+    // 3) DEDUP: an existing MR for this source branch ⇒ reuse it, create nothing.
+    const existing = await gitlabGetJson<GitlabMr[]>(exec, baseUrl, `${proj}/merge_requests`, {
+      source_branch: branch,
+      state: "all",
+    });
+    const found = existing?.find((m) => typeof m.web_url === "string" && m.web_url.length > 0);
+    if (found?.web_url) {
+      log(`spec-writer-gitlab: reusing existing spec MR for ${branch} on ${projectPath}`);
+      return { ok: true, prUrl: found.web_url, reused: true };
+    }
+
+    // 4) Default branch (also proves the project is reachable with this PAT).
+    const project = await gitlabGetJson<{ default_branch?: string }>(exec, baseUrl, proj);
+    const base = project?.default_branch;
+    if (!base || typeof base !== "string" || base.length === 0) {
+      log(`spec-writer-gitlab: no default branch for ${projectPath} (degraded) — skip`);
+      return { ok: false, reason: "no-default-branch" };
+    }
+
+    // 5) Create the branch (probe first so an idempotent re-run continues).
+    const branchExists = await gitlabGetJson<{ name?: string }>(
+      exec,
+      baseUrl,
+      `${proj}/repository/branches/${encodeURIComponent(branch)}`,
+    );
+    if (branchExists?.name === branch) {
+      log(`spec-writer-gitlab: branch ${branch} already exists on ${projectPath} — continuing`);
+    } else {
+      const refRes = await gitlabSendJson(exec, "POST", baseUrl, `${proj}/repository/branches`, {
+        branch,
+        ref: base,
+      });
+      if (!refRes.ok) {
+        log(`spec-writer-gitlab: branch create failed on ${projectPath}: ${refRes.reason}`);
+        return { ok: false, reason: "branch-create-failed" };
+      }
+    }
+
+    // 6) Commit the spec file on the branch (base64 content = inert bytes).
+    const encPath = encodeURIComponent(filePath);
+    const fileExists = await gitlabGetJson<{ file_path?: string }>(
+      exec,
+      baseUrl,
+      `${proj}/repository/files/${encPath}`,
+      { ref: branch },
+    );
+    if (fileExists?.file_path) {
+      log(`spec-writer-gitlab: file ${filePath} already present on ${branch} — continuing to MR`);
+    } else {
+      const fileRes = await gitlabSendJson(exec, "POST", baseUrl, `${proj}/repository/files/${encPath}`, {
+        branch,
+        content: Buffer.from(fileContent, "utf8").toString("base64"),
+        encoding: "base64",
+        commit_message: commitMessage,
+      });
+      if (!fileRes.ok) {
+        log(`spec-writer-gitlab: file create failed on ${projectPath}: ${fileRes.reason}`);
+        return { ok: false, reason: "file-create-failed" };
+      }
+    }
+
+    // 7) Open the MR. A race-created duplicate is recovered via re-dedup.
+    const mrRes = await gitlabSendJson(exec, "POST", baseUrl, `${proj}/merge_requests`, {
+      source_branch: branch,
+      target_branch: base,
+      title,
+      description: prBody,
+    });
+    if (!mrRes.ok) {
+      const recovered = await gitlabGetJson<GitlabMr[]>(exec, baseUrl, `${proj}/merge_requests`, {
+        source_branch: branch,
+        state: "all",
+      });
+      const mr = recovered?.find((m) => typeof m.web_url === "string" && m.web_url.length > 0);
+      if (mr?.web_url) return { ok: true, prUrl: mr.web_url, reused: true };
+      log(`spec-writer-gitlab: mr create failed on ${projectPath}: ${mrRes.reason}`);
+      return { ok: false, reason: "pr-create-failed" };
+    }
+    let mrUrl: string | undefined;
+    try {
+      mrUrl = (JSON.parse(mrRes.body) as GitlabMr).web_url;
+    } catch {
+      /* fall through to the failure below */
+    }
+    if (!mrUrl) {
+      log(`spec-writer-gitlab: mr created on ${projectPath} but no web_url in response`);
+      return { ok: false, reason: "pr-create-failed" };
+    }
+    log(`spec-writer-gitlab: opened spec MR ${mrUrl}`);
+    return { ok: true, prUrl: mrUrl, reused: false };
+  } catch (err) {
+    // Belt-and-braces: the seam never throws, but keep the writer never-throw too.
+    log(`spec-writer-gitlab: unexpected error: ${(err as Error)?.message ?? String(err)}`);
+    return { ok: false, reason: "exception" };
+  }
+}

--- a/server/services/consilium/trackers/spec-writer.ts
+++ b/server/services/consilium/trackers/spec-writer.ts
@@ -88,8 +88,9 @@ export type WriteSpecPrResult =
   | { ok: true; prUrl: string; reused: boolean }
   | { ok: false; reason: string };
 
-/** Single-line control-strip + clamp for the PR title (sanitizeEventLabel discipline). */
-function sanitizeTitle(value: string, max = 200): string {
+/** Single-line control-strip + clamp for the PR/MR title (sanitizeEventLabel
+ *  discipline). Exported so the GitLab dialect (`spec-writer-gitlab.ts`) shares it. */
+export function sanitizeSpecTitle(value: string, max = 200): string {
   return value
     // eslint-disable-next-line no-control-regex
     .replace(/[\u0000-\u001f\u007f]+/g, " ")
@@ -142,7 +143,7 @@ export async function writeSpecPr(
       log("spec-writer: rejected leading-dash PR title (flag injection)");
       return { ok: false, reason: "bad-title" };
     }
-    const title = sanitizeTitle(prTitle);
+    const title = sanitizeSpecTitle(prTitle);
     if (title.length === 0 || title.startsWith("-")) {
       return { ok: false, reason: "bad-title" };
     }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1879,6 +1879,12 @@ export interface TrackerEventTriggerConfig {
   /** Optional operator JQL predicate (trusted config) ANDed into the label search. */
   jql?: string;
   /**
+   * Jira REST dialect: `"3"` (Cloud, default) or `"2"` (self-hosted Server/Data
+   * Center — those installs serve only `/rest/api/2` and take plain-string comment
+   * bodies instead of ADF). Absent ⇒ `"3"` (existing configs byte-identical).
+   */
+  jiraApiVersion?: "2" | "3";
+  /**
    * Optional pickup "transition", interpreted per connector (best-effort): Jira → a
    * workflow transition name/id; GitLab → a LABEL to add (no arbitrary states);
    * Bitbucket → an issue STATE; Linear → a workflow-state name; Azure → `System.State`;

--- a/tests/unit/consilium/trackers/jira-connector.test.ts
+++ b/tests/unit/consilium/trackers/jira-connector.test.ts
@@ -234,3 +234,65 @@ describe("write-back — comment idempotency + transition", () => {
     expect(miss.reason).toBe("no-such-transition");
   });
 });
+
+describe('apiVersion "2" — Jira Server / Data Center dialect', () => {
+  const V2 = { apiVersion: "2" as const, baseUrl: "https://jira.example.co" };
+
+  it("routes every request through /rest/api/2 (search, issue, comment, transitions)", async () => {
+    const { conn, calls } = connector(V2, (c) => {
+      if (c.url.includes("/search")) return json({ issues: [] });
+      if (c.method === "GET" && c.url.includes("/comment")) return json({ comments: [] });
+      if (c.method === "POST" && c.url.includes("/comment")) return { status: 201, body: "{}" };
+      if (c.method === "GET" && c.url.includes("/transitions")) return json({ transitions: [] });
+      return json({ key: "ACME-7", fields: {} });
+    });
+    await conn.pollTickets();
+    await conn.readTicket("ACME-7");
+    await conn.writeback.comment("ACME-7", "x", "<!-- m -->");
+    await conn.writeback.transition!("ACME-7", "Done");
+    expect(calls.length).toBeGreaterThan(0);
+    for (const c of calls) expect(c.url).toContain("/rest/api/2/");
+    expect(calls.some((c) => c.url.includes("/rest/api/3/"))).toBe(false);
+  });
+
+  it("posts the comment body as a PLAIN STRING (marker + text), not ADF", async () => {
+    const { conn, calls } = connector(V2, (c) => {
+      if (c.method === "GET" && c.url.includes("/comment")) return json({ comments: [] });
+      if (c.method === "POST" && c.url.includes("/comment")) return { status: 201, body: "{}" };
+      return json({});
+    });
+    const res = await conn.writeback.comment("ACME-7", "picked up", "<!-- marker -->");
+    expect(res.posted).toBe(true);
+    const post = calls.find((c) => c.method === "POST" && c.url.includes("/comment"));
+    const parsed = JSON.parse(post!.body!) as { body: unknown };
+    expect(typeof parsed.body).toBe("string");
+    expect(parsed.body).toBe("<!-- marker -->\npicked up");
+  });
+
+  it("marker dedup reads v2 plain-string comment bodies (no double-post)", async () => {
+    const existing = { body: "<!-- marker -->\npicked up earlier" };
+    const { conn, calls } = connector(V2, (c) => {
+      if (c.method === "GET" && c.url.includes("/comment")) return json({ comments: [existing] });
+      return json({});
+    });
+    const res = await conn.writeback.comment("ACME-7", "picked up", "<!-- marker -->");
+    expect(res.posted).toBe(false);
+    expect(calls.some((c) => c.method === "POST")).toBe(false);
+  });
+
+  it("maps a v2 string description straight through to the ticket body", async () => {
+    const issue = {
+      key: "PDO-850",
+      fields: { summary: "Enable caching", description: "plain v2 text", labels: ["automation"] },
+    };
+    const { conn } = connector(V2, (c) =>
+      c.url.includes("/search") ? json({ issues: [issue] }) : json({}),
+    );
+    const tickets = await conn.pollTickets();
+    expect(tickets![0]).toMatchObject({
+      id: "PDO-850",
+      body: "plain v2 text",
+      url: "https://jira.example.co/browse/PDO-850",
+    });
+  });
+});

--- a/tests/unit/consilium/trackers/jira-exec.test.ts
+++ b/tests/unit/consilium/trackers/jira-exec.test.ts
@@ -1,0 +1,71 @@
+/**
+ * jira-exec auth-dialect tests — the Cloud (Basic email:token) vs Data Center
+ * PAT (Bearer) selection added for self-hosted Jira instances.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  readJiraAuthFromEnv,
+  jiraGetJson,
+  type JiraHttpFn,
+} from "../../../../server/services/consilium/trackers/jira-exec";
+
+const noLog = () => undefined;
+
+function captureHttp(): { fn: JiraHttpFn; headers: () => Record<string, string> } {
+  let captured: Record<string, string> = {};
+  const fn: JiraHttpFn = async (req) => {
+    captured = req.headers;
+    return { status: 200, body: JSON.stringify({ ok: true }) };
+  };
+  return { fn, headers: () => captured };
+}
+
+describe("readJiraAuthFromEnv", () => {
+  it("returns null when the token is absent (fail-closed)", () => {
+    expect(readJiraAuthFromEnv({} as NodeJS.ProcessEnv)).toBeNull();
+    expect(
+      readJiraAuthFromEnv({ JIRA_EMAIL: "a@b.co" } as NodeJS.ProcessEnv),
+    ).toBeNull();
+  });
+
+  it("returns email+token for the Cloud (Basic) dialect", () => {
+    expect(
+      readJiraAuthFromEnv({
+        JIRA_EMAIL: "a@b.co",
+        JIRA_API_TOKEN: "tok",
+      } as NodeJS.ProcessEnv),
+    ).toEqual({ email: "a@b.co", token: "tok" });
+  });
+
+  it("returns an empty email for the Data Center PAT (Bearer) dialect", () => {
+    expect(
+      readJiraAuthFromEnv({ JIRA_API_TOKEN: "pat" } as NodeJS.ProcessEnv),
+    ).toEqual({ email: "", token: "pat" });
+  });
+});
+
+describe("jiraGetJson Authorization header", () => {
+  it("sends Basic base64(email:token) when an email is present", async () => {
+    const { fn, headers } = captureHttp();
+    const res = await jiraGetJson(
+      { http: fn, auth: { email: "a@b.co", token: "tok" }, log: noLog },
+      "https://jira.example.com",
+      "rest/api/2/myself",
+    );
+    expect(res).toEqual({ ok: true });
+    expect(headers().Authorization).toBe(
+      "Basic " + Buffer.from("a@b.co:tok", "utf8").toString("base64"),
+    );
+  });
+
+  it("sends Bearer <token> when the email is empty (Data Center PAT)", async () => {
+    const { fn, headers } = captureHttp();
+    const res = await jiraGetJson(
+      { http: fn, auth: { email: "", token: "pat" }, log: noLog },
+      "https://jira.example.com",
+      "rest/api/2/myself",
+    );
+    expect(res).toEqual({ ok: true });
+    expect(headers().Authorization).toBe("Bearer pat");
+  });
+});

--- a/tests/unit/consilium/trackers/spec-writer-gitlab.test.ts
+++ b/tests/unit/consilium/trackers/spec-writer-gitlab.test.ts
@@ -1,0 +1,237 @@
+/**
+ * spec-writer-gitlab tests — remote-only GitLab spec-MR creation (the GitLab
+ * dialect of spec-writer): origin parsing (nested groups), the REST flow,
+ * dedup/idempotent re-run, degrade paths, and the spec-intake forge sniff.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  parseGitlabRemote,
+  writeSpecMr,
+} from "../../../../server/services/consilium/trackers/spec-writer-gitlab";
+import { crystallizeTicket } from "../../../../server/services/consilium/trackers/spec-intake";
+import type { GitlabHttpFn } from "../../../../server/services/consilium/trackers/gitlab-exec";
+
+const noLog = () => undefined;
+const AUTH = { token: "glpat-test" };
+
+interface Call {
+  method: string;
+  url: string;
+  body?: string;
+}
+
+/** Route-programmable fake GitLab API that records every call. */
+function fakeGitlab(routes: Array<{ match: RegExp; method?: string; status: number; body: unknown }>) {
+  const calls: Call[] = [];
+  const fn: GitlabHttpFn = async (req) => {
+    calls.push({ method: req.method, url: req.url, body: req.body });
+    const route = routes.find(
+      (r) => r.match.test(req.url) && (!r.method || r.method === req.method),
+    );
+    if (!route) return { status: 404, body: JSON.stringify({ message: "404" }) };
+    return { status: route.status, body: JSON.stringify(route.body) };
+  };
+  return { fn, calls };
+}
+
+const PARAMS = {
+  targetRepoPath: "/repos/iac",
+  branch: "spec/jira-PDO-1",
+  filePath: "docs/specs/jira-PDO-1-test.md",
+  fileContent: "# spec",
+  commitMessage: "feat: add spec for PDO-1",
+  prTitle: "spec: test (PDO-1)",
+  prBody: "body",
+};
+
+const remote = async () => "git@gitlab.com:werush-platform/platform/iac.git";
+
+describe("parseGitlabRemote", () => {
+  it("parses ssh remotes with nested groups", () => {
+    expect(parseGitlabRemote("git@gitlab.com:werush-platform/platform/iac.git")).toEqual({
+      baseUrl: "https://gitlab.com",
+      projectPath: "werush-platform/platform/iac",
+    });
+  });
+
+  it("parses https remotes", () => {
+    expect(parseGitlabRemote("https://gitlab.example.com/group/proj.git")).toEqual({
+      baseUrl: "https://gitlab.example.com",
+      projectPath: "group/proj",
+    });
+  });
+
+  it("rejects single-segment and malformed remotes (fail-closed)", () => {
+    expect(parseGitlabRemote("git@gitlab.com:proj.git")).toBeNull();
+    expect(parseGitlabRemote("not a url")).toBeNull();
+    expect(parseGitlabRemote("git@gitlab.com:-bad/flag.git")).toBeNull();
+  });
+});
+
+describe("writeSpecMr", () => {
+  it("creates branch, file, and MR on the happy path", async () => {
+    const { fn, calls } = fakeGitlab([
+      { match: /merge_requests\?/, method: "GET", status: 200, body: [] },
+      { match: /projects\/[^/]+$/, method: "GET", status: 200, body: { default_branch: "main" } },
+      { match: /repository\/branches\//, method: "GET", status: 404, body: {} },
+      { match: /repository\/branches$/, method: "POST", status: 201, body: { name: PARAMS.branch } },
+      { match: /repository\/files\/.*\?/, method: "GET", status: 404, body: {} },
+      { match: /repository\/files\//, method: "POST", status: 201, body: {} },
+      {
+        match: /merge_requests$/,
+        method: "POST",
+        status: 201,
+        body: { web_url: "https://gitlab.com/werush-platform/platform/iac/-/merge_requests/7" },
+      },
+    ]);
+    const res = await writeSpecMr(
+      { gitlabHttp: fn, gitlabAuth: AUTH, gitRemoteUrl: remote, log: noLog },
+      PARAMS,
+    );
+    expect(res).toEqual({
+      ok: true,
+      prUrl: "https://gitlab.com/werush-platform/platform/iac/-/merge_requests/7",
+      reused: false,
+    });
+    // The project path travels URL-encoded (nested groups → %2F).
+    expect(calls.every((c) => c.url.includes("werush-platform%2Fplatform%2Fiac"))).toBe(true);
+    const mrCreate = calls.find((c) => c.method === "POST" && /merge_requests$/.test(c.url.split("?")[0]));
+    expect(JSON.parse(mrCreate!.body!)).toMatchObject({
+      source_branch: PARAMS.branch,
+      target_branch: "main",
+      title: PARAMS.prTitle,
+    });
+  });
+
+  it("reuses an existing MR for the branch (dedup — creates nothing)", async () => {
+    const { fn, calls } = fakeGitlab([
+      {
+        match: /merge_requests\?/,
+        method: "GET",
+        status: 200,
+        body: [{ web_url: "https://gitlab.com/x/-/merge_requests/1", state: "opened" }],
+      },
+    ]);
+    const res = await writeSpecMr(
+      { gitlabHttp: fn, gitlabAuth: AUTH, gitRemoteUrl: remote, log: noLog },
+      PARAMS,
+    );
+    expect(res).toEqual({ ok: true, prUrl: "https://gitlab.com/x/-/merge_requests/1", reused: true });
+    expect(calls.filter((c) => c.method === "POST")).toHaveLength(0);
+  });
+
+  it("continues past an existing branch and file (idempotent re-run)", async () => {
+    const { fn, calls } = fakeGitlab([
+      { match: /merge_requests\?/, method: "GET", status: 200, body: [] },
+      { match: /projects\/[^/]+$/, method: "GET", status: 200, body: { default_branch: "main" } },
+      { match: /repository\/branches\//, method: "GET", status: 200, body: { name: PARAMS.branch } },
+      {
+        match: /repository\/files\/.*\?/,
+        method: "GET",
+        status: 200,
+        body: { file_path: PARAMS.filePath },
+      },
+      { match: /merge_requests$/, method: "POST", status: 201, body: { web_url: "https://g/mr/2" } },
+    ]);
+    const res = await writeSpecMr(
+      { gitlabHttp: fn, gitlabAuth: AUTH, gitRemoteUrl: remote, log: noLog },
+      PARAMS,
+    );
+    expect(res).toEqual({ ok: true, prUrl: "https://g/mr/2", reused: false });
+    // No branch/file POSTs — only the MR create.
+    expect(calls.filter((c) => c.method === "POST")).toHaveLength(1);
+  });
+
+  it("degrades to no-default-branch when the project is unreachable", async () => {
+    const { fn } = fakeGitlab([
+      { match: /merge_requests\?/, method: "GET", status: 200, body: [] },
+      // project GET falls through to 404.
+    ]);
+    const res = await writeSpecMr(
+      { gitlabHttp: fn, gitlabAuth: AUTH, gitRemoteUrl: remote, log: noLog },
+      PARAMS,
+    );
+    expect(res).toEqual({ ok: false, reason: "no-default-branch" });
+  });
+
+  it("rejects a bad branch and a flag-shaped title", async () => {
+    const { fn } = fakeGitlab([]);
+    const bad = await writeSpecMr(
+      { gitlabHttp: fn, gitlabAuth: AUTH, gitRemoteUrl: remote, log: noLog },
+      { ...PARAMS, branch: "evil/branch" },
+    );
+    expect(bad).toEqual({ ok: false, reason: "bad-branch" });
+    const flag = await writeSpecMr(
+      { gitlabHttp: fn, gitlabAuth: AUTH, gitRemoteUrl: remote, log: noLog },
+      { ...PARAMS, prTitle: "--flag" },
+    );
+    expect(flag).toEqual({ ok: false, reason: "bad-title" });
+  });
+
+  it("degrades when the MR create fails and no MR is recoverable", async () => {
+    const { fn } = fakeGitlab([
+      { match: /merge_requests\?/, method: "GET", status: 200, body: [] },
+      { match: /projects\/[^/]+$/, method: "GET", status: 200, body: { default_branch: "main" } },
+      { match: /repository\/branches\//, method: "GET", status: 404, body: {} },
+      { match: /repository\/branches$/, method: "POST", status: 201, body: {} },
+      { match: /repository\/files\/.*\?/, method: "GET", status: 404, body: {} },
+      { match: /repository\/files\//, method: "POST", status: 201, body: {} },
+      { match: /merge_requests$/, method: "POST", status: 500, body: { message: "boom" } },
+    ]);
+    const res = await writeSpecMr(
+      { gitlabHttp: fn, gitlabAuth: AUTH, gitRemoteUrl: remote, log: noLog },
+      PARAMS,
+    );
+    expect(res).toEqual({ ok: false, reason: "pr-create-failed" });
+  });
+});
+
+describe("crystallizeTicket forge sniff", () => {
+  const input = {
+    source: { kind: "jira", ref: "PDO-1", url: "https://jira/browse/PDO-1" },
+    targetRepoPath: "/repos/iac",
+    branch: "spec/jira-PDO-1",
+    filePath: "docs/specs/jira-PDO-1-test.md",
+    title: "test",
+    status: "ready" as const,
+    problem: "p",
+    criteria: ["c1"],
+    commitMessage: "feat: add spec for PDO-1",
+    prTitle: "spec: test (PDO-1)",
+    prBody: "body",
+  };
+  const writeback = {
+    pickup: async () => ({ posted: true }),
+    needCriteria: async () => ({ posted: true }),
+  };
+
+  it("routes a gitlab origin to the MR writer (gh never invoked)", async () => {
+    const { fn, calls } = fakeGitlab([
+      { match: /merge_requests\?/, method: "GET", status: 200, body: [] },
+      { match: /projects\/[^/]+$/, method: "GET", status: 200, body: { default_branch: "main" } },
+      { match: /repository\/branches\//, method: "GET", status: 404, body: {} },
+      { match: /repository\/branches$/, method: "POST", status: 201, body: {} },
+      { match: /repository\/files\/.*\?/, method: "GET", status: 404, body: {} },
+      { match: /repository\/files\//, method: "POST", status: 201, body: {} },
+      { match: /merge_requests$/, method: "POST", status: 201, body: { web_url: "https://g/mr/9" } },
+    ]);
+    let ghCalled = false;
+    const res = await crystallizeTicket(
+      {
+        gitRemoteUrl: remote,
+        gitlabHttp: fn,
+        gitlabAuth: AUTH,
+        runGh: (async () => {
+          ghCalled = true;
+          return { stdout: "", stderr: "" };
+        }) as never,
+        writeback,
+        log: noLog,
+      },
+      input,
+    );
+    expect(res).toEqual({ outcome: "spec-pr", prUrl: "https://g/mr/9", reused: false });
+    expect(ghCalled).toBe(false); // the GitLab seam handled it, not gh.
+    expect(calls.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Что
Jira-intake коннектор хардкодил `/rest/api/3` (Cloud-only) и слал комментарии в ADF. Против self-hosted Jira Server/Data Center (там есть только `/rest/api/2`, комментарии — plain string) каждый poll-цикл молча деградировал (v3 отвечает 302/404 → `null` → skip).

## Как
- `JiraConnectorConfig.apiVersion` (`"2" | "3"`, default `"3"`): переключает базу путей и формат тела комментария. Чтение диалект-агностично — `adfToText` пропускает v2-строки как есть.
- `TrackerEventTriggerConfig.jiraApiVersion` — поле конфига триггера, поллер пробрасывает его в коннектор.
- Поле отсутствует ⇒ поведение существующих конфигов байт-в-байт прежнее (Cloud).

## Тесты
- 4 новых кейса v2-диалекта: все пути через `/rest/api/2`, plain-string тело комментария, marker-дедуп по v2-строкам, string-description passthrough.
- `vitest`: jira-connector + jira-issues-poller — 30 passed. `tsc --noEmit` чистый.

## Проверено вживую
`jira.werush.co`: `GET /rest/api/2/myself` → 200, `/rest/api/3/myself` → 302 (подтверждает диагноз).