### PR TITLE
feat(intake): direct-intake reviews the fresh remote default (fetch + reviewRef)

### DIFF
--- a/server/services/consilium/trackers/jira-issues-poller.ts
+++ b/server/services/consilium/trackers/jira-issues-poller.ts
@@ -103,6 +103,14 @@ export interface JiraIssuesPollerDeps {
     trigger: TriggerRow,
     args: TicketLaunchArgs,
   ) => Promise<ConsiliumDispatchResult>;
+  /**
+   * ADR-004: resolve the FRESH review target for a direct intake — fetch origin
+   * (best-effort) and return `origin/<default-branch>` so the review reads the
+   * remote default via git, never the operator's working tree / current branch.
+   * Injectable for tests; default runs real `git`. `null` ⇒ working-tree HEAD
+   * (the pre-existing behaviour, e.g. a clone with no usable origin).
+   */
+  resolveFreshRef?: (repoPath: string) => Promise<string | null>;
   log: (message: string) => void;
   now?: () => number;
 }
@@ -120,6 +128,46 @@ async function defaultGitRemoteUrl(repoPath: string): Promise<string | null> {
   } catch {
     return null;
   }
+}
+
+/**
+ * ADR-004 default `resolveFreshRef`: `git fetch origin` (best-effort — stale remote
+ * refs still beat the working tree), then `origin/<default>` via the origin/HEAD
+ * symref, falling back to probing `origin/main` / `origin/master`. NEVER throws;
+ * `null` ⇒ the caller launches against the working-tree HEAD as before.
+ */
+async function defaultResolveFreshRef(repoPath: string): Promise<string | null> {
+  try {
+    await execFileAsync("git", ["-C", repoPath, "fetch", "origin", "--quiet"], {
+      timeout: 60_000,
+    });
+  } catch {
+    /* offline / no origin — keep resolving against whatever refs exist */
+  }
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", repoPath, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+      { timeout: 10_000 },
+    );
+    const ref = (stdout ?? "").trim(); // e.g. `origin/main`
+    if (ref.length > 0) return ref;
+  } catch {
+    /* symref unset in some clones — probe the common defaults */
+  }
+  for (const cand of ["origin/main", "origin/master"]) {
+    try {
+      await execFileAsync(
+        "git",
+        ["-C", repoPath, "rev-parse", "--verify", "--quiet", `${cand}^{commit}`],
+        { timeout: 10_000 },
+      );
+      return cand;
+    } catch {
+      /* try the next candidate */
+    }
+  }
+  return null;
 }
 
 /** Best-effort realpath (collapses symlinks/`..`), else lexical resolve. */
@@ -338,6 +386,16 @@ export class JiraIssuesPoller {
             );
             continue; // no watermark — an edit that adds criteria retries next cycle.
           }
+          // Fresh target: fetch origin + resolve `origin/<default>` so the review
+          // reads the remote default via git — never the operator's working tree.
+          const ref = await (this.deps.resolveFreshRef ?? defaultResolveFreshRef)(
+            targetRepoPath,
+          );
+          if (ref === null) {
+            this.deps.log(
+              `jira tracker poll: no origin default ref for ${key} — reviewing working-tree HEAD`,
+            );
+          }
           let launch: ConsiliumDispatchResult;
           try {
             launch = await this.deps.launchDirect(trigger, {
@@ -345,6 +403,7 @@ export class JiraIssuesPoller {
               repoPath: targetRepoPath,
               ticket: { kind: "jira", key, title: ticket.title, url: ticket.url },
               spec: { problem, scope, outOfScope, criteria },
+              ref,
             });
           } catch (e) {
             this.deps.log(`jira tracker poll: direct launch threw for ${key}: ${(e as Error).message}`);

--- a/server/services/consilium/trigger-dispatch.ts
+++ b/server/services/consilium/trigger-dispatch.ts
@@ -601,6 +601,14 @@ export interface TicketLaunchArgs {
   ticket: { kind: string; key: string; title: string; url?: string };
   /** The extracted/synthesised task definition (criteria = condition of done). */
   spec: { problem?: string; scope?: string; outOfScope?: string; criteria: string[] };
+  /**
+   * ADR-004: the review target ref (e.g. `origin/main`, resolved by the poller
+   * after a fetch) so the loop reads the FRESH remote default via git instead of
+   * the operator's working tree. Absent/null ⇒ working-tree HEAD. Validated
+   * strictly by the factory (`validateReviewRef`) — an invalid ref fails the
+   * launch (T4) rather than being persisted.
+   */
+  ref?: string | null;
 }
 
 /**
@@ -641,6 +649,8 @@ export async function launchTicketReview(
     projectId: args.projectId,
     repoPath: args.repoPath,
     preset: args.preset ?? SPEC_DEFAULT_PRESET,
+    // ADR-004: review the fresh remote default (poller-resolved), not the tree.
+    ref: args.ref ?? null,
     engineerInstruction,
     // Per-ticket dedup: the synthetic anchor rides the spec-dedup seam, so two
     // tickets targeting one repo each fire their own loop (mirrors per-spec dedup).

--- a/tests/unit/consilium/ticket-direct-dispatch.test.ts
+++ b/tests/unit/consilium/ticket-direct-dispatch.test.ts
@@ -77,6 +77,8 @@ describe("launchTicketReview (ADR-004 Block A)", () => {
     // T6: an unattended launch NEVER reaches the coder — review-only.
     expect(plan.maxRounds).toBe(1);
     expect(plan.preset).toBe("sdlc-cross-review");
+    // No poller-resolved ref ⇒ working-tree HEAD (null), the pre-existing default.
+    expect(plan.ref).toBeNull();
 
     // DoD-first: criteria reach the objective BEFORE the body (H1 clamp discipline).
     const instruction = plan.engineerInstruction as string;
@@ -85,6 +87,16 @@ describe("launchTicketReview (ADR-004 Block A)", () => {
       instruction.indexOf("Pipelines are slow"),
     );
     expect(recordFire).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the poller-resolved fresh ref through to the launch plan", async () => {
+    const { deps, created } = makeDeps();
+    const res = await launchTicketReview(deps as never, trigger(), {
+      ...ARGS,
+      ref: "origin/main",
+    });
+    expect(res).toBe("launched");
+    expect(created[0].ref).toBe("origin/main");
   });
 
   it("dedup-suppresses when an ACTIVE loop already carries the same ticket anchor", async () => {

--- a/tests/unit/consilium/trackers/jira-issues-poller.test.ts
+++ b/tests/unit/consilium/trackers/jira-issues-poller.test.ts
@@ -107,6 +107,7 @@ interface HarnessOpts {
   allowedRepoPaths?: () => string[];
   synthesizer?: TicketSynthesizer;
   launchDirect?: (trigger: TriggerRow, args: TicketLaunchArgs) => Promise<ConsiliumDispatchResult>;
+  resolveFreshRef?: (repoPath: string) => Promise<string | null>;
   logs?: string[];
 }
 
@@ -126,6 +127,8 @@ function harness(opts: HarnessOpts) {
     allowedRepoPaths: opts.allowedRepoPaths ?? (() => ["/repo/widget"]),
     synthesizer: opts.synthesizer,
     launchDirect: opts.launchDirect,
+    // Test default: never run real `git` — direct-intake tests inject their own.
+    resolveFreshRef: opts.resolveFreshRef ?? (async () => "origin/main"),
     runGh: opts.gh,
     jiraHttp: opts.jira,
     jiraAuth: { email: "a@b.co", token: "secret" },
@@ -321,6 +324,8 @@ describe("direct intake (ADR-004 Block A)", () => {
       ticket: { kind: "jira", key: "ACME-1", title: "Add rate limiting" },
     });
     expect(seen[0].spec.criteria).toEqual(["returns 429 over 100 rpm", "resets after window"]);
+    // Fresh target: the poller-resolved remote default rides into the launch args.
+    expect(seen[0].ref).toBe("origin/main");
 
     // NO spec-PR machinery at all — gh is never touched.
     expect(argv.length).toBe(0);
@@ -403,5 +408,29 @@ describe("direct intake (ADR-004 Block A)", () => {
     await poller.pollAll();
     expect(launchDirect).not.toHaveBeenCalled();
     expect(count(argv, isPrCreate)).toBe(1);
+  });
+});
+
+describe("direct intake — fresh review ref (fetch + origin default)", () => {
+  it("no resolvable origin default → ref null (working-tree fallback) + log", async () => {
+    const { http } = fakeJira({ issues: [SHAPED_ISSUE] });
+    const { run } = fakeGh();
+    const seen: TicketLaunchArgs[] = [];
+    const logs: string[] = [];
+    const { poller } = harness({
+      trigger: jiraTrigger({ intakeMode: "direct" }),
+      jira: http,
+      gh: run,
+      launchDirect: async (_t, args) => {
+        seen.push(args);
+        return "launched";
+      },
+      resolveFreshRef: async () => null,
+      logs,
+    });
+    await poller.pollAll();
+    expect(seen).toHaveLength(1);
+    expect(seen[0].ref).toBeNull();
+    expect(logs.some((l) => l.includes("no origin default ref"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Проблема
Direct-интейк (ADR-004 Block A) запускал ревью по working-tree HEAD: какая ветка случайно выбрана в клоне оператора + его незакоммиченные файлы, и никто не делал fetch. Цель ревью была недетерминированной (наблюдалось вживую: клон werush/cicd стоял на feature-ветке и отставал от origin).

## Решение
- Поллер: seam `resolveFreshRef` — `git fetch origin` (best-effort) → `origin/<default>` через symref origin/HEAD, fallback-проба `origin/main|master`. `null` ⇒ прежнее поведение (working-tree HEAD) + строка в лог.
- `TicketLaunchArgs.ref` → `ReviewLaunchPlan.ref`: loop читает контент **на ref через git** (`composeObjectiveAtRef`), рабочее дерево не участвует; фабрика строго валидирует (`validateReviewRef`).

## Тесты
Харнес инжектит `resolveFreshRef` (никакого настоящего git в тестах); ассерты ref в launch-args, null-fallback и passthrough. **21 passed**, tsc чистый.