### PR TITLE
feat(ui): per-task execution time in the Lifecycle dev task list

### DIFF
--- a/client/src/hooks/use-consilium-loops.ts
+++ b/client/src/hooks/use-consilium-loops.ts
@@ -85,6 +85,9 @@ export interface DevProgress {
     i: number;
     title: string;
     status: "pending" | "active" | "completed" | "partial" | "failed";
+    /** Epoch-ms stamps for the per-task duration chip (absent on old snapshots). */
+    startedAt?: number;
+    endedAt?: number;
   }>;
 }
 

--- a/client/src/pages/ConsiliumLoopDetail.tsx
+++ b/client/src/pages/ConsiliumLoopDetail.tsx
@@ -2064,6 +2064,14 @@ const DEV_STEP_LABELS: Record<NonNullable<DevProgress["step"]>, string> = {
  * SECURITY: every `title` is model-authored verdict text, server-sanitized and
  * rendered as INERT React text (never HTML, never a link/attribute).
  */
+/** Compact human duration for a task chip: `42s`, `4m 12s`, `1h 07m`. */
+function fmtDuration(ms: number): string {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  const m = Math.floor(s / 60);
+  if (m >= 60) return `${Math.floor(m / 60)}h ${String(m % 60).padStart(2, "0")}m`;
+  return m > 0 ? `${m}m ${String(s % 60).padStart(2, "0")}s` : `${s}s`;
+}
+
 function DevTaskList({ progress }: { progress: DevProgress }) {
   const aps = progress.aps ?? [];
   if (aps.length === 0) return null;
@@ -2071,6 +2079,12 @@ function DevTaskList({ progress }: { progress: DevProgress }) {
     <ul className="space-y-1">
       {aps.map((ap) => {
         const isActive = ap.status === "active";
+        // Per-task wall clock: settled → start..end; active → start..now (refreshes
+        // with the poll cycle). Absent stamps (old snapshot) render nothing.
+        const runMs =
+          ap.startedAt !== undefined
+            ? (ap.endedAt ?? Date.now()) - ap.startedAt
+            : undefined;
         return (
           <li key={ap.i} className="flex items-start gap-2 text-xs leading-relaxed">
             <span className="mt-0.5">
@@ -2090,6 +2104,11 @@ function DevTaskList({ progress }: { progress: DevProgress }) {
                     </span>
                   )}
                 </Badge>
+              )}
+              {runMs !== undefined && runMs >= 1000 && (
+                <span className="ml-1.5 tabular-nums text-[10px] text-muted-foreground align-middle">
+                  {isActive ? `⏱ ${fmtDuration(runMs)}` : fmtDuration(runMs)}
+                </span>
               )}
             </span>
           </li>

--- a/server/services/sdlc/executor.ts
+++ b/server/services/sdlc/executor.ts
@@ -299,7 +299,15 @@ export interface SdlcProgress {
    * working and a new consumer degrades to the single-line rendering when it is
    * absent. Display only.
    */
-  aps?: Array<{ i: number; title: string; status: ApProgressStatus }>;
+  aps?: Array<{
+    i: number;
+    title: string;
+    status: ApProgressStatus;
+    /** Epoch-ms when the AP first flipped to `active`. Display only. */
+    startedAt?: number;
+    /** Epoch-ms when the AP settled (completed/partial/failed). Display only. */
+    endedAt?: number;
+  }>;
 }
 
 /** Optional progress sink threaded through the per-AP loop + push/PR phases. */
@@ -964,7 +972,13 @@ function makeProgressTracker(
   if (!onProgress) return { beat: () => {}, setStatus: () => {} };
   // Build the live task list ONCE. Titles are UNTRUSTED → sanitized + clamped EXACTLY
   // like actionPointTitle (same scrub + PROGRESS_TITLE_MAX). Capped defensively.
-  const aps: Array<{ i: number; title: string; status: ApProgressStatus }> = actionPoints
+  const aps: Array<{
+    i: number;
+    title: string;
+    status: ApProgressStatus;
+    startedAt?: number;
+    endedAt?: number;
+  }> = actionPoints
     .slice(0, PROGRESS_APS_MAX)
     .map((ap, i) => ({
       i: i + 1,
@@ -982,7 +996,14 @@ function makeProgressTracker(
     },
     setStatus(index, status) {
       const a = aps[index - 1];
-      if (a) a.status = status;
+      if (!a) return;
+      a.status = status;
+      // Wall-clock stamps for the UI's per-task duration (display only): first
+      // `active` marks the start; any settled status marks the end.
+      if (status === "active" && a.startedAt === undefined) a.startedAt = Date.now();
+      if (status === "completed" || status === "partial" || status === "failed") {
+        a.endedAt = Date.now();
+      }
     },
   };
 }


### PR DESCRIPTION
## Что
В Lifecycle-списке задач develop-фазы виден только статус — не отличить медленную-но-живую задачу от застрявшей.

- `ProgressTracker.setStatus` штампует `startedAt` (первый active) / `endedAt` (completed/partial/failed) per action-point — аддитивные display-only epoch-ms в существующем `aps`-снапшоте.
- `DevTaskList` рендерит чип длительности: завершённые — start..end, активная — тикает start..now с poll-циклом (префикс ⏱).

## Проверки
tsc + vite build чистые; executor-сьют 29 passed.