### PR TITLE
feat(intake): ADR-004 Block A — direct ticket intake, one MR per task

### DIFF
--- a/docs/adr/ADR-004-one-mr-per-task-intake.md
+++ b/docs/adr/ADR-004-one-mr-per-task-intake.md
@@ -1,0 +1,73 @@
+# ADR-004: One MR per task — ticket-direct intake, spec as input, MR as result
+
+- **Status**: accepted (Block A implemented; Blocks B/C planned)
+- **Date**: 2026-07-18
+- **Owners**: factory intake (Track-3/5), consilium loop delivery
+
+## Context
+
+The Track-3/5 tracker intake crystallised every matched ticket into a **committed-spec
+PR/MR** (`docs/specs/jira-<KEY>-….md`); merging that spec fired the SPEC-1 spec-watch,
+which launched the loop, which later opened a **second** MR with the implementation.
+Live use against a real Jira/GitLab project (PDO-850, 2026-07-18) surfaced the problem:
+
+1. **Two MRs per task** — a spec-only MR carries no work product, yet demands a review
+   and a merge, and permanently deposits `docs/specs/*` files into the target repo.
+2. **Wrong MR semantics for the host forge.** In the team's GitLab workflow an MR is a
+   FINISHED piece of work (code written and tested, ready for full human review); an
+   unfinished one is a Draft. A spec is neither — it is the task definition
+   (condition-of-done), i.e. an *input*, not a deliverable.
+
+## Decision
+
+Adopt these invariants for factory intake and delivery:
+
+1. **An MR is a result, never an input.** Exactly ONE MR exists per task — the
+   implementation MR the loop produces. It opens as **Draft** while the loop works
+   (Block B) and is marked ready only when code + tests + the loop's internal review
+   have converged. A spec-only PR/MR is never created.
+2. **A spec is the task definition.** It arrives via one of two equal intake sources:
+   - **a tracker ticket** (Jira/GitLab/…): consent label + explicit acceptance
+     criteria in the ticket (or synthesised criteria approved in the ticket);
+   - **a spec file in the repo** (`docs/specs/**`, SPEC-1): committed by a HUMAN
+     through the team's normal flow — that commit *is* the scope approval.
+   Both normalise into the same task shape `{source, title, problem, scope, criteria,
+   repo}` and the same launch core (`launchReviewWithDedup`).
+3. **Scope approval moves to the source.** Ticket path: the consent label (plus, when
+   criteria were synthesised, a human `criteria-ok` signal — Block C) replaces the old
+   "merge the spec PR" gate. Repo-spec path: unchanged (the human commit is the gate).
+4. **T6 stands.** Any automatically-fired launch is review-only (`maxRounds: 1`);
+   escalation to DEVELOPING remains a human action. A future dark-factory profile
+   (omnius) may relax this behind an explicit per-trigger opt-in — never by default.
+5. **Claim protocol (Block C).** Multiple engines (multiqlti, omnius) watch the same
+   sources; the claim marker in the ticket + the per-ticket dedup anchor
+   (`ticket:<kind>:<key>`) form the mutex — first claimer works, others skip.
+
+## Block A (implemented here)
+
+`TrackerEventTriggerConfig.intakeMode: "spec-pr" | "direct"` (default `"spec-pr"`,
+byte-identical for existing triggers). In `"direct"` mode the Jira poller skips
+crystallisation entirely and calls `launchTicketReview` → `launchReviewWithDedup`:
+
+- dedup anchor `ticket:jira:<KEY>` rides the spec-dedup seam (one active loop per
+  ticket, not per repo);
+- provenance `spec.source = {kind: "jira", ref, url}` — write-back can join later;
+- the objective is built by the SAME `buildSpecInstruction` (DoD-first, byte-clamped)
+  the spec-watch path uses;
+- tickets without criteria (after synthesis) get the need-criteria comment and are
+  retried on edit — no watermark;
+- `"launched"` → pickup comment + optional transition + watermark;
+  `"skipped-dedup"` → watermark only; `"failed"`/`"skipped"` → retry next cycle.
+
+## Consequences
+
+- The target repo history contains only real work (implementation MRs); no
+  `docs/specs/*` deposits from tickets. Repo-resident specs remain fully supported
+  for teams that author them deliberately.
+- The old spec-PR path stays the default until operators opt triggers into
+  `"direct"`; Track-5 connectors (Azure/Linear/ClickUp/…) can adopt the same seam
+  incrementally.
+- Blocks B (Draft-first implementation MR + ready flip on convergence) and C
+  (claim marker + `criteria-ok` approval signal) complete the pipeline; until B
+  lands, a direct-intake loop still opens its implementation MR at delivery time
+  (non-Draft), which is acceptable for review-only launches.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -59,7 +59,7 @@ import { registerConsultRoutes } from "./routes/consult";
 import { WorkspaceManager } from "./workspace/manager";
 import { registerStandingRoleRoutes } from "./routes/standing-roles";
 import { createConsiliumReview } from "./services/consilium/review-factory";
-import { maybeLaunchConsiliumReview, maybeLaunchGitHubReview, maybeLaunchGitLabReview, maybeLaunchRoleWake, resolveSpecWatchConfig, deriveRepoRoot } from "./services/consilium/trigger-dispatch";
+import { maybeLaunchConsiliumReview, maybeLaunchGitHubReview, maybeLaunchGitLabReview, maybeLaunchRoleWake, resolveSpecWatchConfig, deriveRepoRoot, launchTicketReview } from "./services/consilium/trigger-dispatch";
 import { ConsiliumLoopController, ConsiliumLoopPoller } from "./services/consilium/consilium-loop-controller";
 import {
   writeSpecStatusRemote,
@@ -769,6 +769,38 @@ export async function registerRoutes(
             }
           },
         },
+        // ADR-004 Block A: direct intake — the ticket IS the task. Launch through the
+        // SAME dedup/owner/T6 core every trigger path uses (launchTicketReview →
+        // launchReviewWithDedup): per-ticket dedup anchor, provenance source={jira,key},
+        // review-only (maxRounds=1). Only fires for `intakeMode: "direct"` triggers.
+        launchDirect: (trigger, args) =>
+          launchTicketReview(
+            {
+              reviewDeps: consiliumLoopController
+                ? {
+                    storage,
+                    orchestrator: taskOrchestrator,
+                    controller: consiliumLoopController,
+                    config: () => appConfigLoader.get(),
+                  }
+                : null,
+              createReview: createConsiliumReview,
+              runInProject: runAsProject,
+              resolveOwnerId: (projectId: string) =>
+                runAsSystem("resolve-trigger-owner", async () => {
+                  const [row] = await db
+                    .select({ ownerId: projects.ownerId })
+                    .from(projects)
+                    .where(eq(projects.id, projectId));
+                  return row?.ownerId ?? null;
+                }),
+              recordFire: (triggerId: string, firedAt: Date) =>
+                storage.incrementTriggerFired(triggerId, firedAt),
+              log: (m: string) => log(m, "jira-tracker-poller"),
+            },
+            trigger,
+            args,
+          ),
         log: (m: string) => log(m, "jira-tracker-poller"),
       });
       jiraIssuesPoller.start();

--- a/server/services/consilium/trackers/jira-issues-poller.ts
+++ b/server/services/consilium/trackers/jira-issues-poller.ts
@@ -45,6 +45,7 @@ import { crystallizeTicket } from "./spec-intake.js";
 import { JiraTrackerConnector, type JiraConnectorConfig } from "./jira-connector.js";
 import { readJiraAuthFromEnv, type JiraAuth, type JiraHttpFn } from "./jira-exec.js";
 import type { GitlabAuth, GitlabHttpFn } from "./gitlab-exec.js";
+import type { TicketLaunchArgs, ConsiliumDispatchResult } from "../trigger-dispatch.js";
 
 /** `owner/repo` (GitHub) or `group/subgroup/project` (GitLab nested groups) —
  *  conservative charset (no leading dash / no flag), 2+ segments. */
@@ -92,6 +93,16 @@ export interface JiraIssuesPollerDeps {
   gitlabAuth?: GitlabAuth | null;
   /** Injectable git-remote reader for the owner/repo derivation (default: real `git`). */
   gitRemoteUrl?: (repoPath: string) => Promise<string | null>;
+  /**
+   * ADR-004 Block A: the direct-intake seam — launch a review loop straight from the
+   * ticket (no spec-PR). Wired by the route to `launchTicketReview` (the shared
+   * dedup/owner/T6 core); absent ⇒ `intakeMode: "direct"` triggers are skipped with
+   * a log (fail-closed) and the default spec-PR path is byte-identical.
+   */
+  launchDirect?: (
+    trigger: TriggerRow,
+    args: TicketLaunchArgs,
+  ) => Promise<ConsiliumDispatchResult>;
   log: (message: string) => void;
   now?: () => number;
 }
@@ -307,6 +318,57 @@ export class JiraIssuesPoller {
           } catch (e) {
             this.deps.log(`jira tracker poll: synthesizer error for ${key}: ${(e as Error).message}`);
           }
+        }
+
+        // ── ADR-004 Block A: direct intake — the ticket IS the task ─────────────
+        // No spec-PR intermediary: launch the review loop now (per-ticket dedup,
+        // review-only per T6). The ONLY MR for the task will be the implementation
+        // MR the loop later produces. Absent seam/config ⇒ the spec-PR path below
+        // is byte-identical.
+        if (config.intakeMode === "direct") {
+          if (!this.deps.launchDirect) {
+            this.deps.log(`jira tracker poll: direct intake for ${key} skipped — launchDirect not wired`);
+            continue;
+          }
+          if (criteria.length === 0) {
+            await connector.writeback.comment(
+              key,
+              `🤖 I can pick this up but need testable acceptance criteria — please add an "Acceptance Criteria" section or checklist items.`,
+              JIRA_NEED_CRITERIA_MARKER,
+            );
+            continue; // no watermark — an edit that adds criteria retries next cycle.
+          }
+          let launch: ConsiliumDispatchResult;
+          try {
+            launch = await this.deps.launchDirect(trigger, {
+              projectId,
+              repoPath: targetRepoPath,
+              ticket: { kind: "jira", key, title: ticket.title, url: ticket.url },
+              spec: { problem, scope, outOfScope, criteria },
+            });
+          } catch (e) {
+            this.deps.log(`jira tracker poll: direct launch threw for ${key}: ${(e as Error).message}`);
+            launch = "failed";
+          }
+          if (launch === "launched") {
+            await connector.writeback.comment(
+              key,
+              `🤖 taken into work by the factory — review loop started for ${key}`,
+              JIRA_PICKUP_MARKER,
+            );
+            if (config.transitionTo && connector.writeback.transition) {
+              await connector.writeback.transition(key, config.transitionTo);
+            }
+            state.intake![key] = { at: new Date(this.now()).toISOString() };
+            intaken++;
+          } else if (launch === "skipped-dedup") {
+            // A loop for this ticket is already active — watermark so we stop retrying.
+            state.intake![key] = { at: new Date(this.now()).toISOString() };
+          } else {
+            // skipped / failed → NO watermark: the next cycle retries (fail-open poll).
+            this.deps.log(`jira tracker poll: direct launch ${launch} for ${key}`);
+          }
+          continue;
         }
 
         const specStatus = config.specStatus ?? "ready";

--- a/server/services/consilium/trigger-dispatch.ts
+++ b/server/services/consilium/trigger-dispatch.ts
@@ -589,6 +589,76 @@ export async function maybeLaunchSpecReview(
   return result;
 }
 
+// ─── ADR-004 Block A: direct ticket intake (ticket → loop, no spec-PR) ─────────
+
+/** The normalised ticket-task a tracker poller hands to the direct-intake launch. */
+export interface TicketLaunchArgs {
+  projectId: string;
+  repoPath: string;
+  /** Loop preset; absent ⇒ the spec default (`sdlc-cross-review`). */
+  preset?: ConsiliumReviewPreset;
+  /** Connector-normalised ticket identity (key already connector-sanitised). */
+  ticket: { kind: string; key: string; title: string; url?: string };
+  /** The extracted/synthesised task definition (criteria = condition of done). */
+  spec: { problem?: string; scope?: string; outOfScope?: string; criteria: string[] };
+}
+
+/**
+ * ADR-004 Block A: launch a review loop DIRECTLY from a tracker ticket — the ticket
+ * IS the task; there is no committed-spec-PR intermediary. Reuses the SAME
+ * `launchReviewWithDedup` core (owner FK, T4 catch, T6 review-only) with:
+ *   - a per-ticket dedup anchor `ticket:<kind>:<key>` riding the spec-dedup seam
+ *     (one active loop per ticket, not per repo);
+ *   - provenance `spec.source = {kind, ref, url}` so write-back can join later;
+ *   - the instruction built by the SAME `buildSpecInstruction` (DoD-first, clamped)
+ *     the spec-watch path uses — the criteria always reach the reviewers.
+ * The caller (poller) owns the consent gate, allowlist check, and watermark.
+ */
+export async function launchTicketReview(
+  deps: ConsiliumTriggerDispatchDeps,
+  trigger: TriggerRow,
+  args: TicketLaunchArgs,
+): Promise<ConsiliumDispatchResult> {
+  if (!deps.reviewDeps) {
+    deps.log(`ticket intake skipped for ${args.ticket.key} — consilium loop disabled`);
+    return "skipped";
+  }
+  const bodyParts = [`## Problem\n${args.spec.problem ?? args.ticket.title}`];
+  if (args.spec.scope) bodyParts.push(`## Scope\n${args.spec.scope}`);
+  if (args.spec.outOfScope) bodyParts.push(`## Out of scope\n${args.spec.outOfScope}`);
+  if (args.ticket.url) bodyParts.push(`Ticket: ${args.ticket.url}`);
+  const engineerInstruction = buildSpecInstruction(bodyParts.join("\n\n"), args.spec.criteria);
+
+  // UNTRUSTED title → single-line control-strip + clamp for the inert passport label.
+  const titleLabel = args.ticket.title
+    // eslint-disable-next-line no-control-regex
+    .replace(/[ -]+/g, " ")
+    .trim()
+    .slice(0, 120);
+  const anchor = `ticket:${args.ticket.kind}:${args.ticket.key}`;
+
+  return launchReviewWithDedup(deps, trigger, {
+    projectId: args.projectId,
+    repoPath: args.repoPath,
+    preset: args.preset ?? SPEC_DEFAULT_PRESET,
+    engineerInstruction,
+    // Per-ticket dedup: the synthetic anchor rides the spec-dedup seam, so two
+    // tickets targeting one repo each fire their own loop (mirrors per-spec dedup).
+    specDedupKey: anchor,
+    specProvenance: {
+      specPath: anchor,
+      status: "ready",
+      source: {
+        kind: args.ticket.kind,
+        ref: args.ticket.key,
+        ...(args.ticket.url ? { url: args.ticket.url } : {}),
+      },
+    },
+    eventSummary: `ticket picked: ${args.ticket.key}${titleLabel ? ` ${titleLabel}` : ""}`,
+    payload: { ticket: args.ticket.key },
+  });
+}
+
 /**
  * The launch plan the shared core turns into a factory call. `preset`/`repoPath`
  * are already chosen by the caller (the action's for file_change/schedule; the

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1885,6 +1885,16 @@ export interface TrackerEventTriggerConfig {
    */
   jiraApiVersion?: "2" | "3";
   /**
+   * ADR-004 (one MR per task): how a matched ticket becomes work.
+   *   - `"spec-pr"` (default) — the historical Track-3/5 path: crystallise the ticket
+   *     into a committed-spec PR/MR; merging that spec fires the loop.
+   *   - `"direct"` — the ticket IS the task: launch the review loop immediately
+   *     (per-ticket dedup, review-only per T6), no spec-PR intermediary; the ONLY MR
+   *     for the task is the implementation MR the loop later produces.
+   * Absent ⇒ `"spec-pr"` (existing triggers byte-identical). Jira-only for now.
+   */
+  intakeMode?: "spec-pr" | "direct";
+  /**
    * Optional pickup "transition", interpreted per connector (best-effort): Jira → a
    * workflow transition name/id; GitLab → a LABEL to add (no arbitrary states);
    * Bitbucket → an issue STATE; Linear → a workflow-state name; Azure → `System.State`;

--- a/tests/unit/consilium/ticket-direct-dispatch.test.ts
+++ b/tests/unit/consilium/ticket-direct-dispatch.test.ts
@@ -1,0 +1,109 @@
+/**
+ * ticket-direct-dispatch.test.ts — ADR-004 Block A: `launchTicketReview` (direct
+ * ticket → loop, no spec-PR). Covers: the launch plan reaching the factory carries
+ * the per-ticket dedup anchor + provenance source and forces review-only (T6);
+ * the instruction is DoD-first (criteria before body); an ACTIVE loop with the same
+ * anchor dedup-suppresses (no second factory call); a disabled consilium loop
+ * (reviewDeps null) skips fail-closed.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { launchTicketReview } from "../../../server/services/consilium/trigger-dispatch.js";
+import type { TriggerRow } from "../../../shared/schema.js";
+
+function trigger(): TriggerRow {
+  return {
+    id: "trk-1",
+    projectId: "proj-1",
+    type: "tracker_event",
+    config: {},
+    enabled: true,
+  } as unknown as TriggerRow;
+}
+
+function makeDeps(existingLoops: unknown[] = []) {
+  const created: Array<Record<string, unknown>> = [];
+  const recordFire = vi.fn(async () => {});
+  const deps = {
+    reviewDeps: {
+      storage: { getLoops: async () => existingLoops },
+      orchestrator: {},
+      controller: {},
+      config: () => ({}),
+    },
+    createReview: vi.fn(async (_rd: unknown, args: Record<string, unknown>) => {
+      created.push(args);
+      return { id: "loop-1" };
+    }),
+    runInProject: async <T,>(_p: string, fn: () => Promise<T>) => fn(),
+    resolveOwnerId: async () => "user-1",
+    recordFire,
+    log: () => {},
+  };
+  return { deps, created, recordFire };
+}
+
+const ARGS = {
+  projectId: "proj-1",
+  repoPath: "/repo/widget",
+  ticket: {
+    kind: "jira",
+    key: "PDO-850",
+    title: "Enable caching",
+    url: "https://jira.example.co/browse/PDO-850",
+  },
+  spec: {
+    problem: "Pipelines are slow",
+    scope: "cicd templates",
+    criteria: ["gradle cache restored", "cache policy is pull"],
+  },
+};
+
+describe("launchTicketReview (ADR-004 Block A)", () => {
+  it("launches with the per-ticket anchor, source provenance, T6 review-only, DoD-first instruction", async () => {
+    const { deps, created, recordFire } = makeDeps();
+    const res = await launchTicketReview(deps as never, trigger(), ARGS);
+    expect(res).toBe("launched");
+    expect(created).toHaveLength(1);
+    const plan = created[0];
+
+    // Per-ticket dedup anchor + join-able provenance source.
+    expect(plan.triggerProvenance).toMatchObject({
+      spec: {
+        specPath: "ticket:jira:PDO-850",
+        status: "ready",
+        source: { kind: "jira", ref: "PDO-850", url: ARGS.ticket.url },
+      },
+    });
+    // T6: an unattended launch NEVER reaches the coder — review-only.
+    expect(plan.maxRounds).toBe(1);
+    expect(plan.preset).toBe("sdlc-cross-review");
+
+    // DoD-first: criteria reach the objective BEFORE the body (H1 clamp discipline).
+    const instruction = plan.engineerInstruction as string;
+    expect(instruction).toContain("gradle cache restored");
+    expect(instruction.indexOf("gradle cache restored")).toBeLessThan(
+      instruction.indexOf("Pipelines are slow"),
+    );
+    expect(recordFire).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedup-suppresses when an ACTIVE loop already carries the same ticket anchor", async () => {
+    const active = {
+      state: "reviewing",
+      repoPath: "/somewhere/else",
+      triggerProvenance: { spec: { specPath: "ticket:jira:PDO-850" } },
+    };
+    const { deps, created } = makeDeps([active]);
+    const res = await launchTicketReview(deps as never, trigger(), ARGS);
+    expect(res).toBe("skipped-dedup");
+    expect(created).toHaveLength(0);
+  });
+
+  it("skips fail-closed when the consilium loop is disabled (reviewDeps null)", async () => {
+    const { deps, created } = makeDeps();
+    (deps as { reviewDeps: unknown }).reviewDeps = null;
+    const res = await launchTicketReview(deps as never, trigger(), ARGS);
+    expect(res).toBe("skipped");
+    expect(created).toHaveLength(0);
+  });
+});

--- a/tests/unit/consilium/trackers/jira-issues-poller.test.ts
+++ b/tests/unit/consilium/trackers/jira-issues-poller.test.ts
@@ -20,6 +20,7 @@ import type { JiraHttpFn, JiraHttpResult } from "../../../../server/services/con
 import type { ExecFileFn } from "../../../../server/services/github-status.js";
 import type { TriggerRow } from "../../../../shared/schema.js";
 import type { AppConfig, TrackerEventTriggerConfig } from "../../../../shared/types.js";
+import type { TicketLaunchArgs, ConsiliumDispatchResult } from "../../../../server/services/consilium/trigger-dispatch.js";
 
 // ─── fakes ───────────────────────────────────────────────────────────────────
 
@@ -105,6 +106,7 @@ interface HarnessOpts {
   trackerOn?: boolean;
   allowedRepoPaths?: () => string[];
   synthesizer?: TicketSynthesizer;
+  launchDirect?: (trigger: TriggerRow, args: TicketLaunchArgs) => Promise<ConsiliumDispatchResult>;
   logs?: string[];
 }
 
@@ -123,6 +125,7 @@ function harness(opts: HarnessOpts) {
     config: cfg(opts.masterOn ?? true, opts.trackerOn ?? true),
     allowedRepoPaths: opts.allowedRepoPaths ?? (() => ["/repo/widget"]),
     synthesizer: opts.synthesizer,
+    launchDirect: opts.launchDirect,
     runGh: opts.gh,
     jiraHttp: opts.jira,
     jiraAuth: { email: "a@b.co", token: "secret" },
@@ -290,5 +293,115 @@ describe("JiraIssuesPoller.start gating", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("direct intake (ADR-004 Block A)", () => {
+  const directTrigger = () => jiraTrigger({ intakeMode: "direct" });
+
+  it("shaped issue → launchDirect with the normalised task + ONE pickup comment + watermark, NO spec PR", async () => {
+    const { http, calls } = fakeJira({ issues: [SHAPED_ISSUE] });
+    const { run, argv } = fakeGh();
+    const seen: TicketLaunchArgs[] = [];
+    const { poller, updates } = harness({
+      trigger: directTrigger(),
+      jira: http,
+      gh: run,
+      launchDirect: async (_t, args) => {
+        seen.push(args);
+        return "launched";
+      },
+    });
+    await poller.pollAll();
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({
+      projectId: "proj-1",
+      repoPath: "/repo/widget",
+      ticket: { kind: "jira", key: "ACME-1", title: "Add rate limiting" },
+    });
+    expect(seen[0].spec.criteria).toEqual(["returns 429 over 100 rpm", "resets after window"]);
+
+    // NO spec-PR machinery at all — gh is never touched.
+    expect(argv.length).toBe(0);
+    // Exactly one pickup comment ("taken into work").
+    expect(jiraPosts(calls, "/comment")).toBe(1);
+    // Watermarked WITHOUT a specPrUrl (there is no spec PR).
+    const last = updates[updates.length - 1].config as TrackerEventTriggerConfig;
+    expect(last.pollState?.intake?.["ACME-1"]).toBeTruthy();
+    expect(last.pollState?.intake?.["ACME-1"]?.specPrUrl).toBeUndefined();
+  });
+
+  it("re-poll → launchDirect NOT called again (watermark dedup)", async () => {
+    const { http } = fakeJira({ issues: [SHAPED_ISSUE] });
+    const { run } = fakeGh();
+    const launchDirect = vi.fn(async () => "launched" as const);
+    const { poller } = harness({ trigger: directTrigger(), jira: http, gh: run, launchDirect });
+    await poller.pollAll();
+    await poller.pollAll();
+    expect(launchDirect).toHaveBeenCalledTimes(1);
+  });
+
+  it("skipped-dedup (active loop) → watermark set, NO comment", async () => {
+    const { http, calls } = fakeJira({ issues: [SHAPED_ISSUE] });
+    const { run } = fakeGh();
+    const { poller, updates } = harness({
+      trigger: directTrigger(),
+      jira: http,
+      gh: run,
+      launchDirect: async () => "skipped-dedup",
+    });
+    await poller.pollAll();
+    expect(jiraPosts(calls, "/comment")).toBe(0);
+    const last = updates[updates.length - 1].config as TrackerEventTriggerConfig;
+    expect(last.pollState?.intake?.["ACME-1"]).toBeTruthy();
+  });
+
+  it("failed launch → NO watermark (next cycle retries), NO comment", async () => {
+    const { http, calls } = fakeJira({ issues: [SHAPED_ISSUE] });
+    const { run } = fakeGh();
+    const { poller, updates } = harness({
+      trigger: directTrigger(),
+      jira: http,
+      gh: run,
+      launchDirect: async () => "failed",
+    });
+    await poller.pollAll();
+    expect(jiraPosts(calls, "/comment")).toBe(0);
+    const last = updates[updates.length - 1].config as TrackerEventTriggerConfig;
+    expect(last.pollState?.intake?.["ACME-1"]).toBeUndefined();
+  });
+
+  it("free-form issue + synth empty → need-criteria comment, launchDirect NOT called, no watermark", async () => {
+    const freeform = {
+      ...SHAPED_ISSUE,
+      key: "ACME-9",
+      fields: { ...SHAPED_ISSUE.fields, description: "just do the thing please" },
+    };
+    const { http, calls } = fakeJira({ issues: [freeform] });
+    const { run } = fakeGh();
+    const launchDirect = vi.fn(async () => "launched" as const);
+    const { poller, updates } = harness({
+      trigger: directTrigger(),
+      jira: http,
+      gh: run,
+      launchDirect,
+      synthesizer: { synthesize: async () => ({ criteria: [] }) },
+    });
+    await poller.pollAll();
+    expect(launchDirect).not.toHaveBeenCalled();
+    expect(jiraPosts(calls, "/comment")).toBe(1); // the need-criteria ask
+    const last = updates[updates.length - 1].config as TrackerEventTriggerConfig;
+    expect(last.pollState?.intake?.["ACME-9"]).toBeUndefined();
+  });
+
+  it("default mode (no intakeMode) → launchDirect never called, spec-PR path byte-identical", async () => {
+    const { http } = fakeJira({ issues: [SHAPED_ISSUE] });
+    const { run, argv } = fakeGh();
+    const launchDirect = vi.fn(async () => "launched" as const);
+    const { poller } = harness({ trigger: jiraTrigger(), jira: http, gh: run, launchDirect });
+    await poller.pollAll();
+    expect(launchDirect).not.toHaveBeenCalled();
+    expect(count(argv, isPrCreate)).toBe(1);
   });
 });


### PR DESCRIPTION
## ADR-004
MR — это **результат** (готовая, протестированная работа на человеческое ревью), спека — это **вход** (определение задачи / condition of done). Старый Track-3 путь делал из каждого тикета spec-only MR: два MR на задачу + вечные `docs/specs/*` в целевом репо. Полная схема: `docs/adr/ADR-004-one-mr-per-task-intake.md`.

## Block A (этот PR)
- `TrackerEventTriggerConfig.intakeMode`: `"spec-pr"` (default, байт-в-байт) | `"direct"`.
- `launchTicketReview` (trigger-dispatch): тикет → loop через общий `launchReviewWithDedup` — пер-тикетный дедуп-якорь `ticket:<kind>:<key>`, провенанс `spec.source={kind,ref,url}`, DoD-first objective (`buildSpecInstruction`), T6 review-only.
- Jira-поллер: в direct-режиме минует crystallise/spec-PR; pickup-коммент + transition + watermark при launch; need-criteria ask без watermark; failed → ретрай следующим циклом.
- routes: `launchDirect` подключён к общему dedup/owner/T6 ядру.

## Тесты
- 6 новых кейсов поллера (direct: launch/дедуп/failed/need-criteria/byte-identical default) + 3 кейса `launchTicketReview`.
- `vitest tests/unit/consilium`: **1389 passed**. `tsc` чистый.

## Следом
Block B — Draft-first implementation MR + ready-flip при сходимости; Block C — claim-протокол + `criteria-ok`.